### PR TITLE
fetch: Write packs to the ODB instead of directly to disk

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -11,6 +11,7 @@
 #include "types.h"
 #include "oid.h"
 #include "odb_backend.h"
+#include "indexer.h"
 
 /**
  * @file git2/odb.h
@@ -261,6 +262,26 @@ GIT_EXTERN(int) git_odb_open_wstream(git_odb_stream **stream, git_odb *db, size_
  * @return 0 if the stream was created; error code otherwise
  */
 GIT_EXTERN(int) git_odb_open_rstream(git_odb_stream **stream, git_odb *db, const git_oid *oid);
+
+/**
+ * Open a stream for writing a pack file to the ODB.
+ *
+ * If the ODB layer understands pack files, then the given
+ * packfile will likely be streamed directly to disk (and a
+ * corresponding index created).  If the ODB layer does not
+ * understand pack files, the objects will be stored in whatever
+ * format the ODB layer uses.
+ *
+ * @see git_odb_writepack
+ *
+ * @param writepack pointer to the writepack functions
+ * @param db object database where the stream will read from
+ * @param progress_cb function to call with progress information.
+ * Be aware that this is called inline with network and indexing operations,
+ * so performance may be affected.
+ * @param progress_payload payload for the progress callback
+ */
+GIT_EXTERN(int) git_odb_write_pack(git_odb_writepack **writepack, git_odb *db, git_transfer_progress_callback progress_cb, void *progress_payload);
 
 /**
  * Determine the object-ID (sha1 hash) of a data buffer

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -89,6 +89,9 @@ typedef struct git_odb_object git_odb_object;
 /** A stream to read/write from the ODB */
 typedef struct git_odb_stream git_odb_stream;
 
+/** A stream to write a packfile to the ODB */
+typedef struct git_odb_writepack git_odb_writepack;
+
 /**
  * Representation of an existing git repository,
  * including all its object contents

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -8,7 +8,6 @@
 #include "git2/oid.h"
 #include "git2/refs.h"
 #include "git2/revwalk.h"
-#include "git2/indexer.h"
 #include "git2/transport.h"
 
 #include "common.h"


### PR DESCRIPTION
Custom ODB users may not have a objects/pack directory on disk.  It would be nice if fetch wrote to the ODB layer instead of directly to disk.

TODO:
[  ] - Have a fake streamer that will disassemble packs and just write() the objects individually.
