### PR TITLE
Fix compilation for mingw32 and cygwin

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -274,11 +274,11 @@ static int verify_server_cert(gitno_ssl *ssl, const char *host)
 	}
 
 	/* Try to parse the host as an IP address to see if it is */
-	if (gitno_inet_pton(AF_INET, host, &addr4)) {
+	if (p_inet_pton(AF_INET, host, &addr4)) {
 		type = GEN_IPADD;
 		addr = &addr4;
 	} else {
-		if(gitno_inet_pton(AF_INET6, host, &addr6)) {
+		if(p_inet_pton(AF_INET6, host, &addr6)) {
 			type = GEN_IPADD;
 			addr = &addr6;
 		}
@@ -596,52 +596,4 @@ int gitno_extract_host_and_port(char **host, char **port, const char *url, const
 	GITERR_CHECK_ALLOC(*host);
 
 	return 0;
-}
-
-int gitno_inet_pton(int af, const char* src, void* dst)
-{
-	/* inet_pton is only available in Windows Vista or later
-	 * mingw32 and cygwin give compile errors */
-#ifndef GIT_WIN32
-	return inet_pton(af, src, dst);
-#else
-	union {
-		struct sockaddr_in6 sin6;
-		struct sockaddr_in sin;
-	} sa;
-	size_t srcsize;
-
-	switch(af)
-	{
-		case AF_INET:
-			sa.sin.sin_family = AF_INET;
-			srcsize = sizeof (sa.sin);
-		break;
-		case AF_INET6:
-			sa.sin6.sin6_family = AF_INET6;
-			srcsize = sizeof (sa.sin6);
-		break;
-		default:
-			errno = WSAEPFNOSUPPORT;
-			return -1;
-	}
-
-	if (WSAStringToAddress(src, af, NULL, (struct sockaddr *) &sa, &srcsize) != 0)
-	{
-		errno = WSAGetLastError();
-		return -1;
-	}
-
-	switch(af)
-	{
-		case AF_INET:
-			memcpy(dst, &sa.sin.sin_addr, sizeof(sa.sin.sin_addr));
-		break;
-		case AF_INET6:
-			memcpy(dst, &sa.sin6.sin6_addr, sizeof(sa.sin6.sin6_addr));
-		break;
-	}
-
-	return 1;
-#endif
 }

--- a/src/netops.h
+++ b/src/netops.h
@@ -67,6 +67,5 @@ int gitno_close(gitno_socket *s);
 int gitno_select_in(gitno_buffer *buf, long int sec, long int usec);
 
 int gitno_extract_host_and_port(char **host, char **port, const char *url, const char *default_port);
-int gitno_inet_pton(int af, const char *src, void *dst);
 
 #endif

--- a/src/posix.c
+++ b/src/posix.c
@@ -205,3 +205,5 @@ int p_write(git_file fd, const void *buf, size_t cnt)
 	}
 	return 0;
 }
+
+

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -21,5 +21,6 @@
 #define p_snprintf(b, c, f, ...) snprintf(b, c, f, __VA_ARGS__)
 #define p_mkstemp(p) mkstemp(p)
 #define p_setenv(n,v,o) setenv(n,v,o)
+#define p_inet_pton(a, b, c) inet_pton(a, b, c)
 
 #endif

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -48,5 +48,6 @@ extern int p_getcwd(char *buffer_out, size_t size);
 extern int p_rename(const char *from, const char *to);
 extern int p_recv(GIT_SOCKET socket, void *buffer, size_t length, int flags);
 extern int p_send(GIT_SOCKET socket, const void *buffer, size_t length, int flags);
+extern int p_inet_pton(int af, const char* src, void* dst);
 
 #endif


### PR DESCRIPTION
inet_pton is available only in windows vista or later,
fixed the issue by reimplementing it using WSAStringToAddress

This problem was referenced in #885 but it's back again
