### PR TITLE
Valgrind reports Invalid Read when the configuration file contains some empty line

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -924,7 +924,7 @@ static int strip_comments(char *line, int in_quotes)
 	}
 
 	/* skip any space at the end */
-	if (git__isspace(ptr[-1])) {
+	if (ptr > line && git__isspace(ptr[-1])) {
 		ptr--;
 	}
 	ptr[0] = '\0';
@@ -1398,7 +1398,7 @@ static int parse_variable(diskfile_backend *cfg, char **var_name, char **var_val
 		value_start = var_end + 1;
 
 	do var_end--;
-	while (git__isspace(*var_end));
+	while (var_end>line && git__isspace(*var_end));
 
 	*var_name = git__strndup(line, var_end - line + 1);
 	GITERR_CHECK_ALLOC(*var_name);

--- a/tests-clar/resources/config/config11
+++ b/tests-clar/resources/config/config11
@@ -1,3 +1,5 @@
 [remote "fancy"]
     url = git://github.com/libgit2/libgit2
     url = git://git.example.com/libgit2
+
+


### PR DESCRIPTION
- Update 'tests-clar/resources/config/config11' in order to reproduce the invalidread with the unittest (just added some \n at the end of the file)
- Fix config_file.c

If the git configuration contains some empty lines (eg: "\n"), valgrind reports the following error: 

==20533== Invalid read of size 1
==20533==    at 0x44140A: strip_comments (config_file.c:930)
==20533==    by 0x4423EA: parse_variable (config_file.c:1394)
==20533==    by 0x441B8E: config_write (config_file.c:1143)
==20533==    by 0x440863: config_set_multivar (config_file.c:501)
==20533==    by 0x435391: git_config_set_multivar (config.c:492)
==20533==    by 0x48F4E6: test_config_multivar__add (multivar.c:75)
==20533==    by 0x46C6E6: clar_run_test (clar_main.c:2408)
==20533==    by 0x46C84A: clar_run_suite (clar_main.c:2456)
==20533==    by 0x46CDF6: clar_test (clar_main.c:2604)
==20533==    by 0x46DD15: main (clar_main.c:3353)
==20533==  Address 0x53de56f is 1 bytes before a block of size 1 alloc'd
==20533==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20533==    by 0x43EABB: git__malloc (util.h:24)
==20533==    by 0x440D23: cfg_readline (config_file.c:668)
==20533==    by 0x4423C4: parse_variable (config_file.c:1390)
==20533==    by 0x441B8E: config_write (config_file.c:1143)
==20533==    by 0x440863: config_set_multivar (config_file.c:501)
==20533==    by 0x435391: git_config_set_multivar (config.c:492)
==20533==    by 0x48F4E6: test_config_multivar__add (multivar.c:75)
==20533==    by 0x46C6E6: clar_run_test (clar_main.c:2408)
==20533==    by 0x46C84A: clar_run_suite (clar_main.c:2456)
==20533==    by 0x46CDF6: clar_test (clar_main.c:2604)
==20533==    by 0x46DD15: main (clar_main.c:3353)
==20533== 
==20533== Invalid read of size 1
==20533==    at 0x442436: parse_variable (config_file.c:1404)
==20533==    by 0x441B8E: config_write (config_file.c:1143)
==20533==    by 0x440863: config_set_multivar (config_file.c:501)
==20533==    by 0x435391: git_config_set_multivar (config.c:492)
==20533==    by 0x48F4E6: test_config_multivar__add (multivar.c:75)
==20533==    by 0x46C6E6: clar_run_test (clar_main.c:2408)
==20533==    by 0x46C84A: clar_run_suite (clar_main.c:2456)
==20533==    by 0x46CDF6: clar_test (clar_main.c:2604)
==20533==    by 0x46DD15: main (clar_main.c:3353)
==20533==  Address 0x53de56f is 1 bytes before a block of size 1 alloc'd
==20533==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20533==    by 0x43EABB: git__malloc (util.h:24)
==20533==    by 0x440D23: cfg_readline (config_file.c:668)
==20533==    by 0x4423C4: parse_variable (config_file.c:1390)
==20533==    by 0x441B8E: config_write (config_file.c:1143)
==20533==    by 0x440863: config_set_multivar (config_file.c:501)
==20533==    by 0x435391: git_config_set_multivar (config.c:492)
==20533==    by 0x48F4E6: test_config_multivar__add (multivar.c:75)
==20533==    by 0x46C6E6: clar_run_test (clar_main.c:2408)
==20533==    by 0x46C84A: clar_run_suite (clar_main.c:2456)
==20533==    by 0x46CDF6: clar_test (clar_main.c:2604)
==20533==    by 0x46DD15: main (clar_main.c:3353)
