### PR TITLE
Revparse: GIT_EAMBIGUOUS

### DIFF
--- a/src/oid.c
+++ b/src/oid.c
@@ -24,9 +24,6 @@ int git_oid_fromstrn(git_oid *out, const char *str, size_t length)
 	size_t p;
 	int v;
 
-	if (length < 4)
-		return oid_error_invalid("input too short");
-
 	if (length > GIT_OID_HEXSZ)
 		length = GIT_OID_HEXSZ;
 

--- a/tests-clar/refs/revparse.c
+++ b/tests-clar/refs/revparse.c
@@ -442,3 +442,12 @@ void test_refs_revparse__disambiguation(void)
 	 */
 	test_object("e90810", "e90810b8df3e80c413d903f631643c716887138d");
 }
+
+void test_refs_revparse__a_too_short_objectid_returns_EAMBIGUOUS(void)
+{
+	int result;
+	
+	result = git_revparse_single(&g_obj, g_repo, "e90");
+	
+	cl_assert_equal_i(GIT_EAMBIGUOUS, result);
+}


### PR DESCRIPTION
Revparse now returns EAMBIGUOUS if the the spec doesn't match any refs/tags, and is <4 characters.

/cc @nulltoken
