### PR TITLE
Fix issue #79 - git_lasterror() isn't appearing in git2.dll in windows.

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -185,6 +185,8 @@ typedef struct {
 
 GIT_EXTERN(void) git_strarray_free(git_strarray *array);
 
+GIT_EXTERN(const char*) git_lasterror(void);
+
 /** @} */
 GIT_END_DECL
 #endif


### PR DESCRIPTION
The GIT_EXPORT macro is used to declare a function to be externally
accessible to other libraries.  This commit uses GIT_EXPORT to declare
the git_lasterror() function as externally exported.  I verified with
depends.exe that the function is available to external callers (i.e.
in the exports table of the PE file).
