### PR TITLE
commit: correctly detect the start of the commit message

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -189,8 +189,8 @@ int git_commit__parse_buffer(git_commit *commit, const void *data, size_t len)
 		buffer = eoln;
 	}
 
-	/* skip blank lines */
-	while (buffer < buffer_end - 1 && *buffer == '\n')
+	/* buffer is now at the end of the header, double-check and move forward into the message */
+	if (buffer < buffer_end && *buffer == '\n')
 		buffer++;
 
 	/* parse commit message */

--- a/tests-clar/commit/parse.c
+++ b/tests-clar/commit/parse.c
@@ -297,7 +297,7 @@ void test_commit_parse__entire_commit(void)
          );
 
 		if (!i)
-			cl_assert_equal_s("\n", git_commit_message(commit));
+			cl_assert_equal_s("", git_commit_message(commit));
 		else
 			cl_assert(git__prefixcmp(
 				git_commit_message(commit), "a simple commit which works") == 0);
@@ -366,3 +366,30 @@ void test_commit_parse__details0(void) {
 	}
 }
 
+void test_commit_parse__leading_lf(void)
+{
+	git_commit *commit;
+	const char *buffer =
+"tree 1810dff58d8a660512d4832e740f692884338ccd\n\
+parent e90810b8df3e80c413d903f631643c716887138d\n\
+author Vicent Marti <tanoku@gmail.com> 1273848544 +0200\n\
+committer Vicent Marti <tanoku@gmail.com> 1273848544 +0200\n\
+\n\
+\n\
+\n\
+This commit has a few LF at the start of the commit message";
+	const char *message =
+"\n\
+\n\
+This commit has a few LF at the start of the commit message";
+
+	commit = (git_commit*)git__malloc(sizeof(git_commit));
+	memset(commit, 0x0, sizeof(git_commit));
+	commit->object.repo = g_repo;
+
+	cl_git_pass(git_commit__parse_buffer(commit, buffer, strlen(buffer)));
+
+	cl_assert_equal_s(message, git_commit_message(commit));
+
+	git_commit__free(commit);
+}


### PR DESCRIPTION
The end of the header is signaled by to consecutive LFs and the commit
message starts immediately after. Jumping over LFs at the start of the
message is a bug and leads to creating different commits if
when rebuilding history.

This also fixes an empty commit message being returned as "\n".

---

The empty message as "\n" seems to have been there quite a while, but it doesn't look like anybody's noticed. It's presumably as rare as having leading LFs in the commit message, but we still need to return the actual contents of the message, or we run into problems when trying to recreate a commit.
