### PR TITLE
Support simple redirect response with HTTP

### DIFF
--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -324,7 +324,7 @@ int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 	t->parent.is_connected = git_smart__is_connected;
 	t->parent.read_flags = git_smart__read_flags;
 	t->parent.cancel = git_smart__cancel;
-	
+
 	t->owner = owner;
 	t->rpc = definition->rpc;
 
@@ -336,7 +336,7 @@ int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 	if (definition->callback(&t->wrapped, &t->parent) < 0) {
 		git__free(t);
 		return -1;
-	}	
+	}
 
 	*out = (git_transport *) t;
 	return 0;


### PR DESCRIPTION
Okay, so I'm somewhat embarrassed about this PR. :flushed:

I know this can't possibly be the right way to do this, but I started at the existing spot where the status code is checked and ran from there, attempting to recognize the 3xx response, update the environment and restart the connection.

I saw a relatively easy way to update the path, but no easy way to update the host from inside the callback, so I started out but just accepting redirects that don't change the host.

At first I just updated the path with the full new location, but since the redirect contains the combined path and service url, but we store those two pieces separately, and I saw no easy way to reliably split the redirect location into the two parts. Instead I just made it so that we only accept a matching service url and as soon as the request is complete, the code restores the original path.

I ran into some infinite loops while I was muddling around which is why I put the stall detection into `gitno_send()` (i.e. if we try to write some data enough times with zero bytes accepted, I'll abort the write loop). Once I got the rest of my problems worked out, I suspect the stall detection is unnecessary. I'm happy to rip that shit out if it is just stupid.

Anyhow, someone who actually understands the network code more deeply please take a look, have a good laugh, and propose an alternate fix that will allow for redirects.
