### PR TITLE
config: make git_config_open_level() work with an empty config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -127,8 +127,6 @@ static int find_internal_file_by_level(
 	file_internal *internal;
 	unsigned int i;
 
-	assert(cfg->files.length);
-
 	/* when passing GIT_CONFIG_HIGHEST_LEVEL, the idea is to get the config file
 	 * which has the highest level. As config files are stored in a vector
 	 * sorted by decreasing order of level, getting the file at position 0

--- a/tests-clar/config/configlevel.c
+++ b/tests-clar/config/configlevel.c
@@ -57,3 +57,16 @@ void test_config_configlevel__can_read_from_a_single_level_focused_file_after_pa
 
 	git_config_free(single_level_cfg);
 }
+
+void test_config_configlevel__fetching_a_level_from_an_empty_compound_config_returns_ENOTFOUND(void)
+{
+	git_config *cfg;
+	git_config *local_cfg;
+	const char *s;
+
+	cl_git_pass(git_config_new(&cfg));
+
+	cl_assert_equal_i(GIT_ENOTFOUND, git_config_open_level(&local_cfg, cfg, GIT_CONFIG_LEVEL_LOCAL));
+
+	git_config_free(cfg);
+}


### PR DESCRIPTION
This should fix the issue encountered in libgit2/libgit2sharp#234 on the TeamCity CI server
