### PR TITLE
Can set default cache size

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -343,6 +343,13 @@ GIT_EXTERN(size_t) git_odb_object_size(git_odb_object *object);
  */
 GIT_EXTERN(git_otype) git_odb_object_type(git_odb_object *object);
 
+/**
+ * Set the default cache size when creating Object DB.
+ *
+ * @param size Cache size
+ */
+GIT_EXTERN(void) git_odb_set_default_cache_size(size_t size);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -567,6 +567,13 @@ GIT_EXTERN(int) git_repository_set_head_detached(
 GIT_EXTERN(int) git_repository_detach_head(
 	git_repository* repo);
 
+/**
+ * Set the default cache size when creating Repository.
+ *
+ * @param size Cache size
+ */
+GIT_EXTERN(void) git_repository_set_default_cache_size(size_t size);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/odb.c
+++ b/src/odb.c
@@ -23,6 +23,8 @@
 #define GIT_LOOSE_PRIORITY 2
 #define GIT_PACKED_PRIORITY 1
 
+static size_t default_cache_size = GIT_DEFAULT_CACHE_SIZE;
+
 typedef struct
 {
 	git_odb_backend *backend;
@@ -340,7 +342,7 @@ int git_odb_new(git_odb **out)
 	git_odb *db = git__calloc(1, sizeof(*db));
 	GITERR_CHECK_ALLOC(db);
 
-	if (git_cache_init(&db->cache, GIT_DEFAULT_CACHE_SIZE, &free_odb_object) < 0 ||
+	if (git_cache_init(&db->cache, default_cache_size, &free_odb_object) < 0 ||
 		git_vector_init(&db->backends, 4, backend_sort_cmp) < 0)
 	{
 		git__free(db);
@@ -790,3 +792,7 @@ int git_odb__error_ambiguous(const char *message)
 	return GIT_EAMBIGUOUS;
 }
 
+void git_odb_set_default_cache_size(size_t size)
+{
+	default_cache_size = size;
+}

--- a/src/repository.c
+++ b/src/repository.c
@@ -29,6 +29,8 @@
 
 #define GIT_TEMPLATE_DIR "/usr/share/git-core/templates"
 
+static size_t default_cache_size = GIT_DEFAULT_CACHE_SIZE;
+
 static void drop_odb(git_repository *repo)
 {
 	if (repo->_odb != NULL) {
@@ -107,7 +109,7 @@ static git_repository *repository_alloc(void)
 
 	memset(repo, 0x0, sizeof(git_repository));
 
-	if (git_cache_init(&repo->objects, GIT_DEFAULT_CACHE_SIZE, &git_object__free) < 0) {
+	if (git_cache_init(&repo->objects, default_cache_size, &git_object__free) < 0) {
 		git__free(repo);
 		return NULL;
 	}
@@ -1536,4 +1538,9 @@ cleanup:
 	git_reference_free(old_head);
 	git_reference_free(new_head);
 	return error;
+}
+
+void git_repository_set_default_cache_size(size_t size)
+{
+	default_cache_size = size;
 }


### PR DESCRIPTION
Currently, the default cache size is 128, which may be too small. A larger cache size may boost performance. I add functions to set default cache size. Program can call it when needed.
