### PR TITLE
Fix Makefile.emebed for mingw32

### DIFF
--- a/Makefile.embed
+++ b/Makefile.embed
@@ -15,13 +15,14 @@ INCLUDES= -I. -Isrc -Iinclude -Ideps/http-parser -Ideps/zlib
 DEFINES= $(INCLUDES) -DNO_VIZ -DSTDC -DNO_GZIP -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE $(EXTRA_DEFINES)
 CFLAGS= -g $(DEFINES) -Wall -Wextra -O2 $(EXTRA_CFLAGS)
 
-SRCS = $(wildcard src/*.c) $(wildcard src/transports/*.c) $(wildcard src/unix/*.c) $(wildcard src/xdiff/*.c) $(wildcard deps/http-parser/*.c) $(wildcard deps/zlib/*.c)
+SRCS = $(wildcard src/*.c) $(wildcard src/transports/*.c) $(wildcard src/xdiff/*.c) $(wildcard deps/http-parser/*.c) $(wildcard deps/zlib/*.c)
 
 ifeq ($(PLATFORM),Msys)
-	SRCS += $(wildcard src/win32/*.c) $(wildcard src/compat/*.c) $(wildcard deps/regex/regex.c)
+	SRCS += $(wildcard src/win32/*.c) $(wildcard src/compat/*.c) deps/regex/regex.c
 	INCLUDES += -Ideps/regex
-     DEFINES += -DWIN32 -D_WIN32_WINNT=0x0501
+	DEFINES += -DWIN32 -D_WIN32_WINNT=0x0501
 else
+	SRCS += $(wildcard src/unix/*.c) 
 	CFLAGS += -fPIC
 endif
 


### PR DESCRIPTION
otherwise we can't compile the native parts of the rugged gem on Windows.
