### PR TITLE
Allow note overwrite

### DIFF
--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -76,6 +76,7 @@ GIT_EXTERN(const git_oid *) git_note_oid(const git_note *note);
  *					defaults to "refs/notes/commits"
  * @param oid OID of the git object to decorate
  * @param note Content of the note to add for object oid
+ * @param force Overwrite existing note
  *
  * @return 0 or an error code
  */
@@ -86,7 +87,8 @@ GIT_EXTERN(int) git_note_create(
 	const git_signature *committer,
 	const char *notes_ref,
 	const git_oid *oid,
-	const char *note);
+	const char *note,
+	int force);
 
 
 /**

--- a/src/notes.c
+++ b/src/notes.c
@@ -270,7 +270,8 @@ static int note_write(git_oid *out,
 	const char *note,
 	git_tree *commit_tree,
 	const char *target,
-	git_commit **parents)
+	git_commit **parents,
+	int allow_note_overwrite)
 {
 	int error;
 	git_oid oid;
@@ -283,7 +284,8 @@ static int note_write(git_oid *out,
 
 	if ((error = manipulate_note_in_tree_r(
 		&tree, repo, commit_tree, &oid, target, 0,
-		insert_note_in_tree_eexists_cb, insert_note_in_tree_enotfound_cb)) < 0)
+		allow_note_overwrite ? insert_note_in_tree_enotfound_cb : insert_note_in_tree_eexists_cb,
+		insert_note_in_tree_enotfound_cb)) < 0)
 		goto cleanup;
 
 	if (out)
@@ -449,7 +451,8 @@ int git_note_create(
 	const git_signature *committer,
 	const char *notes_ref,
 	const git_oid *oid,
-	const char *note)
+	const char *note,
+	int allow_note_overwrite)
 {
 	int error;
 	char *target = NULL;
@@ -465,7 +468,7 @@ int git_note_create(
 		goto cleanup;
 
 	error = note_write(out, repo, author, committer, notes_ref,
-			note, tree, target, &commit);
+			note, tree, target, &commit, allow_note_overwrite);
 
 cleanup:
 	git__free(target);

--- a/tests-clar/notes/notes.c
+++ b/tests-clar/notes/notes.c
@@ -34,7 +34,7 @@ static void create_note(git_oid *note_oid, const char *canonical_namespace, cons
 	git_oid oid;
 
 	cl_git_pass(git_oid_fromstr(&oid, target_sha));
-	cl_git_pass(git_note_create(note_oid, _repo, _sig, _sig, canonical_namespace, &oid, message));
+	cl_git_pass(git_note_create(note_oid, _repo, _sig, _sig, canonical_namespace, &oid, message, 0));
 }
 
 static struct {
@@ -194,14 +194,38 @@ void test_notes_notes__creating_a_note_on_a_target_which_already_has_one_returns
 	cl_git_pass(git_oid_fromstr(&target_oid, "08b041783f40edfe12bb406c9c9a8a040177c125"));
 
 	create_note(&note_oid, NULL, "08b041783f40edfe12bb406c9c9a8a040177c125", "hello world\n");
-	error = git_note_create(&note_oid, _repo, _sig, _sig, NULL, &target_oid, "hello world\n");
+	error = git_note_create(&note_oid, _repo, _sig, _sig, NULL, &target_oid, "hello world\n", 0);
 	cl_git_fail(error);
 	cl_assert_equal_i(GIT_EEXISTS, error);
 
 	create_note(&note_oid, "refs/notes/some/namespace", "08b041783f40edfe12bb406c9c9a8a040177c125", "hello world\n");
-	error = git_note_create(&note_oid, _repo, _sig, _sig, "refs/notes/some/namespace", &target_oid, "hello world\n");
+	error = git_note_create(&note_oid, _repo, _sig, _sig, "refs/notes/some/namespace", &target_oid, "hello world\n", 0);
 	cl_git_fail(error);
 	cl_assert_equal_i(GIT_EEXISTS, error);
+}
+
+
+void test_notes_notes__creating_a_note_on_a_target_can_overwrite_existing_note(void)
+{
+	git_oid note_oid, target_oid;
+	git_note *note, *namespace_note;
+
+	cl_git_pass(git_oid_fromstr(&target_oid, "08b041783f40edfe12bb406c9c9a8a040177c125"));
+
+	create_note(&note_oid, NULL, "08b041783f40edfe12bb406c9c9a8a040177c125", "hello old world\n");
+	cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, NULL, &target_oid, "hello new world\n", 1));
+
+	cl_git_pass(git_note_read(&note, _repo, NULL, &target_oid));
+	assert_note_equal(note, "hello new world\n", &note_oid);
+
+	create_note(&note_oid, "refs/notes/some/namespace", "08b041783f40edfe12bb406c9c9a8a040177c125", "hello old world\n");
+	cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, "refs/notes/some/namespace", &target_oid, "hello new ref world\n", 1));
+
+	cl_git_pass(git_note_read(&namespace_note, _repo, "refs/notes/some/namespace", &target_oid));
+	assert_note_equal(namespace_note, "hello new ref world\n", &note_oid);
+
+	git_note_free(note);
+	git_note_free(namespace_note);
 }
 
 static char *messages[] = {
@@ -244,7 +268,7 @@ void test_notes_notes__can_insert_a_note_in_an_existing_fanout(void)
 	cl_git_pass(git_oid_fromstr(&target_oid, "08b041783f40edfe12bb406c9c9a8a040177c125"));
 	
 	for (i = 0; i <  MESSAGES_COUNT; i++) {
-		cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, "refs/notes/fanout", &target_oid, messages[i]));
+		cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, "refs/notes/fanout", &target_oid, messages[i], 0));
 		cl_git_pass(git_note_read(&_note, _repo, "refs/notes/fanout", &target_oid));
 		git_note_free(_note);
 

--- a/tests-clar/notes/notesref.c
+++ b/tests-clar/notes/notesref.c
@@ -42,7 +42,7 @@ void test_notes_notesref__config_corenotesref(void)
 
 	cl_git_pass(git_config_set_string(_cfg, "core.notesRef", "refs/notes/mydefaultnotesref"));
 
-	cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, NULL, &oid, "test123test\n"));
+	cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, NULL, &oid, "test123test\n", 0));
 
 	cl_git_pass(git_note_read(&_note, _repo, NULL, &oid));
 	cl_assert(!strcmp(git_note_message(_note), "test123test\n"));


### PR DESCRIPTION
This adds the option to overwrite object's notes + a small trailing whitespace fix in notes.c

git_note_create now has an extra 'force' parameter similar to git_tag_create
