### PR TITLE
tree builder: add convenience functions for inserting a blob or a tree

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -283,6 +283,33 @@ GIT_EXTERN(int) git_treebuilder_insert(
 	const git_oid *id,
 	unsigned int attributes);
 
+
+/**
+ * Add or update a blob in the builder
+ *
+ * Just like git_treebuilder_insert, but inserts the entry with the
+ * correct attributes for a blob.
+ */
+GIT_EXTERN(int) git_treebuilder_insert_blob(
+	const git_tree_entry **entry_out,
+	git_treebuilder *bld,
+	const char *filename,
+	const git_oid *id,
+	int executable);
+
+/**
+ * Add or update a tree in the builder
+ *
+ * Just like git_treebuilder_insert, but inserts the entry with the
+ * correct attributes for a tree.
+ */
+GIT_EXTERN(int) git_treebuilder_insert_tree(
+	const git_tree_entry **entry_out,
+	git_treebuilder *bld,
+	const char *filename,
+	const git_oid *id);
+
+
 /**
  * Remove an entry from the builder by its filename
  *

--- a/src/tree.c
+++ b/src/tree.c
@@ -566,6 +566,30 @@ on_error:
 	return -1;
 }
 
+int git_treebuilder_insert_blob(
+	const git_tree_entry **entry_out,
+	git_treebuilder *bld,
+	const char *filename,
+	const git_oid *id,
+	int executable)
+{
+	unsigned int attr = S_IFREG;
+
+	attr |= executable ? 0755 : 0644;
+
+	return git_treebuilder_insert(entry_out, bld, filename, id, attr);
+}
+
+int git_treebuilder_insert_tree(
+	const git_tree_entry **entry_out,
+	git_treebuilder *bld,
+	const char *filename,
+	const git_oid *id)
+{
+	return git_treebuilder_insert(entry_out, bld, filename, id, 040000);
+}
+
+
 int git_treebuilder_insert(
 	const git_tree_entry **entry_out,
 	git_treebuilder *bld,


### PR DESCRIPTION
Passing the attributes for a blob or tree manually can be
error-prone. Add convencience functions so we can add blobs and trees
without needing to know what attributes git needs for them.

---

Since git's attributes are just for file, executable file, dir, symlink and submodule, it seems to me that we can make that clearer from the function names what we're trying to do (from the user's perspective, reading the code weeks down the line), which also reduces the chances of getting the attributes wrong. They're not that hard to get right, but who actually gets octal right the first time around?
