### PR TITLE
Don't use '__attribute__ visibility' with gcc unless it's at version 4 or better

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -40,7 +40,7 @@
 #endif
 
 /** Declare a public function exported for application use. */
-#ifdef __GNUC__
+#if __GNUC__ >= 4
 # define GIT_EXTERN(type) extern \
 			  __attribute__((visibility("default"))) \
 			  type
@@ -51,7 +51,7 @@
 #endif
 
 /** Declare a public TLS symbol exported for application use. */
-#ifdef __GNUC__
+#if __GNUC__ >= 4
 # define GIT_EXTERN_TLS(type) extern \
 			      __attribute__((visibility("default"))) \
 			      GIT_TLS \


### PR DESCRIPTION
While building libgit2 on an old linux machine using gcc 3.2.3 I found that gcc 3.x does not support **attribute**((visibility)). This is a patch to allow libgit2 to build with gcc3.

Note: there's a similar problem that -Wextra isn't recognized by gcc3. I hacked around this but don't know enough about CMake to submit a patch for it.
