### PR TITLE
Handle packed peeled objects without trailing newlines

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -328,7 +328,7 @@ static int packed_parse_peel(
 	if (git__prefixcmp(tag_ref->name, GIT_REFS_TAGS_DIR) != 0)
 		goto corrupt;
 
-	if (buffer + GIT_OID_HEXSZ >= buffer_end)
+	if (buffer + GIT_OID_HEXSZ > buffer_end)
 		goto corrupt;
 
 	/* Is this a valid object id? */
@@ -339,10 +339,13 @@ static int packed_parse_peel(
 	if (*buffer == '\r')
 		buffer++;
 
-	if (*buffer != '\n')
+	if (*buffer == '\n')
+		buffer++;
+
+	if (buffer != buffer_end)
 		goto corrupt;
 
-	*buffer_out = buffer + 1;
+	*buffer_out = buffer;
 	return 0;
 
 corrupt:


### PR DESCRIPTION
Fixes #1262
