### PR TITLE
Port MSVC specific Waf compilation flags to CMake and remove dynamic dependency to msvcr100.dll on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ OPTION (BUILD_SHARED_LIBS "Build Shared Library (OFF for Static)" ON)
 OPTION (BUILD_TESTS "Build Tests" ON)
 OPTION (THREADSAFE "Build libgit2 as threadsafe" OFF)
 
+# Platform specific compilation flags
+IF (MSVC)
+	SET(CMAKE_C_FLAGS "/TC /W4 /WX /nologo /Zi")
+	SET(CMAKE_C_FLAGS_DEBUG "/Od /RTC1 /RTCc /DEBUG /MTd")
+	SET(CMAKE_C_FLAGS_RELEASE "/MT /O2")
+ENDIF()
+
 # Build Release by default
 IF (NOT CMAKE_BUILD_TYPE)
     SET(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)


### PR DESCRIPTION
Port MSVC specific Waf compilation flags to CMake and remove dynamic dependence to msvcr100.dll on Windows

The '/MT' and '/MTd' flags replace the dynamic link to 'msvcr100.dll' with a static link to 'libcmt.lib'. This has the nice effect to ease the deployment of libgit2 by removing the dependence on 'msvcr100.dll' which is not deployed by default on Windows.

This should fix #255 as well.
