### PR TITLE
Make refcounting atomic

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -188,20 +188,20 @@ extern int git__strncmp(const char *a, const char *b, size_t sz);
 extern int git__strncasecmp(const char *a, const char *b, size_t sz);
 
 typedef struct {
-	short refcount;
+	git_atomic refcount;
 	void *owner;
 } git_refcount;
 
 typedef void (*git_refcount_freeptr)(void *r);
 
 #define GIT_REFCOUNT_INC(r) { \
-	((git_refcount *)(r))->refcount++; \
+	git_atomic_inc(&((git_refcount *)(r))->refcount);	\
 }
 
 #define GIT_REFCOUNT_DEC(_r, do_free) { \
 	git_refcount *r = (git_refcount *)(_r); \
-	r->refcount--; \
-	if (r->refcount <= 0 && r->owner == NULL) { do_free(_r); } \
+	int val = git_atomic_dec(&r->refcount); \
+	if (val <= 0 && r->owner == NULL) { do_free(_r); } \
 }
 
 #define GIT_REFCOUNT_OWN(r, o) { \

--- a/tests-clar/repo/getters.c
+++ b/tests-clar/repo/getters.c
@@ -31,10 +31,10 @@ void test_repo_getters__retrieving_the_odb_honors_the_refcount(void)
 	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
 
 	cl_git_pass(git_repository_odb(&odb, repo));
-	cl_assert(((git_refcount *)odb)->refcount == 2);
+	cl_assert(((git_refcount *)odb)->refcount.val == 2);
 
 	git_repository_free(repo);
-	cl_assert(((git_refcount *)odb)->refcount == 1);
+	cl_assert(((git_refcount *)odb)->refcount.val == 1);
 
 	git_odb_free(odb);
 }

--- a/tests-clar/repo/setters.c
+++ b/tests-clar/repo/setters.c
@@ -69,13 +69,13 @@ void test_repo_setters__setting_a_new_index_on_a_repo_which_has_already_loaded_o
 	git_index *new_index;
 
 	cl_git_pass(git_index_open(&new_index, "./my-index"));
-	cl_assert(((git_refcount *)new_index)->refcount == 1);
+	cl_assert(((git_refcount *)new_index)->refcount.val == 1);
 
 	git_repository_set_index(repo, new_index);
-	cl_assert(((git_refcount *)new_index)->refcount == 2);
+	cl_assert(((git_refcount *)new_index)->refcount.val == 2);
 
 	git_repository_free(repo);
-	cl_assert(((git_refcount *)new_index)->refcount == 1);
+	cl_assert(((git_refcount *)new_index)->refcount.val == 1);
 
 	git_index_free(new_index);
 
@@ -90,13 +90,13 @@ void test_repo_setters__setting_a_new_odb_on_a_repo_which_already_loaded_one_pro
 	git_odb *new_odb;
 
 	cl_git_pass(git_odb_open(&new_odb, "./testrepo.git/objects"));
-	cl_assert(((git_refcount *)new_odb)->refcount == 1);
+	cl_assert(((git_refcount *)new_odb)->refcount.val == 1);
 
 	git_repository_set_odb(repo, new_odb);
-	cl_assert(((git_refcount *)new_odb)->refcount == 2);
+	cl_assert(((git_refcount *)new_odb)->refcount.val == 2);
 
 	git_repository_free(repo);
-	cl_assert(((git_refcount *)new_odb)->refcount == 1);
+	cl_assert(((git_refcount *)new_odb)->refcount.val == 1);
 
 	git_odb_free(new_odb);
 


### PR DESCRIPTION
Putting the `objects::cache` test through `drd`'s threading tests shows that you can end up with a wrong refcount if two threads want to allocate an odb for themselves. The same would happen for the index, config.

There still seems to be some issues inside the pack code, but this is a quick fix that gets us closer.

//cc @arrbee
