### PR TITLE
test helpers: Fix file close on error

### DIFF
--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -197,7 +197,8 @@ int copy_file(const char *src, const char *dst)
 
 cleanup:
 	git_buf_free(&source_buf);
-	p_close(dst_fd);
+	if (dst_fd >= 0)
+		p_close(dst_fd);
 
 	return error;
 }


### PR DESCRIPTION
when the call to `git_futils_creat_withpath()` fails in `copy_file()` we shouldn't attempt to call `close()`.

The fix prevents an assert from failing (at least on Windows).
