### PR TITLE
git_status_foreach issue

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -61,7 +61,6 @@ static int status_srch(const void *key, const void *array_member)
 
 static int find_status_entry(git_vector *entries, const char *path)
 {
-	git_vector_sort(entries);
 	return git_vector_bsearch2(entries, status_srch, path);
 }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -426,7 +426,6 @@ static git_tree_entry *treebuilder_get(git_treebuilder *bld, const char *filenam
 	if (build_ksearch(&ksearch, filename) < GIT_SUCCESS)
 		return NULL;
 
-	sort_entries(bld);
 	idx = git_vector_bsearch2(&bld->entries, entry_search_cmp, &ksearch);
 	if (idx == GIT_ENOTFOUND)
 		return NULL;


### PR DESCRIPTION
Hello,
I'm using libgit2 and I found a bug with git_status_foreach.
The bug is in recurse_tree_entries, there is a return instead of a continue, so this function stop to parse after the first subdirectory. This is probably a copy/paste bug with  recurse_tree_entry.

During investigation, i found 2 little things, an unused variable, and some duplicated sort.
git_vector_bsearch2 sort the vector, so there is no need to sort it before to call this function.

regards, 
Luc.
