### PR TITLE
Use better check for null-terminator in cfg_Readline() 

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -555,7 +555,9 @@ static char *cfg_readline(diskfile_backend *cfg)
 
 	line[line_len] = '\0';
 
-	while (--line_len >= 0 && isspace(line[line_len]))
+    // Count back from line_len.
+    // By the time line len is one the zeroth index is checked and the next pass will return false.
+	while (line_len && isspace(line[--line_len]))
 		line[line_len] = '\0';
 
 	if (*line_end == '\n')


### PR DESCRIPTION
Checking a size_t >= 0 is always going to return true, so at the moment the loop is only being broken when a non space character is found in the array. If a space isn't found line_len could wrap around.

This will at least break after the whole array is checked, and will prevent line_len from looping around. It also quietens the warning that is generated by the check.
