### PR TITLE
fix git_treebuilder_insert probrem.

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -364,7 +364,7 @@ int git_treebuilder_insert(git_tree_entry **entry_out, git_treebuilder *bld, con
 	git_oid_cpy(&entry->oid, id);
 	entry->attr = attributes;
 
-	if (pos != GIT_ENOTFOUND) {
+	if (pos == GIT_ENOTFOUND) {
 		if (git_vector_insert(&bld->entries, entry) < 0)
 			return GIT_ENOMEM;
 	}

--- a/tests/t09-tree.c
+++ b/tests/t09-tree.c
@@ -29,6 +29,10 @@
 
 static const char *tree_oid = "1810dff58d8a660512d4832e740f692884338ccd";
 
+static const char *blob_oid = "fa49b077972391ad58037050f2a75f74e3671e92";
+static const char *first_tree  = "181037049a54a1eb5fab404658a3a250b44335d7";
+static const char *second_tree = "f60079018b664e4e79329a7ef9559c8d9e0378d1";
+
 #if 0
 static int print_tree(git_repository *repo, const git_oid *tree_oid, int depth)
 {
@@ -126,11 +130,36 @@ BEGIN_TEST(write0, "write a tree from an index")
 END_TEST
 #endif
 
+BEGIN_TEST(write2, "write a tree from a memory")
+	git_repository *repo;
+	git_index *index;
+	git_treebuilder *builder;
+	git_tree *tree;
+	git_oid id;
+	git_oid bid;
+	git_oid rid;
+
+	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
+	git_oid_mkstr(&id, first_tree);
+	git_oid_mkstr(&bid, blob_oid);
+
+	//create a second tree from first tree using `git_treebuilder_insert` on REPOSITORY_FOLDER.
+	must_pass(git_tree_lookup(&tree, repo, &id));
+	must_pass(git_treebuilder_create(&builder, tree));
+	must_pass(git_treebuilder_insert(NULL,builder,"new.txt",&bid,0100644));
+	must_pass(git_treebuilder_write(&rid,repo,builder));
+
+	char out[41];
+	git_oid_to_string(out,41,&rid);
+	must_pass(strcmp(out,second_tree));
+END_TEST
+
 BEGIN_SUITE(tree)
 	//ADD_TEST(print0);
 	ADD_TEST(read0);
 	ADD_TEST(read1);
 	//ADD_TEST(write0);
 	//ADD_TEST(write1);
+	ADD_TEST(write2);
 END_SUITE
 


### PR DESCRIPTION
couldn't add new entry when inserting new one with `git_treebuilder_insert`.

by the way, does zlib settings something diffrence?
original tree object started 0x0178,  but `git_treebuilder_write` started 0x9c78..

```
[original]
0000000 0178 292b ....

[git_treebuilder_write]
0000000 9c78 292b ....
```

these files can read correctry so its not a proprem. just share this info :D

Cheers,
Shuhei
