### PR TITLE
Fix message prettify length check

### DIFF
--- a/include/git2/message.h
+++ b/include/git2/message.h
@@ -23,8 +23,9 @@ GIT_BEGIN_DECL
  *
  * Optionally, can remove lines starting with a "#".
  *
- * @param message_out The user allocated buffer which will be filled with 
- * the cleaned up message.
+ * @param message_out The user allocated buffer which will be filled with
+ * the cleaned up message. Pass NULL if you just want to get the size of the
+ * prettified message as the output value.
  *
  * @param size The size of the allocated buffer message_out.
  *
@@ -32,7 +33,8 @@ GIT_BEGIN_DECL
  *
  * @param strip_comments 1 to remove lines starting with a "#", 0 otherwise.
  *
- * @return GIT_SUCCESS or an error code
+ * @return -1 on error, else number of characters in prettified message
+ * including the trailing NUL byte
  */
 GIT_EXTERN(int) git_message_prettify(char *message_out, size_t buffer_size, const char *message, int strip_comments);
 

--- a/tests-clar/object/commit/commitstagedfile.c
+++ b/tests-clar/object/commit/commitstagedfile.c
@@ -109,7 +109,7 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	cl_git_pass(git_signature_new(&signature, "nulltoken", "emeric.fermas@gmail.com", 1323847743, 60));
 	cl_git_pass(git_tree_lookup(&tree, repo, &tree_oid));
 
-	cl_git_pass(git_message_prettify(buffer, 128, "Initial commit", 0));
+	cl_assert_equal_i(16, git_message_prettify(buffer, 128, "Initial commit", 0));
 
 	cl_git_pass(git_commit_create_v(
 		&commit_oid,
@@ -133,34 +133,35 @@ void test_object_commit_commitstagedfile__message_prettify(void)
 {
 	char buffer[100];
 
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer), "", 0));
+	cl_assert(git_message_prettify(buffer, sizeof(buffer), "", 0) == 1);
 	cl_assert_equal_s(buffer, "");
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer), "", 1));
+	cl_assert(git_message_prettify(buffer, sizeof(buffer), "", 1) == 1);
 	cl_assert_equal_s(buffer, "");
 
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer), "Short", 0));
-	cl_assert_equal_s(buffer, "Short\n");
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer), "Short", 1));
-	cl_assert_equal_s(buffer, "Short\n");
+	cl_assert_equal_i(7, git_message_prettify(buffer, sizeof(buffer), "Short", 0));
+	cl_assert_equal_s("Short\n", buffer);
+	cl_assert_equal_i(7, git_message_prettify(buffer, sizeof(buffer), "Short", 1));
+	cl_assert_equal_s("Short\n", buffer);
 
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer), "This is longer\nAnd multiline\n# with some comments still in\n", 0));
+	cl_assert(git_message_prettify(buffer, sizeof(buffer), "This is longer\nAnd multiline\n# with some comments still in\n", 0) > 0);
 	cl_assert_equal_s(buffer, "This is longer\nAnd multiline\n# with some comments still in\n");
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer), "This is longer\nAnd multiline\n# with some comments still in\n", 1));
+
+	cl_assert(git_message_prettify(buffer, sizeof(buffer), "This is longer\nAnd multiline\n# with some comments still in\n", 1) > 0);
 	cl_assert_equal_s(buffer, "This is longer\nAnd multiline\n");
 
 	/* try out overflow */
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer),
+	cl_assert(git_message_prettify(buffer, sizeof(buffer),
 		"1234567890" "1234567890" "1234567890" "1234567890" "1234567890"
 		"1234567890" "1234567890" "1234567890" "1234567890" "12345678",
-		0));
+		0) > 0);
 	cl_assert_equal_s(buffer,
 		"1234567890" "1234567890" "1234567890" "1234567890" "1234567890"
 		"1234567890" "1234567890" "1234567890" "1234567890" "12345678\n");
 
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer),
+	cl_assert(git_message_prettify(buffer, sizeof(buffer),
 		"1234567890" "1234567890" "1234567890" "1234567890" "1234567890"
 		"1234567890" "1234567890" "1234567890" "1234567890" "12345678\n",
-		0));
+		0) > 0);
 	cl_assert_equal_s(buffer,
 		"1234567890" "1234567890" "1234567890" "1234567890" "1234567890"
 		"1234567890" "1234567890" "1234567890" "1234567890" "12345678\n");
@@ -182,9 +183,13 @@ void test_object_commit_commitstagedfile__message_prettify(void)
 		"1234567890" "1234567890" "1234567890" "1234567890" "1234567890""x",
 		0));
 
-	cl_git_pass(git_message_prettify(buffer, sizeof(buffer),
+	cl_assert(git_message_prettify(buffer, sizeof(buffer),
 		"1234567890" "1234567890" "1234567890" "1234567890" "1234567890\n"
 		"# 1234567890" "1234567890" "1234567890" "1234567890" "1234567890\n"
 		"1234567890",
-		1));
+		1) > 0);
+
+	cl_assert(git_message_prettify(NULL, 0, "", 0) == 1);
+	cl_assert(git_message_prettify(NULL, 0, "Short test", 0) == 12);
+	cl_assert(git_message_prettify(NULL, 0, "Test\n# with\nComments", 1) == 15);
 }


### PR DESCRIPTION
As an alternative to #869, this updates `git_message_prettify` in two ways:
1. This computes the prettified message **before** checking the length of the output buffer so the length check will be exact instead of roughly right. This means if you have a message with a lot of comments, you won't have to include space for them in the output buffer just to pass the estimated length check.
2. The function now returns the number of bytes that are / would be written to the output buffer. In combination with allowing a NULL output buffer, this means you can use this like `snprintf` to get the necessary buffer size and do an allocation to insure sufficient space. You can, of course, still use the function the old way and you will get a -1 output if there is insufficient space in the output buffer.
