### PR TITLE
Include common.h in hashtable.h

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -4,6 +4,7 @@
 #include "git2/common.h"
 #include "git2/oid.h"
 #include "git2/odb.h"
+#include "common.h"
 
 #define GIT_HASHTABLE_HASHES 3
 


### PR DESCRIPTION
Without this, hashtable.h doesn't know what uint32_t is and the
compiler thinks that it's a function type.

Somehow both parents compile, but the merge result has a problem.
