### PR TITLE
WIP - graph: make ahead_behind() detect and return a potential common ancestor

### DIFF
--- a/include/git2/graph.h
+++ b/include/git2/graph.h
@@ -23,13 +23,25 @@ GIT_BEGIN_DECL
 /**
  * Count the number of unique commits between two commit objects
  *
- * @param ahead number of commits, starting at `one`, unique from commits in `two`
- * @param behind number of commits, starting at `two`, unique from commits in `one`
+ * @param ahead_out number of commits, starting at `one`, unique from commits
+ *			in `two`
+ * @param behind_out number of commits, starting at `two`, unique from commits
+ *			in `one`
+ * @param common_ancestor_out oid of the found common ancestor; Zero oid if no
+ *			common ancestor has been found. Use `git_oid_iszero()` to check
+ *			the content of the oid.
  * @param repo the repository where the commits exist
  * @param one one of the commits
  * @param two the other commit
+ * @return 0 on success or -1 on error
  */
-GIT_EXTERN(int) git_graph_ahead_behind(size_t *ahead, size_t *behind, git_repository *repo, const git_oid *one, const git_oid *two);
+GIT_EXTERN(int) git_graph_ahead_behind(
+	size_t *ahead_out,
+	size_t *behind_out,
+	git_oid *common_ancestor_out,
+	git_repository *repo,
+	const git_oid *one,
+	const git_oid *two);
 
 /** @} */
 GIT_END_DECL


### PR DESCRIPTION
Beside being handy to display the `ahead_by` and `behind_by` counts of two branches, this should help indicate if they share a common ancestor.