### PR TITLE
Bump the builtin http-parser to v2.0

### DIFF
--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -21,59 +21,98 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include <http_parser.h>
+#include "http_parser.h"
 #include <assert.h>
 #include <stddef.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
 
+#ifndef ULLONG_MAX
+# define ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
+#endif
 
 #ifndef MIN
 # define MIN(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
+#ifndef ARRAY_SIZE
+# define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
 
-#if HTTP_PARSER_DEBUG
-#define SET_ERRNO(e)                                                 \
-do {                                                                 \
-  parser->http_errno = (e);                                          \
-  parser->error_lineno = __LINE__;                                   \
-} while (0)
-#else
+#ifndef BIT_AT
+# define BIT_AT(a, i)                                                \
+  (!!((unsigned int) (a)[(unsigned int) (i) >> 3] &                  \
+   (1 << ((unsigned int) (i) & 7))))
+#endif
+
+#ifndef ELEM_AT
+# define ELEM_AT(a, i, v) ((unsigned int) (i) < ARRAY_SIZE(a) ? (a)[(i)] : (v))
+#endif
+
 #define SET_ERRNO(e)                                                 \
 do {                                                                 \
   parser->http_errno = (e);                                          \
 } while(0)
-#endif
 
 
-#define CALLBACK2(FOR)                                               \
+/* Run the notify callback FOR, returning ER if it fails */
+#define CALLBACK_NOTIFY_(FOR, ER)                                    \
 do {                                                                 \
+  assert(HTTP_PARSER_ERRNO(parser) == HPE_OK);                       \
+                                                                     \
   if (settings->on_##FOR) {                                          \
     if (0 != settings->on_##FOR(parser)) {                           \
       SET_ERRNO(HPE_CB_##FOR);                                       \
-      return (p - data);                                             \
+    }                                                                \
+                                                                     \
+    /* We either errored above or got paused; get out */             \
+    if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {                       \
+      return (ER);                                                   \
     }                                                                \
   }                                                                  \
 } while (0)
 
+/* Run the notify callback FOR and consume the current byte */
+#define CALLBACK_NOTIFY(FOR)            CALLBACK_NOTIFY_(FOR, p - data + 1)
 
-#define MARK(FOR)                                                    \
-do {                                                                 \
-  FOR##_mark = p;                                                    \
-} while (0)
+/* Run the notify callback FOR and don't consume the current byte */
+#define CALLBACK_NOTIFY_NOADVANCE(FOR)  CALLBACK_NOTIFY_(FOR, p - data)
 
-#define CALLBACK(FOR)                                                \
+/* Run data callback FOR with LEN bytes, returning ER if it fails */
+#define CALLBACK_DATA_(FOR, LEN, ER)                                 \
 do {                                                                 \
+  assert(HTTP_PARSER_ERRNO(parser) == HPE_OK);                       \
+                                                                     \
   if (FOR##_mark) {                                                  \
     if (settings->on_##FOR) {                                        \
-      if (0 != settings->on_##FOR(parser,                            \
-                                 FOR##_mark,                         \
-                                 p - FOR##_mark))                    \
-      {                                                              \
+      if (0 != settings->on_##FOR(parser, FOR##_mark, (LEN))) {      \
         SET_ERRNO(HPE_CB_##FOR);                                     \
-        return (p - data);                                           \
+      }                                                              \
+                                                                     \
+      /* We either errored above or got paused; get out */           \
+      if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {                     \
+        return (ER);                                                 \
       }                                                              \
     }                                                                \
     FOR##_mark = NULL;                                               \
+  }                                                                  \
+} while (0)
+  
+/* Run the data callback FOR and consume the current byte */
+#define CALLBACK_DATA(FOR)                                           \
+    CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)
+
+/* Run the data callback FOR and don't consume the current byte */
+#define CALLBACK_DATA_NOADVANCE(FOR)                                 \
+    CALLBACK_DATA_(FOR, p - FOR##_mark, p - data)
+
+/* Set the mark FOR; non-destructive if mark is already set */
+#define MARK(FOR)                                                    \
+do {                                                                 \
+  if (!FOR##_mark) {                                                 \
+    FOR##_mark = p;                                                  \
   }                                                                  \
 } while (0)
 
@@ -89,30 +128,10 @@ do {                                                                 \
 
 
 static const char *method_strings[] =
-  { "DELETE"
-  , "GET"
-  , "HEAD"
-  , "POST"
-  , "PUT"
-  , "CONNECT"
-  , "OPTIONS"
-  , "TRACE"
-  , "COPY"
-  , "LOCK"
-  , "MKCOL"
-  , "MOVE"
-  , "PROPFIND"
-  , "PROPPATCH"
-  , "UNLOCK"
-  , "REPORT"
-  , "MKACTIVITY"
-  , "CHECKOUT"
-  , "MERGE"
-  , "M-SEARCH"
-  , "NOTIFY"
-  , "SUBSCRIBE"
-  , "UNSUBSCRIBE"
-  , "PATCH"
+  {
+#define XX(num, name, string) #string,
+  HTTP_METHOD_MAP(XX)
+#undef XX
   };
 
 
@@ -133,9 +152,9 @@ static const char tokens[256] = {
 /*  24 can   25 em    26 sub   27 esc   28 fs    29 gs    30 rs    31 us  */
         0,       0,       0,       0,       0,       0,       0,       0,
 /*  32 sp    33  !    34  "    35  #    36  $    37  %    38  &    39  '  */
-       ' ',      '!',     '"',     '#',     '$',     '%',     '&',    '\'',
+        0,      '!',      0,      '#',     '$',     '%',     '&',    '\'',
 /*  40  (    41  )    42  *    43  +    44  ,    45  -    46  .    47  /  */
-        0,       0,      '*',     '+',      0,      '-',     '.',     '/',
+        0,       0,      '*',     '+',      0,      '-',     '.',      0,
 /*  48  0    49  1    50  2    51  3    52  4    53  5    54  6    55  7  */
        '0',     '1',     '2',     '3',     '4',     '5',     '6',     '7',
 /*  56  8    57  9    58  :    59  ;    60  <    61  =    62  >    63  ?  */
@@ -155,7 +174,7 @@ static const char tokens[256] = {
 /* 112  p   113  q   114  r   115  s   116  t   117  u   118  v   119  w  */
        'p',     'q',     'r',     's',     't',     'u',     'v',     'w',
 /* 120  x   121  y   122  z   123  {   124  |   125  }   126  ~   127 del */
-       'x',     'y',     'z',      0,      '|',     '}',     '~',       0 };
+       'x',     'y',     'z',      0,      '|',      0,      '~',       0 };
 
 
 static const int8_t unhex[256] =
@@ -170,40 +189,48 @@ static const int8_t unhex[256] =
   };
 
 
-static const uint8_t normal_url_char[256] = {
-/*   0 nul    1 soh    2 stx    3 etx    4 eot    5 enq    6 ack    7 bel  */
-        0,       0,       0,       0,       0,       0,       0,       0,
-/*   8 bs     9 ht    10 nl    11 vt    12 np    13 cr    14 so    15 si   */
-        0,       0,       0,       0,       0,       0,       0,       0,
-/*  16 dle   17 dc1   18 dc2   19 dc3   20 dc4   21 nak   22 syn   23 etb */
-        0,       0,       0,       0,       0,       0,       0,       0,
-/*  24 can   25 em    26 sub   27 esc   28 fs    29 gs    30 rs    31 us  */
-        0,       0,       0,       0,       0,       0,       0,       0,
-/*  32 sp    33  !    34  "    35  #    36  $    37  %    38  &    39  '  */
-        0,       1,       1,       0,       1,       1,       1,       1,
-/*  40  (    41  )    42  *    43  +    44  ,    45  -    46  .    47  /  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/*  48  0    49  1    50  2    51  3    52  4    53  5    54  6    55  7  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/*  56  8    57  9    58  :    59  ;    60  <    61  =    62  >    63  ?  */
-        1,       1,       1,       1,       1,       1,       1,       0,
-/*  64  @    65  A    66  B    67  C    68  D    69  E    70  F    71  G  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/*  72  H    73  I    74  J    75  K    76  L    77  M    78  N    79  O  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/*  80  P    81  Q    82  R    83  S    84  T    85  U    86  V    87  W  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/*  88  X    89  Y    90  Z    91  [    92  \    93  ]    94  ^    95  _  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/*  96  `    97  a    98  b    99  c   100  d   101  e   102  f   103  g  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/* 104  h   105  i   106  j   107  k   108  l   109  m   110  n   111  o  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/* 112  p   113  q   114  r   115  s   116  t   117  u   118  v   119  w  */
-        1,       1,       1,       1,       1,       1,       1,       1,
-/* 120  x   121  y   122  z   123  {   124  |   125  }   126  ~   127 del */
-        1,       1,       1,       1,       1,       1,       1,       0, };
+#if HTTP_PARSER_STRICT
+# define T(v) 0
+#else
+# define T(v) v
+#endif
 
+
+static const uint8_t normal_url_char[32] = {
+/*   0 nul    1 soh    2 stx    3 etx    4 eot    5 enq    6 ack    7 bel  */
+        0    |   0    |   0    |   0    |   0    |   0    |   0    |   0,
+/*   8 bs     9 ht    10 nl    11 vt    12 np    13 cr    14 so    15 si   */
+        0    | T(2)   |   0    |   0    | T(16)  |   0    |   0    |   0,
+/*  16 dle   17 dc1   18 dc2   19 dc3   20 dc4   21 nak   22 syn   23 etb */
+        0    |   0    |   0    |   0    |   0    |   0    |   0    |   0,
+/*  24 can   25 em    26 sub   27 esc   28 fs    29 gs    30 rs    31 us  */
+        0    |   0    |   0    |   0    |   0    |   0    |   0    |   0,
+/*  32 sp    33  !    34  "    35  #    36  $    37  %    38  &    39  '  */
+        0    |   2    |   4    |   0    |   16   |   32   |   64   |  128,
+/*  40  (    41  )    42  *    43  +    44  ,    45  -    46  .    47  /  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/*  48  0    49  1    50  2    51  3    52  4    53  5    54  6    55  7  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/*  56  8    57  9    58  :    59  ;    60  <    61  =    62  >    63  ?  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |   0,
+/*  64  @    65  A    66  B    67  C    68  D    69  E    70  F    71  G  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/*  72  H    73  I    74  J    75  K    76  L    77  M    78  N    79  O  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/*  80  P    81  Q    82  R    83  S    84  T    85  U    86  V    87  W  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/*  88  X    89  Y    90  Z    91  [    92  \    93  ]    94  ^    95  _  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/*  96  `    97  a    98  b    99  c   100  d   101  e   102  f   103  g  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/* 104  h   105  i   106  j   107  k   108  l   109  m   110  n   111  o  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/* 112  p   113  q   114  r   115  s   116  t   117  u   118  v   119  w  */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |  128,
+/* 120  x   121  y   122  z   123  {   124  |   125  }   126  ~   127 del */
+        1    |   2    |   4    |   8    |   16   |   32   |   64   |   0, };
+
+#undef T
 
 enum state
   { s_dead = 1 /* important that this is > 0 */
@@ -231,8 +258,9 @@ enum state
   , s_req_schema
   , s_req_schema_slash
   , s_req_schema_slash_slash
-  , s_req_host
-  , s_req_port
+  , s_req_server_start
+  , s_req_server
+  , s_req_server_with_at
   , s_req_path
   , s_req_query_string_start
   , s_req_query_string
@@ -261,9 +289,11 @@ enum state
   , s_chunk_size
   , s_chunk_parameters
   , s_chunk_size_almost_done
-  
+
   , s_headers_almost_done
-  /* Important: 's_headers_almost_done' must be the last 'header' state. All
+  , s_headers_done
+
+  /* Important: 's_headers_done' must be the last 'header' state. All
    * states beyond this must be 'body' states. It is used for overflow
    * checking. See the PARSING_HEADER() macro.
    */
@@ -274,10 +304,12 @@ enum state
 
   , s_body_identity
   , s_body_identity_eof
+
+  , s_message_done
   };
 
 
-#define PARSING_HEADER(state) (state <= s_headers_almost_done)
+#define PARSING_HEADER(state) (state <= s_headers_done)
 
 
 enum header_states
@@ -306,22 +338,43 @@ enum header_states
   , h_connection_close
   };
 
+enum http_host_state
+  {
+    s_http_host_dead = 1
+  , s_http_userinfo_start
+  , s_http_userinfo
+  , s_http_host_start
+  , s_http_host_v6_start
+  , s_http_host
+  , s_http_host_v6
+  , s_http_host_v6_end
+  , s_http_host_port_start
+  , s_http_host_port
+};
 
 /* Macros for character classes; depends on strict-mode  */
 #define CR                  '\r'
 #define LF                  '\n'
 #define LOWER(c)            (unsigned char)(c | 0x20)
-#define TOKEN(c)            (tokens[(unsigned char)c])
 #define IS_ALPHA(c)         (LOWER(c) >= 'a' && LOWER(c) <= 'z')
 #define IS_NUM(c)           ((c) >= '0' && (c) <= '9')
 #define IS_ALPHANUM(c)      (IS_ALPHA(c) || IS_NUM(c))
+#define IS_HEX(c)           (IS_NUM(c) || (LOWER(c) >= 'a' && LOWER(c) <= 'f'))
+#define IS_MARK(c)          ((c) == '-' || (c) == '_' || (c) == '.' || \
+  (c) == '!' || (c) == '~' || (c) == '*' || (c) == '\'' || (c) == '(' || \
+  (c) == ')')
+#define IS_USERINFO_CHAR(c) (IS_ALPHANUM(c) || IS_MARK(c) || (c) == '%' || \
+  (c) == ';' || (c) == ':' || (c) == '&' || (c) == '=' || (c) == '+' || \
+  (c) == '$' || (c) == ',')
 
 #if HTTP_PARSER_STRICT
-#define IS_URL_CHAR(c)      (normal_url_char[(unsigned char) (c)])
+#define TOKEN(c)            (tokens[(unsigned char)c])
+#define IS_URL_CHAR(c)      (BIT_AT(normal_url_char, (unsigned char)c))
 #define IS_HOST_CHAR(c)     (IS_ALPHANUM(c) || (c) == '.' || (c) == '-')
 #else
+#define TOKEN(c)            ((c == ' ') ? ' ' : tokens[(unsigned char)c])
 #define IS_URL_CHAR(c)                                                         \
-  (normal_url_char[(unsigned char) (c)] || ((c) & 0x80))
+  (BIT_AT(normal_url_char, (unsigned char)c) || ((c) & 0x80))
 #define IS_HOST_CHAR(c)                                                        \
   (IS_ALPHANUM(c) || (c) == '.' || (c) == '-' || (c) == '_')
 #endif
@@ -355,6 +408,166 @@ static struct {
 };
 #undef HTTP_STRERROR_GEN
 
+int http_message_needs_eof(const http_parser *parser);
+
+/* Our URL parser.
+ *
+ * This is designed to be shared by http_parser_execute() for URL validation,
+ * hence it has a state transition + byte-for-byte interface. In addition, it
+ * is meant to be embedded in http_parser_parse_url(), which does the dirty
+ * work of turning state transitions URL components for its API.
+ *
+ * This function should only be invoked with non-space characters. It is
+ * assumed that the caller cares about (and can detect) the transition between
+ * URL and non-URL states by looking for these.
+ */
+static enum state
+parse_url_char(enum state s, const char ch)
+{
+  if (ch == ' ' || ch == '\r' || ch == '\n') {
+    return s_dead;
+  }
+
+#if HTTP_PARSER_STRICT
+  if (ch == '\t' || ch == '\f') {
+    return s_dead;
+  }
+#endif
+
+  switch (s) {
+    case s_req_spaces_before_url:
+      /* Proxied requests are followed by scheme of an absolute URI (alpha).
+       * All methods except CONNECT are followed by '/' or '*'.
+       */
+
+      if (ch == '/' || ch == '*') {
+        return s_req_path;
+      }
+
+      if (IS_ALPHA(ch)) {
+        return s_req_schema;
+      }
+
+      break;
+
+    case s_req_schema:
+      if (IS_ALPHA(ch)) {
+        return s;
+      }
+
+      if (ch == ':') {
+        return s_req_schema_slash;
+      }
+
+      break;
+
+    case s_req_schema_slash:
+      if (ch == '/') {
+        return s_req_schema_slash_slash;
+      }
+
+      break;
+
+    case s_req_schema_slash_slash:
+      if (ch == '/') {
+        return s_req_server_start;
+      }
+
+      break;
+
+    case s_req_server_with_at:
+      if (ch == '@') {
+        return s_dead;
+      }
+
+    /* FALLTHROUGH */
+    case s_req_server_start:
+    case s_req_server:
+      if (ch == '/') {
+        return s_req_path;
+      }
+
+      if (ch == '?') {
+        return s_req_query_string_start;
+      }
+
+      if (ch == '@') {
+        return s_req_server_with_at;
+      }
+
+      if (IS_USERINFO_CHAR(ch) || ch == '[' || ch == ']') {
+        return s_req_server;
+      }
+
+      break;
+
+    case s_req_path:
+      if (IS_URL_CHAR(ch)) {
+        return s;
+      }
+
+      switch (ch) {
+        case '?':
+          return s_req_query_string_start;
+
+        case '#':
+          return s_req_fragment_start;
+      }
+
+      break;
+
+    case s_req_query_string_start:
+    case s_req_query_string:
+      if (IS_URL_CHAR(ch)) {
+        return s_req_query_string;
+      }
+
+      switch (ch) {
+        case '?':
+          /* allow extra '?' in query string */
+          return s_req_query_string;
+
+        case '#':
+          return s_req_fragment_start;
+      }
+
+      break;
+
+    case s_req_fragment_start:
+      if (IS_URL_CHAR(ch)) {
+        return s_req_fragment;
+      }
+
+      switch (ch) {
+        case '?':
+          return s_req_fragment;
+
+        case '#':
+          return s;
+      }
+
+      break;
+
+    case s_req_fragment:
+      if (IS_URL_CHAR(ch)) {
+        return s;
+      }
+
+      switch (ch) {
+        case '?':
+        case '#':
+          return s;
+      }
+
+      break;
+
+    default:
+      break;
+  }
+
+  /* We should never fall out of the switch above unless there's an error */
+  return s_dead;
+}
 
 size_t http_parser_execute (http_parser *parser,
                             const http_parser_settings *settings,
@@ -363,27 +576,24 @@ size_t http_parser_execute (http_parser *parser,
 {
   char c, ch;
   int8_t unhex_val;
-  const char *p = data, *pe;
-  size_t to_read;
-  enum state state;
-  enum header_states header_state;
-  size_t index = parser->index;
-  size_t nread = parser->nread;
-  const char *header_field_mark, *header_value_mark, *url_mark;
-  const char *matcher;
+  const char *p = data;
+  const char *header_field_mark = 0;
+  const char *header_value_mark = 0;
+  const char *url_mark = 0;
+  const char *body_mark = 0;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
     return 0;
   }
 
-  state = (enum state) parser->state;
-  header_state = (enum header_states) parser->header_state;
-
   if (len == 0) {
-    switch (state) {
+    switch (parser->state) {
       case s_body_identity_eof:
-        CALLBACK2(message_complete);
+        /* Use of CALLBACK_NOTIFY() here would erroneously return 1 byte read if
+         * we got paused.
+         */
+        CALLBACK_NOTIFY_NOADVANCE(message_complete);
         return 0;
 
       case s_dead:
@@ -398,42 +608,49 @@ size_t http_parser_execute (http_parser *parser,
     }
   }
 
-  /* technically we could combine all of these (except for url_mark) into one
-     variable, saving stack space, but it seems more clear to have them
-     separated. */
-  header_field_mark = 0;
-  header_value_mark = 0;
-  url_mark = 0;
 
-  if (state == s_header_field)
+  if (parser->state == s_header_field)
     header_field_mark = data;
-  if (state == s_header_value)
+  if (parser->state == s_header_value)
     header_value_mark = data;
-  if (state == s_req_path || state == s_req_schema || state == s_req_schema_slash
-      || state == s_req_schema_slash_slash || state == s_req_port
-      || state == s_req_query_string_start || state == s_req_query_string
-      || state == s_req_host
-      || state == s_req_fragment_start || state == s_req_fragment)
+  switch (parser->state) {
+  case s_req_path:
+  case s_req_schema:
+  case s_req_schema_slash:
+  case s_req_schema_slash_slash:
+  case s_req_server_start:
+  case s_req_server:
+  case s_req_server_with_at:
+  case s_req_query_string_start:
+  case s_req_query_string:
+  case s_req_fragment_start:
+  case s_req_fragment:
     url_mark = data;
+    break;
+  }
 
-  for (p=data, pe=data+len; p != pe; p++) {
+  for (p=data; p != data + len; p++) {
     ch = *p;
 
-    if (PARSING_HEADER(state)) {
-      ++nread;
+    if (PARSING_HEADER(parser->state)) {
+      ++parser->nread;
       /* Buffer overflow attack */
-      if (nread > HTTP_MAX_HEADER_SIZE) {
+      if (parser->nread > HTTP_MAX_HEADER_SIZE) {
         SET_ERRNO(HPE_HEADER_OVERFLOW);
         goto error;
       }
     }
 
-    switch (state) {
+    reexecute_byte:
+    switch (parser->state) {
 
       case s_dead:
         /* this state is used after a 'Connection: close' message
          * the parser will error out if it reads another message
          */
+        if (ch == CR || ch == LF)
+          break;
+
         SET_ERRNO(HPE_CLOSED_CONNECTION);
         goto error;
 
@@ -442,23 +659,25 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
-        parser->content_length = -1;
+        parser->content_length = ULLONG_MAX;
 
-        CALLBACK2(message_begin);
+        if (ch == 'H') {
+          parser->state = s_res_or_resp_H;
 
-        if (ch == 'H')
-          state = s_res_or_resp_H;
-        else {
+          CALLBACK_NOTIFY(message_begin);
+        } else {
           parser->type = HTTP_REQUEST;
-          goto start_req_method_assign;
+          parser->state = s_start_req;
+          goto reexecute_byte;
         }
+
         break;
       }
 
       case s_res_or_resp_H:
         if (ch == 'T') {
           parser->type = HTTP_RESPONSE;
-          state = s_res_HT;
+          parser->state = s_res_HT;
         } else {
           if (ch != 'E') {
             SET_ERRNO(HPE_INVALID_CONSTANT);
@@ -467,21 +686,19 @@ size_t http_parser_execute (http_parser *parser,
 
           parser->type = HTTP_REQUEST;
           parser->method = HTTP_HEAD;
-          index = 2;
-          state = s_req_method;
+          parser->index = 2;
+          parser->state = s_req_method;
         }
         break;
 
       case s_start_res:
       {
         parser->flags = 0;
-        parser->content_length = -1;
-
-        CALLBACK2(message_begin);
+        parser->content_length = ULLONG_MAX;
 
         switch (ch) {
           case 'H':
-            state = s_res_H;
+            parser->state = s_res_H;
             break;
 
           case CR:
@@ -492,44 +709,46 @@ size_t http_parser_execute (http_parser *parser,
             SET_ERRNO(HPE_INVALID_CONSTANT);
             goto error;
         }
+
+        CALLBACK_NOTIFY(message_begin);
         break;
       }
 
       case s_res_H:
         STRICT_CHECK(ch != 'T');
-        state = s_res_HT;
+        parser->state = s_res_HT;
         break;
 
       case s_res_HT:
         STRICT_CHECK(ch != 'T');
-        state = s_res_HTT;
+        parser->state = s_res_HTT;
         break;
 
       case s_res_HTT:
         STRICT_CHECK(ch != 'P');
-        state = s_res_HTTP;
+        parser->state = s_res_HTTP;
         break;
 
       case s_res_HTTP:
         STRICT_CHECK(ch != '/');
-        state = s_res_first_http_major;
+        parser->state = s_res_first_http_major;
         break;
 
       case s_res_first_http_major:
-        if (ch < '1' || ch > '9') {
+        if (ch < '0' || ch > '9') {
           SET_ERRNO(HPE_INVALID_VERSION);
           goto error;
         }
 
         parser->http_major = ch - '0';
-        state = s_res_http_major;
+        parser->state = s_res_http_major;
         break;
 
       /* major HTTP version or dot */
       case s_res_http_major:
       {
         if (ch == '.') {
-          state = s_res_first_http_minor;
+          parser->state = s_res_first_http_minor;
           break;
         }
 
@@ -557,14 +776,14 @@ size_t http_parser_execute (http_parser *parser,
         }
 
         parser->http_minor = ch - '0';
-        state = s_res_http_minor;
+        parser->state = s_res_http_minor;
         break;
 
       /* minor HTTP version or end of request line */
       case s_res_http_minor:
       {
         if (ch == ' ') {
-          state = s_res_first_status_code;
+          parser->state = s_res_first_status_code;
           break;
         }
 
@@ -595,7 +814,7 @@ size_t http_parser_execute (http_parser *parser,
           goto error;
         }
         parser->status_code = ch - '0';
-        state = s_res_status_code;
+        parser->state = s_res_status_code;
         break;
       }
 
@@ -604,13 +823,13 @@ size_t http_parser_execute (http_parser *parser,
         if (!IS_NUM(ch)) {
           switch (ch) {
             case ' ':
-              state = s_res_status;
+              parser->state = s_res_status;
               break;
             case CR:
-              state = s_res_line_almost_done;
+              parser->state = s_res_line_almost_done;
               break;
             case LF:
-              state = s_header_field_start;
+              parser->state = s_header_field_start;
               break;
             default:
               SET_ERRNO(HPE_INVALID_STATUS);
@@ -634,19 +853,19 @@ size_t http_parser_execute (http_parser *parser,
         /* the human readable status. e.g. "NOT FOUND"
          * we are not humans so just ignore this */
         if (ch == CR) {
-          state = s_res_line_almost_done;
+          parser->state = s_res_line_almost_done;
           break;
         }
 
         if (ch == LF) {
-          state = s_header_field_start;
+          parser->state = s_header_field_start;
           break;
         }
         break;
 
       case s_res_line_almost_done:
         STRICT_CHECK(ch != LF);
-        state = s_header_field_start;
+        parser->state = s_header_field_start;
         break;
 
       case s_start_req:
@@ -654,18 +873,15 @@ size_t http_parser_execute (http_parser *parser,
         if (ch == CR || ch == LF)
           break;
         parser->flags = 0;
-        parser->content_length = -1;
-
-        CALLBACK2(message_begin);
+        parser->content_length = ULLONG_MAX;
 
         if (!IS_ALPHA(ch)) {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
 
-      start_req_method_assign:
         parser->method = (enum http_method) 0;
-        index = 1;
+        parser->index = 1;
         switch (ch) {
           case 'C': parser->method = HTTP_CONNECT; /* or COPY, CHECKOUT */ break;
           case 'D': parser->method = HTTP_DELETE; break;
@@ -676,341 +892,158 @@ size_t http_parser_execute (http_parser *parser,
           case 'N': parser->method = HTTP_NOTIFY; break;
           case 'O': parser->method = HTTP_OPTIONS; break;
           case 'P': parser->method = HTTP_POST;
-            /* or PROPFIND or PROPPATCH or PUT or PATCH */
+            /* or PROPFIND|PROPPATCH|PUT|PATCH|PURGE */
             break;
           case 'R': parser->method = HTTP_REPORT; break;
-          case 'S': parser->method = HTTP_SUBSCRIBE; break;
+          case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH */ break;
           case 'T': parser->method = HTTP_TRACE; break;
           case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE */ break;
           default:
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
         }
-        state = s_req_method;
+        parser->state = s_req_method;
+
+        CALLBACK_NOTIFY(message_begin);
+
         break;
       }
 
       case s_req_method:
       {
+        const char *matcher;
         if (ch == '\0') {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
 
         matcher = method_strings[parser->method];
-        if (ch == ' ' && matcher[index] == '\0') {
-          state = s_req_spaces_before_url;
-        } else if (ch == matcher[index]) {
+        if (ch == ' ' && matcher[parser->index] == '\0') {
+          parser->state = s_req_spaces_before_url;
+        } else if (ch == matcher[parser->index]) {
           ; /* nada */
         } else if (parser->method == HTTP_CONNECT) {
-          if (index == 1 && ch == 'H') {
+          if (parser->index == 1 && ch == 'H') {
             parser->method = HTTP_CHECKOUT;
-          } else if (index == 2  && ch == 'P') {
+          } else if (parser->index == 2  && ch == 'P') {
             parser->method = HTTP_COPY;
           } else {
             goto error;
           }
         } else if (parser->method == HTTP_MKCOL) {
-          if (index == 1 && ch == 'O') {
+          if (parser->index == 1 && ch == 'O') {
             parser->method = HTTP_MOVE;
-          } else if (index == 1 && ch == 'E') {
+          } else if (parser->index == 1 && ch == 'E') {
             parser->method = HTTP_MERGE;
-          } else if (index == 1 && ch == '-') {
+          } else if (parser->index == 1 && ch == '-') {
             parser->method = HTTP_MSEARCH;
-          } else if (index == 2 && ch == 'A') {
+          } else if (parser->index == 2 && ch == 'A') {
             parser->method = HTTP_MKACTIVITY;
           } else {
             goto error;
           }
-        } else if (index == 1 && parser->method == HTTP_POST) {
+        } else if (parser->method == HTTP_SUBSCRIBE) {
+          if (parser->index == 1 && ch == 'E') {
+            parser->method = HTTP_SEARCH;
+          } else {
+            goto error;
+          }
+        } else if (parser->index == 1 && parser->method == HTTP_POST) {
           if (ch == 'R') {
             parser->method = HTTP_PROPFIND; /* or HTTP_PROPPATCH */
           } else if (ch == 'U') {
-            parser->method = HTTP_PUT;
+            parser->method = HTTP_PUT; /* or HTTP_PURGE */
           } else if (ch == 'A') {
             parser->method = HTTP_PATCH;
           } else {
             goto error;
           }
-        } else if (index == 2 && parser->method == HTTP_UNLOCK && ch == 'S') {
-          parser->method = HTTP_UNSUBSCRIBE;
-        } else if (index == 4 && parser->method == HTTP_PROPFIND && ch == 'P') {
+        } else if (parser->index == 2) {
+          if (parser->method == HTTP_PUT) {
+            if (ch == 'R') parser->method = HTTP_PURGE;
+          } else if (parser->method == HTTP_UNLOCK) {
+            if (ch == 'S') parser->method = HTTP_UNSUBSCRIBE;
+          }
+        } else if (parser->index == 4 && parser->method == HTTP_PROPFIND && ch == 'P') {
           parser->method = HTTP_PROPPATCH;
         } else {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
         }
 
-        ++index;
+        ++parser->index;
         break;
       }
+
       case s_req_spaces_before_url:
       {
         if (ch == ' ') break;
 
-        if (ch == '/' || ch == '*') {
-          MARK(url);
-          state = s_req_path;
-          break;
+        MARK(url);
+        if (parser->method == HTTP_CONNECT) {
+          parser->state = s_req_server_start;
         }
 
-        /* Proxied requests are followed by scheme of an absolute URI (alpha).
-         * CONNECT is followed by a hostname, which begins with alphanum.
-         * All other methods are followed by '/' or '*' (handled above).
-         */
-        if (IS_ALPHA(ch) || (parser->method == HTTP_CONNECT && IS_NUM(ch))) {
-          MARK(url);
-          state = (parser->method == HTTP_CONNECT) ? s_req_host : s_req_schema;
-          break;
+        parser->state = parse_url_char((enum state)parser->state, ch);
+        if (parser->state == s_dead) {
+          SET_ERRNO(HPE_INVALID_URL);
+          goto error;
         }
 
-        SET_ERRNO(HPE_INVALID_URL);
-        goto error;
+        break;
       }
 
       case s_req_schema:
-      {
-        if (IS_ALPHA(ch)) break;
-
-        if (ch == ':') {
-          state = s_req_schema_slash;
-          break;
-        }
-
-        SET_ERRNO(HPE_INVALID_URL);
-        goto error;
-      }
-
       case s_req_schema_slash:
-        STRICT_CHECK(ch != '/');
-        state = s_req_schema_slash_slash;
-        break;
-
       case s_req_schema_slash_slash:
-        STRICT_CHECK(ch != '/');
-        state = s_req_host;
-        break;
-
-      case s_req_host:
+      case s_req_server_start:
       {
-        if (IS_HOST_CHAR(ch)) break;
         switch (ch) {
-          case ':':
-            state = s_req_port;
-            break;
-          case '/':
-            state = s_req_path;
-            break;
+          /* No whitespace allowed here */
           case ' ':
-            /* The request line looks like:
-             *   "GET http://foo.bar.com HTTP/1.1"
-             * That is, there is no path.
-             */
-            CALLBACK(url);
-            state = s_req_http_start;
-            break;
-          case '?':
-            state = s_req_query_string_start;
-            break;
-          default:
-            SET_ERRNO(HPE_INVALID_HOST);
+          case CR:
+          case LF:
+            SET_ERRNO(HPE_INVALID_URL);
             goto error;
+          default:
+            parser->state = parse_url_char((enum state)parser->state, ch);
+            if (parser->state == s_dead) {
+              SET_ERRNO(HPE_INVALID_URL);
+              goto error;
+            }
         }
+
         break;
       }
 
-      case s_req_port:
-      {
-        if (IS_NUM(ch)) break;
-        switch (ch) {
-          case '/':
-            state = s_req_path;
-            break;
-          case ' ':
-            /* The request line looks like:
-             *   "GET http://foo.bar.com:1234 HTTP/1.1"
-             * That is, there is no path.
-             */
-            CALLBACK(url);
-            state = s_req_http_start;
-            break;
-          case '?':
-            state = s_req_query_string_start;
-            break;
-          default:
-            SET_ERRNO(HPE_INVALID_PORT);
-            goto error;
-        }
-        break;
-      }
-
+      case s_req_server:
+      case s_req_server_with_at:
       case s_req_path:
-      {
-        if (IS_URL_CHAR(ch)) break;
-
-        switch (ch) {
-          case ' ':
-            CALLBACK(url);
-            state = s_req_http_start;
-            break;
-          case CR:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_req_line_almost_done;
-            break;
-          case LF:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_header_field_start;
-            break;
-          case '?':
-            state = s_req_query_string_start;
-            break;
-          case '#':
-            state = s_req_fragment_start;
-            break;
-          default:
-            SET_ERRNO(HPE_INVALID_PATH);
-            goto error;
-        }
-        break;
-      }
-
       case s_req_query_string_start:
-      {
-        if (IS_URL_CHAR(ch)) {
-          state = s_req_query_string;
-          break;
-        }
-
-        switch (ch) {
-          case '?':
-            break; /* XXX ignore extra '?' ... is this right? */
-          case ' ':
-            CALLBACK(url);
-            state = s_req_http_start;
-            break;
-          case CR:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_req_line_almost_done;
-            break;
-          case LF:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_header_field_start;
-            break;
-          case '#':
-            state = s_req_fragment_start;
-            break;
-          default:
-            SET_ERRNO(HPE_INVALID_QUERY_STRING);
-            goto error;
-        }
-        break;
-      }
-
       case s_req_query_string:
-      {
-        if (IS_URL_CHAR(ch)) break;
-
-        switch (ch) {
-          case '?':
-            /* allow extra '?' in query string */
-            break;
-          case ' ':
-            CALLBACK(url);
-            state = s_req_http_start;
-            break;
-          case CR:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_req_line_almost_done;
-            break;
-          case LF:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_header_field_start;
-            break;
-          case '#':
-            state = s_req_fragment_start;
-            break;
-          default:
-            SET_ERRNO(HPE_INVALID_QUERY_STRING);
-            goto error;
-        }
-        break;
-      }
-
       case s_req_fragment_start:
-      {
-        if (IS_URL_CHAR(ch)) {
-          state = s_req_fragment;
-          break;
-        }
-
-        switch (ch) {
-          case ' ':
-            CALLBACK(url);
-            state = s_req_http_start;
-            break;
-          case CR:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_req_line_almost_done;
-            break;
-          case LF:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_header_field_start;
-            break;
-          case '?':
-            state = s_req_fragment;
-            break;
-          case '#':
-            break;
-          default:
-            SET_ERRNO(HPE_INVALID_FRAGMENT);
-            goto error;
-        }
-        break;
-      }
-
       case s_req_fragment:
       {
-        if (IS_URL_CHAR(ch)) break;
-
         switch (ch) {
           case ' ':
-            CALLBACK(url);
-            state = s_req_http_start;
+            parser->state = s_req_http_start;
+            CALLBACK_DATA(url);
             break;
           case CR:
-            CALLBACK(url);
-            parser->http_major = 0;
-            parser->http_minor = 9;
-            state = s_req_line_almost_done;
-            break;
           case LF:
-            CALLBACK(url);
             parser->http_major = 0;
             parser->http_minor = 9;
-            state = s_header_field_start;
-            break;
-          case '?':
-          case '#':
+            parser->state = (ch == CR) ?
+              s_req_line_almost_done :
+              s_header_field_start;
+            CALLBACK_DATA(url);
             break;
           default:
-            SET_ERRNO(HPE_INVALID_FRAGMENT);
-            goto error;
+            parser->state = parse_url_char((enum state)parser->state, ch);
+            if (parser->state == s_dead) {
+              SET_ERRNO(HPE_INVALID_URL);
+              goto error;
+            }
         }
         break;
       }
@@ -1018,7 +1051,7 @@ size_t http_parser_execute (http_parser *parser,
       case s_req_http_start:
         switch (ch) {
           case 'H':
-            state = s_req_http_H;
+            parser->state = s_req_http_H;
             break;
           case ' ':
             break;
@@ -1030,22 +1063,22 @@ size_t http_parser_execute (http_parser *parser,
 
       case s_req_http_H:
         STRICT_CHECK(ch != 'T');
-        state = s_req_http_HT;
+        parser->state = s_req_http_HT;
         break;
 
       case s_req_http_HT:
         STRICT_CHECK(ch != 'T');
-        state = s_req_http_HTT;
+        parser->state = s_req_http_HTT;
         break;
 
       case s_req_http_HTT:
         STRICT_CHECK(ch != 'P');
-        state = s_req_http_HTTP;
+        parser->state = s_req_http_HTTP;
         break;
 
       case s_req_http_HTTP:
         STRICT_CHECK(ch != '/');
-        state = s_req_first_http_major;
+        parser->state = s_req_first_http_major;
         break;
 
       /* first digit of major HTTP version */
@@ -1056,14 +1089,14 @@ size_t http_parser_execute (http_parser *parser,
         }
 
         parser->http_major = ch - '0';
-        state = s_req_http_major;
+        parser->state = s_req_http_major;
         break;
 
       /* major HTTP version or dot */
       case s_req_http_major:
       {
         if (ch == '.') {
-          state = s_req_first_http_minor;
+          parser->state = s_req_first_http_minor;
           break;
         }
 
@@ -1091,19 +1124,19 @@ size_t http_parser_execute (http_parser *parser,
         }
 
         parser->http_minor = ch - '0';
-        state = s_req_http_minor;
+        parser->state = s_req_http_minor;
         break;
 
       /* minor HTTP version or end of request line */
       case s_req_http_minor:
       {
         if (ch == CR) {
-          state = s_req_line_almost_done;
+          parser->state = s_req_line_almost_done;
           break;
         }
 
         if (ch == LF) {
-          state = s_header_field_start;
+          parser->state = s_header_field_start;
           break;
         }
 
@@ -1133,23 +1166,22 @@ size_t http_parser_execute (http_parser *parser,
           goto error;
         }
 
-        state = s_header_field_start;
+        parser->state = s_header_field_start;
         break;
       }
 
       case s_header_field_start:
-      header_field_start:
       {
         if (ch == CR) {
-          state = s_headers_almost_done;
+          parser->state = s_headers_almost_done;
           break;
         }
 
         if (ch == LF) {
           /* they might be just sending \n instead of \r\n so this would be
            * the second \n to denote the end of headers*/
-          state = s_headers_almost_done;
-          goto headers_almost_done;
+          parser->state = s_headers_almost_done;
+          goto reexecute_byte;
         }
 
         c = TOKEN(ch);
@@ -1161,28 +1193,28 @@ size_t http_parser_execute (http_parser *parser,
 
         MARK(header_field);
 
-        index = 0;
-        state = s_header_field;
+        parser->index = 0;
+        parser->state = s_header_field;
 
         switch (c) {
           case 'c':
-            header_state = h_C;
+            parser->header_state = h_C;
             break;
 
           case 'p':
-            header_state = h_matching_proxy_connection;
+            parser->header_state = h_matching_proxy_connection;
             break;
 
           case 't':
-            header_state = h_matching_transfer_encoding;
+            parser->header_state = h_matching_transfer_encoding;
             break;
 
           case 'u':
-            header_state = h_matching_upgrade;
+            parser->header_state = h_matching_upgrade;
             break;
 
           default:
-            header_state = h_general;
+            parser->header_state = h_general;
             break;
         }
         break;
@@ -1193,31 +1225,31 @@ size_t http_parser_execute (http_parser *parser,
         c = TOKEN(ch);
 
         if (c) {
-          switch (header_state) {
+          switch (parser->header_state) {
             case h_general:
               break;
 
             case h_C:
-              index++;
-              header_state = (c == 'o' ? h_CO : h_general);
+              parser->index++;
+              parser->header_state = (c == 'o' ? h_CO : h_general);
               break;
 
             case h_CO:
-              index++;
-              header_state = (c == 'n' ? h_CON : h_general);
+              parser->index++;
+              parser->header_state = (c == 'n' ? h_CON : h_general);
               break;
 
             case h_CON:
-              index++;
+              parser->index++;
               switch (c) {
                 case 'n':
-                  header_state = h_matching_connection;
+                  parser->header_state = h_matching_connection;
                   break;
                 case 't':
-                  header_state = h_matching_content_length;
+                  parser->header_state = h_matching_content_length;
                   break;
                 default:
-                  header_state = h_general;
+                  parser->header_state = h_general;
                   break;
               }
               break;
@@ -1225,60 +1257,60 @@ size_t http_parser_execute (http_parser *parser,
             /* connection */
 
             case h_matching_connection:
-              index++;
-              if (index > sizeof(CONNECTION)-1
-                  || c != CONNECTION[index]) {
-                header_state = h_general;
-              } else if (index == sizeof(CONNECTION)-2) {
-                header_state = h_connection;
+              parser->index++;
+              if (parser->index > sizeof(CONNECTION)-1
+                  || c != CONNECTION[parser->index]) {
+                parser->header_state = h_general;
+              } else if (parser->index == sizeof(CONNECTION)-2) {
+                parser->header_state = h_connection;
               }
               break;
 
             /* proxy-connection */
 
             case h_matching_proxy_connection:
-              index++;
-              if (index > sizeof(PROXY_CONNECTION)-1
-                  || c != PROXY_CONNECTION[index]) {
-                header_state = h_general;
-              } else if (index == sizeof(PROXY_CONNECTION)-2) {
-                header_state = h_connection;
+              parser->index++;
+              if (parser->index > sizeof(PROXY_CONNECTION)-1
+                  || c != PROXY_CONNECTION[parser->index]) {
+                parser->header_state = h_general;
+              } else if (parser->index == sizeof(PROXY_CONNECTION)-2) {
+                parser->header_state = h_connection;
               }
               break;
 
             /* content-length */
 
             case h_matching_content_length:
-              index++;
-              if (index > sizeof(CONTENT_LENGTH)-1
-                  || c != CONTENT_LENGTH[index]) {
-                header_state = h_general;
-              } else if (index == sizeof(CONTENT_LENGTH)-2) {
-                header_state = h_content_length;
+              parser->index++;
+              if (parser->index > sizeof(CONTENT_LENGTH)-1
+                  || c != CONTENT_LENGTH[parser->index]) {
+                parser->header_state = h_general;
+              } else if (parser->index == sizeof(CONTENT_LENGTH)-2) {
+                parser->header_state = h_content_length;
               }
               break;
 
             /* transfer-encoding */
 
             case h_matching_transfer_encoding:
-              index++;
-              if (index > sizeof(TRANSFER_ENCODING)-1
-                  || c != TRANSFER_ENCODING[index]) {
-                header_state = h_general;
-              } else if (index == sizeof(TRANSFER_ENCODING)-2) {
-                header_state = h_transfer_encoding;
+              parser->index++;
+              if (parser->index > sizeof(TRANSFER_ENCODING)-1
+                  || c != TRANSFER_ENCODING[parser->index]) {
+                parser->header_state = h_general;
+              } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
+                parser->header_state = h_transfer_encoding;
               }
               break;
 
             /* upgrade */
 
             case h_matching_upgrade:
-              index++;
-              if (index > sizeof(UPGRADE)-1
-                  || c != UPGRADE[index]) {
-                header_state = h_general;
-              } else if (index == sizeof(UPGRADE)-2) {
-                header_state = h_upgrade;
+              parser->index++;
+              if (parser->index > sizeof(UPGRADE)-1
+                  || c != UPGRADE[parser->index]) {
+                parser->header_state = h_general;
+              } else if (parser->index == sizeof(UPGRADE)-2) {
+                parser->header_state = h_upgrade;
               }
               break;
 
@@ -1286,7 +1318,7 @@ size_t http_parser_execute (http_parser *parser,
             case h_content_length:
             case h_transfer_encoding:
             case h_upgrade:
-              if (ch != ' ') header_state = h_general;
+              if (ch != ' ') parser->header_state = h_general;
               break;
 
             default:
@@ -1297,20 +1329,20 @@ size_t http_parser_execute (http_parser *parser,
         }
 
         if (ch == ':') {
-          CALLBACK(header_field);
-          state = s_header_value_start;
+          parser->state = s_header_value_start;
+          CALLBACK_DATA(header_field);
           break;
         }
 
         if (ch == CR) {
-          state = s_header_almost_done;
-          CALLBACK(header_field);
+          parser->state = s_header_almost_done;
+          CALLBACK_DATA(header_field);
           break;
         }
 
         if (ch == LF) {
-          CALLBACK(header_field);
-          state = s_header_field_start;
+          parser->state = s_header_field_start;
+          CALLBACK_DATA(header_field);
           break;
         }
 
@@ -1324,36 +1356,36 @@ size_t http_parser_execute (http_parser *parser,
 
         MARK(header_value);
 
-        state = s_header_value;
-        index = 0;
+        parser->state = s_header_value;
+        parser->index = 0;
 
         if (ch == CR) {
-          CALLBACK(header_value);
-          header_state = h_general;
-          state = s_header_almost_done;
+          parser->header_state = h_general;
+          parser->state = s_header_almost_done;
+          CALLBACK_DATA(header_value);
           break;
         }
 
         if (ch == LF) {
-          CALLBACK(header_value);
-          state = s_header_field_start;
+          parser->state = s_header_field_start;
+          CALLBACK_DATA(header_value);
           break;
         }
 
         c = LOWER(ch);
 
-        switch (header_state) {
+        switch (parser->header_state) {
           case h_upgrade:
             parser->flags |= F_UPGRADE;
-            header_state = h_general;
+            parser->header_state = h_general;
             break;
 
           case h_transfer_encoding:
             /* looking for 'Transfer-Encoding: chunked' */
             if ('c' == c) {
-              header_state = h_matching_transfer_encoding_chunked;
+              parser->header_state = h_matching_transfer_encoding_chunked;
             } else {
-              header_state = h_general;
+              parser->header_state = h_general;
             }
             break;
 
@@ -1369,17 +1401,17 @@ size_t http_parser_execute (http_parser *parser,
           case h_connection:
             /* looking for 'Connection: keep-alive' */
             if (c == 'k') {
-              header_state = h_matching_connection_keep_alive;
+              parser->header_state = h_matching_connection_keep_alive;
             /* looking for 'Connection: close' */
             } else if (c == 'c') {
-              header_state = h_matching_connection_close;
+              parser->header_state = h_matching_connection_close;
             } else {
-              header_state = h_general;
+              parser->header_state = h_general;
             }
             break;
 
           default:
-            header_state = h_general;
+            parser->header_state = h_general;
             break;
         }
         break;
@@ -1389,19 +1421,20 @@ size_t http_parser_execute (http_parser *parser,
       {
 
         if (ch == CR) {
-          CALLBACK(header_value);
-          state = s_header_almost_done;
+          parser->state = s_header_almost_done;
+          CALLBACK_DATA(header_value);
           break;
         }
 
         if (ch == LF) {
-          CALLBACK(header_value);
-          goto header_almost_done;
+          parser->state = s_header_almost_done;
+          CALLBACK_DATA_NOADVANCE(header_value);
+          goto reexecute_byte;
         }
 
         c = LOWER(ch);
 
-        switch (header_state) {
+        switch (parser->header_state) {
           case h_general:
             break;
 
@@ -1411,70 +1444,83 @@ size_t http_parser_execute (http_parser *parser,
             break;
 
           case h_content_length:
+          {
+            uint64_t t;
+
             if (ch == ' ') break;
+
             if (!IS_NUM(ch)) {
               SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
               goto error;
             }
 
-            parser->content_length *= 10;
-            parser->content_length += ch - '0';
+            t = parser->content_length;
+            t *= 10;
+            t += ch - '0';
+
+            /* Overflow? */
+            if (t < parser->content_length || t == ULLONG_MAX) {
+              SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+              goto error;
+            }
+
+            parser->content_length = t;
             break;
+          }
 
           /* Transfer-Encoding: chunked */
           case h_matching_transfer_encoding_chunked:
-            index++;
-            if (index > sizeof(CHUNKED)-1
-                || c != CHUNKED[index]) {
-              header_state = h_general;
-            } else if (index == sizeof(CHUNKED)-2) {
-              header_state = h_transfer_encoding_chunked;
+            parser->index++;
+            if (parser->index > sizeof(CHUNKED)-1
+                || c != CHUNKED[parser->index]) {
+              parser->header_state = h_general;
+            } else if (parser->index == sizeof(CHUNKED)-2) {
+              parser->header_state = h_transfer_encoding_chunked;
             }
             break;
 
           /* looking for 'Connection: keep-alive' */
           case h_matching_connection_keep_alive:
-            index++;
-            if (index > sizeof(KEEP_ALIVE)-1
-                || c != KEEP_ALIVE[index]) {
-              header_state = h_general;
-            } else if (index == sizeof(KEEP_ALIVE)-2) {
-              header_state = h_connection_keep_alive;
+            parser->index++;
+            if (parser->index > sizeof(KEEP_ALIVE)-1
+                || c != KEEP_ALIVE[parser->index]) {
+              parser->header_state = h_general;
+            } else if (parser->index == sizeof(KEEP_ALIVE)-2) {
+              parser->header_state = h_connection_keep_alive;
             }
             break;
 
           /* looking for 'Connection: close' */
           case h_matching_connection_close:
-            index++;
-            if (index > sizeof(CLOSE)-1 || c != CLOSE[index]) {
-              header_state = h_general;
-            } else if (index == sizeof(CLOSE)-2) {
-              header_state = h_connection_close;
+            parser->index++;
+            if (parser->index > sizeof(CLOSE)-1 || c != CLOSE[parser->index]) {
+              parser->header_state = h_general;
+            } else if (parser->index == sizeof(CLOSE)-2) {
+              parser->header_state = h_connection_close;
             }
             break;
 
           case h_transfer_encoding_chunked:
           case h_connection_keep_alive:
           case h_connection_close:
-            if (ch != ' ') header_state = h_general;
+            if (ch != ' ') parser->header_state = h_general;
             break;
 
           default:
-            state = s_header_value;
-            header_state = h_general;
+            parser->state = s_header_value;
+            parser->header_state = h_general;
             break;
         }
         break;
       }
 
       case s_header_almost_done:
-      header_almost_done:
       {
         STRICT_CHECK(ch != LF);
 
-        state = s_header_value_lws;
+        parser->state = s_header_value_lws;
 
-        switch (header_state) {
+        switch (parser->header_state) {
           case h_connection_keep_alive:
             parser->flags |= F_CONNECTION_KEEP_ALIVE;
             break;
@@ -1487,44 +1533,47 @@ size_t http_parser_execute (http_parser *parser,
           default:
             break;
         }
+
         break;
       }
 
       case s_header_value_lws:
       {
         if (ch == ' ' || ch == '\t')
-          state = s_header_value_start;
+          parser->state = s_header_value_start;
         else
         {
-          state = s_header_field_start;
-          goto header_field_start;
+          parser->state = s_header_field_start;
+          goto reexecute_byte;
         }
         break;
       }
 
       case s_headers_almost_done:
-      headers_almost_done:
       {
         STRICT_CHECK(ch != LF);
 
         if (parser->flags & F_TRAILING) {
           /* End of a chunked request */
-          CALLBACK2(message_complete);
-          state = NEW_MESSAGE();
+          parser->state = NEW_MESSAGE();
+          CALLBACK_NOTIFY(message_complete);
           break;
         }
 
-        nread = 0;
+        parser->state = s_headers_done;
 
-        if (parser->flags & F_UPGRADE || parser->method == HTTP_CONNECT) {
-          parser->upgrade = 1;
-        }
+        /* Set this here so that on_headers_complete() callbacks can see it */
+        parser->upgrade =
+          (parser->flags & F_UPGRADE || parser->method == HTTP_CONNECT);
 
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
          * will interpret that as saying that this message has no body. This
          * is needed for the annoying case of recieving a response to a HEAD
          * request.
+         *
+         * We'd like to use CALLBACK_NOTIFY_NOADVANCE() here but we cannot, so
+         * we have to simulate it by handling a change in errno below.
          */
         if (settings->on_headers_complete) {
           switch (settings->on_headers_complete(parser)) {
@@ -1536,40 +1585,54 @@ size_t http_parser_execute (http_parser *parser,
               break;
 
             default:
-              parser->state = state;
               SET_ERRNO(HPE_CB_headers_complete);
               return p - data; /* Error */
           }
         }
 
+        if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
+          return p - data;
+        }
+
+        goto reexecute_byte;
+      }
+
+      case s_headers_done:
+      {
+        STRICT_CHECK(ch != LF);
+
+        parser->nread = 0;
+
         /* Exit, the rest of the connect is in a different protocol. */
         if (parser->upgrade) {
-          CALLBACK2(message_complete);
+          parser->state = NEW_MESSAGE();
+          CALLBACK_NOTIFY(message_complete);
           return (p - data) + 1;
         }
 
         if (parser->flags & F_SKIPBODY) {
-          CALLBACK2(message_complete);
-          state = NEW_MESSAGE();
+          parser->state = NEW_MESSAGE();
+          CALLBACK_NOTIFY(message_complete);
         } else if (parser->flags & F_CHUNKED) {
           /* chunked encoding - ignore Content-Length header */
-          state = s_chunk_size_start;
+          parser->state = s_chunk_size_start;
         } else {
           if (parser->content_length == 0) {
             /* Content-Length header given but zero: Content-Length: 0\r\n */
-            CALLBACK2(message_complete);
-            state = NEW_MESSAGE();
-          } else if (parser->content_length > 0) {
+            parser->state = NEW_MESSAGE();
+            CALLBACK_NOTIFY(message_complete);
+          } else if (parser->content_length != ULLONG_MAX) {
             /* Content-Length header given and non-zero */
-            state = s_body_identity;
+            parser->state = s_body_identity;
           } else {
-            if (parser->type == HTTP_REQUEST || http_should_keep_alive(parser)) {
+            if (parser->type == HTTP_REQUEST ||
+                !http_message_needs_eof(parser)) {
               /* Assume content-length 0 - read the next */
-              CALLBACK2(message_complete);
-              state = NEW_MESSAGE();
+              parser->state = NEW_MESSAGE();
+              CALLBACK_NOTIFY(message_complete);
             } else {
               /* Read body until EOF */
-              state = s_body_identity_eof;
+              parser->state = s_body_identity_eof;
             }
           }
         }
@@ -1578,30 +1641,56 @@ size_t http_parser_execute (http_parser *parser,
       }
 
       case s_body_identity:
-        to_read = (size_t)MIN(pe - p, parser->content_length);
-        if (to_read > 0) {
-          if (settings->on_body) settings->on_body(parser, p, to_read);
-          p += to_read - 1;
-          parser->content_length -= to_read;
-          if (parser->content_length == 0) {
-            CALLBACK2(message_complete);
-            state = NEW_MESSAGE();
-          }
+      {
+        uint64_t to_read = MIN(parser->content_length,
+                               (uint64_t) ((data + len) - p));
+
+        assert(parser->content_length != 0
+            && parser->content_length != ULLONG_MAX);
+
+        /* The difference between advancing content_length and p is because
+         * the latter will automaticaly advance on the next loop iteration.
+         * Further, if content_length ends up at 0, we want to see the last
+         * byte again for our message complete callback.
+         */
+        MARK(body);
+        parser->content_length -= to_read;
+        p += to_read - 1;
+
+        if (parser->content_length == 0) {
+          parser->state = s_message_done;
+
+          /* Mimic CALLBACK_DATA_NOADVANCE() but with one extra byte.
+           *
+           * The alternative to doing this is to wait for the next byte to
+           * trigger the data callback, just as in every other case. The
+           * problem with this is that this makes it difficult for the test
+           * harness to distinguish between complete-on-EOF and
+           * complete-on-length. It's not clear that this distinction is
+           * important for applications, but let's keep it for now.
+           */
+          CALLBACK_DATA_(body, p - body_mark + 1, p - data);
+          goto reexecute_byte;
         }
+
         break;
+      }
 
       /* read until EOF */
       case s_body_identity_eof:
-        to_read = pe - p;
-        if (to_read > 0) {
-          if (settings->on_body) settings->on_body(parser, p, to_read);
-          p += to_read - 1;
-        }
+        MARK(body);
+        p = data + len - 1;
+
+        break;
+
+      case s_message_done:
+        parser->state = NEW_MESSAGE();
+        CALLBACK_NOTIFY(message_complete);
         break;
 
       case s_chunk_size_start:
       {
-        assert(nread == 1);
+        assert(parser->nread == 1);
         assert(parser->flags & F_CHUNKED);
 
         unhex_val = unhex[(unsigned char)ch];
@@ -1611,16 +1700,18 @@ size_t http_parser_execute (http_parser *parser,
         }
 
         parser->content_length = unhex_val;
-        state = s_chunk_size;
+        parser->state = s_chunk_size;
         break;
       }
 
       case s_chunk_size:
       {
+        uint64_t t;
+
         assert(parser->flags & F_CHUNKED);
 
         if (ch == CR) {
-          state = s_chunk_size_almost_done;
+          parser->state = s_chunk_size_almost_done;
           break;
         }
 
@@ -1628,7 +1719,7 @@ size_t http_parser_execute (http_parser *parser,
 
         if (unhex_val == -1) {
           if (ch == ';' || ch == ' ') {
-            state = s_chunk_parameters;
+            parser->state = s_chunk_parameters;
             break;
           }
 
@@ -1636,8 +1727,17 @@ size_t http_parser_execute (http_parser *parser,
           goto error;
         }
 
-        parser->content_length *= 16;
-        parser->content_length += unhex_val;
+        t = parser->content_length;
+        t *= 16;
+        t += unhex_val;
+
+        /* Overflow? */
+        if (t < parser->content_length || t == ULLONG_MAX) {
+          SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+          goto error;
+        }
+
+        parser->content_length = t;
         break;
       }
 
@@ -1646,7 +1746,7 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
         /* just ignore this shit. TODO check for overflow */
         if (ch == CR) {
-          state = s_chunk_size_almost_done;
+          parser->state = s_chunk_size_almost_done;
           break;
         }
         break;
@@ -1657,46 +1757,53 @@ size_t http_parser_execute (http_parser *parser,
         assert(parser->flags & F_CHUNKED);
         STRICT_CHECK(ch != LF);
 
-        nread = 0;
+        parser->nread = 0;
 
         if (parser->content_length == 0) {
           parser->flags |= F_TRAILING;
-          state = s_header_field_start;
+          parser->state = s_header_field_start;
         } else {
-          state = s_chunk_data;
+          parser->state = s_chunk_data;
         }
         break;
       }
 
       case s_chunk_data:
       {
+        uint64_t to_read = MIN(parser->content_length,
+                               (uint64_t) ((data + len) - p));
+
         assert(parser->flags & F_CHUNKED);
+        assert(parser->content_length != 0
+            && parser->content_length != ULLONG_MAX);
 
-        to_read = (size_t)MIN(pe - p, parser->content_length);
-
-        if (to_read > 0) {
-          if (settings->on_body) settings->on_body(parser, p, to_read);
-          p += to_read - 1;
-        }
-
-        if ((signed)to_read == parser->content_length) {
-          state = s_chunk_data_almost_done;
-        }
-
+        /* See the explanation in s_body_identity for why the content
+         * length and data pointers are managed this way.
+         */
+        MARK(body);
         parser->content_length -= to_read;
+        p += to_read - 1;
+
+        if (parser->content_length == 0) {
+          parser->state = s_chunk_data_almost_done;
+        }
+
         break;
       }
 
       case s_chunk_data_almost_done:
         assert(parser->flags & F_CHUNKED);
+        assert(parser->content_length == 0);
         STRICT_CHECK(ch != CR);
-        state = s_chunk_data_done;
+        parser->state = s_chunk_data_done;
+        CALLBACK_DATA(body);
         break;
 
       case s_chunk_data_done:
         assert(parser->flags & F_CHUNKED);
         STRICT_CHECK(ch != LF);
-        state = s_chunk_size_start;
+        parser->nread = 0;
+        parser->state = s_chunk_size_start;
         break;
 
       default:
@@ -1706,14 +1813,25 @@ size_t http_parser_execute (http_parser *parser,
     }
   }
 
-  CALLBACK(header_field);
-  CALLBACK(header_value);
-  CALLBACK(url);
+  /* Run callbacks for any marks that we have leftover after we ran our of
+   * bytes. There should be at most one of these set, so it's OK to invoke
+   * them in series (unset marks will not result in callbacks).
+   *
+   * We use the NOADVANCE() variety of callbacks here because 'p' has already
+   * overflowed 'data' and this allows us to correct for the off-by-one that
+   * we'd otherwise have (since CALLBACK_DATA() is meant to be run with a 'p'
+   * value that's in-bounds).
+   */
 
-  parser->state = state;
-  parser->header_state = header_state;
-  parser->index = (unsigned char) index;
-  parser->nread = nread;
+  assert(((header_field_mark ? 1 : 0) +
+          (header_value_mark ? 1 : 0) +
+          (url_mark ? 1 : 0)  +
+          (body_mark ? 1 : 0)) <= 1);
+
+  CALLBACK_DATA_NOADVANCE(header_field);
+  CALLBACK_DATA_NOADVANCE(header_value);
+  CALLBACK_DATA_NOADVANCE(url);
+  CALLBACK_DATA_NOADVANCE(body);
 
   return len;
 
@@ -1726,43 +1844,65 @@ error:
 }
 
 
+/* Does the parser need to see an EOF to find the end of the message? */
 int
-http_should_keep_alive (http_parser *parser)
+http_message_needs_eof (const http_parser *parser)
+{
+  if (parser->type == HTTP_REQUEST) {
+    return 0;
+  }
+
+  /* See RFC 2616 section 4.4 */
+  if (parser->status_code / 100 == 1 || /* 1xx e.g. Continue */
+      parser->status_code == 204 ||     /* No Content */
+      parser->status_code == 304 ||     /* Not Modified */
+      parser->flags & F_SKIPBODY) {     /* response to a HEAD request */
+    return 0;
+  }
+
+  if ((parser->flags & F_CHUNKED) || parser->content_length != ULLONG_MAX) {
+    return 0;
+  }
+
+  return 1;
+}
+
+
+int
+http_should_keep_alive (const http_parser *parser)
 {
   if (parser->http_major > 0 && parser->http_minor > 0) {
     /* HTTP/1.1 */
     if (parser->flags & F_CONNECTION_CLOSE) {
       return 0;
-    } else {
-      return 1;
     }
   } else {
     /* HTTP/1.0 or earlier */
-    if (parser->flags & F_CONNECTION_KEEP_ALIVE) {
-      return 1;
-    } else {
+    if (!(parser->flags & F_CONNECTION_KEEP_ALIVE)) {
       return 0;
     }
   }
+
+  return !http_message_needs_eof(parser);
 }
 
 
-const char * http_method_str (enum http_method m)
+const char *
+http_method_str (enum http_method m)
 {
-  return method_strings[m];
+  return ELEM_AT(method_strings, m, "<unknown>");
 }
 
 
 void
 http_parser_init (http_parser *parser, enum http_parser_type t)
 {
+  void *data = parser->data; /* preserve application data */
+  memset(parser, 0, sizeof(*parser));
+  parser->data = data;
   parser->type = t;
   parser->state = (t == HTTP_REQUEST ? s_start_req : (t == HTTP_RESPONSE ? s_start_res : s_start_req_or_res));
-  parser->nread = 0;
-  parser->upgrade = 0;
-  parser->flags = 0;
-  parser->method = 0;
-  parser->http_errno = 0;
+  parser->http_errno = HPE_OK;
 }
 
 const char *
@@ -1775,4 +1915,260 @@ const char *
 http_errno_description(enum http_errno err) {
   assert(err < (sizeof(http_strerror_tab)/sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].description;
+}
+
+static enum http_host_state
+http_parse_host_char(enum http_host_state s, const char ch) {
+  switch(s) {
+    case s_http_userinfo:
+    case s_http_userinfo_start:
+      if (ch == '@') {
+        return s_http_host_start;
+      }
+
+      if (IS_USERINFO_CHAR(ch)) {
+        return s_http_userinfo;
+      }
+      break;
+
+    case s_http_host_start:
+      if (ch == '[') {
+        return s_http_host_v6_start;
+      }
+
+      if (IS_HOST_CHAR(ch)) {
+        return s_http_host;
+      }
+
+      break;
+
+    case s_http_host:
+      if (IS_HOST_CHAR(ch)) {
+        return s_http_host;
+      }
+
+    /* FALLTHROUGH */
+    case s_http_host_v6_end:
+      if (ch == ':') {
+        return s_http_host_port_start;
+      }
+
+      break;
+
+    case s_http_host_v6:
+      if (ch == ']') {
+        return s_http_host_v6_end;
+      }
+
+    /* FALLTHROUGH */
+    case s_http_host_v6_start:
+      if (IS_HEX(ch) || ch == ':') {
+        return s_http_host_v6;
+      }
+
+      break;
+
+    case s_http_host_port:
+    case s_http_host_port_start:
+      if (IS_NUM(ch)) {
+        return s_http_host_port;
+      }
+
+      break;
+
+    default:
+      break;
+  }
+  return s_http_host_dead;
+}
+
+static int
+http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
+  enum http_host_state s;
+
+  const char *p;
+  size_t buflen = u->field_data[UF_HOST].off + u->field_data[UF_HOST].len;
+
+  u->field_data[UF_HOST].len = 0;
+
+  s = found_at ? s_http_userinfo_start : s_http_host_start;
+
+  for (p = buf + u->field_data[UF_HOST].off; p < buf + buflen; p++) {
+    enum http_host_state new_s = http_parse_host_char(s, *p);
+
+    if (new_s == s_http_host_dead) {
+      return 1;
+    }
+
+    switch(new_s) {
+      case s_http_host:
+        if (s != s_http_host) {
+          u->field_data[UF_HOST].off = p - buf;
+        }
+        u->field_data[UF_HOST].len++;
+        break;
+
+      case s_http_host_v6:
+        if (s != s_http_host_v6) {
+          u->field_data[UF_HOST].off = p - buf;
+        }
+        u->field_data[UF_HOST].len++;
+        break;
+
+      case s_http_host_port:
+        if (s != s_http_host_port) {
+          u->field_data[UF_PORT].off = p - buf;
+          u->field_data[UF_PORT].len = 0;
+          u->field_set |= (1 << UF_PORT);
+        }
+        u->field_data[UF_PORT].len++;
+        break;
+
+      case s_http_userinfo:
+        if (s != s_http_userinfo) {
+          u->field_data[UF_USERINFO].off = p - buf ;
+          u->field_data[UF_USERINFO].len = 0;
+          u->field_set |= (1 << UF_USERINFO);
+        }
+        u->field_data[UF_USERINFO].len++;
+        break;
+
+      default:
+        break;
+    }
+    s = new_s;
+  }
+
+  /* Make sure we don't end somewhere unexpected */
+  switch (s) {
+    case s_http_host_start:
+    case s_http_host_v6_start:
+    case s_http_host_v6:
+    case s_http_host_port_start:
+    case s_http_userinfo:
+    case s_http_userinfo_start:
+      return 1;
+    default:
+      break;
+  }
+
+  return 0;
+}
+
+int
+http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
+                      struct http_parser_url *u)
+{
+  enum state s;
+  const char *p;
+  enum http_parser_url_fields uf, old_uf;
+  int found_at = 0;
+
+  u->port = u->field_set = 0;
+  s = is_connect ? s_req_server_start : s_req_spaces_before_url;
+  uf = old_uf = UF_MAX;
+
+  for (p = buf; p < buf + buflen; p++) {
+    s = parse_url_char(s, *p);
+
+    /* Figure out the next field that we're operating on */
+    switch (s) {
+      case s_dead:
+        return 1;
+
+      /* Skip delimeters */
+      case s_req_schema_slash:
+      case s_req_schema_slash_slash:
+      case s_req_server_start:
+      case s_req_query_string_start:
+      case s_req_fragment_start:
+        continue;
+
+      case s_req_schema:
+        uf = UF_SCHEMA;
+        break;
+
+      case s_req_server_with_at:
+        found_at = 1;
+
+      /* FALLTROUGH */
+      case s_req_server:
+        uf = UF_HOST;
+        break;
+
+      case s_req_path:
+        uf = UF_PATH;
+        break;
+
+      case s_req_query_string:
+        uf = UF_QUERY;
+        break;
+
+      case s_req_fragment:
+        uf = UF_FRAGMENT;
+        break;
+
+      default:
+        assert(!"Unexpected state");
+        return 1;
+    }
+
+    /* Nothing's changed; soldier on */
+    if (uf == old_uf) {
+      u->field_data[uf].len++;
+      continue;
+    }
+
+    u->field_data[uf].off = p - buf;
+    u->field_data[uf].len = 1;
+
+    u->field_set |= (1 << uf);
+    old_uf = uf;
+  }
+
+  /* host must be present if there is a schema */
+  /* parsing http:///toto will fail */
+  if ((u->field_set & ((1 << UF_SCHEMA) | (1 << UF_HOST))) != 0) {
+    if (http_parse_host(buf, u, found_at) != 0) {
+      return 1;
+    }
+  }
+
+  /* CONNECT requests can only contain "hostname:port" */
+  if (is_connect && u->field_set != ((1 << UF_HOST)|(1 << UF_PORT))) {
+    return 1;
+  }
+
+  if (u->field_set & (1 << UF_PORT)) {
+    /* Don't bother with endp; we've already validated the string */
+    unsigned long v = strtoul(buf + u->field_data[UF_PORT].off, NULL, 10);
+
+    /* Ports have a max value of 2^16 */
+    if (v > 0xffff) {
+      return 1;
+    }
+
+    u->port = (uint16_t) v;
+  }
+
+  return 0;
+}
+
+void
+http_parser_pause(http_parser *parser, int paused) {
+  /* Users should only be pausing/unpausing a parser that is not in an error
+   * state. In non-debug builds, there's not much that we can do about this
+   * other than ignore it.
+   */
+  if (HTTP_PARSER_ERRNO(parser) == HPE_OK ||
+      HTTP_PARSER_ERRNO(parser) == HPE_PAUSED) {
+    SET_ERRNO((paused) ? HPE_PAUSED : HPE_OK);
+  } else {
+    assert(0 && "Attempting to pause parser in error state");
+  }
+}
+
+int
+http_body_is_final(const struct http_parser *parser) {
+    return parser->state == s_message_done;
 }


### PR DESCRIPTION
This is a pre-requisite for merging #1005. This brings `http-parser` up to speed with upstream. Windows compilation still works as expected, and HTTP clones are working just fine.

I'd appreciate a couple extra eyes looking into this.
