### PR TITLE
Try harder to find global config file

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -544,12 +544,6 @@ int git_futils_find_global_file(git_buf *path, const char *filename)
 		/* try to look up file under path */
 		if (!win32_find_file(path, &root, filename))
 			return 0;
-
-		/* No error if file not found under %HOME%, b/c we don't trust it,
-		 * but do error if another var is set and yet file is not found.
-		 */
-		if (tmpl != tmpls)
-			break;
 	}
 
 	giterr_set(GITERR_OS, "The global file '%s' doesn't exist", filename);


### PR DESCRIPTION
Do not stop looking for the user's global .gitconfig file when the path exists, but there is no .gitconfig file.

As discussed, this is a deviation from msys git behavior, but the proposed change seems to reflect the expected behavior from libgit2. The current behavior has already caused issues (e.g. #952). Instead of consumers working around the current behavior, this updates libgit2 to try harder to find the user's global config file on Windows.

/cc @arrbee, @Haacked, @clboles, @phkelley, @ethomson
