### PR TITLE
CMake still lacks proper SQLite support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,23 @@ ELSEIF ()
     SET(SHA1_TYPE "builtin" CACHE STRING "Which SHA1 implementation to use: builtin, ppc")
 ENDIF ()
 
-# Try to find SQLite3 to compile the SQLite backend
-IF (NOT WIN32)
-	INCLUDE(FindPkgConfig)
+INCLUDE(FindPkgConfig)
+
+# Show SQLite3 settings in GUI (if they won't be found out)
+SET(SQLITE3_INCLUDE_DIRS "" CACHE PATH "SQLite include directory")
+SET(SQLITE3_LIBRARIES "" CACHE FILEPATH "SQLite library")
+
+# Are SQLite3 variables already set up? (poor Windows/no pkg-config/no sqlite3.pc)
+IF (SQLITE3_INCLUDE_DIRS AND SQLITE3_LIBRARIES)
+	SET(SQLITE3_FOUND 1)
+ENDIF ()
+
+# Try to find SQLite3 via pkg-config
+IF (PKG_CONFIG_FOUND AND NOT SQLITE3_FOUND)
 	pkg_check_modules(SQLITE3 sqlite3)
 ENDIF ()
 
+# Compile SQLite backend if SQLite3 is available
 IF (SQLITE3_FOUND)
 	ADD_DEFINITIONS(-DGIT2_SQLITE_BACKEND)
 	INCLUDE_DIRECTORIES(${SQLITE3_INCLUDE_DIRS})


### PR DESCRIPTION
But don't worry, it's easy to fix and I've already done it. Moreover, I even explained in the commit message why [part of f443a879](https://github.com/libgit2/libgit2/commit/f443a8793fc7c30916b08faad835fa04e85aa301#L0R35) (which is "answer" to my [comment](https://github.com/libgit2/libgit2/issues/closed#issue/18/comment/742207) after closing [issue 18](https://github.com/libgit2/libgit2/issues/closed#issue/18)) was not universally correct.

Sorry I've not added SQLite support in CMake myself after writing the comment (a bit tart as I see it now) back then, but I am pretty busy recently.
