### PR TITLE
Cmake flags clean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,15 @@ ELSE ()
 	ENDIF ()
 ENDIF()
 
-# Build Debug by default
-IF (NOT CMAKE_BUILD_TYPE)
-	SET(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
-ENDIF ()
+IF( NOT CMAKE_CONFIGURATION_TYPES )
+	# Build Debug by default
+	IF (NOT CMAKE_BUILD_TYPE)
+		SET(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+	ENDIF ()
+ELSE()
+	# Using a multi-configuration generator eg MSVC or Xcode
+	# that uses CMAKE_CONFIGURATION_TYPES and not CMAKE_BUILD_TYPE
+ENDIF()
 
 IF (OPENSSL_FOUND)
   ADD_DEFINITIONS(-DGIT_SSL)


### PR DESCRIPTION
4 commits on CMakeLists.txt
Aimed at improving maintainability and ability of compiling developer to control via cmake.
Clarifies but does not change present behaviour.

Remove duplicate CMAKE_C_FLAGS inside CMAKE_C_FLAGS_DEBUG.
    - For Debug builds, CMake uses concatenated
      CMAKE_C_FLAGS and CMAKE_C_FLAGS_DEBUG
    - This reverts commit 291f7122927d2cc170dc63c378a08fa78515d987.
      (CMAKE_C_FLAGS is still controllable from cache, pre-filled from environment's CFLAGS)

Remove "-O2 -g" from default CMAKE_C_FLAGS.
    - Those are the RelWithDebInfo flags.
    - They should be controlled from CMAKE_BUILD_TYPE

Removed overwrite of CMAKE_C_FLAGS_DEBUG.
    - No overwriting allows control from cmake cache or cmdline
    - -g is already the CMake default
    - -O0 is already gcc's default

Leave CMAKE_BUILD_TYPE absent on those generators which don't use it.
