### PR TITLE
Check for filemode range

### DIFF
--- a/src/git2/tree.h
+++ b/src/git2/tree.h
@@ -215,7 +215,7 @@ GIT_EXTERN(void) git_tree_entry_set_name(git_tree_entry *entry, const char *name
  * @param entry Entry object which will be modified
  * @param oid new attributes for the entry
  */
-GIT_EXTERN(void) git_tree_entry_set_attributes(git_tree_entry *entry, int attr);
+GIT_EXTERN(int) git_tree_entry_set_attributes(git_tree_entry *entry, int attr);
 
 /** @} */
 GIT_END_DECL


### PR DESCRIPTION
Passing too big values as an attribute for an tree_entry results in stack corruption.

I came across this when I was testing my own bindings to libgit2 and thought to contribute something. The commit checks the attribute range and return GIT_ERROR if the attribute has an incorrect value. Of course asserting it could be also considered but that I think is up to personal taste. 

I would appreciate if some check  like this would be included if for no other reason than saving me time in troubleshooting when I next run into it.
