### PR TITLE
Tree: Added a function that returns the type of a tree entry.

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -129,6 +129,14 @@ GIT_EXTERN(const char *) git_tree_entry_name(const git_tree_entry *entry);
 GIT_EXTERN(const git_oid *) git_tree_entry_id(const git_tree_entry *entry);
 
 /**
+ * Get the type of the object pointed by the entry
+ *
+ * @param entry a tree entry
+ * @return the type of the pointed object
+ */
+GIT_EXTERN(git_otype) git_tree_entry_type(const git_tree_entry *entry);
+
+/**
  * Convert a tree entry to the git_object it points too.
  *
  * @param object pointer to the converted object

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -20,6 +20,9 @@
 #define GIT_PLATFORM_PATH_SEP '/'
 #endif
 
+#define S_IFGITLINK 0160000
+#define S_ISGITLINK(m) (((m) & S_IFMT) == S_IFGITLINK)
+
 #ifdef GIT_WIN32
 GIT_INLINE(int) link(const char *GIT_UNUSED(old), const char *GIT_UNUSED(new))
 {

--- a/src/tree.c
+++ b/src/tree.c
@@ -100,6 +100,18 @@ const git_oid *git_tree_entry_id(const git_tree_entry *entry)
 	return &entry->oid;
 }
 
+git_otype git_tree_entry_type(const git_tree_entry *entry)
+{
+	assert(entry);
+
+	if (S_ISGITLINK(entry->attr))
+		return GIT_OBJ_COMMIT;
+	else if (S_ISDIR(entry->attr))
+		return GIT_OBJ_TREE;
+	else
+		return GIT_OBJ_BLOB;
+}
+
 int git_tree_entry_2object(git_object **object_out, git_repository *repo, const git_tree_entry *entry)
 {
 	assert(entry && object_out);


### PR DESCRIPTION
Getting the type of an object could be achieved by using the 2object function, but sometimes a tree contains an object that were not added to the database (see `t1010-mktree` from `git.git`) so there is a need for a function that returns the type of the entry even if it doesn't exists in database.

This helped me writing the `ls-tree` command in our git2 client https://github.com/Romain-Geissler/git2 (the command had not yet been pushed to the public repo)
