### PR TITLE
travis: Only run Valgrind when all tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ script:
  - ctest -V .
 
 # Run Tests
-after_script:
- - if [ -f ./libgit2_clar ]; then valgrind --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -ionline; else echo "Skipping valgrind"; fi
+after_success:
+ - valgrind --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -ionline
 
 # Only watch the development branch
 branches:


### PR DESCRIPTION
According to the [documentation](http://about.travis-ci.org/docs/user/build-configuration/#Build-Lifecycle), `after_script` is always run whatever the build passed or not.

In order to prevent false positive leaks, make Valgrind run only upon a successful build, as an `after_success` step.
