### PR TITLE
refs: explicitly catch leading slashes

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -1667,6 +1667,9 @@ int git_reference__normalize_name(
 	process_flags = flags;
 	current = (char *)name;
 
+	if (*current == '/')
+		goto cleanup;
+
 	if (normalize)
 		git_buf_clear(buf);
 

--- a/tests-clar/refs/lookup.c
+++ b/tests-clar/refs/lookup.c
@@ -32,6 +32,12 @@ void test_refs_lookup__with_resolve(void)
 	git_reference_free(a);
 }
 
+void test_refs_lookup__invalid_name(void)
+{
+	git_oid oid;
+	cl_git_fail(git_reference_name_to_id(&oid, g_repo, "/refs/tags/point_to_blob"));
+}
+
 void test_refs_lookup__oid(void)
 {
 	git_oid tag, expected;


### PR DESCRIPTION
It's somewhat common to try to write "/refs/tags/something". There is
no easy way to catch it during the main body of the function, as there
is no way to distinguish whether it's a leading slash or a double
slash somewhere in the middle.

Catch this at the beginning so we don't trigger the assert in
is_all_caps_and_underscore().

---

Not pretty, but effective. The case when we're not normalising is already handled, but when normalising, this is the simplest approach.
