### PR TITLE
config: do not set an error for GIT_ENOTFOUND

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -391,7 +391,6 @@ int git_config_get_string(const char **out, git_config *cfg, const char *name)
 			return ret;
 	}
 
-	giterr_set(GITERR_CONFIG, "Config variable '%s' not found", name);
 	return GIT_ENOTFOUND;
 }
 


### PR DESCRIPTION
An unset config variable isn't bad per se -- let the call site set an error in case GIT_ENOTFOUND isn't acceptable.
