### PR TITLE
git_repository_config: open global config file automatically

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -292,13 +292,10 @@ GIT_EXTERN(int) git_repository_is_bare(git_repository *repo);
 /**
  * Retrieve the relevant configuration for a repository
  *
- * By default he returned `git_config` instance contains a single
- * configuration file, the `.gitconfig' file that may be found
- * inside the repository.
- *
- * If the `user_config_path` variable is not NULL, the given config
- * file will be also included in the configuration set. On most UNIX
- * systems, this file may be found on `$HOME/.gitconfig`.
+ * By default he returned `git_config` instance contains the two most
+ * common configuration files, the `config' file that may be found
+ * inside the repository, and the `$HOME/.gitconfig' "global"
+ * configuration file.
  *
  * If the `system_config_path` variable is not NULL, the given config
  * file will be also included in the configuration set. On most UNIX
@@ -308,23 +305,21 @@ GIT_EXTERN(int) git_repository_is_bare(git_repository *repo);
  * order:
  *
  *	- Repository configuration file
- *	- User configuration file
+ *	- Global configuration file
  *	- System configuration file
  *
- * The method will fail if any of the passed config files cannot be
- * found or accessed.
+ * The method will fail if any of the passed system config file found
+ * or accessed.
  *
  * The returned `git_config` instance is owned by the caller and must
  * be manually free'd once it's no longer on use.
  *
  * @param out the repository's configuration
  * @param repo the repository for which to get the config
- * @param user_config_path Path to the user config file
  * @param system_config_path Path to the system-wide config file
  */
 GIT_EXTERN(int) git_repository_config(git_config **out,
 	git_repository *repo,
-	const char *user_config_path,
 	const char *system_config_path);
 
 /** @} */

--- a/src/repository.c
+++ b/src/repository.c
@@ -288,7 +288,6 @@ cleanup:
 int git_repository_config(
 		git_config **out,
 		git_repository *repo,
-		const char *user_config_path,
 		const char *system_config_path)
 {
 	char config_path[GIT_PATH_MAX];
@@ -305,10 +304,9 @@ int git_repository_config(
 	if (error < GIT_SUCCESS)
 		goto cleanup;
 
-	if (user_config_path != NULL) {
-		error = git_config_add_file_ondisk(*out, user_config_path, 2);
-		if (error < GIT_SUCCESS)
-			goto cleanup;
+	error = git_config_find_global(config_path);
+	if (error == GIT_SUCCESS) {
+		error = git_config_add_file_ondisk(*out, config_path, 2);
 	}
 
 	if (system_config_path != NULL) {

--- a/tests/t15-config.c
+++ b/tests/t15-config.c
@@ -214,26 +214,40 @@ BEGIN_TEST(config10, "a repo's config overrides the global config")
 	git_repository *repo;
 	git_config *cfg;
 	int version;
+	char *old_home;
+
+	old_home = git__strdup(getenv("HOME"));
+	setenv("HOME", CONFIG_BASE, 1);
 
 	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
-	must_pass(git_repository_config(&cfg, repo, CONFIG_BASE "/.gitconfig", NULL));
+	must_pass(git_repository_config(&cfg, repo, NULL));
 	must_pass(git_config_get_int(cfg, "core.repositoryformatversion", &version));
 	must_be_true(version == 0);
 	git_config_free(cfg);
 	git_repository_free(repo);
+
+	setenv("HOME", old_home, 1);
+	free(old_home);
 END_TEST
 
 BEGIN_TEST(config11, "fall back to the global config")
 	git_repository *repo;
 	git_config *cfg;
 	int num;
+	char *old_home;
+
+	old_home = git__strdup(getenv("HOME"));
+	setenv("HOME", CONFIG_BASE, 1);
 
 	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
-	must_pass(git_repository_config(&cfg, repo, CONFIG_BASE "/.gitconfig", NULL));
+	must_pass(git_repository_config(&cfg, repo, NULL));
 	must_pass(git_config_get_int(cfg, "core.something", &num));
 	must_be_true(num == 2);
 	git_config_free(cfg);
 	git_repository_free(repo);
+
+	setenv("HOME", old_home, 1);
+	free(old_home);
 END_TEST
 
 BEGIN_TEST(config12, "delete a value")

--- a/tests/t16-remotes.c
+++ b/tests/t16-remotes.c
@@ -31,9 +31,13 @@ BEGIN_TEST(remotes0, "remote parsing works")
 	git_remote *remote;
 	git_repository *repo;
 	git_config *cfg;
+	char *old_home;
+
+	old_home = git__strdup(getenv("HOME"));
+	setenv("HOME", "/dev/null", 1);
 
 	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
-	must_pass(git_repository_config(&cfg, repo, NULL, NULL));
+	must_pass(git_repository_config(&cfg, repo, NULL));
 	must_pass(git_remote_get(&remote, cfg, "test"));
 	must_be_true(!strcmp(git_remote_name(remote), "test"));
 	must_be_true(!strcmp(git_remote_url(remote), "git://github.com/libgit2/libgit2"));
@@ -41,6 +45,9 @@ BEGIN_TEST(remotes0, "remote parsing works")
 	git_remote_free(remote);
 	git_config_free(cfg);
 	git_repository_free(repo);
+
+	setenv("HOME", old_home, 1);
+	free(old_home);
 END_TEST
 
 BEGIN_TEST(refspec0, "remote with refspec works")
@@ -48,9 +55,13 @@ BEGIN_TEST(refspec0, "remote with refspec works")
 	git_repository *repo;
 	git_config *cfg;
 	const git_refspec *refspec = NULL;
+	char *old_home;
+
+	old_home = git__strdup(getenv("HOME"));
+	setenv("HOME", "/dev/null", 1);
 
 	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
-	must_pass(git_repository_config(&cfg, repo, NULL, NULL));
+	must_pass(git_repository_config(&cfg, repo, NULL));
 	must_pass(git_remote_get(&remote, cfg, "test"));
 	refspec = git_remote_fetchspec(remote);
 	must_be_true(refspec != NULL);
@@ -59,6 +70,9 @@ BEGIN_TEST(refspec0, "remote with refspec works")
 	git_remote_free(remote);
 	git_config_free(cfg);
 	git_repository_free(repo);
+
+	setenv("HOME", old_home, 1);
+	free(old_home);
 END_TEST
 
 BEGIN_TEST(refspec1, "remote fnmatch works as expected")
@@ -66,9 +80,13 @@ BEGIN_TEST(refspec1, "remote fnmatch works as expected")
 	git_repository *repo;
 	git_config *cfg;
 	const git_refspec *refspec = NULL;
+	char *old_home;
+
+	old_home = git__strdup(getenv("HOME"));
+	setenv("HOME", "/dev/null", 1);
 
 	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
-	must_pass(git_repository_config(&cfg, repo, NULL, NULL));
+	must_pass(git_repository_config(&cfg, repo, NULL));
 	must_pass(git_remote_get(&remote, cfg, "test"));
 	refspec = git_remote_fetchspec(remote);
 	must_be_true(refspec != NULL);
@@ -77,6 +95,9 @@ BEGIN_TEST(refspec1, "remote fnmatch works as expected")
 	git_remote_free(remote);
 	git_config_free(cfg);
 	git_repository_free(repo);
+
+	setenv("HOME", old_home, 1);
+	free(old_home);
 END_TEST
 
 BEGIN_TEST(refspec2, "refspec transform")
@@ -85,9 +106,13 @@ BEGIN_TEST(refspec2, "refspec transform")
 	git_config *cfg;
 	const git_refspec *refspec = NULL;
 	char ref[1024] = {0};
+	char *old_home;
+
+	old_home = git__strdup(getenv("HOME"));
+	setenv("HOME", "/dev/null", 1);
 
 	must_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
-	must_pass(git_repository_config(&cfg, repo, NULL, NULL));
+	must_pass(git_repository_config(&cfg, repo, NULL));
 	must_pass(git_remote_get(&remote, cfg, "test"));
 	refspec = git_remote_fetchspec(remote);
 	must_be_true(refspec != NULL);
@@ -96,6 +121,9 @@ BEGIN_TEST(refspec2, "refspec transform")
 	git_remote_free(remote);
 	git_config_free(cfg);
 	git_repository_free(repo);
+
+	setenv("HOME", old_home, 1);
+	free(old_home);
 END_TEST
 
 BEGIN_SUITE(remotes)


### PR DESCRIPTION
If the global configuration file is missing, it is ignored, which should be safe enough, as

```
HOME=/dev/null git config user.email
```

doesn't complain all that much (it does exit with error 1).
