### PR TITLE
Two commits to make things sane for git-fsck

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -304,7 +304,7 @@ int git_tree__writeback(git_tree *tree, git_odb_source *src)
 
 		entry = git_vector_get(&tree->entries, i);
 	
-		sprintf(filemode, "%06o ", entry->attr);
+		sprintf(filemode, "%o ", entry->attr);
 
 		git__source_write(src, filemode, strlen(filemode));
 		git__source_write(src, entry->filename, strlen(entry->filename) + 1);


### PR DESCRIPTION
A user reported to me that running git fsck on a libgit2-created repository results in hundreds of errors.  The problems turned out to be related to the way entries are written out.  I've fixed both problems by the commits in this pull request.  Thanks!
