### PR TITLE
Options structure for git_clone

### DIFF
--- a/examples/network/clone.c
+++ b/examples/network/clone.c
@@ -66,6 +66,7 @@ int do_clone(git_repository *repo, int argc, char **argv)
 {
 	progress_data pd;
 	git_repository *cloned_repo = NULL;
+	git_remote *origin;
 	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
 	git_checkout_opts checkout_opts = GIT_CHECKOUT_OPTS_INIT;
 	const char *url = argv[1];
@@ -87,23 +88,21 @@ int do_clone(git_repository *repo, int argc, char **argv)
 	checkout_opts.progress_payload = &pd;
 
 	// Create the origin remote, and set up for auth
-	error = git_remote_new(&clone_opts.origin_remote, NULL, "origin", url, GIT_REMOTE_DEFAULT_FETCH);
+	error = git_remote_new(&origin, NULL, "origin", url, GIT_REMOTE_DEFAULT_FETCH);
 	if (error != 0) {
 		const git_error *err = giterr_last();
 		if (err) printf("ERROR %d: %s\n", err->klass, err->message);
 		else printf("ERROR %d: no detailed info\n", error);
 		return error;
 	}
-	git_remote_set_cred_acquire_cb(clone_opts.origin_remote, cred_acquire, NULL);
+	git_remote_set_cred_acquire_cb(origin, cred_acquire, NULL);
 
 	// Do the clone
-	clone_opts.out = &cloned_repo;
-	clone_opts.local_path = path;
 	clone_opts.checkout_opts = &checkout_opts;
 	clone_opts.fetch_progress_cb = &fetch_progress;
 	clone_opts.fetch_progress_payload = &pd;
-	error = git_clone(&clone_opts);
-	git_remote_free(clone_opts.origin_remote);
+	error = git_clone(&cloned_repo, origin, path, &clone_opts);
+	git_remote_free(origin);
 	printf("\n");
 	if (error != 0) {
 		const git_error *err = giterr_last();

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -30,9 +30,6 @@ GIT_BEGIN_DECL
  *
  *		git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
  *
- * - `out` is a pointer that receives the resulting repository object
- * - `origin_remote` is a remote which will act as the initial fetch source
- * - `local_path` is local directory to clone into
  * - `bare` should be set to zero to create a standard repo, non-zero for
  *   a bare repo
  * - `fetch_progress_cb` is optional callback for fetch progress. Be aware that
@@ -46,9 +43,6 @@ GIT_BEGIN_DECL
 typedef struct git_clone_options {
 	unsigned int version;
 
-	git_repository **out;
-	git_remote *origin_remote;
-	const char *local_path;
 	int bare;
 	git_transfer_progress_callback fetch_progress_cb;
 	void *fetch_progress_payload;
@@ -62,11 +56,19 @@ typedef struct git_clone_options {
  * Clone a remote repository, and checkout the branch pointed to by the remote
  * HEAD.
  *
- * @param options configuration options for the clone
+ * @param out pointer that will receive the resulting repository object
+ * @param origin_remote a remote which will act as the initial fetch source
+ * @param local_path local directory to clone to
+ * @param options configuration options for the clone.  If NULL, the function
+ * works as though GIT_OPTIONS_INIT were passed.
  * @return 0 on success, GIT_ERROR otherwise (use giterr_last for information
  * about the error)
  */
-GIT_EXTERN(int) git_clone(git_clone_options *options);
+GIT_EXTERN(int) git_clone(
+		git_repository **out,
+		git_remote *origin,
+		const char *local_path,
+		const git_clone_options *options);
 
 /** @} */
 GIT_END_DECL

--- a/src/clone.c
+++ b/src/clone.c
@@ -355,16 +355,23 @@ static int clone_internal(
 	return retcode;
 }
 
-int git_clone(git_clone_options *options)
+int git_clone(
+	git_repository **out,
+	git_remote *origin,
+	const char *local_path,
+	const git_clone_options *options)
 {
-	assert(options && options->out && options->origin_remote && options->local_path);
+	git_clone_options dummy_options = GIT_CLONE_OPTIONS_INIT;
+
+	assert(out && origin && local_path);
+	if (!options) options = &dummy_options;
 
 	GITERR_CHECK_VERSION(options, GIT_CLONE_OPTIONS_VERSION, "git_clone_options");
 
 	return clone_internal(
-		options->out,
-		options->origin_remote,
-		options->local_path,
+		out,
+		origin,
+		local_path,
 		options->fetch_progress_cb,
 		options->fetch_progress_payload,
 		options->checkout_opts,

--- a/tests-clar/clone/nonetwork.c
+++ b/tests-clar/clone/nonetwork.c
@@ -6,6 +6,7 @@
 #define LIVE_REPO_URL "git://github.com/libgit2/TestGitRepository"
 
 static git_clone_options g_options;
+static git_remote *g_origin;
 static git_repository *g_repo;
 
 void test_clone_nonetwork__initialize(void)
@@ -14,14 +15,12 @@ void test_clone_nonetwork__initialize(void)
 
 	memset(&g_options, 0, sizeof(git_clone_options));
 	g_options.version = GIT_CLONE_OPTIONS_VERSION;
-	g_options.out = &g_repo;
-	g_options.local_path = "./foo";
-	cl_git_pass(git_remote_new(&g_options.origin_remote, NULL, "origin", cl_git_fixture_url("testrepo.git"), GIT_REMOTE_DEFAULT_FETCH));
+	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", cl_git_fixture_url("testrepo.git"), GIT_REMOTE_DEFAULT_FETCH));
 }
 
 void test_clone_nonetwork__cleanup(void)
 {
-	git_remote_free(g_options.origin_remote);
+	git_remote_free(g_origin);
 }
 
 static void cleanup_repository(void *path)
@@ -37,38 +36,38 @@ static void cleanup_repository(void *path)
 void test_clone_nonetwork__bad_url(void)
 {
 	/* Clone should clean up the mess if the URL isn't a git repository */
-	git_remote_free(g_options.origin_remote);
-	cl_git_pass(git_remote_new(&g_options.origin_remote, NULL, "origin", "not_a_repo", GIT_REMOTE_DEFAULT_FETCH));
+	git_remote_free(g_origin);
+	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", "not_a_repo", GIT_REMOTE_DEFAULT_FETCH));
 
-	cl_git_fail(git_clone(&g_options));
+	cl_git_fail(git_clone(&g_repo, g_origin, "./foo", &g_options));
 	cl_assert(!git_path_exists("./foo"));
 	g_options.bare = true;
-	cl_git_fail(git_clone(&g_options));
+	cl_git_fail(git_clone(&g_repo, g_origin, "./foo", &g_options));
 	cl_assert(!git_path_exists("./foo"));
 }
 
 void test_clone_nonetwork__local(void)
 {
 	cl_set_cleanup(&cleanup_repository, "./foo");
-	cl_git_pass(git_clone(&g_options));
+	cl_git_pass(git_clone(&g_repo, g_origin, "./foo", &g_options));
 }
 
 void test_clone_nonetwork__local_absolute_path(void)
 {
 	const char *local_src = cl_fixture("testrepo.git");
-	git_remote_free(g_options.origin_remote);
-	cl_git_pass(git_remote_new(&g_options.origin_remote, NULL, "origin", local_src, GIT_REMOTE_DEFAULT_FETCH));
+	git_remote_free(g_origin);
+	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", local_src, GIT_REMOTE_DEFAULT_FETCH));
 
 	cl_set_cleanup(&cleanup_repository, "./foo");
 
-	cl_git_pass(git_clone(&g_options));
+	cl_git_pass(git_clone(&g_repo, g_origin, "./foo", &g_options));
 }
 
 void test_clone_nonetwork__local_bare(void)
 {
 	cl_set_cleanup(&cleanup_repository, "./foo");
 	g_options.bare = true;
-	cl_git_pass(git_clone(&g_options));
+	cl_git_pass(git_clone(&g_repo, g_origin, "./foo", &g_options));
 }
 
 void test_clone_nonetwork__fail_when_the_target_is_a_file(void)
@@ -76,7 +75,7 @@ void test_clone_nonetwork__fail_when_the_target_is_a_file(void)
 	cl_set_cleanup(&cleanup_repository, "./foo");
 
 	cl_git_mkfile("./foo", "Bar!");
-	cl_git_fail(git_clone(&g_options));
+	cl_git_fail(git_clone(&g_repo, g_origin, "./foo", &g_options));
 }
 
 void test_clone_nonetwork__fail_with_already_existing_but_non_empty_directory(void)
@@ -85,5 +84,5 @@ void test_clone_nonetwork__fail_with_already_existing_but_non_empty_directory(vo
 
 	p_mkdir("./foo", GIT_DIR_MODE);
 	cl_git_mkfile("./foo/bar", "Baz!");
-	cl_git_fail(git_clone(&g_options));
+	cl_git_fail(git_clone(&g_repo, g_origin, "./foo", &g_options));
 }

--- a/tests-clar/fetchhead/network.c
+++ b/tests-clar/fetchhead/network.c
@@ -10,6 +10,7 @@ CL_IN_CATEGORY("network")
 #define LIVE_REPO_URL "git://github.com/libgit2/TestGitRepository"
 
 static git_repository *g_repo;
+static git_remote *g_origin;
 static git_clone_options g_options;
 
 void test_fetchhead_network__initialize(void)
@@ -18,14 +19,12 @@ void test_fetchhead_network__initialize(void)
 
 	memset(&g_options, 0, sizeof(git_clone_options));
 	g_options.version = GIT_CLONE_OPTIONS_VERSION;
-	g_options.out = &g_repo;
-	g_options.local_path = "./foo";
-	cl_git_pass(git_remote_new(&g_options.origin_remote, NULL, "origin", LIVE_REPO_URL, GIT_REMOTE_DEFAULT_FETCH));
+	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", LIVE_REPO_URL, GIT_REMOTE_DEFAULT_FETCH));
 }
 
 void test_fetchhead_network__cleanup(void)
 {
-	git_remote_free(g_options.origin_remote);
+	git_remote_free(g_origin);
 }
 
 static void cleanup_repository(void *path)
@@ -43,7 +42,7 @@ static void fetchhead_test_clone(void)
 {
 	cl_set_cleanup(&cleanup_repository, "./foo");
 
-	cl_git_pass(git_clone(&g_options));
+	cl_git_pass(git_clone(&g_repo, g_origin, "./foo", &g_options));
 }
 
 static void fetchhead_test_fetch(const char *fetchspec, const char *expected_fetchhead)

--- a/tests-clar/network/fetch.c
+++ b/tests-clar/network/fetch.c
@@ -87,15 +87,13 @@ void test_network_fetch__doesnt_retrieve_a_pack_when_the_repository_is_up_to_dat
 {
 	git_repository *_repository;
 	bool invoked = false;
-	git_remote *remote;
+	git_remote *remote, *origin;
 	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
 
-	opts.out = &_repository;
-	opts.local_path = "./fetch/lg2";
 	opts.bare = true;
-	cl_git_pass(git_remote_new(&opts.origin_remote, NULL, "origin", "https://github.com/libgit2/TestGitRepository.git", GIT_REMOTE_DEFAULT_FETCH));
+	cl_git_pass(git_remote_new(&origin, NULL, "origin", "https://github.com/libgit2/TestGitRepository.git", GIT_REMOTE_DEFAULT_FETCH));
 
-	cl_git_pass(git_clone(&opts));
+	cl_git_pass(git_clone(&_repository, origin, "./fetch/lg2", &opts));
 	git_repository_free(_repository);
 
 	cl_git_pass(git_repository_open(&_repository, "./fetch/lg2"));
@@ -113,6 +111,6 @@ void test_network_fetch__doesnt_retrieve_a_pack_when_the_repository_is_up_to_dat
 	git_remote_disconnect(remote);
 
 	git_remote_free(remote);
-	git_remote_free(opts.origin_remote);
+	git_remote_free(origin);
 	git_repository_free(_repository);
 }


### PR DESCRIPTION
In preparation for the argument explosion that will be triggered by #1142, this collapses all the parameters passed to `git_clone` into one options structure.  This avoids function-signature changes in the future, and allows us to preserve ABI compatibility even while adding things to the options struct. Also, it avoids this:

``` c
git_clone(&r, origin, "./foo", false, NULL, NULL, NULL, NULL, NULL, false, true, 0);
```

Currently, this is only preserving the current feature set. `git_clone_bare` disappeared into a boolean option.
