### PR TITLE
Implment p_access and use it in git_fileutils_exists

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -127,7 +127,7 @@ int git_futils_isfile(const char *path)
 int git_futils_exists(const char *path)
 {
 	assert(path);
-	return access(path, F_OK);
+	return p_access(path, F_OK);
 }
 
 git_off_t git_futils_filesize(git_file fd)

--- a/src/posix.h
+++ b/src/posix.h
@@ -52,6 +52,7 @@ extern char* p_getenv(const char* name);
 #define p_chdir(p) chdir(p)
 #define p_rmdir(p) rmdir(p)
 #define p_chmod(p,m) chmod(p, m)
+#define p_access(p,m) access(p,m)
 
 #endif
 

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -43,6 +43,6 @@ extern int p_stat(const char* path, struct stat* buf);
 extern int p_chdir(const char* path);
 extern int p_chmod(const char* path, int mode);
 extern int p_rmdir(const char* path);
-
+extern int p_access(const char* path, int mode);
 
 #endif

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -401,3 +401,14 @@ int p_setenv(const char* name, const char* value, int overwrite)
 
 	return (SetEnvironmentVariableA(name, value) == 0 ? GIT_EOSERR : GIT_SUCCESS);
 }
+
+int p_access(const char* path, int mode)
+{
+	wchar_t *buf = conv_utf8_to_utf16(path);
+	int ret;
+
+	ret = _waccess(buf, mode);
+	free(buf);
+
+	return ret;
+}


### PR DESCRIPTION
What the title says. It looks quite straightforward and the tests pass, but since we don't really test the correctness of the Unicode FS access, who knows.
