### PR TITLE
Use cl_assert_equal_s() instead of strcmp().

### DIFF
--- a/tests-clar/commit/parse.c
+++ b/tests-clar/commit/parse.c
@@ -159,8 +159,8 @@ void test_commit_parse__signature(void)
       size_t len = strlen(passcase->string);
       struct git_signature person = {0};
       cl_git_pass(git_signature__parse(&person, &str, str + len, passcase->header, '\n'));
-      cl_assert(strcmp(passcase->name, person.name) == 0);
-      cl_assert(strcmp(passcase->email, person.email) == 0);
+      cl_assert_equal_s(passcase->name, person.name);
+      cl_assert_equal_s(passcase->email, person.email);
       cl_assert(passcase->time == person.when.time);
       cl_assert(passcase->offset == person.when.offset);
       git__free(person.name); git__free(person.email);
@@ -347,10 +347,10 @@ void test_commit_parse__details0(void) {
 		commit_time = git_commit_time(commit);
 		parents = git_commit_parentcount(commit);
 
-		cl_assert(strcmp(author->name, "Scott Chacon") == 0);
-		cl_assert(strcmp(author->email, "schacon@gmail.com") == 0);
-		cl_assert(strcmp(committer->name, "Scott Chacon") == 0);
-		cl_assert(strcmp(committer->email, "schacon@gmail.com") == 0);
+		cl_assert_equal_s("Scott Chacon", author->name);
+		cl_assert_equal_s("schacon@gmail.com", author->email);
+		cl_assert_equal_s("Scott Chacon", committer->name);
+		cl_assert_equal_s("schacon@gmail.com", committer->email);
 		cl_assert(message != NULL);
 		cl_assert(strchr(message, '\n') != NULL);
 		cl_assert(commit_time > 0);

--- a/tests-clar/commit/write.c
+++ b/tests-clar/commit/write.c
@@ -78,19 +78,19 @@ void test_commit_write__from_memory(void)
    /* Check attributes were set correctly */
    author1 = git_commit_author(commit);
    cl_assert(author1 != NULL);
-   cl_assert(strcmp(author1->name, committer_name) == 0);
-   cl_assert(strcmp(author1->email, committer_email) == 0);
+   cl_assert_equal_s(committer_name, author1->name);
+   cl_assert_equal_s(committer_email, author1->email);
    cl_assert(author1->when.time == 987654321);
    cl_assert(author1->when.offset == 90);
 
    committer1 = git_commit_committer(commit);
    cl_assert(committer1 != NULL);
-   cl_assert(strcmp(committer1->name, committer_name) == 0);
-   cl_assert(strcmp(committer1->email, committer_email) == 0);
+   cl_assert_equal_s(committer_name, committer1->name);
+   cl_assert_equal_s(committer_email, committer1->email);
    cl_assert(committer1->when.time == 123456789);
    cl_assert(committer1->when.offset == 60);
 
-   cl_assert(strcmp(git_commit_message(commit), commit_message) == 0);
+   cl_assert_equal_s(commit_message, git_commit_message(commit));
 }
 
 // create a root commit
@@ -142,5 +142,5 @@ void test_commit_write__root(void)
 	cl_git_pass(git_reference_lookup(&branch, g_repo, branch_name));
 	branch_oid = git_reference_target(branch);
 	cl_git_pass(git_oid_cmp(branch_oid, &commit_id));
-	cl_assert(!strcmp(git_commit_message(commit), root_commit_message));
+	cl_assert_equal_s(root_commit_message, git_commit_message(commit));
 }

--- a/tests-clar/config/read.c
+++ b/tests-clar/config/read.c
@@ -194,7 +194,7 @@ void test_config_read__escaping_quotes(void)
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config13")));
 	cl_git_pass(git_config_get_string(&str, cfg, "core.editor"));
-	cl_assert(strcmp(str, "\"C:/Program Files/Nonsense/bah.exe\" \"--some option\"") == 0);
+	cl_assert_equal_s("\"C:/Program Files/Nonsense/bah.exe\" \"--some option\"", str);
 
 	git_config_free(cfg);
 }

--- a/tests-clar/config/stress.c
+++ b/tests-clar/config/stress.c
@@ -45,13 +45,13 @@ void test_config_stress__comments(void)
 	cl_git_pass(git_config_open_ondisk(&config, cl_fixture("config/config12")));
 
 	cl_git_pass(git_config_get_string(&str, config, "some.section.other"));
-	cl_assert(!strcmp(str, "hello! \" ; ; ; "));
+	cl_assert_equal_s("hello! \" ; ; ; ", str);
 
 	cl_git_pass(git_config_get_string(&str, config, "some.section.multi"));
-	cl_assert(!strcmp(str, "hi, this is a ; multiline comment # with ;\n special chars and other stuff !@#"));
+	cl_assert_equal_s("hi, this is a ; multiline comment # with ;\n special chars and other stuff !@#", str);
 
 	cl_git_pass(git_config_get_string(&str, config, "some.section.back"));
-	cl_assert(!strcmp(str, "this is \ba phrase"));
+	cl_assert_equal_s("this is \ba phrase", str);
 
 	git_config_free(config);
 }
@@ -70,6 +70,6 @@ void test_config_stress__escape_subsection_names(void)
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
 
 	cl_git_pass(git_config_get_string(&str, config, "some.sec\\tion.other"));
-	cl_assert(!strcmp("foo", str));
+	cl_assert_equal_s("foo", str);
 	git_config_free(config);
 }

--- a/tests-clar/config/write.c
+++ b/tests-clar/config/write.c
@@ -116,7 +116,7 @@ void test_config_write__write_subsection(void)
 
 	cl_git_pass(git_config_open_ondisk(&cfg, "config9"));
 	cl_git_pass(git_config_get_string(&str, cfg, "my.own.var"));
-	cl_git_pass(strcmp(str, "works"));
+	cl_assert_equal_s("works", str);
 	git_config_free(cfg);
 }
 

--- a/tests-clar/fetchhead/nonetwork.c
+++ b/tests-clar/fetchhead/nonetwork.c
@@ -124,12 +124,12 @@ static int fetchhead_ref_cb(const char *name, const char *url,
 	cl_assert(expected->is_merge == is_merge);
 
 	if (expected->ref_name)
-		cl_assert(strcmp(expected->ref_name, name) == 0);
+		cl_assert_equal_s(expected->ref_name, name);
 	else
 		cl_assert(name == NULL);
 
 	if (expected->remote_url)
-		cl_assert(strcmp(expected->remote_url, url) == 0);
+		cl_assert_equal_s(expected->remote_url, url);
 	else
 		cl_assert(url == NULL);
 
@@ -199,8 +199,8 @@ static int read_type_missing(const char *ref_name, const char *remote_url,
 
 	git_oid_fromstr(&expected, "49322bb17d3acc9146f98c97d078513228bbf3c0");
 
-	cl_assert(strcmp(ref_name, "name") == 0);
-	cl_assert(strcmp(remote_url, "remote_url") == 0);
+	cl_assert_equal_s("name", ref_name);
+	cl_assert_equal_s("remote_url", remote_url);
 	cl_assert(git_oid_cmp(&expected, oid) == 0);
 	cl_assert(is_merge == 0);
 
@@ -227,7 +227,7 @@ static int read_name_missing(const char *ref_name, const char *remote_url,
 	git_oid_fromstr(&expected, "49322bb17d3acc9146f98c97d078513228bbf3c0");
 
 	cl_assert(ref_name == NULL);
-	cl_assert(strcmp(remote_url, "remote_url") == 0);
+	cl_assert_equal_s("remote_url", remote_url);
 	cl_assert(git_oid_cmp(&expected, oid) == 0);
 	cl_assert(is_merge == 0);
 

--- a/tests-clar/index/conflicts.c
+++ b/tests-clar/index/conflicts.c
@@ -104,7 +104,7 @@ void test_index_conflicts__get(void)
 	cl_git_pass(git_index_conflict_get(&conflict_entry[0], &conflict_entry[1],
 		&conflict_entry[2], repo_index, "conflicts-one.txt"));
 
-	cl_assert(strcmp(conflict_entry[0]->path, "conflicts-one.txt") == 0);
+	cl_assert_equal_s("conflicts-one.txt", conflict_entry[0]->path);
 
 	git_oid_fromstr(&oid, CONFLICTS_ONE_ANCESTOR_OID);
 	cl_assert(git_oid_cmp(&conflict_entry[0]->oid, &oid) == 0);
@@ -118,7 +118,7 @@ void test_index_conflicts__get(void)
 	cl_git_pass(git_index_conflict_get(&conflict_entry[0], &conflict_entry[1],
 		&conflict_entry[2], repo_index, "conflicts-two.txt"));
 
-	cl_assert(strcmp(conflict_entry[0]->path, "conflicts-two.txt") == 0);
+	cl_assert_equal_s("conflicts-two.txt", conflict_entry[0]->path);
 
 	git_oid_fromstr(&oid, CONFLICTS_TWO_ANCESTOR_OID);
 	cl_assert(git_oid_cmp(&conflict_entry[0]->oid, &oid) == 0);

--- a/tests-clar/index/reuc.c
+++ b/tests-clar/index/reuc.c
@@ -47,7 +47,7 @@ void test_index_reuc__add(void)
 
 	cl_assert(reuc = git_index_reuc_get_bypath(repo_index, "newfile.txt"));
 
-	cl_assert(strcmp(reuc->path, "newfile.txt") == 0);
+	cl_assert_equal_s("newfile.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -72,7 +72,7 @@ void test_index_reuc__add_no_ancestor(void)
 
 	cl_assert(reuc = git_index_reuc_get_bypath(repo_index, "newfile.txt"));
 
-	cl_assert(strcmp(reuc->path, "newfile.txt") == 0);
+	cl_assert_equal_s("newfile.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -90,7 +90,7 @@ void test_index_reuc__read_bypath(void)
 
 	cl_assert(reuc = git_index_reuc_get_bypath(repo_index, "two.txt"));
 
-	cl_assert(strcmp(reuc->path, "two.txt") == 0);
+	cl_assert_equal_s("two.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -103,7 +103,7 @@ void test_index_reuc__read_bypath(void)
 
 	cl_assert(reuc = git_index_reuc_get_bypath(repo_index, "one.txt"));
 
-	cl_assert(strcmp(reuc->path, "one.txt") == 0);
+	cl_assert_equal_s("one.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -135,7 +135,7 @@ void test_index_reuc__ignore_case(void)
 
 	cl_assert(reuc = git_index_reuc_get_bypath(repo_index, "TWO.txt"));
 
-	cl_assert(strcmp(reuc->path, "two.txt") == 0);
+	cl_assert_equal_s("two.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -156,7 +156,7 @@ void test_index_reuc__read_byindex(void)
 
 	cl_assert(reuc = git_index_reuc_get_byindex(repo_index, 0));
 
-	cl_assert(strcmp(reuc->path, "one.txt") == 0);
+	cl_assert_equal_s("one.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -169,7 +169,7 @@ void test_index_reuc__read_byindex(void)
 
 	cl_assert(reuc = git_index_reuc_get_byindex(repo_index, 1));
 
-	cl_assert(strcmp(reuc->path, "two.txt") == 0);
+	cl_assert_equal_s("two.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -212,7 +212,7 @@ void test_index_reuc__updates_existing(void)
 
 	cl_assert(reuc = git_index_reuc_get_byindex(repo_index, 0));
 
-	cl_assert(strcmp(reuc->path, "TWO.txt") == 0);
+	cl_assert_equal_s("TWO.txt", reuc->path);
 	git_oid_fromstr(&oid, TWO_OUR_OID);
 	cl_assert(git_oid_cmp(&reuc->oid[0], &oid) == 0);
 	git_oid_fromstr(&oid, TWO_THEIR_OID);
@@ -235,7 +235,7 @@ void test_index_reuc__remove(void)
 
 	cl_assert(reuc = git_index_reuc_get_byindex(repo_index, 0));
 
-	cl_assert(strcmp(reuc->path, "two.txt") == 0);
+	cl_assert_equal_s("two.txt", reuc->path);
 	cl_assert(reuc->mode[0] == 0100644);
 	cl_assert(reuc->mode[1] == 0100644);
 	cl_assert(reuc->mode[2] == 0100644);
@@ -280,9 +280,9 @@ void test_index_reuc__write(void)
 
 	/* ensure sort order was round-tripped correct */
 	cl_assert(reuc = git_index_reuc_get_byindex(repo_index, 0));
-	cl_assert(strcmp(reuc->path, "one.txt") == 0);
+	cl_assert_equal_s("one.txt", reuc->path);
 	
 	cl_assert(reuc = git_index_reuc_get_byindex(repo_index, 1));
-	cl_assert(strcmp(reuc->path, "two.txt") == 0);
+	cl_assert_equal_s("two.txt", reuc->path);
 }
 

--- a/tests-clar/network/remotes.c
+++ b/tests-clar/network/remotes.c
@@ -257,9 +257,9 @@ void test_network_remotes__add(void)
 
 	cl_git_pass(git_remote_load(&_remote, _repo, "addtest"));
 	_refspec = git_remote_fetchspec(_remote);
-	cl_assert(!strcmp(git_refspec_src(_refspec), "refs/heads/*"));
+	cl_assert_equal_s("refs/heads/*", git_refspec_src(_refspec));
 	cl_assert(git_refspec_force(_refspec) == 1);
-	cl_assert(!strcmp(git_refspec_dst(_refspec), "refs/remotes/addtest/*"));
+	cl_assert_equal_s("refs/remotes/addtest/*", git_refspec_dst(_refspec));
 	cl_assert_equal_s(git_remote_url(_remote), "http://github.com/libgit2/libgit2");
 }
 
@@ -309,12 +309,12 @@ void test_network_remotes__tagopt(void)
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_ALL);
 	cl_git_pass(git_remote_save(_remote));
 	cl_git_pass(git_config_get_string(&opt, cfg, "remote.test.tagopt"));
-	cl_assert(!strcmp(opt, "--tags"));
+	cl_assert_equal_s("--tags", opt);
 
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_NONE);
 	cl_git_pass(git_remote_save(_remote));
 	cl_git_pass(git_config_get_string(&opt, cfg, "remote.test.tagopt"));
-	cl_assert(!strcmp(opt, "--no-tags"));
+	cl_assert_equal_s("--no-tags", opt);
 
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_AUTO);
 	cl_git_pass(git_remote_save(_remote));

--- a/tests-clar/notes/notesref.c
+++ b/tests-clar/notes/notesref.c
@@ -45,20 +45,20 @@ void test_notes_notesref__config_corenotesref(void)
 	cl_git_pass(git_note_create(&note_oid, _repo, _sig, _sig, NULL, &oid, "test123test\n", 0));
 
 	cl_git_pass(git_note_read(&_note, _repo, NULL, &oid));
-	cl_assert(!strcmp(git_note_message(_note), "test123test\n"));
+	cl_assert_equal_s("test123test\n", git_note_message(_note));
 	cl_assert(!git_oid_cmp(git_note_oid(_note), &note_oid));
 
 	git_note_free(_note);
 
 	cl_git_pass(git_note_read(&_note, _repo, "refs/notes/mydefaultnotesref", &oid));
-	cl_assert(!strcmp(git_note_message(_note), "test123test\n"));
+	cl_assert_equal_s("test123test\n", git_note_message(_note));
 	cl_assert(!git_oid_cmp(git_note_oid(_note), &note_oid));
 
 	cl_git_pass(git_note_default_ref(&default_ref, _repo));
-	cl_assert(!strcmp(default_ref, "refs/notes/mydefaultnotesref"));
+	cl_assert_equal_s("refs/notes/mydefaultnotesref", default_ref);
 
 	cl_git_pass(git_config_delete_entry(_cfg, "core.notesRef"));
 
 	cl_git_pass(git_note_default_ref(&default_ref, _repo));
-	cl_assert(!strcmp(default_ref, GIT_NOTES_DEFAULT_REF));
+	cl_assert_equal_s(GIT_NOTES_DEFAULT_REF, default_ref);
 }

--- a/tests-clar/refs/branches/delete.c
+++ b/tests-clar/refs/branches/delete.c
@@ -35,7 +35,7 @@ void test_refs_branches_delete__can_not_delete_a_branch_pointed_at_by_HEAD(void)
 
 	/* Ensure HEAD targets the local master branch */
 	cl_git_pass(git_reference_lookup(&head, repo, GIT_HEAD_FILE));
-	cl_assert(strcmp("refs/heads/master", git_reference_symbolic_target(head)) == 0);
+	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(head));
 	git_reference_free(head);
 
 	cl_git_pass(git_branch_lookup(&branch, repo, "master", GIT_BRANCH_LOCAL));

--- a/tests-clar/refs/normalize.c
+++ b/tests-clar/refs/normalize.c
@@ -14,7 +14,7 @@ static void ensure_refname_normalized(
 
 	cl_git_pass(git_reference_normalize_name(buffer_out, sizeof(buffer_out), input_refname, flags));
 
-	cl_assert_equal_i(0, strcmp(buffer_out, expected_refname));
+	cl_assert_equal_s(expected_refname, buffer_out);
 }
 
 static void ensure_refname_invalid(unsigned int flags, const char *input_refname)

--- a/tests-clar/refs/unicode.c
+++ b/tests-clar/refs/unicode.c
@@ -28,14 +28,14 @@ void test_refs_unicode__create_and_lookup(void)
 	/* Create the reference */
 	cl_git_pass(git_reference_lookup(&ref0, repo, master));
 	cl_git_pass(git_reference_create(&ref1, repo, REFNAME, git_reference_target(ref0), 0));
-	cl_assert(strcmp(REFNAME, git_reference_name(ref1)) == 0);
+	cl_assert_equal_s(REFNAME, git_reference_name(ref1));
 
 	/* Lookup the reference in a different instance of the repository */
 	cl_git_pass(git_repository_open(&repo2, "testrepo.git"));
 	cl_git_pass(git_reference_lookup(&ref2, repo2, REFNAME));
 
 	cl_assert(git_oid_cmp(git_reference_target(ref1), git_reference_target(ref2)) == 0);
-	cl_assert(strcmp(REFNAME, git_reference_name(ref2)) == 0);
+	cl_assert_equal_s(REFNAME, git_reference_name(ref2));
 
 	git_reference_free(ref0);
 	git_reference_free(ref1);


### PR DESCRIPTION
In one former PR I used the pattern cl_assert(!strcmp()) for testing for string equality because I observed the pattern in the current code. It was suggested to use cl_assert_equal_s(), which is used more prominently. In this RP, all cl_assert(!strcmp()) or semantically equivalent forms are replaced by cl_assert_equal_s() so newbies no longer will observe the wrong pattern :)
