### PR TITLE
Fix various build warnings

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -39,10 +39,13 @@ git_reference *git_reference__alloc(
 	const char *symbolic)
 {
 	git_reference *ref;
+	size_t namelen;
 
 	assert(refdb && name && ((oid && !symbolic) || (!oid && symbolic)));
-	
-	if ((ref = git__calloc(1, sizeof(git_reference) + strlen(name) + 1)) == NULL)
+
+	namelen = strlen(name);
+
+	if ((ref = git__calloc(1, sizeof(git_reference) + namelen + 1)) == NULL)
 		return NULL;
 
 	if (oid) {
@@ -51,13 +54,15 @@ git_reference *git_reference__alloc(
 	} else {
 		ref->type = GIT_REF_SYMBOLIC;
 
-		if ((ref->target.symbolic = git__strdup(symbolic)) == NULL)
+		if ((ref->target.symbolic = git__strdup(symbolic)) == NULL) {
+			git__free(ref);
 			return NULL;
+		}
 	}
-	
+
 	ref->db = refdb;
-	strcpy(ref->name, name);
-	
+	memcpy(ref->name, name, namelen + 1);
+
 	return ref;
 }
 
@@ -70,7 +75,7 @@ void git_reference_free(git_reference *reference)
 		git__free(reference->target.symbolic);
 		reference->target.symbolic = NULL;
 	}
-	
+
 	reference->db = NULL;
 	reference->type = GIT_REF_INVALID;
 

--- a/tests-clar/commit/parse.c
+++ b/tests-clar/commit/parse.c
@@ -155,7 +155,7 @@ void test_commit_parse__signature(void)
       cl_git_pass(git_signature__parse(&person, &str, str + len, passcase->header, '\n'));
       cl_assert_equal_s(passcase->name, person.name);
       cl_assert_equal_s(passcase->email, person.email);
-      cl_assert_equal_i(passcase->time, person.when.time);
+      cl_assert_equal_i((int)passcase->time, (int)person.when.time);
       cl_assert_equal_i(passcase->offset, person.when.offset);
       git__free(person.name); git__free(person.email);
    }

--- a/tests-clar/refs/pack.c
+++ b/tests-clar/refs/pack.c
@@ -19,10 +19,10 @@ void test_refs_pack__cleanup(void)
    cl_git_sandbox_cleanup();
 }
 
-void packall()
+static void packall(void)
 {
 	git_refdb *refdb;
-	
+
 	cl_git_pass(git_repository_refdb(&refdb, g_repo));
 	cl_git_pass(git_refdb_compress(refdb));
 }

--- a/tests-clar/trace/trace.c
+++ b/tests-clar/trace/trace.c
@@ -5,6 +5,8 @@ static int written = 0;
 
 static void trace_callback(git_trace_level_t level, const char *message)
 {
+	GIT_UNUSED(level);
+
 	cl_assert(strcmp(message, "Hello world!") == 0);
 
 	written = 1;


### PR DESCRIPTION
This fixes various build warnings on Mac and Windows (64-bit).

There are two noteworthy changes, I think.
1. I replaced a strcpy with a memcpy in `git_reference__alloc()` because the string length is known (which is why the strcpy was safe).
2. In `winhttp.c:put_uuid_string()` I replaced the call to `wsprintfW` with `StringCbPrintfW` which takes an extra parameter to ensure that the output buffer is not overrun. To be honest, I'm really not sure about this change, but there was a Windows deprecation warning for the old function and this is what MSDN recommended (and a sprintf that's not a snprintf always makes me nervous even though this was being checked beforehand).

I also removed some duplicated parameter validation code in `winhttp.c:get_temp_file()` and tried to clean up the associated code a bit.
