### PR TITLE
LIBGIT2_VER_MINOR now matches LIBGIT2_VERSION (0.11.0)

### DIFF
--- a/include/git2.h
+++ b/include/git2.h
@@ -28,7 +28,7 @@
 
 #define LIBGIT2_VERSION "0.11.0"
 #define LIBGIT2_VER_MAJOR 0
-#define LIBGIT2_VER_MINOR 10
+#define LIBGIT2_VER_MINOR 11
 #define LIBGIT2_VER_REVISION 0
 
 #include "git2/common.h"


### PR DESCRIPTION
LIBGIT2_VER_MINOR was left at 10 instead of 11.
