### PR TITLE
test_lib.c: flush stdout after every test-run

### DIFF
--- a/tests/test_lib.c
+++ b/tests/test_lib.c
@@ -189,6 +189,8 @@ int git_testsuite_run(git_testsuite *ts)
 			putchar('F');
 		} else
 			putchar('.');
+
+		fflush(stdout);
 	}
 	printf("\n  ");
 	print_details(ts);


### PR DESCRIPTION
Make sure the user immediately sees the feedback, '.' or 'F', for a
test. If it's only in the buffer, it may gets "lost" in case of error.
