### PR TITLE
Fix git_branch_tracking() for branches with empty merge and/or remote config entries

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -257,8 +257,8 @@ int git_branch_tracking(
 
 	if ((error = retrieve_tracking_configuration(&merge_name, branch, "branch.%s.merge")) < 0)
 		goto cleanup;
-    
-    if (remote_name == NULL || merge_name == NULL) {
+
+    if (!*remote_name || !*merge_name) {
         error = GIT_ENOTFOUND;
         goto cleanup;
     }

--- a/tests-clar/refs/branches/tracking.c
+++ b/tests-clar/refs/branches/tracking.c
@@ -60,3 +60,35 @@ void test_refs_branches_tracking__trying_to_retrieve_a_remote_tracking_reference
 
 	cl_assert_equal_i(GIT_ENOTFOUND, git_branch_tracking(&tracking, branch));
 }
+
+static void assert_merge_and_or_remote_key_missing(git_repository *repository, git_object *target, const char *entry_name)
+{
+	git_reference *branch;
+
+	cl_git_pass(git_branch_create(&branch, repository, entry_name, target, 0));
+
+	cl_assert_equal_i(GIT_ENOTFOUND, git_branch_tracking(&tracking, branch));
+
+	git_reference_free(branch);
+}
+
+void test_refs_branches_tracking__retrieve_a_remote_tracking_reference_from_a_branch_with_no_remote_returns_GIT_ENOTFOUND(void)
+{
+	git_reference *head;
+	git_repository *repository;
+	git_object *target;
+
+	repository = cl_git_sandbox_init("testrepo.git");
+
+	cl_git_pass(git_repository_head(&head, repository));
+	cl_git_pass(git_reference_peel(&target, head, GIT_OBJ_COMMIT));
+	git_reference_free(head);
+
+	assert_merge_and_or_remote_key_missing(repository, target, "remoteless");
+	assert_merge_and_or_remote_key_missing(repository, target, "mergeless");
+	assert_merge_and_or_remote_key_missing(repository, target, "mergeandremoteless");
+
+	git_object_free(target);
+
+	cl_git_sandbox_cleanup();
+}

--- a/tests-clar/resources/testrepo.git/config
+++ b/tests-clar/resources/testrepo.git/config
@@ -25,3 +25,12 @@
 [branch "cannot-fetch"]
    remote = joshaber
    merge = refs/heads/cannot-fetch
+[branch "remoteless"]
+   remote =
+   merge = refs/heads/master
+[branch "mergeless"]
+   remote = test
+   merge = 
+[branch "mergeandremoteless"]
+   remote = 
+   merge = 


### PR DESCRIPTION
A slight change introduced by 0da81d2b39290fe4d444953acb6d68795ed1ef42 changes the way `git_config_get_string()` handles config entries with no value.

This makes `git_branch_tracking()` cope with this new behavior
