### PR TITLE
Wrappers around git_object_close for each object type

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -53,6 +53,24 @@ GIT_INLINE(int) git_blob_lookup(git_blob **blob, git_repository *repo, const git
 }
 
 /**
+ * Close an open blob
+ *
+ * This is a wrapper around git_object_close()
+ *
+ * IMPORTANT:
+ * It *is* necessary to call this method when you stop
+ * using a blob. Failure to do so will cause a memory leak.
+ *
+ * @param blob the blob to close
+ */
+
+GIT_INLINE(void) git_blob_close(git_blob *blob)
+{
+	return git_object_close((git_object *) blob);
+}
+
+
+/**
  * Get a read-only buffer with the raw content of a blob.
  *
  * A pointer to the raw content of a blob is returned;

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -54,6 +54,23 @@ GIT_INLINE(int) git_commit_lookup(git_commit **commit, git_repository *repo, con
 }
 
 /**
+ * Close an open commit
+ *
+ * This is a wrapper around git_object_close()
+ *
+ * IMPORTANT:
+ * It *is* necessary to call this method when you stop
+ * using a commit. Failure to do so will cause a memory leak.
+ *
+ * @param commit the commit to close
+ */
+
+GIT_INLINE(void) git_commit_close(git_commit *commit)
+{
+	return git_object_close((git_object *) commit);
+}
+
+/**
  * Get the id of a commit.
  *
  * @param commit a previously loaded commit.

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -53,6 +53,24 @@ GIT_INLINE(int) git_tag_lookup(git_tag **tag, git_repository *repo, const git_oi
 }
 
 /**
+ * Close an open tag
+ *
+ * This is a wrapper around git_object_close()
+ *
+ * IMPORTANT:
+ * It *is* necessary to call this method when you stop
+ * using a tag. Failure to do so will cause a memory leak.
+ *
+ * @param tag the tag to close
+ */
+
+GIT_INLINE(void) git_tag_close(git_tag *tag)
+{
+	return git_object_close((git_object *) tag);
+}
+
+
+/**
  * Get the id of a tag.
  *
  * @param tag a previously loaded tag.

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -53,6 +53,24 @@ GIT_INLINE(int) git_tree_lookup(git_tree **tree, git_repository *repo, const git
 }
 
 /**
+ * Close an open tree
+ *
+ * This is a wrapper around git_object_close()
+ *
+ * IMPORTANT:
+ * It *is* necessary to call this method when you stop
+ * using a tree. Failure to do so will cause a memory leak.
+ *
+ * @param tree the tree to close
+ */
+
+GIT_INLINE(void) git_tree_close(git_tree *tree)
+{
+	return git_object_close((git_object *) tree);
+}
+
+
+/**
  * Get the id of a tree.
  *
  * @param tree a previously loaded tree.


### PR DESCRIPTION
This should cover all of them. I'm (for now) only using `git_commit_close` locally, but the others seem trivial.
