### PR TITLE
Add parrot-libgit2 to the list of language bindings in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Here are the bindings to libgit2 that are currently available:
 * libgit2-ocaml (ocaml bindings) <https://github.com/burdges/libgit2-ocaml>
 * Geef (Erlang bindings) <https://github.com/schacon/geef>
 * libgit2net (.NET bindings, low level) <https://github.com/txdv/libgit2net>
+* parrot-libgit2 (Parrot Virtual Machine bindings) <https://github.com/letolabs/parrot-libgit2>
 
 If you start another language binding to libgit2, please let us know so
 we can add it to the list.


### PR DESCRIPTION
These bindings allow all languages running on Parrot VM to talk to libgit2. The bindings target the 'development' branch of libgit2 and are still being improved, but we have passing tests!
