### PR TITLE
clear REUC on checkout

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -564,6 +564,14 @@ GIT_EXTERN(int) git_index_reuc_add(git_index *index, const char *path,
  */
 GIT_EXTERN(int) git_index_reuc_remove(git_index *index, size_t n);
 
+/**
+ * Remove all resolve undo entries from the index
+ *
+ * @param index an existing index object
+ * @return 0 or an error code
+ */
+GIT_EXTERN(void) git_index_reuc_clear(git_index *index);
+
 /**@}*/
 
 /** @} */

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1143,6 +1143,9 @@ static int checkout_data_init(
 			if ((error = git_repository_index(&data->index, data->repo)) < 0 ||
 				(error = git_index_read(data->index)) < 0)
 				goto cleanup;
+			
+			/* clear the REUC when doing a tree or commit checkout */
+			git_index_reuc_clear(data->index);
 		}
 	}
 

--- a/src/index.c
+++ b/src/index.c
@@ -297,18 +297,8 @@ int git_index_new(git_index **out)
 
 static void index_free(git_index *index)
 {
-	git_index_entry *e;
-	git_index_reuc_entry *reuc;
-	size_t i;
-
 	git_index_clear(index);
-	git_vector_foreach(&index->entries, i, e) {
-		index_entry_free(e);
-	}
 	git_vector_free(&index->entries);
-	git_vector_foreach(&index->reuc, i, reuc) {
-		index_entry_reuc_free(reuc);
-	}
 	git_vector_free(&index->reuc);
 
 	git__free(index->index_file_path);
@@ -335,16 +325,10 @@ void git_index_clear(git_index *index)
 		git__free(e->path);
 		git__free(e);
 	}
-
-	for (i = 0; i < index->reuc.length; ++i) {
-		git_index_reuc_entry *e;
-		e = git_vector_get(&index->reuc, i);
-		git__free(e->path);
-		git__free(e);
-	}
-
 	git_vector_clear(&index->entries);
-	git_vector_clear(&index->reuc);
+
+	git_index_reuc_clear(index);
+	
 	git_futils_filestamp_set(&index->stamp, NULL);
 
 	git_tree_cache_free(index->tree);
@@ -1149,6 +1133,21 @@ int git_index_reuc_remove(git_index *index, size_t position)
 		index_entry_reuc_free(reuc);
 
 	return error;
+}
+
+void git_index_reuc_clear(git_index *index)
+{
+	size_t i;
+	git_index_reuc_entry *reuc;
+
+	assert(index);
+
+	git_vector_foreach(&index->reuc, i, reuc) {
+		git__free(reuc->path);
+		git__free(reuc);
+	}
+
+	git_vector_clear(&index->reuc);
 }
 
 static int index_error_invalid(const char *message)

--- a/tests-clar/index/reuc.c
+++ b/tests-clar/index/reuc.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 #include "index.h"
 #include "git2/repository.h"
+#include "../reset/reset_helpers.h"
 
 static git_repository *repo;
 static git_index *repo_index;
@@ -286,3 +287,87 @@ void test_index_reuc__write(void)
 	cl_assert_equal_s("two.txt", reuc->path);
 }
 
+static int reuc_entry_exists(void)
+{
+	return (git_index_reuc_get_bypath(repo_index, "newfile.txt") != NULL);
+}
+
+void test_index_reuc__cleaned_on_reset_hard(void)
+{
+	git_object *target;
+	
+	retrieve_target_from_oid(&target, repo, "3a34580a35add43a4cf361e8e9a30060a905c876");
+	
+	test_index_reuc__add();
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD));
+	cl_assert(reuc_entry_exists() == false);
+	
+	git_object_free(target);
+}
+
+void test_index_reuc__cleaned_on_reset_mixed(void)
+{
+	git_object *target;
+	
+	retrieve_target_from_oid(&target, repo, "3a34580a35add43a4cf361e8e9a30060a905c876");
+
+	test_index_reuc__add();	
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED));
+	cl_assert(reuc_entry_exists() == false);
+	
+	git_object_free(target);
+}
+
+void test_index_reuc__retained_on_reset_soft(void)
+{
+	git_object *target;
+	
+	retrieve_target_from_oid(&target, repo, "3a34580a35add43a4cf361e8e9a30060a905c876");
+	
+	git_reset(repo, target, GIT_RESET_HARD);
+
+	test_index_reuc__add();
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT));
+	cl_assert(reuc_entry_exists() == true);
+	
+	git_object_free(target);
+}
+
+void test_index_reuc__cleaned_on_checkout_tree(void)
+{
+	git_oid oid;
+	git_object *obj;
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	
+	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_UPDATE_ONLY;
+
+	test_index_reuc__add();
+	git_reference_name_to_id(&oid, repo, "refs/heads/master");
+	git_object_lookup(&obj, repo, &oid, GIT_OBJ_ANY);
+	git_checkout_tree(repo, obj, &opts);
+	cl_assert(reuc_entry_exists() == false);
+	
+	git_object_free(obj);
+}
+
+void test_index_reuc__cleaned_on_checkout_head(void)
+{
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	
+	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_UPDATE_ONLY;
+	
+	test_index_reuc__add();
+	git_checkout_head(repo, &opts);
+	cl_assert(reuc_entry_exists() == false);
+}
+
+void test_index_reuc__retained_on_checkout_index(void)
+{
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	
+	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_UPDATE_ONLY;
+	
+	test_index_reuc__add();
+	git_checkout_index(repo, repo_index, &opts);
+	cl_assert(reuc_entry_exists() == true);
+}


### PR DESCRIPTION
Clear the REUC on checkout (except `git_checkout_index`).

Remove some unused cruft from `index_free` (calling `git_index_clear` emptied the index entries and the REUC already).

Some tests to ensure the REUC is cleared on resets and checkouts.
