### PR TITLE
escape non-utf8 char

### DIFF
--- a/tests-clar/core/env.c
+++ b/tests-clar/core/env.c
@@ -21,7 +21,7 @@ static char *home_values[] = {
 	"fακε_hοmέ",  /* having fun with greek */
 	"faงe_นome", /* now I have no idea, but thai characters */
 	"f\xe1\x9cx80ke_\xe1\x9c\x91ome", /* tagalog characters */
-	"\xe1\xb8\x9fẢke_hoṁe", /* latin extended additional */
+	"\xe1\xb8\x9fẢke_ho�\x81" "e", /* latin extended additional */
 	"\xf0\x9f\x98\x98\xf0\x9f\x98\x82", /* emoticons */
 	NULL
 };


### PR DESCRIPTION
Escape non-utf8 char in the test.  

Caused python3 to fail miserably:

```
3>  Traceback (most recent call last):
3>    File "generate.py", line 235, in <module>
3>      suite.load(options.force)
3>    File "generate.py", line 180, in load
3>      if not self.modules[name].refresh(path):
3>    File "generate.py", line 117, in refresh
3>      raw_content = fp.read()
3>    File "C:\Program Files\Python33\lib\encodings\cp1252.py", line 23, in decode
3>      return codecs.charmap_decode(input,self.errors,decoding_table)[0]
3>  UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 656: character maps to <undefined>
3>C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V110\Microsoft.CppCommon.targets(172,5): error MSB6006: "cmd.exe" exited with code 1.
```
