### PR TITLE
Add checks for NULL to the config and remote free functions

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -43,6 +43,9 @@ void git_config_free(git_config *cfg)
 	git_config_file *file;
 	file_internal *internal;
 
+	if (cfg == NULL)
+		return;
+
 	for(i = 0; i < cfg->files.length; ++i){
 		internal = git_vector_get(&cfg->files, i);
 		file = internal->file;

--- a/src/remote.c
+++ b/src/remote.c
@@ -267,6 +267,9 @@ int git_remote_update_tips(struct git_remote *remote)
 
 void git_remote_free(git_remote *remote)
 {
+	if (remote == NULL)
+		return;
+
 	free(remote->fetch.src);
 	free(remote->fetch.dst);
 	free(remote->push.src);


### PR DESCRIPTION
The first victims of the clay testing suite.
