### PR TITLE
Fix link issue in network examples

### DIFF
--- a/examples/network/Makefile
+++ b/examples/network/Makefile
@@ -3,7 +3,8 @@ default: all
 CC = gcc
 CFLAGS += -g
 CFLAGS += -I../../include
-LDFLAGS += -L../../build -L../.. -lgit2 -lpthread
+LDFLAGS += -L../../build -L../..
+LIBRARIES += -lgit2 -lpthread
 
 OBJECTS = \
   git2.o \
@@ -13,7 +14,7 @@ OBJECTS = \
   index-pack.o
 
 all: $(OBJECTS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o git2 $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o git2 $(OBJECTS) $(LIBRARIES)
 
 clean:
 	$(RM) $(OBJECTS)


### PR DESCRIPTION
Hi,

gcc version 4.6.3 complains if libraries are "declared" before object files on build line. I created a new variable in examples/network/Makefile to split LDFLAGS and libraries name.

Lionel
