### PR TITLE
Allow bare repos without index files

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -91,12 +91,6 @@ static int parse_repository_folders(git_repository *repo, const char *repository
 		return GIT_ERROR;
 	repo->path_odb = git__strdup(path_aux);
 
-	/* index file */
-	strcpy(path_aux + path_len, "index");
-	if (gitfo_exists(path_aux) < 0)
-		return GIT_ERROR;
-	repo->path_index = git__strdup(path_aux);
-
 	/* HEAD file */
 	strcpy(path_aux + path_len, "HEAD");
 	if (gitfo_exists(path_aux) < 0)
@@ -111,6 +105,12 @@ static int parse_repository_folders(git_repository *repo, const char *repository
 
 		path_aux[i + 1] = 0;
 		repo->path_workdir = git__strdup(path_aux);
+
+		/* index file */
+		strcpy(path_aux + path_len, "index");
+		if (gitfo_exists(path_aux) < 0)
+			return GIT_ERROR;
+		repo->path_index = git__strdup(path_aux);
 
 	} else {
 		repo->is_bare = 1;


### PR DESCRIPTION
Index files are used to stage contents from the working tree, which bare repos don't have. More to the point, "git {clone,init} --bare" doesn't create an index file, so we can't require it.

I didn't write tests because I didn't know where they should go in the tXXXX hierarchy. If you suggest a location I'd be happy to write them.

(I did test it against my Python wrapper code (pushing Any Day Now (c)) and a repo created with git init --bare, so I'm pretty sure it works.)
