### PR TITLE
Fix bug in mac os x! #if defined(CONST) concatenation does not accept

### DIFF
--- a/include/git2/zlib.h
+++ b/include/git2/zlib.h
@@ -36,7 +36,7 @@
  */
 GIT_BEGIN_DECL
 
-#if defined(NO_DEFLATE_BOUND) || ZLIB_VERNUM < 0x1200
+#if defined(NO_DEFLATE_BOUND)
 /**
  * deflateBound returns an upper bound on the compressed size.
  *
@@ -51,8 +51,15 @@ GIT_INLINE(size_t) deflateBound(z_streamp stream, size_t s)
 {
 	return (s + ((s + 7) >> 3) + ((s + 63) >> 6) + 11);
 }
-#endif
 
+#elsif ZLIB_VERNUM < 0x1200
+
+GIT_INLINE(size_t) deflateBound(z_streamp stream, size_t s)
+{
+	return (s + ((s + 7) >> 3) + ((s + 63) >> 6) + 11);
+}
+
+#endif
 /** @} */
 GIT_END_DECL
 #endif


### PR DESCRIPTION
Error before change:
$ gcc -o main main.c -I /usr/local/include/git2 -L /usr/local/lib/ -lgit2
In file included from /usr/local/include/git2.h:36,
                 from main.c:1:
/usr/local/include/git2/zlib.h:50: error: expected ‘)’ before ‘stream’
