### PR TITLE
object: make git_object_lookup() return GIT_ENOTFOUND - The sequel

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -109,8 +109,8 @@ int git_object_lookup_prefix(
 		if (object != NULL) {
 			if (type != GIT_OBJ_ANY && type != object->type) {
 				git_object_free(object);
-				giterr_set(GITERR_INVALID, "The given type does not match the type in ODB");
-				return -1;
+				giterr_set(GITERR_ODB, "The given type does not match the type in ODB");
+				return GIT_ENOTFOUND;
 			}
 
 			*object_out = object;

--- a/tests-clar/object/lookup.c
+++ b/tests-clar/object/lookup.c
@@ -35,3 +35,29 @@ void test_object_lookup__lookup_nonexisting_returns_enotfound(void)
 	cl_assert_equal_i(
 		GIT_ENOTFOUND, git_object_lookup(&object, g_repo, &oid, GIT_OBJ_ANY));
 }
+
+void test_object_lookup__lookup_wrong_type_by_abbreviated_id_returns_enotfound(void)
+{
+	const char *commit = "e90810b";
+	git_oid oid;
+	git_object *object;
+
+	cl_git_pass(git_oid_fromstrn(&oid, commit, strlen(commit)));
+	cl_assert_equal_i(
+		GIT_ENOTFOUND, git_object_lookup_prefix(&object, g_repo, &oid, strlen(commit), GIT_OBJ_TAG));
+}
+
+void test_object_lookup__lookup_wrong_type_eventually_returns_enotfound(void)
+{
+	const char *commit = "e90810b8df3e80c413d903f631643c716887138d";
+	git_oid oid;
+	git_object *object;
+
+	cl_git_pass(git_oid_fromstr(&oid, commit));
+
+	cl_git_pass(git_object_lookup(&object, g_repo, &oid, GIT_OBJ_COMMIT));
+	git_object_free(object);
+
+	cl_assert_equal_i(
+		GIT_ENOTFOUND, git_object_lookup(&object, g_repo, &oid, GIT_OBJ_TAG));
+}


### PR DESCRIPTION
This fix complements cb0ce16bbe8efe2098ef9cfffcf158301b036565 and cover the following additional use cases
- retrieving an object which has been previously searched, found and cached
- retrieving an object through an non ambiguous abbreviated id
