### PR TITLE
tests-clar/core: fix non-null warning

### DIFF
--- a/tests-clar/core/env.c
+++ b/tests-clar/core/env.c
@@ -48,8 +48,11 @@ static int cl_setenv(const char *name, const char *value)
 
 #include <stdlib.h>
 #define cl_getenv(n)   getenv(n)
-#define cl_setenv(n,v) (v) ? setenv((n),(v),1) : unsetenv(n)
 
+static int cl_setenv(const char *name, const char *value)
+{
+	return (value == NULL) ? unsetenv(name) : setenv(name, value, 1);
+}
 #endif
 
 #ifdef GIT_WIN32


### PR DESCRIPTION
gcc 4.7.0 apparently doesn't see that we won't call setenv with NULL as second argument.
