### PR TITLE
Fix trailing slash issue to the gitdir path when the repo is opened through a workdir

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -166,7 +166,7 @@ int git_repository_open(git_repository **repo_out, const char *path)
 	 * of the working dir, by testing if it contains a `.git`
 	 * folder inside of it.
 	 */
-	git_path_contains_dir(&path_buf, DOT_GIT, 1); /* append on success */
+	git_path_contains_dir(&path_buf, GIT_DIR, 1); /* append on success */
 	/* ignore error, since it just means `path/.git` doesn't exist */
 
 	if (quickcheck_repository_dir(&path_buf) < GIT_SUCCESS) {

--- a/tests-clar/refs/listall.c
+++ b/tests-clar/refs/listall.c
@@ -1,0 +1,36 @@
+#include "clar_libgit2.h"
+#include "posix.h"
+
+static git_repository *repo;
+static git_strarray ref_list;
+
+static void ensure_no_refname_starts_with_a_forward_slash(const char *path)
+{
+	int i;
+
+	cl_git_pass(git_repository_open(&repo, path));
+	cl_git_pass(git_reference_listall(&ref_list, repo, GIT_REF_LISTALL));
+
+	cl_assert(ref_list.count > 0);
+
+	for (i = 0; i < ref_list.count; i++)
+		cl_assert(git__prefixcmp(ref_list.strings[i], "/") != 0);
+
+	git_strarray_free(&ref_list);
+	git_repository_free(repo);
+}
+
+void test_refs_listall__from_repository_opened_through_workdir_path(void)
+{
+	cl_fixture_sandbox("status");
+	cl_git_pass(p_rename("status/.gitted", "status/.git"));
+
+	ensure_no_refname_starts_with_a_forward_slash("status");
+
+	cl_fixture_cleanup("status");
+}
+
+void test_refs_listall__from_repository_opened_through_gitdir_path(void)
+{
+	ensure_no_refname_starts_with_a_forward_slash(cl_fixture("testrepo.git"));
+}

--- a/tests-clar/repo/open.c
+++ b/tests-clar/repo/open.c
@@ -1,24 +1,46 @@
 #include "clar_libgit2.h"
 #include "posix.h"
 
-void test_repo_open__bare_empty_repo(void)
+static git_repository *repo;
+
+void test_repo_open__cleanup(void)
 {
-	git_repository *repo;
-
-	cl_git_pass(git_repository_open(&repo, cl_fixture("empty_bare.git")));
-	cl_assert(git_repository_path(repo) != NULL);
-	cl_assert(git_repository_workdir(repo) == NULL);
-
 	git_repository_free(repo);
 }
 
-void test_repo_open__standard_empty_repo(void)
+void test_repo_open__bare_empty_repo(void)
 {
-	git_repository *repo;
+	cl_git_pass(git_repository_open(&repo, cl_fixture("empty_bare.git")));
 
-	cl_git_pass(git_repository_open(&repo, cl_fixture("empty_standard_repo/.gitted")));
 	cl_assert(git_repository_path(repo) != NULL);
-	cl_assert(git_repository_workdir(repo) != NULL);
+	cl_assert(git__suffixcmp(git_repository_path(repo), "/") == 0);
 
-	git_repository_free(repo);
+	cl_assert(git_repository_workdir(repo) == NULL);
+}
+
+void test_repo_open__standard_empty_repo_through_gitdir(void)
+{
+	cl_git_pass(git_repository_open(&repo, cl_fixture("empty_standard_repo/.gitted")));
+
+	cl_assert(git_repository_path(repo) != NULL);
+	cl_assert(git__suffixcmp(git_repository_path(repo), "/") == 0);
+
+	cl_assert(git_repository_workdir(repo) != NULL);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo), "/") == 0);
+}
+
+void test_repo_open__standard_empty_repo_through_workdir(void)
+{
+	cl_fixture_sandbox("empty_standard_repo");
+	cl_git_pass(p_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
+
+	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
+
+	cl_assert(git_repository_path(repo) != NULL);
+	cl_assert(git__suffixcmp(git_repository_path(repo), "/") == 0);
+
+	cl_assert(git_repository_workdir(repo) != NULL);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo), "/") == 0);
+
+	cl_fixture_cleanup("empty_standard_repo");
 }


### PR DESCRIPTION
This ensures that the path to the .git directory ends with a forward slash when opening a repository through a working directory path

This fixes libgit2/libgit2sharp#108 which was detected while using one of the libgit2 bindings. The lack of the trailing forward slash led the name of references returned by `git_reference_listall()` to be prefixed with a forward slash.
- Add a new `listall.c` in `tests-clar/refs` which ensure that no refname starts with a forward slash
- Add some new assertions in existing tests in `tests-clar/repo/open.c` to ensure that the `repository_path` and `workdir_path` are suffixed with a forward slash.
- Add a new test in `tests-clar/repo/open.c` to ensure that the `repository_path` and `workdir_path` are suffixed with a forward slash when the repository is opened through a path to the working directory.

/cc @carlosmn @arrbee
