### PR TITLE
Separated git_strarray from common.h.  Added doxy comments.

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -10,7 +10,7 @@
 #include "common.h"
 #include "types.h"
 #include "indexer.h"
-
+#include "strarray.h"
 
 /**
  * @file git2/checkout.h

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -85,14 +85,6 @@ GIT_BEGIN_DECL
  */
 #define GIT_PATH_MAX 4096
 
-typedef struct {
-	char **strings;
-	size_t count;
-} git_strarray;
-
-GIT_EXTERN(void) git_strarray_free(git_strarray *array);
-GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
-
 /**
  * Return the version of the libgit2 library
  * being currently used.
@@ -128,4 +120,5 @@ GIT_EXTERN(int) git_libgit2_capabilities(void);
 
 /** @} */
 GIT_END_DECL
+
 #endif

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -10,6 +10,7 @@
 #include "common.h"
 #include "types.h"
 #include "oid.h"
+#include "strarray.h"
 
 /**
  * @file git2/refs.h

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -12,6 +12,7 @@
 #include "refspec.h"
 #include "net.h"
 #include "indexer.h"
+#include "strarray.h"
 
 /**
  * @file git2/remote.h

--- a/include/git2/strarray.h
+++ b/include/git2/strarray.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2012 the libgit2 contributors
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_strarray_h__
+#define INCLUDE_git_strarray_h__
+
+#include "common.h"
+
+/**
+ * @file git2/strarray.h
+ * @brief Git string array routines
+ * @defgroup git_strarray Git string array routines
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/** Array of strings */
+typedef struct _git_strarray git_strarray;
+struct _git_strarray {
+    char **strings;
+    size_t count;
+};
+
+/**
+ * Close a string array object
+ *
+ * This method must always be called once a git_strarray is no
+ * longer needed, otherwise memory will leak.
+ *
+ * @param array array to close
+ */
+GIT_EXTERN(void) git_strarray_free(git_strarray *array);
+
+/**
+ * Copy a string array object from source to target.
+ * 
+ * Note: target is overwritten and hence should be empty, 
+ * otherwise its contents are leaked.
+ *
+ * @param tgt target
+ * @param src source
+ */
+GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
+
+
+/** @} */
+GIT_END_DECL
+
+#endif
+ 

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -11,6 +11,7 @@
 #include "types.h"
 #include "oid.h"
 #include "object.h"
+#include "strarray.h"
 
 /**
  * @file git2/tag.h

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -8,6 +8,7 @@
 #define INCLUDE_buffer_h__
 
 #include "common.h"
+#include "git2/strarray.h"
 #include <stdarg.h>
 
 typedef struct {


### PR DESCRIPTION
I moved git_strarray public interface from include/git2/common.h  into include/git2/strarray.h

The code in src is still in src/util.c

I intially just wanted to re-syntax it's declaration into:
typedef struct _git_strarray git_strarray;
struct _git_strarray {
    char **strings;
    size_t count;
};
So I could forward-declare it for my c++ bindings.

But then I thought it would be better refactored out, and doxy comments added.

Should git_strarray become an opaque object like most of the other git2 objects?
