### PR TITLE
git_message_prettify: Include both \n and \0 when checking for available space

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -63,7 +63,7 @@ int git_message_prettify(char *message_out, size_t buffer_size, const char *mess
 {
 	git_buf buf = GIT_BUF_INIT;
 
-	if (strlen(message) + 1 > buffer_size) {	/* We have to account for a potentially missing \n */
+	if (strlen(message) + 2 > buffer_size) {	/* We have to account for a potentially missing \n */
 		giterr_set(GITERR_INVALID, "Buffer too short to hold the cleaned message");
 		return -1;
 	}


### PR DESCRIPTION
git_message_prettify requires that the output buffer has enough space
for an added \n, but doesn't ensure that the output buffer has enough
space for the trailing \0.  strlen(message) gives the length of the
input buffer without the trailing \0, so add 2 to account for both the
\n and the \0.
