### PR TITLE
Recognize and report server-side error messages

### DIFF
--- a/src/pkt.h
+++ b/src/pkt.h
@@ -23,6 +23,7 @@ enum git_pkt_type {
 	GIT_PKT_NAK,
 	GIT_PKT_PACK,
 	GIT_PKT_COMMENT,
+	GIT_PKT_ERR,
 };
 
 /* Used for multi-ack */
@@ -63,6 +64,11 @@ typedef struct {
 	enum git_pkt_type type;
 	char comment[GIT_FLEX_ARRAY];
 } git_pkt_comment;
+
+typedef struct {
+	enum git_pkt_type type;
+	char error[GIT_FLEX_ARRAY];
+} git_pkt_err;
 
 int git_pkt_parse_line(git_pkt **head, const char *line, const char **out, size_t len);
 int git_pkt_buffer_flush(git_buf *buf);

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -40,6 +40,13 @@ int git_protocol_store_refs(git_protocol *p, const char *data, size_t len)
 			return p->error = -1;
 
 		git_buf_consume(buf, line_end);
+
+		if (pkt->type == GIT_PKT_ERR) {
+			giterr_set(GITERR_NET, "Remote error: %s", ((git_pkt_err *)pkt)->error);
+			git__free(pkt);
+			return -1;
+		}
+
 		if (git_vector_insert(refs, pkt) < 0)
 			return p->error = -1;
 


### PR DESCRIPTION
When e.g. a repository isn't found, the server sends an error saying
so. Put that error message in our error buffer.

This actually produces a better error message than git, as we pretend that the dumb HTTP transport never existed and actually say what the other end gave us. If you typo really bad and hit a real HTTP server, we'll probably get HTML in return, but I'm going to say that's outside of the library's scope.
