### PR TITLE
Remove an overly zealous check for gitdir actually being called ".git"

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -144,10 +144,10 @@ static int guess_repository_dirs(git_repository *repo, const char *repository_pa
 	if (git_path_basename_r(buffer, sizeof(buffer), repository_path) < 0)
 		return git__throw(GIT_EINVALIDPATH, "Unable to parse folder name from `%s`", repository_path);
 
-		/* Path to working dir */
-		if (git_path_dirname_r(buffer, sizeof(buffer), repository_path) < 0)
-			return git__throw(GIT_EINVALIDPATH, "Unable to parse parent folder name from `%s`", repository_path);
-		path_work_tree = buffer;
+	/* Path to working dir */
+	if (git_path_dirname_r(buffer, sizeof(buffer), repository_path) < 0)
+		return git__throw(GIT_EINVALIDPATH, "Unable to parse parent folder name from `%s`", repository_path);
+	path_work_tree = buffer;
 
 	return assign_repository_dirs(repo, repository_path, NULL, NULL, path_work_tree);
 }


### PR DESCRIPTION
This allows the gitdir to be called something else.

Easily tested by having a repo with the gitdir being called something else and referenced in the gitfile. `git_repository_discover` works fine, but `git_repository_open`, albeit returning without an error code, actually creates a repo object with a NULL index entry. This will cause `git_repository_index` to fail as it can't find the index.
