### PR TITLE
Embedded makefile fixes

### DIFF
--- a/Makefile.embed
+++ b/Makefile.embed
@@ -6,8 +6,8 @@ LIBNAME=libgit2.a
 
 INCLUDES= -I. -Isrc -Iinclude -Ideps/http-parser -Ideps/zlib
 
-DEFINES= $(INCLUDES) -DNO_VIZ -DSTDC -DNO_GZIP -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
-CFLAGS= -g $(DEFINES) -Wall -Wextra -fPIC -O2
+DEFINES= $(INCLUDES) -DNO_VIZ -DSTDC -DNO_GZIP -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE $(EXTRA_DEFINES)
+CFLAGS= -g $(DEFINES) -Wall -Wextra -fPIC -O2 $(EXTRA_CFLAGS)
 
 SRCS = $(wildcard src/*.c) $(wildcard src/transports/*.c) $(wildcard src/unix/*.c) $(wildcard src/xdiff/*.c) $(wildcard deps/http-parser/*.c) $(wildcard deps/zlib/*.c)
 OBJS = $(patsubst %.c,%.o,$(SRCS))


### PR DESCRIPTION
One minor improvement to the embedded Makefile that lets us use it and one critical fix to let it work at all (building xdiff).

(I'm using this in a new language binding.)
