### PR TITLE
additional debugging information (reflecting OS level error) to git_filebuf_commit

### DIFF
--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -298,7 +298,7 @@ cleanup:
 	if (error < GIT_SUCCESS)
 	{
 		if (error == GIT_ERROR)
-			git__rethrow(error, "Failed to commit locked file from buffer (%s)", strerror(errno));
+			return git__rethrow(error, "Failed to commit locked file from buffer (%s)", strerror(errno));
 		else
 			return git__rethrow(error, "Failed to commit locked file from buffer");
 	}


### PR DESCRIPTION
This is a very small commit to reflect some of the underlaying OS level errors when git_filebuf_commit fails.

For example, if git_filebuf_commit fails on renaming the file, the function just returns GIT_ERROR. This makes debugging what actually went wrong really hard, at the library users level.

This patch adds error information (thanks to strerror) to the git error thrown from the function.
