### PR TITLE
Add function to query for compile time settings.

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -103,6 +103,29 @@ GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
  */
 GIT_EXTERN(void) git_libgit2_version(int *major, int *minor, int *rev);
 
+/**
+ * Combinations of these values describe the capabilities of libgit2.
+ */
+enum {
+	GIT_CAP_THREADS			= ( 1 << 0 ),
+	GIT_CAP_HTTPS			= ( 1 << 1 )
+};
+
+/**
+ * Query compile time options for libgit2.
+ *
+ * @return A combination of GIT_CAP_* values.
+ *
+ * - GIT_CAP_THREADS
+ *   Libgit2 was compiled with thread support. Note that thread support is still to be seen as a
+ *   'work in progress'.
+ *
+ * - GIT_CAP_HTTPS
+ *   Libgit2 supports the https:// protocol. This requires the open ssl library to be
+ *   found when compiling libgit2.
+ */
+GIT_EXTERN(int) git_libgit2_capabilities(void);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -22,6 +22,18 @@ void git_libgit2_version(int *major, int *minor, int *rev)
 	*rev = LIBGIT2_VER_REVISION;
 }
 
+int git_libgit2_capabilities()
+{
+	return 0
+#ifdef GIT_THREADS
+		| GIT_CAP_THREADS
+#endif
+#ifdef GIT_SSL
+		| GIT_CAP_HTTPS
+#endif
+	;
+}
+
 void git_strarray_free(git_strarray *array)
 {
 	size_t i;


### PR DESCRIPTION
This patch adds a `git_libgit2_capabilities()` function to query what settings were used to compile libgit2.

Currently there are 2 capabilities:
- `GIT_CAP_HTTPS` => Tells, if open ssl was found at compile time. This can't currently be figured out at run time (`git_remote_supported_url` will say "yes", only when trying to connect, a `git_transport` is created which _then_ fails with an error).
- `GIT_CAP_THREADS` => Tells about the `THREADSAFE` build time option; though doesn't matter (yet) as the only really threadsafe thing we have seems to be the odb cache - but #469 explicitly ask for this.
