### PR TITLE
Add a function to create a signature with a current timestamp

### DIFF
--- a/include/git2/signature.h
+++ b/include/git2/signature.h
@@ -50,6 +50,17 @@ GIT_BEGIN_DECL
 GIT_EXTERN(git_signature *) git_signature_new(const char *name, const char *email, git_time_t time, int offset);
 
 /**
+ * Create a new action signature with a timestamp of 'now'. The
+ * signature must be freed manually or using git_signature_free
+ *
+ * @param name name of the person
+ * @param email email of the person
+ * @return the new sig, NULL on out of memory
+ */
+GIT_EXTERN(git_signature *) git_signature_new_now(const char *name, const char *email);
+
+
+/**
  * Create a copy of an existing signature.
  *
  * All internal strings are also duplicated.

--- a/src/signature.c
+++ b/src/signature.c
@@ -65,6 +65,25 @@ git_signature *git_signature_dup(const git_signature *sig)
 	return git_signature_new(sig->name, sig->email, sig->when.time, sig->when.offset);
 }
 
+git_signature *git_signature_new_now(const char *name, const char *email)
+{
+	time_t now;
+	struct tm utc_tm, local_tm;
+	int offset;
+
+	time(&now);
+
+	gmtime_r(&now, &utc_tm);
+	localtime_r(&now, &local_tm);
+
+	offset = mktime(&local_tm) - mktime(&utc_tm);
+	offset /= 60;
+	/* mktime takes care of setting tm_isdst correctly */
+	if (local_tm.tm_isdst)
+		offset += 60;
+
+	return git_signature_new(name, email, now, offset);
+}
 
 static int parse_timezone_offset(const char *buffer, int *offset_out)
 {


### PR DESCRIPTION
Dealing with time is a horrible affair (this simple patch took me most of the morning) and most tags will want to be current. Add a function for this case.

As a bonus, the first commit in this branch fixes the documentation.
