### PR TITLE
Reset all static variables to NULL in clar's __cleanup

### DIFF
--- a/tests-clar/checkout/tree.c
+++ b/tests-clar/checkout/tree.c
@@ -18,6 +18,7 @@ void test_checkout_tree__initialize(void)
 void test_checkout_tree__cleanup(void)
 {
 	git_object_free(g_object);
+	g_object = NULL;
 
 	cl_git_sandbox_cleanup();
 }

--- a/tests-clar/clone/network.c
+++ b/tests-clar/clone/network.c
@@ -17,8 +17,10 @@ void test_clone_network__initialize(void)
 
 static void cleanup_repository(void *path)
 {
-	if (g_repo)
+	if (g_repo) {
 		git_repository_free(g_repo);
+		g_repo = NULL;
+	}
 	cl_fixture_cleanup((const char *)path);
 }
 

--- a/tests-clar/clone/nonetwork.c
+++ b/tests-clar/clone/nonetwork.c
@@ -14,8 +14,11 @@ void test_clone_nonetwork__initialize(void)
 
 static void cleanup_repository(void *path)
 {
-	if (g_repo)
+	if (g_repo) {
 		git_repository_free(g_repo);
+		g_repo = NULL;
+	}
+
 	cl_fixture_cleanup((const char *)path);
 }
 

--- a/tests-clar/commit/commit.c
+++ b/tests-clar/commit/commit.c
@@ -11,6 +11,8 @@ void test_commit_commit__initialize(void)
 void test_commit_commit__cleanup(void)
 {
 	git_repository_free(_repo);
+	_repo = NULL;
+
 	cl_fixture_cleanup("testrepo.git");
 }
 

--- a/tests-clar/commit/parent.c
+++ b/tests-clar/commit/parent.c
@@ -16,7 +16,10 @@ void test_commit_parent__initialize(void)
 void test_commit_parent__cleanup(void)
 {
 	git_commit_free(commit);
+	commit = NULL;
+
 	git_repository_free(_repo);
+	_repo = NULL;
 }
 
 static void assert_nth_gen_parent(unsigned int gen, const char *expected_oid)

--- a/tests-clar/commit/write.c
+++ b/tests-clar/commit/write.c
@@ -17,16 +17,22 @@ void test_commit_write__initialize(void)
 {
    g_repo = cl_git_sandbox_init("testrepo");
 }
+
 void test_commit_write__cleanup(void)
 {
-   git_reference_free(head);
-   git_reference_free(branch);
+	git_reference_free(head);
+	head = NULL;
 
-   git_commit_free(commit);
+	git_reference_free(branch);
+	branch = NULL;
 
-   git__free(head_old);
+	git_commit_free(commit);
+	commit = NULL;
 
-   cl_git_sandbox_cleanup();
+	git__free(head_old);
+	head_old = NULL;
+
+	cl_git_sandbox_cleanup();
 }
 
 

--- a/tests-clar/core/env.c
+++ b/tests-clar/core/env.c
@@ -29,6 +29,7 @@ void test_core_env__cleanup(void)
 #ifdef GIT_WIN32
 		git__free(env_save[i]);
 #endif
+		env_save[i] = NULL;
 	}
 }
 

--- a/tests-clar/diff/blob.c
+++ b/tests-clar/diff/blob.c
@@ -30,7 +30,10 @@ void test_diff_blob__initialize(void)
 void test_diff_blob__cleanup(void)
 {
 	git_blob_free(d);
+	d = NULL;
+
 	git_blob_free(alien);
+	alien = NULL;
 
 	cl_git_sandbox_cleanup();
 }

--- a/tests-clar/fetchhead/network.c
+++ b/tests-clar/fetchhead/network.c
@@ -18,8 +18,11 @@ void test_fetchhead_network__initialize(void)
 
 static void cleanup_repository(void *path)
 {
-	if (g_repo)
+	if (g_repo) {
 		git_repository_free(g_repo);
+		g_repo = NULL;
+	}
+
 	cl_fixture_cleanup((const char *)path);
 }
 

--- a/tests-clar/fetchhead/nonetwork.c
+++ b/tests-clar/fetchhead/nonetwork.c
@@ -15,8 +15,11 @@ void test_fetchhead_nonetwork__initialize(void)
 
 static void cleanup_repository(void *path)
 {
-	if (g_repo)
+	if (g_repo) {
 		git_repository_free(g_repo);
+		g_repo = NULL;
+	}
+
 	cl_fixture_cleanup((const char *)path);
 }
 

--- a/tests-clar/index/conflicts.c
+++ b/tests-clar/index/conflicts.c
@@ -30,6 +30,8 @@ void test_index_conflicts__initialize(void)
 void test_index_conflicts__cleanup(void)
 {
 	git_index_free(repo_index);
+	repo_index = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/index/reuc.c
+++ b/tests-clar/index/reuc.c
@@ -26,6 +26,8 @@ void test_index_reuc__initialize(void)
 void test_index_reuc__cleanup(void)
 {
 	git_index_free(repo_index);
+	repo_index = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/index/stage.c
+++ b/tests-clar/index/stage.c
@@ -18,6 +18,8 @@ void test_index_stage__initialize(void)
 void test_index_stage__cleanup(void)
 {
 	git_index_free(repo_index);
+	repo_index = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/network/createremotethenload.c
+++ b/tests-clar/network/createremotethenload.c
@@ -22,7 +22,11 @@ void test_network_createremotethenload__initialize(void)
 void test_network_createremotethenload__cleanup(void)
 {
 	git_remote_free(_remote);
+	_remote = NULL;
+
 	git_repository_free(_repo);
+	_repo = NULL;
+
 	cl_fixture_cleanup("testrepo.git");
 }
 

--- a/tests-clar/network/fetch.c
+++ b/tests-clar/network/fetch.c
@@ -13,6 +13,8 @@ void test_network_fetch__initialize(void)
 void test_network_fetch__cleanup(void)
 {
 	git_repository_free(_repo);
+	_repo = NULL;
+
 	cl_fixture_cleanup("./fetch");
 }
 

--- a/tests-clar/network/remotelocal.c
+++ b/tests-clar/network/remotelocal.c
@@ -15,9 +15,14 @@ void test_network_remotelocal__initialize(void)
 
 void test_network_remotelocal__cleanup(void)
 {
-	git_remote_free(remote);
 	git_buf_free(&file_path_buf);
+
+	git_remote_free(remote);
+	remote = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_fixture_cleanup("remotelocal");
 }
 

--- a/tests-clar/network/remoterename.c
+++ b/tests-clar/network/remoterename.c
@@ -16,6 +16,7 @@ void test_network_remoterename__initialize(void)
 void test_network_remoterename__cleanup(void)
 {
 	git_remote_free(_remote);
+	_remote = NULL;
 
 	cl_git_sandbox_cleanup();
 }

--- a/tests-clar/network/remotes.c
+++ b/tests-clar/network/remotes.c
@@ -20,6 +20,8 @@ void test_network_remotes__initialize(void)
 void test_network_remotes__cleanup(void)
 {
 	git_remote_free(_remote);
+	_remote = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/notes/notes.c
+++ b/tests-clar/notes/notes.c
@@ -12,6 +12,8 @@ void test_notes_notes__initialize(void)
 void test_notes_notes__cleanup(void)
 {
 	git_signature_free(_sig);
+	_sig = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/notes/notesref.c
+++ b/tests-clar/notes/notesref.c
@@ -16,10 +16,17 @@ void test_notes_notesref__initialize(void)
 void test_notes_notesref__cleanup(void)
 {
 	git_note_free(_note);
+	_note = NULL;
+
 	git_signature_free(_sig);
+	_sig = NULL;
+
 	git_config_free(_cfg);
+	_cfg = NULL;
 
 	git_repository_free(_repo);
+	_repo = NULL;
+
 	cl_fixture_cleanup("testrepo.git");
 }
 

--- a/tests-clar/object/commit/commitstagedfile.c
+++ b/tests-clar/object/commit/commitstagedfile.c
@@ -13,6 +13,8 @@ void test_object_commit_commitstagedfile__initialize(void)
 void test_object_commit_commitstagedfile__cleanup(void)
 {
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_fixture_cleanup("treebuilder");
 }
 

--- a/tests-clar/object/lookup.c
+++ b/tests-clar/object/lookup.c
@@ -11,7 +11,8 @@ void test_object_lookup__initialize(void)
 
 void test_object_lookup__cleanup(void)
 {
-   git_repository_free(g_repo);
+	git_repository_free(g_repo);
+	g_repo = NULL;
 }
 
 void test_object_lookup__lookup_wrong_type_returns_enotfound(void)

--- a/tests-clar/object/peel.c
+++ b/tests-clar/object/peel.c
@@ -10,6 +10,7 @@ void test_object_peel__initialize(void)
 void test_object_peel__cleanup(void)
 {
 	git_repository_free(g_repo);
+	g_repo = NULL;
 }
 
 static void assert_peel(

--- a/tests-clar/object/tag/peel.c
+++ b/tests-clar/object/tag/peel.c
@@ -14,8 +14,13 @@ void test_object_tag_peel__initialize(void)
 void test_object_tag_peel__cleanup(void)
 {
 	git_tag_free(tag);
+	tag = NULL;
+
 	git_object_free(target);
+	target = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 
 	cl_fixture_cleanup("testrepo.git");
 }

--- a/tests-clar/object/tree/frompath.c
+++ b/tests-clar/object/tree/frompath.c
@@ -19,7 +19,10 @@ void test_object_tree_frompath__initialize(void)
 void test_object_tree_frompath__cleanup(void)
 {
 	git_tree_free(tree);
+	tree = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 }
 
 static void assert_tree_from_path(

--- a/tests-clar/odb/mixed.c
+++ b/tests-clar/odb/mixed.c
@@ -11,6 +11,7 @@ void test_odb_mixed__initialize(void)
 void test_odb_mixed__cleanup(void)
 {
 	git_odb_free(_odb);
+	_odb = NULL;
 }
 
 void test_odb_mixed__dup_oid(void) {

--- a/tests-clar/odb/packed.c
+++ b/tests-clar/odb/packed.c
@@ -12,6 +12,7 @@ void test_odb_packed__initialize(void)
 void test_odb_packed__cleanup(void)
 {
 	git_odb_free(_odb);
+	_odb = NULL;
 }
 
 void test_odb_packed__mass_read(void)

--- a/tests-clar/odb/packed_one.c
+++ b/tests-clar/odb/packed_one.c
@@ -17,6 +17,7 @@ void test_odb_packed_one__initialize(void)
 void test_odb_packed_one__cleanup(void)
 {
 	git_odb_free(_odb);
+	_odb = NULL;
 }
 
 void test_odb_packed_one__mass_read(void)

--- a/tests-clar/pack/packbuilder.c
+++ b/tests-clar/pack/packbuilder.c
@@ -7,6 +7,7 @@ static git_revwalk *_revwalker;
 static git_packbuilder *_packbuilder;
 static git_indexer *_indexer;
 static git_vector _commits;
+static int _commits_is_initialized;
 
 void test_pack_packbuilder__initialize(void)
 {
@@ -14,6 +15,7 @@ void test_pack_packbuilder__initialize(void)
 	cl_git_pass(git_revwalk_new(&_revwalker, _repo));
 	cl_git_pass(git_packbuilder_new(&_packbuilder, _repo));
 	cl_git_pass(git_vector_init(&_commits, 0, NULL));
+	_commits_is_initialized = 1;
 }
 
 void test_pack_packbuilder__cleanup(void)
@@ -21,15 +23,25 @@ void test_pack_packbuilder__cleanup(void)
 	git_oid *o;
 	unsigned int i;
 
-	git_vector_foreach(&_commits, i, o) {
-		git__free(o);
+	if (_commits_is_initialized) {
+		_commits_is_initialized = 0;
+		git_vector_foreach(&_commits, i, o) {
+			git__free(o);
+		}
+		git_vector_free(&_commits);
 	}
-	git_vector_free(&_commits);
+
 	git_packbuilder_free(_packbuilder);
+	_packbuilder = NULL;
+
 	git_revwalk_free(_revwalker);
+	_revwalker = NULL;
+
 	git_indexer_free(_indexer);
 	_indexer = NULL;
+
 	git_repository_free(_repo);
+	_repo = NULL;
 }
 
 static void seed_packbuilder(void)

--- a/tests-clar/refs/branches/create.c
+++ b/tests-clar/refs/branches/create.c
@@ -16,9 +16,13 @@ void test_refs_branches_create__initialize(void)
 void test_refs_branches_create__cleanup(void)
 {
 	git_reference_free(branch);
+	branch = NULL;
 
 	git_object_free(target);
+	target = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 
 	cl_fixture_cleanup("testrepo.git");
 }

--- a/tests-clar/refs/branches/delete.c
+++ b/tests-clar/refs/branches/delete.c
@@ -20,7 +20,10 @@ void test_refs_branches_delete__initialize(void)
 void test_refs_branches_delete__cleanup(void)
 {
 	git_reference_free(fake_remote);
+	fake_remote = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 
 	cl_fixture_cleanup("testrepo.git");
 }

--- a/tests-clar/refs/branches/foreach.c
+++ b/tests-clar/refs/branches/foreach.c
@@ -18,7 +18,10 @@ void test_refs_branches_foreach__initialize(void)
 void test_refs_branches_foreach__cleanup(void)
 {
 	git_reference_free(fake_remote);
+	fake_remote = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 
 	cl_fixture_cleanup("testrepo.git");
 }

--- a/tests-clar/refs/branches/ishead.c
+++ b/tests-clar/refs/branches/ishead.c
@@ -13,7 +13,10 @@ void test_refs_branches_ishead__initialize(void)
 void test_refs_branches_ishead__cleanup(void)
 {
 	git_reference_free(branch);
+	branch = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 }
 
 void test_refs_branches_ishead__can_tell_if_a_branch_is_pointed_at_by_HEAD(void)

--- a/tests-clar/refs/branches/lookup.c
+++ b/tests-clar/refs/branches/lookup.c
@@ -14,8 +14,10 @@ void test_refs_branches_lookup__initialize(void)
 void test_refs_branches_lookup__cleanup(void)
 {
 	git_reference_free(branch);
+	branch = NULL;
 
 	git_repository_free(repo);
+	repo = NULL;
 }
 
 void test_refs_branches_lookup__can_retrieve_a_local_branch(void)

--- a/tests-clar/refs/branches/move.c
+++ b/tests-clar/refs/branches/move.c
@@ -15,6 +15,8 @@ void test_refs_branches_move__initialize(void)
 void test_refs_branches_move__cleanup(void)
 {
 	git_reference_free(ref);
+	ref = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/refs/branches/tracking.c
+++ b/tests-clar/refs/branches/tracking.c
@@ -14,8 +14,10 @@ void test_refs_branches_tracking__initialize(void)
 void test_refs_branches_tracking__cleanup(void)
 {
 	git_reference_free(branch);
+	branch = NULL;
 
 	git_repository_free(repo);
+	repo = NULL;
 }
 
 void test_refs_branches_tracking__can_retrieve_the_remote_tracking_reference_of_a_local_branch(void)

--- a/tests-clar/refs/foreachglob.c
+++ b/tests-clar/refs/foreachglob.c
@@ -18,7 +18,10 @@ void test_refs_foreachglob__initialize(void)
 void test_refs_foreachglob__cleanup(void)
 {
 	git_reference_free(fake_remote);
+	fake_remote = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
 
 	cl_fixture_cleanup("testrepo.git");
 }

--- a/tests-clar/refs/peel.c
+++ b/tests-clar/refs/peel.c
@@ -10,6 +10,7 @@ void test_refs_peel__initialize(void)
 void test_refs_peel__cleanup(void)
 {
 	git_repository_free(g_repo);
+	g_repo = NULL;
 }
 
 static void assert_peel(

--- a/tests-clar/refs/read.c
+++ b/tests-clar/refs/read.c
@@ -22,6 +22,7 @@ void test_refs_read__initialize(void)
 void test_refs_read__cleanup(void)
 {
 	git_repository_free(g_repo);
+	g_repo = NULL;
 }
 
 void test_refs_read__loose_tag(void)

--- a/tests-clar/refs/reflog/drop.c
+++ b/tests-clar/refs/reflog/drop.c
@@ -22,6 +22,7 @@ void test_refs_reflog_drop__initialize(void)
 void test_refs_reflog_drop__cleanup(void)
 {
 	git_reflog_free(g_reflog);
+	g_reflog = NULL;
 
 	cl_git_sandbox_cleanup();
 }

--- a/tests-clar/refs/unicode.c
+++ b/tests-clar/refs/unicode.c
@@ -12,6 +12,8 @@ void test_refs_unicode__initialize(void)
 void test_refs_unicode__cleanup(void)
 {
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_fixture_cleanup("testrepo.git");
 }
 

--- a/tests-clar/repo/head.c
+++ b/tests-clar/repo/head.c
@@ -3,7 +3,7 @@
 #include "repo_helpers.h"
 #include "posix.h"
 
-git_repository *repo;
+static git_repository *repo;
 
 void test_repo_head__initialize(void)
 {

--- a/tests-clar/repo/init.c
+++ b/tests-clar/repo/init.c
@@ -19,6 +19,8 @@ void test_repo_init__initialize(void)
 static void cleanup_repository(void *path)
 {
 	git_repository_free(_repo);
+	_repo = NULL;
+
 	cl_fixture_cleanup((const char *)path);
 }
 

--- a/tests-clar/repo/setters.c
+++ b/tests-clar/repo/setters.c
@@ -17,6 +17,8 @@ void test_repo_setters__initialize(void)
 void test_repo_setters__cleanup(void)
 {
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_fixture_cleanup("testrepo.git");
 	cl_fixture_cleanup("new_workdir");
 }

--- a/tests-clar/reset/hard.c
+++ b/tests-clar/reset/hard.c
@@ -16,6 +16,8 @@ void test_reset_hard__initialize(void)
 void test_reset_hard__cleanup(void)
 {
 	git_object_free(target);
+	target = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/reset/mixed.c
+++ b/tests-clar/reset/mixed.c
@@ -15,6 +15,8 @@ void test_reset_mixed__initialize(void)
 void test_reset_mixed__cleanup(void)
 {
 	git_object_free(target);
+	target = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/reset/soft.c
+++ b/tests-clar/reset/soft.c
@@ -15,6 +15,8 @@ void test_reset_soft__initialize(void)
 void test_reset_soft__cleanup(void)
 {
 	git_object_free(target);
+	target = NULL;
+
 	cl_git_sandbox_cleanup();
 }
 

--- a/tests-clar/revwalk/basic.c
+++ b/tests-clar/revwalk/basic.c
@@ -103,7 +103,9 @@ void test_revwalk_basic__initialize(void)
 void test_revwalk_basic__cleanup(void)
 {
 	git_revwalk_free(_walk);
+	_walk = NULL;
 	git_repository_free(_repo);
+	_repo = NULL;
 }
 
 void test_revwalk_basic__sorting_modes(void)

--- a/tests-clar/revwalk/mergebase.c
+++ b/tests-clar/revwalk/mergebase.c
@@ -12,6 +12,7 @@ void test_revwalk_mergebase__initialize(void)
 void test_revwalk_mergebase__cleanup(void)
 {
 	git_repository_free(_repo);
+	_repo = NULL;
 }
 
 void test_revwalk_mergebase__single1(void)

--- a/tests-clar/revwalk/signatureparsing.c
+++ b/tests-clar/revwalk/signatureparsing.c
@@ -12,7 +12,10 @@ void test_revwalk_signatureparsing__initialize(void)
 void test_revwalk_signatureparsing__cleanup(void)
 {
 	git_revwalk_free(_walk);
+	_walk = NULL;
+
 	git_repository_free(_repo);
+	_repo = NULL;
 }
 
 void test_revwalk_signatureparsing__do_not_choke_when_name_contains_angle_brackets(void)

--- a/tests-clar/stash/drop.c
+++ b/tests-clar/stash/drop.c
@@ -14,7 +14,11 @@ void test_stash_drop__initialize(void)
 void test_stash_drop__cleanup(void)
 {
 	git_signature_free(signature);
+	signature = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_git_pass(git_futils_rmdir_r("stash", NULL, GIT_RMDIR_REMOVE_FILES));
 }
 

--- a/tests-clar/stash/foreach.c
+++ b/tests-clar/stash/foreach.c
@@ -29,7 +29,11 @@ void test_stash_foreach__initialize(void)
 void test_stash_foreach__cleanup(void)
 {
 	git_signature_free(signature);
+	signature = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_git_pass(git_futils_rmdir_r(REPO_NAME, NULL, GIT_RMDIR_REMOVE_FILES));
 }
 

--- a/tests-clar/stash/save.c
+++ b/tests-clar/stash/save.c
@@ -26,7 +26,11 @@ void test_stash_save__initialize(void)
 void test_stash_save__cleanup(void)
 {
 	git_signature_free(signature);
+	signature = NULL;
+
 	git_repository_free(repo);
+	repo = NULL;
+
 	cl_git_pass(git_futils_rmdir_r("stash", NULL, GIT_RMDIR_REMOVE_FILES));
 }
 


### PR DESCRIPTION
Without this change, any failed assertion in the second (or a later) test
inside a test suite has a chance of double deleting memory, resulting in
a heap corruption. See #1096 for details.

This leaves alone the test cases where we "just" use cl_git_sandbox_init()
and cl_git_sandbox_cleanup(). These methods already take good care to not
double delete a repository.
