### PR TITLE
fix build for x64

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -64,7 +64,7 @@
 # define GIT_FORMAT_PRINTF(a,b) /* empty */
 #endif
 
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if (defined(_WIN32) || defined(_WIN64)) && !defined(__CYGWIN__)
 #define GIT_WIN32 1
 #endif
 


### PR DESCRIPTION
This change is still missing in development branch in order to make it work on Windows x64, but it was included in issue #442 and got lost for 0.15.0. :(
