### PR TITLE
Inline convention

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -167,6 +167,3 @@ All inlined functions must be declared as:
 GIT_INLINE(result_type) git_modulename_functionname(arg_list);
 ```
 
-
-
-


### PR DESCRIPTION
Tell the folks not to use raw `static inline` and use `GIT_INLINE` in the conventions
