### PR TITLE
RFC: Some cleanups/features in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,29 @@ FUNCTION(TARGET_OS_LIBRARIES target)
 	ENDIF()
 ENDFUNCTION()
 
+# For the MSVC IDE, this function splits up the source files like windows explorer does.
+# This is esp. useful with the libgit2_clar project, were usually 2 or more files share
+# the same name.
+# Sadly, this file grouping is a per-directory option in cmake and not per-target, resulting
+# in empty virtual folders "tests-clar" for the git2.dll
+FUNCTION(MSVC_SPLIT_SOURCES target)
+	IF(MSVC_IDE)
+		GET_TARGET_PROPERTY(sources ${target} SOURCES)
+		FOREACH(source ${sources})
+			IF(source MATCHES ".*/")
+				STRING(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" rel ${source})
+				IF(rel)
+					STRING(REGEX REPLACE "/([^/]*)$" "" rel ${rel})
+					IF(rel)
+						STRING(REPLACE "/" "\\\\" rel ${rel})
+						SOURCE_GROUP(${rel} FILES ${source})
+					ENDIF()
+				ENDIF()
+			ENDIF()
+		ENDFOREACH()
+	ENDIF()
+ENDFUNCTION()
+
 FILE(STRINGS "include/git2/version.h" GIT2_HEADER REGEX "^#define LIBGIT2_VERSION \"[^\"]*\"$")
 
 STRING(REGEX REPLACE "^.*LIBGIT2_VERSION \"([0-9]+).*$" "\\1" LIBGIT2_VERSION_MAJOR "${GIT2_HEADER}")
@@ -186,6 +209,8 @@ ADD_LIBRARY(git2 ${SRC_GIT2} ${SRC_OS} ${SRC_ZLIB} ${SRC_HTTP} ${SRC_REGEX} ${SR
 TARGET_LINK_LIBRARIES(git2 ${SSL_LIBRARIES})
 TARGET_OS_LIBRARIES(git2)
 
+MSVC_SPLIT_SOURCES(git2)
+
 SET_TARGET_PROPERTIES(git2 PROPERTIES VERSION ${LIBGIT2_VERSION_STRING})
 SET_TARGET_PROPERTIES(git2 PROPERTIES SOVERSION ${LIBGIT2_VERSION_MAJOR})
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libgit2.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libgit2.pc @ONLY)
@@ -229,6 +254,7 @@ IF (BUILD_CLAR)
 	ADD_EXECUTABLE(libgit2_clar ${SRC_GIT2} ${SRC_OS} ${CLAR_PATH}/clar_main.c ${SRC_TEST} ${SRC_ZLIB} ${SRC_HTTP} ${SRC_REGEX} ${SRC_SHA1})
 	TARGET_LINK_LIBRARIES(libgit2_clar ${SSL_LIBRARIES})
 	TARGET_OS_LIBRARIES(libgit2_clar)
+	MSVC_SPLIT_SOURCES(libgit2_clar)
 
         IF (MSVC_IDE)
            # Precompiled headers


### PR DESCRIPTION
I've done a few cleanups in the CMakeLists.txt file, because it contains a lot of duplication, out-dated stuff - and in general becomes more and more unreadable as time goes by. I'd like to have some feedback on this.

Changes are:
- Move all user-tweakable things to the top of the file, so they can be easier spotted.
- Try to explicitly state what implications the `STDCALL` - `/Gz` thingy brings (hopefully without revealing my personal opinon on that topic once more :innocent: )
- `src/compat` isn't a directory we have anymore in the source tree. Don't scan for it.
- Remove some duplication (Though there is still more)

And 2 new features:
- Scan for zlib on windows, too. This allows the user to give CMake a `-DZLIB_LIBRARIES=-l/foo/bar -DZLIB_INCLUDE_DIRS=/where/it/dwells` to circumvent our zlib-copy to get included if there is already another instance in the project.
- Teach CMake to group files in Visual Studio projects. It's a bit hard to navigate in the clar-tests when there are up to 5 files with the same name in just a flat list.
