### PR TITLE
don't stat until the file is written

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -666,11 +666,11 @@ static int buffer_to_file(
 		giterr_set(GITERR_OS, "Could not write to '%s'", path);
 		(void)p_close(fd);
 	} else {
-		if ((error = p_fstat(fd, st)) < 0)
-			giterr_set(GITERR_OS, "Error while statting '%s'", path);
-
 		if ((error = p_close(fd)) < 0)
 			giterr_set(GITERR_OS, "Error while closing '%s'", path);
+
+		if ((error = p_stat(path, st)) < 0)
+			giterr_set(GITERR_OS, "Error while statting '%s'", path);
 	}
 
 	if (!error &&


### PR DESCRIPTION
Aha.  Turns out that Windows will update `mtime` on close.  Who knew?

I spent a while trying to figure out how to test this and failed.  Do note that the following will fail on Windows:

```
void test_checkout(void)
{
    int fd;
    struct stat st_before, st_after;

#ifdef GIT_WIN32
    cl_assert((fd = p_open("./crlf/new-file", O_RDWR|O_CREAT, 0666)) >= 0);
    cl_git_pass(p_write(fd, "FOO!\r\n", 7));
    cl_git_pass(p_fstat(fd, &st_before));
#ifdef GIT_WIN32
    Sleep(2000);
#else
    sleep(2);
#endif
    cl_git_pass(p_close(fd));
    cl_git_pass(p_stat("./crlf/new-file", &st_after));

    cl_assert(st_before.st_mtime == st_after.st_mtime);
}
```

(Note that I was a little concerned about `stat(2)` here, since it has to resolve the inode by name.  After testing, any difference appears to be roughly epsilon, at least on Mac OS.)
