### PR TITLE
Diff with pathspec

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -87,6 +87,7 @@ typedef struct {
 } git_strarray;
 
 GIT_EXTERN(void) git_strarray_free(git_strarray *array);
+GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
 
 /**
  * Return the version of the libgit2 library

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -334,6 +334,10 @@ int git_attr_fnmatch__parse(
 			spec->flags = spec->flags | GIT_ATTR_FNMATCH_FULLPATH;
 			slash_count++;
 		}
+		/* remember if we see an unescaped wildcard in pattern */
+		else if ((*scan == '*' || *scan == '.' || *scan == '[') &&
+			(scan == pattern || (*(scan - 1) != '\\')))
+			spec->flags = spec->flags | GIT_ATTR_FNMATCH_HASWILD;
 	}
 
 	*base = scan;

--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -20,6 +20,7 @@
 #define GIT_ATTR_FNMATCH_FULLPATH	(1U << 2)
 #define GIT_ATTR_FNMATCH_MACRO		(1U << 3)
 #define GIT_ATTR_FNMATCH_IGNORE		(1U << 4)
+#define GIT_ATTR_FNMATCH_HASWILD	(1U << 5)
 
 typedef struct {
 	char *pattern;

--- a/src/diff.h
+++ b/src/diff.h
@@ -24,6 +24,7 @@ enum {
 struct git_diff_list {
 	git_repository   *repo;
 	git_diff_options opts;
+	git_vector       pathspec;
 	git_vector       deltas;    /* vector of git_diff_file_delta */
 	git_iterator_type_t old_src;
 	git_iterator_type_t new_src;

--- a/src/status.c
+++ b/src/status.c
@@ -205,6 +205,7 @@ int git_status_foreach(
 {
 	git_status_options opts;
 
+	memset(&opts, 0, sizeof(opts));
 	opts.show  = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
 	opts.flags = GIT_STATUS_OPT_INCLUDE_IGNORED |
 		GIT_STATUS_OPT_INCLUDE_UNTRACKED |

--- a/src/util.c
+++ b/src/util.c
@@ -31,6 +31,35 @@ void git_strarray_free(git_strarray *array)
 	git__free(array->strings);
 }
 
+int git_strarray_copy(git_strarray *tgt, const git_strarray *src)
+{
+	size_t i;
+
+	assert(tgt && src);
+
+	memset(tgt, 0, sizeof(*tgt));
+
+	if (!src->count)
+		return 0;
+
+	tgt->strings = git__calloc(src->count, sizeof(char *));
+	GITERR_CHECK_ALLOC(tgt->strings);
+
+	for (i = 0; i < src->count; ++i) {
+		tgt->strings[tgt->count] = git__strdup(src->strings[i]);
+
+		if (!tgt->strings[tgt->count]) {
+			git_strarray_free(tgt);
+			memset(tgt, 0, sizeof(*tgt));
+			return -1;
+		}
+
+		tgt->count++;
+	}
+
+	return 0;
+}
+
 int git__fnmatch(const char *pattern, const char *name, int flags)
 {
 	int ret;

--- a/tests-clar/attr/file.c
+++ b/tests-clar/attr/file.c
@@ -20,7 +20,7 @@ void test_attr_file__simple_read(void)
 	cl_assert(rule != NULL);
 	cl_assert_strequal("*", rule->match.pattern);
 	cl_assert(rule->match.length == 1);
-	cl_assert(rule->match.flags == 0);
+	cl_assert((rule->match.flags & GIT_ATTR_FNMATCH_HASWILD) != 0);
 
 	cl_assert(rule->assigns.length == 1);
 	assign = get_assign(rule, 0);
@@ -74,14 +74,16 @@ void test_attr_file__match_variants(void)
 
 	rule = get_rule(4);
 	cl_assert_strequal("pat4.*", rule->match.pattern);
-	cl_assert(rule->match.flags == 0);
+	cl_assert((rule->match.flags & GIT_ATTR_FNMATCH_HASWILD) != 0);
 
 	rule = get_rule(5);
 	cl_assert_strequal("*.pat5", rule->match.pattern);
+	cl_assert((rule->match.flags & GIT_ATTR_FNMATCH_HASWILD) != 0);
 
 	rule = get_rule(7);
 	cl_assert_strequal("pat7[a-e]??[xyz]", rule->match.pattern);
 	cl_assert(rule->assigns.length == 1);
+	cl_assert((rule->match.flags & GIT_ATTR_FNMATCH_HASWILD) != 0);
 	assign = get_assign(rule,0);
 	cl_assert_strequal("attr7", assign->name);
 	cl_assert(GIT_ATTR_TRUE(assign->value));

--- a/tests-clar/diff/workdir.c
+++ b/tests-clar/diff/workdir.c
@@ -164,6 +164,79 @@ void test_diff_workdir__to_tree(void)
 	git_tree_free(b);
 }
 
+void test_diff_workdir__to_index_with_pathspec(void)
+{
+	git_diff_options opts = {0};
+	git_diff_list *diff = NULL;
+	diff_expects exp;
+	char *pathspec = NULL;
+
+	opts.context_lines = 3;
+	opts.interhunk_lines = 1;
+	opts.flags |= GIT_DIFF_INCLUDE_IGNORED | GIT_DIFF_INCLUDE_UNTRACKED;
+	opts.pathspec.strings = &pathspec;
+	opts.pathspec.count   = 1;
+
+	memset(&exp, 0, sizeof(exp));
+
+	cl_git_pass(git_diff_workdir_to_index(g_repo, &opts, &diff));
+	cl_git_pass(git_diff_foreach(diff, &exp, diff_file_fn, NULL, NULL));
+
+	cl_assert_equal_i(12, exp.files);
+	cl_assert_equal_i(0, exp.file_adds);
+	cl_assert_equal_i(4, exp.file_dels);
+	cl_assert_equal_i(4, exp.file_mods);
+	cl_assert_equal_i(1, exp.file_ignored);
+	cl_assert_equal_i(3, exp.file_untracked);
+
+	git_diff_list_free(diff);
+
+	memset(&exp, 0, sizeof(exp));
+	pathspec = "modified_file";
+
+	cl_git_pass(git_diff_workdir_to_index(g_repo, &opts, &diff));
+	cl_git_pass(git_diff_foreach(diff, &exp, diff_file_fn, NULL, NULL));
+
+	cl_assert_equal_i(1, exp.files);
+	cl_assert_equal_i(0, exp.file_adds);
+	cl_assert_equal_i(0, exp.file_dels);
+	cl_assert_equal_i(1, exp.file_mods);
+	cl_assert_equal_i(0, exp.file_ignored);
+	cl_assert_equal_i(0, exp.file_untracked);
+
+	git_diff_list_free(diff);
+
+	memset(&exp, 0, sizeof(exp));
+	pathspec = "subdir";
+
+	cl_git_pass(git_diff_workdir_to_index(g_repo, &opts, &diff));
+	cl_git_pass(git_diff_foreach(diff, &exp, diff_file_fn, NULL, NULL));
+
+	cl_assert_equal_i(3, exp.files);
+	cl_assert_equal_i(0, exp.file_adds);
+	cl_assert_equal_i(1, exp.file_dels);
+	cl_assert_equal_i(1, exp.file_mods);
+	cl_assert_equal_i(0, exp.file_ignored);
+	cl_assert_equal_i(1, exp.file_untracked);
+
+	git_diff_list_free(diff);
+
+	memset(&exp, 0, sizeof(exp));
+	pathspec = "*_deleted";
+
+	cl_git_pass(git_diff_workdir_to_index(g_repo, &opts, &diff));
+	cl_git_pass(git_diff_foreach(diff, &exp, diff_file_fn, NULL, NULL));
+
+	cl_assert_equal_i(2, exp.files);
+	cl_assert_equal_i(0, exp.file_adds);
+	cl_assert_equal_i(2, exp.file_dels);
+	cl_assert_equal_i(0, exp.file_mods);
+	cl_assert_equal_i(0, exp.file_ignored);
+	cl_assert_equal_i(0, exp.file_untracked);
+
+	git_diff_list_free(diff);
+}
+
 /* PREPARATION OF TEST DATA
  *
  * Since there is no command line equivalent of git_diff_workdir_to_tree,


### PR DESCRIPTION
This adds preliminary support for pathspecs to diff and status. The implementation is not very optimized (it still looks at every single file and evaluated the the pathspec match against them), but it works.
