### PR TITLE
Fix tree-entry attribute convertion (fix corrupted trees)

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -424,7 +424,8 @@ int git_treebuilder_write(git_oid *oid, git_repository *repo, git_treebuilder *b
 		if (entry->removed)
 			continue;
 
-		size += (entry->attr > 0x7FF) ? 7 : 6;
+		snprintf(filemode, sizeof(filemode), "%o ", entry->attr);
+		size += strlen(filemode);
 		size += entry->filename_len + 1;
 		size += GIT_OID_RAWSZ;
 	}


### PR DESCRIPTION
Magic constant replaced by direct to-string covertion because of:
1) with value length = 6 (040000 - subtree) final tree will be corrupted;
2) for wrong values length < 6 final tree will be corrupted too.
