### PR TITLE
git_checkout_tree() always adds files to working tree even if not requested

### DIFF
--- a/tests-clar/checkout/tree.c
+++ b/tests-clar/checkout/tree.c
@@ -85,3 +85,23 @@ void test_checkout_tree__calls_progress_callback(void)
 
 	cl_assert_equal_i(was_called, true);
 }
+
+void test_checkout_tree__doesnt_write_unrequested_files_to_worktree(void)
+{
+  git_oid master_oid;
+  git_oid chomped_oid;
+  git_commit* p_master_commit;
+  git_commit* p_chomped_commit;
+  git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+
+  git_oid_fromstr(&master_oid, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
+  git_oid_fromstr(&chomped_oid, "e90810b8df3e80c413d903f631643c716887138d");
+  cl_git_pass(git_commit_lookup(&p_master_commit, g_repo, &master_oid));
+  cl_git_pass(git_commit_lookup(&p_chomped_commit, g_repo, &chomped_oid));
+
+  /* A GIT_CHECKOUT_DEFAULT checkout is not allowed to add any file to the
+   * working tree from the index as it is supposed to be a dry run. */
+  opts.checkout_strategy = GIT_CHECKOUT_DEFAULT;
+  git_checkout_tree(g_repo, (git_object*)p_chomped_commit, &opts);
+  cl_assert_equal_i(false, git_path_isfile("testrepo/readme.txt"));
+}


### PR DESCRIPTION
Hi there,

the docs for `git_checkout_tree()` state this: 

```
* By default, checkout is not allowed to modify any files.  Anything
* needing a change would be considered a conflict.
[...]
* GIT_CHECKOUT_UPDATE_MISSING means checkout can create a missing file
* that exists in the index and does not exist in the working directory.
```

Source: https://github.com/libgit2/libgit2/blob/development/include/git2/checkout.h#L37

Calling `git_checkout_tree()`with only the minimal argument of `GIT_CHECKOUT_DEFAULT` and not specifying `GIT_CHECKOUT_UPDATE_MISSING` at all however always adds files not present in the working directory, but in the checked-out tree to the working tree without any way to prevent this. 

This pull request defines a single failing testcase that demonstrates the behaviour. If this is really a bug and not some kind of misunderstanding, I can try my hands on it to fix it (but no guarantee I can work it out).

Valete,
Marvin
