### PR TITLE
Don't call pthread_exit() in the callback of the fetch example

### DIFF
--- a/examples/network/fetch.c
+++ b/examples/network/fetch.c
@@ -42,7 +42,7 @@ static void *download(void *ptr)
 
 exit:
 	data->finished = 1;
-	pthread_exit(&data->ret);
+	return &data->ret;
 }
 
 static int update_cb(const char *refname, const git_oid *a, const git_oid *b, void *data)


### PR DESCRIPTION
Compilers that are not aware that pthread_exit() does not return
issue a warning when compiling the present code. This change
exchanges the call to pthread_exit() with a simple return
statement. According to the pthread specification this is
equivalent.
