### PR TITLE
Failing config related test

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -362,6 +362,11 @@ int git_config_set_string(git_config *cfg, const char *name, const char *value)
 	git_config_backend *file;
 	file_internal *internal;
 
+	if (!value) {
+		giterr_set(GITERR_CONFIG, "The value to set cannot be NULL");
+		return -1;
+	}
+
 	internal = git_vector_get(&cfg->files, 0);
 	file = internal->file;
 

--- a/tests-clar/config/write.c
+++ b/tests-clar/config/write.c
@@ -228,3 +228,17 @@ void test_config_write__add_value_at_file_with_no_clrf_at_the_end(void)
 
 	git_config_free(cfg);
 }
+
+void test_config_write__can_set_a_value_to_NULL(void)
+{
+    git_repository *repository;
+    git_config *config;
+
+    repository = cl_git_sandbox_init("testrepo.git");
+
+    cl_git_pass(git_repository_config(&config, repository));
+    cl_git_fail(git_config_set_string(config, "a.b.c", NULL));
+    git_config_free(config);
+
+    cl_git_sandbox_cleanup();
+}

--- a/tests-clar/online/fetchhead.c
+++ b/tests-clar/online/fetchhead.c
@@ -79,8 +79,8 @@ void test_online_fetchhead__no_merges(void)
 	fetchhead_test_clone();
 
 	cl_git_pass(git_repository_config(&config, g_repo));
-	cl_git_pass(git_config_set_string(config, "branch.master.remote", NULL));
-	cl_git_pass(git_config_set_string(config, "branch.master.merge", NULL));
+	cl_git_pass(git_config_delete_entry(config, "branch.master.remote"));
+	cl_git_pass(git_config_delete_entry(config, "branch.master.merge"));
 	git_config_free(config);
 
 	fetchhead_test_fetch(NULL, FETCH_HEAD_NO_MERGE_DATA);


### PR DESCRIPTION
``` c
void test_config_write__can_set_a_value_to_NULL(void)
{
    git_repository *repository;
    git_config *config;

    repository = cl_git_sandbox_init("testrepo.git");

    cl_git_pass(git_repository_config(&config, repository));
    cl_git_pass(git_config_set_string(config, "a.b.c", NULL));
    git_config_free(config);

    cl_git_sandbox_cleanup();
}
```

Fails with message `"Race condition when writing a config file (a cvar has been removed)"`

/cc @carlosmn 
