### PR TITLE
Move all non-ascii test data to raw hex

### DIFF
--- a/tests-clar/core/env.c
+++ b/tests-clar/core/env.c
@@ -16,12 +16,12 @@ static char *env_save[NUM_VARS];
 
 static char *home_values[] = {
 	"fake_home",
-	"fáke_hõme", /* all in latin-1 supplement */
-	"fĀke_Ĥome", /* latin extended */
-	"fακε_hοmέ",  /* having fun with greek */
-	"faงe_นome", /* now I have no idea, but thai characters */
+	"f\xc3\xa1ke_h\xc3\xb5me", /* all in latin-1 supplement */
+	"f\xc4\x80ke_\xc4\xa4ome", /* latin extended */
+	"f\xce\xb1\xce\xba\xce\xb5_h\xce\xbfm\xce\xad",  /* having fun with greek */
+	"fa\xe0" "\xb8" "\x87" "e_\xe0" "\xb8" "\x99" "ome", /* thai characters */
 	"f\xe1\x9cx80ke_\xe1\x9c\x91ome", /* tagalog characters */
-	"\xe1\xb8\x9fẢke_hoṁe", /* latin extended additional */
+	"\xe1\xb8\x9f\xe1\xba\xa2" "ke_ho" "\xe1" "\xb9" "\x81" "e", /* latin extended additional */
 	"\xf0\x9f\x98\x98\xf0\x9f\x98\x82", /* emoticons */
 	NULL
 };


### PR DESCRIPTION
This takes all of the characters in `core::env` and makes them use hex sequences instead of keeping tricky character data inline in the test.
