### PR TITLE
Add GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -131,6 +131,9 @@ typedef enum {
 	/** Don't refresh index/config/etc before doing checkout */
 	GIT_CHECKOUT_NO_REFRESH = (1u << 9),
 
+	/** Treat pathspec as simple list of exact match file paths */
+	GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH = (1u << 13),
+
 	/**
 	 * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
 	 */
@@ -222,7 +225,8 @@ typedef struct git_checkout_opts {
 	void *progress_payload;
 
 	/** When not zeroed out, array of fnmatch patterns specifying which
-	 *  paths should be taken into account, otherwise all files.
+	 *  paths should be taken into account, otherwise all files.  Use
+	 *  GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH to treat as simple list.
 	 */
 	git_strarray paths;
 

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -222,7 +222,9 @@ static int checkout_action_wd_only(
 	git_checkout_notify_t notify = GIT_CHECKOUT_NOTIFY_NONE;
 
 	if (!git_pathspec_match_path(
-			pathspec, wd->path, false, workdir->ignore_case))
+			pathspec, wd->path,
+			(data->strategy & GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH) != 0,
+			workdir->ignore_case))
 		return 0;
 
 	/* check if item is tracked in the index but not in the checkout diff */
@@ -1209,6 +1211,8 @@ int git_checkout_iterator(
 		GIT_DIFF_INCLUDE_TYPECHANGE |
 		GIT_DIFF_INCLUDE_TYPECHANGE_TREES |
 		GIT_DIFF_SKIP_BINARY_CHECK;
+	if (data.opts.checkout_strategy & GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH)
+		diff_opts.flags |= GIT_DIFF_DISABLE_PATHSPEC_MATCH;
 	if (data.opts.paths.count > 0)
 		diff_opts.pathspec = data.opts.paths;
 


### PR DESCRIPTION
This adds an option to checkout a la the diff option to turn off fnmatch evaluation for pathspec entries.  This can be useful to make sure your "pattern" in really interpreted as an exact file match only.

This fixes issue #1217
