### PR TITLE
reflog: Fix reflog writer/reader

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -209,12 +209,12 @@ int commit_parse_buffer(git_commit *commit, const void *data, size_t len)
 	}
 
 	commit->author = git__malloc(sizeof(git_signature));
-	if ((error = git_signature__parse(commit->author, &buffer, buffer_end, "author ")) < GIT_SUCCESS)
+	if ((error = git_signature__parse(commit->author, &buffer, buffer_end, "author ", '\n')) < GIT_SUCCESS)
 		return git__rethrow(error, "Failed to parse buffer");
 
 	/* Always parse the committer; we need the commit time */
 	commit->committer = git__malloc(sizeof(git_signature));
-	if ((error = git_signature__parse(commit->committer, &buffer, buffer_end, "committer ")) < GIT_SUCCESS)
+	if ((error = git_signature__parse(commit->committer, &buffer, buffer_end, "committer ", '\n')) < GIT_SUCCESS)
 		return git__rethrow(error, "Failed to parse buffer");
 
 	/* parse commit message */

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -74,9 +74,11 @@ static int reflog_write(git_repository *repo, const char *ref_name,
 		return git__throw(GIT_ERROR, "Failed to write reflog. `%s` is directory", log_path);
 
 	git_buf_puts(&log, oid_old);
+	git_buf_putc(&log, ' ');
+
 	git_buf_puts(&log, oid_new);
 
-	git_signature__writebuf(&log, NULL, committer);
+	git_signature__writebuf(&log, " ", committer);
 	log.size--; /* drop LF */
 
 	if (msg) {
@@ -122,10 +124,10 @@ static int reflog_parse(git_reflog *log, const char *buf, size_t buf_size)
 			return GIT_ENOMEM;
 
 		entry->oid_old = git__strndup(buf, GIT_OID_HEXSZ);
-		seek_forward(GIT_OID_HEXSZ+1);
+		seek_forward(GIT_OID_HEXSZ + 1);
 
 		entry->oid_cur = git__strndup(buf, GIT_OID_HEXSZ);
-		seek_forward(GIT_OID_HEXSZ+1);
+		seek_forward(GIT_OID_HEXSZ + 1);
 
 		ptr = buf;
 
@@ -137,7 +139,7 @@ static int reflog_parse(git_reflog *log, const char *buf, size_t buf_size)
 		if (entry->committer == NULL)
 			return GIT_ENOMEM;
 
-		if ((error = git_signature__parse(entry->committer, &ptr, buf + buf_size, NULL)) < GIT_SUCCESS)
+		if ((error = git_signature__parse(entry->committer, &ptr, buf + 1, NULL, *buf)) < GIT_SUCCESS)
 			goto cleanup;
 
 		if (*buf == '\t') {

--- a/src/signature.c
+++ b/src/signature.c
@@ -253,7 +253,7 @@ int parse_time(git_time_t *time_out, const char *buffer)
 }
 
 int git_signature__parse(git_signature *sig, const char **buffer_out,
-		const char *buffer_end, const char *header)
+		const char *buffer_end, const char *header, char ender)
 {
 	const char *buffer = *buffer_out;
 	const char *line_end, *name_end, *email_end, *tz_start, *time_start;
@@ -261,7 +261,7 @@ int git_signature__parse(git_signature *sig, const char **buffer_out,
 
 	memset(sig, 0x0, sizeof(git_signature));
 
-	if ((line_end = memchr(buffer, '\n', buffer_end - buffer)) == NULL)
+	if ((line_end = memchr(buffer, ender, buffer_end - buffer)) == NULL)
 		return git__throw(GIT_EOBJCORRUPTED, "Failed to parse signature. No newline given");
 
 	if (header) {

--- a/src/signature.h
+++ b/src/signature.h
@@ -6,7 +6,7 @@
 #include "repository.h"
 #include <time.h>
 
-int git_signature__parse(git_signature *sig, const char **buffer_out, const char *buffer_end, const char *header);
+int git_signature__parse(git_signature *sig, const char **buffer_out, const char *buffer_end, const char *header, char ender);
 void git_signature__writebuf(git_buf *buf, const char *header, const git_signature *sig);
 
 #endif

--- a/src/tag.c
+++ b/src/tag.c
@@ -144,7 +144,7 @@ static int parse_tag_buffer(git_tag *tag, const char *buffer, const char *buffer
 	if (tag->tagger == NULL)
 		return GIT_ENOMEM;
 
-	if ((error = git_signature__parse(tag->tagger, &buffer, buffer_end, "tagger ")) != 0) {
+	if ((error = git_signature__parse(tag->tagger, &buffer, buffer_end, "tagger ", '\n')) != 0) {
 		free(tag->tag_name);
 		git_signature_free(tag->tagger);
 		return git__rethrow(error, "Failed to parse tag");

--- a/tests/t04-commit.c
+++ b/tests/t04-commit.c
@@ -157,7 +157,7 @@ BEGIN_TEST(parse1, "parse the signature line in a commit")
 	const char *ptr = _string; \
 	size_t len = strlen(_string);\
 	git_signature person = {NULL, NULL, {0, 0}}; \
-	must_pass(git_signature__parse(&person, &ptr, ptr + len, _header));\
+	must_pass(git_signature__parse(&person, &ptr, ptr + len, _header, '\n'));\
 	must_be_true(strcmp(_name, person.name) == 0);\
 	must_be_true(strcmp(_email, person.email) == 0);\
 	must_be_true(_time == person.when.time);\
@@ -169,7 +169,7 @@ BEGIN_TEST(parse1, "parse the signature line in a commit")
 	const char *ptr = _string; \
 	size_t len = strlen(_string);\
 	git_signature person = {NULL, NULL, {0, 0}}; \
-	must_fail(git_signature__parse(&person, &ptr, ptr + len, _header));\
+	must_fail(git_signature__parse(&person, &ptr, ptr + len, _header, '\n'));\
 	free(person.name); free(person.email);\
 }
 

--- a/tests/t18-status.c
+++ b/tests/t18-status.c
@@ -210,4 +210,3 @@ BEGIN_SUITE(status)
 	ADD_TEST(singlestatus0);
 	ADD_TEST(singlestatus1);
 END_SUITE
-


### PR DESCRIPTION
- Use a space to separate oids and signature
- Enforce test coverage
- Make test run in a temporary folder in order not to alter the test repository
- Pull Request #10&pi;
