### PR TITLE
git_object_owner() return type is now const

### DIFF
--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -80,7 +80,7 @@ GIT_EXTERN(git_otype) git_object_type(const git_object *obj);
  * @param obj the object
  * @return the repository who owns this object
  */
-GIT_EXTERN(git_repository *) git_object_owner(const git_object *obj);
+GIT_EXTERN(const git_repository *) git_object_owner(const git_object *obj);
 
 /**
  * Close an open object

--- a/src/object.c
+++ b/src/object.c
@@ -211,7 +211,7 @@ git_otype git_object_type(const git_object *obj)
 	return obj->type;
 }
 
-git_repository *git_object_owner(const git_object *obj)
+const git_repository *git_object_owner(const git_object *obj)
 {
 	assert(obj);
 	return obj->repo;


### PR DESCRIPTION
The git_repository\* returned by git_object_owner() can't be freed otherwise
bad things will happen.
