### PR TITLE
config: support trailing backslashes

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1319,8 +1319,15 @@ out:
 
 static int is_multiline_var(const char *str)
 {
+	int count = 0;
 	const char *end = str + strlen(str);
-	return (end > str) && (end[-1] == '\\');
+	while (end > str && end[-1] == '\\') {
+		count++;
+		end--;
+	}
+
+	/* An odd number means last backslash wasn't escaped, so it's multiline */
+	return (end > str) && (count & 1);
 }
 
 static int parse_multiline_variable(diskfile_backend *cfg, git_buf *value, int in_quotes)

--- a/tests-clar/config/stress.c
+++ b/tests-clar/config/stress.c
@@ -73,3 +73,20 @@ void test_config_stress__escape_subsection_names(void)
 	cl_assert(!strcmp("foo", str));
 	git_config_free(config);
 }
+
+void test_config_stress__trailing_backslash(void)
+{
+	git_config *config;
+	const char *str;
+	const char *path =  "C:\\iam\\some\\windows\\path\\";
+
+	cl_assert(git_path_exists("git-test-config"));
+	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
+	cl_git_pass(git_config_set_string(config, "windows.path", path));
+	git_config_free(config);
+
+	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
+	cl_git_pass(git_config_get_string(&str, config, "windows.path"));
+	cl_assert_equal_s(path, str);
+	git_config_free(config);
+}


### PR DESCRIPTION
Check whether the backslash at the end of the line is being escaped or
not so as not to consider it a continuation marker when it's e.g. a
Windows-style path.
