### PR TITLE
Expose stock user/pass credential utility

### DIFF
--- a/include/git2/cred_helpers.h
+++ b/include/git2/cred_helpers.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_cred_helpers_h__
+#define INCLUDE_git_cred_helpers_h__
+
+#include "git2/transport.h"
+
+/**
+ * @file git2/cred_helpers.h
+ * @brief Utility functions for credential management
+ * @defgroup git_cred_helpers credential management helpers
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Payload for git_cred_stock_userpass_plaintext.
+ */
+typedef struct git_cred_userpass_payload {
+	char *username;
+	char *password;
+} git_cred_userpass_payload;
+
+
+/**
+ * Stock callback usable as a git_cred_acquire_cb.  This calls
+ * git_cred_userpass_plaintext_new unless the protocol has not specified
+ * GIT_CREDTYPE_USERPASS_PLAINTEXT as an allowed type.
+ *
+ * @param cred The newly created credential object.
+ * @param url The resource for which we are demanding a credential.
+ * @param allowed_types A bitmask stating which cred types are OK to return.
+ * @param payload The payload provided when specifying this callback.  (This is
+ *        interpreted as a `git_cred_userpass_payload*`.)
+ */
+GIT_EXTERN(int) git_cred_userpass(
+		git_cred **cred,
+		const char *url,
+		unsigned int allowed_types,
+		void *payload);
+
+
+/** @} */
+GIT_END_DECL
+#endif

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -61,32 +61,13 @@ GIT_EXTERN(int) git_cred_userpass_plaintext_new(
  * @param cred The newly created credential object.
  * @param url The resource for which we are demanding a credential.
  * @param allowed_types A bitmask stating which cred types are OK to return.
+ * @param payload The payload provided when specifying this callback.
  */
 typedef int (*git_cred_acquire_cb)(
 	git_cred **cred,
 	const char *url,
 	unsigned int allowed_types,
 	void *payload);
-
-/**
- * Payload for git_cred_stock_userpass_plaintext.
- */
-typedef struct git_cred_stock_userpass_plaintext_payload {
-	char *username;
-	char *password;
-} git_cred_stock_userpass_plaintext_payload;
-
-
-/**
- * Stock callback usable as a git_cred_acquire_cb.  This calls
- * git_cred_userpass_plaintext_new unless the protocol has not specified
- * GIT_CREDTYPE_USERPASS_PLAINTEXT as an allowed type.
- */
-GIT_EXTERN(int) git_cred_stock_userpass_plaintext(
-		git_cred **cred,
-		const char *url,
-		unsigned int allowed_types,
-		void *payload);
 
 /*
  *** End interface for credentials acquisition ***

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -7,6 +7,7 @@
 
 #include "git2.h"
 #include "smart.h"
+#include "git2/cred_helpers.h"
 
 static void plaintext_free(struct git_cred *cred)
 {
@@ -55,25 +56,5 @@ int git_cred_userpass_plaintext_new(
 	}
 
 	*cred = &c->parent;
-	return 0;
-}
-
-int git_cred_stock_userpass_plaintext(
-		git_cred **cred,
-		const char *url,
-		unsigned int allowed_types,
-		void *payload)
-{
-	git_cred_stock_userpass_plaintext_payload *userpass = 
-		(git_cred_stock_userpass_plaintext_payload*)payload;
-
-	GIT_UNUSED(url);
-
-	if (!userpass || !userpass->username || !userpass->password) return -1;
-
-	if ((GIT_CREDTYPE_USERPASS_PLAINTEXT & allowed_types) == 0 ||
-			git_cred_userpass_plaintext_new(cred, userpass->username, userpass->password) < 0)
-		return -1;
-
 	return 0;
 }

--- a/src/transports/cred_helpers.c
+++ b/src/transports/cred_helpers.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "git2/cred_helpers.h"
+
+int git_cred_userpass(
+		git_cred **cred,
+		const char *url,
+		unsigned int allowed_types,
+		void *payload)
+{
+	git_cred_userpass_payload *userpass = (git_cred_userpass_payload*)payload;
+
+	GIT_UNUSED(url);
+
+	if (!userpass || !userpass->username || !userpass->password) return -1;
+
+	if ((GIT_CREDTYPE_USERPASS_PLAINTEXT & allowed_types) == 0 ||
+			git_cred_userpass_plaintext_new(cred, userpass->username, userpass->password) < 0)
+		return -1;
+
+	return 0;
+}

--- a/tests-clar/network/cred.c
+++ b/tests-clar/network/cred.c
@@ -1,27 +1,27 @@
 #include "clar_libgit2.h"
 
-#include "git2/transport.h"
+#include "git2/cred_helpers.h"
 
 void test_network_cred__stock_userpass_validates_args(void)
 {
-	git_cred_stock_userpass_plaintext_payload payload = {0};
+	git_cred_userpass_payload payload = {0};
 
-	cl_git_fail(git_cred_stock_userpass_plaintext(NULL, NULL, 0, NULL));
+	cl_git_fail(git_cred_userpass(NULL, NULL, 0, NULL));
 
 	payload.username = "user";
-	cl_git_fail(git_cred_stock_userpass_plaintext(NULL, NULL, 0, &payload));
+	cl_git_fail(git_cred_userpass(NULL, NULL, 0, &payload));
 
 	payload.username = NULL;
 	payload.username = "pass";
-	cl_git_fail(git_cred_stock_userpass_plaintext(NULL, NULL, 0, &payload));
+	cl_git_fail(git_cred_userpass(NULL, NULL, 0, &payload));
 }
 
 void test_network_cred__stock_userpass_validates_that_method_is_allowed(void)
 {
 	git_cred *cred;
-	git_cred_stock_userpass_plaintext_payload payload = {"user", "pass"};
+	git_cred_userpass_payload payload = {"user", "pass"};
 
-	cl_git_fail(git_cred_stock_userpass_plaintext(&cred, NULL, 0, &payload));
-	cl_git_pass(git_cred_stock_userpass_plaintext(&cred, NULL, GIT_CREDTYPE_USERPASS_PLAINTEXT, &payload));
+	cl_git_fail(git_cred_userpass(&cred, NULL, 0, &payload));
+	cl_git_pass(git_cred_userpass(&cred, NULL, GIT_CREDTYPE_USERPASS_PLAINTEXT, &payload));
 	git__free(cred);
 }

--- a/tests-clar/online/clone.c
+++ b/tests-clar/online/clone.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 
 #include "git2/clone.h"
+#include "git2/cred_helpers.h"
 #include "repository.h"
 
 #define LIVE_REPO_URL "http://github.com/libgit2/TestGitRepository"
@@ -138,14 +139,14 @@ void test_online_clone__credentials(void)
 {
 	/* Remote URL environment variable must be set.  User and password are optional.  */
 	const char *remote_url = cl_getenv("GITTEST_REMOTE_URL");
-	git_cred_stock_userpass_plaintext_payload user_pass = {
+	git_cred_userpass_payload user_pass = {
 		cl_getenv("GITTEST_REMOTE_USER"),
 		cl_getenv("GITTEST_REMOTE_PASS")
 	};
 
 	if (!remote_url) return;
 
-	g_options.cred_acquire_cb = git_cred_stock_userpass_plaintext;
+	g_options.cred_acquire_cb = git_cred_userpass;
 	g_options.cred_acquire_payload = &user_pass;
 
 	cl_git_pass(git_clone(&g_repo, remote_url, "./foo", &g_options));


### PR DESCRIPTION
Populating a `git_cred **` from managed code in libgit2sharp is hard. Let's go shopping!

This PR takes a function that was used for the clar tests, bullet-proofs it a bit, and exposes it as a stock authentication method usable as a `git_cred_acquire_cb`. 

_[Also, a couple of the online clone tests weren't renamed when clar 2.0 happened. Ssh.]_
