### PR TITLE
new config file locations and defaults

### DIFF
--- a/src/attr.h
+++ b/src/attr.h
@@ -11,6 +11,7 @@
 #include "strmap.h"
 
 #define GIT_ATTR_CONFIG   "core.attributesfile"
+#define GIT_ATTR_CONFIG_DEFAULT ".config/git/attributes"
 #define GIT_IGNORE_CONFIG "core.excludesfile"
 #define GIT_IGNORE_CONFIG_DEFAULT ".config/git/ignore"
 

--- a/src/config.c
+++ b/src/config.c
@@ -449,7 +449,12 @@ int git_config_set_multivar(git_config *cfg, const char *name, const char *regex
 
 int git_config_find_global_r(git_buf *path)
 {
-	return git_futils_find_global_file(path, GIT_CONFIG_FILENAME);
+	int error = git_futils_find_global_file(path, GIT_CONFIG_FILENAME);
+
+	if (error == GIT_ENOTFOUND)
+		error = git_futils_find_global_file(path, GIT_CONFIG_FILENAME_ALT);
+
+	return error;
 }
 
 int git_config_find_global(char *global_config_path, size_t length)

--- a/src/config.h
+++ b/src/config.h
@@ -13,6 +13,7 @@
 #include "repository.h"
 
 #define GIT_CONFIG_FILENAME ".gitconfig"
+#define GIT_CONFIG_FILENAME_ALT ".config/git/config"
 #define GIT_CONFIG_FILENAME_INREPO "config"
 #define GIT_CONFIG_FILENAME_SYSTEM "gitconfig"
 #define GIT_CONFIG_FILE_MODE 0666


### PR DESCRIPTION
I found this new features in git v1.7.12-rc2 release notes
- Per-user $HOME/.gitconfig file can optionally be stored in
  $HOME/.config/git/config instead, which is in line with XDG.
- The value of core.attributesfile and core.excludesfile default to
  $HOME/.config/git/attributes and $HOME/.config/git/ignore respectively
  when these files exist.
