### PR TITLE
Created typedefs for all function pointers

### DIFF
--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -19,6 +19,12 @@
  */
 GIT_BEGIN_DECL
 
+typedef int (*git_config_file_open_cb)(struct git_config_file *);
+typedef int (*git_config_file_get_cb)(struct git_config_file *, const char *key, const char **value);
+typedef int (*git_config_file_set_cb)(struct git_config_file *, const char *key, const char *value);
+typedef int (*git_config_file_foreach_cb)(struct git_config_file *, int (*fn)(const char *, const char *, void *), void *data);
+typedef void (*git_config_file_free_cb)(struct git_config_file *);
+
 /**
  * Generic backend that implements the interface to
  * access a configuration file
@@ -27,11 +33,11 @@ struct git_config_file {
 	struct git_config *cfg;
 
 	/* Open means open the file/database and parse if necessary */
-	int (*open)(struct git_config_file *);
-	int (*get)(struct git_config_file *, const char *key, const char **value);
-	int (*set)(struct git_config_file *, const char *key, const char *value);
-	int (*foreach)(struct git_config_file *, int (*fn)(const char *, const char *, void *), void *data);
-	void (*free)(struct git_config_file *);
+	git_config_file_open_cb open;
+	git_config_file_get_cb get;
+	git_config_file_set_cb set;
+	git_config_file_foreach_cb foreach;
+	git_config_file_free_cb free;
 };
 
 /**
@@ -255,6 +261,7 @@ GIT_EXTERN(int) git_config_set_string(git_config *cfg, const char *name, const c
  */
 GIT_EXTERN(int) git_config_delete(git_config *cfg, const char *name);
 
+typedef int (*git_config_cb)(const char *var_name, const char *value, void *payload);
 /**
  * Perform an operation on each config variable.
  *
@@ -270,7 +277,7 @@ GIT_EXTERN(int) git_config_delete(git_config *cfg, const char *name);
  */
 GIT_EXTERN(int) git_config_foreach(
 	git_config *cfg,
-	int (*callback)(const char *var_name, const char *value, void *payload),
+	git_config_cb callback,
 	void *payload);
 
 /** @} */

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -20,16 +20,54 @@
  */
 GIT_BEGIN_DECL
 
+typedef int (* git_odb_backend_read_cb)(
+	void **, size_t *, git_otype *,
+	struct git_odb_backend *,
+	const git_oid *);
+
+typedef int (* git_odb_backend_read_prefix_cb)(
+	git_oid *,
+	void **, size_t *, git_otype *,
+	struct git_odb_backend *,
+	const git_oid *,
+	unsigned int);
+
+typedef int (* git_odb_backend_read_header_cb)(
+	size_t *, git_otype *,
+	struct git_odb_backend *,
+	const git_oid *);
+
+typedef int (* git_odb_backend_write_cb)(
+	git_oid *,
+	struct git_odb_backend *,
+	const void *,
+	size_t,
+	git_otype);
+
+typedef int (* git_odb_backend_writestream_cb)(
+	struct git_odb_stream **,
+	struct git_odb_backend *,
+	size_t,
+	git_otype);
+
+typedef int (* git_odb_backend_readstream_cb)(
+	struct git_odb_stream **,
+	struct git_odb_backend *,
+	const git_oid *);
+
+typedef int (* git_odb_backend_exists_cb)(
+	struct git_odb_backend *,
+	const git_oid *);
+
+typedef void (* git_odb_backend_free_cb)(struct git_odb_backend *);
+
 struct git_odb_stream;
 
 /** An instance for a custom backend */
 struct git_odb_backend {
 	git_odb *odb;
 
-	int (* read)(
-			void **, size_t *, git_otype *,
-			struct git_odb_backend *,
-			const git_oid *);
+	git_odb_backend_read_cb read;
 
 	/* To find a unique object given a prefix
 	 * of its oid.
@@ -37,52 +75,35 @@ struct git_odb_backend {
 	 * remaining (GIT_OID_HEXSZ - len)*4 bits
 	 * are 0s.
 	 */
-	int (* read_prefix)(
-			git_oid *,
-			void **, size_t *, git_otype *,
-			struct git_odb_backend *,
-			const git_oid *,
-			unsigned int);
+	git_odb_backend_read_prefix_cb read_prefix;
 
-	int (* read_header)(
-			size_t *, git_otype *,
-			struct git_odb_backend *,
-			const git_oid *);
+	git_odb_backend_read_header_cb read_header;
 
-	int (* write)(
-			git_oid *,
-			struct git_odb_backend *,
-			const void *,
-			size_t,
-			git_otype);
+	git_odb_backend_write_cb write;
 
-	int (* writestream)(
-			struct git_odb_stream **,
-			struct git_odb_backend *,
-			size_t,
-			git_otype);
+	git_odb_backend_writestream_cb writestream;
 
-	int (* readstream)(
-			struct git_odb_stream **,
-			struct git_odb_backend *,
-			const git_oid *);
+	git_odb_backend_readstream_cb readstream;
 
-	int (* exists)(
-			struct git_odb_backend *,
-			const git_oid *);
+	git_odb_backend_exists_cb exists;
 
-	void (* free)(struct git_odb_backend *);
+	git_odb_backend_free_cb free;
 };
+
+typedef int (*git_odb_stream_read_cb)(struct git_odb_stream *stream, char *buffer, size_t len);
+typedef int (*git_odb_stream_write_cb)(struct git_odb_stream *stream, const char *buffer, size_t len);
+typedef int (*git_odb_stream_finalize_write_cb)(git_oid *oid_p, struct git_odb_stream *stream);
+typedef void (*git_odb_stream_free_cb)(struct git_odb_stream *stream);
 
 /** A stream to read/write from a backend */
 struct git_odb_stream {
 	struct git_odb_backend *backend;
 	int mode;
 
-	int (*read)(struct git_odb_stream *stream, char *buffer, size_t len);
-	int (*write)(struct git_odb_stream *stream, const char *buffer, size_t len);
-	int (*finalize_write)(git_oid *oid_p, struct git_odb_stream *stream);
-	void (*free)(struct git_odb_stream *stream);
+	git_odb_stream_read_cb read;
+	git_odb_stream_write_cb write;
+	git_odb_stream_finalize_write_cb finalize_write;
+	git_odb_stream_free_cb free;
 };
 
 /** Streaming mode */

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -243,6 +243,7 @@ GIT_EXTERN(int) git_reference_packall(git_repository *repo);
 GIT_EXTERN(int) git_reference_listall(git_strarray *array, git_repository *repo, unsigned int list_flags);
 
 
+typedef int (*git_reference_cb)(const char *, void *);
 /**
  * Perform an operation on each reference in the repository
  *
@@ -262,7 +263,7 @@ GIT_EXTERN(int) git_reference_listall(git_strarray *array, git_repository *repo,
  * @param payload Additional data to pass to the callback
  * @return GIT_SUCCESS or an error code
  */
-GIT_EXTERN(int) git_reference_foreach(git_repository *repo, unsigned int list_flags, int (*callback)(const char *, void *), void *payload);
+GIT_EXTERN(int) git_reference_foreach(git_repository *repo, unsigned int list_flags, git_reference_cb callback, void *payload);
 
 /**
  * Check if a reference has been loaded from a packfile

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -241,6 +241,7 @@ GIT_EXTERN(int) git_treebuilder_insert(git_tree_entry **entry_out, git_treebuild
  */
 GIT_EXTERN(int) git_treebuilder_remove(git_treebuilder *bld, const char *filename);
 
+typedef int (*git_filter_cb)(const git_tree_entry *, void *);
 /**
  * Filter the entries in the tree
  *
@@ -252,7 +253,7 @@ GIT_EXTERN(int) git_treebuilder_remove(git_treebuilder *bld, const char *filenam
  * @param bld Tree builder
  * @param filter Callback to filter entries
  */
-GIT_EXTERN(void) git_treebuilder_filter(git_treebuilder *bld, int (*filter)(const git_tree_entry *, void *), void *payload);
+GIT_EXTERN(void) git_treebuilder_filter(git_treebuilder *bld, git_filter_cb filter, void *payload);
 
 /**
  * Write the contents of the tree builder as a tree object

--- a/src/config.c
+++ b/src/config.c
@@ -139,7 +139,7 @@ int git_config_add_file(git_config *cfg, git_config_file *file, int priority)
  * Loop over all the variables
  */
 
-int git_config_foreach(git_config *cfg, int (*fn)(const char *, const char *, void *), void *data)
+int git_config_foreach(git_config *cfg, git_config_cb fn, void *data)
 {
 	int ret = GIT_SUCCESS;
 	unsigned int i;

--- a/src/refs.c
+++ b/src/refs.c
@@ -1467,7 +1467,7 @@ int git_reference_packall(git_repository *repo)
 int git_reference_foreach(
 	git_repository *repo,
 	unsigned int list_flags,
-	int (*callback)(const char *, void *),
+	git_reference_cb callback,
 	void *payload)
 {
 	int error;

--- a/src/tree.c
+++ b/src/tree.c
@@ -576,7 +576,7 @@ int git_treebuilder_write(git_oid *oid, git_repository *repo, git_treebuilder *b
 	return error == GIT_SUCCESS ? GIT_SUCCESS : git__rethrow(error, "Failed to write tree");
 }
 
-void git_treebuilder_filter(git_treebuilder *bld, int (*filter)(const git_tree_entry *, void *), void *payload)
+void git_treebuilder_filter(git_treebuilder *bld, git_filter_cb filter, void *payload)
 {
 	unsigned int i;
 


### PR DESCRIPTION
I've been working on a Vala binding per #189 and it is difficult for Vala to deal with function pointers that do not have typedefs. This patch changes all the unadorned function pointers to typedefs.
