### PR TITLE
Search objects of different types given OID prefix

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -53,6 +53,23 @@ GIT_INLINE(int) git_blob_lookup(git_blob **blob, git_repository *repo, const git
 }
 
 /**
+ * Lookup a blob object from a repository,
+ * given a prefix of its identifier (short id).
+ *
+ * @see git_object_lookup_prefix
+ *
+ * @param blob pointer to the looked up blob
+ * @param repo the repo to use when locating the blob.
+ * @param id identity of the blob to locate.
+ * @param len the length of the short identifier
+ * @return 0 on success; error code otherwise
+ */
+GIT_INLINE(int) git_blob_lookup_prefix(git_blob **blob, git_repository *repo, const git_oid *id, unsigned int len)
+{
+	return git_object_lookup_prefix((git_object **)blob, repo, id, len, GIT_OBJ_BLOB);
+}
+
+/**
  * Close an open blob
  *
  * This is a wrapper around git_object_close()

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -54,6 +54,24 @@ GIT_INLINE(int) git_commit_lookup(git_commit **commit, git_repository *repo, con
 }
 
 /**
+ * Lookup a commit object from a repository,
+ * given a prefix of its identifier (short id).
+ *
+ * @see git_object_lookup_prefix
+ *
+ * @param commit pointer to the looked up commit
+ * @param repo the repo to use when locating the commit.
+ * @param id identity of the commit to locate.  If the object is
+ *        an annotated tag it will be peeled back to the commit.
+ * @param len the length of the short identifier
+ * @return 0 on success; error code otherwise
+ */
+GIT_INLINE(int) git_commit_lookup_prefix(git_commit **commit, git_repository *repo, const git_oid *id, unsigned len)
+{
+	return git_object_lookup_prefix((git_object **)commit, repo, id, len, GIT_OBJ_COMMIT);
+}
+
+/**
  * Close an open commit
  *
  * This is a wrapper around git_object_close()

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -53,6 +53,23 @@ GIT_INLINE(int) git_tag_lookup(git_tag **tag, git_repository *repo, const git_oi
 }
 
 /**
+ * Lookup a tag object from the repository,
+ * given a prefix of its identifier (short id).
+ *
+ * @see git_object_lookup_prefix
+ *
+ * @param tag pointer to the looked up tag
+ * @param repo the repo to use when locating the tag.
+ * @param id identity of the tag to locate.
+ * @param len the length of the short identifier
+ * @return 0 on success; error code otherwise
+ */
+GIT_INLINE(int) git_tag_lookup_prefix(git_tag **tag, git_repository *repo, const git_oid *id, unsigned int len)
+{
+	return git_object_lookup_prefix((git_object **)tag, repo, id, len, (git_otype)GIT_OBJ_TAG);
+}
+
+/**
  * Close an open tag
  *
  * This is a wrapper around git_object_close()

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -53,6 +53,23 @@ GIT_INLINE(int) git_tree_lookup(git_tree **tree, git_repository *repo, const git
 }
 
 /**
+ * Lookup a tree object from the repository,
+ * given a prefix of its identifier (short id).
+ *
+ * @see git_object_lookup_prefix
+ *
+ * @param tree pointer to the looked up tree
+ * @param repo the repo to use when locating the tree.
+ * @param id identity of the tree to locate.
+ * @param len the length of the short identifier
+ * @return 0 on success; error code otherwise
+ */
+GIT_INLINE(int) git_tree_lookup_prefix(git_tree **tree, git_repository *repo, const git_oid *id, unsigned int len)
+{
+	return git_object_lookup_prefix((git_object **)tree, repo, id, len, GIT_OBJ_TREE);
+}
+
+/**
  * Close an open tree
  *
  * This is a wrapper around git_object_close()


### PR DESCRIPTION
I already added git_object_lookup_prefix. We should have a similar method for each type of objects (tree, blob, tag).
