### PR TITLE
Added notes to all GIT_INLINE functions that they are not exported

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -24,6 +24,11 @@ GIT_BEGIN_DECL
 /**
  * Lookup a blob object from a repository.
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_lookup
+ * 
  * @param blob pointer to the looked up blob
  * @param repo the repo to use when locating the blob.
  * @param id identity of the blob to locate.
@@ -38,6 +43,9 @@ GIT_INLINE(int) git_blob_lookup(git_blob **blob, git_repository *repo, const git
  * Lookup a blob object from a repository,
  * given a prefix of its identifier (short id).
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ * 
  * @see git_object_lookup_prefix
  *
  * @param blob pointer to the looked up blob
@@ -60,6 +68,11 @@ GIT_INLINE(int) git_blob_lookup_prefix(git_blob **blob, git_repository *repo, co
  * It *is* necessary to call this method when you stop
  * using a blob. Failure to do so will cause a memory leak.
  *
+ * NOTE:
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_free
+ * 
  * @param blob the blob to close
  */
 
@@ -71,6 +84,11 @@ GIT_INLINE(void) git_blob_free(git_blob *blob)
 /**
  * Get the id of a blob.
  *
+ * NOTE:
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_id
+ * 
  * @param blob a previously loaded blob.
  * @return SHA1 hash for this blob.
  */

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -24,6 +24,11 @@ GIT_BEGIN_DECL
 /**
  * Lookup a commit object from a repository.
  *
+ * NOTE:
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_lookup
+ * 
  * @param commit pointer to the looked up commit
  * @param repo the repo to use when locating the commit.
  * @param id identity of the commit to locate. If the object is
@@ -38,6 +43,9 @@ GIT_INLINE(int) git_commit_lookup(git_commit **commit, git_repository *repo, con
 /**
  * Lookup a commit object from a repository,
  * given a prefix of its identifier (short id).
+ *
+ * NOTE:
+ * This is an inline function and therefore not exported in the shared library.
  *
  * @see git_object_lookup_prefix
  *
@@ -62,6 +70,11 @@ GIT_INLINE(int) git_commit_lookup_prefix(git_commit **commit, git_repository *re
  * It *is* necessary to call this method when you stop
  * using a commit. Failure to do so will cause a memory leak.
  *
+ * NOTE:
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_free
+ *
  * @param commit the commit to close
  */
 
@@ -72,6 +85,11 @@ GIT_INLINE(void) git_commit_free(git_commit *commit)
 
 /**
  * Get the id of a commit.
+ * 
+ * NOTE:
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_id
  *
  * @param commit a previously loaded commit.
  * @return object identity for the commit.

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -141,6 +141,9 @@ GIT_EXTERN(void) git_oid_cpy(git_oid *out, const git_oid *src);
 /**
  * Compare two oid structures.
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ * 
  * @param a first oid structure.
  * @param b second oid structure.
  * @return <0, 0, >0 if a < b, a == b, a > b.
@@ -162,6 +165,9 @@ GIT_INLINE(int) git_oid_cmp(const git_oid *a, const git_oid *b)
 /**
  * Compare two oid structures for equality
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ * 
  * @param a first oid structure.
  * @param b second oid structure.
  * @return true if equal, false otherwise

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -25,6 +25,11 @@ GIT_BEGIN_DECL
 /**
  * Lookup a tag object from the repository.
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_lookup
+ * 
  * @param out pointer to the looked up tag
  * @param repo the repo to use when locating the tag.
  * @param id identity of the tag to locate.
@@ -40,6 +45,9 @@ GIT_INLINE(int) git_tag_lookup(
 /**
  * Lookup a tag object from the repository,
  * given a prefix of its identifier (short id).
+ *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
  *
  * @see git_object_lookup_prefix
  *
@@ -64,6 +72,11 @@ GIT_INLINE(int) git_tag_lookup_prefix(
  * IMPORTANT: You MUST call this method when you are through with a tag to
  * release memory. Failure to do so will cause a memory leak.
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_free
+ * 
  * @param tag the tag to close
  */
 

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -23,6 +23,11 @@ GIT_BEGIN_DECL
 
 /**
  * Lookup a tree object from the repository.
+ * 
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_lookup
  *
  * @param out Pointer to the looked up tree
  * @param repo The repo to use when locating the tree.
@@ -38,6 +43,9 @@ GIT_INLINE(int) git_tree_lookup(
 /**
  * Lookup a tree object from the repository,
  * given a prefix of its identifier (short id).
+ *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
  *
  * @see git_object_lookup_prefix
  *
@@ -65,6 +73,11 @@ GIT_INLINE(int) git_tree_lookup_prefix(
  * IMPORTANT: You MUST call this method when you stop using a tree to
  * release memory. Failure to do so will cause a memory leak.
  *
+ * NOTE: 
+ * This is an inline function and therefore not exported in the shared library.
+ *
+ * @see git_object_free
+ * 
  * @param tree The tree to close
  */
 GIT_INLINE(void) git_tree_free(git_tree *tree)


### PR DESCRIPTION
This pull request originated from issue #1508 GIT_INLINE not exported.

I added a NOTE to each INLINE method that it is not exported and added  @see to the corresponding exported function.

Please let me know if this needs any rewording or reformatting.  

Kind regard,

Wim Oudshoorn.
