### PR TITLE
Add new switch ./waf configure --without-sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The waf build system for libgit2 accepts the following flags:
 	--arch=[ia64|x64|x86|x86_amd64|x86_ia64]
 		Force a specific architecture for compilers that support it.
 
+	--without-sqlite
+		Disable sqlite support.
+
 You can run `./waf --help` to see a full list of install options and
 targets.
 

--- a/wscript
+++ b/wscript
@@ -29,6 +29,8 @@ PPC optimized version (ppc) or the SHA1 functions from OpenSSL (openssl)")
         help='Force a specific MSVC++ version (7.1, 8.0, 9.0, 10.0), if more than one is installed')
     opt.add_option('--arch', action='store', default='x86',
         help='Select target architecture (ia64, x64, x86, x86_amd64, x86_ia64)')
+    opt.add_option('--without-sqlite', action='store_false', default=True,
+        dest='use_sqlite', help='Disable sqlite support')
 
 def configure(conf):
 
@@ -67,7 +69,8 @@ def configure(conf):
     conf.check_cc(lib=zlib_name, uselib_store='z', install_path=None)
 
     # check for sqlite3
-    if conf.check_cc(lib='sqlite3', uselib_store='sqlite3', install_path=None, mandatory=False):
+    if conf.options.use_sqlite and conf.check_cc(
+        lib='sqlite3', uselib_store='sqlite3', install_path=None, mandatory=False):
         conf.env.DEFINES += ['GIT2_SQLITE_BACKEND']
 
     if conf.options.sha1 not in ['openssl', 'ppc', 'builtin']:


### PR DESCRIPTION
I don't need to use sqlite backend and libgit2 is not compiling with sqlite on one of my servers (old version of sqlite3 without sqlite3_prepare_v2 symbol) but I have currently no way to disable sqlite3 in waf configure.

 I have added a new switch --without-sqlite to do that.
