### PR TITLE
Add `git_repository_open_bare`

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -124,6 +124,21 @@ GIT_EXTERN(int) git_repository_open_ext(
 	const char *ceiling_dirs);
 
 /**
+ * Open a bare repository on the serverside.
+ *
+ * This is a fast open for bare repositories that will come in handy
+ * if you're e.g. hosting git repositories and need to access them
+ * efficiently
+ *
+ * @param out Pointer to the repo which will be opened.
+ * @param bare_path Direct path to the bare repository
+ * @return 0 on success, or an error code
+ */
+GIT_EXTERN(int) git_repository_open_bare(
+	git_repository **out,
+	const char *bare_path);
+
+/**
  * Free a previously allocated repository
  *
  * Note that after a repository is free'd, all the objects it has spawned

--- a/src/repository.c
+++ b/src/repository.c
@@ -368,6 +368,37 @@ static int find_repo(
 	return error;
 }
 
+int git_repository_open_bare(
+	git_repository **repo_ptr,
+	const char *bare_path)
+{
+	int error;
+	git_buf path = GIT_BUF_INIT;
+	git_repository *repo = NULL;
+
+	if ((error = git_path_prettify_dir(&path, bare_path, NULL)) < 0)
+		return error;
+
+	if (!valid_repository_path(&path)) {
+		git_buf_free(&path);
+		giterr_set(GITERR_REPOSITORY, "Path is not a repository: %s", bare_path);
+		return GIT_ENOTFOUND;
+	}
+
+	repo = repository_alloc();
+	GITERR_CHECK_ALLOC(repo);
+
+	repo->path_repository = git_buf_detach(&path);
+	GITERR_CHECK_ALLOC(repo->path_repository);
+
+	/* of course we're bare! */
+	repo->is_bare = 1;
+	repo->workdir = NULL;
+
+	*repo_ptr = repo;
+	return 0;
+}
+
 int git_repository_open_ext(
 	git_repository **repo_ptr,
 	const char *start_path,


### PR DESCRIPTION
Loading a repository can be an expensive operation if you gotta parse all the config files, find the working tree, and so on, and so forth.

If you happen to work for a company that hosts a lot of repositories, and they are all stored as bare repositories on disk, this new API call will make opening repositories much more efficient.

/cc @arrbee 
