### PR TITLE
Add git_branch_name()

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -142,6 +142,24 @@ GIT_EXTERN(int) git_branch_lookup(
 		git_branch_t branch_type);
 
 /**
+ * Return the name of the given local or remote branch.
+ *
+ * The name of the branch matches the definition of the name
+ * for git_branch_lookup. That is, if the returned name is given
+ * to git_branch_lookup() then the reference is returned that
+ * was given to this function.
+ *
+ * @param out where the pointer of branch name is stored;
+ * this is valid as long as the ref is not freed.
+ * @param ref the reference ideally pointing to a branch
+ *
+ * @return 0 on success; otherwise an error code (e.g., if the
+ *  ref is no local or remote branch).
+ */
+GIT_EXTERN(int) git_branch_name(const char **out,
+		git_reference *ref);
+
+/**
  * Return the reference supporting the remote tracking branch,
  * given a local branch reference.
  *

--- a/src/branch.c
+++ b/src/branch.c
@@ -221,6 +221,27 @@ int git_branch_lookup(
 	return retrieve_branch_reference(ref_out, repo, branch_name, branch_type == GIT_BRANCH_REMOTE);
 }
 
+int git_branch_name(const char **out, git_reference *ref)
+{
+	const char *branch_name;
+
+	assert(out && ref);
+
+	branch_name = ref->name;
+
+	if (git_reference_is_branch(ref)) {
+		branch_name += strlen(GIT_REFS_HEADS_DIR);
+	} else if (git_reference_is_remote(ref)) {
+		branch_name += strlen(GIT_REFS_REMOTES_DIR);
+	} else {
+		giterr_set(GITERR_INVALID,
+				"Reference '%s' is neither a local nor a remote branch.", ref->name);
+		return -1;
+	}
+	*out = branch_name;
+	return 0;
+}
+
 static int retrieve_tracking_configuration(
 	const char **out,
 	git_repository *repo,

--- a/tests-clar/refs/branches/name.c
+++ b/tests-clar/refs/branches/name.c
@@ -1,0 +1,45 @@
+#include "clar_libgit2.h"
+#include "branch.h"
+
+static git_repository *repo;
+static git_reference *ref;
+
+void test_refs_branches_name__initialize(void)
+{
+	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
+}
+
+void test_refs_branches_name__cleanup(void)
+{
+	git_reference_free(ref);
+	ref = NULL;
+
+	git_repository_free(repo);
+	repo = NULL;
+}
+
+void test_refs_branches_name__can_get_local_branch_name(void)
+{
+	const char *name;
+
+	cl_git_pass(git_branch_lookup(&ref,repo,"master",GIT_BRANCH_LOCAL));
+	cl_git_pass(git_branch_name(&name,ref));
+	cl_assert_equal_s("master",name);
+}
+
+void test_refs_branches_name__can_get_remote_branch_name(void)
+{
+	const char *name;
+
+	cl_git_pass(git_branch_lookup(&ref,repo,"test/master",GIT_BRANCH_REMOTE));
+	cl_git_pass(git_branch_name(&name,ref));
+	cl_assert_equal_s("test/master",name);
+}
+
+void test_refs_branches_name__error_when_ref_is_no_branch(void)
+{
+	const char *name;
+
+	cl_git_pass(git_reference_lookup(&ref,repo,"refs/notes/fanout"));
+	cl_git_fail(git_branch_name(&name,ref));
+}


### PR DESCRIPTION
The git branch API seems to abstract abstract the ref prefixes of branches. But I haven't found a way to get the name of a branch without manually skipping the ref prefixes. This is a suggestion to add the function git_branch_name() to the API which analogously to the rest of the branch API abstract away skipping the ref prefixes.
