### PR TITLE
odb_pack: try lookup before refreshing packs

### DIFF
--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -268,12 +268,12 @@ static int pack_entry_find(struct git_pack_entry *e, struct pack_backend *backen
 	int error;
 	unsigned int i;
 
-	if ((error = packfile_refresh_all(backend)) < 0)
-		return error;
-
 	if (backend->last_found &&
 		git_pack_entry_find(e, backend->last_found, oid, GIT_OID_HEXSZ) == 0)
 		return 0;
+
+	if ((error = packfile_refresh_all(backend)) < 0)
+		return error;
 
 	for (i = 0; i < backend->packs.length; ++i) {
 		struct git_pack_file *p;


### PR DESCRIPTION
This reduces the rate of syscalls for the common case of sequences of
object reads from the same pack.

Best of 5 timings for `libgit2_clar` before this patch:

```
real    0m5.375s
user    0m0.392s
sys     0m3.564s
```

After applying this patch:

```
real    0m5.285s
user    0m0.356s
sys     0m3.544s
```

0.6% improvement in system time.
9.2% improvement in user time.
1.7% improvement in elapsed time.

Confirmed a 0.6% reduction in number of system calls with `strace`.

Expect greater improvement for graph-traversal with large packs.
