### PR TITLE
Fix bugs for status

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -403,9 +403,14 @@ int git_attr_cache__push_file(
 		goto finish;
 	}
 
-	if (!file &&
-		(error = git_attr_file__new(&file, source, relfile, &cache->pool)) < 0)
-		goto finish;
+	/* if we got here, we have to parse and/or reparse the file */
+	if (file)
+		git_attr_file__clear_rules(file);
+	else {
+		error = git_attr_file__new(&file, source, relfile, &cache->pool);
+		if (error < 0)
+			goto finish;
+	}
 
 	if (parse && (error = parse(repo, content, file)) < 0)
 		goto finish;

--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -22,6 +22,7 @@
 #define GIT_ATTR_FNMATCH_MACRO		(1U << 3)
 #define GIT_ATTR_FNMATCH_IGNORE		(1U << 4)
 #define GIT_ATTR_FNMATCH_HASWILD	(1U << 5)
+#define GIT_ATTR_FNMATCH_ALLOWSPACE	(1U << 6)
 
 typedef struct {
 	char *pattern;
@@ -87,6 +88,8 @@ extern int git_attr_file__new_and_load(
 	git_attr_file **attrs_ptr, const char *path);
 
 extern void git_attr_file__free(git_attr_file *file);
+
+extern void git_attr_file__clear_rules(git_attr_file *file);
 
 extern int git_attr_file__parse_buffer(
 	git_repository *repo, const char *buf, git_attr_file *file);

--- a/src/diff.c
+++ b/src/diff.c
@@ -342,6 +342,7 @@ static git_diff_list *git_diff_list_alloc(
 		git_attr_fnmatch *match = git__calloc(1, sizeof(git_attr_fnmatch));
 		if (!match)
 			goto fail;
+		match->flags = GIT_ATTR_FNMATCH_ALLOWSPACE;
 		ret = git_attr_fnmatch__parse(match, &diff->pool, NULL, &pattern);
 		if (ret == GIT_ENOTFOUND) {
 			git__free(match);

--- a/tests-clar/attr/attr_expect.h
+++ b/tests-clar/attr/attr_expect.h
@@ -18,19 +18,20 @@ struct attr_expected {
 GIT_INLINE(void) attr_check_expected(
 	enum attr_expect_t expected,
 	const char *expected_str,
+	const char *name,
 	const char *value)
 {
 	switch (expected) {
 	case EXPECT_TRUE:
-		cl_assert(GIT_ATTR_TRUE(value));
+		cl_assert_(GIT_ATTR_TRUE(value), name);
 		break;
 
 	case EXPECT_FALSE:
-		cl_assert(GIT_ATTR_FALSE(value));
+		cl_assert_(GIT_ATTR_FALSE(value), name);
 		break;
 
 	case EXPECT_UNDEFINED:
-		cl_assert(GIT_ATTR_UNSPECIFIED(value));
+		cl_assert_(GIT_ATTR_UNSPECIFIED(value), name);
 		break;
 
 	case EXPECT_STRING:

--- a/tests-clar/attr/file.c
+++ b/tests-clar/attr/file.c
@@ -114,7 +114,7 @@ static void check_one_assign(
 	cl_assert_equal_s(name, assign->name);
 	cl_assert(assign->name_hash == git_attr_file__name_hash(assign->name));
 
-	attr_check_expected(expected, expected_str, assign->value);
+	attr_check_expected(expected, expected_str, assign->name, assign->value);
 }
 
 void test_attr_file__assign_variants(void)

--- a/tests-clar/attr/lookup.c
+++ b/tests-clar/attr/lookup.c
@@ -44,7 +44,7 @@ static void run_test_cases(git_attr_file *file, struct attr_expected *cases, int
 		error = git_attr_file__lookup_one(file,&path,c->attr,&value);
 		cl_git_pass(error);
 
-		attr_check_expected(c->expected, c->expected_str, value);
+		attr_check_expected(c->expected, c->expected_str, c->attr, value);
 
 		git_attr_path__free(&path);
 	}

--- a/tests-clar/attr/repo.c
+++ b/tests-clar/attr/repo.c
@@ -65,7 +65,7 @@ void test_attr_repo__get_one(void)
 	for (scan = test_cases; scan->path != NULL; scan++) {
 		const char *value;
 		cl_git_pass(git_attr_get(&value, g_repo, 0, scan->path, scan->attr));
-		attr_check_expected(scan->expected, scan->expected_str, value);
+		attr_check_expected(scan->expected, scan->expected_str, scan->attr, value);
 	}
 
 	cl_assert(git_attr_cache__is_cached(g_repo, 0, ".git/info/attributes"));

--- a/tests-clar/core/env.c
+++ b/tests-clar/core/env.c
@@ -52,8 +52,11 @@ static int cl_setenv(const char *name, const char *value)
 
 #endif
 
-static char *env_home = NULL;
+#ifdef GIT_WIN32
 static char *env_userprofile = NULL;
+#else
+static char *env_home = NULL;
+#endif
 
 void test_core_env__initialize(void)
 {


### PR DESCRIPTION
This fixes two bugs:
- Issue #728 where git_status_file was not working for files that contain spaces.  This was caused by reusing the "fnmatch" parsing code from ignore and attribute files to interpret the "pathspec" that constrained the files to apply the status to. In that code, unescaped whitespace was considered terminal to the pattern, so a file with internal whitespace was excluded from the matched files.  The fix was to add a mode to that code that allows spaces and tabs inside patterns.
- The other issue was undetected, but it was in the recently added code to reload gitattributes / gitignores when they were changed on disk.  That code was not clearing out the old values from the cached file content before reparsing which meant that newly added patterns would be read in, but deleted patterns would not be removed.  The fix was to clear the vector of patterns in a cached file before parsing the new contents of the file.
