### PR TITLE
Make git_oid_fromstrn support hex strings of odd length

### DIFF
--- a/src/oid.c
+++ b/src/oid.c
@@ -54,6 +54,9 @@ int git_oid_fromstrn(git_oid *out, const char *str, size_t length)
 
 	if (length % 2) {
 		v = (from_hex[(unsigned char)str[p + 0]] << 4);
+		if (v < 0)
+			return git__throw(GIT_ENOTOID, "Failed to generate sha1. Given string is not a valid sha1 hash");
+
 		out->id[p / 2] = (unsigned char)v;
 		p += 2;
 	}


### PR DESCRIPTION
This fixes issue 433.
