### PR TITLE
netops: on SSL teardown only send shutdown alert

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -198,10 +198,7 @@ static int gitno_ssl_teardown(gitno_ssl *ssl)
 {
 	int ret;
 
-	do {
-		ret = SSL_shutdown(ssl->ssl);
-	} while (ret == 0);
-
+	ret = SSL_shutdown(ssl->ssl);
 	if (ret < 0)
 		ret = ssl_set_error(ssl, ret);
 	else


### PR DESCRIPTION
I'm not sure about f2b00cb, but can't find any reason why the shutdown should fail. Am I missing something?

/cc @carlosmn
