### PR TITLE
Tests: wrap 'getenv' and friends for Win32 tests.

### DIFF
--- a/tests-clar/clar_helpers.c
+++ b/tests-clar/clar_helpers.c
@@ -48,6 +48,62 @@ void cl_git_rewritefile(const char *filename, const char *new_content)
 	cl_git_write2file(filename, new_content, O_WRONLY | O_CREAT | O_TRUNC);
 }
 
+#ifdef GIT_WIN32
+
+#include "win32/utf-conv.h"
+
+char *cl_getenv(const char *name)
+{
+	wchar_t *name_utf16 = gitwin_to_utf16(name);
+	DWORD value_len, alloc_len;
+	wchar_t *value_utf16;
+	char *value_utf8;
+
+	cl_assert(name_utf16);
+	alloc_len = GetEnvironmentVariableW(name_utf16, NULL, 0);
+	if (alloc_len <= 0)
+		return NULL;
+
+	cl_assert(value_utf16 = git__calloc(alloc_len, sizeof(wchar_t)));
+
+	value_len = GetEnvironmentVariableW(name_utf16, value_utf16, alloc_len);
+	cl_assert_equal_i(value_len, alloc_len - 1);
+
+	cl_assert(value_utf8 = gitwin_from_utf16(value_utf16));
+
+	git__free(value_utf16);
+
+	return value_utf8;
+}
+
+int cl_setenv(const char *name, const char *value)
+{
+	wchar_t *name_utf16 = gitwin_to_utf16(name);
+	wchar_t *value_utf16 = value ? gitwin_to_utf16(value) : NULL;
+
+	cl_assert(name_utf16);
+	cl_assert(SetEnvironmentVariableW(name_utf16, value_utf16));
+
+	git__free(name_utf16);
+	git__free(value_utf16);
+
+	return 0;
+
+}
+#else
+
+#include <stdlib.h>
+char *cl_getenv(const char *name)
+{
+   return getenv(name);
+}
+
+int cl_setenv(const char *name, const char *value)
+{
+	return (value == NULL) ? unsetenv(name) : setenv(name, value, 1);
+}
+#endif
+
 static const char *_cl_sandbox = NULL;
 static git_repository *_cl_repo = NULL;
 
@@ -98,3 +154,4 @@ void cl_git_sandbox_cleanup(void)
 		_cl_sandbox = NULL;
 	}
 }
+

--- a/tests-clar/clar_libgit2.h
+++ b/tests-clar/clar_libgit2.h
@@ -40,6 +40,10 @@ void cl_git_append2file(const char *filename, const char *new_content);
 void cl_git_rewritefile(const char *filename, const char *new_content);
 void cl_git_write2file(const char *filename, const char *new_content, int mode);
 
+/* Environment wrappers */
+char *cl_getenv(const char *name);
+int cl_setenv(const char *name, const char *value);
+
 /* Git sandbox setup helpers */
 
 git_repository *cl_git_sandbox_init(const char *sandbox);

--- a/tests-clar/core/env.c
+++ b/tests-clar/core/env.c
@@ -3,59 +3,6 @@
 #include "path.h"
 
 #ifdef GIT_WIN32
-
-#include "win32/utf-conv.h"
-
-static char *cl_getenv(const char *name)
-{
-	wchar_t *name_utf16 = gitwin_to_utf16(name);
-	DWORD value_len, alloc_len;
-	wchar_t *value_utf16;
-	char *value_utf8;
-
-	cl_assert(name_utf16);
-	alloc_len = GetEnvironmentVariableW(name_utf16, NULL, 0);
-	if (alloc_len <= 0)
-		return NULL;
-
-	cl_assert(value_utf16 = git__calloc(alloc_len, sizeof(wchar_t)));
-
-	value_len = GetEnvironmentVariableW(name_utf16, value_utf16, alloc_len);
-	cl_assert_equal_i(value_len, alloc_len - 1);
-
-	cl_assert(value_utf8 = gitwin_from_utf16(value_utf16));
-
-	git__free(value_utf16);
-
-	return value_utf8;
-}
-
-static int cl_setenv(const char *name, const char *value)
-{
-	wchar_t *name_utf16 = gitwin_to_utf16(name);
-	wchar_t *value_utf16 = value ? gitwin_to_utf16(value) : NULL;
-
-	cl_assert(name_utf16);
-	cl_assert(SetEnvironmentVariableW(name_utf16, value_utf16));
-
-	git__free(name_utf16);
-	git__free(value_utf16);
-
-	return 0;
-
-}
-#else
-
-#include <stdlib.h>
-#define cl_getenv(n)   getenv(n)
-
-static int cl_setenv(const char *name, const char *value)
-{
-	return (value == NULL) ? unsetenv(name) : setenv(name, value, 1);
-}
-#endif
-
-#ifdef GIT_WIN32
 static char *env_userprofile = NULL;
 static char *env_programfiles = NULL;
 #else

--- a/tests-clar/refs/revparse.c
+++ b/tests-clar/refs/revparse.c
@@ -24,10 +24,10 @@ static void test_object(const char *spec, const char *expected_oid)
 
 void test_refs_revparse__initialize(void)
 {
-   char *tz = getenv("TZ");
+   char *tz = cl_getenv("TZ");
    if (tz)
       strcpy(g_orig_tz, tz);
-   setenv("TZ", "UTC", 1);
+   cl_setenv("TZ", "UTC");
    g_repo = cl_git_sandbox_init("testrepo.git");
 }
 
@@ -35,7 +35,7 @@ void test_refs_revparse__cleanup(void)
 {
    cl_git_sandbox_cleanup();
    g_obj = NULL;
-   setenv("TZ", g_orig_tz, 1);
+   cl_setenv("TZ", g_orig_tz);
 }
 
 


### PR DESCRIPTION
Fixes a build warning on msvc about `getenv` being undefined. Now using wrappers that resolve to native `getenv` and `setenv` on posix, but use native Win32 APIs on that platform.
