### PR TITLE
util: Add git__strcmp_cb() wrapper

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -503,7 +503,7 @@ static int packed_load(git_repository *repo)
 		ref_cache->packfile = git_hashtable_alloc(
 			default_table_size,
 			reftable_hash,
-			(git_hash_keyeq_ptr)strcmp);
+			(git_hash_keyeq_ptr)(&git__strcmp_cb));
 
 		if (ref_cache->packfile == NULL) {
 			error = GIT_ENOMEM;
@@ -1609,7 +1609,7 @@ int git_repository__refcache_init(git_refcache *refs)
 	refs->loose_cache = git_hashtable_alloc(
 		default_table_size,
 		reftable_hash,
-		(git_hash_keyeq_ptr)strcmp);
+		(git_hash_keyeq_ptr)(&git__strcmp_cb));
 
 	/* packfile loaded lazily */
 	refs->packfile = NULL;
@@ -1753,5 +1753,3 @@ int git_reference__normalize_name_oid(char *buffer_out, size_t out_size, const c
 {
 	return normalize_name(buffer_out, out_size, name, 1);
 }
-
-

--- a/src/transport_local.c
+++ b/src/transport_local.c
@@ -14,13 +14,6 @@ typedef struct {
 	git_vector *refs;
 } transport_local;
 
-static int cmp_refs(const void *a, const void *b)
-{
-	const char *stra = (const char *)a;
-	const char *strb = (const char *)b;
-	return strcmp(stra, strb);
-}
-
 /*
  * Try to open the url as a git directory. The direction doesn't
  * matter in this case because we're calulating the heads ourselves.
@@ -147,7 +140,7 @@ static int local_ls(git_transport *transport, git_headarray *array)
 		return error;
 
 	/* Sort the references first */
-	git__tsort((void **)refs.strings, refs.count, &cmp_refs);
+	git__tsort((void **)refs.strings, refs.count, &git__strcmp_cb);
 
 	/* Add HEAD */
 	error = add_ref(GIT_HEAD_FILE, repo, vec);

--- a/src/util.c
+++ b/src/util.c
@@ -355,3 +355,16 @@ void **git__bsearch(const void *key, void **base, size_t nmemb, int (*compar)(co
         return NULL;
 }
 
+/**
+ * A strcmp wrapper
+ * 
+ * We don't want direct pointers to the CRT on Windows, we may
+ * get stdcall conflicts.
+ */
+int git__strcmp_cb(const void *a, const void *b)
+{
+	const char *stra = (const char *)a;
+	const char *strb = (const char *)b;
+
+	return strcmp(stra, strb);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -120,4 +120,6 @@ extern void git__tsort(void **dst, size_t size, int (*cmp)(const void *, const v
 extern void **git__bsearch(const void *key, void **base, size_t nmemb,
 	int (*compar)(const void *, const void *));
 
+extern int git__strcmp_cb(const void *a, const void *b);
+
 #endif /* INCLUDE_util_h__ */


### PR DESCRIPTION
We don't want direct pointers to the CRT on Windows, we may get stdcall conflicts.

Beside the addition, this has the nice side effect of making the tests **pass** on Windows in Release mode as well :)
