### PR TITLE
tree: fix insertion of entries with invalid filenames

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -379,10 +379,12 @@ int git_treebuilder_insert(git_tree_entry **entry_out, git_treebuilder *bld, con
 	assert(bld && id && filename);
 
 	if (!valid_attributes(attributes))
-		return git__throw(GIT_ERROR, "Failed to insert entry. Invalid atrributes");
+		return git__throw(GIT_ERROR, "Failed to insert entry. Invalid attributes");
 
-	if (build_ksearch(&ksearch, filename) == GIT_SUCCESS &&
-		(pos = git_vector_bsearch2(&bld->entries, entry_search_cmp, &ksearch)) != GIT_ENOTFOUND) {
+	if (build_ksearch(&ksearch, filename) < GIT_SUCCESS)
+		return git__throw(GIT_ERROR, "Failed to insert entry. Invalid filename '%s'", filename);
+
+	if ((pos = git_vector_bsearch2(&bld->entries, entry_search_cmp, &ksearch)) != GIT_ENOTFOUND) {
 		entry = git_vector_get(&bld->entries, pos);
 		if (entry->removed) {
 			entry->removed = 0;

--- a/tests/t09-tree.c
+++ b/tests/t09-tree.c
@@ -150,6 +150,11 @@ BEGIN_TEST(write2, "write a tree from a memory")
 	//create a second tree from first tree using `git_treebuilder_insert` on REPOSITORY_FOLDER.
 	must_pass(git_tree_lookup(&tree, repo, &id));
 	must_pass(git_treebuilder_create(&builder, tree));
+
+	must_fail(git_treebuilder_insert(NULL, builder, "", &bid, 0100644));
+	must_fail(git_treebuilder_insert(NULL, builder, "/", &bid, 0100644));
+	must_fail(git_treebuilder_insert(NULL, builder, "folder/new.txt", &bid, 0100644));
+
 	must_pass(git_treebuilder_insert(NULL,builder,"new.txt",&bid,0100644));
 	must_pass(git_treebuilder_write(&rid,repo,builder));
 


### PR DESCRIPTION
Also prevents MSVC from yelling in pain with a "potentially uninitialized local variable 'pos' used"
