### PR TITLE
Mark travis build as failed if any test fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ script:
  - cd _build
  - cmake .. -DCMAKE_INSTALL_PREFIX=../_install $OPTIONS
  - cmake --build . --target install
+ - ctest -V .
 
 # Run Tests
 after_script:
- - ctest -V .
  - if [ -f ./libgit2_clar ]; then valgrind --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -iall; else echo "Skipping valgrind"; fi
 
 # Only watch the development branch


### PR DESCRIPTION
According to [Travis docs](http://about.travis-ci.org/docs/user/build-configuration/#Build-Lifecycle), only the commands run by the `scripts` section are _allowed to mark the build as failed_.

Obviously, I couldn't test this, but it's straight forward according to the docs.
