### PR TITLE
fix crash issue on mingw caused by variable argument list type promotion.

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -232,7 +232,7 @@ int p_open(const char *path, int flags, ...)
 		va_list arg_list;
 
 		va_start(arg_list, flags);
-		mode = va_arg(arg_list, mode_t);
+		mode = (mode_t)va_arg(arg_list, int);
 		va_end(arg_list);
 	}
 


### PR DESCRIPTION
1. compile warning:

D:\libgit2.git\src\win32\posix_w32.c: In function 'p_open':
D:\libgit2.git\src\win32\posix_w32.c:235:10: warning: 'mode_t' is promoted to 'int' when passed through '...' [enabled by default]
D:\libgit2.git\src\win32\posix_w32.c:235:10: note: (so you should pass 'int' not 'mode_t' to 'va_arg')
D:\libgit2.git\src\win32\posix_w32.c:235:10: note: if this code is reached, the program will abort
1. test crash.
2. the above two issues are same root cause. please see http://www.eskimo.com/~scs/cclass/int/sx11c.html
