### PR TITLE
Fix memory leak when wrong object type is looked up from cache

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -117,7 +117,10 @@ int git_object_lookup_prefix(git_object **object_out, git_repository *repo, cons
 		object = git_cache_get(&repo->objects, id);
 		if (object != NULL) {
 			if (type != GIT_OBJ_ANY && type != object->type)
+			{
+				git_object_close(object);
 				return git__throw(GIT_EINVALIDTYPE, "Failed to lookup object. The given type does not match the type on the ODB");
+			}
 
 			*object_out = object;
 			return GIT_SUCCESS;

--- a/tests/t09-tree.c
+++ b/tests/t09-tree.c
@@ -104,9 +104,11 @@ BEGIN_TEST(read1, "read a tree from the repository")
 
 	/* GH-86: git_object_lookup() should also check the type if the object comes from the cache */
 	must_be_true(git_object_lookup(&obj, repo, &id, GIT_OBJ_TREE) == 0);
+	must_be_true(obj != NULL);
 	git_object_close(obj);
+	obj = NULL;
 	must_be_true(git_object_lookup(&obj, repo, &id, GIT_OBJ_BLOB) == GIT_EINVALIDTYPE);
-	git_object_close(obj);
+	must_be_true(obj == NULL);
 
 	entry = git_tree_entry_byname(tree, "README");
 	must_be_true(entry != NULL);
@@ -114,6 +116,7 @@ BEGIN_TEST(read1, "read a tree from the repository")
 	must_be_true(strcmp(git_tree_entry_name(entry), "README") == 0);
 
 	must_pass(git_tree_entry_2object(&obj, repo, entry));
+	must_be_true(obj != NULL);
 
 	git_object_close(obj);
 	git_tree_close(tree);


### PR DESCRIPTION
Hello,

I've stumbled across this leak, the object was referenced but not freed when EINVALIDTYPE was thrown.

For the unit test part, leaving the test unmodified lead to memory errors, so I removed the git_object_close(obj), and resetted the pointer value to NULL after the previous test.

Thanks,
Lambert
