### PR TITLE
Ignore pat leading slash

### DIFF
--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -10,6 +10,7 @@
 #include "git2/attr.h"
 #include "vector.h"
 #include "pool.h"
+#include "buffer.h"
 
 #define GIT_ATTR_FILE			".gitattributes"
 #define GIT_ATTR_FILE_INREPO	"info/attributes"
@@ -54,9 +55,10 @@ typedef struct {
 } git_attr_file;
 
 typedef struct {
+	git_buf     full;
 	const char *path;
 	const char *basename;
-	int is_dir;
+	int         is_dir;
 } git_attr_path;
 
 /*
@@ -113,6 +115,8 @@ extern git_attr_assignment *git_attr_rule__lookup_assignment(
 
 extern int git_attr_path__init(
 	git_attr_path *info, const char *path, const char *base);
+
+extern void git_attr_path__free(git_attr_path *info);
 
 extern int git_attr_assignment__parse(
 	git_repository *repo, /* needed to expand macros */

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -176,20 +176,23 @@ int git_ignore__lookup(git_ignores *ignores, const char *pathname, int *ignored)
 	/* first process builtins - success means path was found */
 	if (ignore_lookup_in_rules(
 			&ignores->ign_internal->rules, &path, ignored))
-		return 0;
+		goto cleanup;
 
 	/* next process files in the path */
 	git_vector_foreach(&ignores->ign_path, i, file) {
 		if (ignore_lookup_in_rules(&file->rules, &path, ignored))
-			return 0;
+			goto cleanup;
 	}
 
 	/* last process global ignores */
 	git_vector_foreach(&ignores->ign_global, i, file) {
 		if (ignore_lookup_in_rules(&file->rules, &path, ignored))
-			return 0;
+			goto cleanup;
 	}
 
 	*ignored = 0;
+
+cleanup:
+	git_attr_path__free(&path);
 	return 0;
 }

--- a/tests-clar/attr/lookup.c
+++ b/tests-clar/attr/lookup.c
@@ -25,6 +25,7 @@ void test_attr_lookup__simple(void)
 	cl_git_pass(git_attr_file__lookup_one(file,&path,"missing",&value));
 	cl_assert(!value);
 
+	git_attr_path__free(&path);
 	git_attr_file__free(file);
 }
 
@@ -45,6 +46,8 @@ static void run_test_cases(git_attr_file *file, struct attr_expected *cases, int
 		cl_git_pass(error);
 
 		attr_check_expected(c->expected, c->expected_str, value);
+
+		git_attr_path__free(&path);
 	}
 }
 
@@ -83,7 +86,7 @@ void test_attr_lookup__match_variants(void)
 		{ "/not/pat2/yousee", "attr2", EXPECT_UNDEFINED, NULL },
 		/* path match */
 		{ "pat3file", "attr3", EXPECT_UNDEFINED, NULL },
-		{ "/pat3dir/pat3file", "attr3", EXPECT_UNDEFINED, NULL },
+		{ "/pat3dir/pat3file", "attr3", EXPECT_TRUE, NULL },
 		{ "pat3dir/pat3file", "attr3", EXPECT_TRUE, NULL },
 		/* pattern* match */
 		{ "pat4.txt", "attr4", EXPECT_TRUE, NULL },
@@ -101,7 +104,7 @@ void test_attr_lookup__match_variants(void)
 		{ "pat6/pat6/.pat6", "attr6", EXPECT_TRUE, NULL },
 		{ "pat6/pat6/extra/foobar.pat6", "attr6", EXPECT_UNDEFINED, NULL },
 		{ "/prefix/pat6/pat6/foobar.pat6", "attr6", EXPECT_UNDEFINED, NULL },
-		{ "/pat6/pat6/foobar.pat6", "attr6", EXPECT_UNDEFINED, NULL },
+		{ "/pat6/pat6/foobar.pat6", "attr6", EXPECT_TRUE, NULL },
 		/* complex pattern */
 		{ "pat7a12z", "attr7", EXPECT_TRUE, NULL },
 		{ "pat7e__x", "attr7", EXPECT_TRUE, NULL },
@@ -139,6 +142,7 @@ void test_attr_lookup__match_variants(void)
 	run_test_cases(file, dir_cases, 1);
 
 	git_attr_file__free(file);
+	git_attr_path__free(&path);
 }
 
 void test_attr_lookup__assign_variants(void)

--- a/tests-clar/status/ignore.c
+++ b/tests-clar/status/ignore.c
@@ -50,3 +50,31 @@ void test_status_ignore__0(void)
 	cl_assert(git_attr_cache__is_cached(g_repo, ".git/info/exclude"));
 	cl_assert(git_attr_cache__is_cached(g_repo, ".gitignore"));
 }
+
+
+void test_status_ignore__1(void)
+{
+	int ignored;
+
+	cl_git_rewritefile("attr/.gitignore", "/*.txt\n/dir/\n");
+	git_attr_cache_flush(g_repo);
+
+	cl_git_pass(git_status_should_ignore(g_repo, "root_test4.txt", &ignored));
+	cl_assert(ignored);
+
+	cl_git_pass(git_status_should_ignore(g_repo, "sub/subdir_test2.txt", &ignored));
+	cl_assert(!ignored);
+
+	cl_git_pass(git_status_should_ignore(g_repo, "dir", &ignored));
+	cl_assert(ignored);
+
+	cl_git_pass(git_status_should_ignore(g_repo, "dir/", &ignored));
+	cl_assert(ignored);
+
+	cl_git_pass(git_status_should_ignore(g_repo, "sub/dir", &ignored));
+	cl_assert(!ignored);
+
+	cl_git_pass(git_status_should_ignore(g_repo, "sub/dir/", &ignored));
+	cl_assert(!ignored);
+}
+


### PR DESCRIPTION
We were not following the git behavior for leading slashes in path names when matching git ignores and git attribute file patterns.  This should fix issue #638.

I'm making a PR of this just so I can look it over more thoroughly before merging it.
