### PR TITLE
Introduce git_branch_tracking_name()

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -158,6 +158,30 @@ GIT_EXTERN(int) git_branch_tracking(
 		git_reference *branch);
 
 /**
+ * Return the name of the reference supporting the remote tracking branch,
+ * given the name of a local branch reference.
+ *
+ * @param tracking_branch_name_out The user-allocated buffer which will be
+ *     filled with the name of the reference. Pass NULL if you just want to
+ *     get the needed size of the name of the reference as the output value.
+ *
+ * @param buffer_size Size of the `out` buffer in bytes.
+ *
+ * @param repo the repository where the branches live
+ *
+ * @param canonical_branch_name name of the local branch.
+ *
+ * @return number of characters in the reference name
+ *     including the trailing NUL byte; GIT_ENOTFOUND when no remote tracking
+ *     reference exists, otherwise an error code.
+ */
+GIT_EXTERN(int) git_branch_tracking_name(
+	char *tracking_branch_name_out,
+	size_t buffer_size,
+	git_repository *repo,
+	const char *canonical_branch_name);
+
+/**
  * Determine if the current local branch is pointed at by HEAD.
  *
  * @param branch Current underlying reference of the branch.

--- a/src/branch.h
+++ b/src/branch.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_branch_h__
+#define INCLUDE_branch_h__
+
+#include "buffer.h"
+
+int git_branch_tracking__name(
+	git_buf *tracking_name,
+	git_repository *repo,
+	const char *canonical_branch_name);
+
+#endif

--- a/src/refs.c
+++ b/src/refs.c
@@ -1905,10 +1905,15 @@ int git_reference_has_log(
 	return result;
 }
 
+int git_reference__is_branch(const char *ref_name)
+{
+	return git__prefixcmp(ref_name, GIT_REFS_HEADS_DIR) == 0;
+}
+
 int git_reference_is_branch(git_reference *ref)
 {
 	assert(ref);
-	return git__prefixcmp(ref->name, GIT_REFS_HEADS_DIR) == 0;
+	return git_reference__is_branch(ref->name);
 }
 
 int git_reference_is_remote(git_reference *ref)

--- a/src/refs.h
+++ b/src/refs.h
@@ -69,6 +69,7 @@ int git_reference__normalize_name_lax(char *buffer_out, size_t out_size, const c
 int git_reference__normalize_name(git_buf *buf, const char *name, unsigned int flags);
 int git_reference__is_valid_name(const char *refname, unsigned int flags);
 int git_reference__update(git_repository *repo, const git_oid *oid, const char *ref_name);
+int git_reference__is_branch(const char *ref_name);
 
 /**
  * Lookup a reference by name and try to resolve to an OID.

--- a/tests-clar/clone/empty.c
+++ b/tests-clar/clone/empty.c
@@ -33,10 +33,21 @@ static void cleanup_repository(void *path)
 
 void test_clone_empty__can_clone_an_empty_local_repo_barely(void)
 {
+	char *local_name = "refs/heads/master";
+	char tracking_name[1024];
+	git_reference *ref;
+
 	cl_set_cleanup(&cleanup_repository, "./empty");
 
 	g_options.bare = true;
 	cl_git_pass(git_clone(&g_repo_cloned, "./empty_bare.git", "./empty", &g_options));
+
+	/* Although the HEAD is orphaned... */
+	cl_assert_equal_i(GIT_ENOTFOUND, git_reference_lookup(&ref, g_repo_cloned, local_name));
+
+	/* ...one can still retrieve the name of the remote tracking reference */
+	cl_assert_equal_i(strlen("refs/remotes/origin/master") + 1, 
+		git_branch_tracking_name(tracking_name, 1024, g_repo_cloned, local_name));
 }
 
 void test_clone_empty__can_clone_an_empty_local_repo(void)

--- a/tests-clar/refs/branches/trackingname.c
+++ b/tests-clar/refs/branches/trackingname.c
@@ -1,0 +1,42 @@
+#include "clar_libgit2.h"
+#include "branch.h"
+
+static git_repository *repo;
+static git_buf tracking_name;
+
+void test_refs_branches_trackingname__initialize(void)
+{
+	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
+
+	git_buf_init(&tracking_name, 0);
+}
+
+void test_refs_branches_trackingname__cleanup(void)
+{
+	git_buf_free(&tracking_name);
+
+	git_repository_free(repo);
+	repo = NULL;
+}
+
+void test_refs_branches_trackingname__can_retrieve_the_remote_tracking_reference_name_of_a_local_branch(void)
+{
+	cl_git_pass(git_branch_tracking__name(
+		&tracking_name, repo, "refs/heads/master"));
+
+	cl_assert_equal_s("refs/remotes/test/master", git_buf_cstr(&tracking_name));
+}
+
+void test_refs_branches_trackingname__can_retrieve_the_local_tracking_reference_name_of_a_local_branch(void)
+{
+	cl_git_pass(git_branch_tracking__name(
+		&tracking_name, repo, "refs/heads/track-local"));
+
+	cl_assert_equal_s("refs/heads/master", git_buf_cstr(&tracking_name));
+}
+
+void test_refs_branches_trackingname__can_return_the_size_of_thelocal_tracking_reference_name_of_a_local_branch(void)
+{
+	cl_assert_equal_i(strlen("refs/heads/master") + 1,
+		git_branch_tracking_name(NULL, 0, repo, "refs/heads/track-local"));
+}


### PR DESCRIPTION
This is an attempt to fix libgit2/libgit2sharp#276.

The current API `git_branch_tracking` only accepts concrete `git_reference`s which can't be produced if the reference doesn't exist yet.

This should help retrieving remote and local tracking branches from orphaned references through exposing text based only refspec transformation.
