### PR TITLE
Fix libgit2 on GNU/Hurd.

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -515,7 +515,7 @@ int git_path_direach(
 		return -1;
 	}
 
-#ifdef __sun
+#if defined(__sun) || defined(__GNU__)
 	de_buf = git__malloc(sizeof(struct dirent) + FILENAME_MAX + 1);
 #else
 	de_buf = git__malloc(sizeof(struct dirent));
@@ -569,7 +569,7 @@ int git_path_dirload(
 		return -1;
 	}
 
-#ifdef __sun
+#if defined(__sun) || defined(__GNU__)
 	de_buf = git__malloc(sizeof(struct dirent) + FILENAME_MAX + 1);
 #else
 	de_buf = git__malloc(sizeof(struct dirent));


### PR DESCRIPTION
On GNU, the d_name field of the dirent structure is defined as "char d_name[1]",
so we must allocate more than sizeof(struct dirent) bytes, just like on Sun.
