### PR TITLE
Fix a leak in iterator code

### DIFF
--- a/src/diff.h
+++ b/src/diff.h
@@ -64,8 +64,8 @@ extern int git_diff__oid_for_file(
 extern int git_diff__from_iterators(
 	git_diff_list **diff_ptr,
 	git_repository *repo,
-	git_iterator *old_iter,
-	git_iterator *new_iter,
+	git_iterator **_old_iter,
+	git_iterator **_new_iter,
 	const git_diff_options *opts);
 
 #endif


### PR DESCRIPTION
The `git_diff__from_iterators` sometimes wraps the given iterators into case insensitively sorted ones. These wrapping iterators would free the wrapped iterators.
However, the call-site, the `DIFF_FROM_ITERATORS` macro doesn't know anything about the wrapping iterators, so it can just free the ones it had setup itself.

@arrbee Maybe you could find a nicer way to do this (Like not freeing the wrappee from the wrapper, but rather do it directly in `git_diff__from_iterators`). The `git_iterator**` that this patch uses looks odd somehow.
