### PR TITLE
Disable ignore_case when writing the index to a tree

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -242,7 +242,7 @@ static unsigned int index_merge_mode(
 	return index_create_mode(mode);
 }
 
-void git_index_set_ignore_case(git_index *index, bool ignore_case)
+void git_index__set_ignore_case(git_index *index, bool ignore_case)
 {
 	index->ignore_case = ignore_case;
 
@@ -390,7 +390,7 @@ int git_index_set_caps(git_index *index, unsigned int caps)
 	}
 
 	if (old_ignore_case != index->ignore_case) {
-		git_index_set_ignore_case(index, index->ignore_case);
+		git_index__set_ignore_case(index, index->ignore_case);
 	}
 
 	return 0;

--- a/src/index.h
+++ b/src/index.h
@@ -48,7 +48,7 @@ extern size_t git_index__prefix_position(git_index *index, const char *path);
 extern int git_index_entry__cmp(const void *a, const void *b);
 extern int git_index_entry__cmp_icase(const void *a, const void *b);
 
-extern void git_index_set_ignore_case(git_index *index, bool ignore_case);
+extern void git_index__set_ignore_case(git_index *index, bool ignore_case);
 
 extern int git_index_read_tree_match(
 	git_index *index, git_tree *tree, git_strarray *strspec);

--- a/src/tree.c
+++ b/src/tree.c
@@ -582,19 +582,19 @@ int git_tree__write_index(
 	}
 
 	/* The tree cache didn't help us; we'll have to write
-	 * out a tree. If the index is ignore_case, we'll must
+	 * out a tree. If the index is ignore_case, we must
 	 * make it case-sensitive for the duration of the tree-write
 	 * operation. */
 
 	if (index->ignore_case) {
 		old_ignore_case = true;
-		git_index_set_ignore_case(index, false);
+		git_index__set_ignore_case(index, false);
 	}
 
 	ret = write_tree(oid, repo, index, "", 0);
 
 	if (old_ignore_case)
-		git_index_set_ignore_case(index, true);
+		git_index__set_ignore_case(index, true);
 
 	return ret < 0 ? ret : 0;
 }


### PR DESCRIPTION
This is a pretty bad bug that can result in corrupt trees being written by libgit2, if for example the index is sorted ignore_case and contains the following items:

Folder\a.txt
FOLDER\b.txt
Folder\c.txt

The logic in `write_tree` in `tree.c` will end up in this case adding "Folder" to the treebuilder twice.

The index _must_ be sorted case-sensitively for tree-writing!
