### PR TITLE
Incremental improvements to pack-objects logic

### DIFF
--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -43,7 +43,6 @@ typedef struct git_pobject {
 
 	int written:1,
 	    recursing:1,
-	    no_try_delta:1,
 	    tagged:1,
 	    filled:1;
 } git_pobject;
@@ -65,6 +64,11 @@ struct git_packbuilder {
 
 	git_oid pack_oid; /* hash of written pack */
 
+	/* synchronization objects */
+	git_mutex cache_mutex;
+	git_mutex progress_mutex;
+	git_cond progress_cond;
+
 	/* configs */
 	unsigned long delta_cache_size;
 	unsigned long max_delta_cache_size;
@@ -77,8 +81,7 @@ struct git_packbuilder {
 	bool done;
 };
 
-
 int git_packbuilder_send(git_packbuilder *pb, git_transport *t);
 int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb);
 
-#endif
+#endif /* INCLUDE_pack_objects_h__ */

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -78,6 +78,7 @@ int pthread_cond_destroy(pthread_cond_t *cond)
 
 	closed = CloseHandle(*cond);
 	assert(closed);
+	GIT_UNUSED(closed);
 
 	*cond = NULL;
 	return 0;
@@ -99,6 +100,7 @@ int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
 
 	wait_result = WaitForSingleObject(*cond, INFINITE);
 	assert(WAIT_OBJECT_0 == wait_result);
+	GIT_UNUSED(wait_result);
 
 	return pthread_mutex_lock(mutex);
 }
@@ -112,6 +114,7 @@ int pthread_cond_signal(pthread_cond_t *cond)
 
 	signaled = SetEvent(*cond);
 	assert(signaled);
+	GIT_UNUSED(signaled);
 
 	return 0;
 }


### PR DESCRIPTION
@schu

One of the approaches I was looking at for solving the condition variables problem on Win32 was to simply stop using condition variables. That's not the direction we ended up taking, but I spent a good bit of time in `pack-objects.c` as part of that investigation.

While I was there I made what I think are some incremental improvements, and I added some comments. The biggest change, I think, is that three synchronization objects that were previously static have been moved into the `git_packbuilder` structure. I also improved the robustness of the `git_packbuilder_new` and `git_packbuilder_free` functions with respect to out-of-memory conditions.

I look forward to hearing if you (or anyone else) have any comments!
