### PR TITLE
Fix failing tests on Win32 platform

### DIFF
--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -1408,7 +1408,7 @@ int git_odb_backend_pack(git_odb_backend **backend_out, const char *objects_dir)
 	git__joinpath(path, objects_dir, "pack");
 	if (gitfo_isdir(path) == GIT_SUCCESS) {
 		backend->pack_folder = git__strdup(path);
-		backend->pack_folder_size = 0;
+		backend->pack_folder_size = -1;
 
 		if (backend->pack_folder == NULL) {
 			free(backend);


### PR DESCRIPTION
Since [Commit 1d00878](https://github.com/libgit2/libgit2/commit/1d0087816e0b6e22cb08a734e440b718e59ffdc0) some tests no longer pass on Win32.

However, even if this allows all the test to pass, as I'm not sure of what led @tanoku to commit the initial change , maybe this fix (which reverts <code>backend->pack_folder_size</code> to its previous value) is not the proper one to apply.
