### PR TITLE
Fixed a memoryh leak in index.c (repo->index not defined)

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -157,6 +157,7 @@ static int index_initialize(git_index **index_out, git_repository *owner, const 
 	}
 
 	index->repository = owner;
+	owner->index = index;
 
 	git_vector_init(&index->entries, 32, index_cmp);
 


### PR DESCRIPTION
While writing a little git client based on libgit2, i noticed a memory leak while using the index : the index object is not freed through a call to git_repository_free.
