### PR TITLE
Fix compilation issues with mingw64 headers

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -31,7 +31,9 @@
 
 # define snprintf _snprintf
 
+#ifndef _SSIZE_T_DEFINED
 typedef SSIZE_T ssize_t;
+#endif
 
 #else
 # include <unistd.h>


### PR DESCRIPTION
This fixes an issue when using the new mingw64 headers, that are meant to replace the old mingw32 headers on both win32 and win64.
