### PR TITLE
remove unmerged files during reset hard

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -235,10 +235,13 @@ static int checkout_action_wd_only(
 	/* check if item is tracked in the index but not in the checkout diff */
 	if (data->index != NULL) {
 		if (wd->mode != GIT_FILEMODE_TREE) {
-			if (git_index_get_bypath(data->index, wd->path, 0) != NULL) {
+			int error;
+
+			if ((error = git_index_find(NULL, data->index, wd->path)) == 0) {
 				notify = GIT_CHECKOUT_NOTIFY_DIRTY;
 				remove = ((data->strategy & GIT_CHECKOUT_FORCE) != 0);
-			}
+			} else if (error != GIT_ENOTFOUND)
+				return error;
 		} else {
 			/* for tree entries, we have to see if there are any index
 			 * entries that are contained inside that tree


### PR DESCRIPTION
Treat an index entry at any stage as if it were staged, in order to clean up working directory items that result from an aborted merge.

Consider that we delete some file `file` in our branch `master` and merge in branch `branch` that contains an edit to the file `file`.  We will be left with an index:

```
100644 27b89ab611e391e6707207e6b9136407bee499a5 1 file
100644 5fbd29033b82cc8d8cc9bb9cd836dc756630fb19 3 file
```

And `file` will be recreated in the workdir from the contents in `branch`.

`git reset --hard` will remove `file` when resetting.  libgit2 should do the same.

(Note that core git cleans up working directory contents for unmerged files always - it does not check that the workdir contents match one of the sides in the index.  Our tests ensures that behavior is consistent.)
