### PR TITLE
Make git_futils_mkdir_r() able to cope with Windows network paths

### DIFF
--- a/src/fileops.h
+++ b/src/fileops.h
@@ -49,6 +49,9 @@ extern int git_futils_creat_locked_withpath(const char *path, const mode_t dirmo
 
 /**
  * Create a path recursively
+ *
+ * If a base parameter is being passed, it's expected to be valued with a path pointing to an already
+ * exisiting directory.
  */
 extern int git_futils_mkdir_r(const char *path, const char *base, const mode_t mode);
 


### PR DESCRIPTION
This partially fixes libgit2/libgit2sharp#153.

This PR contains no test. Indeed, I haven't been able to come up with an easy way to unit test the recursive creation of folders on a Windows network path.

However the following steps should allow one adventurous reviewer to check the correctness of this fix:
1. Within an existing `C:\Temp` folder, create a new `shared` folder.
2. Share the `shared` folder and make it read-write accessible to the identity under which the clar tests are being run.
3. Add the following test to `tests-clar/repo/init.c`
4. Replace `COMPUTER_NAME` with... well... the name of the computer

``` c
void test_repo_init__standard_repo_on_a_network_path(void)
{
    if (git_path_isdir("C:/temp/shared/boom"));
        git_futils_rmdir_r("C:/temp/shared/boom", GIT_DIRREMOVAL_FILES_AND_DIRS);

    cl_git_pass(git_repository_init(&_repo, "//COMPUTER_NAME/shared/boom", false));
    git_repository_free(_repo);

    cl_git_pass(git_repository_open(&_repo, "//COMPUTER_NAME/shared/boom"));
}
```
