### PR TITLE
Improve valgrind suppressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ script:
 
 # Run Tests
 after_success:
- - valgrind --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -ionline
+ - valgrind --num-callers=30 --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -ionline
 
 # Only watch the development branch
 branches:
  only:
    - development
-   
+
 # Notify development list when needed
 notifications:
  irc:

--- a/libgit2_clar.supp
+++ b/libgit2_clar.supp
@@ -1,22 +1,44 @@
 {
-        ignore-zlib-errors-cond
-        Memcheck:Cond
-        obj:*libz.so*
+	ignore-zlib-errors-cond
+	Memcheck:Cond
+	obj:*libz.so*
 }
 
 {
-        ignore-giterr-set-leak
-        Memcheck:Leak
-        ...
-        fun:giterr_set
+	ignore-giterr-set-leak
+	Memcheck:Leak
+	...
+	fun:giterr_set
 }
 
 {
+	ignore-git-global-state-leak
+	Memcheck:Leak
+	...
+	fun:git__global_state
+}
+
+{
+	ignore-openssl-ssl-leak
+	Memcheck:Leak
 	...
 	obj:*libssl.so*
+	...
+	fun:ssl_setup
 }
 
 {
+	ignore-openssl-crypto-leak
+	Memcheck:Leak
 	...
 	obj:*libcrypto.so*
+	...
+	fun:ssl_setup
+}
+
+{
+	ignore-openssl-crypto-cond
+	Memcheck:Cond
+	obj:*libcrypto.so*
+	...
 }


### PR DESCRIPTION
Now that we have an https fetch in the test suite, valgrind has gotten clogged up with libssl and libcrypto allocations that don't go away. This PR:
- Cleans those libcrypto and libssl allocations up
- Cleans up the `git__global_state` allocation when `GIT_THREADS` is enabled
- Fixes whitespace issues in travis.yml and in the valgrind suppressions file

The valgrind backtrace frame count is set to 30 frames, so that valgrind can correctly suppress some very deep allocations that do in fact still originate from our `ssl_setup` method.

With this PR, travis now shows 0 bytes leaked.
