### PR TITLE
Jv linux mode32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,9 @@ OPTION (BUILD_CLAR "Build Tests using the Clar suite" ON)
 OPTION (BUILD_EXAMPLES "Build library usage example apps" OFF)
 OPTION (TAGS "Generate tags" OFF)
 OPTION (PROFILE "Generate profiling information" OFF)
-OPTION (MODE32 "Build 32bit library" OFF)
+IF (NOT WIN32 OR MINGW)
+	OPTION (MODE32 "Build 32bit library (UNIX/MINGW only, for MSVC use 'setenv /x86' before building)" OFF)
+ENDIF()
 
 # Platform specific compilation flags
 IF (MSVC)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following CMake variables are declared:
 - `BUILD_SHARED_LIBS`: Build libgit2 as a Shared Library (defaults to ON)
 - `BUILD_CLAR`: Build [Clar](https://github.com/tanoku/clar)-based test suite (defaults to ON)
 - `THREADSAFE`: Build libgit2 with threading support (defaults to OFF)
+- `MODE32`: Build 32bit libgit2 library even if building on 64bit system - UNIX only (defaults to OFF)
 
 Language Bindings
 ==================================


### PR DESCRIPTION
Added new option MODE32 to build 32bit library when on 64bit system. 
It's a bit hacky, but is seems that CMake lacks support for doing such a build. 
