### PR TITLE
Increment reference counter in git_repository_set_config

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -553,6 +553,7 @@ void git_repository_set_config(git_repository *repo, git_config *config)
 
 	repo->_config = config;
 	GIT_REFCOUNT_OWN(repo->_config, repo);
+	GIT_REFCOUNT_INC(repo->_config);
 }
 
 int git_repository_odb__weakptr(git_odb **out, git_repository *repo)


### PR DESCRIPTION
This fixes #1365

When a config is attached to a repository, the repository becomes the config's owner. When the repository is freed, this ownership vanishes and the config has to manage it's lifetime by it self again. However, if we do not increase the reference count when attaching, the reference count is mismatched after freeing the repository.
