### PR TITLE
Hide ".git" directory on Windows upon creation of a non bare repository

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -746,4 +746,16 @@ int gitfo_readlink__w32(const char *link, char *target, size_t target_len)
 	return dwRet;
 }
 
+int gitfo_hide_directory__w32(const char *path)
+{
+	int error;
+
+	error = SetFileAttributes(path, FILE_ATTRIBUTE_HIDDEN) != 0 ?
+        GIT_SUCCESS : GIT_ERROR; /* MSDN states a "non zero" value indicates a success */
+
+	if (error < GIT_SUCCESS)	
+		error = git__throw(GIT_EOSERR, "Failed to hide directory '%s'", path);
+
+	return error;
+}
 #endif

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -99,6 +99,7 @@ extern int gitfo_mv_force(const char *from, const char *to);
 
    extern int gitfo_lstat__w32(const char *file_name, struct stat *buf);
    extern int gitfo_readlink__w32(const char *link, char *target, size_t target_len);
+   extern int gitfo_hide_directory__w32(const char *path);
 #else
 #  define gitfo_lstat(p,b) lstat(p,b)
 #  define gitfo_readlink(a, b, c) readlink(a, b, c)

--- a/src/repository.c
+++ b/src/repository.c
@@ -648,6 +648,15 @@ static int repo_init_structure(repo_init *results)
 	if (gitfo_mkdir_recurs(git_dir, mode))
 		return git__throw(GIT_ERROR, "Failed to initialize repository structure. Could not mkdir");
 
+#ifdef GIT_WIN32
+	/* Hides the ".git" directory */
+	if (!results->is_bare) {
+		error = gitfo_hide_directory__w32(git_dir);
+		if (error < GIT_SUCCESS)
+			return git__rethrow(error, "Failed to initialize repository structure");
+	}
+#endif
+
 	/* Creates the '/objects/info/' directory */
 	git__joinpath(temp_path, git_dir, GIT_OBJECTS_INFO_DIR);
 	error = gitfo_mkdir_recurs(temp_path, mode);

--- a/tests/t12-repo.c
+++ b/tests/t12-repo.c
@@ -127,6 +127,11 @@ static int ensure_repository_init(
 		if (git__suffixcmp(repo->path_index, expected_path_index) != 0)
 			goto cleanup;
 
+#ifdef GIT_WIN32
+		if ((GetFileAttributes(repo->path_repository) & FILE_ATTRIBUTE_HIDDEN) == 0)
+			goto cleanup;
+#endif
+
 		if (git_repository_is_bare(repo) == 1)
 			goto cleanup;
 	} else if (git_repository_is_bare(repo) == 0)


### PR DESCRIPTION
Directory which name starts with a dot are hidden on Linux platforms.

This patch makes libgit2 behaves similarly on Windows.
