### PR TITLE
WIN32 is not always defined, use GIT_WIN32 instead

### DIFF
--- a/src/xdiff/xinclude.h
+++ b/src/xdiff/xinclude.h
@@ -29,7 +29,7 @@
 #include <string.h>
 #include <limits.h>
 
-#ifdef WIN32
+#ifdef GIT_WIN32
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Cannot  compile libgit2 on Win64 with VS 2008.

compare issue #442
