### PR TITLE
By default do not set tagopt when cloning

### DIFF
--- a/tests-clar/clone/nonetwork.c
+++ b/tests-clar/clone/nonetwork.c
@@ -172,6 +172,7 @@ void test_clone_nonetwork__custom_push_spec(void)
 
 void test_clone_nonetwork__custom_autotag(void)
 {
+	git_remote *origin;
 	git_strarray tags = {0};
 
 	g_options.remote_autotag = GIT_REMOTE_DOWNLOAD_TAGS_NONE;
@@ -179,6 +180,23 @@ void test_clone_nonetwork__custom_autotag(void)
 
 	cl_git_pass(git_tag_list(&tags, g_repo));
 	cl_assert_equal_sz(0, tags.count);
+
+	cl_git_pass(git_remote_load(&origin, g_repo, "origin"));
+	cl_assert_equal_i(GIT_REMOTE_DOWNLOAD_TAGS_NONE, origin->download_tags);
+
+	git_strarray_free(&tags);
+}
+
+void test_clone_nonetwork__custom_autotag_tags_all(void)
+{
+	git_strarray tags = {0};
+	git_remote *origin;
+
+	g_options.remote_autotag = GIT_REMOTE_DOWNLOAD_TAGS_ALL;
+	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
+
+	cl_git_pass(git_remote_load(&origin, g_repo, "origin"));
+	cl_assert_equal_i(GIT_REMOTE_DOWNLOAD_TAGS_ALL, origin->download_tags);
 
 	git_strarray_free(&tags);
 }

--- a/tests-clar/online/clone.c
+++ b/tests-clar/online/clone.c
@@ -3,6 +3,7 @@
 #include "git2/clone.h"
 #include "git2/cred_helpers.h"
 #include "repository.h"
+#include "remote.h"
 
 #define LIVE_REPO_URL "http://github.com/libgit2/TestGitRepository"
 #define LIVE_EMPTYREPO_URL "http://github.com/libgit2/TestEmptyRepository"
@@ -41,6 +42,8 @@ void test_online_clone__network_full(void)
 	cl_git_pass(git_clone(&g_repo, LIVE_REPO_URL, "./foo", &g_options));
 	cl_assert(!git_repository_is_bare(g_repo));
 	cl_git_pass(git_remote_load(&origin, g_repo, "origin"));
+
+	cl_assert_equal_i(GIT_REMOTE_DOWNLOAD_TAGS_AUTO, origin->download_tags);
 
 	git_remote_free(origin);
 }


### PR DESCRIPTION
Cloning with libgit2 using the default clone options results in "remote.<name>.tagopt" being set to --tags for the origin remote. This means that the default fetch behavior is to fetch tags only (fetch with the `refs/tags/:refs/tags/` refspec, instead of the default configured refspec). This leads to unexpected behavior when fetching from the command line and also differs from the default remote as configured by core git:

cloning from command line:

```
[remote "origin"]
    url = https://github.com/libgit2/libgit2sharp.git
    fetch = +refs/heads/*:refs/remotes/origin/*
```

cloning from libgit2 with default options:

```
[remote "origin"]
    url = http://github.com/libgit2/libgit2.git
    fetch = +refs/heads/*:refs/remotes/origin/*
    tagopt = --tags
```

This change sets the default clone opts to auto, which results in tagopt not being set. We could also just not normalize this particular clone option, which I believe would achieve the same result.
