### PR TITLE
Fix compilation error in MSVC when compiling for c++

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -43,7 +43,7 @@ GIT_INLINE(char *) git__strndup(const char *str, size_t n)
 	if (n < length)
 		length = n;
 
-	ptr = malloc(length + 1);
+	ptr = (char*)malloc(length + 1);
 	if (!ptr)
 		git__throw(GIT_ENOMEM, "Out of memory. Failed to duplicate string");
 


### PR DESCRIPTION
This one was still not fixed. This change is needed when a project using libgit2 is compiled using MSVC c++
