### PR TITLE
fix solaris build

### DIFF
--- a/wscript
+++ b/wscript
@@ -65,6 +65,9 @@ def configure(conf):
     else:
         conf.env.PLATFORM = 'unix'
 
+    if conf.env.DEST_OS == 'sunos':
+        conf.env.DEFINES += ['NO_VIZ']
+
     if conf.options.threadsafe:
         if conf.env.PLATFORM == 'unix':
             conf.check_cc(lib='pthread', uselib_store='pthread')


### PR DESCRIPTION
Before this patch the build failure looked like:

```
...
../../deps/zlib/inffast.c: In function `inflate_fast':
../../deps/zlib/inffast.c:324: warning: visibility attribute not supported in this configuration; ignored
[34/38] c: src/revwalk.c -> build/shared/src/revwalk.c.0.o
../../deps/zlib/inftrees.c: In function `inflate_table':
../../deps/zlib/inftrees.c:330: warning: visibility attribute not supported in this configuration; ignored
[35/38] c: deps/zlib/zutil.c -> build/shared/deps/zlib/zutil.c.0.o
[36/38] c: deps/zlib/trees.c -> build/shared/deps/zlib/trees.c.0.o
../../deps/zlib/zutil.c: In function `zcalloc':
../../deps/zlib/zutil.c:308: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/zutil.c: In function `zcfree':
../../deps/zlib/zutil.c:316: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/trees.c:1244: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/trees.c:1244: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/trees.c: In function `_tr_init':
../../deps/zlib/trees.c:410: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/trees.c: In function `_tr_align':
../../deps/zlib/trees.c:919: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/trees.c: In function `_tr_stored_block':
../../deps/zlib/trees.c:883: warning: visibility attribute not supported in this configuration; ignored

../../deps/zlib/trees.c: In function `_tr_flush_block':
../../deps/zlib/trees.c:1020: warning: visibility attribute not supported in this configuration; ignored
../../deps/zlib/trees.c: In function `_tr_tally':
../../deps/zlib/trees.c:1071: warning: visibility attribute not supported in this configuration; ignored
[37/38] cshlib: build/shared/src/blob.c.0.o build/shared/src/cache.c.0.o build/shared/src/commit.c.0.o build/shared/src/delta-apply.c.0.o build/shared/src/errors.c.0.o build/shared/src/filebuf.c.0.o build/shared/src/fileops.c.0.o build/shared/src/hash.c.0.o build/shared/src/hashtable.c.0.o build/shared/src/index.c.0.o build/shared/src/object.c.0.o build/shared/src/odb.c.0.o build/shared/src/odb_loose.c.0.o build/shared/src/odb_pack.c.0.o build/shared/src/oid.c.0.o build/shared/src/pqueue.c.0.o build/shared/src/refs.c.0.o build/shared/src/repository.c.0.o build/shared/src/revwalk.c.0.o build/shared/src/signature.c.0.o build/shared/src/tag.c.0.o build/shared/src/thread-utils.c.0.o build/shared/src/tree.c.0.o build/shared/src/util.c.0.o build/shared/src/vector.c.0.o build/shared/src/unix/map.c.0.o build/shared/src/backends/hiredis.c.0.o build/shared/src/backends/sqlite.c.0.o build/shared/deps/zlib/adler32.c.0.o build/shared/deps/zlib/deflate.c.0.o build/shared/deps/zlib/inffast.c.0.o build/shared/deps/zlib/inflate.c.0.o build/shared/deps/zlib/inftrees.c.0.o build/shared/deps/zlib/trees.c.0.o build/shared/deps/zlib/zutil.c.0.o build/shared/src/block-sha1/sha1.c.0.o -> build/shared/libgit2.so
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol zcfree: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol zcalloc: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _length_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _dist_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _length_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _dist_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _dist_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _length_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _dist_code: a GOT relative relocation must reference a local symbol
ld: fatal: relocation error: R_386_GOTOFF: file deps/zlib/deflate.c.0.o: symbol _dist_code: a GOT relative relocation must reference a local symbol
collect2: ld returned 1 exit status
Waf: Leaving directory `/home/node/src/libgit2/build/shared'
Build failed
 -> task failed (exit status 1): 
        {task 138650764: cshlib blob.c.0.o,cache.c.0.o,commit.c.0.o,delta-apply.c.0.o,errors.c.0.o,filebuf.c.0.o,fileops.c.0.o,hash.c.0.o,hashtable.c.0.o,index.c.0.o,object.c.0.o,odb.c.0.o,odb_loose.c.0.o,odb_pack.c.0.o,oid.c.0.o,pqueue.c.0.o,refs.c.0.o,repository.c.0.o,revwalk.c.0.o,signature.c.0.o,tag.c.0.o,thread-utils.c.0.o,tree.c.0.o,util.c.0.o,vector.c.0.o,map.c.0.o,hiredis.c.0.o,sqlite.c.0.o,adler32.c.0.o,deflate.c.0.o,inffast.c.0.o,inflate.c.0.o,inftrees.c.0.o,trees.c.0.o,zutil.c.0.o,sha1.c.0.o -> libgit2.so}
['/home/node/local/bin/gcc', '', 'src/blob.c.0.o', 'src/cache.c.0.o', 'src/commit.c.0.o', 'src/delta-apply.c.0.o', 'src/errors.c.0.o', 'src/filebuf.c.0.o', 'src/fileops.c.0.o', 'src/hash.c.0.o', 'src/hashtable.c.0.o', 'src/index.c.0.o', 'src/object.c.0.o', 'src/odb.c.0.o', 'src/odb_loose.c.0.o', 'src/odb_pack.c.0.o', 'src/oid.c.0.o', 'src/pqueue.c.0.o', 'src/refs.c.0.o', 'src/repository.c.0.o', 'src/revwalk.c.0.o', 'src/signature.c.0.o', 'src/tag.c.0.o', 'src/thread-utils.c.0.o', 'src/tree.c.0.o', 'src/util.c.0.o', 'src/vector.c.0.o', 'src/unix/map.c.0.o', 'src/backends/hiredis.c.0.o', 'src/backends/sqlite.c.0.o', 'deps/zlib/adler32.c.0.o', 'deps/zlib/deflate.c.0.o', 'deps/zlib/inffast.c.0.o', 'deps/zlib/inflate.c.0.o', 'deps/zlib/inftrees.c.0.o', 'deps/zlib/trees.c.0.o', 'deps/zlib/zutil.c.0.o', 'src/block-sha1/sha1.c.0.o', '-o', '', '/home/node/src/libgit2/build/shared/libgit2.so', '-Wl,-Bstatic', '-Wl,-Bdynamic', '-shared', '-Wl,-h,libgit2.so.0']
...
```

If helpful, here is the equivalent error with varnish: http://www.varnish-cache.org/trac/ticket/852
and the autoconf/configure handling for the equivalent in python: http://hg.python.org/cpython/file/96e0e79d33de/Modules/zlib/configure#l513

So a _better_ fix would probably be to reproduce that configure logic (see similar in the Varnish patch) ... but I'm not sure if shelling out to the C compiler (however waf spells that) is wanted in wscript here.

It would be great to have a libgit2 release with the quicker fix for Solaris. My actual issue is with building node-gitteh.

Thanks,
Trent
