### PR TITLE
Fix going into infinite loop in read_header_loose()

### DIFF
--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -434,6 +434,9 @@ static int read_header_loose(git_rawobj *out, const char *loc)
 		if ((read_bytes = read(fd, raw_buffer, sizeof(raw_buffer))) > 0) {
 			set_stream_input(&zs, raw_buffer, read_bytes);
 			z_return = inflate(&zs, 0);
+		} else {
+			z_return = Z_STREAM_END;
+			break;
 		}
 	} while (z_return == Z_OK);
 


### PR DESCRIPTION
read_header_loose causes infinite loop on this file:
$ cat ../libcppgit/bin/sample-repo/test_mailbox/.git/objects/8f/e274605cbc740a2a957f44b2722a8a73915a09 | base64
eAErKUpNVTAzYzA0MDAzMVHISUxKzSlmWLgkuyN5+rxr6juMPR2EmN8s7Vl9D6oiN7UkkcHJdLbl
7Z3N/oxfE0W8wrSbuFRkAwDFfBn1
