### PR TITLE
Remove use of English expletives

### DIFF
--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -1744,7 +1744,7 @@ size_t http_parser_execute (http_parser *parser,
       case s_chunk_parameters:
       {
         assert(parser->flags & F_CHUNKED);
-        /* just ignore this shit. TODO check for overflow */
+        /* just ignore this. TODO check for overflow */
         if (ch == CR) {
           parser->state = s_chunk_size_almost_done;
           break;

--- a/deps/regex/regex_internal.h
+++ b/deps/regex/regex_internal.h
@@ -63,7 +63,7 @@
 #endif
 #else /* GAWK */
 /*
- * This is a freaking mess. On glibc systems you have to define
+ * This is a mess. On glibc systems you have to define
  * a magic constant to get isblank() out of <ctype.h>, since it's
  * a C99 function.  To heck with all that and borrow a page from
  * dfa.c's book.

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -863,7 +863,7 @@ static int skip_bom(diskfile_backend *cfg)
 		cfg->reader.read_ptr += sizeof(utf8_bom);
 
 	/* TODO: the reference implementation does pretty stupid
-		shit with the BoM
+		stuff with the BoM
 	*/
 
 	return 0;

--- a/src/date.c
+++ b/src/date.c
@@ -106,15 +106,15 @@ static const struct {
 	{ "MESZ",  +1, 1, },	/* Middle European Summer */
 	{ "FWT",   +1, 0, },	/* French Winter */
 	{ "FST",   +1, 1, },	/* French Summer */
-	{ "EET",   +2, 0, },	/* Eastern Europe, USSR Zone 1 */
+	{ "EET",   +2, 0, },	/* Eastern Europe */
 	{ "EEST",  +2, 1, },	/* Eastern European Daylight */
 	{ "WAST",  +7, 0, },	/* West Australian Standard */
 	{ "WADT",  +7, 1, },	/* West Australian Daylight */
-	{ "CCT",   +8, 0, },	/* China Coast, USSR Zone 7 */
-	{ "JST",   +9, 0, },	/* Japan Standard, USSR Zone 8 */
+	{ "CCT",   +8, 0, },	/* China Coast */
+	{ "JST",   +9, 0, },	/* Japan Standard */
 	{ "EAST", +10, 0, },	/* Eastern Australian Standard */
 	{ "EADT", +10, 1, },	/* Eastern Australian Daylight */
-	{ "GST",  +10, 0, },	/* Guam Standard, USSR Zone 9 */
+	{ "GST",  +10, 0, },	/* Guam Standard */
 	{ "NZT",  +12, 0, },	/* New Zealand */
 	{ "NZST", +12, 0, },	/* New Zealand Standard */
 	{ "NZDT", +12, 1, },	/* New Zealand Daylight */
@@ -195,7 +195,7 @@ static size_t match_alpha(const char *date, struct tm *tm, int *offset)
 		return 2;
 	}
 
-	/* BAD CRAP */
+	/* BAD */
 	return skip_alpha(date);
 }
 
@@ -425,16 +425,16 @@ static size_t match_tz(const char *date, int *offp)
 		min = hour % 100;
 		hour = hour / 100;
 	} else if (n != 2) {
-		min = 99; /* random crap */
+		min = 99; /* random stuff */
 	} else if (*end == ':') {
 		/* hh:mm? */
 		min = strtoul(end + 1, &end, 10);
 		if (end - (date + 1) != 5)
-			min = 99; /* random crap */
+			min = 99; /* random stuff */
 	} /* otherwise we parsed "hh" */
 
 	/*
-	 * Don't accept any random crap. Even though some places have
+	 * Don't accept any random stuff. Even though some places have
 	 * offset larger than 12 hours (e.g. Pacific/Kiritimati is at
 	 * UTC+14), there is something wrong if hour part is much
 	 * larger than that. We might also want to check that the
@@ -521,7 +521,7 @@ static int parse_date_basic(const char *date, git_time_t *timestamp, int *offset
 			match = match_tz(date, offset);
 
 		if (!match) {
-			/* BAD CRAP */
+			/* BAD */
 			match = 1;
 		}
 
@@ -817,7 +817,7 @@ static void pending_number(struct tm *tm, int *num)
 				tm->tm_year = number;
 			else if (number < 38)
 				tm->tm_year = 100 + number;
-			/* We screw up for number = 00 ? */
+			/* We mess up for number = 00 ? */
 		}
 	}
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -469,7 +469,7 @@ int git_indexer_stream_finalize(git_indexer_stream *idx, git_transfer_progress *
 
 	/* Test for this before resolve_deltas(), as it plays with idx->off */
 	if (idx->off < idx->pack->mwf.size - GIT_OID_RAWSZ) {
-		giterr_set(GITERR_INDEXER, "Indexing error: junk at the end of the pack");
+		giterr_set(GITERR_INDEXER, "Indexing error: unexpected data at the end of the pack");
 		return -1;
 	}
 

--- a/src/oid.c
+++ b/src/oid.c
@@ -293,7 +293,7 @@ void git_oid_shorten_free(git_oid_shorten *os)
  *	- Each normal node points to 16 children (one for each possible
  *	character in the oid). This is *not* stored in an array of
  *	pointers, because in a 64-bit arch this would be sucking
- *	16*sizeof(void*) = 128 bytes of memory per node, which is fucking
+ *	16*sizeof(void*) = 128 bytes of memory per node, which is
  *	insane. What we do is store Node Indexes, and use these indexes
  *	to look up each node in the om->index array. These indexes are
  *	signed shorts, so this limits the amount of unique OIDs that

--- a/src/pack.c
+++ b/src/pack.c
@@ -321,7 +321,7 @@ static int packfile_unpack_delta(
 	git__free(base.data);
 	git__free(delta.data);
 
-	/* TODO: we might want to cache this shit. eventually */
+	/* TODO: we might want to cache this. eventually */
 	//add_delta_base_cache(p, base_offset, base, base_size, *type);
 
 	return error; /* error set by git__delta_apply */


### PR DESCRIPTION
Remove words such as fuck, crap, shit etc.
Remove other potentially offensive words from comments.
Tidy up other geopolicital terms in comments.
