### PR TITLE
Clone should not clean up directories it did not create

### DIFF
--- a/src/fileops.h
+++ b/src/fileops.h
@@ -128,12 +128,20 @@ typedef enum {
 /**
  * Remove path and any files and directories beneath it.
  *
- * @param path Path to to top level directory to process.
+ * @param path Path to the top level directory to process.
  * @param base Root for relative path.
  * @param flags Combination of git_futils_rmdir_flags values
  * @return 0 on success; -1 on error.
  */
 extern int git_futils_rmdir_r(const char *path, const char *base, uint32_t flags);
+
+/**
+ * Remove all files and directories beneath the specified path.
+ *
+ * @param path Path to the top level directory to process.
+ * @return 0 on success; -1 on error.
+ */
+extern int git_futils_cleanupdir_r(const char *path);
 
 /**
  * Create and open a temporary file with a `_git2_` suffix.


### PR DESCRIPTION
Currently, clone will remove the directory it is cloning to when it fails. This change will cause clone to only clean up directories that it creates.

This does appear to be a slight deviation from core git, where in my testing, it will attempt to remove the directory on clone, even if it didn't create it. However, I think the correct behavior would be to not remote things that you did not create.
