### PR TITLE
Handle packed refs with no trailing newline

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -373,7 +373,7 @@ static int packed_parse_oid(
 
 	refname_end = memchr(refname_begin, '\n', buffer_end - refname_begin);
 	if (refname_end == NULL)
-		goto corrupt;
+		refname_end = buffer_end;
 
 	if (refname_end[-1] == '\r')
 		refname_end--;


### PR DESCRIPTION
I saw a repo in the wild today which had a master branch ref which was packed, but had no trailing newline. Git handled it fine, but libgit2 choked on it. Fix seems simple enough. If we don't see a newline, assume the end of the buffer is the end of the ref line.
