### PR TITLE
Define git_reference_listall macro for backward compatibility.

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -258,6 +258,9 @@ GIT_EXTERN(int) git_reference_packall(git_repository *repo);
  */
 GIT_EXTERN(int) git_reference_list(git_strarray *array, git_repository *repo, unsigned int list_flags);
 
+/* The macro is for backward compatibility */
+#define git_reference_listall git_reference_list
+
 
 /**
  * Perform an operation on each reference in the repository


### PR DESCRIPTION
The function name change breaks the backward compatibility: 4fbd1c007e6c72b32c0dd2a29036a5670f85120a

Wish you could merge this pull request to keep the backward compatibility.
