### PR TITLE
Removed check size_t (unsigned long int) >= 0, which is always true. in config_file.c

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -555,7 +555,7 @@ static char *cfg_readline(diskfile_backend *cfg)
 
 	line[line_len] = '\0';
 
-	while (--line_len >= 0 && isspace(line[line_len]))
+	while (isspace(line[line_len--]))
 		line[line_len] = '\0';
 
 	if (*line_end == '\n')


### PR DESCRIPTION
Tests still pass after this correction.

The warning was bugging me.
