### PR TITLE
No bitfields in public headers b/c packing is compiler-specific

### DIFF
--- a/include/git2/net.h
+++ b/include/git2/net.h
@@ -37,7 +37,7 @@ typedef enum {
  * Remote head description, given out on `ls` calls.
  */
 struct git_remote_head {
-	int local:1; /* available locally */
+	int local; /* available locally */
 	git_oid oid;
 	git_oid loid;
 	char *name;

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -300,7 +300,7 @@ typedef struct git_smart_subtransport_definition {
 
 	/* True if the protocol is stateless; false otherwise. For example,
 	 * http:// is stateless, but git:// is not. */
-	unsigned rpc : 1;
+	unsigned rpc;
 } git_smart_subtransport_definition;
 
 /* Smart transport subtransports that come with libgit2 */


### PR DESCRIPTION
There's been some discussion about gcc, clang, and MSVC packing these structs differently. Given that these are the only bitfields in the public headers, @carlosmn and I propose that we just avoid any potential problems here and ban bitfields from public structures.
