### PR TITLE
New git_time_t type specifier

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -97,7 +97,7 @@ GIT_EXTERN(const char *) git_commit_message(git_commit *commit);
  * @param commit a previously loaded commit.
  * @return the time of a commit
  */
-GIT_EXTERN(time_t) git_commit_time(git_commit *commit);
+GIT_EXTERN(git_time_t) git_commit_time(git_commit *commit);
 
 /**
  * Get the commit timezone offset (i.e. committer's preferred timezone) of a commit.

--- a/include/git2/signature.h
+++ b/include/git2/signature.h
@@ -47,7 +47,7 @@ GIT_BEGIN_DECL
  * @offset timezone offset in minutes for the time
  * @return the new sig, NULl on out of memory
  */
-GIT_EXTERN(git_signature *) git_signature_new(const char *name, const char *email, time_t time, int offset);
+GIT_EXTERN(git_signature *) git_signature_new(const char *name, const char *email, git_time_t time, int offset);
 
 /**
  * Create a copy of an existing signature.

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -52,12 +52,12 @@ GIT_BEGIN_DECL
 #if defined(_MSC_VER)
 
 typedef __int64 git_off_t;
-typedef __time64_t git_time_t;
+typedef __time64_t  git_time_t;
 
 #elif defined(__MINGW32__)
 
 typedef off64_t git_off_t;
-typedef time_t git_time_t;
+typedef time64_t git_time_t;
 
 #else  /* POSIX */
 
@@ -66,8 +66,8 @@ typedef time_t git_time_t;
  * before us (directly or indirectly), they'll get 32 bit off_t in their client
  * app, even though /we/ define _FILE_OFFSET_BITS=64.
  */
-typedef long long git_off_t;
-typedef time_t git_time_t;
+typedef int64_t git_off_t;
+typedef time64_t git_time_t;
 
 #endif
 
@@ -124,7 +124,7 @@ typedef struct git_index git_index;
 
 /** Time in a signature */
 typedef struct git_time {
-	time_t time; /** time in seconds from epoch */
+	git_time_t time; /** time in seconds from epoch */
 	int offset; /** timezone offset, in minutes */
 } git_time;
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -195,7 +195,7 @@ GIT_COMMIT_GETTER(const git_signature *, author, commit->author)
 GIT_COMMIT_GETTER(const git_signature *, committer, commit->committer)
 GIT_COMMIT_GETTER(const char *, message, commit->message)
 GIT_COMMIT_GETTER(const char *, message_short, commit->message_short)
-GIT_COMMIT_GETTER(time_t, time, commit->committer->when.time)
+GIT_COMMIT_GETTER(git_time_t, time, commit->committer->when.time)
 GIT_COMMIT_GETTER(int, time_offset, commit->committer->when.offset)
 GIT_COMMIT_GETTER(unsigned int, parentcount, commit->parent_oids.length)
 

--- a/src/index.c
+++ b/src/index.c
@@ -312,8 +312,8 @@ int git_index_add(git_index *index, const char *rel_path, int stage)
 
 	memset(&entry, 0x0, sizeof(git_index_entry));
 
-	entry.ctime.seconds = st.st_ctime;
-	entry.mtime.seconds = st.st_mtime;
+	entry.ctime.seconds = (git_time_t)st.st_ctime;
+	entry.mtime.seconds = (git_time_t)st.st_mtime;
 	/* entry.mtime.nanoseconds = st.st_mtimensec; */
 	/* entry.ctime.nanoseconds = st.st_ctimensec; */
 	entry.dev= st.st_rdev;
@@ -491,10 +491,10 @@ static size_t read_entry(git_index_entry *dest, const void *buffer, size_t buffe
 
 	source = (const struct entry_short *)(buffer);
 
-	dest->ctime.seconds = (time_t)ntohl(source->ctime.seconds);
-	dest->ctime.nanoseconds = (time_t)ntohl(source->ctime.nanoseconds);
-	dest->mtime.seconds = (time_t)ntohl(source->mtime.seconds);
-	dest->mtime.nanoseconds = (time_t)ntohl(source->mtime.nanoseconds);
+	dest->ctime.seconds = (git_time_t)ntohl(source->ctime.seconds);
+	dest->ctime.nanoseconds = ntohl(source->ctime.nanoseconds);
+	dest->mtime.seconds = (git_time_t)ntohl(source->mtime.seconds);
+	dest->mtime.nanoseconds = ntohl(source->mtime.nanoseconds);
 	dest->dev = ntohl(source->dev);
 	dest->ino = ntohl(source->ino);
 	dest->mode = ntohl(source->mode);

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -93,7 +93,7 @@ struct pack_file {
 	git_oid *bad_object_sha1; /* array of git_oid */
 
 	int index_version;
-	time_t mtime;
+	git_time_t mtime;
 	int pack_fd;
 	unsigned pack_local:1, pack_keep:1;
 	git_oid sha1;
@@ -827,7 +827,7 @@ static int packfile_check(struct pack_file **pack_out, const char *path, int loc
 	 */
 	p->pack_size = (off_t)st.st_size;
 	p->pack_local = local;
-	p->mtime = st.st_mtime;
+	p->mtime = (git_time_t)st.st_mtime;
 
 	/* see if we can parse the sha1 oid in the packfile name */
 	if (path_len < 40 ||

--- a/src/signature.c
+++ b/src/signature.c
@@ -38,7 +38,7 @@ void git_signature_free(git_signature *sig)
 	free(sig);
 }
 
-git_signature *git_signature_new(const char *name, const char *email, time_t time, int offset)
+git_signature *git_signature_new(const char *name, const char *email, git_time_t time, int offset)
 {
 	git_signature *p = NULL;
 

--- a/tests/t04-commit.c
+++ b/tests/t04-commit.c
@@ -366,7 +366,7 @@ BEGIN_TEST(details0, "query the details on a parsed commit")
 
 		const git_signature *author, *committer;
 		const char *message, *message_short;
-		time_t commit_time;
+		git_time_t commit_time;
 		unsigned int parents, p;
 		git_commit *parent;
 

--- a/tests/t06-index.c
+++ b/tests/t06-index.c
@@ -34,7 +34,7 @@ struct test_entry {
 	unsigned int index;
 	char path[128];
 	git_off_t file_size;
-	time_t mtime;
+	git_time_t mtime;
 };
 
 struct test_entry TEST_ENTRIES[] = {


### PR DESCRIPTION
time_t is defined as a <code>int64</code> on Windows.  
time_t is defined as an <code>int32</code> or a <code>int64</code> depending on the Linux distribution.

git_time_t is defined as a <code>signed int64</code>.
