### PR TITLE
Rename git_oid_to_string to git_oid_tostr

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -119,7 +119,7 @@ GIT_EXTERN(char *) git_oid_allocfmt(const git_oid *oid);
  * @return the out buffer pointer, assuming no input parameter
  *			errors, otherwise a pointer to an empty string.
  */
-GIT_EXTERN(char *) git_oid_to_string(char *out, size_t n, const git_oid *oid);
+GIT_EXTERN(char *) git_oid_tostr(char *out, size_t n, const git_oid *oid);
 
 /**
  * Copy an oid from one structure to another.

--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -532,8 +532,8 @@ static int print_oid_range(diff_print_info *pi, git_diff_delta *delta)
 	char start_oid[8], end_oid[8];
 
 	/* TODO: Determine a good actual OID range to print */
-	git_oid_to_string(start_oid, sizeof(start_oid), &delta->old_file.oid);
-	git_oid_to_string(end_oid, sizeof(end_oid), &delta->new_file.oid);
+	git_oid_tostr(start_oid, sizeof(start_oid), &delta->old_file.oid);
+	git_oid_tostr(end_oid, sizeof(end_oid), &delta->new_file.oid);
 
 	/* TODO: Match git diff more closely */
 	if (delta->old_file.mode == delta->new_file.mode) {

--- a/src/oid.c
+++ b/src/oid.c
@@ -88,7 +88,7 @@ char *git_oid_allocfmt(const git_oid *oid)
 	return str;
 }
 
-char *git_oid_to_string(char *out, size_t n, const git_oid *oid)
+char *git_oid_tostr(char *out, size_t n, const git_oid *oid)
 {
 	char str[GIT_OID_HEXSZ];
 

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -237,7 +237,7 @@ int git_reflog_write(git_reference *ref, const git_oid *oid_old,
 		return error;
 	}
 
-	git_oid_to_string(new, GIT_OID_HEXSZ+1, oid);
+	git_oid_tostr(new, GIT_OID_HEXSZ+1, oid);
 
 	git_reference_free(r);
 
@@ -263,7 +263,7 @@ int git_reflog_write(git_reference *ref, const git_oid *oid_old,
 		goto cleanup;
 
 	if (oid_old)
-		git_oid_to_string(old, sizeof(old), oid_old);
+		git_oid_tostr(old, sizeof(old), oid_old);
 	else
 		p_snprintf(old, sizeof(old), "%0*d", GIT_OID_HEXSZ, 0);
 

--- a/tests-clar/object/raw/convert.c
+++ b/tests-clar/object/raw/convert.c
@@ -14,24 +14,24 @@ void test_object_raw_convert__succeed_on_oid_to_string_conversion(void)
 	cl_git_pass(git_oid_fromstr(&in, exp));
 
 	/* NULL buffer pointer, returns static empty string */
-	str = git_oid_to_string(NULL, sizeof(out), &in);
+	str = git_oid_tostr(NULL, sizeof(out), &in);
 	cl_assert(str && *str == '\0' && str != out);
 
 	/* zero buffer size, returns static empty string */
-	str = git_oid_to_string(out, 0, &in);
+	str = git_oid_tostr(out, 0, &in);
 	cl_assert(str && *str == '\0' && str != out);
 
 	/* NULL oid pointer, returns static empty string */
-	str = git_oid_to_string(out, sizeof(out), NULL);
+	str = git_oid_tostr(out, sizeof(out), NULL);
 	cl_assert(str && *str == '\0' && str != out);
 
 	/* n == 1, returns out as an empty string */
-	str = git_oid_to_string(out, 1, &in);
+	str = git_oid_tostr(out, 1, &in);
 	cl_assert(str && *str == '\0' && str == out);
 
 	for (i = 1; i < GIT_OID_HEXSZ; i++) {
 		out[i+1] = 'Z';
-		str = git_oid_to_string(out, i+1, &in);
+		str = git_oid_tostr(out, i+1, &in);
 		/* returns out containing c-string */
 		cl_assert(str && str == out);
 		/* must be '\0' terminated */
@@ -43,7 +43,7 @@ void test_object_raw_convert__succeed_on_oid_to_string_conversion(void)
 	}
 
 	/* returns out as hex formatted c-string */
-	str = git_oid_to_string(out, sizeof(out), &in);
+	str = git_oid_tostr(out, sizeof(out), &in);
 	cl_assert(str && str == out && *(str+GIT_OID_HEXSZ) == '\0');
 	cl_assert(strcmp(exp, out) == 0);
 }
@@ -64,7 +64,7 @@ void test_object_raw_convert__succeed_on_oid_to_string_conversion_big(void)
 	big[GIT_OID_HEXSZ+3] = 'Z'; /* ditto */
 
 	/* returns big as hex formatted c-string */
-	str = git_oid_to_string(big, sizeof(big), &in);
+	str = git_oid_tostr(big, sizeof(big), &in);
 	cl_assert(str && str == big && *(str+GIT_OID_HEXSZ) == '\0');
 	cl_assert(strcmp(exp, big) == 0);
 

--- a/tests/t01-rawobj.c
+++ b/tests/t01-rawobj.c
@@ -237,24 +237,24 @@ BEGIN_TEST(oid14, "convert raw oid to string")
 	must_pass(git_oid_fromstr(&in, exp));
 
 	/* NULL buffer pointer, returns static empty string */
-	str = git_oid_to_string(NULL, sizeof(out), &in);
+	str = git_oid_tostr(NULL, sizeof(out), &in);
 	must_be_true(str && *str == '\0' && str != out);
 
 	/* zero buffer size, returns static empty string */
-	str = git_oid_to_string(out, 0, &in);
+	str = git_oid_tostr(out, 0, &in);
 	must_be_true(str && *str == '\0' && str != out);
 
 	/* NULL oid pointer, returns static empty string */
-	str = git_oid_to_string(out, sizeof(out), NULL);
+	str = git_oid_tostr(out, sizeof(out), NULL);
 	must_be_true(str && *str == '\0' && str != out);
 
 	/* n == 1, returns out as an empty string */
-	str = git_oid_to_string(out, 1, &in);
+	str = git_oid_tostr(out, 1, &in);
 	must_be_true(str && *str == '\0' && str == out);
 
 	for (i = 1; i < GIT_OID_HEXSZ; i++) {
 		out[i+1] = 'Z';
-		str = git_oid_to_string(out, i+1, &in);
+		str = git_oid_tostr(out, i+1, &in);
 		/* returns out containing c-string */
 		must_be_true(str && str == out);
 		/* must be '\0' terminated */
@@ -266,7 +266,7 @@ BEGIN_TEST(oid14, "convert raw oid to string")
 	}
 
 	/* returns out as hex formatted c-string */
-	str = git_oid_to_string(out, sizeof(out), &in);
+	str = git_oid_tostr(out, sizeof(out), &in);
 	must_be_true(str && str == out && *(str+GIT_OID_HEXSZ) == '\0');
 	must_be_true(strcmp(exp, out) == 0);
 END_TEST
@@ -286,7 +286,7 @@ BEGIN_TEST(oid15, "convert raw oid to string (big)")
 	big[GIT_OID_HEXSZ+3] = 'Z'; /* ditto */
 
 	/* returns big as hex formatted c-string */
-	str = git_oid_to_string(big, sizeof(big), &in);
+	str = git_oid_tostr(big, sizeof(big), &in);
 	must_be_true(str && str == big && *(str+GIT_OID_HEXSZ) == '\0');
 	must_be_true(strcmp(exp, big) == 0);
 

--- a/tests/t10-refs.c
+++ b/tests/t10-refs.c
@@ -1234,17 +1234,17 @@ BEGIN_TEST(reflog0, "write a reflog for a given reference and ensure it can be r
 
 	entry = (git_reflog_entry *)git_vector_get(&reflog->entries, 0);
 	must_pass(assert_signature(committer, entry->committer));
-	git_oid_to_string(oid_str, GIT_OID_HEXSZ+1, &entry->oid_old);
+	git_oid_tostr(oid_str, GIT_OID_HEXSZ+1, &entry->oid_old);
 	must_be_true(strcmp("0000000000000000000000000000000000000000", oid_str) == 0);
-	git_oid_to_string(oid_str, GIT_OID_HEXSZ+1, &entry->oid_cur);
+	git_oid_tostr(oid_str, GIT_OID_HEXSZ+1, &entry->oid_cur);
 	must_be_true(strcmp(current_master_tip, oid_str) == 0);
 	must_be_true(entry->msg == NULL);
 
 	entry = (git_reflog_entry *)git_vector_get(&reflog->entries, 1);
 	must_pass(assert_signature(committer, entry->committer));
-	git_oid_to_string(oid_str, GIT_OID_HEXSZ+1, &entry->oid_old);
+	git_oid_tostr(oid_str, GIT_OID_HEXSZ+1, &entry->oid_old);
 	must_be_true(strcmp(current_master_tip, oid_str) == 0);
-	git_oid_to_string(oid_str, GIT_OID_HEXSZ+1, &entry->oid_cur);
+	git_oid_tostr(oid_str, GIT_OID_HEXSZ+1, &entry->oid_cur);
 	must_be_true(strcmp(current_master_tip, oid_str) == 0);
 	must_be_true(strcmp(commit_msg, entry->msg) == 0);
 


### PR DESCRIPTION
To conform the naming scheme of git_oid_fromstr we should change the
name of git_oid_to_string to git_oid_tostr.
