### PR TITLE
wscript: Use -O0 on debug

### DIFF
--- a/wscript
+++ b/wscript
@@ -4,7 +4,7 @@ from waflib.Build import BuildContext, CleanContext, \
 
 # Unix flags
 CFLAGS_UNIX = ["-O2", "-Wall", "-Wextra"]
-CFLAGS_UNIX_DBG = ['-g']
+CFLAGS_UNIX_DBG = ['-g', '-O0']
 
 # Windows MSVC flags
 CFLAGS_WIN32_COMMON = ['/TC', '/W4', '/WX', '/nologo', '/Zi']


### PR DESCRIPTION
If we want debugging symbols, we most likely want them to point to the
right place. With -O2, gdb or valgrind may give wrong information.

Signed-off-by: Carlos Martín Nieto cmn@elego.de
