### PR TITLE
Cleanup

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -18,15 +18,6 @@
 
 #include <stdarg.h>
 
-#define COMMIT_BASIC_PARSE 0x0
-#define COMMIT_FULL_PARSE 0x1
-
-#define COMMIT_PRINT(commit) {\
-	char oid[41]; oid[40] = 0;\
-	git_oid_fmt(oid, &commit->object.id);\
-	printf("Oid: %s | In degree: %d | Time: %u\n", oid, commit->in_degree, commit->commit_time);\
-}
-
 static void clear_parents(git_commit *commit)
 {
 	unsigned int i;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -839,7 +839,6 @@ int git_indexer_run(git_indexer *idx, git_indexer_stats *stats)
 		git_oid_cpy(&pentry->sha1, &oid);
 		pentry->offset = entry_start;
 		git_oid_fmt(fmt, &oid);
-		printf("adding %s to cache\n", fmt);
 		error = git_vector_insert(&idx->pack->cache, pentry);
 		if (error < 0)
 			goto cleanup;


### PR DESCRIPTION
- indexer: remove leftover printf
- commit: remove unused macros COMMIT_BASIC_PARSE, COMMIT_FULL_PARSE and COMMIT_PRINT
