### PR TITLE
hash: remove git_hash_init from internal api

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -31,7 +31,6 @@ typedef struct {
 	size_t len;
 } git_buf_vec;
 
-int git_hash_init(git_hash_ctx *c);
 int git_hash_update(git_hash_ctx *c, const void *data, size_t len);
 int git_hash_final(git_oid *out, git_hash_ctx *c);
 

--- a/src/hash/hash_generic.c
+++ b/src/hash/hash_generic.c
@@ -221,7 +221,7 @@ static void hash__block(git_hash_ctx *ctx, const unsigned int *data)
 	ctx->H[4] += E;
 }
 
-int git_hash_init(git_hash_ctx *ctx)
+int git_hash_ctx_init(git_hash_ctx *ctx)
 {
 	ctx->size = 0;
 
@@ -232,7 +232,7 @@ int git_hash_init(git_hash_ctx *ctx)
 	ctx->H[3] = 0x10325476;
 	ctx->H[4] = 0xc3d2e1f0;
 
-    return 0;
+	return 0;
 }
 
 int git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)

--- a/src/hash/hash_generic.h
+++ b/src/hash/hash_generic.h
@@ -18,7 +18,6 @@ struct git_hash_ctx {
 
 #define git_hash_global_init() 0
 #define git_hash_global_shutdown() /* noop */
-#define git_hash_ctx_init(ctx) git_hash_init(ctx)
 #define git_hash_ctx_cleanup(ctx)
 
 #endif /* INCLUDE_hash_generic_h__ */

--- a/src/hash/hash_win32.c
+++ b/src/hash/hash_win32.c
@@ -134,7 +134,7 @@ GIT_INLINE(int) hash_ctx_cryptoapi_init(git_hash_ctx *ctx)
 	ctx->type = CRYPTOAPI;
 	ctx->prov = &hash_prov;
 
-	return git_hash_init(ctx);
+	return git_hash_ctx_init(ctx);
 }
 
 GIT_INLINE(int) hash_cryptoapi_init(git_hash_ctx *ctx)
@@ -262,7 +262,7 @@ int git_hash_ctx_init(git_hash_ctx *ctx)
 	return (hash_prov.type == CNG) ? hash_ctx_cng_init(ctx) : hash_ctx_cryptoapi_init(ctx);
 }
 
-int git_hash_init(git_hash_ctx *ctx)
+int git_hash_ctx_init(git_hash_ctx *ctx)
 {
 	assert(ctx && ctx->type);
 	return (ctx->type == CNG) ? hash_cng_init(ctx) : hash_cryptoapi_init(ctx);

--- a/tests-clar/object/raw/hash.c
+++ b/tests-clar/object/raw/hash.c
@@ -8,11 +8,11 @@
 
 static void hash_object_pass(git_oid *oid, git_rawobj *obj)
 {
-   cl_git_pass(git_odb_hash(oid, obj->data, obj->len, obj->type));
+	cl_git_pass(git_odb_hash(oid, obj->data, obj->len, obj->type));
 }
 static void hash_object_fail(git_oid *oid, git_rawobj *obj)
 {
-   cl_git_fail(git_odb_hash(oid, obj->data, obj->len, obj->type));
+	cl_git_fail(git_odb_hash(oid, obj->data, obj->len, obj->type));
 }
 
 static char *hello_id = "22596363b3de40b06f981fb85d82312e8c0ed511";
@@ -23,144 +23,144 @@ static char *bye_text = "bye world\n";
 
 void test_object_raw_hash__hash_by_blocks(void)
 {
-    git_hash_ctx ctx;
-    git_oid id1, id2;
+	git_hash_ctx ctx;
+	git_oid id1, id2;
 
 	cl_git_pass(git_hash_ctx_init(&ctx));
 
 	/* should already be init'd */
-    cl_git_pass(git_hash_update(&ctx, hello_text, strlen(hello_text)));
-    cl_git_pass(git_hash_final(&id2, &ctx));
-    cl_git_pass(git_oid_fromstr(&id1, hello_id));
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_hash_update(&ctx, hello_text, strlen(hello_text)));
+	cl_git_pass(git_hash_final(&id2, &ctx));
+	cl_git_pass(git_oid_fromstr(&id1, hello_id));
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 
 	/* reinit should permit reuse */
-    cl_git_pass(git_hash_init(&ctx));
-    cl_git_pass(git_hash_update(&ctx, bye_text, strlen(bye_text)));
-    cl_git_pass(git_hash_final(&id2, &ctx));
-    cl_git_pass(git_oid_fromstr(&id1, bye_id));
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_hash_ctx_init(&ctx));
+	cl_git_pass(git_hash_update(&ctx, bye_text, strlen(bye_text)));
+	cl_git_pass(git_hash_final(&id2, &ctx));
+	cl_git_pass(git_oid_fromstr(&id1, bye_id));
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 
-    git_hash_ctx_cleanup(&ctx);
+	git_hash_ctx_cleanup(&ctx);
 }
 
 void test_object_raw_hash__hash_buffer_in_single_call(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, hello_id));
-    git_hash_buf(&id2, hello_text, strlen(hello_text));
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, hello_id));
+	git_hash_buf(&id2, hello_text, strlen(hello_text));
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_vector(void)
 {
-    git_oid id1, id2;
-    git_buf_vec vec[2];
+	git_oid id1, id2;
+	git_buf_vec vec[2];
 
-    cl_git_pass(git_oid_fromstr(&id1, hello_id));
+	cl_git_pass(git_oid_fromstr(&id1, hello_id));
 
-    vec[0].data = hello_text;
-    vec[0].len  = 4;
-    vec[1].data = hello_text+4;
-    vec[1].len  = strlen(hello_text)-4;
+	vec[0].data = hello_text;
+	vec[0].len  = 4;
+	vec[1].data = hello_text+4;
+	vec[1].len  = strlen(hello_text)-4;
 
-    git_hash_vec(&id2, vec, 2);
+	git_hash_vec(&id2, vec, 2);
 
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_junk_data(void)
 {
-    git_oid id, id_zero;
+	git_oid id, id_zero;
 
-    cl_git_pass(git_oid_fromstr(&id_zero, zero_id));
+	cl_git_pass(git_oid_fromstr(&id_zero, zero_id));
 
-    /* invalid types: */
-    junk_obj.data = some_data;
-    hash_object_fail(&id, &junk_obj);
+	/* invalid types: */
+	junk_obj.data = some_data;
+	hash_object_fail(&id, &junk_obj);
 
-    junk_obj.type = GIT_OBJ__EXT1;
-    hash_object_fail(&id, &junk_obj);
+	junk_obj.type = GIT_OBJ__EXT1;
+	hash_object_fail(&id, &junk_obj);
 
-    junk_obj.type = GIT_OBJ__EXT2;
-    hash_object_fail(&id, &junk_obj);
+	junk_obj.type = GIT_OBJ__EXT2;
+	hash_object_fail(&id, &junk_obj);
 
-    junk_obj.type = GIT_OBJ_OFS_DELTA;
-    hash_object_fail(&id, &junk_obj);
+	junk_obj.type = GIT_OBJ_OFS_DELTA;
+	hash_object_fail(&id, &junk_obj);
 
-    junk_obj.type = GIT_OBJ_REF_DELTA;
-    hash_object_fail(&id, &junk_obj);
+	junk_obj.type = GIT_OBJ_REF_DELTA;
+	hash_object_fail(&id, &junk_obj);
 
-    /* data can be NULL only if len is zero: */
-    junk_obj.type = GIT_OBJ_BLOB;
-    junk_obj.data = NULL;
-    hash_object_pass(&id, &junk_obj);
-    cl_assert(git_oid_cmp(&id, &id_zero) == 0);
+	/* data can be NULL only if len is zero: */
+	junk_obj.type = GIT_OBJ_BLOB;
+	junk_obj.data = NULL;
+	hash_object_pass(&id, &junk_obj);
+	cl_assert(git_oid_cmp(&id, &id_zero) == 0);
 
-    junk_obj.len = 1;
-    hash_object_fail(&id, &junk_obj);
+	junk_obj.len = 1;
+	hash_object_fail(&id, &junk_obj);
 }
 
 void test_object_raw_hash__hash_commit_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, commit_id));
-    hash_object_pass(&id2, &commit_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, commit_id));
+	hash_object_pass(&id2, &commit_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_tree_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, tree_id));
-    hash_object_pass(&id2, &tree_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, tree_id));
+	hash_object_pass(&id2, &tree_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_tag_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, tag_id));
-    hash_object_pass(&id2, &tag_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, tag_id));
+	hash_object_pass(&id2, &tag_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_zero_length_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, zero_id));
-    hash_object_pass(&id2, &zero_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, zero_id));
+	hash_object_pass(&id2, &zero_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_one_byte_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, one_id));
-    hash_object_pass(&id2, &one_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, one_id));
+	hash_object_pass(&id2, &one_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_two_byte_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, two_id));
-    hash_object_pass(&id2, &two_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, two_id));
+	hash_object_pass(&id2, &two_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 
 void test_object_raw_hash__hash_multi_byte_object(void)
 {
-    git_oid id1, id2;
+	git_oid id1, id2;
 
-    cl_git_pass(git_oid_fromstr(&id1, some_id));
-    hash_object_pass(&id2, &some_obj);
-    cl_assert(git_oid_cmp(&id1, &id2) == 0);
+	cl_git_pass(git_oid_fromstr(&id1, some_id));
+	hash_object_pass(&id2, &some_obj);
+	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }


### PR DESCRIPTION
Along with that, fix indentation in tests-clar/object/raw/hash.c

/cc @ethomson
