### PR TITLE
Fix git_repository_set_odb() refcount issue

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -549,6 +549,7 @@ void git_repository_set_odb(git_repository *repo, git_odb *odb)
 
 	repo->_odb = odb;
 	GIT_REFCOUNT_OWN(repo->_odb, repo);
+	GIT_REFCOUNT_INC(odb);
 }
 
 int git_repository_index__weakptr(git_index **out, git_repository *repo)

--- a/tests-clar/repo/getters.c
+++ b/tests-clar/repo/getters.c
@@ -68,3 +68,19 @@ void test_repo_getters__head_orphan(void)
 	git_reference_free(ref);
 	git_repository_free(repo);
 }
+
+void test_repo_getters__retrieving_the_odb_honors_the_refcount(void)
+{
+	git_odb *odb;
+	git_repository *repo;
+
+	cl_git_pass(git_repository_open(&repo, "testrepo.git"));
+
+	cl_git_pass(git_repository_odb(&odb, repo));
+	cl_assert(((git_refcount *)odb)->refcount == 2);
+
+	git_repository_free(repo);
+	cl_assert(((git_refcount *)odb)->refcount == 1);
+
+	git_odb_free(odb);
+}

--- a/tests-clar/repo/setters.c
+++ b/tests-clar/repo/setters.c
@@ -57,3 +57,24 @@ void test_repo_setters__setting_a_new_index_on_a_repo_which_has_already_loaded_o
 	 */
 	repo = NULL;
 }
+
+void test_repo_setters__setting_a_new_odb_on_a_repo_which_already_loaded_one_properly_honors_the_refcount(void)
+{
+	git_odb *new_odb;
+
+	cl_git_pass(git_odb_open(&new_odb, "./testrepo.git/objects"));
+	cl_assert(((git_refcount *)new_odb)->refcount == 1);
+
+	git_repository_set_odb(repo, new_odb);
+	cl_assert(((git_refcount *)new_odb)->refcount == 2);
+
+	git_repository_free(repo);
+	cl_assert(((git_refcount *)new_odb)->refcount == 1);
+
+	git_odb_free(new_odb);
+
+	/* 
+	 * Ensure the cleanup method won't try to free the repo as it's already been taken care of
+	 */
+	repo = NULL;
+}


### PR DESCRIPTION
`git_repository_free()` calls `git_odb_free()` if the owned `odb` is not null.

According to the doc, when setting a new odb through `git_repository_set_odb()` the caller has to take care of releasing the odb by himself.
