### PR TITLE
util: Fix git__isspace() implementation

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -206,7 +206,7 @@ GIT_INLINE(bool) git__isalpha(int c)
 
 GIT_INLINE(bool) git__isspace(int c)
 {
-    return (c == ' ' || c == '\t' || c == '\n' || c == '\12');
+    return (c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r' || c == '\v');
 }
 
 #endif /* INCLUDE_util_h__ */


### PR DESCRIPTION
The characters `<space>`, `<form-feed>`, `<newline>`, `<carriage-return>`, `<tab>`, and `<vertical-tab>` are part of the "space" definition.

cf. http://www.kernel.org/doc/man-pages/online/pages/man5/locale.5.html
