### PR TITLE
config: avoid segfault on invalid name in get_string_at_file().

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -400,7 +400,7 @@ static int get_string_at_file(const char **out, git_config_file *file, const cha
 	*out = NULL;
 
 	res = file->get(file, name, &entry);
-	if (res != GIT_ENOTFOUND)
+	if (entry && res != GIT_ENOTFOUND)
 		*out = entry->value;
 
 	return res;


### PR DESCRIPTION
If the requested name is invalid, you get:
- normalize_name() returns -1
- config_get() returns -1  (when called as file->get() in get_string_at_file())
- entry is NULL, but res != GIT_ENOTFOUND

In this case, you _don't_ want to try and dereference entry.

Signed-off-by: W. Trevor King wking@tremily.us
