### PR TITLE
Prevent segfaulting on Windows when building a temporary filename

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -365,7 +365,7 @@ extern int p_creat(const char *path, mode_t mode);
 int p_mkstemp(char *tmp_path)
 {
 #if defined(_MSC_VER)
-	if (_mktemp_s(tmp_path, GIT_PATH_MAX) != 0)
+	if (_mktemp_s(tmp_path, strlen(tmp_path) + 1) != 0)
 		return GIT_EOSERR;
 #else
 	if (_mktemp(tmp_path) == NULL)


### PR DESCRIPTION
According to [MSDN](http://msdn.microsoft.com/en-us/library/t8ex5e91.aspx), this function is a bit picky and expects the "size of the buffer in single-byte characters in _mktemp_s including the null terminator." as the second parameter.

GIT_PATH_MAX doesn't rule any more :-/
