### PR TITLE
Allow empty config object and use it for tests

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -426,8 +426,6 @@ static int get_string(const char **out, const git_config *cfg, const char *name)
 	file_internal *internal;
 	unsigned int i;
 
-	assert(cfg->files.length);
-
 	git_vector_foreach(&cfg->files, i, internal) {
 		int res = get_string_at_file(out, internal->file, name);
 
@@ -466,8 +464,6 @@ int git_config_get_entry(const git_config_entry **out, const git_config *cfg, co
 	file_internal *internal;
 	unsigned int i;
 
-	assert(cfg->files.length);
-
 	*out = NULL;
 
 	git_vector_foreach(&cfg->files, i, internal) {
@@ -487,8 +483,6 @@ int git_config_get_multivar(const git_config *cfg, const char *name, const char 
 	git_config_backend *file;
 	int ret = GIT_ENOTFOUND;
 	size_t i;
-
-	assert(cfg->files.length);
 
 	/*
 	 * This loop runs the "wrong" way 'round because we need to

--- a/tests-clar/diff/patch.c
+++ b/tests-clar/diff/patch.c
@@ -150,9 +150,8 @@ void test_diff_patch__hunks_have_correct_line_numbers(void)
 
 	g_repo = cl_git_sandbox_init("renames");
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
-	cl_git_pass(git_config_set_bool(cfg, "core.autocrlf", false));
-	git_config_free(cfg);
+	cl_git_pass(git_config_new(&cfg));
+	git_repository_set_config(g_repo, cfg);
 
 	cl_git_rewritefile("renames/songof7cities.txt", new_content);
 
@@ -278,9 +277,8 @@ void test_diff_patch__line_counts_with_eofnl(void)
 
 	g_repo = cl_git_sandbox_init("renames");
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
-	cl_git_pass(git_config_set_bool(cfg, "core.autocrlf", false));
-	git_config_free(cfg);
+	cl_git_pass(git_config_new(&cfg));
+	git_repository_set_config(g_repo, cfg);
 
 	cl_git_pass(git_futils_readbuffer(&content, "renames/songof7cities.txt"));
 


### PR DESCRIPTION
This removes assertions that prevent us from having an empty `git_config` object and then updates some tests that were dependent on global config state to use an empty config before running anything.
