### PR TITLE
Consider environment-specified CFLAGS

### DIFF
--- a/wscript
+++ b/wscript
@@ -50,7 +50,7 @@ def configure(conf):
 
     dbg = conf.options.debug
 
-    conf.env.CFLAGS = CFLAGS_UNIX + (CFLAGS_UNIX_DBG if dbg else [])
+    conf.env.CFLAGS += CFLAGS_UNIX + (CFLAGS_UNIX_DBG if dbg else [])
 
     if conf.env.DEST_OS == 'win32':
         conf.env.PLATFORM = 'win32'


### PR DESCRIPTION
Have wscript use the environment-provided CFLAGS as per WAF's documented behavior.

My use-case for this is that I need to build a fat binary for my Mac OS application, and using <tt>--arch</tt> is not doing anything (it still builds for x86_64 no matter what). I would like something more graceful, but since the Waf documentation states CFLAGS is taken into account when running <tt>waf configure</tt>, it seemed like a pretty fast way to get my issue addressed.
