### PR TITLE
Use git_odb_object_data/_size whereever possible

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -17,19 +17,21 @@
 const void *git_blob_rawcontent(const git_blob *blob)
 {
 	assert(blob);
-	return blob->odb_object->buffer;
+	return git_odb_object_data(blob->odb_object);
 }
 
 git_off_t git_blob_rawsize(const git_blob *blob)
 {
 	assert(blob);
-	return (git_off_t)blob->odb_object->cached.size;
+	return (git_off_t)git_odb_object_size(blob->odb_object);
 }
 
 int git_blob__getbuf(git_buf *buffer, git_blob *blob)
 {
 	return git_buf_set(
-		buffer, blob->odb_object->buffer, blob->odb_object->cached.size);
+		buffer,
+		git_odb_object_data(blob->odb_object),
+		git_odb_object_size(blob->odb_object));
 }
 
 void git_blob__free(git_blob *blob)

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -698,8 +698,8 @@ static int blob_content_to_file(
 	git_vector filters = GIT_VECTOR_INIT;
 
 	/* Create a fake git_buf from the blob raw data... */
-	filtered.ptr = blob->odb_object->buffer;
-	filtered.size = blob->odb_object->cached.size;
+	filtered.ptr  = (void *)git_blob_rawcontent(blob);
+	filtered.size = (size_t)git_blob_rawsize(blob);
 	/* ... and make sure it doesn't get unexpectedly freed */
 	dont_free_filtered = true;
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -209,7 +209,8 @@ bad_buffer:
 int git_commit__parse(git_commit *commit, git_odb_object *obj)
 {
 	assert(commit);
-	return git_commit__parse_buffer(commit, obj->buffer, obj->cached.size);
+	return git_commit__parse_buffer(
+		commit, git_odb_object_data(obj), git_odb_object_size(obj));
 }
 
 #define GIT_COMMIT_GETTER(_rvalue, _name, _return) \

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -103,12 +103,12 @@ git_commit_list_node *git_commit_list_pop(git_commit_list **stack)
 static int commit_quick_parse(
 	git_revwalk *walk,
 	git_commit_list_node *commit,
-	uint8_t *buffer,
+	const uint8_t *buffer,
 	size_t buffer_len)
 {
 	const size_t parent_len = strlen("parent ") + GIT_OID_HEXSZ + 1;
-	uint8_t *buffer_end = buffer + buffer_len;
-	uint8_t *parents_start, *committer_start;
+	const uint8_t *buffer_end = buffer + buffer_len;
+	const uint8_t *parents_start, *committer_start;
 	int i, parents = 0;
 	int commit_time;
 
@@ -127,7 +127,7 @@ static int commit_quick_parse(
 	for (i = 0; i < parents; ++i) {
 		git_oid oid;
 
-		if (git_oid_fromstr(&oid, (char *)buffer + strlen("parent ")) < 0)
+		if (git_oid_fromstr(&oid, (const char *)buffer + strlen("parent ")) < 0)
 			return -1;
 
 		commit->parents[i] = git_revwalk__commit_lookup(walk, &oid);
@@ -189,7 +189,10 @@ int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit)
 		giterr_set(GITERR_INVALID, "Object is no commit object");
 		error = -1;
 	} else
-		error = commit_quick_parse(walk, commit, obj->buffer, obj->cached.size);
+		error = commit_quick_parse(
+			walk, commit,
+			(const uint8_t *)git_odb_object_data(obj),
+			git_odb_object_size(obj));
 
 	git_odb_object_free(obj);
 	return error;

--- a/src/tag.c
+++ b/src/tag.c
@@ -396,7 +396,8 @@ int git_tag_delete(git_repository *repo, const char *tag_name)
 int git_tag__parse(git_tag *tag, git_odb_object *obj)
 {
 	assert(tag);
-	return git_tag__parse_buffer(tag, obj->buffer, obj->cached.size);
+	return git_tag__parse_buffer(
+		tag, git_odb_object_data(obj), git_odb_object_size(obj));
 }
 
 typedef struct {

--- a/src/tree.c
+++ b/src/tree.c
@@ -371,7 +371,8 @@ static int tree_error(const char *str, const char *path)
 	return -1;
 }
 
-static int tree_parse_buffer(git_tree *tree, const char *buffer, const char *buffer_end)
+static int tree_parse_buffer(
+	git_tree *tree, const char *buffer, const char *buffer_end)
 {
 	if (git_vector_init(&tree->entries, DEFAULT_TREE_SIZE, entry_sort_cmp) < 0)
 		return -1;
@@ -418,10 +419,13 @@ static int tree_parse_buffer(git_tree *tree, const char *buffer, const char *buf
 
 int git_tree__parse(git_tree *tree, git_odb_object *obj)
 {
-	assert(tree);
-	return tree_parse_buffer(tree,
-		(char *)obj->buffer,
-		(char *)obj->buffer + obj->cached.size);
+	const char *buf;
+
+	assert(tree && obj);
+
+	buf = (const char *)git_odb_object_data(obj);
+
+	return tree_parse_buffer(tree, buf, buf + git_odb_object_size(obj));
 }
 
 static size_t find_next_dir(const char *dirname, git_index *index, size_t start)


### PR DESCRIPTION
@vmg This is the change to use the odb object accessors that I had suggested...
