### PR TITLE
Small revparse colon syntax improvements

### DIFF
--- a/src/revparse.c
+++ b/src/revparse.c
@@ -485,7 +485,7 @@ static int handle_caret_syntax(git_object **out, git_repository *repo, git_objec
 	}
 
 	if (git_commit_parent(&commit, commit, n-1) < 0) {
-		return GIT_ERROR;
+		return GIT_ENOTFOUND;
 	}
 
 	*out = (git_object*)commit;

--- a/tests-clar/refs/revparse.c
+++ b/tests-clar/refs/revparse.c
@@ -85,6 +85,8 @@ void test_refs_revparse__nth_parent(void)
 	test_object("be3563a^1^1", "4a202b346bb0fb0db7eff3cffeb3c70babbd2045");
 	test_object("be3563a^2^1", "5b5b025afb0b4c913b4c338a42934a3863bf3644");
 	test_object("be3563a^0", "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
+
+	cl_assert_equal_i(GIT_ENOTFOUND, git_revparse_single(&g_obj, g_repo, "be3563a^42"));
 }
 
 void test_refs_revparse__not_tag(void)


### PR DESCRIPTION
- Make it able to return tree objects
- Make it correctly handle bogus path with a intermediate segment which points at a blob
- Make it return `GIT_ENOTFOUND` when no object matches a specified path or a nth parent

Replaced as well the spaced indentations with tabs
