### PR TITLE
Add missing semicolon

### DIFF
--- a/src/win32/utf-conv.h
+++ b/src/win32/utf-conv.h
@@ -11,7 +11,7 @@
 #define INCLUDE_git_utfconv_h__
 
 wchar_t* gitwin_to_utf16(const char* str);
-int gitwin_append_utf16(wchar_t *buffer, const char *str, size_t len)
+int gitwin_append_utf16(wchar_t *buffer, const char *str, size_t len);
 char* gitwin_from_utf16(const wchar_t* str);
 
 #endif


### PR DESCRIPTION
Fix up the broken Win32 build.
