### PR TITLE
refs: add git_reference_target_type

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -104,6 +104,17 @@ GIT_EXTERN(const git_oid *) git_reference_oid(git_reference *ref);
 GIT_EXTERN(const char *) git_reference_target(git_reference *ref);
 
 /**
+ * Get type of the object this reference points to
+ *
+ * Works for both symbolic and direct references.
+ *
+ * @param type Pointer to type
+ * @param ref The reference
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_reference_target_type(git_otype *type, git_reference *ref);
+
+/**
  * Get the type of a reference
  *
  * Either direct (GIT_REF_OID) or symbolic (GIT_REF_SYMBOLIC)

--- a/src/refs.c
+++ b/src/refs.c
@@ -1764,3 +1764,28 @@ int git_reference__update(git_repository *repo, const git_oid *oid, const char *
 	git_reference_free(ref);
 	return res;
 }
+
+int git_reference_target_type(git_otype *type, git_reference *ref)
+{
+	int error;
+	git_object *o;
+	git_reference *r;
+	const git_oid *oid;
+
+	error = git_reference_resolve(&r, ref);
+	if (error < 0)
+		return error;
+
+	oid = git_reference_oid(r);
+
+	error = git_object_lookup(&o, r->owner, oid, GIT_OBJ_ANY);
+	git_reference_free(r);
+
+	if (error < 0)
+		return error;
+
+	*type = git_object_type(o);
+	git_object_free(o);
+
+	return 0;
+}

--- a/tests-clar/refs/read.c
+++ b/tests-clar/refs/read.c
@@ -67,8 +67,11 @@ void test_refs_read__symbolic(void)
 	git_reference *reference, *resolved_ref;
 	git_object *object;
 	git_oid id;
+	git_otype type;
 
 	cl_git_pass(git_reference_lookup(&reference, g_repo, GIT_HEAD_FILE));
+	cl_git_pass(git_reference_target_type(&type, reference));
+	cl_assert(type == GIT_OBJ_COMMIT);
 	cl_assert(git_reference_type(reference) & GIT_REF_SYMBOLIC);
 	cl_assert(git_reference_is_packed(reference) == 0);
 	cl_assert_equal_s(reference->name, GIT_HEAD_FILE);


### PR DESCRIPTION
Allow users to easily retrieve the type of the object a reference points to.

@brianmario: that's what you were looking for?
