### PR TITLE
Fixed nasty bug preventing correct generation of the signature

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -193,7 +193,7 @@ int git_signature__write(git_odb_source *src, const char *header, const git_sign
 	hours = offset / 60;
 	mins = offset % 60;
 
-	return git__source_printf(src, "%s %s <%s> %u %c%02d%02d\n", header, sig->name, sig->email, sig->when.time, sign, hours, mins);
+	return git__source_printf(src, "%s %s <%s> %u %c%02d%02d\n", header, sig->name, sig->email, (unsigned)sig->when.time, sign, hours, mins);
 }
 
 


### PR DESCRIPTION
Casting the <code>time_t</code> to <code>unsigned</code> seems to help the vsnprintf formatting. At least, on a Windows based box.

I _knew_ I've messed up somewhere. :-/
