### PR TITLE
Add remotes test to clay

### DIFF
--- a/tests-clay/clay_main.c
+++ b/tests-clay/clay_main.c
@@ -684,6 +684,12 @@ extern void test_core_string__1(void);
 extern void test_core_vector__0(void);
 extern void test_core_vector__1(void);
 extern void test_core_vector__2(void);
+extern void test_network_remotes__initialize(void);
+extern void test_network_remotes__cleanup(void);
+extern void test_network_remotes__parsing(void);
+extern void test_network_remotes__refspec_parsing(void);
+extern void test_network_remotes__fnmatch(void);
+extern void test_network_remotes__transform(void);
 extern void test_status_single__hash_single_file(void);
 extern void test_status_worktree__initialize(void);
 extern void test_status_worktree__cleanup(void);
@@ -711,9 +717,13 @@ static const struct clay_func _all_callbacks[] = {
 	{"0", &test_core_vector__0, 5},
 	{"1", &test_core_vector__1, 5},
 	{"2", &test_core_vector__2, 5},
-	{"hash_single_file", &test_status_single__hash_single_file, 6},
-	{"whole_repository", &test_status_worktree__whole_repository, 7},
-	{"empty_repository", &test_status_worktree__empty_repository, 7}
+	{"parsing", &test_network_remotes__parsing, 6},
+	{"refspec_parsing", &test_network_remotes__refspec_parsing, 6},
+	{"fnmatch", &test_network_remotes__fnmatch, 6},
+	{"transform", &test_network_remotes__transform, 6},
+	{"hash_single_file", &test_status_single__hash_single_file, 7},
+	{"whole_repository", &test_status_worktree__whole_repository, 8},
+	{"empty_repository", &test_status_worktree__empty_repository, 8}
 };
 
 static const struct clay_suite _all_suites[] = {
@@ -754,26 +764,32 @@ static const struct clay_suite _all_suites[] = {
         &_all_callbacks[17], 3
     },
 	{
+        "network::remotes",
+        {"initialize", &test_network_remotes__initialize, 6},
+        {"cleanup", &test_network_remotes__cleanup, 6},
+        &_all_callbacks[20], 4
+    },
+	{
         "status::single",
         {NULL, NULL, 0},
         {NULL, NULL, 0},
-        &_all_callbacks[20], 1
+        &_all_callbacks[24], 1
     },
 	{
         "status::worktree",
-        {"initialize", &test_status_worktree__initialize, 7},
-        {"cleanup", &test_status_worktree__cleanup, 7},
-        &_all_callbacks[21], 2
+        {"initialize", &test_status_worktree__initialize, 8},
+        {"cleanup", &test_status_worktree__cleanup, 8},
+        &_all_callbacks[25], 2
     }
 };
 
-static const char _suites_str[] = "core::dirent, core::filebuf, core::path, core::rmdir, core::string, core::vector, status::single, status::worktree";
+static const char _suites_str[] = "core::dirent, core::filebuf, core::path, core::rmdir, core::string, core::vector, network::remotes, status::single, status::worktree";
 
 int _CC main(int argc, char *argv[])
 {
     return clay_test(
         argc, argv, _suites_str,
-        _all_callbacks, 23,
-        _all_suites, 8
+        _all_callbacks, 27,
+        _all_suites, 9
     );
 }

--- a/tests-clay/network/remotes.c
+++ b/tests-clay/network/remotes.c
@@ -1,0 +1,52 @@
+#include "clay_libgit2.h"
+
+#define REPOSITORY_FOLDER "testrepo.git"
+
+static git_remote *remote;
+static git_repository *repo;
+static git_config *cfg;
+static const git_refspec *refspec;
+
+void test_network_remotes__initialize(void)
+{
+	cl_fixture_sandbox(REPOSITORY_FOLDER);
+	cl_git_pass(git_repository_open(&repo, REPOSITORY_FOLDER));
+	cl_git_pass(git_repository_config(&cfg, repo, NULL, NULL));
+	cl_git_pass(git_remote_get(&remote, cfg, "test"));
+	refspec = git_remote_fetchspec(remote);
+	cl_assert(refspec != NULL);
+}
+
+void test_network_remotes__cleanup(void)
+{
+	git_config_free(cfg);
+	git_repository_free(repo);
+	git_remote_free(remote);
+}
+
+void test_network_remotes__parsing(void)
+{
+	cl_assert(!strcmp(git_remote_name(remote), "test"));
+	cl_assert(!strcmp(git_remote_url(remote), "git://github.com/libgit2/libgit2"));
+}
+
+void test_network_remotes__refspec_parsing(void)
+{
+	cl_assert(!strcmp(git_refspec_src(refspec), "refs/heads/*"));
+	cl_assert(!strcmp(git_refspec_dst(refspec), "refs/remotes/test/*"));
+}
+
+void test_network_remotes__fnmatch(void)
+{
+	cl_git_pass(git_refspec_src_match(refspec, "refs/heads/master"));
+	cl_git_pass(git_refspec_src_match(refspec, "refs/heads/multi/level/branch"));
+}
+
+void test_network_remotes__transform(void)
+{
+	char ref[1024];
+
+	memset(ref, 0x0, sizeof(ref));
+	cl_git_pass(git_refspec_transform(ref, sizeof(ref), refspec, "refs/heads/master"));
+	cl_assert(!strcmp(ref, "refs/remotes/test/master"));
+}


### PR DESCRIPTION
This depends on PR #399 getting merged, as it segfaults otherwise.
