### PR TITLE
really reset walker with git_revwalk_reset

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -838,5 +838,8 @@ void git_revwalk_reset(git_revwalk *walk)
 	commit_list_free(&walk->iterator_rand);
 	commit_list_free(&walk->iterator_reverse);
 	walk->walking = 0;
+
+	walk->one = NULL;
+	git_vector_clear(&walk->twos);
 }
 


### PR DESCRIPTION
From the description  of `git_revwalk_reset` in revwalk.h the function should clear all pushed and hidden commits, and leave the walker in a blank state (just like at creation). Apparently everything gets reseted appart of pushed commits (walk->one and walk->twos). Is this intended? Either the docs are not up-to-date or it should get fixed.
