### PR TITLE
Adding multi-cpu compile option when generating MSVC projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ IF (MSVC)
 	# Not using __stdcall with the CRT causes problems
 	OPTION (STDCALL "Buildl libgit2 with the __stdcall convention" ON)
 
-	SET(CMAKE_C_FLAGS "/W4 /nologo /Zi ${CMAKE_C_FLAGS}")
+	SET(CMAKE_C_FLAGS "/W4 /MP /nologo /Zi ${CMAKE_C_FLAGS}")
 	IF (STDCALL)
 	  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gz")
 	ENDIF ()


### PR DESCRIPTION
This adds the `/MP` option when calling `cl.exe` in the MSVC toolchain. This results in a nice reduction of compile time. I tried this by running clean and slightly-dirty builds, using msbuild with options that closely mimic the behavior with Visual Studio but with more information.

<table>
<thead>
<th>Description</th>
<th>Time (without flag, seconds)</th>
<th>Time (with flag, seconds)</th>
</thead>
<tbody>
<tr>
<td>Clean build</td>
<td>75.74</td>
<td>56.41</td>
</tr>
<tr>
<td>Added a test</td>
<td>31.02</td>
<td>21.83</td>
</tr>
</tbody>
</table>


You can see the full logs [here](https://gist.github.com/2144073). "Change" builds were generated by adding this line to `tests-clar/commit/commit.c`:

```
void test_commit_commit__new_test(void) {}
```

The command for building was this:

```
msbuild .\libgit2.sln /m /detailedsummary
```
