### PR TITLE
remote: support fetch cancelation

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -199,6 +199,14 @@ GIT_EXTERN(int) git_remote_download(git_remote *remote, git_off_t *bytes, git_in
 GIT_EXTERN(int) git_remote_connected(git_remote *remote);
 
 /**
+ * Cancel the operation
+ *
+ * At certain points in its operation, the network code checks whether
+ * the operation has been cancelled and if so stops the operation.
+ */
+GIT_EXTERN(void) git_remote_stop(git_remote *remote);
+
+/**
  * Disconnect from the remote
  *
  * Close the connection to the remote and free the underlying

--- a/src/remote.c
+++ b/src/remote.c
@@ -558,6 +558,11 @@ int git_remote_connected(git_remote *remote)
 	return remote->transport == NULL ? 0 : remote->transport->connected;
 }
 
+void git_remote_stop(git_remote *remote)
+{
+	git_atomic_set(&remote->transport->cancel, 1);
+}
+
 void git_remote_disconnect(git_remote *remote)
 {
 	assert(remote);

--- a/src/transport.h
+++ b/src/transport.h
@@ -91,6 +91,8 @@ struct git_transport {
 	GIT_SOCKET socket;
 	git_transport_caps caps;
 	void *cb_data;
+	git_atomic cancel;
+
 	/**
 	 * Connect and store the remote heads
 	 */


### PR DESCRIPTION
Introduce git_remote_stop() which sets a variable that is checked by
the fetch process in a few key places. If this is variable is set, the
fetch is aborted.
