### PR TITLE
Topic/reset error message

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -51,6 +51,14 @@
 
 #define GITERR_CHECK_ALLOC(ptr) if (ptr == NULL) { return -1; }
 
+GIT_INLINE(int) giterr__no_message(int error) 
+{
+	giterr_clear();
+	return error;
+}
+
+#define GITERR_OK giterr__no_message(0)
+
 void giterr_set_oom(void);
 void giterr_set(int error_class, const char *string, ...);
 void giterr_clear(void);


### PR DESCRIPTION
Hello,

While peeking at #864 (bf266e8), and talking with @nulltoken, I started thinking about how such errors could be avoided in the future.

Identified problems:
- High: Having an error message set, which does not correspond to the returned error code
- Minor: Having an error message set and a `GIT_OK` or 0 returned error code

The proposal is to clear the current message when:
- we are returning a `GIT_Exxxx` error code without specifying an error message. (through the use of the new `giterr__no_message(int)` function)
- we are returning 0 (through the `GITERR_OK` macro)

However, the current message should NOT be cleared when:
- we are returning an error value returned by a sub layer (the called function is responsible for setting both the return value and the error message)

I did the modifications that I was thinking about on one file only (`attr.c`), and I stopped before going further to get some feedback:
- Should I go further on this PR?
- What about performance issues related to TLS access?
- `GITERR_OK` => I'm not comfortable with that name, I would happily change it to something better if you have some ideas
