### PR TITLE
RFC: A proposal for setting callbacks

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -190,7 +190,7 @@ GIT_EXTERN(void) git_remote_free(git_remote *remote);
  * @param remote the remote to update
  * @param cb callback to run on each ref update. 'a' is the old value, 'b' is then new value
  */
-GIT_EXTERN(int) git_remote_update_tips(git_remote *remote, int (*cb)(const char *refname, const git_oid *a, const git_oid *b));
+GIT_EXTERN(int) git_remote_update_tips(git_remote *remote);
 
 /**
  * Return whether a string is a valid remote URL
@@ -228,6 +228,25 @@ GIT_EXTERN(int) git_remote_list(git_strarray *remotes_list, git_repository *repo
  * @param url the remote's url
  */
 GIT_EXTERN(int) git_remote_add(git_remote **out, git_repository *repo, const char *name, const char *url);
+
+typedef enum {
+	GIT_CALLBACK_PROGRESS,
+	GIT_CALLBACK_ERROR,
+	GIT_CALLBACK_AUTH,
+	GIT_CALLBACK_UPDATE_TIPS,
+	GIT_CALLBACK_DONE,
+} git_callback_t;
+
+typedef int (*git_update_tips_cb)(const char *refname, const git_oid *a, const git_oid *b, void *data);
+/**
+ * Set a callback for a particular event
+ *
+ * @param remote The remote to act on
+ * @param opt Which callback to set
+ * @param callback function pointer to the callback
+ * @param data user-supplied data to pass to the callback
+ */
+GIT_EXTERN(int) git_remote_callback(git_remote *remote, git_callback_t opt, void *callback, void *data);
 
 /** @} */
 GIT_END_DECL

--- a/src/remote.c
+++ b/src/remote.c
@@ -324,7 +324,7 @@ int git_remote_download(git_remote *remote, git_off_t *bytes, git_indexer_stats 
 	return git_fetch_download_pack(remote, bytes, stats);
 }
 
-int git_remote_update_tips(git_remote *remote, int (*cb)(const char *refname, const git_oid *a, const git_oid *b))
+int git_remote_update_tips(git_remote *remote)
 {
 	int error = 0;
 	unsigned int i = 0;
@@ -371,8 +371,8 @@ int git_remote_update_tips(git_remote *remote, int (*cb)(const char *refname, co
 
 		git_reference_free(ref);
 
-		if (cb != NULL) {
-			if (cb(refname.ptr, &old, &head->oid) < 0)
+		if (remote->update_tips != NULL) {
+			if (remote->update_tips(refname.ptr, &old, &head->oid, remote->update_tips_data) < 0)
 				goto on_error;
 		}
 	}
@@ -384,6 +384,22 @@ on_error:
 	git_buf_free(&refname);
 	return -1;
 
+}
+
+int git_remote_callback(git_remote *remote, git_callback_t opt, void *fn, void *data)
+{
+	switch (opt) {
+	case GIT_CALLBACK_UPDATE_TIPS:
+		remote->update_tips = (git_update_tips_cb)fn;
+		remote->update_tips_data = data;
+		break;
+	default:
+		/* Set an error when we do this for real */
+		return -1;
+		break;
+	}
+
+	return 0;
 }
 
 int git_remote_connected(git_remote *remote)

--- a/src/remote.h
+++ b/src/remote.h
@@ -20,6 +20,8 @@ struct git_remote {
 	git_transport *transport;
 	git_repository *repo;
 	unsigned int need_pack:1;
+	git_update_tips_cb update_tips;
+	void *update_tips_data;
 };
 
 #endif


### PR DESCRIPTION
The code right now doesn't use many callbacks, but pretend that we do support the side-band (coming soon). Either we pass two callbacks to `git_remote_download` and hope that the git protocol never changes in a way that would cause side-band data to be sent before we call that function, or we set the callbacks before we start talking to the server.

We'll also need to use two callbacks for the connection phase (one if we don't like the server and one if the server doesn't like us).

At some point we might want to add a `git_fetch()` function that does all of the remote handling for the user, and we could end up having to pass four or five callbacks to it.

So I'd like to propose to use either this or something similar (maybe use a different function to set each callback, but I'm not sure that's preferable). It's not particularly pretty, but the whole connecting to another computer thing is a dirty business.
