### PR TITLE
Add missing prototype for p_realpath().

### DIFF
--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -21,6 +21,8 @@
 /* The OpenBSD realpath function behaves differently */
 #if !defined(__OpenBSD__)
 # define p_realpath(p, po) realpath(p, po)
+#else
+char *p_realpath(const char *, char *);
 #endif
 
 #define p_vsnprintf(b, c, f, a) vsnprintf(b, c, f, a)


### PR DESCRIPTION
There is currently a small issue which this PR addresses:
- warning: implicit declaration of function 'p_realpath'
  since p_realpath returns a char *, combined with the fact that GCC will assume an int is returned, bad things will happen. So provide a prototype for p_realpath() on OpenBSD.

This patch will also be also be included in the OpenBSD port of libgit2.
