### PR TITLE
Fixed leaking of git_vector object in git_commit__free().

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -50,6 +50,7 @@ static void clear_parents(git_commit *commit)
 void git_commit__free(git_commit *commit)
 {
 	clear_parents(commit);
+	git_vector_free(&commit->parents);
 
 	git_signature_free(commit->author);
 	git_signature_free(commit->committer);


### PR DESCRIPTION
For every git_commit object create a git_vector object will be leaked.
