### PR TITLE
Fix: GIT_PATH_PATH_SEPARATOR is now a semi-colon under Windows.

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -76,6 +76,10 @@
 # define GIT_FORMAT_PRINTF(a,b) /* empty */
 #endif
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#define GIT_WIN32 1
+#endif
+
 /**
  * @file git2/common.h
  * @brief Git common platform definitions
@@ -85,6 +89,22 @@
  */
 
 GIT_BEGIN_DECL
+
+/**
+ * The separator used in path list strings (ie like in the PATH
+ * environment variable). A semi-colon ";" is used on Windows, and
+ * a colon ":" for all other systems.
+ */
+#ifdef GIT_WIN32
+#define GIT_PATH_LIST_SEPARATOR ';'
+#else
+#define GIT_PATH_LIST_SEPARATOR ':'
+#endif
+
+/**
+ * The maximum length of a git valid git path.
+ */
+#define GIT_PATH_MAX 4096
 
 typedef struct {
 	char **strings;

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -151,9 +151,9 @@ GIT_EXTERN(int) git_repository_open3(git_repository **repository,
  * @param across_fs If true, then the lookup will not stop when a filesystem device change
  * is detected while exploring parent directories.
  *
- * @param ceiling_dirs A colon separated of absolute symbolic link free paths. The lookup will
- * stop when any of this paths is reached. Note that the lookup always performs on start_path
- * no matter start_path appears in ceiling_dirs
+ * @param ceiling_dirs A GIT_PATH_LIST_SEPARATOR separated list of absolute symbolic link
+ * free paths. The lookup will stop when any of this paths is reached. Note that the
+ * lookup always performs on start_path no matter start_path appears in ceiling_dirs
  * ceiling_dirs might be NULL (which is equivalent to an empty string)
  *
  * @return 0 on success; error code otherwise

--- a/src/common.h
+++ b/src/common.h
@@ -1,12 +1,10 @@
 #ifndef INCLUDE_common_h__
 #define INCLUDE_common_h__
 
+#include "git2/common.h"
+
 /** Force 64 bit off_t size on POSIX. */
 #define _FILE_OFFSET_BITS 64
-
-#if defined(_WIN32) && !defined(__CYGWIN__)
-#define GIT_WIN32 1
-#endif
 
 #include "git2/thread-utils.h"
 #include "cc-compat.h"
@@ -48,13 +46,11 @@ typedef SSIZE_T ssize_t;
 # endif
 #endif
 
-#include "git2/common.h"
 #include "git2/types.h"
 #include "git2/errors.h"
 #include "thread-utils.h"
 #include "bswap.h"
 
-#define GIT_PATH_MAX 4096
 extern int git__throw(int error, const char *, ...) GIT_FORMAT_PRINTF(2, 3);
 extern int git__rethrow(int error, const char *, ...) GIT_FORMAT_PRINTF(2, 3);
 

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -12,8 +12,6 @@
 #include <fcntl.h>
 #include <time.h>
 
-#define GIT_PATH_LIST_SEPARATOR ':'
-
 #ifdef GIT_WIN32
 #define GIT_PLATFORM_PATH_SEP '\\'
 #else

--- a/tests/t12-repo.c
+++ b/tests/t12-repo.c
@@ -334,7 +334,7 @@ static int append_ceiling_dir(char *ceiling_dirs, const char *path)
 		return git__rethrow(error, "Failed to append ceiling directory.");
 
 	if (len)
-		ceiling_dirs[len] = ':';
+		ceiling_dirs[len] = GIT_PATH_LIST_SEPARATOR;
 
 	return GIT_SUCCESS;
 }


### PR DESCRIPTION
@nulltoken and me fixed the second issue from #251. Tests should now works on Windows with both cmake and waf (even if the latter has been abandoned a few days ago).

There are also some declarations made public, as discussed in fd0574e5ad4e2e5924ff0d0869da7d5846225d8b
