### PR TITLE
Add git_push_options, to set packbuilder parallelism

### DIFF
--- a/include/git2/push.h
+++ b/include/git2/push.h
@@ -19,6 +19,26 @@
 GIT_BEGIN_DECL
 
 /**
+ * Controls the behavior of a git_push object.
+ */
+typedef struct {
+	unsigned int version;
+
+	/**
+	 * If the transport being used to push to the remote requires the creation
+	 * of a pack file, this controls the number of worker threads used by
+	 * the packbuilder when creating that pack file to be sent to the remote.
+	 *
+	 * If set to 0, the packbuilder will auto-detect the number of threads
+	 * to create. The default value is 1.
+	 */
+	unsigned int pb_parallelism;
+} git_push_options;
+
+#define GIT_PUSH_OPTIONS_VERSION 1
+#define GIT_PUSH_OPTIONS_INIT { GIT_PUSH_OPTIONS_VERSION }
+
+/**
  * Create a new push object
  *
  * @param out New push object
@@ -27,6 +47,18 @@ GIT_BEGIN_DECL
  * @return 0 or an error code
  */
 GIT_EXTERN(int) git_push_new(git_push **out, git_remote *remote);
+
+/**
+ * Set options on a push object
+ *
+ * @param push The push object
+ * @param opts The options to set on the push object
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_push_set_options(
+	git_push *push,
+	const git_push_options *opts);
 
 /**
  * Add a refspec to be pushed

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -144,7 +144,14 @@ on_error:
 unsigned int git_packbuilder_set_threads(git_packbuilder *pb, unsigned int n)
 {
 	assert(pb);
+
+#ifdef GIT_THREADS
 	pb->nr_threads = n;
+#else
+	GIT_UNUSED(n);
+	assert(1 == pb->nr_threads);
+#endif
+
 	return pb->nr_threads;
 }
 

--- a/src/push.h
+++ b/src/push.h
@@ -36,6 +36,9 @@ struct git_push {
 	/* report-status */
 	bool unpack_ok;
 	git_vector status;
+
+	/* options */
+	unsigned pb_parallelism;
 };
 
 #endif

--- a/tests-clar/online/push.c
+++ b/tests-clar/online/push.c
@@ -349,13 +349,18 @@ static void do_push(const char *refspecs[], size_t refspecs_len,
 	expected_ref expected_refs[], size_t expected_refs_len, int expected_ret)
 {
 	git_push *push;
+	git_push_options opts = GIT_PUSH_OPTIONS_INIT;
 	size_t i;
 	int ret;
 
 	if (_remote) {
+		/* Auto-detect the number of threads to use */
+		opts.pb_parallelism = 0;
+
 		cl_git_pass(git_remote_connect(_remote, GIT_DIRECTION_PUSH));
 
 		cl_git_pass(git_push_new(&push, _remote));
+		cl_git_pass(git_push_set_options(push, &opts));
 
 		for (i = 0; i < refspecs_len; i++)
 			cl_git_pass(git_push_add_refspec(push, refspecs[i]));


### PR DESCRIPTION
The packbuilder code that @schu ported from git.git allows for the use of multiple worker threads during deltafication. This knob is already exposed in the API `git_packbuilder_set_threads`. 1 thread (no additional workers) is the default. A value of 0 is special, and uses `git_online_cpus` to set the degree of parallelism to the number of cores in the system.

This PR creates a `git_push_options` structure and `git_push_set_options` function so that the degree of parallelism of a `git_push`'s packbuilder can be set.

Because the threading logic comes from git.git, it is already well-tested, and I have enabled auto-detection in our own push tests. Testing was done on Windows (x86 and x64) and Linux (amd64), with and without GIT_THREADS defined.
