### PR TITLE
Resolve crash with diff against empty file

### DIFF
--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -376,6 +376,9 @@ static int get_workdir_content(
 			goto close_and_cleanup;
 
 		if (error == 0) { /* note: git_filters_load returns filter count */
+			if (!file->size)
+				goto close_and_cleanup;
+
 			error = git_futils_mmap_ro(map, fd, 0, (size_t)file->size);
 			file->flags |= GIT_DIFF_FILE_UNMAP_DATA;
 		} else {

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -121,7 +121,7 @@ mode_t git_futils_canonical_mode(mode_t raw_mode)
 
 int git_futils_readbuffer_fd(git_buf *buf, git_file fd, size_t len)
 {
-	ssize_t read_size;
+	ssize_t read_size = 0;
 
 	git_buf_clear(buf);
 


### PR DESCRIPTION
It is not legal inside our `p_mmap` function to mmap a zero length file.  This adds a test that exercises that case inside diff and fixes the code path where we would try to do that.

The fix turns out not to be a lot of code since our default file content is already initialized to `""` which works in this case.

Fixes #1210
