### PR TITLE
New refspec code leaks memory

### DIFF
--- a/include/git2/refspec.h
+++ b/include/git2/refspec.h
@@ -28,6 +28,13 @@ GIT_BEGIN_DECL
 GIT_EXTERN(int) git_refspec_parse(git_refspec *refspec, const char *str);
 
 /**
+ * Release memory associated with a refspec object
+ *
+ * @param refspec pointer to the refspec that was filled with parse
+ */
+GIT_EXTERN(void) git_refspec_clear(git_refspec *refspec);
+
+/**
  * Get the source specifier
  *
  * @param refspec the refspec

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -156,6 +156,17 @@ int git_refspec_parse(git_refspec *refspec, const char *str)
 	return 0;
 }
 
+void git_refspec_clear(git_refspec *refspec)
+{
+	if (refspec) {
+		git__free(refspec->src);
+		refspec->src = NULL;
+
+		git__free(refspec->dst);
+		refspec->dst = NULL;
+	}
+}
+
 const char *git_refspec_src(const git_refspec *refspec)
 {
 	return refspec == NULL ? NULL : refspec->src;

--- a/tests-clar/network/refspecs.c
+++ b/tests-clar/network/refspecs.c
@@ -13,6 +13,8 @@ static void assert_refspec(unsigned int direction, const char *input, bool is_ex
 		cl_assert_equal_i(0, error);
 	else
 		cl_assert_equal_i(GIT_ERROR, error);
+
+	git_refspec_clear(&refspec);
 }
 
 void test_network_refspecs__parsing(void)


### PR DESCRIPTION
This fixes a memory leak in the tests that I found in valgrind along with adding a new API so that other users can also free the memory of the refspec object.

I'm doing this as a pull request because I'm wondering if I'm just missing something about how users are supposed to handle `git_refspec` objects and thought maybe @carlosmn or someone would comment...
