### PR TITLE
message: Expose git_message_prettify()

### DIFF
--- a/include/git2.h
+++ b/include/git2.h
@@ -45,5 +45,6 @@
 #include "git2/submodule.h"
 #include "git2/notes.h"
 #include "git2/reset.h"
+#include "git2/message.h"
 
 #endif

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -182,8 +182,8 @@ GIT_EXTERN(const git_oid *) git_commit_parent_oid(git_commit *commit, unsigned i
  * Create a new commit in the repository using `git_object`
  * instances as parameters.
  *
- * The message will be cleaned up from excess whitespace
- * it will be made sure that the last line ends with a '\n'.
+ * The message will not be cleaned up. This can be achieved
+ * through `git_message_prettify()`.
  *
  * @param oid Pointer where to store the OID of the
  *	newly created commit

--- a/include/git2/message.h
+++ b/include/git2/message.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2009-2012 the libgit2 contributors
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_message_h__
+#define INCLUDE_git_message_h__
+
+#include "common.h"
+
+/**
+ * @file git2/message.h
+ * @brief Git message management routines
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Clean up message from excess whitespace and make sure that the last line
+ * ends with a '\n'.
+ *
+ * Optionally, can remove lines starting with a "#".
+ *
+ * @param message_out The user allocated buffer which will be filled with 
+ * the cleaned up message.
+ *
+ * @param size The size of the allocated buffer message_out.
+ *
+ * @param message The message to be prettified.
+ *
+ * @param strip_comments 1 to remove lines starting with a "#", 0 otherwise.
+ *
+ * @return GIT_SUCCESS or an error code
+ */
+GIT_EXTERN(int) git_message_prettify(char *message_out, size_t buffer_size, const char *message, int strip_comments);
+
+/** @} */
+GIT_END_DECL
+#endif /* INCLUDE_git_message_h__ */

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -137,8 +137,8 @@ GIT_EXTERN(const char *) git_tag_message(git_tag *tag);
  * this tag object. If `force` is true and a reference
  * already exists with the given name, it'll be replaced.
  *
- * The message will be cleaned up from excess whitespace
- * it will be made sure that the last line ends with a '\n'.
+ * The message will not be cleaned up. This can be achieved
+ * through `git_message_prettify()`.
  *
  * @param oid Pointer where to store the OID of the
  * newly created tag. If the tag already exists, this parameter

--- a/src/message.c
+++ b/src/message.c
@@ -6,7 +6,6 @@
  */
 
 #include "message.h"
-#include <ctype.h>
 
 static size_t line_length_without_trailing_spaces(const char *line, size_t len)
 {
@@ -22,7 +21,7 @@ static size_t line_length_without_trailing_spaces(const char *line, size_t len)
 
 /* Greatly inspired from git.git "stripspace" */
 /* see https://github.com/git/git/blob/497215d8811ac7b8955693ceaad0899ecd894ed2/builtin/stripspace.c#L4-67 */
-int git_message_prettify(git_buf *message_out, const char *message, int strip_comments)
+int git_message__prettify(git_buf *message_out, const char *message, int strip_comments)
 {
 	const size_t message_len = strlen(message);
 
@@ -58,4 +57,26 @@ int git_message_prettify(git_buf *message_out, const char *message, int strip_co
 	}
 
 	return git_buf_oom(message_out) ? -1 : 0;
+}
+
+int git_message_prettify(char *message_out, size_t buffer_size, const char *message, int strip_comments)
+{
+	git_buf buf = GIT_BUF_INIT;
+
+	if (strlen(message) + 1 > buffer_size) {	/* We have to account for a potentially missing \n */
+		giterr_set(GITERR_INVALID, "Buffer too short to hold the cleaned message");
+		return -1;
+	}
+
+	*message_out = '\0';
+
+	if (git_message__prettify(&buf, message, strip_comments) < 0) {
+		git_buf_free(&buf);
+		return -1;
+	}
+
+	git_buf_copy_cstr(message_out, buffer_size, &buf);
+	git_buf_free(&buf);
+
+	return 0;
 }

--- a/src/message.h
+++ b/src/message.h
@@ -7,8 +7,9 @@
 #ifndef INCLUDE_message_h__
 #define INCLUDE_message_h__
 
+#include "git2/message.h"
 #include "buffer.h"
 
-int git_message_prettify(git_buf *message_out, const char *message, int strip_comments);
+int git_message__prettify(git_buf *message_out, const char *message, int strip_comments);
 
 #endif /* INCLUDE_message_h__ */

--- a/src/tag.c
+++ b/src/tag.c
@@ -196,7 +196,7 @@ static int write_tag_annotation(
 		const git_signature *tagger,
 		const char *message)
 {
-	git_buf tag = GIT_BUF_INIT, cleaned_message = GIT_BUF_INIT;
+	git_buf tag = GIT_BUF_INIT;
 	git_odb *odb;
 
 	git_oid__writebuf(&tag, "object ", git_object_id(target));
@@ -205,14 +205,8 @@ static int write_tag_annotation(
 	git_signature__writebuf(&tag, "tagger ", tagger);
 	git_buf_putc(&tag, '\n');
 
-	/* Remove comments by default */
-	if (git_message_prettify(&cleaned_message, message, 1) < 0)
+	if (git_buf_puts(&tag, message) < 0)
 		goto on_error;
-
-	if (git_buf_puts(&tag, git_buf_cstr(&cleaned_message)) < 0)
-		goto on_error;
-
-	git_buf_free(&cleaned_message);
 
 	if (git_repository_odb__weakptr(&odb, repo) < 0)
 		goto on_error;
@@ -225,7 +219,6 @@ static int write_tag_annotation(
 
 on_error:
 	git_buf_free(&tag);
-	git_buf_free(&cleaned_message);
 	giterr_set(GITERR_OBJECT, "Failed to create tag annotation.");
 	return -1;
 }

--- a/tests-clar/object/commit/commitstagedfile.c
+++ b/tests-clar/object/commit/commitstagedfile.c
@@ -23,6 +23,7 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	git_oid expected_blob_oid, tree_oid, expected_tree_oid, commit_oid, expected_commit_oid;
 	git_signature *signature;
 	git_tree *tree;
+	char buffer[128];
 
 	/*
 	 * The test below replicates the following git scenario
@@ -61,7 +62,7 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	 * 100644 blob 9daeafb9864cf43055ae93beb0afd6c7d144bfa4    test.txt
 	 */
 
-	cl_git_pass(git_oid_fromstr(&expected_commit_oid, "b78d8ac0e448a305bf2806a00947ade8e8966d58"));
+	cl_git_pass(git_oid_fromstr(&expected_commit_oid, "1fe3126578fc4eca68c193e4a3a0a14a0704624d"));
 	cl_git_pass(git_oid_fromstr(&expected_tree_oid, "2b297e643c551e76cfa1f93810c50811382f9117"));
 	cl_git_pass(git_oid_fromstr(&expected_blob_oid, "9daeafb9864cf43055ae93beb0afd6c7d144bfa4"));
 
@@ -107,6 +108,9 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	 */
 	cl_git_pass(git_signature_new(&signature, "nulltoken", "emeric.fermas@gmail.com", 1323847743, 60));
 	cl_git_pass(git_tree_lookup(&tree, repo, &tree_oid));
+
+	cl_git_pass(git_message_prettify(buffer, 128, "Initial commit", 0));
+
 	cl_git_pass(git_commit_create_v(
 		&commit_oid,
 		repo,
@@ -114,7 +118,7 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 		signature,
 		signature,
 		NULL,
-		"Initial commit",
+		buffer,
 		tree,
 		0));
 

--- a/tests-clar/object/message.c
+++ b/tests-clar/object/message.c
@@ -6,7 +6,7 @@ static void assert_message_prettifying(char *expected_output, char *input, int s
 {
 	git_buf prettified_message = GIT_BUF_INIT;
 
-	git_message_prettify(&prettified_message, input, strip_comments);
+	git_message__prettify(&prettified_message, input, strip_comments);
 	cl_assert_equal_s(expected_output, git_buf_cstr(&prettified_message));
 
 	git_buf_free(&prettified_message);


### PR DESCRIPTION
git_commit() and git_tag() no longer prettify the message by default. This has to be taken care of by the caller.

This has the nice side effect of putting the caller in position to actually choose to strip the comments or not.
