### PR TITLE
CMakeLists: no need in split debug/release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,10 @@ IF (MSVC)
 	SET(CMAKE_C_FLAGS_DEBUG "/Od /DEBUG /MTd")
 	SET(CMAKE_C_FLAGS_RELEASE "/MT /O2")
 ELSE ()
-	SET(CMAKE_C_FLAGS "-Wall -Wextra")
+	SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wextra")
 	IF (NOT MINGW) # MinGW always does PIC and complains if we tell it to
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 	ENDIF ()
-	SET(CMAKE_C_FLAGS_DEBUG "-g -O0")
-	SET(CMAKE_C_FLAGS_RELEASE "-O2")
 ENDIF()
 
 # Build Debug by default


### PR DESCRIPTION
With GNU toolchain there's no need to split debug/release build.

It's useful to have -O2 in debug envitonment since GCC show more
warnings in this case. -O2 -g works fine.

For release purpose, debug information can be stripted on later stage.

Signed-off-by: Kirill A. Shutemov kirill@shutemov.name
