### PR TITLE
Better name for git_oid_match

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -144,7 +144,7 @@ GIT_EXTERN(int) git_oid_cmp(const git_oid *a, const git_oid *b);
  * @param b second oid structure.
  * @return 0 in case of a match
  */
-GIT_EXTERN(int) gid_oid_match(unsigned int len, git_oid *a, git_oid *b);
+GIT_EXTERN(int) gid_oid_ncmp(unsigned int len, git_oid *a, git_oid *b);
 
 /**
  * OID Shortener object

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -492,7 +492,7 @@ int fn_locate_object_short_oid(void *state, char *pathbuf) {
 
 	if (!gitfo_exists(pathbuf) && gitfo_isdir(pathbuf)) {
 		/* We are already in the directory matching the 2 first hex characters */
-		if (!git_oid_match_hex(sstate->short_oid_len-2, sstate->short_oid+2, (unsigned char *)pathbuf + sstate->dir_len)) {
+		if (!git_oid_ncmp_hex(sstate->short_oid_len-2, sstate->short_oid+2, (unsigned char *)pathbuf + sstate->dir_len)) {
 			if (!sstate->found) {
 				sstate->res_oid[0] = sstate->short_oid[0];
 				sstate->res_oid[1] = sstate->short_oid[1];

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -1011,7 +1011,7 @@ static int pack_entry_find_offset(
 		if (pos < (int)p->num_objects) {
 			current = index + pos * stride;
 
-			if (!git_oid_match_raw(len, short_oid->id, current)) {
+			if (!git_oid_ncmp_raw(len, short_oid->id, current)) {
 				found = 1;
 			}
 		}
@@ -1021,7 +1021,7 @@ static int pack_entry_find_offset(
 		/* Check for ambiguousity */
 		const unsigned char *next = current + stride;
 
-		if (!git_oid_match_raw(len, short_oid->id, next)) {
+		if (!git_oid_ncmp_raw(len, short_oid->id, next)) {
 			found = 2;
 		}
 	}

--- a/src/oid.c
+++ b/src/oid.c
@@ -173,7 +173,7 @@ int git_oid_cmp(const git_oid *a, const git_oid *b)
 }
 
 
-int git_oid_match_raw(unsigned int len, const unsigned char *a, const unsigned char *b)
+int git_oid_ncmp_raw(unsigned int len, const unsigned char *a, const unsigned char *b)
 {
         do {
                 if (*a != *b)
@@ -188,14 +188,14 @@ int git_oid_match_raw(unsigned int len, const unsigned char *a, const unsigned c
         return 0;
 }
 
-int git_oid_match_hex(unsigned int len, const unsigned char *a, const unsigned char *b)
+int git_oid_ncmp_hex(unsigned int len, const unsigned char *a, const unsigned char *b)
 {
 	return memcmp(a, b, len);
 }
 
-int gid_oid_match(unsigned int len, git_oid *a, git_oid *b)
+int gid_oid_ncmp(unsigned int len, git_oid *a, git_oid *b)
 {
-	return git_oid_match_raw(len, a->id, b->id);
+	return git_oid_ncmp_raw(len, a->id, b->id);
 }
 
 typedef short node_index;

--- a/src/oid.h
+++ b/src/oid.h
@@ -6,12 +6,12 @@
  * This can be useful for internal use.
  * Return 0 if they match.
  */
-int git_oid_match_raw(unsigned int len, const unsigned char *a, const unsigned char *b);
+int git_oid_ncmp_raw(unsigned int len, const unsigned char *a, const unsigned char *b);
 
 /**
  * Compare the first 'len' characters of two hex formatted oids.
  * Return 0 if they match.
  */
-int git_oid_match_hex(unsigned int len, const unsigned char *a, const unsigned char *b);
+int git_oid_ncmp_hex(unsigned int len, const unsigned char *a, const unsigned char *b);
 
 #endif


### PR DESCRIPTION
As suggested by carlosmn, git_oid_ncmp would probably
be a better name than git_oid_match, for it does the same
as git_oid_cmp but only up to a certain amount of hex digits.
