### PR TITLE
Fix a bug and GCC warning introduced in 932669b

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -553,10 +553,8 @@ static char *cfg_readline(diskfile_backend *cfg)
 
 	memcpy(line, line_src, line_len);
 
-	line[line_len] = '\0';
-
-	while (--line_len >= 0 && isspace(line[line_len]))
-		line[line_len] = '\0';
+	do line[line_len] = '\0';
+	while (line_len-- > 0 && isspace(line[line_len]));
 
 	if (*line_end == '\n')
 		line_end++;


### PR DESCRIPTION
For unsigned types, the comparison >= 0 is always true.
