### PR TITLE
Fix a few minor typos in comments and error messages

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -641,7 +641,7 @@ static int parse_section_header_ext(const char *line, const char *base_name, cha
 	ret = snprintf(*section_name, total_len, "%s %s", base_name, subsection);
 	if (ret >= total_len) {
 		/* If this fails, we've checked the length wrong */
-		error = git__throw(GIT_ERROR, "Failed to parse ext header. Wrong total lenght calculation");
+		error = git__throw(GIT_ERROR, "Failed to parse ext header. Wrong total length calculation");
 		goto out;
 	} else if (ret < 0) {
 		error = git__throw(GIT_EOSERR, "Failed to parse ext header. OS error: %s", strerror(errno));
@@ -804,7 +804,7 @@ static int config_parse(file_backend *cfg_file)
 	char *var_value;
 	cvar_t *var;
 
-	/* Initialise the reading position */
+	/* Initialize the reading position */
 	cfg_file->reader.read_ptr = cfg_file->reader.buffer.data;
 	cfg_file->reader.eof = 0;
 
@@ -1001,7 +1001,7 @@ static int parse_variable(file_backend *cfg, char **var_name, char **var_value)
 
 		*var_value = tmp;
 	} else {
-		/* If thre is no value, boolean true is assumed */
+		/* If there is no value, boolean true is assumed */
 		*var_value = NULL;
 	}
 

--- a/src/msvc-compat.h
+++ b/src/msvc-compat.h
@@ -17,7 +17,7 @@
 # define S_ISREG(m)   (((m) & _S_IFMT) == _S_IFREG)
 # define S_ISFIFO(m)  (((m) & _S_IFMT) == _S_IFIFO)
 
-/* case-insensitive string comparision */
+/* case-insensitive string comparison */
 # define strcasecmp   _stricmp
 # define strncasecmp  _strnicmp
 


### PR DESCRIPTION
Hi,

I just realized I introduced a typo in a comment in one of my last commits, so I fix it here along with some other minor typos I happened to come across.

Regarding "initialize" vs. "initialise", www.dict.cc says the first is American
English whereas the latter in British English. For consistency, we should
stick to American English.
