### PR TITLE
Fix -Wunused-but-set-variable warnings

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -684,7 +684,7 @@ static int packed_loadloose(git_repository *repository)
 
 	/* Remove any loose references from the cache */
 	{
-		const void *_unused;
+		const void *GIT_UNUSED(_unused);
 		git_reference *reference;
 
 		GIT_HASHTABLE_FOREACH(repository->references.loose_cache, _unused, reference,
@@ -868,7 +868,7 @@ static int packed_write(git_repository *repo)
 	/* Load all the packfile into a vector */
 	{
 		git_reference *reference;
-		const void *_unused;
+		const void *GIT_UNUSED(_unused);
 
 		GIT_HASHTABLE_FOREACH(repo->references.packfile, _unused, reference,
 			git_vector_insert(&packing_list, reference);  /* cannot fail: vector already has the right size */
@@ -1518,7 +1518,7 @@ int git_reference_listcb(git_repository *repo, unsigned int list_flags, int (*ca
 	/* list all the packed references first */
 	if (list_flags & GIT_REF_PACKED) {
 		const char *ref_name;
-		void *_unused;
+		void *GIT_UNUSED(_unused);
 
 		if ((error = packed_load(repo)) < GIT_SUCCESS)
 			return error;
@@ -1597,7 +1597,7 @@ int git_repository__refcache_init(git_refcache *refs)
 void git_repository__refcache_free(git_refcache *refs)
 {
 	git_reference *reference;
-	const void *_unused;
+	const void *GIT_UNUSED(_unused);
 
 	assert(refs);
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -58,7 +58,6 @@ static int assign_repository_dirs(
 		const char *git_work_tree)
 {
 	char path_aux[GIT_PATH_MAX];
-	size_t git_dir_path_len;
 	int error = GIT_SUCCESS;
 
 	assert(repo);
@@ -69,8 +68,6 @@ static int assign_repository_dirs(
 	error = gitfo_prettify_dir_path(path_aux, sizeof(path_aux), git_dir);
 	if (error < GIT_SUCCESS)
 		return error;
-
-	git_dir_path_len = strlen(path_aux);
 
 	/* store GIT_DIR */
 	repo->path_repository = git__strdup(path_aux);

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -483,7 +483,7 @@ int git_revwalk_new(git_revwalk **revwalk_out, git_repository *repo)
 void git_revwalk_free(git_revwalk *walk)
 {
 	unsigned int i;
-	const void *_unused;
+	const void *GIT_UNUSED(_unused);
 	commit_object *commit;
 
 	if (walk == NULL)
@@ -558,7 +558,7 @@ int git_revwalk_next(git_oid *oid, git_revwalk *walk)
 
 void git_revwalk_reset(git_revwalk *walk)
 {
-	const void *_unused;
+	const void *GIT_UNUSED(_unused);
 	commit_object *commit;
 
 	assert(walk);

--- a/tests/t07-hashtable.c
+++ b/tests/t07-hashtable.c
@@ -155,7 +155,7 @@ BEGIN_TEST(tableit0, "iterate through all the contents of the table")
 	const int objects_n = 32;
 	int i;
 	table_item *objects, *ob;
-	const void *_unused;
+	const void *GIT_UNUSED(_unused);
 
 	git_hashtable *table = NULL;
 


### PR DESCRIPTION
As of gcc 4.6 -Wall includes -Wunused-but-set-variable. Use GIT_UNUSED
or remove actually unused variables to prevent those warnings.
