### PR TITLE
Fix cdecl issues with strcmp function ptrs

### DIFF
--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -66,4 +66,10 @@
 #	endif
 #endif
 
+#if defined (_MSC_VER)
+#	define GIT_CDECL __cdecl
+#else
+#	define GIT_CDECL
+#endif
+
 #endif /* INCLUDE_compat_h__ */

--- a/src/diff.h
+++ b/src/diff.h
@@ -42,8 +42,8 @@ struct git_diff_list {
 	git_iterator_type_t new_src;
 	uint32_t diffcaps;
 
-	int (*strcomp)(const char *, const char *);
-	int (*strncomp)(const char *, const char *, size_t);
+	git__strcmp_fn  strcomp;
+	git__strncmp_fn strncomp;
 	int (*pfxcomp)(const char *str, const char *pfx);
 	int (*entrycomp)(const void *a, const void *b);
 };

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -110,8 +110,8 @@ bool git_pathspec_match_path(
 	unsigned int i;
 	git_attr_fnmatch *match;
 	int fnmatch_flags = 0;
-	int (*use_strcmp)(const char *, const char *);
-	int (*use_strncmp)(const char *, const char *, size_t);
+	git__strcmp_fn  use_strcmp;
+	git__strncmp_fn use_strncmp;
 
 	if (!vspec || !vspec->length)
 		return true;

--- a/src/util.h
+++ b/src/util.h
@@ -134,6 +134,9 @@ extern int git__bsearch(
 
 extern int git__strcmp_cb(const void *a, const void *b);
 
+typedef int (GIT_CDECL *git__strcmp_fn)(const char *, const char *);
+typedef int (GIT_CDECL *git__strncmp_fn)(const char *, const char *, size_t);
+
 typedef struct {
 	short refcount;
 	void *owner;


### PR DESCRIPTION
Can't use `strcmp` `strncmp` `strcasecmp` etc. as function pointers on Win32 without some trickery. This just makes some standard function pointer types that can be used for these functions...
