### PR TITLE
Update remote tips on push

### DIFF
--- a/include/git2/push.h
+++ b/include/git2/push.h
@@ -39,6 +39,15 @@ GIT_EXTERN(int) git_push_new(git_push **out, git_remote *remote);
 GIT_EXTERN(int) git_push_add_refspec(git_push *push, const char *refspec);
 
 /**
+ * Update remote tips after a push
+ *
+ * @param push The push object
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_push_update_tips(git_push *push);
+
+/**
  * Actually push all given refspecs
  *
  * @param push The push object


### PR DESCRIPTION
This PR is to expose a function to update the client's remote tips after on a push operation. This is to handle the issue raised in #1179.

This takes some if the ideas from that discussion, but does not implement this in the `git_remote_update_tips` function.

The general algorithm here is to 

```
for each push_status
    find the corresponding remote ref that was updated (mapping done through the fetch spec)
    find corresponding push ref spec
    update the remote reference with the loid of the push spec (local / source id of the push ref spec)
```

The testing code might still need some polish, but I was hoping for some feedback on the overall algorithm.

/cc @carlosmn, @schu
