### PR TITLE
Fix incorrect array size in example for git_config_get_mapped

### DIFF
--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -342,7 +342,7 @@ GIT_EXTERN(int) git_config_foreach_match(
  *
  * A mapping array looks as follows:
  *
- *	git_cvar_map autocrlf_mapping[3] = {
+ *	git_cvar_map autocrlf_mapping[] = {
  *		{GIT_CVAR_FALSE, NULL, GIT_AUTO_CRLF_FALSE},
  *		{GIT_CVAR_TRUE, NULL, GIT_AUTO_CRLF_TRUE},
  *		{GIT_CVAR_STRING, "input", GIT_AUTO_CRLF_INPUT},


### PR DESCRIPTION
In the documentation for git_config_get_mapped, the sample mapping
array uses [3] but has 4 entries.  Fix by dropping the size entirely and
letting the compiler figure it out.
