### PR TITLE
Staged file status does not handle CRLF (issue #690)

### DIFF
--- a/tests-clar/status/worktree.c
+++ b/tests-clar/status/worktree.c
@@ -446,3 +446,30 @@ void test_status_worktree__first_commit_in_progress(void)
 	git_index_free(index);
 	git_repository_free(repo);
 }
+
+void test_status_worktree__new_staged_file_must_handle_crlf(void)
+{
+	git_repository *repo;
+	git_index *index;
+	git_config *config;
+	unsigned int status;
+
+	cl_git_pass(git_repository_init(&repo, "getting_started", 0));
+
+	// Ensure that repo has core.autocrlf=true
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_bool(config, "core.autocrlf", true));
+
+	cl_git_mkfile("getting_started/testfile.txt", "content\r\n");	// Content with CRLF
+
+	cl_git_pass(git_repository_index(&index, repo));
+	cl_git_pass(git_index_add(index, "testfile.txt", 0));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_status_file(&status, repo, "testfile.txt"));
+	cl_assert_equal_i(GIT_STATUS_INDEX_NEW, status);
+
+	git_config_free(config);
+	git_index_free(index);
+	git_repository_free(repo);
+}


### PR DESCRIPTION
This test fails on my machine. I have core.autocrlf=true in my global settings.
