### PR TITLE
expose merge metadata cleanup

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -490,6 +490,15 @@ GIT_EXTERN(int) git_repository_message(char *out, size_t len, git_repository *re
  */
 GIT_EXTERN(int) git_repository_message_remove(git_repository *repo);
 
+/**
+ * Remove all the metadata associated with an ongoing git merge, including
+ * MERGE_HEAD, MERGE_MSG, etc.
+ *
+ * @param repo A repository object
+ * @return 0 on success, or error
+ */
+GIT_EXTERN(int) git_repository_merge_cleanup(git_repository *repo);
+
 typedef int (*git_repository_fetchhead_foreach_cb)(const char *ref_name,
 	const char *remote_url,
 	const git_oid *oid,

--- a/src/merge.c
+++ b/src/merge.c
@@ -15,7 +15,7 @@
 #include "git2/reset.h"
 #include "commit_list.h"
 
-int git_merge__cleanup(git_repository *repo)
+int git_repository_merge_cleanup(git_repository *repo)
 {
 	int error = 0;
 	git_buf merge_head_path = GIT_BUF_INIT,

--- a/src/merge.h
+++ b/src/merge.h
@@ -16,7 +16,6 @@
 
 #define MERGE_CONFIG_FILE_MODE	0666
 
-int git_merge__cleanup(git_repository *repo);
 int git_merge__bases_many(git_commit_list **out, git_revwalk *walk, git_commit_list_node *one, git_vector *twos);
 
 #endif

--- a/src/reset.c
+++ b/src/reset.c
@@ -126,7 +126,7 @@ int git_reset(
 		goto cleanup;
 	}
 
-	if ((error = git_merge__cleanup(repo)) < 0) {
+	if ((error = git_repository_merge_cleanup(repo)) < 0) {
 		giterr_set(GITERR_INDEX, "%s - Failed to clean up merge data.", ERROR_MSG);
 		goto cleanup;
 	}


### PR DESCRIPTION
expose functionality for consumers to remove the various files created by "git merge", eg: MERGE_MSG, MERGE_HEAD, etc.
