### PR TITLE
Merge the push report into the refs to avoid a 3rd network call

### DIFF
--- a/src/push.c
+++ b/src/push.c
@@ -14,6 +14,20 @@
 #include "vector.h"
 #include "push.h"
 
+static int push_spec_rref_cmp(const void *a, const void *b)
+{
+	const push_spec *push_spec_a = a, *push_spec_b = b;
+
+	return strcmp(push_spec_a->rref, push_spec_b->rref);
+}
+
+static int push_status_ref_cmp(const void *a, const void *b)
+{
+	const push_status *push_status_a = a, *push_status_b = b;
+
+	return strcmp(push_status_a->ref, push_status_b->ref);
+}
+
 int git_push_new(git_push **out, git_remote *remote)
 {
 	git_push *p;
@@ -27,12 +41,12 @@ int git_push_new(git_push **out, git_remote *remote)
 	p->remote = remote;
 	p->report_status = 1;
 
-	if (git_vector_init(&p->specs, 0, NULL) < 0) {
+	if (git_vector_init(&p->specs, 0, push_spec_rref_cmp) < 0) {
 		git__free(p);
 		return -1;
 	}
 
-	if (git_vector_init(&p->status, 0, NULL) < 0) {
+	if (git_vector_init(&p->status, 0, push_status_ref_cmp) < 0) {
 		git_vector_free(&p->specs);
 		git__free(p);
 		return -1;

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -294,6 +294,13 @@ static void git_smart__free(git_transport *transport)
 	git__free(t);
 }
 
+static int ref_name_cmp(const void *a, const void *b)
+{
+	const git_pkt_ref *ref_a = a, *ref_b = b;
+
+	return strcmp(ref_a->head.name, ref_b->head.name);
+}
+
 int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 {
 	transport_smart *t;
@@ -321,7 +328,7 @@ int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 	t->owner = owner;
 	t->rpc = definition->rpc;
 
-	if (git_vector_init(&t->refs, 16, NULL) < 0) {
+	if (git_vector_init(&t->refs, 16, ref_name_cmp) < 0) {
 		git__free(t);
 		return -1;
 	}

--- a/src/vector.h
+++ b/src/vector.h
@@ -64,7 +64,7 @@ GIT_INLINE(void *) git_vector_last(const git_vector *v)
 	for ((iter) = 0; (iter) < (v)->length && ((elem) = (v)->contents[(iter)], 1); (iter)++ )
 
 #define git_vector_rforeach(v, iter, elem)	\
-	for ((iter) = (v)->length; (iter) > 0 && ((elem) = (v)->contents[(iter)-1], 1); (iter)-- )
+	for ((iter) = (v)->length - 1; (iter) < SIZE_MAX && ((elem) = (v)->contents[(iter)], 1); (iter)-- )
 
 int git_vector_insert(git_vector *v, void *element);
 int git_vector_insert_sorted(git_vector *v, void *element,


### PR DESCRIPTION
When @schu and I wrote push, we cheated a little bit and threw in a network call at the end to `info/refs?service=git-receive-pack` to find out what the refs had been updated to, so that `git_remote_ls` would return accurate results immediately after `git_push_finish`.

We left a TODO in place to come back and fix that up later. This PR removes that network call, and uses the push report to update the remote's refs vector. This is faster.
