### PR TITLE
Declare version number components as unsigned

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -101,7 +101,7 @@ GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
  * @param minor Store the minor version number
  * @param rev Store the revision (patch) number
  */
-GIT_EXTERN(void) git_libgit2_version(int *major, int *minor, int *rev);
+GIT_EXTERN(void) git_libgit2_version(unsigned *major, unsigned *minor, unsigned *rev);
 
 /**
  * Combinations of these values describe the capabilities of libgit2.

--- a/src/util.c
+++ b/src/util.c
@@ -15,7 +15,7 @@
 # include <Shlwapi.h>
 #endif
 
-void git_libgit2_version(int *major, int *minor, int *rev)
+void git_libgit2_version(unsigned *major, unsigned *minor, unsigned *rev)
 {
 	*major = LIBGIT2_VER_MAJOR;
 	*minor = LIBGIT2_VER_MINOR;


### PR DESCRIPTION
git_libgit2_version returns three signed ints, but it doesn't make sense
to have negative version number components; change them to unsigned.
