### PR TITLE
Fix diff header comments and missing const

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -285,7 +285,7 @@ static git_diff_list *git_diff_list_alloc(
 		goto fail;
 
 	if (diff->opts.flags & GIT_DIFF_REVERSE) {
-		char *swap = diff->opts.old_prefix;
+		const char *swap = diff->opts.old_prefix;
 		diff->opts.old_prefix = diff->opts.new_prefix;
 		diff->opts.new_prefix = swap;
 	}


### PR DESCRIPTION
Based on the recent work to wrap diff in objective-git, this includes a fix for a missing const and a number of clarifications of the documentation. There is still more work to be done on documentation, but I thought it wouldn't hurt to get this in.
