### PR TITLE
Fix misspelling of git_index_append2 (was git_index_apppend2).

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -232,10 +232,10 @@ GIT_EXTERN(int) git_index_append(git_index *index, const char *path, int stage);
  * @param source_entry new entry object
  * @return 0 on success, otherwise an error code
  */
-GIT_EXTERN(int) git_index_apppend2(git_index *index, const git_index_entry *source_entry);
+GIT_EXTERN(int) git_index_append2(git_index *index, const git_index_entry *source_entry);
 
 /**
- * Remove an entry from the index 
+ * Remove an entry from the index
  *
  * @param index an existing index object
  * @param position position of the entry to remove

--- a/src/index.c
+++ b/src/index.c
@@ -421,7 +421,7 @@ int git_index_add2(git_index *index, const git_index_entry *source_entry)
 	return index_insert(index, source_entry, 1);
 }
 
-int git_index_apppend2(git_index *index, const git_index_entry *source_entry)
+int git_index_append2(git_index *index, const git_index_entry *source_entry)
 {
 	return index_insert(index, source_entry, 0);
 }


### PR DESCRIPTION
Just a spelling fix. (And an accidental commit of removing a trailing space from a comment line.)
