### PR TITLE
Export git_attr_value

### DIFF
--- a/include/git2/attr.h
+++ b/include/git2/attr.h
@@ -96,7 +96,7 @@ typedef enum {
  *	@param attr The attribute
  *	@return the value type for the attribute
  */
-git_attr_t git_attr_value(const char *attr);
+GIT_EXTERN(git_attr_t) git_attr_value(const char *attr);
 
 /**
  * Check attribute flags: Reading values from index and working directory.


### PR DESCRIPTION
Commit 0c9eacf3d2c83256736a5bb2a240e73afd13d55f introduced the function
git_attr_value and switched the GIT_ATTR_\* macros to use it, but
attempting to use that function leads to a linker error (undefined
reference to `git_attr_value').  Export git_attr_value so programs can
actually call it.
