### PR TITLE
Fix the reference character check for Unicode

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -1647,7 +1647,7 @@ void git_repository__refcache_free(git_refcache *refs)
  *****************************************/
 static int check_valid_ref_char(char ch)
 {
-	if (ch <= ' ')
+	if ((unsigned) ch <= ' ')
 		return GIT_ERROR;
 
 	switch (ch) {


### PR DESCRIPTION
We need to do an unsigned comparison, as otherwise UTF-8 characters
might look like they have the sign bit set and the check will fail.
## 

Though I feel we should be transforming the string to a wide-char string. But if this is what git does, it must be right.
