### PR TITLE
Added git_treebuilder_entrycount

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -190,6 +190,14 @@ GIT_EXTERN(int) git_treebuilder_create(git_treebuilder **builder_p, const git_tr
 GIT_EXTERN(void) git_treebuilder_clear(git_treebuilder *bld);
 
 /**
+ * Get the number of entries listed in a treebuilder
+ *
+ * @param tree a previously loaded treebuilder.
+ * @return the number of entries in the treebuilder
+ */
+GIT_EXTERN(unsigned int) git_treebuilder_entrycount(git_treebuilder *bld);
+
+/**
  * Free a tree builder
  *
  * This will clear all the entries and free to builder.

--- a/src/tree.c
+++ b/src/tree.c
@@ -231,6 +231,12 @@ unsigned int git_tree_entrycount(git_tree *tree)
 	return tree->entries.length;
 }
 
+unsigned int git_treebuilder_entrycount(git_treebuilder *bld)
+{
+	assert(bld);
+	return bld->entries.length;
+}
+
 static int tree_error(const char *str)
 {
 	giterr_set(GITERR_TREE, "%s", str);


### PR DESCRIPTION
I need this method in order to implement a significant optimization in hlibgit2, since it frees me entirely from having to deal with git_tree objects, and I can work solely with treebuilders to generate tree oids.

It would also be very nice to have a version of commit which, instead of requiring a git_tree and an array of git_commits for parents, would access just git_oid values for both, since I've already written all the information to disk.  In fact, I'll put this next on my list!
