### PR TITLE
Add git_tag_create_frombuffer API

### DIFF
--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -188,6 +188,20 @@ GIT_EXTERN(int) git_tag_create_o(
 		const git_signature *tagger,
 		const char *message);
 
+/**
+ * Create a new tag in the repository from a buffer
+ *
+ * @param oid Pointer where to store the OID of the newly created tag
+ *
+ * @param repo Repository where to store the tag
+ *
+ * @param buffer Raw tag data
+ */
+GIT_EXTERN(int) git_tag_create_frombuffer(
+		git_oid *oid,
+		git_repository *repo,
+		const char *buffer);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/tag.c
+++ b/src/tag.c
@@ -241,6 +241,43 @@ int git_tag_create(
 	return error;
 }
 
+int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *buffer)
+{
+	git_tag tag;
+	int error;
+	char *buf;
+	git_object *obj;
+
+	assert(oid && buffer);
+
+	memset(&tag, 0, sizeof(tag));
+
+	buf = strdup(buffer);
+	if(buf == NULL)
+		return GIT_ENOMEM;
+
+	if((error = parse_tag_buffer(&tag, buf, buf + strlen(buf))) < 0)
+	   goto exit_freebuf;
+
+	error = git_object_lookup(&obj, repo, &tag.target, tag.type);
+	if(error < 0)
+		goto exit_freetag;
+
+	error = git_tag_create_o(oid, repo, tag.tag_name, obj,
+							 tag.tagger, tag.message);
+
+	git_object_close(obj);
+
+ exit_freetag:
+	git_signature_free(tag.tagger);
+	free(tag.tag_name);
+	free(tag.message);
+ exit_freebuf:
+	free(buf);
+
+	return error;
+}
+
 
 int git_tag__parse(git_tag *tag, git_odb_object *obj)
 {


### PR DESCRIPTION
With this, `mktag` (and presumably others) don't have to duplicate the parsing that's in the library. The first commit is a small memory leak in case the parsing fails.
