### PR TITLE
Win32: Make sure error messages are consistently UTF-8 encoded

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,7 @@
 # include <windows.h>
 # include "win32/msvc-compat.h"
 # include "win32/mingw-compat.h"
+# include "win32/error.h"
 # ifdef GIT_THREADS
 #	include "win32/pthread.h"
 #endif

--- a/src/errors.c
+++ b/src/errors.c
@@ -51,34 +51,11 @@ void giterr_set(int error_class, const char *string, ...)
 
 	if (error_class == GITERR_OS) {
 #ifdef GIT_WIN32
-		if (win32_error_code) {
-			LPWSTR lpMsgBuf = NULL;
-			int size = FormatMessageW(
-					FORMAT_MESSAGE_ALLOCATE_BUFFER |
-					FORMAT_MESSAGE_FROM_SYSTEM |
-					FORMAT_MESSAGE_IGNORE_INSERTS,
-					NULL, win32_error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-					(LPWSTR)&lpMsgBuf, 0, NULL);
-
-			if (size) {
-				int utf8_size = WideCharToMultiByte(CP_UTF8, 0, lpMsgBuf, -1, NULL, 0, NULL, NULL);
-
-				char *lpMsgBuf_utf8 = git__malloc(utf8_size * sizeof(char));
-				if (lpMsgBuf_utf8 == NULL) {
-					LocalFree(lpMsgBuf);
-					return;
-				}
-				if (!WideCharToMultiByte(CP_UTF8, 0, lpMsgBuf, -1, lpMsgBuf_utf8, utf8_size, NULL, NULL)) {
-					LocalFree(lpMsgBuf);
-					git__free(lpMsgBuf_utf8);
-					return;
-				}
-
-				git_buf_PUTS(&buf, ": ");
-				git_buf_puts(&buf, lpMsgBuf_utf8);
-				LocalFree(lpMsgBuf);
-				git__free(lpMsgBuf_utf8);
-			}
+		char * win32_error = git_win32_get_error_message(win32_error_code);
+		if (win32_error) {
+			git_buf_PUTS(&buf, ": ");
+			git_buf_puts(&buf, win32_error);
+			git__free(win32_error);
 
 			SetLastError(0);
 		}

--- a/src/win32/error.c
+++ b/src/win32/error.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "error.h"
+
+char *git_win32_get_error_message(DWORD error_code)
+{
+	LPWSTR lpMsgBuf = NULL;
+
+	if (!error_code)
+		return NULL;
+
+	if (FormatMessageW(
+				FORMAT_MESSAGE_ALLOCATE_BUFFER |
+				FORMAT_MESSAGE_FROM_SYSTEM |
+				FORMAT_MESSAGE_IGNORE_INSERTS,
+				NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+				(LPWSTR)&lpMsgBuf, 0, NULL)) {
+		int utf8_size = WideCharToMultiByte(CP_UTF8, 0, lpMsgBuf, -1, NULL, 0, NULL, NULL);
+
+		char *lpMsgBuf_utf8 = git__malloc(utf8_size * sizeof(char));
+		if (lpMsgBuf_utf8 == NULL) {
+			LocalFree(lpMsgBuf);
+			return NULL;
+		}
+		if (!WideCharToMultiByte(CP_UTF8, 0, lpMsgBuf, -1, lpMsgBuf_utf8, utf8_size, NULL, NULL)) {
+			LocalFree(lpMsgBuf);
+			git__free(lpMsgBuf_utf8);
+			return NULL;
+		}
+
+		LocalFree(lpMsgBuf);
+		return lpMsgBuf_utf8;
+	}
+	return NULL;
+}

--- a/src/win32/error.h
+++ b/src/win32/error.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_git_win32_error_h__
+#define INCLUDE_git_win32_error_h__
+
+extern char *git_win32_get_error_message(DWORD error_code);
+
+#endif


### PR DESCRIPTION
W/o this a libgit2 error message could have a mixed encoding:
e.g. a filename in UTF-8 combined with a native Windows error message
encoded with the local code page.

Signed-off-by: Sven Strickroth email@cs-ware.de
