### PR TITLE
missunderstand repository type.

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -35,7 +35,7 @@
 
 #include "refs.h"
 
-#define GIT_DIR "/.git/"
+#define GIT_DIR ".git/"
 #define GIT_OBJECTS_DIR "objects/"
 #define GIT_OBJECTS_INFO_DIR GIT_OBJECTS_DIR "info/"
 #define GIT_OBJECTS_PACK_DIR GIT_OBJECTS_DIR "pack/"


### PR DESCRIPTION
Hi tanoku.

thanks to fix my issue. i can use `git_repository_open` by relative path.

but that fix has another issue. always `guess_repository_DIRs` detects bare repository.
i called `git_open_repository` with 2nd parameter "/path/to/.git/".  git_open_repository missunderstand repository type.

https://github.com/libgit2/libgit2/blob/master/src/util.c#L187

`git__topdir` modify `/path/to/.git/` to `.git/`.

https://github.com/libgit2/libgit2/blob/master/src/repository.c#L193

then always missunderstood repository type.

i modified `GIT_DIR` to `.git/`. because that fix simple and `GIT_DIR` seems only use there.
 if you have better fix this probrem then you should use that.

I'm looking forward to using git_config :)

Cheers!
Shuhei
