### PR TITLE
Cleanup the empty-clone test correctly

### DIFF
--- a/tests-clar/clone/empty.c
+++ b/tests-clar/clone/empty.c
@@ -22,6 +22,7 @@ void test_clone_empty__initialize(void)
 void test_clone_empty__cleanup(void)
 {
 	git_remote_free(g_origin);
+	g_origin = NULL;
 	cl_git_sandbox_cleanup();
 }
 
@@ -35,6 +36,7 @@ void test_clone_empty__can_clone_an_empty_local_repo_barely(void)
 	cl_set_cleanup(&cleanup_repository, "./empty");
 
 	git_remote_free(g_origin);
+	g_origin = NULL;
 	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", "./empty_bare.git", GIT_REMOTE_DEFAULT_FETCH));
 
 	g_options.bare = true;
@@ -46,6 +48,7 @@ void test_clone_empty__can_clone_an_empty_local_repo(void)
 	cl_set_cleanup(&cleanup_repository, "./empty");
 
 	git_remote_free(g_origin);
+	g_origin = NULL;
 	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", "./empty_bare.git", GIT_REMOTE_DEFAULT_FETCH));
 
 	cl_git_pass(git_clone(&g_repo, g_origin, "./empty", &g_options));
@@ -56,9 +59,9 @@ void test_clone_empty__can_clone_an_empty_standard_repo(void)
 	cl_git_sandbox_cleanup();
 	g_repo = cl_git_sandbox_init("empty_standard_repo");
 	cl_git_remove_placeholders(git_repository_path(g_repo), "dummy-marker.txt");
-	git_repository_free(g_repo);
 
 	git_remote_free(g_origin);
+	g_origin = NULL;
 	cl_git_pass(git_remote_new(&g_origin, NULL, "origin", "./empty_standard_repo", GIT_REMOTE_DEFAULT_FETCH));
 
 	cl_set_cleanup(&cleanup_repository, "./empty");


### PR DESCRIPTION
The test in `clone/empty.c` currently fails to execute correctly. This is for 2 reasons:
a) It doesn't set a global state to "I have clean up", resulting in double deletions.
b) `cl_git_sandbox_init` doesn't increment the reference counter on the returned repository, thus freeing this pointer with `git_repository_free` brings the reference counting out of balance.

Compare recent [travis builds](https://travis-ci.org/libgit2/libgit2/jobs/3704156). Why does Travis mark these builds "green", when there are clearly visible segfaults?
