### PR TITLE
Add git_repository_is_bare() accessor

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -212,6 +212,14 @@ GIT_EXTERN(const char *) git_repository_path(git_repository *repo);
  */
 GIT_EXTERN(const char *) git_repository_workdir(git_repository *repo);
 
+/**
+ * Check if a repository is bare
+ *
+ * @param repo Repo to test
+ * @return 1 if the repository is empty, 0 otherwise.
+ */
+GIT_EXTERN(int) git_repository_is_bare(git_repository *repo);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -509,3 +509,9 @@ const char *git_repository_workdir(git_repository *repo)
 	assert(repo);
 	return repo->path_workdir;
 }
+
+int git_repository_is_bare(git_repository *repo)
+{
+	assert(repo);
+	return repo->is_bare;
+}

--- a/tests/t12-repo.c
+++ b/tests/t12-repo.c
@@ -126,7 +126,14 @@ static int ensure_repository_init(
 	if (repo->path_index != NULL || expected_path_index != NULL) {
 		if (git__suffixcmp(repo->path_index, expected_path_index) != 0)
 			goto cleanup;
-	}
+
+		if (git_repository_is_bare(repo) == 1)
+			goto cleanup;
+	} else if (git_repository_is_bare(repo) == 0)
+			goto cleanup;
+
+	if (git_repository_is_empty(repo) == 0)
+		goto cleanup;
 
 	git_repository_free(repo);
 	rmdir_recurs(working_directory);


### PR DESCRIPTION
- Convenience method for bindings
- Works for bare AND non bare repositories (Wow!)
- State-of-the-art rocket science algorithm
- Patent free
