### PR TITLE
Fix a bug where ignorecase wasn't applied to ignores

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -48,13 +48,14 @@ static int parse_ignore_file(
 
 		match->flags = GIT_ATTR_FNMATCH_ALLOWSPACE;
 
-		if (ignore_case)
-			match->flags |= GIT_ATTR_FNMATCH_ICASE;
-
 		if (!(error = git_attr_fnmatch__parse(
 			match, ignores->pool, context, &scan)))
 		{
-			match->flags = match->flags | GIT_ATTR_FNMATCH_IGNORE;
+			match->flags |= GIT_ATTR_FNMATCH_IGNORE;
+
+			if (ignore_case)
+				match->flags |= GIT_ATTR_FNMATCH_ICASE;
+
 			scan = git__next_line(scan);
 			error = git_vector_insert(&ignores->rules, match);
 		}

--- a/tests-clar/status/ignore.c
+++ b/tests-clar/status/ignore.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 #include "fileops.h"
 #include "git2/attr.h"
+#include "ignore.h"
 #include "attr.h"
 #include "status_helpers.h"
 
@@ -150,6 +151,26 @@ void test_status_ignore__ignore_pattern_contains_space(void)
 
 	cl_git_pass(git_status_file(&flags, g_repo, "foo/look-ma.txt"));
 	cl_assert(flags == GIT_STATUS_WT_NEW);
+}
+
+void test_status_ignore__ignore_pattern_ignorecase(void)
+{
+	unsigned int flags;
+	const mode_t mode = 0777;
+	bool ignore_case;
+	git_index *index;
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+	cl_git_rewritefile("empty_standard_repo/.gitignore", "a.txt\n");
+
+	cl_git_mkfile("empty_standard_repo/A.txt", "Differs in case");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	ignore_case = index->ignore_case;
+	git_index_free(index);
+
+	cl_git_pass(git_status_file(&flags, g_repo, "A.txt"));
+	cl_assert(flags == ignore_case ? GIT_STATUS_IGNORED : GIT_STATUS_WT_NEW);
 }
 
 void test_status_ignore__adding_internal_ignores(void)


### PR DESCRIPTION
There was a mistake in my previous submission for core.ignorecase support, where I was setting a flag just prior to calling a function which masked out the very bit I was trying to set! The result was that with ignorecase set, a .gitignore rule saying to ignore a.txt would not match A.txt. The file would show up as added, when it should actually be ignored.

This patch fixes the bug and adds a test case to verify correct operation and prevent future regression.
