### PR TITLE
git_tree_walk callback return value semantic does not match documentation

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -351,8 +351,9 @@ enum git_treewalk_mode {
  * the current (relative) root for the entry and the entry
  * data itself.
  *
- * If the callback returns a negative value, the passed entry
- * will be skipped on the traversal.
+ * If the callback returns a positive value, the passed entry will be
+ * skipped on the traversal (in pre mode). A negative value stops the
+ * walk.
  *
  * @param tree The tree to walk
  * @param callback Function to call on each tree entry

--- a/src/tree.c
+++ b/src/tree.c
@@ -787,8 +787,13 @@ static int tree_walk(
 	for (i = 0; i < tree->entries.length; ++i) {
 		git_tree_entry *entry = tree->entries.contents[i];
 
-		if (preorder && callback(path->ptr, entry, payload) < 0)
-			continue
+		if (preorder) {
+			error = callback(path->ptr, entry, payload);
+			if (error > 0)
+				continue;
+			if (error < 0)
+				return GIT_EUSER;
+		}
 
 		if (git_tree_entry__is_tree(entry)) {
 			git_tree *subtree;
@@ -813,7 +818,7 @@ static int tree_walk(
 			git_tree_free(subtree);
 		}
 
-		if (!preorder && callback(path->ptr, entry, payload)) {
+		if (!preorder && callback(path->ptr, entry, payload) < 0) {
 			error = GIT_EUSER;
 			break;
 		}


### PR DESCRIPTION
According to the documentation for git_tree_walk, "If the callback returns a negative value, the passed entry will be skipped on the traversal.".  However, this does not match the behavior of the code: if the callback returns a negative value, git_tree_walk aborts the traversal completely and returns GIT_EUSER.
