### PR TITLE
Optimized implementation of git_buf_join

### DIFF
--- a/tests-clay/clay.h
+++ b/tests-clay/clay.h
@@ -92,6 +92,7 @@ extern void test_core_buffer__5(void);
 extern void test_core_buffer__6(void);
 extern void test_core_buffer__7(void);
 extern void test_core_buffer__8(void);
+extern void test_core_buffer__9(void);
 extern void test_core_dirent__dont_traverse_dot(void);
 extern void test_core_dirent__dont_traverse_empty_folders(void);
 extern void test_core_dirent__traverse_slash_terminated_folder(void);

--- a/tests-clay/clay_libgit2.h
+++ b/tests-clay/clay_libgit2.h
@@ -29,15 +29,16 @@
  * Wrapper for string comparison that knows about nulls.
  */
 #define cl_assert_strequal(a,b) \
-	cl_assert_strequal_internal(a,b,__FILE__,__LINE__)
+	cl_assert_strequal_internal(a,b,__FILE__,__LINE__,"string mismatch: " #a " != " #b)
 
-GIT_INLINE(void) cl_assert_strequal_internal(const char *a, const char *b, const char *file, int line)
+GIT_INLINE(void) cl_assert_strequal_internal(
+	const char *a, const char *b, const char *file, int line, const char *err)
 {
 	int match = (a == NULL || b == NULL) ? (a == b) : (strcmp(a, b) == 0);
 	if (!match) {
 		char buf[4096];
 		snprintf(buf, 4096, "'%s' != '%s'", a, b);
-		clay__assert(0, file, line, buf, "Strings do not match", 1);
+		clay__assert(0, file, line, buf, err, 1);
 	}
 }
 

--- a/tests-clay/clay_main.c
+++ b/tests-clay/clay_main.c
@@ -145,7 +145,8 @@ static const struct clay_func _clay_cb_core_buffer[] = {
 	{"5", &test_core_buffer__5},
 	{"6", &test_core_buffer__6},
 	{"7", &test_core_buffer__7},
-	{"8", &test_core_buffer__8}
+	{"8", &test_core_buffer__8},
+	{"9", &test_core_buffer__9}
 };
 static const struct clay_func _clay_cb_core_dirent[] = {
     {"dont_traverse_dot", &test_core_dirent__dont_traverse_dot},
@@ -326,7 +327,7 @@ static const struct clay_suite _clay_suites[] = {
         "core::buffer",
         {NULL, NULL},
         {NULL, NULL},
-        _clay_cb_core_buffer, 9
+        _clay_cb_core_buffer, 10
     },
 	{
         "core::dirent",
@@ -493,7 +494,7 @@ static const struct clay_suite _clay_suites[] = {
 };
 
 static size_t _clay_suite_count = 34;
-static size_t _clay_callback_count = 112;
+static size_t _clay_callback_count = 113;
 
 /* Core test functions */
 static void


### PR DESCRIPTION
This update streamlines git_buf_join and removes the join-append behavior, opting instead for a very compact join-replace of the git_buf contents. As an extra benefit, if separator == 0, this now just joins the two strings into the buffer.

The unit tests had to be updated to remove the join-append tests and have a bunch more exhaustive tests added.

I'm pretty pleased with how the compact version turned out. What do you think?
