### PR TITLE
t12-repo.c: fix failing test discover0

### DIFF
--- a/tests/t12-repo.c
+++ b/tests/t12-repo.c
@@ -388,8 +388,8 @@ BEGIN_TEST(discover0, "test discover")
 	char found_path[GIT_PATH_MAX];
 	int mode = 0755;
 
-	must_pass(append_ceiling_dir(ceiling_dirs, TEMP_REPO_FOLDER));
 	git_futils_mkdir_r(DISCOVER_FOLDER, mode);
+	must_pass(append_ceiling_dir(ceiling_dirs, TEMP_REPO_FOLDER));
 
 	must_be_true(git_repository_discover(repository_path, sizeof(repository_path), DISCOVER_FOLDER, 0, ceiling_dirs) == GIT_ENOTAREPO);
 


### PR DESCRIPTION
discover0 tried to stat a non existing directory. Create it beforehand.

Fix: https://github.com/libgit2/libgit2/commit/c24ceffe61f15e0cb499de80b052a906ea5dc7cc#tests/t12-repo.c-P14
