### PR TITLE
config: iterate through config files in git_config_set_multivar()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -471,11 +471,17 @@ int git_config_set_multivar(git_config *cfg, const char *name, const char *regex
 {
 	git_config_file *file;
 	file_internal *internal;
+	unsigned int i;
 
-	internal = git_vector_get(&cfg->files, 0);
-	file = internal->file;
+	assert(cfg->files.length);
 
-	return file->set_multivar(file, name, regexp, value);
+	git_vector_foreach(&cfg->files, i, internal) {
+		file = internal->file;
+		int res = file->set_multivar(file, name, regexp, value);
+		if (res >= 0)
+			return res;
+	}
+	return GIT_ENOTFOUND;
 }
 
 int git_config_find_global_r(git_buf *path)


### PR DESCRIPTION
I duplicated the logic from config_get().  The change will be made to
the config file in which the variable you're replacing was originally
defined.

It's possible that other multivar functions need to be extended to support config-file looping, but I didn't check.
