### PR TITLE
odb_pack: don't do ambiguity checks for fully qualified SHA1 hashes

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -722,7 +722,7 @@ static int pack_entry_find_offset(
 		}
 	}
 
-	if (found && pos + 1 < (int)p->num_objects) {
+	if (found && len != GIT_OID_HEXSZ && pos + 1 < (int)p->num_objects) {
 		/* Check for ambiguousity */
 		const unsigned char *next = current + stride;
 


### PR DESCRIPTION
This makes libgit2 more closely match Git, which only checks for ambiguous pack entries when given short hashes.

Note that the only time this is ever relevant is when a pack has the same object more than once (it's happened in the wild, I promise).

(I've made this fix against master so it can be rolled into a 0.15.1 stable release.)
