### PR TITLE
allow empty dirs to exist when doing checkout

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -467,6 +467,7 @@ static int checkout_action(
 	int cmp = -1, act;
 	int (*strcomp)(const char *, const char *) = data->diff->strcomp;
 	int (*pfxcomp)(const char *str, const char *pfx) = data->diff->pfxcomp;
+	int error;
 
 	/* move workdir iterator to follow along with deltas */
 
@@ -490,8 +491,11 @@ static int checkout_action(
 			if (cmp == 0) {
 				if (wd->mode == GIT_FILEMODE_TREE) {
 					/* case 2 - entry prefixed by workdir tree */
-					if (git_iterator_advance_into(&wd, workdir) < 0)
-						goto fail;
+					if ((error = git_iterator_advance_into(&wd, workdir)) < 0) {
+						if (error != GIT_ENOTFOUND ||
+							git_iterator_advance(&wd, workdir) < 0)
+							goto fail;
+					}
 
 					*wditem_ptr = wd;
 					continue;

--- a/tests-clar/checkout/tree.c
+++ b/tests-clar/checkout/tree.c
@@ -501,3 +501,28 @@ void test_checkout_tree__issue_1397(void)
 
 	git_object_free(tree);
 }
+
+void test_checkout_tree__can_write_to_empty_dirs(void)
+{
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	git_oid oid;
+	git_object *obj = NULL;
+
+	assert_on_branch(g_repo, "master");
+
+	cl_git_pass(p_mkdir("testrepo/a", 0777));
+
+	/* do first checkout with FORCE because we don't know if testrepo
+	 * base data is clean for a checkout or not
+	 */
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/dir"));
+	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
+
+	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
+
+	cl_assert(git_path_isfile("testrepo/a/b.txt"));
+
+	git_object_free(obj);
+}


### PR DESCRIPTION
Cannot checkout when there exists an empty directory in the working directory and there are files beneath that directory to be checked out.  Checkout will fail with `-1` and not set an error.

This is because when we `advance_into` an empty directory, we return `GIT_ENOTFOUND`.  Checkout will propagate this as an error condition.  Instead, we should simply treat this as advisory and advance to the next workdir item in this case, which will allow the checkout to proceed.

@arrbee could you sanity check?
