### PR TITLE
pack: iterate objects in offset order

### DIFF
--- a/src/pack.h
+++ b/src/pack.h
@@ -64,6 +64,7 @@ struct git_pack_file {
 	unsigned pack_local:1, pack_keep:1, has_cache:1;
 	git_oid sha1;
 	git_vector cache;
+	git_oid **oids;
 
 	/* something like ".git/objects/pack/xxxxx.pack" */
 	char pack_name[GIT_FLEX_ARRAY]; /* more */


### PR DESCRIPTION
Compute the ordering on demand and persist until the index is freed.
