### PR TITLE
portability: Improve x86/amd64 compatibility

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -46,7 +46,7 @@ GIT_INLINE(int) git_blob_lookup(git_blob **blob, git_repository *repo, const git
  * @param len the length of the short identifier
  * @return 0 or an error code
  */
-GIT_INLINE(int) git_blob_lookup_prefix(git_blob **blob, git_repository *repo, const git_oid *id, unsigned int len)
+GIT_INLINE(int) git_blob_lookup_prefix(git_blob **blob, git_repository *repo, const git_oid *id, size_t len)
 {
 	return git_object_lookup_prefix((git_object **)blob, repo, id, len, GIT_OBJ_BLOB);
 }

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -48,7 +48,7 @@ GIT_INLINE(int) git_commit_lookup(git_commit **commit, git_repository *repo, con
  * @param len the length of the short identifier
  * @return 0 or an error code
  */
-GIT_INLINE(int) git_commit_lookup_prefix(git_commit **commit, git_repository *repo, const git_oid *id, unsigned len)
+GIT_INLINE(int) git_commit_lookup_prefix(git_commit **commit, git_repository *repo, const git_oid *id, size_t len)
 {
 	return git_object_lookup_prefix((git_object **)commit, repo, id, len, GIT_OBJ_COMMIT);
 }

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -279,7 +279,7 @@ GIT_EXTERN(int) git_index_remove(git_index *index, int position);
  * @param n the position of the entry
  * @return a pointer to the entry; NULL if out of bounds
  */
-GIT_EXTERN(git_index_entry *) git_index_get(git_index *index, unsigned int n);
+GIT_EXTERN(git_index_entry *) git_index_get(git_index *index, size_t n);
 
 /**
  * Get the count of entries currently in the index
@@ -319,7 +319,7 @@ GIT_EXTERN(const git_index_entry_unmerged *) git_index_get_unmerged_bypath(git_i
  * @param n the position of the entry
  * @return a pointer to the unmerged entry; NULL if out of bounds
  */
-GIT_EXTERN(const git_index_entry_unmerged *) git_index_get_unmerged_byindex(git_index *index, unsigned int n);
+GIT_EXTERN(const git_index_entry_unmerged *) git_index_get_unmerged_byindex(git_index *index, size_t n);
 
 /**
  * Return the stage number from a git index entry

--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -75,7 +75,7 @@ GIT_EXTERN(int) git_object_lookup_prefix(
 		git_object **object_out,
 		git_repository *repo,
 		const git_oid *id,
-		unsigned int len,
+		size_t len,
 		git_otype type);
 
 /**

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -139,7 +139,7 @@ GIT_EXTERN(int) git_odb_read(git_odb_object **out, git_odb *db, const git_oid *i
  *	GIT_ENOTFOUND if the object is not in the database.
  *	GIT_EAMBIGUOUS if the prefix is ambiguous (several objects match the prefix)
  */
-GIT_EXTERN(int) git_odb_read_prefix(git_odb_object **out, git_odb *db, const git_oid *short_id, unsigned int len);
+GIT_EXTERN(int) git_odb_read_prefix(git_odb_object **out, git_odb *db, const git_oid *short_id, size_t len);
 
 /**
  * Read the header of an object from the database, without

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -42,7 +42,7 @@ struct git_odb_backend {
 			void **, size_t *, git_otype *,
 			struct git_odb_backend *,
 			const git_oid *,
-			unsigned int);
+			size_t);
 
 	int (* read_header)(
 			size_t *, git_otype *,

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -147,7 +147,7 @@ GIT_EXTERN(int) git_oid_cmp(const git_oid *a, const git_oid *b);
  * @param len the number of hex chars to compare
  * @return 0 in case of a match
  */
-GIT_EXTERN(int) git_oid_ncmp(const git_oid *a, const git_oid *b, unsigned int len);
+GIT_EXTERN(int) git_oid_ncmp(const git_oid *a, const git_oid *b, size_t len);
 
 /**
  * Check if an oid equals an hex formatted object id.

--- a/include/git2/reflog.h
+++ b/include/git2/reflog.h
@@ -84,7 +84,7 @@ GIT_EXTERN(unsigned int) git_reflog_entrycount(git_reflog *reflog);
  * @param idx the position to lookup
  * @return the entry; NULL if not found
  */
-GIT_EXTERN(const git_reflog_entry *) git_reflog_entry_byindex(git_reflog *reflog, unsigned int idx);
+GIT_EXTERN(const git_reflog_entry *) git_reflog_entry_byindex(git_reflog *reflog, size_t idx);
 
 /**
  * Get the old oid

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -46,7 +46,7 @@ GIT_INLINE(int) git_tag_lookup(git_tag **tag, git_repository *repo, const git_oi
  * @param len the length of the short identifier
  * @return 0 or an error code
  */
-GIT_INLINE(int) git_tag_lookup_prefix(git_tag **tag, git_repository *repo, const git_oid *id, unsigned int len)
+GIT_INLINE(int) git_tag_lookup_prefix(git_tag **tag, git_repository *repo, const git_oid *id, size_t len)
 {
 	return git_object_lookup_prefix((git_object **)tag, repo, id, len, (git_otype)GIT_OBJ_TAG);
 }

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -50,7 +50,7 @@ GIT_INLINE(int) git_tree_lookup_prefix(
 	git_tree **tree,
 	git_repository *repo,
 	const git_oid *id,
-	unsigned int len)
+	size_t len)
 {
 	return git_object_lookup_prefix((git_object **)tree, repo, id, len, GIT_OBJ_TREE);
 }
@@ -126,7 +126,7 @@ GIT_EXTERN(const git_tree_entry *) git_tree_entry_byname(git_tree *tree, const c
  * @param idx the position in the entry list
  * @return the tree entry; NULL if not found
  */
-GIT_EXTERN(const git_tree_entry *) git_tree_entry_byindex(git_tree *tree, unsigned int idx);
+GIT_EXTERN(const git_tree_entry *) git_tree_entry_byindex(git_tree *tree, size_t idx);
 
 /**
  * Get the UNIX file attributes of a tree entry

--- a/src/attr.c
+++ b/src/attr.c
@@ -22,7 +22,7 @@ int git_attr_get(
 	int error;
 	git_attr_path path;
 	git_vector files = GIT_VECTOR_INIT;
-	unsigned int i, j;
+	size_t i, j;
 	git_attr_file *file;
 	git_attr_name attr;
 	git_attr_rule *rule;
@@ -74,7 +74,7 @@ int git_attr_get_many(
 	int error;
 	git_attr_path path;
 	git_vector files = GIT_VECTOR_INIT;
-	unsigned int i, j, k;
+	size_t i, j, k;
 	git_attr_file *file;
 	git_attr_rule *rule;
 	attr_get_many_info *info = NULL;
@@ -138,7 +138,7 @@ int git_attr_foreach(
 	int error;
 	git_attr_path path;
 	git_vector files = GIT_VECTOR_INIT;
-	unsigned int i, j, k;
+	size_t i, j, k;
 	git_attr_file *file;
 	git_attr_rule *rule;
 	git_attr_assignment *assign;

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -183,7 +183,7 @@ int git_attr_file__lookup_one(
 	const char *attr,
 	const char **value)
 {
-	unsigned int i;
+	size_t i;
 	git_attr_name name;
 	git_attr_rule *rule;
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -226,7 +226,7 @@ GIT_COMMIT_GETTER(const char *, message, commit->message)
 GIT_COMMIT_GETTER(const char *, message_encoding, commit->message_encoding)
 GIT_COMMIT_GETTER(git_time_t, time, commit->committer->when.time)
 GIT_COMMIT_GETTER(int, time_offset, commit->committer->when.offset)
-GIT_COMMIT_GETTER(unsigned int, parentcount, commit->parent_oids.length)
+GIT_COMMIT_GETTER(unsigned int, parentcount, (unsigned int)commit->parent_oids.length)
 GIT_COMMIT_GETTER(const git_oid *, tree_oid, &commit->tree_oid);
 
 int git_commit_tree(git_tree **tree_out, git_commit *commit)

--- a/src/config.c
+++ b/src/config.c
@@ -410,7 +410,7 @@ int git_config_get_multivar(git_config *cfg, const char *name, const char *regex
 	file_internal *internal;
 	git_config_file *file;
 	int ret = GIT_ENOTFOUND;
-	unsigned int i;
+	size_t i;
 
 	assert(cfg->files.length);
 
@@ -434,7 +434,7 @@ int git_config_set_multivar(git_config *cfg, const char *name, const char *regex
 	file_internal *internal;
 	git_config_file *file;
 	int ret = GIT_ENOTFOUND;
-	unsigned int i;
+	size_t i;
 
 	for (i = cfg->files.length; i > 0; --i) {
 		internal = git_vector_get(&cfg->files, i - 1);

--- a/src/date.c
+++ b/src/date.c
@@ -121,9 +121,9 @@ static const struct {
 	{ "IDLE", +12, 0, },	/* International Date Line East */
 };
 
-static int match_string(const char *date, const char *str)
+static size_t match_string(const char *date, const char *str)
 {
-	int i = 0;
+	size_t i = 0;
 
 	for (i = 0; *date; date++, str++, i++) {
 		if (*date == *str)
@@ -149,12 +149,12 @@ static int skip_alpha(const char *date)
 /*
 * Parse month, weekday, or timezone name
 */
-static int match_alpha(const char *date, struct tm *tm, int *offset)
+static size_t match_alpha(const char *date, struct tm *tm, int *offset)
 {
 	unsigned int i;
 
 	for (i = 0; i < 12; i++) {
-		int match = match_string(date, month_names[i]);
+		size_t match = match_string(date, month_names[i]);
 		if (match >= 3) {
 			tm->tm_mon = i;
 			return match;
@@ -162,7 +162,7 @@ static int match_alpha(const char *date, struct tm *tm, int *offset)
 	}
 
 	for (i = 0; i < 7; i++) {
-		int match = match_string(date, weekday_names[i]);
+		size_t match = match_string(date, weekday_names[i]);
 		if (match >= 3) {
 			tm->tm_wday = i;
 			return match;
@@ -170,7 +170,7 @@ static int match_alpha(const char *date, struct tm *tm, int *offset)
 	}
 
 	for (i = 0; i < ARRAY_SIZE(timezone_names); i++) {
-		int match = match_string(date, timezone_names[i].name);
+		size_t match = match_string(date, timezone_names[i].name);
 		if (match >= 3 || match == (int)strlen(timezone_names[i].name)) {
 			int off = timezone_names[i].offset;
 
@@ -241,7 +241,7 @@ static int is_date(int year, int month, int day, struct tm *now_tm, time_t now, 
 	return 0;
 }
 
-static int match_multi_number(unsigned long num, char c, const char *date, char *end, struct tm *tm)
+static size_t match_multi_number(unsigned long num, char c, const char *date, char *end, struct tm *tm)
 {
 	time_t now;
 	struct tm now_tm;
@@ -319,9 +319,9 @@ static int nodate(struct tm *tm)
 /*
  * We've seen a digit. Time? Year? Date?
  */
-static int match_digit(const char *date, struct tm *tm, int *offset, int *tm_gmt)
+static size_t match_digit(const char *date, struct tm *tm, int *offset, int *tm_gmt)
 {
-	int n;
+	size_t n;
 	char *end;
 	unsigned long num;
 
@@ -349,7 +349,7 @@ static int match_digit(const char *date, struct tm *tm, int *offset, int *tm_gmt
 	case '/':
 	case '-':
 		if (isdigit(end[1])) {
-			int match = match_multi_number(num, *end, date, end, tm);
+			size_t match = match_multi_number(num, *end, date, end, tm);
 			if (match)
 				return match;
 		}
@@ -413,11 +413,11 @@ static int match_digit(const char *date, struct tm *tm, int *offset, int *tm_gmt
 	return n;
 }
 
-static int match_tz(const char *date, int *offp)
+static size_t match_tz(const char *date, int *offp)
 {
 	char *end;
 	int hour = strtoul(date + 1, &end, 10);
-	int n = end - (date + 1);
+	size_t n = end - (date + 1);
 	int min = 0;
 
 	if (n == 4) {
@@ -506,7 +506,7 @@ static int parse_date_basic(const char *date, git_time_t *timestamp, int *offset
 	    !match_object_header_date(date + 1, timestamp, offset))
 		return 0; /* success */
 	for (;;) {
-		int match = 0;
+		size_t match = 0;
 		unsigned char c = *date;
 
 		/* Stop at end of string or newline */
@@ -685,7 +685,7 @@ static const char *approxidate_alpha(const char *date, struct tm *tm, struct tm 
 		;
 
 	for (i = 0; i < 12; i++) {
-		int match = match_string(date, month_names[i]);
+		size_t match = match_string(date, month_names[i]);
 		if (match >= 3) {
 			tm->tm_mon = i;
 			*touched = 1;
@@ -694,7 +694,7 @@ static const char *approxidate_alpha(const char *date, struct tm *tm, struct tm 
 	}
 
 	for (s = special; s->name; s++) {
-		int len = strlen(s->name);
+		size_t len = strlen(s->name);
 		if (match_string(date, s->name) == len) {
 			s->fn(tm, now, num);
 			*touched = 1;
@@ -704,7 +704,7 @@ static const char *approxidate_alpha(const char *date, struct tm *tm, struct tm 
 
 	if (!*num) {
 		for (i = 1; i < 11; i++) {
-			int len = strlen(number_name[i]);
+			size_t len = strlen(number_name[i]);
 			if (match_string(date, number_name[i]) == len) {
 				*num = i;
 				*touched = 1;
@@ -720,7 +720,7 @@ static const char *approxidate_alpha(const char *date, struct tm *tm, struct tm 
 
 	tl = typelen;
 	while (tl->type) {
-		int len = strlen(tl->type);
+		size_t len = strlen(tl->type);
 		if (match_string(date, tl->type) >= len-1) {
 			update_tm(tm, now, tl->length * *num);
 			*num = 0;
@@ -731,7 +731,7 @@ static const char *approxidate_alpha(const char *date, struct tm *tm, struct tm 
 	}
 
 	for (i = 0; i < 7; i++) {
-		int match = match_string(date, weekday_names[i]);
+		size_t match = match_string(date, weekday_names[i]);
 		if (match >= 3) {
 			int diff, n = *num -1;
 			*num = 0;
@@ -783,7 +783,7 @@ static const char *approxidate_digit(const char *date, struct tm *tm, int *num)
 	case '/':
 	case '-':
 		if (isdigit(end[1])) {
-			int match = match_multi_number(number, *end, date, end, tm);
+			size_t match = match_multi_number(number, *end, date, end, tm);
 			if (match)
 				return date + match;
 		}

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -156,7 +156,7 @@ void git_ignore__free(git_ignores *ignores)
 static bool ignore_lookup_in_rules(
 	git_vector *rules, git_attr_path *path, int *ignored)
 {
-	unsigned int j;
+	size_t j;
 	git_attr_fnmatch *match;
 
 	git_vector_rforeach(rules, j, match) {

--- a/src/index.c
+++ b/src/index.c
@@ -329,16 +329,16 @@ int git_index_write(git_index *index)
 unsigned int git_index_entrycount(git_index *index)
 {
 	assert(index);
-	return index->entries.length;
+	return (unsigned int)index->entries.length;
 }
 
 unsigned int git_index_entrycount_unmerged(git_index *index)
 {
 	assert(index);
-	return index->unmerged.length;
+	return (unsigned int)index->unmerged.length;
 }
 
-git_index_entry *git_index_get(git_index *index, unsigned int n)
+git_index_entry *git_index_get(git_index *index, size_t n)
 {
 	git_vector_sort(&index->entries);
 	return git_vector_get(&index->entries, n);
@@ -584,7 +584,7 @@ const git_index_entry_unmerged *git_index_get_unmerged_bypath(
 }
 
 const git_index_entry_unmerged *git_index_get_unmerged_byindex(
-	git_index *index, unsigned int n)
+	git_index *index, size_t n)
 {
 	assert(index);
 	return git_vector_get(&index->unmerged, n);
@@ -963,7 +963,7 @@ static int write_index(git_index *index, git_filebuf *file)
 
 	header.signature = htonl(INDEX_HEADER_SIG);
 	header.version = htonl(is_extended ? INDEX_VERSION_NUMBER_EXT : INDEX_VERSION_NUMBER);
-	header.entry_count = htonl(index->entries.length);
+	header.entry_count = htonl((uint32_t)index->entries.length);
 
 	if (git_filebuf_write(file, &header, sizeof(struct index_header)) < 0)
 		return -1;

--- a/src/netops.c
+++ b/src/netops.c
@@ -61,7 +61,7 @@ static int ssl_set_error(gitno_ssl *ssl, int error)
 }
 #endif
 
-void gitno_buffer_setup(git_transport *t, gitno_buffer *buf, char *data, unsigned int len)
+void gitno_buffer_setup(git_transport *t, gitno_buffer *buf, char *data, size_t len)
 {
 	memset(buf, 0x0, sizeof(gitno_buffer));
 	memset(data, 0x0, len);

--- a/src/netops.h
+++ b/src/netops.h
@@ -21,7 +21,7 @@ typedef struct gitno_buffer {
 #endif
 } gitno_buffer;
 
-void gitno_buffer_setup(git_transport *t, gitno_buffer *buf, char *data, unsigned int len);
+void gitno_buffer_setup(git_transport *t, gitno_buffer *buf, char *data, size_t len);
 int gitno_recv(gitno_buffer *buf);
 
 void gitno_consume(gitno_buffer *buf, const char *ptr);

--- a/src/notes.c
+++ b/src/notes.c
@@ -522,7 +522,8 @@ static int process_entry_path(
 	int (*note_cb)(git_note_data *note_data, void *payload),
 	void *payload)
 {
-	int i = 0, j = 0, error = -1, len;
+	int error = -1;
+	size_t i = 0, j = 0, len;
 	git_buf buf = GIT_BUF_INIT;
 	git_note_data note_data;
 

--- a/src/object.c
+++ b/src/object.c
@@ -81,7 +81,7 @@ int git_object_lookup_prefix(
 	git_object **object_out,
 	git_repository *repo,
 	const git_oid *id,
-	unsigned int len,
+	size_t len,
 	git_otype type)
 {
 	git_object *object = NULL;

--- a/src/odb.c
+++ b/src/odb.c
@@ -553,7 +553,7 @@ int git_odb_read(git_odb_object **out, git_odb *db, const git_oid *id)
 }
 
 int git_odb_read_prefix(
-	git_odb_object **out, git_odb *db, const git_oid *short_id, unsigned int len)
+	git_odb_object **out, git_odb *db, const git_oid *short_id, size_t len)
 {
 	unsigned int i;
 	int error = GIT_ENOTFOUND;

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -42,7 +42,7 @@ typedef struct loose_backend {
 typedef struct {
 	size_t dir_len;
 	unsigned char short_oid[GIT_OID_HEXSZ]; /* hex formatted oid to match */
-	unsigned int short_oid_len;
+	size_t short_oid_len;
 	int found;				/* number of matching
 						 * objects already found */
 	unsigned char res_oid[GIT_OID_HEXSZ];	/* hex formatted oid of
@@ -502,7 +502,7 @@ static int locate_object_short_oid(
 	git_oid *res_oid,
 	loose_backend *backend,
 	const git_oid *short_oid,
-	unsigned int len)
+	size_t len)
 {
 	char *objects_dir = backend->objects_dir;
 	size_t dir_len = strlen(objects_dir);
@@ -629,7 +629,7 @@ static int loose_backend__read_prefix(
 	git_otype *type_p,
 	git_odb_backend *backend,
 	const git_oid *short_oid,
-	unsigned int len)
+	size_t len)
 {
 	int error = 0;
 

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -149,7 +149,7 @@ static int pack_entry_find_prefix(
 	struct git_pack_entry *e,
 	struct pack_backend *backend,
 	const git_oid *short_oid,
-	unsigned int len);
+	size_t len);
 
 
 
@@ -295,7 +295,7 @@ static int pack_entry_find_prefix(
 	struct git_pack_entry *e,
 	struct pack_backend *backend,
 	const git_oid *short_oid,
-	unsigned int len)
+	size_t len)
 {
 	int error;
 	unsigned int i;
@@ -384,7 +384,7 @@ static int pack_backend__read_prefix(
 	git_otype *type_p,
 	git_odb_backend *backend,
 	const git_oid *short_oid,
-	unsigned int len)
+	size_t len)
 {
 	int error = 0;
 

--- a/src/oid.c
+++ b/src/oid.c
@@ -166,7 +166,7 @@ int git_oid_cmp(const git_oid *a, const git_oid *b)
 	return memcmp(a->id, b->id, sizeof(a->id));
 }
 
-int git_oid_ncmp(const git_oid *oid_a, const git_oid *oid_b, unsigned int len)
+int git_oid_ncmp(const git_oid *oid_a, const git_oid *oid_b, size_t len)
 {
 	const unsigned char *a = oid_a->id;
 	const unsigned char *b = oid_b->id;

--- a/src/pack.c
+++ b/src/pack.c
@@ -38,7 +38,7 @@ static int pack_entry_find_offset(
 		git_oid *found_oid,
 		struct git_pack_file *p,
 		const git_oid *short_oid,
-		unsigned int len);
+		size_t len);
 
 static int packfile_error(const char *message)
 {
@@ -734,7 +734,7 @@ static int pack_entry_find_offset(
 	git_oid *found_oid,
 	struct git_pack_file *p,
 	const git_oid *short_oid,
-	unsigned int len)
+	size_t len)
 {
 	const uint32_t *level1_ofs = p->index_map.data;
 	const unsigned char *index = p->index_map.data;
@@ -827,7 +827,7 @@ int git_pack_entry_find(
 		struct git_pack_entry *e,
 		struct git_pack_file *p,
 		const git_oid *short_oid,
-		unsigned int len)
+		size_t len)
 {
 	git_off_t offset;
 	git_oid found_oid;

--- a/src/pack.h
+++ b/src/pack.h
@@ -101,7 +101,7 @@ int git_pack_entry_find(
 		struct git_pack_entry *e,
 		struct git_pack_file *p,
 		const git_oid *short_oid,
-		unsigned int len);
+		size_t len);
 int git_pack_foreach_entry(
 		struct git_pack_file *p,
 		int (*cb)(git_oid *oid, void *data),

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -338,10 +338,10 @@ int git_reflog_delete(git_reference *ref)
 unsigned int git_reflog_entrycount(git_reflog *reflog)
 {
 	assert(reflog);
-	return reflog->entries.length;
+	return (unsigned int)reflog->entries.length;
 }
 
-const git_reflog_entry * git_reflog_entry_byindex(git_reflog *reflog, unsigned int idx)
+const git_reflog_entry * git_reflog_entry_byindex(git_reflog *reflog, size_t idx)
 {
 	assert(reflog);
 	return git_vector_get(&reflog->entries, idx);

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -338,7 +338,7 @@ cleanup:
 	return error;
 }
 
-static int handle_at_syntax(git_object **out, git_reference **ref, const char *spec, int identifier_len, git_repository* repo, const char *curly_braces_content)
+static int handle_at_syntax(git_object **out, git_reference **ref, const char *spec, size_t identifier_len, git_repository* repo, const char *curly_braces_content)
 {
 	bool is_numeric;
 	int parsed = 0, error = -1;
@@ -547,7 +547,7 @@ static int handle_caret_curly_syntax(git_object **out, git_object *obj, const ch
 	return git_object_peel(out, obj, expected_type);
 }
 
-static int extract_curly_braces_content(git_buf *buf, const char *spec, int *pos)
+static int extract_curly_braces_content(git_buf *buf, const char *spec, size_t *pos)
 {
 	git_buf_clear(buf);
 
@@ -572,7 +572,7 @@ static int extract_curly_braces_content(git_buf *buf, const char *spec, int *pos
 	return 0;
 }
 
-static int extract_path(git_buf *buf, const char *spec, int *pos)
+static int extract_path(git_buf *buf, const char *spec, size_t *pos)
 {
 	git_buf_clear(buf);
 
@@ -588,7 +588,7 @@ static int extract_path(git_buf *buf, const char *spec, int *pos)
 	return 0;
 }
 
-static int extract_how_many(int *n, const char *spec, int *pos)
+static int extract_how_many(int *n, const char *spec, size_t *pos)
 {
 	const char *end_ptr;
 	int parsed, accumulated;
@@ -633,7 +633,7 @@ static int object_from_reference(git_object **object, git_reference *reference)
 	return error;
 }
 
-static int ensure_base_rev_loaded(git_object **object, git_reference **reference, const char *spec, int identifier_len, git_repository *repo, bool allow_empty_identifier)
+static int ensure_base_rev_loaded(git_object **object, git_reference **reference, const char *spec, size_t identifier_len, git_repository *repo, bool allow_empty_identifier)
 {
 	int error;
 	git_buf identifier = GIT_BUF_INIT;
@@ -670,7 +670,7 @@ static int ensure_base_rev_is_not_known_yet(git_object *object, const char *spec
 	return revspec_error(spec);
 }
 
-static bool any_left_hand_identifier(git_object *object, git_reference *reference, int identifier_len)
+static bool any_left_hand_identifier(git_object *object, git_reference *reference, size_t identifier_len)
 {
 	if (object != NULL)
 		return true;
@@ -694,7 +694,7 @@ static int ensure_left_hand_identifier_is_not_known_yet(git_object *object, git_
 
 int git_revparse_single(git_object **out, git_repository *repo, const char *spec)
 {
-	int pos = 0, identifier_len = 0;
+	size_t pos = 0, identifier_len = 0;
 	int error = -1, n;
 	git_buf buf = GIT_BUF_INIT;
 

--- a/src/status.c
+++ b/src/status.c
@@ -81,7 +81,7 @@ int git_status_foreach_ext(
 	git_status_show_t show =
 		opts ? opts->show : GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
 	git_diff_delta *i2h, *w2i;
-	unsigned int i, j, i_max, j_max;
+	size_t i, j, i_max, j_max;
 
 	assert(show <= GIT_STATUS_SHOW_INDEX_THEN_WORKDIR);
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -234,7 +234,7 @@ const git_tree_entry *git_tree_entry_byname(git_tree *tree, const char *filename
 	return entry_fromname(tree, filename, strlen(filename));
 }
 
-const git_tree_entry *git_tree_entry_byindex(git_tree *tree, unsigned int idx)
+const git_tree_entry *git_tree_entry_byindex(git_tree *tree, size_t idx)
 {
 	assert(tree);
 	return git_vector_get(&tree->entries, idx);
@@ -270,7 +270,7 @@ int git_tree__prefix_position(git_tree *tree, const char *path)
 unsigned int git_tree_entrycount(git_tree *tree)
 {
 	assert(tree);
-	return tree->entries.length;
+	return (unsigned int)tree->entries.length;
 }
 
 static int tree_error(const char *str)
@@ -501,7 +501,7 @@ static void sort_entries(git_treebuilder *bld)
 int git_treebuilder_create(git_treebuilder **builder_p, const git_tree *source)
 {
 	git_treebuilder *bld;
-	unsigned int i, source_entries = DEFAULT_TREE_SIZE;
+	size_t i, source_entries = DEFAULT_TREE_SIZE;
 
 	assert(builder_p);
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -35,7 +35,7 @@ void git_vector_free(git_vector *v)
 	v->_alloc_size = 0;
 }
 
-int git_vector_init(git_vector *v, unsigned int initial_size, git_vector_cmp cmp)
+int git_vector_init(git_vector *v, size_t initial_size, git_vector_cmp cmp)
 {
 	assert(v);
 

--- a/src/vector.h
+++ b/src/vector.h
@@ -12,16 +12,16 @@
 typedef int (*git_vector_cmp)(const void *, const void *);
 
 typedef struct git_vector {
-	unsigned int _alloc_size;
+	size_t _alloc_size;
 	git_vector_cmp _cmp;
 	void **contents;
-	unsigned int length;
+	size_t length;
 	int sorted;
 } git_vector;
 
 #define GIT_VECTOR_INIT {0}
 
-int git_vector_init(git_vector *v, unsigned int initial_size, git_vector_cmp cmp);
+int git_vector_init(git_vector *v, size_t initial_size, git_vector_cmp cmp);
 void git_vector_free(git_vector *v);
 void git_vector_clear(git_vector *v);
 void git_vector_swap(git_vector *a, git_vector *b);
@@ -45,12 +45,12 @@ GIT_INLINE(int) git_vector_bsearch2(
 	return git_vector_bsearch3(NULL, v, cmp, key);
 }
 
-GIT_INLINE(void *) git_vector_get(git_vector *v, unsigned int position)
+GIT_INLINE(void *) git_vector_get(git_vector *v, size_t position)
 {
 	return (position < v->length) ? v->contents[position] : NULL;
 }
 
-GIT_INLINE(const void *) git_vector_get_const(const git_vector *v, unsigned int position)
+GIT_INLINE(const void *) git_vector_get_const(const git_vector *v, size_t position)
 {
 	return (position < v->length) ? v->contents[position] : NULL;
 }

--- a/tests-clar/diff/diff_helpers.c
+++ b/tests-clar/diff/diff_helpers.c
@@ -5,7 +5,7 @@ git_tree *resolve_commit_oid_to_tree(
 	git_repository *repo,
 	const char *partial_oid)
 {
-	unsigned int len = (unsigned int)strlen(partial_oid);
+	size_t len = strlen(partial_oid);
 	git_oid oid;
 	git_object *obj = NULL;
 	git_tree *tree = NULL;

--- a/tests-clar/object/blob/fromchunks.c
+++ b/tests-clar/object/blob/fromchunks.c
@@ -30,7 +30,7 @@ static int text_chunked_source_cb(char *content, size_t max_length, void *payloa
 		return 0;
 
 	strcpy(content, textual_content);
-	return strlen(textual_content);
+	return (int)strlen(textual_content);
 }
 
 void test_object_blob_fromchunks__can_create_a_blob_from_a_in_memory_chunk_provider(void)


### PR DESCRIPTION
- Fix most of the compilation warnings on Win x64 (except regexp).
- Replace `unsigned int` to `size_t` where it makes sense (when either expressing a length or an index)
