### PR TITLE
indexer: use a hashtable for keeping track of offsets

### DIFF
--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -21,8 +21,6 @@
 #include "git2/indexer.h"
 #include "git2/config.h"
 
-GIT__USE_OIDMAP;
-
 struct unpacked {
 	git_pobject *object;
 	void *data;

--- a/src/pack.c
+++ b/src/pack.c
@@ -760,13 +760,14 @@ git_off_t get_delta_base(
 	} else if (type == GIT_OBJ_REF_DELTA) {
 		/* If we have the cooperative cache, search in it first */
 		if (p->has_cache) {
-			size_t pos;
-			struct git_pack_entry key;
+			khiter_t k;
+			git_oid oid;
 
-			git_oid_fromraw(&key.sha1, base_info);
-			if (!git_vector_bsearch(&pos, &p->cache, &key)) {
+			git_oid_fromraw(&oid, base_info);
+			k = kh_get(oid, p->idx_cache, &oid);
+			if (k != kh_end(p->idx_cache)) {
 				*curpos += 20;
-				return ((struct git_pack_entry *)git_vector_get(&p->cache, pos))->offset;
+				return ((struct git_pack_entry *)kh_value(p->idx_cache, k))->offset;
 			}
 		}
 		/* The base entry _must_ be in the same pack */

--- a/src/pack.h
+++ b/src/pack.h
@@ -16,6 +16,7 @@
 #include "map.h"
 #include "mwindow.h"
 #include "odb.h"
+#include "oidmap.h"
 
 #define GIT_PACK_FILE_MODE 0444
 
@@ -62,6 +63,7 @@ typedef struct git_pack_cache_entry {
 #include "offmap.h"
 
 GIT__USE_OFFMAP;
+GIT__USE_OIDMAP;
 
 #define GIT_PACK_CACHE_MEMORY_LIMIT 16 * 1024 * 1024
 #define GIT_PACK_CACHE_SIZE_LIMIT 1024 * 1024 /* don't bother caching anything over 1MB */
@@ -86,7 +88,7 @@ struct git_pack_file {
 	git_time_t mtime;
 	unsigned pack_local:1, pack_keep:1, has_cache:1;
 	git_oid sha1;
-	git_vector cache;
+	git_oidmap *idx_cache;
 	git_oid **oids;
 
 	git_pack_cache bases; /* delta base cache */


### PR DESCRIPTION
These offsets are needed for REF_DELTA objects, which encode which
object they use as a base, but not where it lies in the packfile, so
we need a list.

These objects are mostly from older packfiles, before OFS_DELTA was
widely spread. The time spent in indexing these packfiles is greatly
reduced, though remains above what git is able to do.

---

This is still two to three times slower than git on the same packfile. `perf` says we spend 55% of the time inflating, so it's most likely due to git caching the deltas in full, while we inflate them twice. We're unlikely to find this type of old packfile in the wild, as most should come from some git server which can generate `OFS_DELTA`, so I wouldn't worry too much about it, as we're not embarrassingly slow anymore.
