### PR TITLE
adding .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Vicent Martí <vicent@github.com> Vicent Marti <tanoku@gmail.com> 
+Vicent Martí <vicent@github.com> Vicent Martí <tanoku@gmail.com>
+Michael Schubert <schu@schu.io> schu <schu-github@schulog.org>


### PR DESCRIPTION
Help clarify who are the top commiters when using 'shortlog -sn'.
