### PR TITLE
branch: Fix git_branch_create() documentation

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -38,10 +38,8 @@ GIT_BEGIN_DECL
  * validated for consistency. It should also not conflict with
  * an already existing branch name.
  *
- * @param target Object to which this branch should point. This object
- * must belong to the given `repo` and can either be a git_commit or a
- * git_tag. When a git_tag is being passed, it should be dereferencable
- * to a git_commit which oid will be used as the target of the branch.
+ * @param target Commit to which this branch should point. This object
+ * must belong to the given `repo`.
  *
  * @param force Overwrite existing branch.
  *


### PR DESCRIPTION
Fix documentation leftover from API cleanup cfbe4be3fb639d96587974794fe437ace0c383c4
