### PR TITLE
git_diff_foreach() : fix submodule dirty states not showing if submodules comes before files

### DIFF
--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -678,7 +678,8 @@ cleanup:
 		if ((delta->flags & GIT_DIFF_FLAG_BINARY) == 0 &&
 			delta->status != GIT_DELTA_UNMODIFIED &&
 			(patch->old_data.len || patch->new_data.len) &&
-			!git_oid_equal(&delta->old_file.oid, &delta->new_file.oid))
+			((patch->old_data.len != patch->new_data.len) ||
+				!git_oid_equal(&delta->old_file.oid, &delta->new_file.oid)))
 			patch->flags |= GIT_DIFF_PATCH_DIFFABLE;
 	}
 


### PR DESCRIPTION
Please download this repo to test
https://www.dropbox.com/s/pnlxccc0ve50ajb/wrong-libgit2-status.7z

Make sure that only `ext/apr` and `ext/apr-util` are dirty submodules.
No other modified files in super repository.

Fix submodule dirty states not showing if submodules comes before files or there are only dirty submodules but no changed files.

GIT_DIFF_PATCH_DIFFABLE was not set, so the diff content was not shown

When submodule is dirty, the hash may be the same, but the length is different because -dirty is appended

We can therefore compare the length or hash.

Note: if you modify `build.txt`, then `build.txt` comes before `ext/apr`.  When processing `build.txt`, GIT_DIFF_PATCH_DIFFABLE is set before processing `ext/apr`, so submodule dirty states can show correctly.
