### PR TITLE
Crash when resolving a ref starting with "/"

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -1691,6 +1691,11 @@ int git_reference__normalize_name(
 			segments_count++;
 		}
 
+		/* This means that there's a leading slash in the refname */
+		if (segment_len == 0 && segments_count == 0) {
+			goto cleanup;
+		}
+
 		if (current[segment_len] == '\0')
 			break;
 

--- a/tests-clar/refs/isvalidname.c
+++ b/tests-clar/refs/isvalidname.c
@@ -10,6 +10,8 @@ void test_refs_isvalidname__can_detect_invalid_formats(void)
 	cl_assert_equal_i(false, git_reference_is_valid_name("_NO_LEADING_UNDERSCORE"));
 	cl_assert_equal_i(false, git_reference_is_valid_name("HEAD/aa"));
 	cl_assert_equal_i(false, git_reference_is_valid_name("lower_case"));
+	cl_assert_equal_i(false, git_reference_is_valid_name("/stupid/name/master"));
+	cl_assert_equal_i(false, git_reference_is_valid_name("/"));
 	cl_assert_equal_i(false, git_reference_is_valid_name(""));
 }
 


### PR DESCRIPTION
<sup>This happened while developing the [Gitteh wrapper](https://github.com/jmendeth/node-gitteh). Forgive me if this has already been fixed.</sup>

Let's make a short, very short program:

``` c
int status;

git_repository* repo;
status = git_repository_open(&repo, "path/to/a/repo");
//check status
git_reference* ref;
status = git_reference_lookup(&ref, "remotes/origin/HEAD");
//check status

git_reference_free(ref);
git_repository_free(repo);
```

Adjust `path/to/a/repo`, compile, run, and everything should go fine.
Now **prepend a `/` before the reference name**: `/remotes/origin/HEAD`
and the program will crash when looking up the reference:

```
nastyProg: /home/sweet/home/libgit2/src/refs.c:1626: is_all_caps_and_underscore: Assertion `name && len > 0' failed.
```

The problem is in `git_reference_normalize_name`, which calls
`is_all_caps_and_underscore` with `len = 0` because the first segment
before the `/` is an empty string.

As you can guess, `git_reference_name_to_id(... "/my/nas1y/sTrIng")`
would trigger this bug as well.
