### PR TITLE
Fix local repository clone failure

### DIFF
--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -318,12 +318,15 @@ static int local_download_pack(
 
 		if (!git_object_lookup((git_object**)&commit, t->repo, &oid, GIT_OBJ_COMMIT)) {
 			const git_oid *tree_oid = git_commit_tree_id(commit);
-			git_commit_free(commit);
 
 			/* Add the commit and its tree */
 			if ((error = git_packbuilder_insert(pack, &oid, NULL)) < 0 ||
-				 (error = git_packbuilder_insert_tree(pack, tree_oid)) < 0)
+				 (error = git_packbuilder_insert_tree(pack, tree_oid)) < 0) {
+				git_commit_free(commit);
 				goto cleanup;
+			}
+
+			git_commit_free(commit);
 		}
 	}
 


### PR DESCRIPTION
avoid use object which is already free

Signed-off-by: Frank Li lznuaa@gmail.com
