### PR TITLE
Add a struct for network callbacks

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -190,7 +190,7 @@ GIT_EXTERN(void) git_remote_free(git_remote *remote);
  * @param remote the remote to update
  * @param cb callback to run on each ref update. 'a' is the old value, 'b' is then new value
  */
-GIT_EXTERN(int) git_remote_update_tips(git_remote *remote, int (*cb)(const char *refname, const git_oid *a, const git_oid *b));
+GIT_EXTERN(int) git_remote_update_tips(git_remote *remote);
 
 /**
  * Return whether a string is a valid remote URL
@@ -237,6 +237,39 @@ GIT_EXTERN(int) git_remote_add(git_remote **out, git_repository *repo, const cha
  */
 
 GIT_EXTERN(void) git_remote_check_cert(git_remote *remote, int check);
+
+/**
+ * Argument to the completion callback which tells it which operation
+ * finished.
+ */
+typedef enum git_remote_completion_type {
+	GIT_REMOTE_COMPLETION_DOWNLOAD,
+	GIT_REMOTE_COMPLETION_INDEXING,
+	GIT_REMOTE_COMPLETION_ERROR,
+} git_remote_completion_type;
+
+/**
+ * The callback settings structure
+ *
+ * Set the calbacks to be called by the remote.
+ */
+struct git_remote_callbacks {
+	int (*progress)(const char *str, void *data);
+	int (*completion)(git_remote_completion_type type, void *data);
+	int (*update_tips)(const char *refname, const git_oid *a, const git_oid *b, void *data);
+	void *data;
+};
+
+/**
+ * Set the callbacks for a remote
+ *
+ * Note that the remote keeps its own copy of the data and you need to
+ * call this function again if you want to change the callbacks.
+ *
+ * @param remote the remote to configure
+ * @param callbacks a pointer to the user's callback settings
+ */
+GIT_EXTERN(void) git_remote_set_callbacks(git_remote *remote, git_remote_callbacks *callbacks);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -179,6 +179,7 @@ typedef struct git_refspec git_refspec;
 typedef struct git_remote git_remote;
 
 typedef struct git_remote_head git_remote_head;
+typedef struct git_remote_callbacks git_remote_callbacks;
 
 /** @} */
 GIT_END_DECL

--- a/src/remote.c
+++ b/src/remote.c
@@ -331,7 +331,7 @@ int git_remote_download(git_remote *remote, git_off_t *bytes, git_indexer_stats 
 	return git_fetch_download_pack(remote, bytes, stats);
 }
 
-int git_remote_update_tips(git_remote *remote, int (*cb)(const char *refname, const git_oid *a, const git_oid *b))
+int git_remote_update_tips(git_remote *remote)
 {
 	int error = 0;
 	unsigned int i = 0;
@@ -381,8 +381,8 @@ int git_remote_update_tips(git_remote *remote, int (*cb)(const char *refname, co
 
 		git_reference_free(ref);
 
-		if (cb != NULL) {
-			if (cb(refname.ptr, &old, &head->oid) < 0)
+		if (remote->callbacks.update_tips != NULL) {
+			if (remote->callbacks.update_tips(refname.ptr, &old, &head->oid, remote->callbacks.data) < 0)
 				goto on_error;
 		}
 	}
@@ -524,4 +524,11 @@ void git_remote_check_cert(git_remote *remote, int check)
 	assert(remote);
 
 	remote->check_cert = check;
+}
+
+void git_remote_set_callbacks(git_remote *remote, git_remote_callbacks *callbacks)
+{
+	assert(remote && callbacks);
+
+	memcpy(&remote->callbacks, callbacks, sizeof(git_remote_callbacks));
 }

--- a/src/remote.h
+++ b/src/remote.h
@@ -19,6 +19,7 @@ struct git_remote {
 	struct git_refspec push;
 	git_transport *transport;
 	git_repository *repo;
+	git_remote_callbacks callbacks;
 	unsigned int need_pack:1,
 		check_cert;
 };


### PR DESCRIPTION
Currently only update_tips is used, but it prepares the way for
progress output during download.
