### PR TITLE
Parse commit time as uint64_t to avoid overflow

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -241,15 +241,15 @@ static const char *scan_for_previous_token(const char *buffer, const char *left_
 
 static int parse_time(git_time_t *time_out, const char *buffer)
 {
-	int time;
 	int error;
+	int64_t time;
 
 	if (*buffer == '+' || *buffer == '-') {
 		giterr_set(GITERR_INVALID, "Failed while parsing time. '%s' actually looks like a timezone offset.", buffer);
 		return -1;
 	}
 
-	error = git__strtol32(&time, buffer, &buffer, 10);
+	error = git__strtol64(&time, buffer, &buffer, 10);
 
 	if (!error)
 		*time_out = (git_time_t)time;

--- a/tests-clar/commit/parse.c
+++ b/tests-clar/commit/parse.c
@@ -121,6 +121,14 @@ passing_signature_test_case passing_signature_cases[] = {
 	{"author A U Thor <author@example.com> and others 1234567890 -0700\n", "author ", "A U Thor", "author@example.com", 1234567890, -420},
 	{"author A U Thor <author@example.com> and others 1234567890\n", "author ", "A U Thor", "author@example.com", 1234567890, 0},
 	{"author A U Thor> <author@example.com> and others 1234567890\n", "author ", "A U Thor>", "author@example.com", 1234567890, 0},
+	/* a variety of dates */
+	{"author Vicent Marti <tanoku@gmail.com> 0 \n", "author ", "Vicent Marti", "tanoku@gmail.com", 0, 0},
+	{"author Vicent Marti <tanoku@gmail.com> 1234567890 \n", "author ", "Vicent Marti", "tanoku@gmail.com", 1234567890, 0},
+	{"author Vicent Marti <tanoku@gmail.com> 2147483647 \n", "author ", "Vicent Marti", "tanoku@gmail.com", 0x7fffffff, 0},
+	{"author Vicent Marti <tanoku@gmail.com> 4294967295 \n", "author ", "Vicent Marti", "tanoku@gmail.com", 0xffffffff, 0},
+	{"author Vicent Marti <tanoku@gmail.com> 4294967296 \n", "author ", "Vicent Marti", "tanoku@gmail.com", 4294967296, 0},
+	{"author Vicent Marti <tanoku@gmail.com> 8589934592 \n", "author ", "Vicent Marti", "tanoku@gmail.com", 8589934592, 0},
+
    {NULL,NULL,NULL,NULL,0,0}
 };
 


### PR DESCRIPTION
The commit time is already stored as a `git_time_t`, but we were parsing it as a `uint32_t`.  This just switches the parser to use `uint64_t` which will handle dates further in the future (and adds some tests of those future dates).

This should fix #1263
