### PR TITLE
Portability fixes for Solaris

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -89,15 +89,16 @@ void giterr_set_str(int error_class, const char *string)
 int giterr_set_regex(const regex_t *regex, int error_code)
 {
 	char error_buf[1024];
+
+	assert(error_code);
+
 	regerror(error_code, regex, error_buf, sizeof(error_buf));
 	giterr_set_str(GITERR_REGEX, error_buf);
 
 	if (error_code == REG_NOMATCH)
 		return GIT_ENOTFOUND;
-	else if (error_code > REG_BADPAT)
-		return GIT_EINVALIDSPEC;
-	else
-		return -1;
+
+	return GIT_EINVALIDSPEC;
 }
 
 void giterr_clear(void)


### PR DESCRIPTION
I don't know how interesting it is for us to support another UNIX besides Mac OS X and Linux, but I ran into a couple of bumps getting libgit2 built on gcc 3.x on Solaris 11. It certainly was an educational test case, and here are the fixes.
1. Some of the compiler flags we are using are supported only on GCC 4 or later, so I conditionalized those in CMakeLists.txt.
2. We made a bad assumption in errors.c that all `REG_` error codes come after `REG_BADPAT`. They do on Linux, but not on Solaris. On Solaris `REG_BADPAT` is 14, which is like 3/4ths of the way down the list of error codes.
3. On Solaris, if you try to `mkdir()` a directory which is an existing mount point, you get `ENOSYS` instead of `EEXIST`. Weird. (In a default install of Solaris 11, my home directory was a mount point.)
4. Just like Windows, Solaris has its own atomic functions, so I rigged us up to use those.
5. I squashed all warnings from gcc 3.x. This is a platform-independent fix.
