### PR TITLE
Missing prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ IF (BUILD_TESTS)
 ENDIF ()
 
 IF (BUILD_CLAY)
+	SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wextra -Wstrict-aliasing=2 -Wstrict-prototypes")
 	SET(CLAY_FIXTURES "${CMAKE_CURRENT_SOURCE_DIR}/tests/resources/")
 	ADD_DEFINITIONS(-DCLAY_FIXTURE_PATH=\"${CLAY_FIXTURES}\")
 


### PR DESCRIPTION
1ba2fc6b shouldn't get merged, but Clay shouldn't require any compiler / build system tweaks, no.?
