### PR TITLE
Fix the build on Emscripten

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -8,6 +8,7 @@
 #	include <sys/types.h>
 #	include <sys/socket.h>
 #	include <sys/select.h>
+#	include <sys/time.h>
 #	include <netdb.h>
 #else
 #	define _WIN32_WINNT 0x0501


### PR DESCRIPTION
struct timeval is used in this file, which requires <sys/time.h> to be
included.
