### PR TITLE
tree cache: loosen negative entry count check

### DIFF
--- a/src/tree-cache.c
+++ b/src/tree-cache.c
@@ -104,7 +104,7 @@ static int read_tree_internal(git_tree_cache **out,
 	tree->name[name_len] = '\0';
 
 	/* Blank-terminated ASCII decimal number of entries in this tree */
-	if (git__strtol32(&count, buffer, &buffer, 10) < 0 || count < -1)
+	if (git__strtol32(&count, buffer, &buffer, 10) < 0)
 		goto corrupted;
 
 	tree->entries = count;


### PR DESCRIPTION
While C Git has been writing entry count -1 (ie. never other negative
numbers) as invalid since day 1, it accepts all negative entry counts
as invalid. JGit follows the same rule. libgit2 should also follow, or
the index that works with C Git or JGit may someday be rejected by
libgit2.

Other reimplementations like dulwich and grit have not bothered with
parsing or writing tree cache.
