### PR TITLE
Threading: Make GIT_TLS defined only when GIT_THREADS is defined

### DIFF
--- a/include/git2/thread-utils.h
+++ b/include/git2/thread-utils.h
@@ -37,23 +37,23 @@
 # undef GIT_TLS
 # define GIT_TLS
 
-#elif defined(__GNUC__) || \
+#elif defined(GIT_THREADS) && (defined(__GNUC__) || \
       defined(__SUNPRO_C) || \
       defined(__SUNPRO_CC) || \
       defined(__xlc__) || \
-      defined(__xlC__)
+      defined(__xlC__))
 # define GIT_TLS __thread
 
-#elif defined(__INTEL_COMPILER)
+#elif defined(GIT_THREADS) && defined(__INTEL_COMPILER)
 # if defined(_WIN32) || defined(_WIN32_CE)
 #  define GIT_TLS __declspec(thread)
 # else
 #  define GIT_TLS __thread
 # endif
 
-#elif defined(_WIN32) || \
+#elif defined(GIT_THREADS) && (defined(_WIN32) || \
       defined(_WIN32_CE) || \
-      defined(__BORLANDC__)
+      defined(__BORLANDC__))
 # define GIT_TLS __declspec(thread)
 
 #else


### PR DESCRIPTION
Since commit 5711ca9, the correct way to retrieve error message is through git_lasterror(). The output of the method call is decorated with GIT_TLS. And GIT_TLS is always defined, even when compiling in THREADSAFE=OFF mode.

This is causing memory related issues on some Win32 platforms when git__throw() is being called
