### PR TITLE
revwalk: unmark commits as uninteresting on reset

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -558,6 +558,7 @@ void git_revwalk_reset(git_revwalk *walk)
 		commit->seen = 0;
 		commit->in_degree = 0;
 		commit->topo_delay = 0;
+		commit->uninteresting = 0;
 	);
 
 	git_pqueue_clear(&walk->iterator_time);


### PR DESCRIPTION
Not doing so hides commits we want to get at during a second walk.
