### PR TITLE
Test category for live network tests

### DIFF
--- a/tests-clar/clone/network.c
+++ b/tests-clar/clone/network.c
@@ -5,8 +5,8 @@
 
 CL_IN_CATEGORY("network")
 
-#define LIVE_REPO_URL "git://github.com/nulltoken/TestGitRepository"
-#define LIVE_EMPTYREPO_URL "git://github.com/nulltoken/TestEmptyRepository"
+#define LIVE_REPO_URL "git://github.com/libgit2/TestGitRepository"
+#define LIVE_EMPTYREPO_URL "git://github.com/libgit2/TestEmptyRepository"
 
 static git_repository *g_repo;
 

--- a/tests-clar/clone/nonetwork.c
+++ b/tests-clar/clone/nonetwork.c
@@ -4,7 +4,7 @@
 #include "repository.h"
 
 #define DO_LOCAL_TEST 0
-#define LIVE_REPO_URL "git://github.com/nulltoken/TestGitRepository"
+#define LIVE_REPO_URL "git://github.com/libgit2/TestGitRepository"
 
 static git_repository *g_repo;
 


### PR DESCRIPTION
Is this how clar categories are intended to be used? The live-network clone tests can now be run with `./libgit2_clar -inetwork -sclone::network`, instead of having to change a `#define` and recompile.
