### PR TITLE
use a longer string for dummy data in test to avoid conflicting w/ index

### DIFF
--- a/tests-clar/checkout/typechange.c
+++ b/tests-clar/checkout/typechange.c
@@ -187,7 +187,7 @@ static void force_create_file(const char *file)
 		GIT_RMDIR_REMOVE_FILES | GIT_RMDIR_REMOVE_BLOCKERS);
 	cl_assert(!error || error == GIT_ENOTFOUND);
 	cl_git_pass(git_futils_mkpath2file(file, 0777));
-	cl_git_rewritefile(file, "yowza!");
+	cl_git_rewritefile(file, "yowza!!");
 }
 
 void test_checkout_typechange__checkout_with_conflicts(void)


### PR DESCRIPTION
Fix an intermittent issue with the test on win32 with autocrlf=true -- if you rewrite a file of the same size quickly after a checkout, the file is not guaranteed to be dirty since the resolution of the index is 1 sec.
