### PR TITLE
Fix download segfault

### DIFF
--- a/src/refspec.c
+++ b/src/refspec.c
@@ -57,7 +57,7 @@ const char *git_refspec_dst(const git_refspec *refspec)
 
 int git_refspec_src_match(const git_refspec *refspec, const char *refname)
 {
-	return refspec == NULL ? GIT_ENOMATCH : git__fnmatch(refspec->src, refname, 0);
+	return (refspec == NULL || refspec->src == NULL) ? GIT_ENOMATCH : git__fnmatch(refspec->src, refname, 0);
 }
 
 int git_refspec_transform(char *out, size_t outlen, const git_refspec *spec, const char *name)


### PR DESCRIPTION
This PR fixes an issue detected by @uluhonolulu (cf this [comment](https://github.com/libgit2/libgit2sharp/issues/65#issuecomment-3546097)).

Prevent `git_remote_download()` from segfaulting when being passed a lightweight remote built with git_remote_new()

Those lightweight remotes have no refspec which was making `git__fnmatch()` very uneasy.

@tanoku What is the current policy regarding network features and tests? Should the tests stay local only? Should they go over the network (and potentially fail because of a proxy error, GitHub downtime, ...)? Should they always run (or be switched on/off through some magic configuration wizardry)?

/cc @carlosmn
