### PR TITLE
add a sorter to the reuc on index creation

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -275,7 +275,8 @@ int git_index_open(git_index **index_out, const char *index_path)
 			index->on_disk = 1;
 	}
 
-	if (git_vector_init(&index->entries, 32, index_cmp) < 0)
+	if (git_vector_init(&index->entries, 32, index_cmp) < 0 ||
+		git_vector_init(&index->reuc, 32, reuc_cmp) < 0)
 		return -1;
 
 	index->entries_cmp_path = index_cmp_path;


### PR DESCRIPTION
`git_index_open` needs to initialize the reuc vector.  Currently we fail to initialize the reuc vector properly on `git_index_new` calls.  (Reading the index will initialize this vector.)
