### PR TITLE
index.c: Return ENOTFOUND when trying to init nonexistant path

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -412,7 +412,7 @@ static int index_init_entry(git_index_entry *entry, git_index *index, const char
 	git__joinpath(full_path, index->repository->path_workdir, rel_path);
 
 	if (gitfo_lstat(full_path, &st) < 0)
-		return git__throw(GIT_EOSERR, "Failed to initialize entry. '%s' cannot be opened", full_path);
+		return git__throw(GIT_ENOTFOUND, "Failed to initialize entry. '%s' cannot be opened", full_path);
 
 	if (stage < 0 || stage > 3)
 		return git__throw(GIT_ERROR, "Failed to initialize entry. Invalid stage %i", stage);


### PR DESCRIPTION
When calling git_index_add or git_index_append on a path that does not
exist, the correct return code thrown by index_init_entry should be
GIT_ENOTFOUND instead of GIT_EOSERR.

I stumbled upon this problem with my own client implementation of git2, which expects a GIT_ENOTFOUND error when trying to determine whether to add or remove a file argument passed to update-index. This stopped working after ae49695.
