### PR TITLE
Added git_commit_create_oid

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -287,6 +287,26 @@ GIT_EXTERN(int) git_commit_create_v(
 		int parent_count,
 		...);
 
+/**
+ * Create a new commit in the repository, as with `git_commit_create`,
+ * using `git_oid` instances as parameters instead of `git_object`.
+ *
+ * See documentation for `git_commit_create` for information about the
+ * parameters, as the meaning is identical excepting that `tree` and
+ * `parents` now take `git_oid`.
+ */
+GIT_EXTERN(int) git_commit_create_oid(
+		git_oid *oid,
+		git_repository *repo,
+		const char *update_ref,
+		const git_signature *author,
+		const git_signature *committer,
+		const char *message_encoding,
+		const char *message,
+		const git_oid *tree,
+		int parent_count,
+		const git_oid *parents[]);
+
 /** @} */
 GIT_END_DECL
 #endif


### PR DESCRIPTION
This function makes it much more efficient to create lots of commits when you are only working with git_oid objects (such as when using treebuilders to create trees, while never having the actual git_tree in memory at any time).  Plus, once a commit has been created it can be freed and the git_oid kept, because that alone is usable as a parent for the next commit to be made.
