### PR TITLE
Fix build errors on MSVC

### DIFF
--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -960,7 +960,7 @@ static int pack_entry_find_offset(
 	const unsigned char *index = p->index_map.data;
 	unsigned hi, lo, stride;
 	int pos, found = 0;
-	const unsigned char *current;
+	const unsigned char *current = 0;
 
 	*offset_out = 0;
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -458,7 +458,7 @@ int git_repository_discover(char *repository_path, size_t size, const char *star
 	char bare_path[GIT_PATH_MAX];
 	char normal_path[GIT_PATH_MAX];
 	char *found_path;
-	dev_t current_device;
+	dev_t current_device = 0;
 
 	assert(start_path && repository_path);
 	memset(&repo, 0x0, sizeof(git_repository));


### PR DESCRIPTION
2 .c files yielded a warning when compiling under MSVC, which stopped compilation. Here's a fix for that.
