### PR TITLE
Deal with invalidated TREE extensions

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -514,8 +514,17 @@ static int read_tree_internal(git_index_tree **out,
 
 	/* Blank-terminated ASCII decimal number of entries in this tree */
 	if (git__strtol32(&count, buffer, &buffer, 10) < GIT_SUCCESS ||
-		count < 0) {
+		count < -1) {
 		error = GIT_EOBJCORRUPTED;
+		goto exit;
+	}
+
+	/* Invalidated TREE. Free the tree but report success */
+	if (count == -1) {
+		buffer = buffer_end;
+		free_tree(tree); /* Needs to be done manually */
+		tree = NULL;
+		error = GIT_SUCCESS;
 		goto exit;
 	}
 


### PR DESCRIPTION
Don't treat an invalidated TREE as an error, but ignore it.

Fixes Issue #202
