### PR TITLE
odb: add git_odb_foreach()

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -173,6 +173,20 @@ GIT_EXTERN(int) git_odb_read_header(size_t *len_p, git_otype *type_p, git_odb *d
 GIT_EXTERN(int) git_odb_exists(git_odb *db, const git_oid *id);
 
 /**
+ * List all objects available in the database
+ *
+ * The callback will be called for each object available in the
+ * database. Note that the objects are likely to be returned in the
+ * index order, which would make accessing the objects in that order
+ * inefficient.
+ *
+ * @param db database to use
+ * @param cb the callback to call for each object
+ * @param data data to pass to the callback
+ */
+GIT_EXTERN(int) git_odb_foreach(git_odb *db, int (*cb)(git_oid *oid, void *data), void *data);
+
+/**
  * Write an object directly into the ODB
  *
  * This method writes a full object straight into the ODB.

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -71,6 +71,12 @@ struct git_odb_backend {
 			struct git_odb_backend *,
 			const git_oid *);
 
+	int (*foreach)(
+		       struct git_odb_backend *,
+		       int (*cb)(git_oid *oid, void *data),
+		       void *data
+		       );
+
 	void (* free)(struct git_odb_backend *);
 };
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -605,6 +605,18 @@ int git_odb_read_prefix(
 	return 0;
 }
 
+int git_odb_foreach(git_odb *db, int (*cb)(git_oid *oid, void *data), void *data)
+{
+	unsigned int i;
+	backend_internal *internal;
+	git_vector_foreach(&db->backends, i, internal) {
+		git_odb_backend *b = internal->backend;
+		b->foreach(b, cb, data);
+	}
+
+	return 0;
+}
+
 int git_odb_write(
 	git_oid *oid, git_odb *db, const void *data, size_t len, git_otype type)
 {

--- a/src/pack.h
+++ b/src/pack.h
@@ -102,5 +102,9 @@ int git_pack_entry_find(
 		struct git_pack_file *p,
 		const git_oid *short_oid,
 		unsigned int len);
+int git_pack_foreach_entry(
+		struct git_pack_file *p,
+		int (*cb)(git_oid *oid, void *data),
+		void *data);
 
 #endif

--- a/tests-clar/odb/foreach.c
+++ b/tests-clar/odb/foreach.c
@@ -1,0 +1,36 @@
+#include "clar_libgit2.h"
+#include "odb.h"
+#include "git2/odb_backend.h"
+#include "pack.h"
+
+static git_odb *_odb;
+static git_repository *_repo;
+static int nobj;
+
+void test_odb_foreach__initialize(void)
+{
+	cl_git_pass(git_repository_open(&_repo, cl_fixture("testrepo.git")));
+	git_repository_odb(&_odb, _repo);
+}
+
+void test_odb_foreach__cleanup(void)
+{
+	git_odb_free(_odb);
+	git_repository_free(_repo);
+}
+
+static int foreach_cb(git_oid *oid, void *data)
+{
+	GIT_UNUSED(data);
+	GIT_UNUSED(oid);
+
+	nobj++;
+
+	return 0;
+}
+
+void test_odb_foreach__foreach(void)
+{
+	cl_git_pass(git_odb_foreach(_odb, foreach_cb, NULL));
+	cl_assert(nobj == 1681);
+}


### PR DESCRIPTION
Go through each backend and list every objects that exists in them. This
allows fsck-like uses.
