### PR TITLE
ignore missing pack file

### DIFF
--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -224,7 +224,10 @@ static int packfile_load__cb(void *_data, char *path)
 	}
 
 	error = git_packfile_check(&pack, path);
-	if (error < GIT_SUCCESS)
+	if (error == GIT_ENOTFOUND) {
+		/* ignore missing .pack file as git does */
+		return GIT_SUCCESS;
+	} else if (error < GIT_SUCCESS)
 		return git__rethrow(error, "Failed to load packfile");
 
 	if (git_vector_insert(&backend->packs, pack) < GIT_SUCCESS) {


### PR DESCRIPTION
libgit2 should ignore a missing .pack-file as git does and not refuse to load a whole directory.

This problem seems to occour for several people, see https://tortoisegit.org/issue/862 and https://tortoisegit.org/issue/903 to pick only two bug reports.

You can find a demo repository in comment 18 (https://tortoisegit.org/issue/862#c18).
