### PR TITLE
Add p_strnlen wrapper and mingw implementation

### DIFF
--- a/src/buf_text.c
+++ b/src/buf_text.c
@@ -5,6 +5,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 #include "buf_text.h"
+#include "posix.h"
 
 int git_buf_text_puts_escaped(
 	git_buf *buf,
@@ -111,7 +112,7 @@ bool git_buf_text_is_binary(const git_buf *buf)
 
 bool git_buf_text_contains_nul(const git_buf *buf)
 {
-	return (strnlen(buf->ptr, buf->size) != buf->size);
+	return (p_strnlen(buf->ptr, buf->size) != buf->size);
 }
 
 int git_buf_text_detect_bom(git_bom_t *bom, const git_buf *buf, size_t offset)

--- a/src/posix.h
+++ b/src/posix.h
@@ -91,6 +91,10 @@ extern int p_gettimeofday(struct timeval *tv, struct timezone *tz);
 #	include "unix/posix.h"
 #endif
 
+#ifndef __MINGW32__
+#define p_strnlen strnlen
+#endif
+
 #ifdef NO_READDIR_R
 #	include <dirent.h>
 GIT_INLINE(int) p_readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result)

--- a/src/win32/mingw-compat.h
+++ b/src/win32/mingw-compat.h
@@ -19,6 +19,13 @@
 # define S_IFLNK _S_IFLNK
 # define S_ISLNK(m) (((m) & _S_IFMT) == _S_IFLNK)
 
+GIT_INLINE(size_t) p_strnlen(const char *s, size_t maxlen)
+{
+	size_t ct;
+	for (ct = 0; ct < maxlen && *s; ++s) ++ct;
+	return ct;
+}
+
 #endif
 
 #endif /* INCLUDE_mingw_compat__ */


### PR DESCRIPTION
Apparently MinGW can't be bothered to support POSIX `strnlen` so this adds a `p_strnlen` wrapper which is a `#define` on all platforms except on MinGW. Also, this has a quick little MinGW implementation for `p_strnlen()` which should get the job done.
