### PR TITLE
Update of text stats calculation

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -33,10 +33,6 @@ void git_text_gather_stats(git_text_stats *stats, const git_buf *text)
 		else if (c == '\n')
 			stats->lf++;
 
-		else if (c == 0x85)
-			/* Unicode CR+LF */
-			stats->crlf++;
-
 		else if (c == 127)
 			/* DEL */
 			stats->nonprintable++;


### PR DESCRIPTION
Hit issue with CRLF conversion not being performed on a text file that had a 0x85 byte. Libgit2 is interpreting this as a Next Line character and because of this decided to not clean the text file before adding it to the index. We should not treat the 0x85 byte as a CRLF char.
