### PR TITLE
Development

### DIFF
--- a/include/git2/pkt.h
+++ b/include/git2/pkt.h
@@ -25,20 +25,13 @@
 
 #include "git2/net.h"
 
-enum git_pkt_type {
-	GIT_PKT_CMD,
-	GIT_PKT_FLUSH,
-	GIT_PKT_REF,
-	GIT_PKT_HAVE,
-};
-
 /* This would be a flush pkt */
 struct git_pkt {
-	enum git_pkt_type type;
+	git_pkt_type type;
 };
 
 struct git_pkt_cmd {
-	enum git_pkt_type type;
+	git_pkt_type type;
 	char *cmd;
 	char *path;
 	char *host;
@@ -46,7 +39,7 @@ struct git_pkt_cmd {
 
 /* This is a pkt-line with some info in it */
 struct git_pkt_ref {
-	enum git_pkt_type type;
+	git_pkt_type type;
 	git_remote_head head;
 	char *capabilities;
 };

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -186,7 +186,13 @@ typedef struct git_remote_head git_remote_head;
 typedef struct git_headarray git_headarray;
 
 /* Several types of packets */
-typedef enum git_pkt_type git_pkt_type;
+typedef enum {
+	GIT_PKT_CMD,
+	GIT_PKT_FLUSH,
+	GIT_PKT_REF,
+	GIT_PKT_HAVE,
+} git_pkt_type;
+
 typedef struct git_pkt git_pkt;
 typedef struct git_pkt_cmd git_pkt_cmd;
 typedef struct git_pkt_ref git_pkt_ref;


### PR DESCRIPTION
Hello, I'm trying to update the C++ binding libqgit2, and I stumbled accross these two things in your code :
- The git_net_direction enum has been removed everywhere except from the types.h file.
- Unlike the other enums, the git_pkt_type values where not in types.h, so I just moved them from pkt.h.

Thank you,
Lambert
