### PR TITLE
Update git_repository_open

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -70,6 +70,20 @@ GIT_EXTERN(int) git_repository_discover(
 		int across_fs,
 		const char *ceiling_dirs);
 
+enum {
+	GIT_REPOSITORY_OPEN_NO_SEARCH = (1 << 0),
+	GIT_REPOSITORY_OPEN_CROSS_FS  = (1 << 1),
+};
+
+/**
+ * Find and open a repository with extended controls.
+ */
+GIT_EXTERN(int) git_repository_open_ext(
+	git_repository **repo,
+	const char *start_path,
+	uint32_t flags,
+	const char *ceiling_dirs);
+
 /**
  * Free a previously allocated repository
  *

--- a/src/diff.c
+++ b/src/diff.c
@@ -253,7 +253,7 @@ static git_diff_list *git_diff_list_alloc(
 	diff->repo = repo;
 
 	/* load config values that affect diff behavior */
-	if (git_repository_config(&cfg, repo) < 0)
+	if (git_repository_config__weakptr(&cfg, repo) < 0)
 		goto fail;
 	if (config_bool(cfg, "core.symlinks", 1))
 		diff->diffcaps = diff->diffcaps | GIT_DIFFCAPS_HAS_SYMLINKS;
@@ -264,7 +264,6 @@ static git_diff_list *git_diff_list_alloc(
 	if (config_bool(cfg, "core.trustctime", 1))
 		diff->diffcaps = diff->diffcaps | GIT_DIFFCAPS_TRUST_CTIME;
 	/* Don't set GIT_DIFFCAPS_USE_DEV - compile time option in core git */
-	git_config_free(cfg);
 
 	if (opts == NULL)
 		return diff;

--- a/src/errors.c
+++ b/src/errors.c
@@ -92,8 +92,12 @@ const char *git_lasterror(void)
 {
 	char *last_error = GIT_GLOBAL->error.last;
 
-	if (!last_error[0])
+	if (!last_error[0]) {
+		const git_error *err = git_error_last();
+		if (err != NULL)
+			return err->message;
 		return NULL;
+	}
 
 	return last_error;
 }

--- a/tests-clar/clar_libgit2.h
+++ b/tests-clar/clar_libgit2.h
@@ -57,6 +57,8 @@ GIT_INLINE(void) cl_assert_strequal_internal(
 /* Write the contents of a buffer to disk */
 void cl_git_mkfile(const char *filename, const char *content);
 void cl_git_append2file(const char *filename, const char *new_content);
+void cl_git_rewritefile(const char *filename, const char *new_content);
+void cl_git_write2file(const char *filename, const char *new_content, int mode);
 
 /* Git sandbox setup helpers */
 

--- a/tests-clar/repo/open.c
+++ b/tests-clar/repo/open.c
@@ -1,25 +1,27 @@
 #include "clar_libgit2.h"
-#include "posix.h"
-
-static git_repository *repo;
+#include "fileops.h"
 
 void test_repo_open__cleanup(void)
 {
-	git_repository_free(repo);
+	cl_git_sandbox_cleanup();
+
+	if (git_path_isdir("alternate"))
+		git_futils_rmdir_r("alternate", 1);
 }
 
 void test_repo_open__bare_empty_repo(void)
 {
-	cl_git_pass(git_repository_open(&repo, cl_fixture("empty_bare.git")));
+	git_repository *repo = cl_git_sandbox_init("empty_bare.git");
 
 	cl_assert(git_repository_path(repo) != NULL);
 	cl_assert(git__suffixcmp(git_repository_path(repo), "/") == 0);
-
 	cl_assert(git_repository_workdir(repo) == NULL);
 }
 
 void test_repo_open__standard_empty_repo_through_gitdir(void)
 {
+	git_repository *repo;
+
 	cl_git_pass(git_repository_open(&repo, cl_fixture("empty_standard_repo/.gitted")));
 
 	cl_assert(git_repository_path(repo) != NULL);
@@ -27,20 +29,246 @@ void test_repo_open__standard_empty_repo_through_gitdir(void)
 
 	cl_assert(git_repository_workdir(repo) != NULL);
 	cl_assert(git__suffixcmp(git_repository_workdir(repo), "/") == 0);
+
+	git_repository_free(repo);
 }
 
 void test_repo_open__standard_empty_repo_through_workdir(void)
 {
-	cl_fixture_sandbox("empty_standard_repo");
-	cl_git_pass(p_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
-
-	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
+	git_repository *repo = cl_git_sandbox_init("empty_standard_repo");
 
 	cl_assert(git_repository_path(repo) != NULL);
 	cl_assert(git__suffixcmp(git_repository_path(repo), "/") == 0);
 
 	cl_assert(git_repository_workdir(repo) != NULL);
 	cl_assert(git__suffixcmp(git_repository_workdir(repo), "/") == 0);
+}
 
-	cl_fixture_cleanup("empty_standard_repo");
+
+void test_repo_open__open_with_discover(void)
+{
+	static const char *variants[] = {
+		"attr", "attr/", "attr/.git", "attr/.git/",
+		"attr/sub", "attr/sub/", "attr/sub/sub", "attr/sub/sub/",
+		NULL
+	};
+	git_repository *repo;
+	const char **scan;
+
+	cl_fixture_sandbox("attr");
+	cl_git_pass(p_rename("attr/.gitted", "attr/.git"));
+
+	for (scan = variants; *scan != NULL; scan++) {
+		cl_git_pass(git_repository_open_ext(&repo, *scan, 0, NULL));
+		cl_assert(git__suffixcmp(git_repository_path(repo), "attr/.git/") == 0);
+		cl_assert(git__suffixcmp(git_repository_workdir(repo), "attr/") == 0);
+		git_repository_free(repo);
+	}
+
+	cl_fixture_cleanup("attr");
+}
+
+void test_repo_open__gitlinked(void)
+{
+	/* need to have both repo dir and workdir set up correctly */
+	git_repository *repo = cl_git_sandbox_init("empty_standard_repo");
+	git_repository *repo2;
+
+	cl_must_pass(p_mkdir("alternate", 0777));
+	cl_git_mkfile("alternate/.git", "gitdir: ../empty_standard_repo/.git");
+
+	cl_git_pass(git_repository_open(&repo2, "alternate"));
+
+	cl_assert(git_repository_path(repo2) != NULL);
+	cl_assert_(git__suffixcmp(git_repository_path(repo2), "empty_standard_repo/.git/") == 0, git_repository_path(repo2));
+	cl_assert_equal_s(git_repository_path(repo), git_repository_path(repo2));
+
+	cl_assert(git_repository_workdir(repo2) != NULL);
+	cl_assert_(git__suffixcmp(git_repository_workdir(repo2), "alternate/") == 0, git_repository_workdir(repo2));
+
+	git_repository_free(repo2);
+}
+
+void test_repo_open__from_git_new_workdir(void)
+{
+	/* The git-new-workdir script that ships with git sets up a bunch of
+	 * symlinks to create a second workdir that shares the object db with
+	 * another checkout.  Libgit2 can open a repo that has been configured
+	 * this way.
+	 */
+	cl_git_sandbox_init("empty_standard_repo");
+
+#ifndef GIT_WIN32
+	git_repository *repo2;
+	git_buf link_tgt = GIT_BUF_INIT, link = GIT_BUF_INIT, body = GIT_BUF_INIT;
+	const char **scan;
+	int link_fd;
+	static const char *links[] = {
+		"config", "refs", "logs/refs", "objects", "info", "hooks",
+		"packed-refs", "remotes", "rr-cache", "svn", NULL
+	};
+	static const char *copies[] = {
+		"HEAD", NULL
+	};
+
+	cl_git_pass(p_mkdir("alternate", 0777));
+	cl_git_pass(p_mkdir("alternate/.git", 0777));
+
+	for (scan = links; *scan != NULL; scan++) {
+		git_buf_joinpath(&link_tgt, "empty_standard_repo/.git", *scan);
+		if (git_path_exists(link_tgt.ptr)) {
+			git_buf_joinpath(&link_tgt, "../../empty_standard_repo/.git", *scan);
+			git_buf_joinpath(&link, "alternate/.git", *scan);
+			if (strchr(*scan, '/'))
+				git_futils_mkpath2file(link.ptr, 0777);
+			cl_assert_(symlink(link_tgt.ptr, link.ptr) == 0, strerror(errno));
+		}
+	}
+	for (scan = copies; *scan != NULL; scan++) {
+		git_buf_joinpath(&link_tgt, "empty_standard_repo/.git", *scan);
+		if (git_path_exists(link_tgt.ptr)) {
+			git_buf_joinpath(&link, "alternate/.git", *scan);
+			cl_git_pass(git_futils_readbuffer(&body, link_tgt.ptr));
+
+			cl_assert((link_fd = git_futils_creat_withpath(link.ptr, 0777, 0666)) >= 0);
+			cl_must_pass(p_write(link_fd, body.ptr, body.size));
+			p_close(link_fd);
+		}
+	}
+
+	git_buf_free(&link_tgt);
+	git_buf_free(&link);
+	git_buf_free(&body);
+
+
+	cl_git_pass(git_repository_open(&repo2, "alternate"));
+
+	cl_assert(git_repository_path(repo2) != NULL);
+	cl_assert_(git__suffixcmp(git_repository_path(repo2), "alternate/.git/") == 0, git_repository_path(repo2));
+
+	cl_assert(git_repository_workdir(repo2) != NULL);
+	cl_assert_(git__suffixcmp(git_repository_workdir(repo2), "alternate/") == 0, git_repository_workdir(repo2));
+
+	git_repository_free(repo2);
+#endif
+}
+
+void test_repo_open__failures(void)
+{
+	git_repository *base, *repo;
+	git_buf ceiling = GIT_BUF_INIT;
+
+	base = cl_git_sandbox_init("attr");
+	cl_git_pass(git_buf_sets(&ceiling, git_repository_workdir(base)));
+
+	/* fail with no searching */
+	cl_git_fail(git_repository_open(&repo, "attr/sub"));
+	cl_git_fail(git_repository_open_ext(
+		&repo, "attr/sub", GIT_REPOSITORY_OPEN_NO_SEARCH, NULL));
+
+	/* fail with ceiling too low */
+	cl_git_pass(git_buf_joinpath(&ceiling, ceiling.ptr, "sub"));
+	cl_git_fail(git_repository_open_ext(&repo, "attr/sub", 0, ceiling.ptr));
+
+	/* fail with no repo */
+	cl_git_pass(p_mkdir("alternate", 0777));
+	cl_git_pass(p_mkdir("alternate/.git", 0777));
+	cl_git_fail(git_repository_open_ext(&repo, "alternate", 0, NULL));
+	cl_git_fail(git_repository_open_ext(&repo, "alternate/.git", 0, NULL));
+
+	git_buf_free(&ceiling);
+}
+
+void test_repo_open__bad_gitlinks(void)
+{
+	git_repository *repo;
+	static const char *bad_links[] = {
+		"garbage\n", "gitdir", "gitdir:\n", "gitdir: foobar",
+		"gitdir: ../invalid", "gitdir: ../invalid2",
+		"gitdir: ../attr/.git with extra stuff",
+		NULL
+	};
+	const char **scan;
+
+	cl_git_sandbox_init("attr");
+
+	cl_git_pass(p_mkdir("alternate", 0777));
+	cl_git_pass(p_mkdir("invalid", 0777));
+	cl_git_pass(git_futils_mkdir_r("invalid2/.git", NULL, 0777));
+
+	for (scan = bad_links; *scan != NULL; scan++) {
+		cl_git_rewritefile("alternate/.git", *scan);
+		cl_git_fail(git_repository_open_ext(&repo, "alternate", 0, NULL));
+	}
+
+	git_futils_rmdir_r("invalid", 1);
+	git_futils_rmdir_r("invalid2", 1);
+}
+
+static void unposix_path(git_buf *path)
+{
+	char *src, *tgt;
+
+	src = tgt = path->ptr;
+
+	/* convert "/d/..." to "d:\..." */
+	if (src[0] == '/' && isalpha(src[1]) && src[2] == '/') {
+		*tgt++ = src[1];
+		*tgt++ = ':';
+		*tgt++ = '\\';
+		src += 3;
+	}
+
+	while (*src) {
+		*tgt++ = (*src == '/') ? '\\' : *src;
+		src++;
+	}
+
+	*tgt = '\0';
+}
+
+void test_repo_open__win32_path(void)
+{
+#ifdef GIT_WIN32
+	git_repository *repo = cl_git_sandbox_init("empty_standard_repo"), *repo2;
+	git_buf winpath = GIT_BUF_INIT;
+	char *src, *tgt;
+	static const char *repo_path = "empty_standard_repo/.git/";
+	static const char *repo_wd   = "empty_standard_repo/";
+
+	cl_assert(git__suffixcmp(git_repository_path(repo), repo_path) == 0);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo), repo_wd) == 0);
+
+	cl_git_pass(git_buf_sets(&winpath, git_repository_path(repo)));
+	unposix_path(&winpath);
+	cl_git_pass(git_repository_open(&repo2, winpath.ptr));
+	cl_assert(git__suffixcmp(git_repository_path(repo2), repo_path) == 0);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo2), repo_wd) == 0);
+	git_repository_free(repo2);
+
+	cl_git_pass(git_buf_sets(&winpath, git_repository_path(repo)));
+	git_buf_truncate(&winpath, winpath.size - 1); /* remove trailing '/' */
+	unposix_path(&winpath);
+	cl_git_pass(git_repository_open(&repo2, winpath.ptr));
+	cl_assert(git__suffixcmp(git_repository_path(repo2), repo_path) == 0);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo2), repo_wd) == 0);
+	git_repository_free(repo2);
+
+	cl_git_pass(git_buf_sets(&winpath, git_repository_workdir(repo)));
+	unposix_path(&winpath);
+	cl_git_pass(git_repository_open(&repo2, winpath.ptr));
+	cl_assert(git__suffixcmp(git_repository_path(repo2), repo_path) == 0);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo2), repo_wd) == 0);
+	git_repository_free(repo2);
+
+	cl_git_pass(git_buf_sets(&winpath, git_repository_workdir(repo)));
+	git_buf_truncate(&winpath, winpath.size - 1); /* remove trailing '/' */
+	unposix_path(&winpath);
+	cl_git_pass(git_repository_open(&repo2, winpath.ptr));
+	cl_assert(git__suffixcmp(git_repository_path(repo2), repo_path) == 0);
+	cl_assert(git__suffixcmp(git_repository_workdir(repo2), repo_wd) == 0);
+	git_repository_free(repo2);
+
+	git_buf_free(&winpath);
+#endif
 }


### PR DESCRIPTION
Add a new command `git_repository_open_ext` with extended options that control how searching for a repository will be done.  The existing `git_repository_open` and `git_repository_discover` are reimplemented on top of it.  We may want to change the default behavior of `git_repository_open` but this commit does not do that.

Improve support for "gitdir" files where the work dir is separate from the repo and support for the "separate-git-dir" config.  Also, add support for opening repos created with `git-new-workdir` script (although I have only confirmed that they can be opened, not that all functions work correctly).

There are also a few minor changes that came up:
- Fix `git_path_prettify` to allow in-place prettifying.
- Fix `git_path_root` to support backslashes on Win32.  This fix should help many repo open/discover scenarios - it is the one function called when opening before prettifying the path.
- Tweak `git_config_get_string` to set the "out" pointer to NULL if the config value is not found.  Allows some other cleanup.
- Fix a couple places that should have been calling `git_repository_config__weakptr` and were not.
- Fix `cl_git_sandbox_init` clar helper to support bare repos.

These changes should help with some old issues:
- For issue #479, this should allow you to open a repository using a Win32 path. This is not a global fix to allow non-posix paths, but a local one that will allow open and discover to work. (The win32 version of `realpath()` was already posix-ifying the path, so I just had to fix `git_path_root()` as mentioned above.)
- For issue #529, `separate-git-dir` should now be fully supported because workdir guessing will respect the config entry.
- For issue #620, I have written tests to confirm that a workdir built with `git-new-workdir` can definitely be opened, so reading will work. I'm guessing that writing is still broken which is more what that issue is about.
