### PR TITLE
Fix p_realpath on OpenBSD

### DIFF
--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -16,7 +16,12 @@
 #define p_unlink(p) unlink(p)
 #define p_mkdir(p,m) mkdir(p, m)
 #define p_fsync(fd) fsync(fd)
-#define p_realpath(p, po) realpath(p, po)
+
+/* The OpenBSD realpath function behaves differently */
+#if !defined(__OpenBSD__)
+# define p_realpath(p, po) realpath(p, po)
+#endif
+
 #define p_vsnprintf(b, c, f, a) vsnprintf(b, c, f, a)
 #define p_snprintf(b, c, f, ...) snprintf(b, c, f, __VA_ARGS__)
 #define p_mkstemp(p) mkstemp(p)

--- a/src/unix/realpath.c
+++ b/src/unix/realpath.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#include <git2/common.h>
+
+#ifdef __OpenBSD__
+
+#include <limits.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+char *p_realpath(const char *pathname, char *resolved)
+{
+	char *ret;
+
+	if ((ret = realpath(pathname, resolved)) == NULL)
+		return NULL;
+
+	/* Figure out if the file exists */
+	if (!access(ret, F_OK))
+		ret;
+
+	return NULL;
+}
+
+#endif


### PR DESCRIPTION
OpenBSD's realpath(3) doesn't require the last part of the path to
exist. Override p_realpath in this OS to bring it in line with the
library's assumptions.
