### PR TITLE
clone: Prevent segfault upon faulted remote creation

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -156,6 +156,7 @@ static int ensure_remote_doesnot_exist(git_repository *repo, const char *name)
 int git_remote_create(git_remote **out, git_repository *repo, const char *name, const char *url)
 {
 	git_buf buf = GIT_BUF_INIT;
+	git_remote *remote = NULL;
 	int error;
 
 	if ((error = ensure_remote_name_is_valid(name)) < 0)
@@ -167,19 +168,21 @@ int git_remote_create(git_remote **out, git_repository *repo, const char *name, 
 	if (git_buf_printf(&buf, "+refs/heads/*:refs/remotes/%s/*", name) < 0)
 		return -1;
 
-	if (create_internal(out, repo, name, url, git_buf_cstr(&buf)) < 0)
+	if (create_internal(&remote, repo, name, url, git_buf_cstr(&buf)) < 0)
 		goto on_error;
 
 	git_buf_free(&buf);
 
-	if (git_remote_save(*out) < 0)
+	if (git_remote_save(remote) < 0)
 		goto on_error;
+
+	*out = remote;
 
 	return 0;
 
 on_error:
 	git_buf_free(&buf);
-	git_remote_free(*out);
+	git_remote_free(remote);
 	return -1;
 }
 


### PR DESCRIPTION
Properly dispose the remote being created, without altering the `out` parameter,  when the process cannot be fulfilled. This fixes a segfault detected in libgit2/libgit2sharp#247 by @darind

Because of a trailing backslash in the url, the writing of the config file was failing.
This error was causing the freeing of the `out` remote in `git_remote_create()`. 

The segfault was happening because the calling function was also attempting to free this same remote.

Note: The backslash issue has been fixed by @carlosmn in #1279
