### PR TITLE
Add Perl to the list of bindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Here are the bindings to libgit2 that are currently available:
 * libgit2net (.NET bindings, low level) <https://github.com/txdv/libgit2net>
 * parrot-libgit2 (Parrot Virtual Machine bindings) <https://github.com/letolabs/parrot-libgit2>
 * hgit2 (Haskell bindings) <https://github.com/norm2782/hgit2>
+* git-xs-pm (Perl bindings) <https://github.com/ingydotnet/git-xs-pm>
 
 If you start another language binding to libgit2, please let us know so
 we can add it to the list.


### PR DESCRIPTION
Got a basic Perl binding working, and installable from CPAN. It's only proof of concept, but should mature rapidly.
