### PR TITLE
refs: prevent locked refs from being enumerated

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -494,6 +494,10 @@ static int _dirent_loose_listall(void *_data, git_buf *full_path)
 			return 0; /* we are filtering out this reference */
 	}
 
+	/* Locked references aren't returned */
+	if (!git__suffixcmp(file_path, GIT_FILELOCK_EXTENSION))
+		return 0;
+
 	if (data->callback(file_path, data->callback_payload))
 		data->callback_error = GIT_EUSER;
 

--- a/tests-clar/refs/list.c
+++ b/tests-clar/refs/list.c
@@ -51,3 +51,18 @@ void test_refs_list__symbolic_only(void)
 
 	git_strarray_free(&ref_list);
 }
+
+void test_refs_list__do_not_retrieve_references_which_name_end_with_a_lock_extension(void)
+{
+	git_strarray ref_list;
+
+	/* Create a fake locked reference */
+	cl_git_mkfile(
+		"./testrepo/.git/refs/heads/hanwen.lock",
+		"144344043ba4d4a405da03de3844aa829ae8be0e\n");
+
+	cl_git_pass(git_reference_list(&ref_list, g_repo, GIT_REF_LISTALL));
+	cl_assert_equal_i((int)ref_list.count, 10);
+
+	git_strarray_free(&ref_list);
+}


### PR DESCRIPTION
Fix #936
