### PR TITLE
Fix diff patch line number calculation

### DIFF
--- a/src/diff_output.h
+++ b/src/diff_output.h
@@ -72,6 +72,7 @@ struct git_diff_patch {
 	size_t hunks_asize, hunks_size;
 	diff_patch_line *lines;
 	size_t lines_asize, lines_size;
+	size_t oldno, newno;
 };
 
 /* context for performing diff on a single delta */


### PR DESCRIPTION
This was just being calculated wrong.  Added a test that verifying patch line numbers even for hunks further into a file and then fixed the algorithm.  I needed to add a little extra state into the patch so that I could track old and new file numbers independently, but it should be okay.

This should fix #1225
