### PR TITLE
Fix MSVC compilation warnings

### DIFF
--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -727,7 +727,7 @@ int git_diff_entrycount(git_diff_list *diff, int delta_t)
 	assert(diff);
 
 	if (delta_t < 0)
-		return diff->deltas.length;
+		return (int)diff->deltas.length;
 
 	git_vector_foreach(&diff->deltas, i, delta) {
 		if (delta->status == (git_delta_t)delta_t)

--- a/src/signature.c
+++ b/src/signature.c
@@ -142,7 +142,7 @@ int git_signature_now(git_signature **sig_out, const char *name, const char *ema
 	time(&now);
 	utc_tm = p_gmtime_r(&now, &_utc);
 	utc_tm->tm_isdst = -1;
-	offset = difftime(now, mktime(utc_tm));
+	offset = (time_t)difftime(now, mktime(utc_tm));
 	offset /= 60;
 
 	if (git_signature_new(&sig, name, email, now, (int)offset) < 0)


### PR DESCRIPTION
- src\signature.c(145): warning C4244: '=' : conversion from 'double' to 'time_t', possible loss of data
- src\diff_output.c(730): warning C4267: 'return' : conversion from 'size_t' to 'int', possible loss of data
