### PR TITLE
Fix warnings from valgrind

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -120,7 +120,7 @@ int git_config_add_file(git_config *cfg, git_config_file *file, int priority)
 	assert(cfg && file);
 
 	if ((error = file->open(file)) < GIT_SUCCESS)
-		return git__rethrow(error, "Failed to open config file");
+		return git__throw(error, "Failed to open config file");
 
 	internal = git__malloc(sizeof(file_internal));
 	if (internal == NULL)

--- a/src/delta-apply.c
+++ b/src/delta-apply.c
@@ -57,7 +57,7 @@ int git__delta_apply(
 	if (hdr_sz(&res_sz, &delta, delta_end) < 0)
 		return git__throw(GIT_ERROR, "Failed to apply delta. Base size does not match given data");
 
-	if ((res_dp = git__malloc(res_sz + 1)) == NULL)
+	if ((res_dp = git__malloc((res_sz + 16) & ~7)) == NULL)
 		return GIT_ENOMEM;
 	res_dp[res_sz] = '\0';
 	out->data = res_dp;

--- a/src/index.c
+++ b/src/index.c
@@ -510,6 +510,7 @@ int git_index_append2(git_index *index, const git_index_entry *source_entry)
 
 int git_index_remove(git_index *index, int position)
 {
+	int error;
 	git_index_entry *entry;
 
 	git_vector_sort(&index->entries);
@@ -517,7 +518,12 @@ int git_index_remove(git_index *index, int position)
 	if (entry != NULL)
 		git_tree_cache_invalidate_path(index->tree, entry->path);
 
-	return git_vector_remove(&index->entries, (unsigned int)position);
+	error = git_vector_remove(&index->entries, (unsigned int)position);
+
+	if (error == GIT_SUCCESS)
+		index_entry_free(entry);
+
+	return error;
 }
 
 int git_index_find(git_index *index, const char *path)

--- a/src/pack.c
+++ b/src/pack.c
@@ -383,8 +383,9 @@ int packfile_unpack_compressed(
 	z_stream stream;
 	unsigned char *buffer, *in;
 
-	buffer = git__malloc(size + 1);
-	memset(buffer, 0x0, size + 1);
+	buffer = git__calloc((size + 16) & ~7, sizeof(char));
+	if (!buffer)
+		return GIT_ENOMEM;
 
 	memset(&stream, 0, sizeof(stream));
 	stream.next_out = buffer;

--- a/tests-clay/object/commit/commitstagedfile.c
+++ b/tests-clay/object/commit/commitstagedfile.c
@@ -7,7 +7,9 @@ void test_object_commit_commitstagedfile__initialize(void)
 {
 	cl_fixture("treebuilder");
 	cl_git_pass(git_repository_init(&repo, "treebuilder/", 0));
-	cl_git_pass(git_repository_open(&repo, "treebuilder/.git"));
+	/* just initialized, so open not needed...
+	 * cl_git_pass(git_repository_open(&repo, "treebuilder/.git"));
+	 */
 	cl_assert(repo != NULL);
 }
 


### PR DESCRIPTION
These fixes are just small things that Valgrind identified.  For example, calling `git__rethrow` without a prior `git__throw` ends up generating a warning.  We can fix this, but it seemed easier to just use `git__throw.`

The oddest part of these fixes is the rounding up of memory allocations in delta-apply.c and pack.c.  Valgrind seems to think that we read (although not write) past the end of these memory allocations, and so adding a little bit of extra memory clears up that warning.  I can't find the offending code, but this does seem to work.
