### PR TITLE
Improve repo initialization to be more like git

### DIFF
--- a/tests-clar/repo/init.c
+++ b/tests-clar/repo/init.c
@@ -141,3 +141,27 @@ void test_repo_init__reinit_too_recent_bare_repo(void)
 
 	cl_fixture_cleanup("reinit.git");
 }
+
+void test_repo_init__additional_templates(void)
+{
+	git_buf path = GIT_BUF_INIT;
+
+	cl_set_cleanup(&cleanup_repository, "tester");
+
+	ensure_repository_init("tester", 0, "tester/.git/", "tester/");
+
+	cl_git_pass(
+		git_buf_joinpath(&path, git_repository_path(_repo), "description"));
+	cl_assert(git_path_isfile(git_buf_cstr(&path)));
+
+	cl_git_pass(
+		git_buf_joinpath(&path, git_repository_path(_repo), "info/exclude"));
+	cl_assert(git_path_isfile(git_buf_cstr(&path)));
+
+	cl_git_pass(
+		git_buf_joinpath(&path, git_repository_path(_repo), "hooks"));
+	cl_assert(git_path_isdir(git_buf_cstr(&path)));
+	/* won't confirm specific contents of hooks dir since it may vary */
+
+	git_buf_free(&path);
+}


### PR DESCRIPTION
This adds a bunch of template files to the initialization for hooks, info/exclude, and description.  This makes our initialized repo look more like core git.  Specifically, this adds:
- `.git/description` identical to core git
- `info/exclude` all commented out, not identical to core git
- `hooks/README.sample` all commented out with a reference to `git help hooks` which is completely different than the many template hooks that core git puts in this directory

The description file is simple and just matches git's behavior. The other two are compromises, ensuring the that info and hooks directories are made and minimally populated, even though the files are simpler than what core git puts there.

I don't love the fact that this is all stored in #defines, but it seemed like the simplest way to get some quick template content written, and I did try to use minimalist templates relative to core git.

The one thing that's missing from this PR is any sort of test that checks for the presence of these various directories and files post-initialization. Since not of the files are required, I wasn't certain what to test, but I suppose it makes sense to have at least one test that verifies that the files get created properly when we initialize a repo.
