### PR TITLE
Add Brian Downing to the hall of fame

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Ankur Sethi
 Ben Noordhuis
 Ben Straub
 Benjamin C Meyer
+Brian Downing
 Brian Lopez
 Carlos Martín Nieto
 Colin Timmermans

--- a/git.git-authors
+++ b/git.git-authors
@@ -41,6 +41,7 @@
 ok	Adam Simpkins <adam@adamsimpkins.net> (http transport)
 ok	Andreas Ericsson <ae@op5.se>
 ok	Boyd Lynn Gerber <gerberb@zenez.com>
+ok	Brian Downing <bdowning@lavos.net>
 ok	Brian Gernhardt <benji@silverinsanity.com>
 ok	Christian Couder <chriscool@tuxfamily.org>
 ok	Daniel Barkalow <barkalow@iabervon.org>


### PR DESCRIPTION
Permission obtained from Brian Downing on Jan 02 2013 to use any of his core Git code in libgit2 licensed under GPLv2 with linking exception.  Adding him to the hall of fame.
