### PR TITLE
refs: expose git_reference_normalize_name()

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -376,6 +376,54 @@ GIT_EXTERN(int) git_reference_has_log(git_reference *ref);
  */
 GIT_EXTERN(int) git_reference_is_branch(git_reference *ref);
 
+enum {
+	GIT_REF_FORMAT_NORMAL = 0,
+
+	/**
+	 * Control whether one-level refnames are accepted
+	 * (i.e., refnames that do not contain multiple /-separated
+	 * components)
+	 */
+	GIT_REF_FORMAT_ALLOW_ONELEVEL = (1 << 0),
+
+	/**
+	 * Interpret the provided name as a reference pattern for a
+	 * refspec (as used with remote repositories). If this option
+	 * is enabled, the name is allowed to contain a single * (<star>)
+	 * in place of a one full pathname component
+	 * (e.g., foo/<star>/bar but not foo/bar<star>).
+	 */
+	GIT_REF_FORMAT_REFSPEC_PATTERN = (1 << 1),
+};
+
+/**
+ * Normalize the reference name by removing any leading
+ * slash (/) characters and collapsing runs of adjacent slashes
+ * between name components into a single slash.
+ *
+ * Once normalized, if the reference name is valid, it will be
+ * returned in the user allocated buffer.
+ *
+ * TODO: Implement handling of GIT_REF_FORMAT_REFSPEC_PATTERN
+ *
+ * @param buffer_out The user allocated buffer where the
+ * normalized name will be stored.
+ *
+ * @param buffer_size buffer_out size
+ *
+ * @param name name to be checked.
+ *
+ * @param flags Flags to determine the options to be applied while
+ * checking the validatity of the name.
+ *
+ * @return 0 or an error code.
+ */
+GIT_EXTERN(int) git_reference_normalize_name(
+	char *buffer_out,
+	size_t buffer_size,
+	const char *name,
+	unsigned int flags);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/tests-clar/refs/normalize.c
+++ b/tests-clar/refs/normalize.c
@@ -4,70 +4,111 @@
 #include "git2/reflog.h"
 #include "reflog.h"
 
-
 // Helpers
-static void ensure_refname_normalized(int is_oid_ref,
+static void ensure_refname_normalized(unsigned int flags,
                                       const char *input_refname,
                                       const char *expected_refname)
 {
 	char buffer_out[GIT_REFNAME_MAX];
 
-	if (is_oid_ref)
-		cl_git_pass(git_reference__normalize_name_oid(buffer_out, sizeof(buffer_out), input_refname));
-	else
-		cl_git_pass(git_reference__normalize_name(buffer_out, sizeof(buffer_out), input_refname));
+	cl_git_pass(git_reference_normalize_name(buffer_out, sizeof(buffer_out), input_refname, flags));
 
-   if (expected_refname)
-	   cl_assert(0 == strcmp(buffer_out, expected_refname));
+	cl_assert_equal_i(0, strcmp(buffer_out, expected_refname));
 }
 
-static void ensure_refname_invalid(int is_oid_ref, const char *input_refname)
+static void ensure_refname_invalid(unsigned int flags, const char *input_refname)
 {
 	char buffer_out[GIT_REFNAME_MAX];
 
-   if (is_oid_ref)
-      cl_git_fail(git_reference__normalize_name_oid(buffer_out, sizeof(buffer_out), input_refname));
-   else
-      cl_git_fail(git_reference__normalize_name(buffer_out, sizeof(buffer_out), input_refname));
+	cl_git_fail(git_reference_normalize_name(buffer_out, sizeof(buffer_out), input_refname, flags));
 }
 
-#define OID_REF 1
-#define SYM_REF 0
-
-
-
-void test_refs_normalize__direct(void)
+void test_refs_normalize__can_normalize_a_direct_reference_name(void)
 {
-   // normalize a direct (OID) reference name
-	ensure_refname_invalid(OID_REF, "a");
-	ensure_refname_invalid(OID_REF, "");
-	ensure_refname_invalid(OID_REF, "refs/heads/a/");
-	ensure_refname_invalid(OID_REF, "refs/heads/a.");
-	ensure_refname_invalid(OID_REF, "refs/heads/a.lock");
-	ensure_refname_normalized(OID_REF, "refs/dummy/a", NULL);
-	ensure_refname_normalized(OID_REF, "refs/stash", NULL);
-	ensure_refname_normalized(OID_REF, "refs/tags/a", "refs/tags/a");
-	ensure_refname_normalized(OID_REF, "refs/heads/a/b", "refs/heads/a/b");
-	ensure_refname_normalized(OID_REF, "refs/heads/a./b", "refs/heads/a./b");
-	ensure_refname_invalid(OID_REF, "refs/heads/foo?bar");
-	ensure_refname_invalid(OID_REF, "refs/heads\foo");
-	ensure_refname_normalized(OID_REF, "refs/heads/v@ation", "refs/heads/v@ation");
-	ensure_refname_normalized(OID_REF, "refs///heads///a", "refs/heads/a");
-	ensure_refname_invalid(OID_REF, "refs/heads/.a/b");
-	ensure_refname_invalid(OID_REF, "refs/heads/foo/../bar");
-	ensure_refname_invalid(OID_REF, "refs/heads/foo..bar");
-	ensure_refname_invalid(OID_REF, "refs/heads/./foo");
-	ensure_refname_invalid(OID_REF, "refs/heads/v@{ation");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/dummy/a", "refs/dummy/a");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/stash", "refs/stash");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/tags/a", "refs/tags/a");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/a/b", "refs/heads/a/b");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/a./b", "refs/heads/a./b");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/v@ation", "refs/heads/v@ation");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "/refs///heads///a", "refs/heads/a");
+}
+
+void test_refs_normalize__can_normalize_some_specific_one_level_direct_reference_names(void)
+{
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "HEAD", "HEAD");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "MERGE_HEAD", "MERGE_HEAD");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "FETCH_HEAD", "FETCH_HEAD");
+}
+
+void test_refs_normalize__cannot_normalize_any_direct_reference_name(void)
+{
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "a");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "/a");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "//a");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/a/");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/a.");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/a.lock");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/foo?bar");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads\foo");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/v@ation", "refs/heads/v@ation");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_NORMAL, "refs///heads///a", "refs/heads/a");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/.a/b");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/foo/../bar");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/foo..bar");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/./foo");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "refs/heads/v@{ation");
 }
 
 void test_refs_normalize__symbolic(void)
 {
-   // normalize a symbolic reference name
-	ensure_refname_normalized(SYM_REF, "a", "a");
-	ensure_refname_normalized(SYM_REF, "a/b", "a/b");
-	ensure_refname_normalized(SYM_REF, "refs///heads///a", "refs/heads/a");
-	ensure_refname_invalid(SYM_REF, "");
-	ensure_refname_invalid(SYM_REF, "heads\foo");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "heads\foo");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "///");
+
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "a", "a");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "a/b", "a/b");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs///heads///a", "refs/heads/a");
+
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "HEAD", "HEAD");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "MERGE_HEAD", "MERGE_HEAD");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "FETCH_HEAD", "FETCH_HEAD");
 }
 
 /* Ported from JGit, BSD licence.
@@ -77,31 +118,42 @@ void test_refs_normalize__jgit_suite(void)
    // tests borrowed from JGit
 
 /* EmptyString */
-	ensure_refname_invalid(SYM_REF, "");
-	ensure_refname_invalid(SYM_REF, "/");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "/");
 
 /* MustHaveTwoComponents */
-	ensure_refname_invalid(OID_REF, "master");
-	ensure_refname_normalized(SYM_REF, "heads/master", "heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_NORMAL, "master");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "heads/master", "heads/master");
 
 /* ValidHead */
 
-	ensure_refname_normalized(SYM_REF, "refs/heads/master", "refs/heads/master");
-	ensure_refname_normalized(SYM_REF, "refs/heads/pu", "refs/heads/pu");
-	ensure_refname_normalized(SYM_REF, "refs/heads/z", "refs/heads/z");
-	ensure_refname_normalized(SYM_REF, "refs/heads/FoO", "refs/heads/FoO");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master", "refs/heads/master");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/pu", "refs/heads/pu");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/z", "refs/heads/z");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/FoO", "refs/heads/FoO");
 
 /* ValidTag */
-	ensure_refname_normalized(SYM_REF, "refs/tags/v1.0", "refs/tags/v1.0");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/tags/v1.0", "refs/tags/v1.0");
 
 /* NoLockSuffix */
-	ensure_refname_invalid(SYM_REF, "refs/heads/master.lock");
+	ensure_refname_invalid(GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master.lock");
 
 /* NoDirectorySuffix */
-	ensure_refname_invalid(SYM_REF, "refs/heads/master/");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master/");
 
 /* NoSpace */
-	ensure_refname_invalid(SYM_REF, "refs/heads/i haz space");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/i haz space");
 
 /* NoAsciiControlCharacters */
 	{
@@ -112,89 +164,153 @@ void test_refs_normalize__jgit_suite(void)
 			strncpy(buffer + 15, (const char *)&c, 1);
 			strncpy(buffer + 16, "er", 2);
 			buffer[18 - 1] = '\0';
-			ensure_refname_invalid(SYM_REF, buffer);
+			ensure_refname_invalid(GIT_REF_FORMAT_ALLOW_ONELEVEL, buffer);
 		}
 	}
 
 /* NoBareDot */
-	ensure_refname_invalid(SYM_REF, "refs/heads/.");
-	ensure_refname_invalid(SYM_REF, "refs/heads/..");
-	ensure_refname_invalid(SYM_REF, "refs/heads/./master");
-	ensure_refname_invalid(SYM_REF, "refs/heads/../master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/.");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/..");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/./master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/../master");
 
 /* NoLeadingOrTrailingDot */
-	ensure_refname_invalid(SYM_REF, ".");
-	ensure_refname_invalid(SYM_REF, "refs/heads/.bar");
-	ensure_refname_invalid(SYM_REF, "refs/heads/..bar");
-	ensure_refname_invalid(SYM_REF, "refs/heads/bar.");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, ".");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/.bar");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/..bar");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/bar.");
 
 /* ContainsDot */
-	ensure_refname_normalized(SYM_REF, "refs/heads/m.a.s.t.e.r", "refs/heads/m.a.s.t.e.r");
-	ensure_refname_invalid(SYM_REF, "refs/heads/master..pu");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/m.a.s.t.e.r", "refs/heads/m.a.s.t.e.r");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master..pu");
 
 /* NoMagicRefCharacters */
-	ensure_refname_invalid(SYM_REF, "refs/heads/master^");
-	ensure_refname_invalid(SYM_REF, "refs/heads/^master");
-	ensure_refname_invalid(SYM_REF, "^refs/heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master^");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/^master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "^refs/heads/master");
 
-	ensure_refname_invalid(SYM_REF, "refs/heads/master~");
-	ensure_refname_invalid(SYM_REF, "refs/heads/~master");
-	ensure_refname_invalid(SYM_REF, "~refs/heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master~");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/~master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "~refs/heads/master");
 
-	ensure_refname_invalid(SYM_REF, "refs/heads/master:");
-	ensure_refname_invalid(SYM_REF, "refs/heads/:master");
-	ensure_refname_invalid(SYM_REF, ":refs/heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master:");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/:master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, ":refs/heads/master");
 
 /* ShellGlob */
-	ensure_refname_invalid(SYM_REF, "refs/heads/master?");
-	ensure_refname_invalid(SYM_REF, "refs/heads/?master");
-	ensure_refname_invalid(SYM_REF, "?refs/heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master?");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/?master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "?refs/heads/master");
 
-	ensure_refname_invalid(SYM_REF, "refs/heads/master[");
-	ensure_refname_invalid(SYM_REF, "refs/heads/[master");
-	ensure_refname_invalid(SYM_REF, "[refs/heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master[");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/[master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "[refs/heads/master");
 
-	ensure_refname_invalid(SYM_REF, "refs/heads/master*");
-	ensure_refname_invalid(SYM_REF, "refs/heads/*master");
-	ensure_refname_invalid(SYM_REF, "*refs/heads/master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master*");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/*master");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "*refs/heads/master");
 
 /* ValidSpecialCharacters */
-	ensure_refname_normalized(SYM_REF, "refs/heads/!", "refs/heads/!");
-	ensure_refname_normalized(SYM_REF, "refs/heads/\"", "refs/heads/\"");
-	ensure_refname_normalized(SYM_REF, "refs/heads/#", "refs/heads/#");
-	ensure_refname_normalized(SYM_REF, "refs/heads/$", "refs/heads/$");
-	ensure_refname_normalized(SYM_REF, "refs/heads/%", "refs/heads/%");
-	ensure_refname_normalized(SYM_REF, "refs/heads/&", "refs/heads/&");
-	ensure_refname_normalized(SYM_REF, "refs/heads/'", "refs/heads/'");
-	ensure_refname_normalized(SYM_REF, "refs/heads/(", "refs/heads/(");
-	ensure_refname_normalized(SYM_REF, "refs/heads/)", "refs/heads/)");
-	ensure_refname_normalized(SYM_REF, "refs/heads/+", "refs/heads/+");
-	ensure_refname_normalized(SYM_REF, "refs/heads/,", "refs/heads/,");
-	ensure_refname_normalized(SYM_REF, "refs/heads/-", "refs/heads/-");
-	ensure_refname_normalized(SYM_REF, "refs/heads/;", "refs/heads/;");
-	ensure_refname_normalized(SYM_REF, "refs/heads/<", "refs/heads/<");
-	ensure_refname_normalized(SYM_REF, "refs/heads/=", "refs/heads/=");
-	ensure_refname_normalized(SYM_REF, "refs/heads/>", "refs/heads/>");
-	ensure_refname_normalized(SYM_REF, "refs/heads/@", "refs/heads/@");
-	ensure_refname_normalized(SYM_REF, "refs/heads/]", "refs/heads/]");
-	ensure_refname_normalized(SYM_REF, "refs/heads/_", "refs/heads/_");
-	ensure_refname_normalized(SYM_REF, "refs/heads/`", "refs/heads/`");
-	ensure_refname_normalized(SYM_REF, "refs/heads/{", "refs/heads/{");
-	ensure_refname_normalized(SYM_REF, "refs/heads/|", "refs/heads/|");
-	ensure_refname_normalized(SYM_REF, "refs/heads/}", "refs/heads/}");
+	ensure_refname_normalized
+		(GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/!", "refs/heads/!");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/\"", "refs/heads/\"");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/#", "refs/heads/#");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/$", "refs/heads/$");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/%", "refs/heads/%");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/&", "refs/heads/&");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/'", "refs/heads/'");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/(", "refs/heads/(");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/)", "refs/heads/)");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/+", "refs/heads/+");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/,", "refs/heads/,");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/-", "refs/heads/-");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/;", "refs/heads/;");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/<", "refs/heads/<");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/=", "refs/heads/=");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/>", "refs/heads/>");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/@", "refs/heads/@");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/]", "refs/heads/]");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/_", "refs/heads/_");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/`", "refs/heads/`");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/{", "refs/heads/{");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/|", "refs/heads/|");
+	ensure_refname_normalized(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/}", "refs/heads/}");
 
 	// This is valid on UNIX, but not on Windows
 	// hence we make in invalid due to non-portability
 	//
-	ensure_refname_invalid(SYM_REF, "refs/heads/\\");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/\\");
 
 /* UnicodeNames */
 	/*
 	 * Currently this fails.
-	 * ensure_refname_normalized(SYM_REF, "refs/heads/\u00e5ngstr\u00f6m", "refs/heads/\u00e5ngstr\u00f6m");
+	 * ensure_refname_normalized(GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/\u00e5ngstr\u00f6m", "refs/heads/\u00e5ngstr\u00f6m");
 	 */
 
 /* RefLogQueryIsValidRef */
-	ensure_refname_invalid(SYM_REF, "refs/heads/master@{1}");
-	ensure_refname_invalid(SYM_REF, "refs/heads/master@{1.hour.ago}");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master@{1}");
+	ensure_refname_invalid(
+		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master@{1.hour.ago}");
+}
+
+void test_refs_normalize__buffer_has_to_be_big_enough_to_hold_the_normalized_version(void)
+{
+	char buffer_out[21];
+
+	cl_git_pass(git_reference_normalize_name(
+		buffer_out, 21, "//refs//heads/long///name", GIT_REF_FORMAT_NORMAL));
+	cl_git_fail(git_reference_normalize_name(
+		buffer_out, 20, "//refs//heads/long///name", GIT_REF_FORMAT_NORMAL));
 }


### PR DESCRIPTION
Make `git_reference_normalize_name()` accessible to bindings.

Some slight changes have also been made in order to make the implementation closer to `git check-ref-format`
- Removed constrained "refs/" namespace for direct references
- Added an enum to allow future implementation of `GIT_REF_FORMAT_REFSPEC_PATTERN`
