### PR TITLE
git_mergebase: Constness-Fix for consistency

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -28,7 +28,7 @@ GIT_BEGIN_DECL
  * @param one one of the commits
  * @param two the other commit
  */
-GIT_EXTERN(int) git_merge_base(git_oid *out, git_repository *repo, git_oid *one, git_oid *two);
+GIT_EXTERN(int) git_merge_base(git_oid *out, git_repository *repo, const git_oid *one, const git_oid *two);
 
 /**
  * Find a merge base given a list of commits

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -419,7 +419,7 @@ cleanup:
 	return error;
 }
 
-int git_merge_base(git_oid *out, git_repository *repo, git_oid *one, git_oid *two)
+int git_merge_base(git_oid *out, git_repository *repo, const git_oid *one, const git_oid *two)
 {
 	git_revwalk *walk;
 	git_vector list;


### PR DESCRIPTION
Simply turns `git_mergebase()`'s `git_oid*` parameters into `const git_od*` ones.

Just a little inconsistency I stumbled upon when playing around with mergebases.
