### PR TITLE
implement support for username@host:path URLs in transport_find_fn()

### DIFF
--- a/src/transport.c
+++ b/src/transport.c
@@ -88,3 +88,9 @@ int git_remote_valid_url(const char *url)
 	return transport_find_fn(url) != NULL;
 }
 
+int git_remote_supported_url(const char* url)
+{
+	git_transport_cb transport_fn = transport_find_fn(url);
+
+	return ((transport_fn != NULL) && (transport_fn != &git_transport_dummy));
+}

--- a/src/transport.h
+++ b/src/transport.h
@@ -102,7 +102,19 @@ int git_transport_local(struct git_transport **transport);
 int git_transport_git(struct git_transport **transport);
 int git_transport_http(struct git_transport **transport);
 int git_transport_dummy(struct git_transport **transport);
+
+/**
+  Returns true if the passed URL is valid (a URL with a Git supported scheme,
+  or pointing to an existing path)
+*/
 int git_transport_valid_url(const char *url);
+
+/**
+  Returns true if the passed URL is supported by this version of libgit2.
+  (or, more technically, the transport method inferred by libgit is supported
+  by this version of libgit2).
+*/
+int git_remote_supported_url(const char* url);
 
 typedef struct git_transport git_transport;
 typedef int (*git_transport_cb)(git_transport **transport);

--- a/tests-clar/network/remotes.c
+++ b/tests-clar/network/remotes.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
 #include "refspec.h"
+#include "transport.h"
 
 static git_remote *_remote;
 static git_repository *_repo;
@@ -35,9 +36,19 @@ void test_network_remotes__parsing_ssh_remote(void)
 	cl_assert( git_remote_valid_url("git@github.com:libgit2/libgit2.git") );
 }
 
-void test_network_remotes__parsing_local_path(void)
+void test_network_remotes__parsing_local_path_fails_if_path_not_found(void)
 {
 	cl_assert( !git_remote_valid_url("/home/git/repos/libgit2.git") );
+}
+
+void test_network_remotes__supported_transport_methods_are_supported(void)
+{
+  cl_assert( git_remote_supported_url("git://github.com/libgit2/libgit2") );
+}
+
+void test_network_remotes__unsupported_transport_methods_are_unsupported(void)
+{
+	cl_assert( !git_remote_supported_url("git@github.com:libgit2/libgit2.git") );
 }
 
 void test_network_remotes__refspec_parsing(void)


### PR DESCRIPTION
I noticed transport_find_fn() had a TODO item to implement username@host:path style SSH paths. I needed this for a project I'm working on, so I went ahead and implemented support for this.

Please let me know if there's anything I can do to make this patch better, etc etc.

Thanks!
