### PR TITLE
Reinitializing a repository now returns GIT_ENOTIMPLEMENTED

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -346,7 +346,7 @@ static int repo_init_reinit(repo_init *results)
 {
 	/* TODO: reinit the repository */
 	results->has_been_reinit = 1;
-	return GIT_SUCCESS;
+	return GIT_ENOTIMPLEMENTED;
 }
 
 static int repo_init_createhead(git_repository *repo)


### PR DESCRIPTION
This should fix [issue#106](https://github.com/libgit2/libgit2/issues/#issue/106)
