### PR TITLE
repository: add failing repo initialization test

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -777,8 +777,8 @@ static int repo_init_config(
 			SET_REPO_CONFIG(string, "core.worktree", work_dir);
 		}
 		else if ((opts->flags & GIT_REPOSITORY_INIT__IS_REINIT) != 0) {
-			if ((error = git_config_delete(config, "core.worktree")) < 0)
-				goto cleanup;
+			if (git_config_delete(config, "core.worktree") < 0)
+				giterr_clear();
 		}
 	} else {
 		if (!are_symlinks_supported(repo_dir))

--- a/tests-clar/repo/init.c
+++ b/tests-clar/repo/init.c
@@ -378,3 +378,18 @@ void test_repo_init__extended_with_template(void)
 
 	cleanup_repository("templated.git");
 }
+
+void test_repo_init__can_reinit_an_initialized_repository(void)
+{
+	git_repository *reinit;
+
+	cl_git_pass(git_futils_mkdir("extended", NULL, 0775, 0));
+	cl_git_pass(git_repository_init(&_repo, "extended", false));
+
+	cl_git_pass(git_repository_init(&reinit, "extended", false));
+
+	cl_assert_equal_s(git_repository_path(_repo), git_repository_path(reinit));
+
+	git_repository_free(reinit);
+	cleanup_repository("extended");
+}


### PR DESCRIPTION
While running the LibGit2Sharp test against the libgit2 #856, a fail popped in.

Here's a C version of it (still failing) :/

```
description: Could not find key 'core.worktree' to delete
```
