### PR TITLE
Consider repository empty even if head does not point to branch master

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1314,11 +1314,6 @@ int git_repository_is_empty(git_repository *repo)
 	if (!(error = git_reference_type(head) == GIT_REF_SYMBOLIC))
 		goto cleanup;
 
-	if (!(error = strcmp(
-		git_reference_symbolic_target(head),
-		GIT_REFS_HEADS_DIR "master") == 0))
-			goto cleanup;
-
 	error = repo_contains_no_reference(repo);
 
 cleanup:

--- a/tests-clar/repo/init.c
+++ b/tests-clar/repo/init.c
@@ -342,8 +342,7 @@ void test_repo_init__extended_1(void)
 	cl_assert(!git__suffixcmp(git_repository_path(_repo), "/c.git/"));
 	cl_assert(git_path_isfile("root/b/c_wd/.git"));
 	cl_assert(!git_repository_is_bare(_repo));
-	/* repo will not be counted as empty because we set head to "development" */
-	cl_assert(!git_repository_is_empty(_repo));
+	cl_assert(git_repository_is_empty(_repo));
 
 	cl_git_pass(git_path_lstat(git_repository_path(_repo), &st));
 	cl_assert(S_ISDIR(st.st_mode));


### PR DESCRIPTION
The result of this change is that a repository can be considered empty even if HEAD does not point to `refs/heads/master`. The current behavior is asserted in existing tests, so maybe I am missing a reason for why `git_repository_is_empty` is checking the current HEAD reference.

The underlying issue this change is addressing is that if you attempt to make the first commit on any branch other than `master` in LibGit2Sharp, it will fail because the `git_repository_is_empty` check returns false.

If there is another side effect that I am missing here where `git_repository_is_empty` should really depend on the current HEAD reference, please let me know. I can open a LibGit2Sharp issue if there is another fix that should be made here instead (and can add a test covering this issue in LibGit2Sharp anyways).
