### PR TITLE
Use dynamic allocation for paths instead of stack-based buffers

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -67,12 +67,13 @@ int git_blob_create_frombuffer(git_oid *oid, git_repository *repo, const void *b
 
 int git_blob_create_fromfile(git_oid *oid, git_repository *repo, const char *path)
 {
-	int error, islnk;
+	int error = GIT_SUCCESS;
+	int islnk = 0;
 	int fd = 0;
-	char full_path[GIT_PATH_MAX];
+	git_buf full_path = GIT_BUF_INIT;
 	char buffer[2048];
 	git_off_t size;
-	git_odb_stream *stream;
+	git_odb_stream *stream = NULL;
 	struct stat st;
 	const char *workdir;
 	git_odb *odb;
@@ -81,11 +82,14 @@ int git_blob_create_fromfile(git_oid *oid, git_repository *repo, const char *pat
 	if (workdir == NULL)
 		return git__throw(GIT_ENOTFOUND, "Failed to create blob. (No working directory found)");
 
-	git_path_join(full_path, workdir, path);
+	error = git_buf_joinpath(&full_path, workdir, path);
+	if (error < GIT_SUCCESS)
+		return error;
 
-	error = p_lstat(full_path, &st);
+	error = p_lstat(full_path.ptr, &st);
 	if (error < 0) {
-		return git__throw(GIT_EOSERR, "Failed to stat blob. %s", strerror(errno));
+		error = git__throw(GIT_EOSERR, "Failed to stat blob. %s", strerror(errno));
+		goto cleanup;
 	}
 
 	islnk = S_ISLNK(st.st_mode);
@@ -93,18 +97,18 @@ int git_blob_create_fromfile(git_oid *oid, git_repository *repo, const char *pat
 
 	error = git_repository_odb__weakptr(&odb, repo);
 	if (error < GIT_SUCCESS)
-		return error;
+		goto cleanup;
 
 	if (!islnk) {
-		if ((fd = p_open(full_path, O_RDONLY)) < 0)
-			return git__throw(GIT_ENOTFOUND, "Failed to create blob. Could not open '%s'", full_path);
+		if ((fd = p_open(full_path.ptr, O_RDONLY)) < 0) {
+			error = git__throw(GIT_ENOTFOUND, "Failed to create blob. Could not open '%s'", full_path.ptr
+);
+			goto cleanup;
+		}
 	}
 
-	if ((error = git_odb_open_wstream(&stream, odb, (size_t)size, GIT_OBJ_BLOB)) < GIT_SUCCESS) {
-		if (!islnk)
-			p_close(fd);
-		return git__rethrow(error, "Failed to create blob");
-	}
+	if ((error = git_odb_open_wstream(&stream, odb, (size_t)size, GIT_OBJ_BLOB)) < GIT_SUCCESS)
+		goto cleanup;
 
 	while (size > 0) {
 		ssize_t read_len;
@@ -112,13 +116,11 @@ int git_blob_create_fromfile(git_oid *oid, git_repository *repo, const char *pat
 		if (!islnk)
 			read_len = p_read(fd, buffer, sizeof(buffer));
 		else
-			read_len = p_readlink(full_path, buffer, sizeof(buffer));
+			read_len = p_readlink(full_path.ptr, buffer, sizeof(buffer));
 
 		if (read_len < 0) {
-			if (!islnk)
-				p_close(fd);
-			stream->free(stream);
-			return git__throw(GIT_EOSERR, "Failed to create blob. Can't read full file");
+			error = git__throw(GIT_EOSERR, "Failed to create blob. Can't read full file");
+			goto cleanup;
 		}
 
 		stream->write(stream, buffer, read_len);
@@ -126,10 +128,15 @@ int git_blob_create_fromfile(git_oid *oid, git_repository *repo, const char *pat
 	}
 
 	error = stream->finalize_write(oid, stream);
-	stream->free(stream);
-	if (!islnk)
-		p_close(fd);
 
-	return error == GIT_SUCCESS ? GIT_SUCCESS : git__rethrow(error, "Failed to create blob");
+cleanup:
+	if (stream)
+		stream->free(stream);
+	if (!islnk && fd)
+		p_close(fd);
+	git_buf_free(&full_path);
+
+	return error == GIT_SUCCESS ? GIT_SUCCESS :
+		git__rethrow(error, "Failed to create blob");
 }
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -18,34 +18,87 @@ extern char git_buf_initbuf[];
 
 #define GIT_BUF_INIT { git_buf_initbuf, 0, 0 }
 
+/**
+ * Initialize a git_buf structure.
+ *
+ * For the cases where GIT_BUF_INIT cannot be used to do static
+ * initialization.
+ */
 void git_buf_init(git_buf *buf, size_t initial_size);
-int git_buf_grow(git_buf *buf, size_t target_size);
-void git_buf_free(git_buf *buf);
-void git_buf_swap(git_buf *buf_a, git_buf *buf_b);
 
 /**
+ * Grow the buffer to hold at least `target_size` bytes.
+ *
+ * If the allocation fails, this will return an error and the buffer
+ * will be marked as invalid for future operations.  The existing
+ * contents of the buffer will be preserved however.
+ * @return GIT_SUCCESS or GIT_ENOMEM on failure
+ */
+int git_buf_grow(git_buf *buf, size_t target_size);
+
+/**
+ * Attempt to grow the buffer to hold at least `target_size` bytes.
+ *
+ * This is just like `git_buf_grow` except that even if the allocation
+ * fails, the git_buf will still be left in a valid state.
+ */
+int git_buf_try_grow(git_buf *buf, size_t target_size);
+
+void git_buf_free(git_buf *buf);
+void git_buf_swap(git_buf *buf_a, git_buf *buf_b);
+char *git_buf_detach(git_buf *buf);
+void git_buf_attach(git_buf *buf, char *ptr, ssize_t asize);
+
+/**
+ * Test if there have been any reallocation failures with this git_buf.
+ *
  * Any function that writes to a git_buf can fail due to memory allocation
  * issues.  If one fails, the git_buf will be marked with an OOM error and
- * further calls to modify the buffer will fail.  You just check
- * git_buf_oom() at the end of your sequence and it will be true if you ran
- * out of memory at any point with that buffer.
+ * further calls to modify the buffer will fail.  Check git_buf_oom() at the
+ * end of your sequence and it will be true if you ran out of memory at any
+ * point with that buffer.
+ * @return 0 if no error, 1 if allocation error.
  */
 int git_buf_oom(const git_buf *buf);
 
-void git_buf_set(git_buf *buf, const char *data, size_t len);
-void git_buf_sets(git_buf *buf, const char *string);
-void git_buf_putc(git_buf *buf, char c);
-void git_buf_put(git_buf *buf, const char *data, size_t len);
-void git_buf_puts(git_buf *buf, const char *string);
-void git_buf_printf(git_buf *buf, const char *format, ...) GIT_FORMAT_PRINTF(2, 3);
+/**
+ * Just like git_buf_oom, except returns appropriate error code.
+ * @return GIT_ENOMEM if allocation error, GIT_SUCCESS if not.
+ */
+int git_buf_lasterror(const git_buf *buf);
+
+/*
+ * The functions below that return int values, will return GIT_ENOMEM
+ * if they fail to expand the git_buf when they are called, otherwise
+ * GIT_SUCCESS.  Passing a git_buf that has failed an allocation will
+ * automatically return GIT_ENOMEM for all further calls.  As a result,
+ * you can ignore the return code of these functions and call them in a
+ * series then just call git_buf_lasterror at the end.
+ */
+int git_buf_set(git_buf *buf, const char *data, size_t len);
+int git_buf_sets(git_buf *buf, const char *string);
+int git_buf_putc(git_buf *buf, char c);
+int git_buf_put(git_buf *buf, const char *data, size_t len);
+int git_buf_puts(git_buf *buf, const char *string);
+int git_buf_printf(git_buf *buf, const char *format, ...) GIT_FORMAT_PRINTF(2, 3);
 void git_buf_clear(git_buf *buf);
 void git_buf_consume(git_buf *buf, const char *end);
-void git_buf_join_n(git_buf *buf, char separator, int nbuf, ...);
-void git_buf_join(git_buf *buf, char separator, const char *str_a, const char *str_b);
+void git_buf_truncate(git_buf *buf, ssize_t len);
+
+int git_buf_join_n(git_buf *buf, char separator, int nbuf, ...);
+int git_buf_join(git_buf *buf, char separator, const char *str_a, const char *str_b);
+
+/**
+ * Join two strings as paths, inserting a slash between as needed.
+ * @return error code or GIT_SUCCESS
+ */
+GIT_INLINE (int) git_buf_joinpath(git_buf *buf, const char *a, const char *b)
+{
+	return git_buf_join(buf, '/', a, b);
+}
 
 const char *git_buf_cstr(git_buf *buf);
-char *git_buf_take_cstr(git_buf *buf);
-void git_buf_copy_cstr(char *data, size_t datasize, git_buf *buf);
+void git_buf_copy_cstr(char *data, size_t datasize, const git_buf *buf);
 
 #define git_buf_PUTS(buf, str) git_buf_put(buf, str, sizeof(str) - 1)
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -129,7 +129,8 @@ int git_commit_create(
 	git_buf_puts(&commit, message);
 
 	if (git_buf_oom(&commit)) {
-		error = git__throw(GIT_ENOMEM, "Not enough memory to build the commit data");
+		error = git__throw(git_buf_lasterror(&commit),
+			"Not enough memory to build the commit data");
 		goto cleanup;
 	}
 

--- a/src/config.h
+++ b/src/config.h
@@ -21,4 +21,7 @@ struct git_config {
 	git_vector files;
 };
 
+extern int git_config_find_global_r(git_buf *global_config_path);
+extern int git_config_find_system_r(git_buf *system_config_path);
+
 #endif

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -196,18 +196,19 @@ int git_filebuf_open(git_filebuf *file, const char *path, int flags)
 
 	/* If we are writing to a temp file */
 	if (flags & GIT_FILEBUF_TEMPORARY) {
-		char tmp_path[GIT_PATH_MAX];
+		git_buf tmp_path = GIT_BUF_INIT;
 
 		/* Open the file as temporary for locking */
-		file->fd = git_futils_mktmp(tmp_path, path);
+		file->fd = git_futils_mktmp(&tmp_path, path);
 		if (file->fd < 0) {
+			git_buf_free(&tmp_path);
 			error = GIT_EOSERR;
 			goto cleanup;
 		}
 
 		/* No original path */
 		file->path_original = NULL;
-		file->path_lock = git__strdup(tmp_path);
+		file->path_lock = git_buf_detach(&tmp_path);
 
 		if (file->path_lock == NULL) {
 			error = GIT_ENOMEM;

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -28,6 +28,7 @@ typedef struct { /* file io buffer */
 extern int git_futils_readbuffer(git_fbuffer *obj, const char *path);
 extern int git_futils_readbuffer_updated(git_fbuffer *obj, const char *path, time_t *mtime, int *updated);
 extern void git_futils_freebuffer(git_fbuffer *obj);
+extern void git_futils_fbuffer_rtrim(git_fbuffer *obj);
 
 /**
  * File utils
@@ -72,9 +73,25 @@ extern int git_futils_isdir(const char *path);
 extern int git_futils_isfile(const char *path);
 
 /**
+ * Check if the given path contains the given subdirectory.
+ *
+ * If `append_if_exists` is true, then the subdir will be appended to the
+ * parent path if it does exists.
+ */
+extern int git_futils_contains_dir(git_buf *parent, const char *subdir, int append_if_exists);
+
+/**
+ * Check if the given path contains the given file
+ *
+ * If `append_if_exists` is true, then the filename will be appended to the
+ * parent path if it does exists.
+ */
+extern int git_futils_contains_file(git_buf *parent, const char *file, int append_if_exists);
+
+/**
  * Create a path recursively
  */
-extern int git_futils_mkdir_r(const char *path, const mode_t mode);
+extern int git_futils_mkdir_r(const char *path, const char *base, const mode_t mode);
 
 /**
  * Create all the folders required to contain
@@ -85,9 +102,11 @@ extern int git_futils_mkpath2file(const char *path, const mode_t mode);
 extern int git_futils_rmdir_r(const char *path, int force);
 
 /**
- * Create and open a temporary file with a `_git2_` suffix
+ * Create and open a temporary file with a `_git2_` suffix.
+ * Writes the filename into path_out.
+ * @return On success, an open file descriptor, else an error code < 0.
  */
-extern int git_futils_mktmp(char *path_out, const char *filename);
+extern int git_futils_mktmp(git_buf *path_out, const char *filename);
 
 /**
  * Move a file on the filesystem, create the
@@ -133,16 +152,14 @@ extern void git_futils_mmap_free(git_map *map);
  *
  * @param pathbuf buffer the function reads the initial directory
  * 		path from, and updates with each successive entry's name.
- * @param pathmax maximum allocation of pathbuf.
  * @param fn function to invoke with each entry. The first arg is
  *		the input state and the second arg is pathbuf. The function
  *		may modify the pathbuf, but only by appending new text.
  * @param state to pass to fn as the first arg.
  */
 extern int git_futils_direach(
-	char *pathbuf,
-	size_t pathmax,
-	int (*fn)(void *, char *),
+	git_buf *pathbuf,
+	int (*fn)(void *, git_buf *),
 	void *state);
 
 extern int git_futils_cmp_path(const char *name1, int len1, int isdir1,

--- a/src/path.h
+++ b/src/path.h
@@ -8,6 +8,7 @@
 #define INCLUDE_path_h__
 
 #include "common.h"
+#include "buffer.h"
 
 /*
  * The dirname() function shall take a pointer to a character string
@@ -22,11 +23,13 @@
  * The `git_path_dirname` implementation is thread safe. The returned
  * string must be manually free'd.
  *
- * The `git_path_dirname_r` implementation expects a string allocated
- * by the user with big enough size.
+ * The `git_path_dirname_r` implementation writes the dirname to a `git_buf`
+ * if the buffer pointer is not NULL.
+ * It returns an error code < 0 if there is an allocation error, otherwise
+ * the length of the dirname (which will be > 0).
  */
 extern char *git_path_dirname(const char *path);
-extern int git_path_dirname_r(char *buffer, size_t bufflen, const char *path);
+extern int git_path_dirname_r(git_buf *buffer, const char *path);
 
 /*
  * This function returns the basename of the file, which is the last
@@ -40,32 +43,22 @@ extern int git_path_dirname_r(char *buffer, size_t bufflen, const char *path);
  * The `git_path_basename` implementation is thread safe. The returned
  * string must be manually free'd.
  *
- * The `git_path_basename_r` implementation expects a string allocated
- * by the user with big enough size.
+ * The `git_path_basename_r` implementation writes the basename to a `git_buf`.
+ * It returns an error code < 0 if there is an allocation error, otherwise
+ * the length of the basename (which will be >= 0).
  */
 extern char *git_path_basename(const char *path);
-extern int git_path_basename_r(char *buffer, size_t bufflen, const char *path);
+extern int git_path_basename_r(git_buf *buffer, const char *path);
 
 extern const char *git_path_topdir(const char *path);
 
-/**
- * Join two paths together. Takes care of properly fixing the
- * middle slashes and everything
- *
- * The paths are joined together into buffer_out; this is expected
- * to be an user allocated buffer of `GIT_PATH_MAX` size
- */
-extern void git_path_join_n(char *buffer_out, int npath, ...);
+extern int git_path_root(const char *path);
 
-GIT_INLINE(void) git_path_join(char *buffer_out, const char *path_a, const char *path_b)
-{
-	git_path_join_n(buffer_out, 2, path_a, path_b);
-}
+extern int git_path_prettify(git_buf *path_out, const char *path, const char *base);
+extern int git_path_prettify_dir(git_buf *path_out, const char *path, const char *base);
 
-int git_path_root(const char *path);
-
-int git_path_prettify(char *path_out, const char *path, const char *base);
-int git_path_prettify_dir(char *path_out, const char *path, const char *base);
+extern int git_path_to_dir(git_buf *path);
+extern void git_path_string_to_dir(char* path, size_t size);
 
 #ifdef GIT_WIN32
 GIT_INLINE(void) git_path_mkposix(char *path)

--- a/src/pkt.c
+++ b/src/pkt.c
@@ -268,8 +268,7 @@ void git_pkt_free(git_pkt *pkt)
 
 int git_pkt_buffer_flush(git_buf *buf)
 {
-	git_buf_put(buf, pkt_flush_str, strlen(pkt_flush_str));
-	return git_buf_oom(buf) ? GIT_ENOMEM : GIT_SUCCESS;
+	return git_buf_put(buf, pkt_flush_str, strlen(pkt_flush_str));
 }
 
 int git_pkt_send_flush(int s)
@@ -291,9 +290,7 @@ static int buffer_want_with_caps(git_remote_head *head, git_transport_caps *caps
 	git_buf_grow(buf, buf->size + len);
 
 	git_oid_fmt(oid, &head->oid);
-	git_buf_printf(buf, "%04xwant %s%c%s\n", len, oid, 0, capstr);
-
-	return git_buf_oom(buf) ? GIT_ENOMEM : GIT_SUCCESS;
+	return git_buf_printf(buf, "%04xwant %s%c%s\n", len, oid, 0, capstr);
 }
 
 static int send_want_with_caps(git_remote_head *head, git_transport_caps *caps, GIT_SOCKET fd)
@@ -401,8 +398,7 @@ int git_pkt_buffer_have(git_oid *oid, git_buf *buf)
 
 	memset(oidhex, 0x0, sizeof(oidhex));
 	git_oid_fmt(oidhex, oid);
-	git_buf_printf(buf, "%s%s\n", pkt_have_prefix, oidhex);
-	return git_buf_oom(buf) ? GIT_ENOMEM : GIT_SUCCESS;
+	return git_buf_printf(buf, "%s%s\n", pkt_have_prefix, oidhex);
 }
 
 int git_pkt_send_have(git_oid *oid, int fd)
@@ -416,8 +412,7 @@ int git_pkt_send_have(git_oid *oid, int fd)
 
 int git_pkt_buffer_done(git_buf *buf)
 {
-	git_buf_puts(buf, pkt_done_str);
-	return git_buf_oom(buf) ? GIT_ENOMEM : GIT_SUCCESS;
+	return git_buf_puts(buf, pkt_done_str);
 }
 
 int git_pkt_send_done(int fd)

--- a/src/posix.c
+++ b/src/posix.c
@@ -35,7 +35,8 @@ int p_getcwd(char *buffer_out, size_t size)
 
 	git_path_mkposix(buffer_out);
 
-	git_path_join(buffer_out, buffer_out, "");	//Ensure the path ends with a trailing slash
+	git_path_string_to_dir(buffer_out, size);	//Ensure the path ends with a trailing slash
+
 	return GIT_SUCCESS;
 }
 

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -93,3 +93,21 @@ int git_refspec_transform(char *out, size_t outlen, const git_refspec *spec, con
 
 	return GIT_SUCCESS;
 }
+
+int git_refspec_transform_r(git_buf *out, const git_refspec *spec, const char *name)
+{
+	if (git_buf_sets(out, spec->dst) < GIT_SUCCESS)
+		return git_buf_lasterror(out);
+
+	/*
+	 * No '*' at the end means that it's mapped to one specific local
+	 * branch, so no actual transformation is needed.
+	 */
+	if (out->size > 0 && out->ptr[out->size - 1] != '*')
+		return GIT_SUCCESS;
+
+	git_buf_truncate(out, out->size - 1); /* remove trailing '*' */
+	git_buf_puts(out, name);
+
+	return git_buf_lasterror(out);
+}

--- a/src/refspec.h
+++ b/src/refspec.h
@@ -8,6 +8,7 @@
 #define INCLUDE_refspec_h__
 
 #include "git2/refspec.h"
+#include "buffer.h"
 
 struct git_refspec {
 	struct git_refspec *next;
@@ -19,5 +20,16 @@ struct git_refspec {
 };
 
 int git_refspec_parse(struct git_refspec *refspec, const char *str);
+
+/**
+ * Transform a reference to its target following the refspec's rules,
+ * and writes the results into a git_buf.
+ *
+ * @param out where to store the target name
+ * @param spec the refspec
+ * @param name the name of the reference to transform
+ * @return GIT_SUCCESS or error if buffer allocation fails
+ */
+int git_refspec_transform_r(git_buf *out, const git_refspec *spec, const char *name);
 
 #endif

--- a/src/signature.c
+++ b/src/signature.c
@@ -16,7 +16,9 @@ void git_signature_free(git_signature *sig)
 		return;
 
 	git__free(sig->name);
+	sig->name = NULL;
 	git__free(sig->email);
+	sig->email = NULL;
 	git__free(sig);
 }
 

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -68,7 +68,7 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 	git_buf_put(request, url, delim - url);
 	git_buf_putc(request, '\0');
 
-	return git_buf_oom(request);
+	return git_buf_lasterror(request);
 }
 
 static int send_request(GIT_SOCKET s, const char *cmd, const char *url)

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -77,10 +77,7 @@ static int gen_request(git_buf *buf, const char *url, const char *host, const ch
 	}
 	git_buf_puts(buf, "\r\n");
 
-	if (git_buf_oom(buf))
-		return GIT_ENOMEM;
-
-	return GIT_SUCCESS;
+	return git_buf_lasterror(buf);
 }
 
 static int do_connect(transport_http *t, const char *host, const char *port)
@@ -608,8 +605,9 @@ static int http_download_pack(char **out, git_transport *transport, git_reposito
 	char buffer[1024];
 	gitno_buffer buf;
 	download_pack_cbdata data;
-	git_filebuf file;
-	char path[GIT_PATH_MAX], suff[] = "/objects/pack/pack-received\0";
+	git_filebuf file = GIT_FILEBUF_INIT;
+	git_buf path = GIT_BUF_INIT;
+	char suff[] = "/objects/pack/pack-received\0";
 
 	/*
 	 * This is part of the previous response, so we don't want to
@@ -625,13 +623,15 @@ static int http_download_pack(char **out, git_transport *transport, git_reposito
 
 	gitno_buffer_setup(&buf, buffer, sizeof(buffer), t->socket);
 
-	git_path_join(path, repo->path_repository, suff);
-
 	if (memcmp(oldbuf->ptr, "PACK", strlen("PACK"))) {
 		return git__throw(GIT_ERROR, "The pack doesn't start with the signature");
 	}
 
-	error = git_filebuf_open(&file, path, GIT_FILEBUF_TEMPORARY);
+	error = git_buf_joinpath(&path, repo->path_repository, suff);
+	if (error < GIT_SUCCESS)
+		goto cleanup;
+
+	error = git_filebuf_open(&file, path.ptr, GIT_FILEBUF_TEMPORARY);
 	if (error < GIT_SUCCESS)
 		goto cleanup;
 
@@ -671,6 +671,7 @@ static int http_download_pack(char **out, git_transport *transport, git_reposito
 cleanup:
 	if (error < GIT_SUCCESS)
 		git_filebuf_cleanup(&file);
+	git_buf_free(&path);
 
 	return error;
 }

--- a/src/tree.c
+++ b/src/tree.c
@@ -577,9 +577,9 @@ int git_treebuilder_write(git_oid *oid, git_repository *repo, git_treebuilder *b
 		git_buf_put(&tree, (char *)entry->oid.id, GIT_OID_RAWSZ);
 	}
 
-	if (git_buf_oom(&tree)) {
+	if ((error = git_buf_lasterror(&tree)) < GIT_SUCCESS) {
 		git_buf_free(&tree);
-		return git__throw(GIT_ENOMEM, "Not enough memory to build the tree data");
+		return git__rethrow(error, "Not enough memory to build the tree data");
 	}
 
 	error = git_repository_odb__weakptr(&odb, repo);
@@ -631,7 +631,7 @@ void git_treebuilder_free(git_treebuilder *bld)
 static int tree_frompath(
 	git_tree **parent_out,
 	git_tree *root,
-	const char *treeentry_path,
+	git_buf *treeentry_path,
 	int offset)
 {
 	char *slash_pos = NULL;
@@ -639,11 +639,11 @@ static int tree_frompath(
 	int error = GIT_SUCCESS;
 	git_tree *subtree;
 
-	if (!*(treeentry_path + offset))
+	if (!*(treeentry_path->ptr + offset))
 		return git__rethrow(GIT_EINVALIDPATH,
-			"Invalid relative path to a tree entry '%s'.", treeentry_path);
+			"Invalid relative path to a tree entry '%s'.", treeentry_path->ptr);
 
-	slash_pos = (char *)strchr(treeentry_path + offset, '/');
+	slash_pos = (char *)strchr(treeentry_path->ptr + offset, '/');
 
 	if (slash_pos == NULL)
 		return git_tree_lookup(
@@ -652,13 +652,13 @@ static int tree_frompath(
 			git_object_id((const git_object *)root)
 		);
 
-	if (slash_pos == treeentry_path + offset)
+	if (slash_pos == treeentry_path->ptr + offset)
 		return git__rethrow(GIT_EINVALIDPATH,
-			"Invalid relative path to a tree entry '%s'.", treeentry_path);
+			"Invalid relative path to a tree entry '%s'.", treeentry_path->ptr);
 
 	*slash_pos = '\0';
 
-	entry = git_tree_entry_byname(root, treeentry_path + offset);
+	entry = git_tree_entry_byname(root, treeentry_path->ptr + offset);
 
 	if (slash_pos != NULL)
 		*slash_pos = '/';
@@ -666,7 +666,7 @@ static int tree_frompath(
 	if (entry == NULL)
 		return git__rethrow(GIT_ENOTFOUND,
 			"No tree entry can be found from "
-			"the given tree and relative path '%s'.", treeentry_path);
+			"the given tree and relative path '%s'.", treeentry_path->ptr);
 
 
 	error = git_tree_lookup(&subtree, root->object.repo, &entry->oid);
@@ -677,7 +677,7 @@ static int tree_frompath(
 		parent_out,
 		subtree,
 		treeentry_path,
-		slash_pos - treeentry_path + 1
+		(slash_pos - treeentry_path->ptr) + 1
 	);
 
 	git_tree_free(subtree);
@@ -689,70 +689,82 @@ int git_tree_get_subtree(
 	git_tree *root,
 	const char *subtree_path)
 {
-	char buffer[GIT_PATH_MAX];
+	int error;
+	git_buf buffer = GIT_BUF_INIT;
 
 	assert(subtree && root && subtree_path);
 
-	strncpy(buffer, subtree_path, GIT_PATH_MAX);
-	return tree_frompath(subtree, root, buffer, 0);
+	if ((error = git_buf_sets(&buffer, subtree_path)) == GIT_SUCCESS)
+		error = tree_frompath(subtree, root, &buffer, 0);
+
+	git_buf_free(&buffer);
+
+	return error;
 }
 
 static int tree_walk_post(
 	git_tree *tree,
 	git_treewalk_cb callback,
-	char *root,
-	size_t root_len,
+	git_buf *path,
 	void *payload)
 {
-	int error;
+	int error = GIT_SUCCESS;
 	unsigned int i;
 
 	for (i = 0; i < tree->entries.length; ++i) {
 		git_tree_entry *entry = tree->entries.contents[i];
 
-		root[root_len] = '\0';
-
-		if (callback(root, entry, payload) < 0)
+		if (callback(path->ptr, entry, payload) < 0)
 			continue;
 
 		if (ENTRY_IS_TREE(entry)) {
 			git_tree *subtree;
+			size_t path_len = path->size;
 
 			if ((error = git_tree_lookup(
 				&subtree, tree->object.repo, &entry->oid)) < 0)
-				return error;
+				break;
 
-			strcpy(root + root_len, entry->filename);
-			root[root_len + entry->filename_len] = '/';
+			/* append the next entry to the path */
+			git_buf_puts(path, entry->filename);
+			git_buf_putc(path, '/');
+			if ((error = git_buf_lasterror(path)) < GIT_SUCCESS)
+				break;
 
-			tree_walk_post(subtree,
-				callback, root,
-				root_len + entry->filename_len + 1,
-				payload
-			);
+			error = tree_walk_post(subtree, callback, path, payload);
+			if (error < GIT_SUCCESS)
+				break;
 
+			git_buf_truncate(path, path_len);
 			git_tree_free(subtree);
 		}
 	}
 
-	return GIT_SUCCESS;
+	return error;
 }
 
 int git_tree_walk(git_tree *tree, git_treewalk_cb callback, int mode, void *payload)
 {
-	char root_path[GIT_PATH_MAX];
+	int error = GIT_SUCCESS;
+	git_buf root_path = GIT_BUF_INIT;
 
-	root_path[0] = '\0';
 	switch (mode) {
 		case GIT_TREEWALK_POST:
-			return tree_walk_post(tree, callback, root_path, 0, payload);
+			error = tree_walk_post(tree, callback, &root_path, payload);
+			break;
 
 		case GIT_TREEWALK_PRE:
-			return git__throw(GIT_ENOTIMPLEMENTED,
+			error = git__throw(GIT_ENOTIMPLEMENTED,
 				"Preorder tree walking is still not implemented");
+			break;
 
 		default:
-			return git__throw(GIT_EINVALIDARGS,
+			error = git__throw(GIT_EINVALIDARGS,
 				"Invalid walking mode for tree walk");
+			break;
 	}
+
+	git_buf_free(&root_path);
+
+	return error;
 }

--- a/tests-clay/clay.h
+++ b/tests-clay/clay.h
@@ -111,6 +111,7 @@ extern void test_core_path__1(void);
 extern void test_core_path__2(void);
 extern void test_core_path__5(void);
 extern void test_core_path__6(void);
+extern void test_core_path__7(void);
 extern void test_core_rmdir__delete_recursive(void);
 extern void test_core_rmdir__fail_to_delete_non_empty_dir(void);
 extern void test_core_rmdir__initialize(void);

--- a/tests-clay/clay_libgit2.h
+++ b/tests-clay/clay_libgit2.h
@@ -42,4 +42,13 @@ GIT_INLINE(void) cl_assert_strequal_internal(
 	}
 }
 
+/*
+ * Some utility macros for building long strings
+ */
+#define REP4(STR)	 STR STR STR STR
+#define REP15(STR)	 REP4(STR) REP4(STR) REP4(STR) STR STR STR
+#define REP16(STR)	 REP4(REP4(STR))
+#define REP256(STR)  REP16(REP16(STR))
+#define REP1024(STR) REP4(REP256(STR))
+
 #endif

--- a/tests-clay/clay_main.c
+++ b/tests-clay/clay_main.c
@@ -171,7 +171,8 @@ static const struct clay_func _clay_cb_core_path[] = {
 	{"1", &test_core_path__1},
 	{"2", &test_core_path__2},
 	{"5", &test_core_path__5},
-	{"6", &test_core_path__6}
+	{"6", &test_core_path__6},
+	{"7", &test_core_path__7}
 };
 static const struct clay_func _clay_cb_core_rmdir[] = {
     {"delete_recursive", &test_core_rmdir__delete_recursive},
@@ -351,7 +352,7 @@ static const struct clay_suite _clay_suites[] = {
         "core::path",
         {NULL, NULL},
         {NULL, NULL},
-        _clay_cb_core_path, 5
+        _clay_cb_core_path, 6
     },
 	{
         "core::rmdir",
@@ -494,7 +495,7 @@ static const struct clay_suite _clay_suites[] = {
 };
 
 static size_t _clay_suite_count = 34;
-static size_t _clay_callback_count = 113;
+static size_t _clay_callback_count = 114;
 
 /* Core test functions */
 static void

--- a/tests-clay/core/rmdir.c
+++ b/tests-clay/core/rmdir.c
@@ -5,24 +5,26 @@ static const char *empty_tmp_dir = "test_gitfo_rmdir_recurs_test";
 
 void test_core_rmdir__initialize(void)
 {
-	char path[GIT_PATH_MAX];
+	git_buf path = GIT_BUF_INIT;
 
 	cl_must_pass(p_mkdir(empty_tmp_dir, 0777));
 
-	git_path_join(path, empty_tmp_dir, "/one");
-	cl_must_pass(p_mkdir(path, 0777));
+	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/one"));
+	cl_must_pass(p_mkdir(path.ptr, 0777));
 
-	git_path_join(path, empty_tmp_dir, "/one/two_one");
-	cl_must_pass(p_mkdir(path, 0777));
+	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/one/two_one"));
+	cl_must_pass(p_mkdir(path.ptr, 0777));
 
-	git_path_join(path, empty_tmp_dir, "/one/two_two");
-	cl_must_pass(p_mkdir(path, 0777));
+	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/one/two_two"));
+	cl_must_pass(p_mkdir(path.ptr, 0777));
 
-	git_path_join(path, empty_tmp_dir, "/one/two_two/three");
-	cl_must_pass(p_mkdir(path, 0777));
+	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/one/two_two/three"));
+	cl_must_pass(p_mkdir(path.ptr, 0777));
 
-	git_path_join(path, empty_tmp_dir, "/two");
-	cl_must_pass(p_mkdir(path, 0777));
+	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/two"));
+	cl_must_pass(p_mkdir(path.ptr, 0777));
+
+	git_buf_free(&path);
 }
 
 /* make sure empty dir can be deleted recusively */
@@ -34,17 +36,19 @@ void test_core_rmdir__delete_recursive(void)
 /* make sure non-empty dir cannot be deleted recusively */
 void test_core_rmdir__fail_to_delete_non_empty_dir(void)
 {
-	char file[GIT_PATH_MAX];
+	git_buf file = GIT_BUF_INIT;
 	int fd;
 
-	git_path_join(file, empty_tmp_dir, "/two/file.txt");
+	cl_git_pass(git_buf_joinpath(&file, empty_tmp_dir, "/two/file.txt"));
 
-	fd = p_creat(file, 0666);
+	fd = p_creat(file.ptr, 0666);
 	cl_assert(fd >= 0);
 
 	cl_must_pass(p_close(fd));
 	cl_git_fail(git_futils_rmdir_r(empty_tmp_dir, 0));
 
-	cl_must_pass(p_unlink(file));
+	cl_must_pass(p_unlink(file.ptr));
 	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, 0));
+
+	git_buf_free(&file);
 }

--- a/tests-clay/repo/init.c
+++ b/tests-clay/repo/init.c
@@ -77,17 +77,19 @@ void test_repo_init__bare_repo_noslash(void)
 
 #if 0
 BEGIN_TEST(init2, "Initialize and open a bare repo with a relative path escaping out of the current working directory")
-	char path_repository[GIT_PATH_MAX];
+	git_buf path_repository = GIT_BUF_INIT;
 	char current_workdir[GIT_PATH_MAX];
 	const mode_t mode = 0777;
 	git_repository* repo;
 
 	must_pass(p_getcwd(current_workdir, sizeof(current_workdir)));
 
-	git_path_join(path_repository, TEMP_REPO_FOLDER, "a/b/c/");
-	must_pass(git_futils_mkdir_r(path_repository, mode));
+	must_pass(git_buf_joinpath(&path_repository, TEMP_REPO_FOLDER, "a/b/c/"));
+	must_pass(git_futils_mkdir_r(path_repository.ptr, mode));
 
-	must_pass(chdir(path_repository));
+	must_pass(chdir(path_repository.ptr));
+
+	git_buf_free(&path_repository);
 
 	must_pass(git_repository_init(&repo, "../d/e.git", 1));
 	must_pass(git__suffixcmp(git_repository_path(_repo), "/a/b/d/e.git/"));

--- a/tests-clay/repo/open.c
+++ b/tests-clay/repo/open.c
@@ -26,23 +26,24 @@ void test_repo_open__standard_empty_repo(void)
 /* TODO TODO */
 #if 0
 BEGIN_TEST(open2, "Open a bare repository with a relative path escaping out of the current working directory")
-	char new_current_workdir[GIT_PATH_MAX];
 	char current_workdir[GIT_PATH_MAX];
-	char path_repository[GIT_PATH_MAX];
+	git_buf new_current_workdir = GIT_BUF_INIT;
+	git_buf path_repository = GIT_BUF_INIT;
 
 	const mode_t mode = 0777;
 	git_repository* repo;
 
 	/* Setup the repository to open */
 	must_pass(p_getcwd(current_workdir, sizeof(current_workdir)));
-	strcpy(path_repository, current_workdir);
-	git_path_join_n(path_repository, 3, path_repository, TEMP_REPO_FOLDER, "a/d/e.git");
-	must_pass(copydir_recurs(REPOSITORY_FOLDER, path_repository));
+	must_pass(git_buf_join_n(&path_repository, 3, current_workdir, TEMP_REPO_FOLDER, "a/d/e.git"));
+	must_pass(copydir_recurs(REPOSITORY_FOLDER, path_repository.ptr));
+	git_buf_free(&path_repository);
 
 	/* Change the current working directory */
-	git_path_join(new_current_workdir, TEMP_REPO_FOLDER, "a/b/c/");
-	must_pass(git_futils_mkdir_r(new_current_workdir, mode));
-	must_pass(chdir(new_current_workdir));
+	must_pass(git_buf_joinpath(&new_current_workdir, TEMP_REPO_FOLDER, "a/b/c/"));
+	must_pass(git_futils_mkdir_r(new_current_workdir.ptr, mode));
+	must_pass(chdir(new_current_workdir.ptr));
+	git_buf_free(&new_current_workdir);
 
 	must_pass(git_repository_open(&repo, "../../d/e.git"));
 

--- a/tests/t18-status.c
+++ b/tests/t18-status.c
@@ -392,15 +392,15 @@ END_TEST
 BEGIN_TEST(singlestatus3, "test retrieving status for a new file in an empty repository")
 	git_repository *repo;
 	unsigned int status_flags;
-	char file_path[GIT_PATH_MAX];
+	git_buf file_path = GIT_BUF_INIT;
 	char filename[] = "new_file";
 	int fd;
 
 	must_pass(copydir_recurs(EMPTY_REPOSITORY_FOLDER, TEST_STD_REPO_FOLDER));
 	must_pass(remove_placeholders(TEST_STD_REPO_FOLDER, "dummy-marker.txt"));
 
-	git_path_join(file_path, TEMP_REPO_FOLDER, filename);
-	fd = p_creat(file_path, 0666);
+	must_pass(git_buf_joinpath(&file_path, TEMP_REPO_FOLDER, filename));
+	fd = p_creat(file_path.ptr, 0666);
 	must_pass(fd);
 	must_pass(p_write(fd, "new_file\n", 9));
 	must_pass(p_close(fd));
@@ -411,6 +411,7 @@ BEGIN_TEST(singlestatus3, "test retrieving status for a new file in an empty rep
 	must_be_true(status_flags == GIT_STATUS_WT_NEW);
 
 	git_repository_free(repo);
+	git_buf_free(&file_path);
 
 	git_futils_rmdir_r(TEMP_REPO_FOLDER, 1);
 END_TEST

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -74,7 +74,7 @@ extern int cmp_files(const char *a, const char *b);
 extern int copy_file(const char *source, const char *dest);
 extern int rmdir_recurs(const char *directory_path);
 extern int copydir_recurs(const char *source_directory_path, const char *destination_directory_path);
-extern int remove_placeholders(char *directory_path, char *filename);
+extern int remove_placeholders(const char *directory_path, const char *filename);
 
 extern int open_temp_repo(git_repository **repo, const char *path);
 extern void close_temp_repo(git_repository *repo);


### PR DESCRIPTION
In order to reduce memory usage and remove potential buffer overflows, this patch converts virtually all of the places that allocate GIT_PATH_MAX buffers on the stack for manipulating paths to use git_buf objects instead.  The patch is pretty careful not to touch the public API for libgit2, so there are a few places that still use GIT_PATH_MAX.

This extends and changes some details of the git_buf implementation to add a couple of extra functions and to make error handling easier.

This includes significant alterations to all the path.c functions and several of the fileops.c ones, too.  Also, there are a number of new functions that parallel existing ones but use a git_buf instead of a stack-based buffer (such as `git_config_find_global_r` that exists alongside `git_config_find_global`).

This also modifies the win32 version of `p_realpath` to allocate whatever buffer size is needed to accommodate the realpath instead of hardcoding a GIT_PATH_MAX limit, but that change needs to be tested still.
