### PR TITLE
Expose a malloc function to 3rd party ODB backends

### DIFF
--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -26,6 +26,10 @@ struct git_odb_stream;
 struct git_odb_backend {
 	git_odb *odb;
 
+	/* read and read_prefix each return to libgit2 a buffer which
+	 * will be freed later. The buffer should be allocated using
+	 * the function git_odb_backend_malloc to ensure that it can
+	 * be safely freed later. */
 	int (* read)(
 			void **, size_t *, git_otype *,
 			struct git_odb_backend *,
@@ -101,6 +105,8 @@ struct git_odb_stream {
 GIT_EXTERN(int) git_odb_backend_pack(git_odb_backend **backend_out, const char *objects_dir);
 GIT_EXTERN(int) git_odb_backend_loose(git_odb_backend **backend_out, const char *objects_dir, int compression_level, int do_fsync);
 GIT_EXTERN(int) git_odb_backend_one_pack(git_odb_backend **backend_out, const char *index_file);
+
+GIT_EXTERN(void *) git_odb_backend_malloc(git_odb_backend *backend, size_t len);
 
 GIT_END_DECL
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -708,6 +708,11 @@ int git_odb_open_rstream(git_odb_stream **stream, git_odb *db, const git_oid *oi
 	return error;
 }
 
+void * git_odb_backend_malloc(git_odb_backend *backend, size_t len)
+{
+	return git__malloc(len);
+}
+
 int git_odb__error_notfound(const char *message, const git_oid *oid)
 {
 	if (oid != NULL) {


### PR DESCRIPTION
The ODB backend interface has functions in it for doing reads. These functions allocate buffers and return them (and ownership of them) to the caller. It is expected right now that the ODB backend allocates these buffers using `git__malloc`. Since this function is not exported, it's not possible to write a third-party ODB backend for libgit2. All backends must be in the git2 library so that they can call `git__malloc`.

This change asks that backends use a new exported function called `git_odb_backend_malloc` to allocate buffers that will change ownership from the backend to libgit2. The fact that this entry point just redirects to `git__malloc` right now is an implementation detail.

This implementation detail means that the existing backends don't have to be switched over to using `git_odb_backend_malloc` (although they could be). It also means that the caller (who takes ownership of the buffer) can still assume that `git__free` is the function to be used to free any buffer that comes back from an ODB backend. 

The implementation could be changed to have a separate heap for `git_odb_backend_malloc` allocations. Doing so would mean that libgit2 would need to keep track of the `free` function for each buffer so that it can call the right function at free time.

This implementation detail does expose `git__malloc` to any outside caller. But anyone using it for a purpose other than allocating a buffer to return from read/read_prefix in libgit2 is in violation of the contract and subject to being broken by the implementation details described above changing.

There are certainly other ways to do this. If this isn't what the team feels like is the best approach then I would be happy to revisit it.

Thanks,
Philip
Microsoft Corporation
