### PR TITLE
Remove uneeded arpa/inet.h include

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -41,7 +41,6 @@ typedef SSIZE_T ssize_t;
 
 #else
 # include <unistd.h>
-# include <arpa/inet.h>
 
 # ifdef GIT_THREADS
 #  include <pthread.h>


### PR DESCRIPTION
This header isn't needed at all and it shows a lot of warnings on
OpenBSD.
