### PR TITLE
indexer: don't use '/objects/pack/' unconditionally

### DIFF
--- a/examples/network/Makefile
+++ b/examples/network/Makefile
@@ -2,7 +2,7 @@ default: all
 
 CC = gcc
 CFLAGS += -g
-CFLAGS += -I../../include -L../../build -lgit2 -lpthread
+CFLAGS += -I../../include -L../../build -L../.. -lgit2 -lpthread
 
 OBJECTS = \
   git2.o \

--- a/examples/network/index-pack.c
+++ b/examples/network/index-pack.c
@@ -25,7 +25,7 @@ int index_pack(git_repository *repo, int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	if (git_indexer_stream_new(&idx, ".git") < 0) {
+	if (git_indexer_stream_new(&idx, ".") < 0) {
 		puts("bad idx");
 		return -1;
 	}

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -29,9 +29,9 @@ typedef struct git_indexer_stream git_indexer_stream;
  * Create a new streaming indexer instance
  *
  * @param out where to store the indexer instance
- * @param path to the gitdir (metadata directory)
+ * @param path to the directory where the packfile should be stored
  */
-GIT_EXTERN(int) git_indexer_stream_new(git_indexer_stream **out, const char *gitdir);
+GIT_EXTERN(int) git_indexer_stream_new(git_indexer_stream **out, const char *path);
 
 /**
  * Add data to the indexer

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -142,7 +142,7 @@ int git_indexer_stream_new(git_indexer_stream **out, const char *prefix)
 {
 	git_indexer_stream *idx;
 	git_buf path = GIT_BUF_INIT;
-	static const char suff[] = "/objects/pack/pack-received";
+	static const char suff[] = "/pack";
 	int error;
 
 	idx = git__calloc(1, sizeof(git_indexer_stream));

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -545,6 +545,7 @@ static int http_download_pack(git_transport *transport, git_repository *repo, gi
 	http_parser_settings settings;
 	char buffer[1024];
 	gitno_buffer buf;
+	git_buf path = GIT_BUF_INIT;
 	git_indexer_stream *idx = NULL;
 	download_pack_cbdata data;
 
@@ -555,7 +556,10 @@ static int http_download_pack(git_transport *transport, git_repository *repo, gi
 		return -1;
 	}
 
-	if (git_indexer_stream_new(&idx, git_repository_path(repo)) < 0)
+	if (git_buf_joinpath(&path, git_repository_path(repo), "objects/pack") < 0)
+		return -1;
+
+	if (git_indexer_stream_new(&idx, git_buf_cstr(&path)) < 0)
 		return -1;
 
 	/*
@@ -600,6 +604,7 @@ static int http_download_pack(git_transport *transport, git_repository *repo, gi
 
 on_error:
 	git_indexer_stream_free(idx);
+	git_buf_free(&path);
 	return -1;
 }
 


### PR DESCRIPTION
Not everyone who indexes a packfile wants to put it in the standard git
repository location.
