### PR TITLE
Fix two warnings from Clang

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -286,7 +286,7 @@ int commit_parse_buffer(git_commit *commit, const void *data, size_t len)
 
 	if (buffer < buffer_end) {
 		const char *line_end;
-		size_t message_len = buffer_end - buffer;
+		size_t message_len;
 
 		/* Long message */
 		message_len = buffer_end - buffer;

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -336,7 +336,6 @@ static int inflate_disk_obj(git_rawobj *out, gitfo_buf *obj)
 {
 	unsigned char head[64], *buf;
 	z_stream zs;
-	int z_status;
 	obj_hdr hdr;
 	size_t used;
 
@@ -350,7 +349,7 @@ static int inflate_disk_obj(git_rawobj *out, gitfo_buf *obj)
 	 * inflate the initial part of the io buffer in order
 	 * to parse the object header (type and size).
 	 */
-	if ((z_status = start_inflate(&zs, obj, head, sizeof(head))) < Z_OK)
+	if (start_inflate(&zs, obj, head, sizeof(head)) < Z_OK)
 		return GIT_ERROR;
 
 	if ((used = get_object_header(&hdr, head)) == 0)


### PR DESCRIPTION
Both are about not reading the value stored in a variable.

Signed-off-by: Carlos Martín Nieto cmn@elego.de
