### PR TITLE
Fix compilation warnings in MSVC

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -638,7 +638,7 @@ static int parse_section_header_ext(const char *line, const char *base_name, cha
 			break;
 		}
 
-		subsection[pos++] = c;
+		subsection[pos++] = (char) c;
 	} while ((c = line[rpos++]) != ']');
 
 	subsection[pos] = '\0';
@@ -719,7 +719,7 @@ static int parse_section_header(diskfile_backend *cfg, char **section_out)
 			goto error;
 		}
 
-		name[name_length++] = tolower(c);
+		name[name_length++] = (char) tolower(c);
 
 	} while ((c = line[pos++]) != ']');
 

--- a/src/util.c
+++ b/src/util.c
@@ -109,7 +109,7 @@ void git__strntolower(char *str, int len)
 	int i;
 
 	for (i = 0; i < len; ++i) {
-		str[i] = tolower(str[i]);
+		str[i] = (char) tolower(str[i]);
 	}
 }
 


### PR DESCRIPTION
> Could you add a cast on lines 641 and 722, So that they read:
> 
> ```
>  subsection[pos++] = (char) c;
> ```
> 
> and
> 
> ```
>   name[name_length++] = (char) tolower(c);
> ```
> 
> respectively?

@carlosmn: done. I also fixed <code>util.c</code>

Waf is now happy again on Windows :-)
