### PR TITLE
Document GIT_SUCCESS

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -45,7 +45,7 @@ GIT_BEGIN_DECL
  * @param blob pointer to the looked up blob
  * @param repo the repo to use when locating the blob.
  * @param id identity of the blob to locate.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_blob_lookup(git_blob **blob, git_repository *repo, const git_oid *id)
 {
@@ -62,7 +62,7 @@ GIT_INLINE(int) git_blob_lookup(git_blob **blob, git_repository *repo, const git
  * @param repo the repo to use when locating the blob.
  * @param id identity of the blob to locate.
  * @param len the length of the short identifier
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_blob_lookup_prefix(git_blob **blob, git_repository *repo, const git_oid *id, unsigned int len)
 {
@@ -117,7 +117,7 @@ GIT_EXTERN(size_t) git_blob_rawsize(git_blob *blob);
  *	this repository cannot be bare
  * @param path file from which the blob will be created,
  *	relative to the repository's working dir
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_blob_create_fromfile(git_oid *oid, git_repository *repo, const char *path);
 
@@ -129,7 +129,7 @@ GIT_EXTERN(int) git_blob_create_fromfile(git_oid *oid, git_repository *repo, con
  * @param repo repository where to blob will be written
  * @param buffer data to be written into the blob
  * @param len length of the data
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_blob_create_frombuffer(git_oid *oid, git_repository *repo, const void *buffer, size_t len);
 

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -46,7 +46,7 @@ GIT_BEGIN_DECL
  * @param repo the repo to use when locating the commit.
  * @param id identity of the commit to locate.  If the object is
  *        an annotated tag it will be peeled back to the commit.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_commit_lookup(git_commit **commit, git_repository *repo, const git_oid *id)
 {
@@ -64,7 +64,7 @@ GIT_INLINE(int) git_commit_lookup(git_commit **commit, git_repository *repo, con
  * @param id identity of the commit to locate.  If the object is
  *        an annotated tag it will be peeled back to the commit.
  * @param len the length of the short identifier
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_commit_lookup_prefix(git_commit **commit, git_repository *repo, const git_oid *id, unsigned len)
 {
@@ -153,7 +153,7 @@ GIT_EXTERN(const git_signature *) git_commit_author(git_commit *commit);
  *
  * @param tree_out pointer where to store the tree object
  * @param commit a previously loaded commit.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_commit_tree(git_tree **tree_out, git_commit *commit);
 
@@ -181,7 +181,7 @@ GIT_EXTERN(unsigned int) git_commit_parentcount(git_commit *commit);
  * @param parent Pointer where to store the parent commit
  * @param commit a previously loaded commit.
  * @param n the position of the parent (from 0 to `parentcount`)
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_commit_parent(git_commit **parent, git_commit *commit, unsigned int n);
 
@@ -235,7 +235,7 @@ GIT_EXTERN(const git_oid *) git_commit_parent_oid(git_commit *commit, unsigned i
  * array may be NULL if `parent_count` is 0 (root commit). All the
  * given commits must be owned by the `repo`.
  *
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  *	The created commit will be written to the Object Database and
  *	the given reference will be updated to point to it
  */

--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -76,7 +76,7 @@ GIT_EXTERN(int) git_config_find_global(char *global_config_path);
  * and opens the located file, if it exists.
  *
  * @param out Pointer to store the config instance
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_open_global(git_config **out);
 
@@ -100,7 +100,7 @@ GIT_EXTERN(int) git_config_file__ondisk(struct git_config_file **out, const char
  * can do anything with it.
  *
  * @param out pointer to the new configuration
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_new(git_config **out);
 
@@ -117,7 +117,7 @@ GIT_EXTERN(int) git_config_new(git_config **out);
  * @param cfg the configuration to add the file to
  * @param file the configuration file (backend) to add
  * @param priority the priority the backend should have
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_add_file(git_config *cfg, git_config_file *file, int priority);
 
@@ -138,7 +138,7 @@ GIT_EXTERN(int) git_config_add_file(git_config *cfg, git_config_file *file, int 
  * @param cfg the configuration to add the file to
  * @param path path to the configuration file (backend) to add
  * @param priority the priority the backend should have
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_add_file_ondisk(git_config *cfg, const char *path, int priority);
 
@@ -153,7 +153,7 @@ GIT_EXTERN(int) git_config_add_file_ondisk(git_config *cfg, const char *path, in
  *
  * @param cfg The configuration instance to create
  * @param path Path to the on-disk file to open
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_open_ondisk(git_config **cfg, const char *path);
 
@@ -170,7 +170,7 @@ GIT_EXTERN(void) git_config_free(git_config *cfg);
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param out pointer to the variable where the value should be stored
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_get_int(git_config *cfg, const char *name, int *out);
 
@@ -180,7 +180,7 @@ GIT_EXTERN(int) git_config_get_int(git_config *cfg, const char *name, int *out);
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param out pointer to the variable where the value should be stored
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_get_long(git_config *cfg, const char *name, long int *out);
 
@@ -193,7 +193,7 @@ GIT_EXTERN(int) git_config_get_long(git_config *cfg, const char *name, long int 
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param out pointer to the variable where the value should be stored
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_get_bool(git_config *cfg, const char *name, int *out);
 
@@ -206,7 +206,7 @@ GIT_EXTERN(int) git_config_get_bool(git_config *cfg, const char *name, int *out)
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param out pointer to the variable's value
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_get_string(git_config *cfg, const char *name, const char **out);
 
@@ -216,7 +216,7 @@ GIT_EXTERN(int) git_config_get_string(git_config *cfg, const char *name, const c
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param value Integer value for the variable
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_set_int(git_config *cfg, const char *name, int value);
 
@@ -226,7 +226,7 @@ GIT_EXTERN(int) git_config_set_int(git_config *cfg, const char *name, int value)
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param value Long integer value for the variable
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_set_long(git_config *cfg, const char *name, long int value);
 
@@ -236,7 +236,7 @@ GIT_EXTERN(int) git_config_set_long(git_config *cfg, const char *name, long int 
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param value the value to store
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_set_bool(git_config *cfg, const char *name, int value);
 
@@ -249,7 +249,7 @@ GIT_EXTERN(int) git_config_set_bool(git_config *cfg, const char *name, int value
  * @param cfg where to look for the variable
  * @param name the variable's name
  * @param value the string to store.
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_config_set_string(git_config *cfg, const char *name, const char *value);
 

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -124,7 +124,7 @@ typedef struct git_index_entry_unmerged {
  *
  * @param index the pointer for the new index
  * @param index_path the path to the index file in disk
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_open(git_index **index, const char *index_path);
 
@@ -149,7 +149,7 @@ GIT_EXTERN(void) git_index_free(git_index *index);
  * by reading from the hard disk.
  *
  * @param index an existing index object
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_read(git_index *index);
 
@@ -158,7 +158,7 @@ GIT_EXTERN(int) git_index_read(git_index *index);
  * using an atomic file lock.
  *
  * @param index an existing index object
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_write(git_index *index);
 
@@ -190,7 +190,7 @@ GIT_EXTERN(void) git_index_uniq(git_index *index);
  * @param index an existing index object
  * @param path filename to add
  * @param stage stage for the entry
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_add(git_index *index, const char *path, int stage);
 
@@ -202,7 +202,7 @@ GIT_EXTERN(int) git_index_add(git_index *index, const char *path, int stage);
  *
  * @param index an existing index object
  * @param source_entry new entry object
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_add2(git_index *index, const git_index_entry *source_entry);
 
@@ -221,7 +221,7 @@ GIT_EXTERN(int) git_index_add2(git_index *index, const git_index_entry *source_e
  * @param index an existing index object
  * @param path filename to add
  * @param stage stage for the entry
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_append(git_index *index, const char *path, int stage);
 
@@ -238,7 +238,7 @@ GIT_EXTERN(int) git_index_append(git_index *index, const char *path, int stage);
  *
  * @param index an existing index object
  * @param source_entry new entry object
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_append2(git_index *index, const git_index_entry *source_entry);
 
@@ -247,7 +247,7 @@ GIT_EXTERN(int) git_index_append2(git_index *index, const git_index_entry *sourc
  *
  * @param index an existing index object
  * @param position position of the entry to remove
- * @return 0 on success, otherwise an error code
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_index_remove(git_index *index, int position);
 

--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -87,7 +87,7 @@ GIT_EXTERN(int) git_object_lookup(
  * @param id a short identifier for the object
  * @param len the length of the short identifier
  * @param type the type of the object
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_object_lookup_prefix(
 		git_object **object_out,

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -47,8 +47,7 @@ GIT_BEGIN_DECL
  *
  * @param out location to store the database pointer, if opened.
  *            Set to NULL if the open failed.
- * @return GIT_SUCCESS if the database was created; otherwise an error
- *         code describing why the open was not possible.
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_odb_new(git_odb **out);
 
@@ -66,8 +65,7 @@ GIT_EXTERN(int) git_odb_new(git_odb **out);
  * @param out location to store the database pointer, if opened.
  *            Set to NULL if the open failed.
  * @param objects_dir path of the backends' "objects" directory.
- * @return GIT_SUCCESS if the database opened; otherwise an error
- *         code describing why the open was not possible.
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_odb_open(git_odb **out, const char *objects_dir);
 
@@ -208,7 +206,7 @@ GIT_EXTERN(int) git_odb_exists(git_odb *db, const git_oid *id);
  * @param data buffer with the data to storr
  * @param len size of the buffer
  * @param type type of the data to store
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_odb_write(git_oid *oid, git_odb *odb, const void *data, size_t len, git_otype type);
 
@@ -277,7 +275,7 @@ GIT_EXTERN(int) git_odb_open_rstream(git_odb_stream **stream, git_odb *db, const
  * @param data data to hash
  * @param len size of the data
  * @param type of the data to hash
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_odb_hash(git_oid *id, const void *data, size_t len, git_otype type);
 
@@ -290,7 +288,7 @@ GIT_EXTERN(int) git_odb_hash(git_oid *id, const void *data, size_t len, git_otyp
  * @param out oid structure the result is written into.
  * @param path file to read and determine object id for
  * @param type the type of the object that will be hashed
- * @return GIT_SUCCESS if valid; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_odb_hashfile(git_oid *out, const char *path, git_otype type);
 

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -61,7 +61,7 @@ struct _git_oid {
  * @param str input hex string; must be pointing at the start of
  *        the hex sequence and have at least the number of bytes
  *        needed for an oid encoded in hex (40 bytes).
- * @return GIT_SUCCESS if valid; GIT_ENOTOID on failure.
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_oid_fromstr(git_oid *out, const char *str);
 
@@ -74,7 +74,7 @@ GIT_EXTERN(int) git_oid_fromstr(git_oid *out, const char *str);
  * @param out oid structure the result is written into.
  * @param str input hex string of at least size `length`
  * @param length length of the input string
- * @return GIT_SUCCESS if valid; GIT_ENOTOID on failure.
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_oid_fromstrn(git_oid *out, const char *str, size_t length);
 

--- a/include/git2/reflog.h
+++ b/include/git2/reflog.h
@@ -46,7 +46,7 @@ GIT_BEGIN_DECL
  *
  * @param reflog pointer to reflog
  * @param ref reference to read the reflog for
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reflog_read(git_reflog **reflog, git_reference *ref);
 
@@ -64,7 +64,7 @@ GIT_EXTERN(int) git_reflog_read(git_reflog **reflog, git_reference *ref);
  * @param oid_old the OID the reference was pointing to
  * @param committer the signature of the committer
  * @param msg the reflog message
- * @return GIT_SUCCESS on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reflog_write(git_reference *ref, const git_oid *oid_old, const git_signature *committer, const char *msg);
 

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -47,7 +47,7 @@ GIT_BEGIN_DECL
  * @param reference_out pointer to the looked-up reference
  * @param repo the repository to look up the reference
  * @param name the long name for the reference (e.g. HEAD, ref/heads/master, refs/tags/v0.1.0, ...)
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_lookup(git_reference **reference_out, git_repository *repo, const char *name);
 
@@ -68,7 +68,7 @@ GIT_EXTERN(int) git_reference_lookup(git_reference **reference_out, git_reposito
  * @param name The name of the reference
  * @param target The target of the reference
  * @param force Overwrite existing references
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_create_symbolic(git_reference **ref_out, git_repository *repo, const char *name, const char *target, int force);
 
@@ -89,7 +89,7 @@ GIT_EXTERN(int) git_reference_create_symbolic(git_reference **ref_out, git_repos
  * @param name The name of the reference
  * @param id The object id pointed to by the reference.
  * @param force Overwrite existing references
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_create_oid(git_reference **ref_out, git_repository *repo, const char *name, const git_oid *id, int force);
 
@@ -142,7 +142,7 @@ GIT_EXTERN(const char *) git_reference_name(git_reference *ref);
  *
  * @param resolved_ref Pointer to the peeled reference
  * @param ref The reference
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_resolve(git_reference **resolved_ref, git_reference *ref);
 
@@ -165,7 +165,7 @@ GIT_EXTERN(git_repository *) git_reference_owner(git_reference *ref);
  *
  * @param ref The reference
  * @param target The new target for the reference
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_set_target(git_reference *ref, const char *target);
 
@@ -180,7 +180,7 @@ GIT_EXTERN(int) git_reference_set_target(git_reference *ref, const char *target)
  *
  * @param ref The reference
  * @param id The new target OID for the reference
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_set_oid(git_reference *ref, const git_oid *id);
 
@@ -222,7 +222,7 @@ GIT_EXTERN(int) git_reference_delete(git_reference *ref);
  * references previously loaded on the cache.
  *
  * @param repo Repository where the loose refs will be packed
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_packall(git_repository *repo);
 
@@ -245,7 +245,7 @@ GIT_EXTERN(int) git_reference_packall(git_repository *repo);
  * @param repo Repository where to find the refs
  * @param list_flags Filtering flags for the reference
  *		listing.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_listall(git_strarray *array, git_repository *repo, unsigned int list_flags);
 
@@ -267,7 +267,7 @@ GIT_EXTERN(int) git_reference_listall(git_strarray *array, git_repository *repo,
  *		listing.
  * @param callback Function which will be called for every listed ref
  * @param payload Additional data to pass to the callback
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_reference_foreach(git_repository *repo, unsigned int list_flags, int (*callback)(const char *, void *), void *payload);
 

--- a/include/git2/refspec.h
+++ b/include/git2/refspec.h
@@ -69,7 +69,7 @@ int git_refspec_src_match(const git_refspec *refspec, const char *refname);
  * @param outlen the size ouf the `out` buffer
  * @param spec the refspec
  * @param name the name of the reference to transform
- * @preturn GIT_SUCCESS, GIT_ESHORTBUFFER or another error
+ * @return GIT_SUCCESS, GIT_ESHORTBUFFER or another error
  */
 int git_refspec_transform(char *out, size_t outlen, const git_refspec *spec, const char *name);
 

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -53,7 +53,7 @@ GIT_BEGIN_DECL
  * @param out pointer to the new remote object
  * @param repo the associtated repository
  * @param url the remote repository's URL
- * @return GIT_SUCCESS or an error message
+ * @return GIT_SUCCESS or an error code
  */
 int git_remote_new(git_remote **out, git_repository *repo, const char *url);
 
@@ -63,7 +63,7 @@ int git_remote_new(git_remote **out, git_repository *repo, const char *url);
  * @param out pointer to the new remote object
  * @param cfg the repository's configuration
  * @param name the remote's name
- * @return 0 on success; error value otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_remote_get(struct git_remote **out, struct git_config *cfg, const char *name);
 

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -59,7 +59,7 @@ GIT_BEGIN_DECL
  *
  * @param repository pointer to the repo which will be opened
  * @param path the path to the repository
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_repository_open(git_repository **repository, const char *path);
 
@@ -88,7 +88,7 @@ GIT_EXTERN(int) git_repository_open(git_repository **repository, const char *pat
  *		Equivalent to $GIT_WORK_TREE.
  *		If NULL, the repository is assumed to be bare.
  *
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_repository_open2(git_repository **repository,
 		const char *git_dir,
@@ -123,7 +123,7 @@ GIT_EXTERN(int) git_repository_open2(git_repository **repository,
  *		Equivalent to $GIT_WORK_TREE.
  *		If NULL, the repository is assumed to be bare.
  *
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 
 GIT_EXTERN(int) git_repository_open3(git_repository **repository,
@@ -156,7 +156,7 @@ GIT_EXTERN(int) git_repository_open3(git_repository **repository,
  * lookup always performs on start_path no matter start_path appears in ceiling_dirs
  * ceiling_dirs might be NULL (which is equivalent to an empty string)
  *
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_repository_discover(char *repository_path, size_t size, const char *start_path, int across_fs, const char *ceiling_dirs);
 
@@ -184,7 +184,7 @@ GIT_EXTERN(git_odb *) git_repository_database(git_repository *repo);
  *
  * @param index Pointer where to store the index
  * @param repo a repository object
- * @return 0 on success; error code if the index could not be opened
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_repository_index(git_index **index, git_repository *repo);
 
@@ -214,7 +214,7 @@ GIT_EXTERN(void) git_repository_free(git_repository *repo);
  *		at the pointed path. If false, provided path will be considered as the working
  *		directory into which the .git directory will be created.
  *
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_repository_init(git_repository **repo_out, const char *path, unsigned is_bare);
 

--- a/include/git2/revwalk.h
+++ b/include/git2/revwalk.h
@@ -83,7 +83,7 @@ GIT_BEGIN_DECL
  *
  * @param walker pointer to the new revision walker
  * @param repo the repo to walk through
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_revwalk_new(git_revwalk **walker, git_repository *repo);
 
@@ -115,7 +115,7 @@ GIT_EXTERN(void) git_revwalk_reset(git_revwalk *walker);
  *
  * @param walk the walker being used for the traversal.
  * @param oid the oid of the commit to start from.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_revwalk_push(git_revwalk *walk, const git_oid *oid);
 
@@ -131,7 +131,7 @@ GIT_EXTERN(int) git_revwalk_push(git_revwalk *walk, const git_oid *oid);
  *
  * @param walk the walker being used for the traversal.
  * @param oid the oid of commit that will be ignored during the traversal
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_revwalk_hide(git_revwalk *walk, const git_oid *oid);
 

--- a/include/git2/signature.h
+++ b/include/git2/signature.h
@@ -46,7 +46,7 @@ GIT_BEGIN_DECL
  * @param email email of the person
  * @param time time when the action happened
  * @param offset timezone offset in minutes for the time
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_signature_new(git_signature **sig_out, const char *name, const char *email, git_time_t time, int offset);
 
@@ -57,7 +57,7 @@ GIT_EXTERN(int) git_signature_new(git_signature **sig_out, const char *name, con
  * @param sig_out new signature, in case of error NULL
  * @param name name of the person
  * @param email email of the person
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_signature_now(git_signature **sig_out, const char *name, const char *email);
 

--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -60,7 +60,7 @@ GIT_BEGIN_DECL
  *
  * @param repo a repository object
  * @param callback the function to call on each file
- * @return GIT_SUCCESS or the return value of the callback which did not return 0;
+ * @return GIT_SUCCESS or the return value of the callback which did not return GIT_SUCCESS
  */
 GIT_EXTERN(int) git_status_foreach(git_repository *repo, int (*callback)(const char *, unsigned int, void *), void *payload);
 
@@ -70,7 +70,7 @@ GIT_EXTERN(int) git_status_foreach(git_repository *repo, int (*callback)(const c
  * @param status_flags the status value
  * @param repo a repository object
  * @param path the file to retrieve status for, rooted at the repo's workdir
- * @return GIT_SUCCESS
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_status_file(unsigned int *status_flags, git_repository *repo, const char *path);
 

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -45,7 +45,7 @@ GIT_BEGIN_DECL
  * @param tag pointer to the looked up tag
  * @param repo the repo to use when locating the tag.
  * @param id identity of the tag to locate.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_tag_lookup(git_tag **tag, git_repository *repo, const git_oid *id)
 {
@@ -62,7 +62,7 @@ GIT_INLINE(int) git_tag_lookup(git_tag **tag, git_repository *repo, const git_oi
  * @param repo the repo to use when locating the tag.
  * @param id identity of the tag to locate.
  * @param len the length of the short identifier
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_tag_lookup_prefix(git_tag **tag, git_repository *repo, const git_oid *id, unsigned int len)
 {
@@ -103,7 +103,7 @@ GIT_EXTERN(const git_oid *) git_tag_id(git_tag *tag);
  *
  * @param target pointer where to store the target
  * @param tag a previously loaded tag.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_tag_target(git_object **target, git_tag *tag);
 
@@ -176,7 +176,7 @@ GIT_EXTERN(const char *) git_tag_message(git_tag *tag);
  *
  * @param force Overwrite existing references
  *
- * @return 0 on success; error code otherwise.
+ * @return GIT_SUCCESS or an error code
  *	A tag object is written to the ODB, and a proper reference
  *	is written in the /refs/tags folder, pointing to it
  */
@@ -227,7 +227,7 @@ GIT_EXTERN(int) git_tag_create_frombuffer(
  *
  * @param force Overwrite existing references
  *
- * @return 0 on success; error code otherwise.
+ * @return GIT_SUCCESS or an error code
  *	A proper reference is written in the /refs/tags folder,
  *  pointing to the provided target object
  */
@@ -246,7 +246,7 @@ GIT_EXTERN(int) git_tag_create_lightweight(
  * @param tag_name Name of the tag to be deleted;
  * this name is validated for consistency.
  *
- * @return 0 on success; error code otherwise.
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_tag_delete(
 		git_repository *repo,
@@ -263,7 +263,7 @@ GIT_EXTERN(int) git_tag_delete(
  * @param tag_names Pointer to a git_strarray structure where
  *		the tag names will be stored
  * @param repo Repository where to find the tags
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_tag_list(
 		git_strarray *tag_names,
@@ -285,7 +285,7 @@ GIT_EXTERN(int) git_tag_list(
  *		the tag names will be stored
  * @param pattern Standard fnmatch pattern
  * @param repo Repository where to find the tags
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_tag_list_match(
 		git_strarray *tag_names,

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -45,7 +45,7 @@ GIT_BEGIN_DECL
  * @param tree pointer to the looked up tree
  * @param repo the repo to use when locating the tree.
  * @param id identity of the tree to locate.
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_tree_lookup(git_tree **tree, git_repository *repo, const git_oid *id)
 {
@@ -62,7 +62,7 @@ GIT_INLINE(int) git_tree_lookup(git_tree **tree, git_repository *repo, const git
  * @param repo the repo to use when locating the tree.
  * @param id identity of the tree to locate.
  * @param len the length of the short identifier
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_INLINE(int) git_tree_lookup_prefix(git_tree **tree, git_repository *repo, const git_oid *id, unsigned int len)
 {
@@ -159,7 +159,7 @@ GIT_EXTERN(git_otype) git_tree_entry_type(const git_tree_entry *entry);
  * @param object pointer to the converted object
  * @param repo repository where to lookup the pointed object
  * @param entry a tree entry
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_tree_entry_2object(git_object **object_out, git_repository *repo, const git_tree_entry *entry);
 
@@ -177,7 +177,7 @@ GIT_EXTERN(int) git_tree_entry_2object(git_object **object_out, git_repository *
  *
  * @param oid Pointer where to store the written tree
  * @param index Index to write
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_tree_create_fromindex(git_oid *oid, git_index *index);
 
@@ -247,7 +247,7 @@ GIT_EXTERN(const git_tree_entry *) git_treebuilder_get(git_treebuilder *bld, con
  * @param filename Filename of the entry
  * @param id SHA1 oid of the entry
  * @param attributes Folder attributes of the entry
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_treebuilder_insert(git_tree_entry **entry_out, git_treebuilder *bld, const char *filename, const git_oid *id, unsigned int attributes);
 
@@ -282,7 +282,7 @@ GIT_EXTERN(void) git_treebuilder_filter(git_treebuilder *bld, int (*filter)(cons
  * @param oid Pointer where to store the written OID
  * @param repo Repository where to store the object
  * @param bld Tree builder to write
- * @return 0 on success; error code otherwise
+ * @return GIT_SUCCESS or an error code
  */
 GIT_EXTERN(int) git_treebuilder_write(git_oid *oid, git_repository *repo, git_treebuilder *bld);
 


### PR DESCRIPTION
This is a cleanup of the doxygen @return lines for functions returning an error code. Currently some refer to GIT_SUCCESS (which is #defined to 0) but the majority say "return 0 ...". And there are a number of variances due to manual editing. This provides them all a standard phrase "@return GIT_SUCCESS or an error code".

There are a few @returns with more detailed explanations of error codes. Not knowing whether the detail is important, I left them alone.

BTW I'm newish to GIt, libgit2, and GitHub.com so if there are mechanical problems with my pull requests please let me know.
