### PR TITLE
removed obsolete reference to api.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ release its source code.
     * Archives: <http://librelist.com/browser/libgit2/>
 * Website: <http://libgit2.github.com>
 * API documentation: <http://libgit2.github.com/libgit2>
-* Usage guide: <http://libgit2.github.com/api.html>
 
 What It Can Do
 ==================================


### PR DESCRIPTION
There was a reference to a file "api.html" that, according to cmn on #libgit2, was not supposed to be there.
