### PR TITLE
added defines for Haiku in types.h

### DIFF
--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -59,6 +59,11 @@ typedef __time64_t  git_time_t;
 typedef off64_t git_off_t;
 typedef __time64_t git_time_t;
 
+#elif defined(__HAIKU__)
+
+typedef __haiku_std_int64 git_off_t;
+typedef __haiku_std_int64 git_time_t;
+
 #else  /* POSIX */
 
 /* 


### PR DESCRIPTION
Tiny change to make libgit2 build on Haiku (http://haiku-os.org). I haven't used it in a Haiku app yet, but it passes the included test.

Great library, thanks :)
