### PR TITLE
Add two new accessors to the repository

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -194,6 +194,24 @@ GIT_EXTERN(int) git_repository_init(git_repository **repo_out, const char *path,
  */
 GIT_EXTERN(int) git_repository_is_empty(git_repository *repo);
 
+/**
+ * Get the normalized path to the git repository.
+ *
+ * @param repo a repository object
+ * @return absolute path to the git directory
+ */
+GIT_EXTERN(const char *) git_repository_path(git_repository *repo);
+
+/**
+ * Get the normalized path to the working directory of the repository.
+ *
+ * If the repository is bare, there is no working directory and NULL we be returned.
+ *
+ * @param repo a repository object
+ * @return NULL if the repository is bare; absolute path to the working directory otherwise.
+ */
+GIT_EXTERN(const char *) git_repository_workdir(git_repository *repo);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -488,3 +488,15 @@ int git_repository_is_empty(git_repository *repo)
 	return git_reference_resolve(&branch, head) == GIT_SUCCESS ? 0 : 1;
 }
 
+const char *git_repository_path(git_repository *repo)
+{
+	assert(repo);
+	return repo->path_repository;
+}
+
+const char *git_repository_workdir(git_repository *repo)
+{
+	assert(repo);
+	return repo->path_workdir;
+}
+

--- a/tests/t12-repo.c
+++ b/tests/t12-repo.c
@@ -194,6 +194,8 @@ BEGIN_TEST(open0, "Open a bare repository that has just been initialized by git"
 	must_pass(remove_placeholders(TEMP_REPO_FOLDER, "dummy-marker.txt"));
 
 	must_pass(git_repository_open(&repo, TEMP_REPO_FOLDER));
+	must_be_true(git_repository_path(repo) != NULL);
+	must_be_true(git_repository_workdir(repo) == NULL);
 
 	git_repository_free(repo);
 	must_pass(rmdir_recurs(TEMP_REPO_FOLDER));
@@ -211,6 +213,8 @@ BEGIN_TEST(open1, "Open a standard repository that has just been initialized by 
 	must_pass(remove_placeholders(DEST_REPOSITORY_FOLDER, "dummy-marker.txt"));
 
 	must_pass(git_repository_open(&repo, DEST_REPOSITORY_FOLDER));
+	must_be_true(git_repository_path(repo) != NULL);
+	must_be_true(git_repository_workdir(repo) != NULL);
 
 	git_repository_free(repo);
 	must_pass(rmdir_recurs(TEMP_REPO_FOLDER));


### PR DESCRIPTION
git_repository_path() and git_repository_workdir() respectively return the path to the git repository and the working directory. Those paths are absolute and normalized.

 The paths that libgit2 internaly deals with may be different from the ones that have been passed to the init or open methods. Providing access to those normalized paths would be quite interesting from a binding consumer  perpective.
