### PR TITLE
Including git2/status.h in the git2.h header.

### DIFF
--- a/include/git2.h
+++ b/include/git2.h
@@ -60,5 +60,6 @@
 #include "git2/refspec.h"
 #include "git2/net.h"
 #include "git2/transport.h"
+#include "git2/status.h"
 
 #endif


### PR DESCRIPTION
Hi, it seemed to me that there was an include missing in the git2.h file. I may be mistaken.
Thanks,
Mike.
