### PR TITLE
More git_revparse_single ENOTFOUND use cases

### DIFF
--- a/src/revparse.c
+++ b/src/revparse.c
@@ -245,7 +245,7 @@ static int walk_ref_history(git_object **out, git_repository *repo, const char *
 						if (numentries < n) {
 							giterr_set(GITERR_REFERENCE, "Reflog for '%s' has only %d entries, asked for %d",
 								git_buf_cstr(&buf), numentries, n);
-							retcode = GIT_ERROR;
+							retcode = GIT_ENOTFOUND;
 						} else {
 							const git_reflog_entry *entry = git_reflog_entry_byindex(reflog, n);
 							const git_oid *oid = git_reflog_entry_oidold(entry);

--- a/tests-clar/refs/revparse.c
+++ b/tests-clar/refs/revparse.c
@@ -129,6 +129,7 @@ void test_refs_revparse__reflog(void)
 	cl_git_fail(git_revparse_single(&g_obj, g_repo, "@{1000}"));
 
 	cl_assert_equal_i(GIT_ENOTFOUND, git_revparse_single(&g_obj, g_repo, "nope@{0}"));
+	cl_assert_equal_i(GIT_ENOTFOUND, git_revparse_single(&g_obj, g_repo, "master@{31415}"));
 
 	test_object("@{-2}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	test_object("@{-1}", "a4a7dce85cf63874e984719f4fdd239f5145052f");


### PR DESCRIPTION
- unfound partially-named ref returns ENOTFOUND
- unfound reflog ref returns ENOTFOUND
- unfound reflog entry returns ENOTFOUND
