### PR TITLE
Make the memory-window conrol structures global

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -9,6 +9,9 @@
 #include "git2/threads.h" 
 #include "thread-utils.h"
 
+
+git_mutex git__mwindow_mutex;
+
 /**
  * Handle the global state with TLS
  *
@@ -47,12 +50,14 @@ void git_threads_init(void)
 
 	_tls_index = TlsAlloc();
 	_tls_init = 1;
+	git_mutex_init(&git__mwindow_mutex);
 }
 
 void git_threads_shutdown(void)
 {
 	TlsFree(_tls_index);
 	_tls_init = 0;
+	git_mutex_free(&git__mwindow_mutex);
 }
 
 git_global_st *git__global_state(void)

--- a/src/global.h
+++ b/src/global.h
@@ -12,11 +12,11 @@
 typedef struct {
 	git_error *last_error;
 	git_error error_t;
-
-	git_mwindow_ctl mem_ctl;
 } git_global_st;
 
 git_global_st *git__global_state(void);
+
+extern git_mutex git__mwindow_mutex;
 
 #define GIT_GLOBAL (git__global_state())
 

--- a/src/mwindow.h
+++ b/src/mwindow.h
@@ -38,7 +38,6 @@ typedef struct git_mwindow_ctl {
 int git_mwindow_contains(git_mwindow *win, git_off_t offset);
 void git_mwindow_free_all(git_mwindow_file *mwf);
 unsigned char *git_mwindow_open(git_mwindow_file *mwf, git_mwindow **cursor, git_off_t offset, size_t extra, unsigned int *left);
-void git_mwindow_scan_lru(git_mwindow_file *mwf, git_mwindow **lru_w, git_mwindow **lru_l);
 int git_mwindow_file_register(git_mwindow_file *mwf);
 int git_mwindow_file_deregister(git_mwindow_file *mwf);
 void git_mwindow_close(git_mwindow **w_cursor);


### PR DESCRIPTION
Up to now, the idea was that the user would do all the operations for
one repository in the same thread. Thus we could have the
memory-mapped window information thread-local and avoid any locking.

This is not practical in a few environments, such as Apple's GCD which
allocates threads arbitrarily or the .NET CLR, where the OS-level
thread can change at any moment.

make the control structur global and protect it with a mutex so we
don't depend on the thread currently executing the code.

---

So this is one way. We could also go the other way and make it repo-specific, as it's unlikely that two repos are going to be sharing the same windows and would be lockless like now.
