### PR TITLE
Fix error hashing empty file.

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -115,7 +115,7 @@ int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 	int hdr_len;
 	char hdr[64], buffer[2048];
 	git_hash_ctx *ctx;
-	ssize_t read_len = -1;
+	ssize_t read_len = 0;
 
 	if (!git_object_typeisloose(type)) {
 		giterr_set(GITERR_INVALID, "Invalid object type for hash");

--- a/tests-clar/status/single.c
+++ b/tests-clar/status/single.c
@@ -25,5 +25,21 @@ void test_status_single__hash_single_file(void)
 	cl_assert(git_oid_cmp(&expected_id, &actual_id) == 0);
 }
 
+/* test retrieving OID from an empty file apart from the ODB */
+void test_status_single__hash_single_empty_file(void)
+{
+	static const char file_name[] = "new_empty_file";
+	static const char file_contents[] = "";
+	static const char file_hash[] = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
 
+	git_oid expected_id, actual_id;
+
+	/* initialization */
+	git_oid_fromstr(&expected_id, file_hash);
+	cl_git_mkfile(file_name, file_contents);
+	cl_set_cleanup(&cleanup__remove_file, (void *)file_name);
+
+	cl_git_pass(git_odb_hashfile(&actual_id, file_name, GIT_OBJ_BLOB));
+	cl_assert(git_oid_cmp(&expected_id, &actual_id) == 0);
+}
 


### PR DESCRIPTION
Pull Request around an issue when hashing an empty (0 byte) files in the working directory of a repository. This issue is hit when getting the status of a repository whose working directory includes an empty file. This includes a test covering this issue.

The hashing logic did not discern between not reading from a file because it was empty and the read function returning an error.

Appreciate any thoughts / comments on this

Thanks!
