### PR TITLE
Fix Windows symlinks

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -103,8 +103,7 @@ static int do_lstat(
 		/* Windows symlinks have zero file size, call readlink to determine
 		 * the length of the path pointed to, which we expect everywhere else
 		 */
-		if (fMode & S_IFLNK)
-		{
+		if (fMode & S_IFLNK) {
 			char target[GIT_WIN_PATH];
 			int readlink_result;
 


### PR DESCRIPTION
This sets file size for symlinks to length of path pointed, like is expected in calls to `p_readlink`.

Fixes #1235 and probably #1314.
