### PR TITLE
Fix typo in repository documentation

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -277,7 +277,7 @@ GIT_EXTERN(const char *) git_repository_path(git_repository *repo, git_repositor
  * Check if a repository is bare
  *
  * @param repo Repo to test
- * @return 1 if the repository is empty, 0 otherwise.
+ * @return 1 if the repository is bare, 0 otherwise.
  */
 GIT_EXTERN(int) git_repository_is_bare(git_repository *repo);
 


### PR DESCRIPTION
It's incorrect to imply a bare repository is always empty. :)
