### PR TITLE
Add support for diffing index with no HEAD

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -631,7 +631,7 @@ int git_diff_index_to_tree(
 {
 	git_iterator *a = NULL, *b = NULL;
 
-	assert(repo && old_tree && diff);
+	assert(repo && diff);
 
 	if (git_iterator_for_tree(repo, old_tree, &a) < 0 ||
 		git_iterator_for_index(repo, &b) < 0)

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -13,6 +13,7 @@
 typedef struct git_iterator git_iterator;
 
 typedef enum {
+	GIT_ITERATOR_EMPTY = 0,
 	GIT_ITERATOR_TREE = 1,
 	GIT_ITERATOR_INDEX = 2,
 	GIT_ITERATOR_WORKDIR = 3
@@ -26,6 +27,8 @@ struct git_iterator {
 	int (*reset)(git_iterator *);
 	void (*free)(git_iterator *);
 };
+
+int git_iterator_for_nothing(git_iterator **iter);
 
 int git_iterator_for_tree(
 	git_repository *repo, git_tree *tree, git_iterator **iter);

--- a/src/status.c
+++ b/src/status.c
@@ -101,7 +101,7 @@ int git_status_foreach_ext(
 		diffopt.flags = diffopt.flags | GIT_DIFF_RECURSE_UNTRACKED_DIRS;
 	/* TODO: support EXCLUDE_SUBMODULES flag */
 
-	if (show != GIT_STATUS_SHOW_WORKDIR_ONLY && head != NULL &&
+	if (show != GIT_STATUS_SHOW_WORKDIR_ONLY &&
 		(err = git_diff_index_to_tree(repo, &diffopt, head, &idx2head)) < 0)
 		goto cleanup;
 


### PR DESCRIPTION
When a repo is first created, there is no HEAD yet and attempting to diff files in the index was showing nothing because a tree iterator could not be constructed.  This adds an "empty" iterator and falls back on that when the head cannot be looked up.
