### PR TITLE
Removed -Gz compile switch when using MSVC. Using WSAStringToAddressW wh...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,11 @@ OPTION (PROFILE "Generate profiling information" OFF)
 
 # Platform specific compilation flags
 IF (MSVC)
-	# Not using __stdcall with the CRT causes problems
-	OPTION (STDCALL "Buildl libgit2 with the __stdcall convention" ON)
+	## Not using __stdcall with the CRT causes problems
+	#OPTION (STDCALL "Buildl libgit2 with the __stdcall convention" ON)
+
+	# Using __stdcall with the CRT causes problems (link.exe refuses to import functions from openssl dlls)
+	OPTION (STDCALL "Build libgit2 with the __stdcall convention" OFF)
 
 	SET(CMAKE_C_FLAGS "/W4 /MP /nologo /Zi ${CMAKE_C_FLAGS}")
 	IF (STDCALL)
@@ -155,6 +158,8 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libgit2.pc.in ${CMAKE_CURRENT_BINARY_
 
 IF (MSVC)
    # Precompiled headers
+   # Comment this out if you use CMake to produce makefiles for nmake (cmake -G "NMake Makefiles" ..)
+   # since this is broken right now
    SET_TARGET_PROPERTIES(git2 PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h /FIprecompiled.h")
    SET_SOURCE_FILES_PROPERTIES(src/win32/precompiled.c COMPILE_FLAGS "/Ycprecompiled.h")
 ENDIF ()

--- a/src/netops.c
+++ b/src/netops.c
@@ -12,6 +12,7 @@
 #	include <netdb.h>
 #       include <arpa/inet.h>
 #else
+#	include <winsock2.h>
 #	include <ws2tcpip.h>
 #	ifdef _MSC_VER
 #		pragma comment(lib, "ws2_32.lib")
@@ -240,6 +241,43 @@ static int verify_server_cert(git_transport *t, const char *host)
 
 
 	/* Try to parse the host as an IP address to see if it is */
+#ifdef _WIN32
+
+	int salength;
+	struct sockaddr sa;
+
+	wchar_t *whost = gitwin_to_utf16(host);
+	if (whost == NULL)
+	{	// can return safely since no resources (incl. OpenSSL) are allocated
+		return -1;
+	}
+
+	salength = sizeof(sa);
+	sa.sa_family = AF_INET;
+	if (WSAStringToAddressW(whost, AF_INET, NULL, &sa, &salength) == 0)
+	{
+		addr4 = ((struct sockaddr_in *)&sa)->sin_addr;
+
+		type = GEN_IPADD;
+		addr = &addr4;
+	}
+	else
+	{
+		salength = sizeof(addr6);
+		sa.sa_family = AF_INET6;
+
+		if (WSAStringToAddressW(whost, AF_INET6, NULL, &sa, &salength) == 0)
+		{
+			addr6 = ((struct sockaddr_in6 *)&sa)->sin6_addr;
+
+			type = GEN_IPADD;
+			addr = &addr6;
+		}
+	}
+
+	git__free(whost);
+
+#else
 	if (inet_pton(AF_INET, host, &addr4)) {
 		type = GEN_IPADD;
 		addr = &addr4;
@@ -249,7 +287,7 @@ static int verify_server_cert(git_transport *t, const char *host)
 			addr = &addr6;
 		}
 	}
-
+#endif // _WIN32
 
 	cert = SSL_get_peer_certificate(t->ssl.ssl);
 


### PR DESCRIPTION
...en compiling for Windows.

Сomments on [#885](https://github.com/libgit2/libgit2/pull/885) have been considered.
See also [libgit2sharp #205](https://github.com/libgit2/libgit2sharp/pull/205).
