### PR TITLE
Modify struct definition to enable forward declare with C++ compiler, thus avoid including C library's header in C++ header.

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -48,10 +48,11 @@ GIT_BEGIN_DECL
 #define GIT_OID_MINPREFIXLEN 4
 
 /** Unique identity of any object (commit, tree, blob, tag). */
-typedef struct {
+typedef struct _git_oid git_oid;
+struct _git_oid {
 	/** raw binary formatted id */
 	unsigned char id[GIT_OID_RAWSZ];
-} git_oid;
+};
 
 /**
  * Parse a hex formatted object id into a git_oid.


### PR DESCRIPTION
Hello,

I've stumbled across the compilation error described here :
http://developer.gnome.org/gtkmm-tutorial/3.0/sec-wrapping-problems.html.en#wrapping-predeclare-structs

when I tried to remove the inclusion of git2 original library headers in libqgit2 C++ headers.

This patch fixes it by following the link's recomendation.

Thanks,
Lambert
