### PR TITLE
add errno to the git_error struct.

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -70,7 +70,10 @@ enum {
 typedef struct {
 	char *message;
 	int klass;
-	int error_code;
+	int os_error;
+#ifdef GIT_WIN32
+	DWORD win32_os_error;
+#endif
 } git_error;
 
 typedef enum {


### PR DESCRIPTION
If an error occurs due to a problem on the OS, set errno on the error
struct so that users of libgit2 can programatically deal with OS errors.

I'm not 100% sure this pull request is correct.  It looks like there is another function that calls `set_error` and doesn't have an errno.  I'm also not sure what to do about windows.  Maybe conditionally add the windows errno to the struct with a macro?

Anyway, I want to get access to errno in Ruby so that we can raise an Errno::ENOENT (or EPERM, etc) rather than raising a generic Rugged::OSError.
