### PR TITLE
Added git_commit_tree_oid and git_commit_parent_oid.

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -136,6 +136,16 @@ GIT_EXTERN(const git_signature *) git_commit_author(git_commit *commit);
 GIT_EXTERN(int) git_commit_tree(git_tree **tree_out, git_commit *commit);
 
 /**
+ * Get the id of the tree pointed to by a commit. This differs from
+ * `git_commit_tree` in that no attempts are made to fetch an object
+ * from the ODB.
+ *
+ * @param commit a previously loaded commit.
+ * @return the id of tree pointed to by commit.
+ */
+GIT_EXTERN(const git_oid *) git_commit_tree_oid(git_commit *commit);
+
+/**
  * Get the number of parents of this commit
  *
  * @param commit a previously loaded commit.
@@ -153,6 +163,16 @@ GIT_EXTERN(unsigned int) git_commit_parentcount(git_commit *commit);
  */
 GIT_EXTERN(int) git_commit_parent(git_commit **parent, git_commit *commit, unsigned int n);
 
+/**
+ * Get the oid of a specified parent for a commit. This is different from
+ * `git_commit_parent`, which will attempt to load the parent commit from
+ * the ODB.
+ *
+ * @param commit a previously loaded commit.
+ * @param n the position of the parent (from 0 to `parentcount`)
+ * @return the id of the parent, NULL on error.
+ */
+GIT_EXTERN(const git_oid *) git_commit_parent_oid(git_commit *commit, unsigned int n);
 
 /**
  * Create a new commit in the repository

--- a/src/commit.c
+++ b/src/commit.c
@@ -318,6 +318,7 @@ GIT_COMMIT_GETTER(const char *, message_short, commit->message_short)
 GIT_COMMIT_GETTER(git_time_t, time, commit->committer->when.time)
 GIT_COMMIT_GETTER(int, time_offset, commit->committer->when.offset)
 GIT_COMMIT_GETTER(unsigned int, parentcount, commit->parent_oids.length)
+GIT_COMMIT_GETTER(const git_oid *, tree_oid, &commit->tree_oid);
 
 
 int git_commit_tree(git_tree **tree_out, git_commit *commit)
@@ -338,4 +339,9 @@ int git_commit_parent(git_commit **parent, git_commit *commit, unsigned int n)
 	return git_commit_lookup(parent, commit->object.repo, parent_oid);
 }
 
+const git_oid *git_commit_parent_oid(git_commit *commit, unsigned int n)
+{
+	assert(commit);
 
+	return git_vector_get(&commit->parent_oids, n);
+}


### PR DESCRIPTION
Hey there,

Very minor patch - I added two functions to commit.c/commit.h - `git_commit_tree_oid` and `git_commit_parent_oid`. These will return the `git_oid` in question instead of retrieving the relevant object with that oid from the ODB.

I used this when I wrote a proof of concept git clone using my Node.js library - I had the problem that while I was retrieving loose objects over HTTP I couldn't use libgit2 to ascertain the commit tree/parents. I was getting invalid oids because the objects didn't exist in the ODB yet.

I made sure the naming of these functions was similar to what's already being done with tags (`git_tag_target_oid`) so I hope that's ok.

-Sam
