### PR TITLE
Fix windows network paths

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -171,6 +171,15 @@ int git_path_root(const char *path)
 	/* Does the root of the path look like a windows drive ? */
 	if (isalpha(path[0]) && (path[1] == ':'))
 		offset += 2;
+
+	/* Are we dealing with a network path? */
+	else if (path[0] == '/' && path[1] == '/') {
+		offset += 2;
+	
+		/* Skip the computer name segment */
+		while (*(path + offset) && *(path + offset) != '/')
+			offset++;
+	}
 #endif
 
 	if (*(path + offset) == '/')

--- a/tests-clar/core/path.c
+++ b/tests-clar/core/path.c
@@ -388,3 +388,18 @@ void test_core_path__11_walkup(void)
 
 	git_buf_free(&p);
 }
+
+void test_core_path__12_offset_to_path_root(void)
+{
+	cl_assert(git_path_root("non/rooted/path") == -1);
+	cl_assert(git_path_root("/rooted/path") == 0);
+
+#ifdef GIT_WIN32
+	/* Windows specific tests */
+	cl_assert(git_path_root("C:non/rooted/path") == -1);
+	cl_assert(git_path_root("C:/rooted/path") == 2);
+	cl_assert(git_path_root("//computername/sharefolder/resource") == 14);
+	cl_assert(git_path_root("//computername/sharefolder") == 14);
+	cl_assert(git_path_root("//computername") == -1);
+#endif
+}


### PR DESCRIPTION
Make `git_path_root()` cope with windows network paths

Fix libgit2/libgit2sharp#125
