### PR TITLE
Can't perform diff with no context lines

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -289,7 +289,7 @@ typedef struct {
 } git_diff_options;
 
 #define GIT_DIFF_OPTIONS_VERSION 1
-#define GIT_DIFF_OPTIONS_INIT {GIT_DIFF_OPTIONS_VERSION}
+#define GIT_DIFF_OPTIONS_INIT {GIT_DIFF_OPTIONS_VERSION, GIT_DIFF_NORMAL, 3}
 
 /**
  * When iterating over a diff, callback that will be made per file.

--- a/src/diff.c
+++ b/src/diff.c
@@ -291,8 +291,11 @@ static git_diff_list *git_diff_list_alloc(
 	 * - diff.noprefix
 	 */
 
-	if (opts == NULL)
+	if (opts == NULL) {
+		/* Make sure we default to 3 lines */
+		diff->opts.context_lines = 3;
 		return diff;
+	}
 
 	memcpy(&diff->opts, opts, sizeof(git_diff_options));
 

--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -202,7 +202,7 @@ static void setup_xdiff_options(
 	memset(param, 0, sizeof(xpparam_t));
 
 	cfg->ctxlen =
-		(!opts || !opts->context_lines) ? 3 : opts->context_lines;
+		(!opts) ? 3 : opts->context_lines;
 	cfg->interhunkctxlen =
 		(!opts) ? 0 : opts->interhunk_lines;
 

--- a/tests-clar/diff/tree.c
+++ b/tests-clar/diff/tree.c
@@ -10,6 +10,8 @@ static diff_expects expect;
 void test_diff_tree__initialize(void)
 {
 	GIT_INIT_STRUCTURE(&opts, GIT_DIFF_OPTIONS_VERSION);
+	/* The default context lines is set by _INIT which we can't use here */
+	opts.context_lines = 3;
 
 	memset(&expect, 0, sizeof(expect));
 


### PR DESCRIPTION
Setting `context_lines` of `git_diff_options` to `0` returns `3` context lines instead.
