### PR TITLE
Add --with-redis flag to list of available build flags in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ The waf build system for libgit2 accepts the following flags:
 	--with-sqlite
 		Enable sqlite support.
 
+	--with-redis
+		Enable redis support.
+
 You can run `./waf --help` to see a full list of install options and
 targets.
 


### PR DESCRIPTION
Saw the new release announcement, but didn't see anything in the README.
