### PR TITLE
compat: make p_open able to accept optional mode when passing the O_CREAT flag

### DIFF
--- a/src/posix.c
+++ b/src/posix.c
@@ -12,9 +12,20 @@
 
 #ifndef GIT_WIN32
 
-int p_open(const char *path, int flags)
+int p_open(const char *path, int flags, ...)
 {
-	return open(path, flags | O_BINARY);
+	mode_t mode = 0;
+
+	if (flags & O_CREAT)
+	{
+		va_list arg_list;
+
+		va_start(arg_list, flags);
+		mode = va_arg(arg_list, mode_t);
+		va_end(arg_list);
+	}
+
+	return open(path, flags | O_BINARY, mode);
 }
 
 int p_creat(const char *path, mode_t mode)

--- a/src/posix.h
+++ b/src/posix.h
@@ -42,7 +42,7 @@ extern int p_write(git_file fd, const void *buf, size_t cnt);
 #define p_close(fd) close(fd)
 #define p_umask(m) umask(m)
 
-extern int p_open(const char *path, int flags);
+extern int p_open(const char *path, int flags, ...);
 extern int p_creat(const char *path, mode_t mode);
 extern int p_getcwd(char *buffer_out, size_t size);
 extern int p_rename(const char *from, const char *to);

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -45,7 +45,7 @@ extern int p_chmod(const char* path, mode_t mode);
 extern int p_rmdir(const char* path);
 extern int p_access(const char* path, mode_t mode);
 extern int p_fsync(int fd);
-extern int p_open(const char *path, int flags);
+extern int p_open(const char *path, int flags, ...);
 extern int p_creat(const char *path, mode_t mode);
 extern int p_getcwd(char *buffer_out, size_t size);
 extern int p_rename(const char *from, const char *to);

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -217,13 +217,27 @@ int p_readlink(const char *link, char *target, size_t target_len)
 	return dwRet;
 }
 
-int p_open(const char *path, int flags)
+int p_open(const char *path, int flags, ...)
 {
 	int fd;
-	wchar_t* buf = gitwin_to_utf16(path);
+	wchar_t* buf;
+	mode_t mode = 0;
+
+	buf = gitwin_to_utf16(path);
 	if (!buf)
 		return -1;
-	fd = _wopen(buf, flags | _O_BINARY);
+
+	if (flags & O_CREAT)
+	{
+		va_list arg_list;
+
+		va_start(arg_list, flags);
+		mode = va_arg(arg_list, mode_t);
+		va_end(arg_list);
+	}
+
+	fd = _wopen(buf, flags | _O_BINARY, mode);
+
 	git__free(buf);
 	return fd;
 }

--- a/tests-clar/clar_helpers.c
+++ b/tests-clar/clar_helpers.c
@@ -30,7 +30,7 @@ void cl_git_mkfile(const char *filename, const char *content)
 
 void cl_git_write2file(const char *filename, const char *new_content, int flags)
 {
-	int fd = open(filename, flags, 0644);
+	int fd = p_open(filename, flags, 0644);
 	cl_assert(fd >= 0);
 	if (!new_content)
 		new_content = "\n";


### PR DESCRIPTION
This has the nice side effect of making `staging_properly_normalizes_line_endings_according_to_gitattributes_directives()` test pass again on Windows.

This test started to fail after commit 674a198 was applied.
