### PR TITLE
Fix bug in the way pthead_mutex_t was being destroyed in win32.

### DIFF
--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -48,16 +48,15 @@ int pthread_join(pthread_t thread, void **value_ptr)
 int pthread_mutex_init(pthread_mutex_t *GIT_RESTRICT mutex,
                        const pthread_mutexattr_t *GIT_RESTRICT GIT_UNUSED(mutexattr))
 {
-	GIT_UNUSED_ARG(mutexattr);
+    GIT_UNUSED_ARG(mutexattr);
     InitializeCriticalSection(mutex);
     return 0;
 }
 
 int pthread_mutex_destroy(pthread_mutex_t *mutex)
 {
-    int ret;
-    ret = CloseHandle(mutex);
-    return -(!ret);
+    DeleteCriticalSection(mutex);
+    return 0;
 }
 
 int pthread_mutex_lock(pthread_mutex_t *mutex)


### PR DESCRIPTION
Win32 critical section objects (CRITICAL_SECTION) are not kernel objects.
Only kernel objects are destroyed by using CloseHandle.  Critical sections
are supposed to be deleted with the DeleteCriticalSection API
(http://msdn.microsoft.com/en-us/library/ms682552(VS.85).aspx).
