### PR TITLE
fix build on FreeBSD

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -18,6 +18,10 @@
 #	endif
 #endif
 
+#ifdef __FreeBSD__
+#	include <netinet/in.h>
+#endif
+
 #ifdef GIT_SSL
 # include <openssl/ssl.h>
 # include <openssl/err.h>


### PR DESCRIPTION
3f9eb1e introduced support for SSL certificates issued for IP
addresses, making use of in_addr and in_addr6 structs.  On FreeBSD
these are defined in (a file included in) <netinet/in.h>, so include
that file on FreeBSD and get the build working again.
