### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ OPTION (BUILD_CLAY "Build Tests using the Clay suite" ON)
 
 # Platform specific compilation flags
 IF (MSVC)
-	SET(CMAKE_C_FLAGS "/W4 /WX /nologo /Zi")
+	SET(CMAKE_C_FLAGS "/W4 /WX /nologo /Zi /wd4127")
 	IF (STDCALL)
 	  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gz")
 	ENDIF ()

--- a/deps/http-parser/http_parser.h
+++ b/deps/http-parser/http_parser.h
@@ -201,13 +201,13 @@ enum http_errno {
 
 struct http_parser {
   /** PRIVATE **/
-  unsigned char type : 2;
-  unsigned char flags : 6; /* F_* values from 'flags' enum; semi-public */
+  unsigned int type : 2;
+  unsigned int flags : 6; /* F_* values from 'flags' enum; semi-public */
   unsigned char state;
   unsigned char header_state;
   unsigned char index;
 
-  uint32_t nread;
+  uint64_t nread;
   int64_t content_length;
 
   /** READ-ONLY **/
@@ -215,14 +215,14 @@ struct http_parser {
   unsigned short http_minor;
   unsigned short status_code; /* responses only */
   unsigned char method;    /* requests only */
-  unsigned char http_errno : 7;
+  unsigned int http_errno : 7;
 
   /* 1 = Upgrade header was present and the parser has exited because of that.
    * 0 = No upgrade header present.
    * Should be checked when http_parser_execute() returns in addition to
    * error checking.
    */
-  unsigned char upgrade : 1;
+  unsigned int upgrade : 1;
 
 #if HTTP_PARSER_DEBUG
   uint32_t error_lineno;

--- a/src/transport-http.c
+++ b/src/transport-http.c
@@ -33,11 +33,11 @@
 #include "buffer.h"
 #include "pkt.h"
 
-typedef enum {
+enum last_cb {
 	NONE,
 	FIELD,
 	VALUE
-} last_cb_type;
+};
 
 typedef struct {
 	git_transport parent;
@@ -48,8 +48,8 @@ typedef struct {
 	int error;
 	int transfer_finished :1,
 		ct_found :1,
-		ct_finished :1,
-		last_cb :3;
+		ct_finished :1;
+	enum last_cb last_cb;
 	char *content_type;
 	char *service;
 } transport_http;
@@ -75,10 +75,13 @@ static int gen_request(git_buf *buf, const char *url, const char *host, const ch
 
 static int do_connect(transport_http *t, const char *service)
 {
-	int s = -1, error;;
-	const char *url = t->parent.url, *prefix = "http://";
-	char *host = NULL, *port = NULL;
 	git_buf request = GIT_BUF_INIT;
+	int s = -1, error;
+	const char *url, *prefix;
+	char *host = NULL, *port = NULL;
+
+	url = t->parent.url;
+	prefix = "http://";
 
 	if (!git__prefixcmp(url, prefix))
 		url += strlen(prefix);


### PR DESCRIPTION
The real work was done by @nulltoken, who fixed the variable definition quirks. The rest is mostly just disabling a few warnings.
