### PR TITLE
Fix "redefinition of typedef git_indexer" build error

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -45,7 +45,7 @@ struct entry {
 	uint64_t offset_long;
 };
 
-typedef struct git_indexer {
+struct git_indexer {
 	struct git_pack_file *pack;
 	struct stat st;
 	struct git_pack_header hdr;
@@ -54,7 +54,7 @@ typedef struct git_indexer {
 	git_filebuf file;
 	unsigned int fanout[256];
 	git_oid hash;
-} git_indexer;
+};
 
 const git_oid *git_indexer_hash(git_indexer *idx)
 {


### PR DESCRIPTION
When building libgit2 I get this error:

```
[ 28%] Building C object CMakeFiles/git2.dir/src/indexer.c.o
/.../libgit2/src/indexer.c:57: error: redefinition of typedef ‘git_indexer’
/.../libgit2/include/git2/indexer.h:17: note: previous declaration of ‘git_indexer’ was here
make[2]: *** [CMakeFiles/git2.dir/src/indexer.c.o] Error 1
make[1]: *** [CMakeFiles/git2.dir/all] Error 2
make: *** [all] Error 2
```

The proposed patch fixes it.
