### PR TITLE
On some header files, GIT_END_DECL was absent while GIT_BEGIN_DECL wasn't

### DIFF
--- a/include/git2/net.h
+++ b/include/git2/net.h
@@ -64,4 +64,6 @@ struct git_headarray {
 	struct git_remote_head **heads;
 };
 
+GIT_END_DECL
+
 #endif

--- a/include/git2/refspec.h
+++ b/include/git2/refspec.h
@@ -72,4 +72,7 @@ int git_refspec_src_match(const git_refspec *refspec, const char *refname);
  * @preturn GIT_SUCCESS, GIT_ESHORTBUFFER or another error
  */
 int git_refspec_transform(char *out, size_t outlen, const git_refspec *spec, const char *name);
+
+GIT_END_DECL
+
 #endif


### PR DESCRIPTION
Some headerfiles didnt end with GIT_END_DECL while they should.
