### PR TITLE
Fix typos

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -130,7 +130,7 @@ typedef enum {
 	GIT_ENOMATCH = -31,
 
 	/**  The buffer is too short to satisfy the request */
-	GIT_ESHORTBUFFER = -32,
+	GIT_ESHORTBUFFER = -32
 } git_error;
 
 /**

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -134,7 +134,7 @@ GIT_EXTERN(const char *) git_reference_name(git_reference *ref);
 /**
  * Resolve a symbolic reference
  *
- * Thie method iteratively peels a symbolic reference
+ * This method iteratively peels a symbolic reference
  * until it resolves to a direct reference to an OID.
  *
  * If a direct reference is passed as an argument,

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -89,7 +89,7 @@ typedef enum {
 	GIT_OBJ_TAG = 4,        /**< An annotated tag object. */
 	GIT_OBJ__EXT2 = 5,      /**< Reserved for future use. */
 	GIT_OBJ_OFS_DELTA = 6,  /**< A delta, base is given by an offset. */
-	GIT_OBJ_REF_DELTA = 7,  /**< A delta, base is given by object id. */
+	GIT_OBJ_REF_DELTA = 7   /**< A delta, base is given by object id. */
 } git_otype;
 
 /** An open object database handle. */
@@ -172,7 +172,7 @@ typedef enum {
 	GIT_REF_SYMBOLIC = 2, /** A reference which points at another reference */
 	GIT_REF_PACKED = 4,
 	GIT_REF_HAS_PEEL = 8,
-	GIT_REF_LISTALL = GIT_REF_OID|GIT_REF_SYMBOLIC|GIT_REF_PACKED,
+	GIT_REF_LISTALL = GIT_REF_OID|GIT_REF_SYMBOLIC|GIT_REF_PACKED
 } git_rtype;
 
 


### PR DESCRIPTION
There should not be a comma in the end of the enums.
