### PR TITLE
RFC: add iterator for status

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -18,6 +18,7 @@
 #include "git2/diff.h"
 #include "diff.h"
 #include "diff_output.h"
+#include "status.h"
 
 static unsigned int index_delta2status(git_delta_t index_status)
 {
@@ -77,32 +78,21 @@ static unsigned int workdir_delta2status(git_delta_t workdir_status)
 	return st;
 }
 
-typedef struct {
-	git_status_cb cb;
-	void *payload;
-	const git_status_options *opts;
-} status_user_callback;
-
-static int status_invoke_cb(
-	git_diff_delta *h2i, git_diff_delta *i2w, void *payload)
+static bool status_compute_flags(
+	unsigned int *out,
+	git_diff_delta *h2i,
+	git_diff_delta *i2w,
+	const git_status_options *opts)
 {
-	status_user_callback *usercb = payload;
-	const char *path = NULL;
 	unsigned int status = 0;
 
-	if (i2w) {
-		path = i2w->old_file.path;
-		status |= workdir_delta2status(i2w->status);
-	}
-	if (h2i) {
-		path = h2i->old_file.path;
+	if (h2i)
 		status |= index_delta2status(h2i->status);
-	}
 
-	/* if excluding submodules and this is a submodule everywhere */
-	if (usercb->opts &&
-		(usercb->opts->flags & GIT_STATUS_OPT_EXCLUDE_SUBMODULES) != 0)
-	{
+	if (i2w)
+		status |= workdir_delta2status(i2w->status);
+
+	if (opts->flags & GIT_STATUS_OPT_EXCLUDE_SUBMODULES) {
 		bool in_tree  = (h2i && h2i->status != GIT_DELTA_ADDED);
 		bool in_index = (h2i && h2i->status != GIT_DELTA_DELETED);
 		bool in_wd    = (i2w && i2w->status != GIT_DELTA_DELETED);
@@ -113,35 +103,76 @@ static int status_invoke_cb(
 			return 0;
 	}
 
-	return usercb->cb(path, status, usercb->payload);
+	*out = status;
+	return 1;
 }
 
-int git_status_foreach_ext(
-	git_repository *repo,
+typedef struct {
+	git_status_cb cb;
+	void *payload;
+	const git_status_options *opts;
+} status_user_callback;
+
+typedef struct {
+	git_diff_delta *head2idx;
+	git_diff_delta *idx2wd;
+} status_entry;
+
+static void status_iterator_setup(
+	git_status_iterator *it,
 	const git_status_options *opts,
-	git_status_cb cb,
-	void *payload)
+	git_diff_list *head2idx,
+	git_diff_list *idx2wd)
+{
+	it->opts = opts;
+
+	it->h2i = head2idx;
+	it->h2i_idx = 0;
+	it->h2i_len = head2idx ? head2idx->deltas.length : 0;
+
+	it->i2w = idx2wd;
+	it->i2w_idx = 0;
+	it->i2w_len = idx2wd ? idx2wd->deltas.length : 0;
+
+   /* Assert both iterators use matching ignore-case. If this function ever
+    * supports merging diffs that are not sorted by the same function, then
+    * it will need to spool and sort on one of the results before merging
+    */
+   if (head2idx && idx2wd) {
+       assert(head2idx->strcomp == idx2wd->strcomp);
+   }
+
+   	it->strcomp = head2idx ? head2idx->strcomp : idx2wd ? idx2wd->strcomp : NULL;
+}
+
+int git_status_iterator_new_ext(
+	git_status_iterator **out,
+	git_repository *repo,
+	const git_status_options *opts)
 {
 	int err = 0;
+	git_status_iterator *it = NULL;
 	git_diff_options diffopt = GIT_DIFF_OPTIONS_INIT;
 	git_diff_list *head2idx = NULL, *idx2wd = NULL;
 	git_tree *head = NULL;
 	git_status_show_t show =
 		opts ? opts->show : GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
-	status_user_callback usercb;
 
 	assert(show <= GIT_STATUS_SHOW_INDEX_THEN_WORKDIR);
 
 	GITERR_CHECK_VERSION(opts, GIT_STATUS_OPTIONS_VERSION, "git_status_options");
 
+	it = git__calloc(1, sizeof(git_status_iterator));
+	GITERR_CHECK_ALLOC(it);
+
 	if (show != GIT_STATUS_SHOW_INDEX_ONLY &&
 		(err = git_repository__ensure_not_bare(repo, "status")) < 0)
-		return err;
+		goto on_error;
 
 	/* if there is no HEAD, that's okay - we'll make an empty iterator */
 	if (((err = git_repository_head_tree(&head, repo)) < 0) &&
 		!(err == GIT_ENOTFOUND || err == GIT_EORPHANEDHEAD))
-		return err;
+		goto on_error;
 
 	memcpy(&diffopt.pathspec, &opts->pathspec, sizeof(diffopt.pathspec));
 
@@ -165,39 +196,179 @@ int git_status_foreach_ext(
 	if (show != GIT_STATUS_SHOW_WORKDIR_ONLY) {
 		err = git_diff_tree_to_index(&head2idx, repo, head, NULL, &diffopt);
 		if (err < 0)
-			goto cleanup;
+			goto on_error;
 	}
 
 	if (show != GIT_STATUS_SHOW_INDEX_ONLY) {
 		err = git_diff_index_to_workdir(&idx2wd, repo, NULL, &diffopt);
 		if (err < 0)
-			goto cleanup;
+			goto on_error;
 	}
 
-	usercb.cb = cb;
-	usercb.payload = payload;
-	usercb.opts = opts;
+	status_iterator_setup(it, opts, head2idx, idx2wd);
 
-	if (show == GIT_STATUS_SHOW_INDEX_THEN_WORKDIR) {
-		if ((err = git_diff__paired_foreach(
-				 head2idx, NULL, status_invoke_cb, &usercb)) < 0)
-			goto cleanup;
+	*out = it;
 
-		git_diff_list_free(head2idx);
-		head2idx = NULL;
-	}
-
-	err = git_diff__paired_foreach(head2idx, idx2wd, status_invoke_cb, &usercb);
-
-cleanup:
 	git_tree_free(head);
+
+	return 0;
+
+on_error:
 	git_diff_list_free(head2idx);
 	git_diff_list_free(idx2wd);
 
-	if (err == GIT_EUSER)
-		giterr_clear();
+	git_tree_free(head);
+
+	git__free(it);
 
 	return err;
+}
+
+static int status_next_index_then_workdir(
+	const char **path_old_out,
+	const char **path_new_out,
+	unsigned int *status_out,
+	git_status_iterator *it)
+{
+	git_diff_delta *delta;
+	unsigned int status = 0;
+	bool found = 0;
+
+	while (!found) {
+		if (it->h2i_idx < it->h2i_len) {
+			delta = git_vector_get(&it->h2i->deltas, it->h2i_idx);
+			it->h2i_idx++;
+
+			found = status_compute_flags(&status, delta, NULL, it->opts);
+		} else if (it->i2w_idx < it->i2w_len) {
+			delta = git_vector_get(&it->i2w->deltas, it->i2w_idx);
+			it->i2w_idx++;
+
+			found = status_compute_flags(&status, NULL, delta, it->opts);
+		} else
+			return GIT_ITEROVER;
+	}
+
+	*path_old_out = delta->old_file.path;
+	*path_new_out = delta->new_file.path;
+	*status_out = status;
+
+	return 0;
+}
+
+static int status_next_paired(
+	const char **path_old_out,
+	const char **path_new_out,
+	unsigned int *status_out,
+	git_status_iterator *it)
+{
+	git_diff_delta *h2i, *i2w;
+	unsigned int status = 0;
+	int cmp;
+	bool found = 0;
+
+	while (!found && (it->h2i_idx < it->h2i_len || it->i2w_idx < it->i2w_len)) {
+		h2i = it->h2i_idx < it->h2i_len ?
+			git_vector_get(&it->h2i->deltas, it->h2i_idx) : NULL;
+		i2w = it->i2w_idx < it->i2w_len ?
+			git_vector_get(&it->i2w->deltas, it->i2w_idx) : NULL;
+
+		cmp = !i2w ? -1 : !h2i ? 1 :
+			it->strcomp(h2i->old_file.path, i2w->old_file.path);
+
+		if (cmp < 0) {
+			it->h2i_idx++;
+			i2w = NULL;
+		} else if(cmp > 0) {
+			h2i = NULL;
+			it->i2w_idx++;
+		} else {
+			it->h2i_idx++;
+			it->i2w_idx++;
+		}
+
+		if ((found = status_compute_flags(&status, h2i, i2w, it->opts)) == 1) {
+			*path_old_out = h2i ? h2i->old_file.path : i2w->old_file.path;
+			*path_new_out = i2w ? i2w->new_file.path : h2i->new_file.path;
+			*status_out = status;
+
+			return 0;
+		}
+	}
+
+	return GIT_ITEROVER;
+}
+
+int git_status_next(
+	const char **path_old,
+	const char **path_new,
+	unsigned int *status,
+	git_status_iterator *it)
+{
+	assert(path_old && path_new && status && it);
+
+	*path_old = NULL;
+	*path_new = NULL;
+	*status = 0;
+
+	return (it->opts->show == GIT_STATUS_SHOW_INDEX_THEN_WORKDIR) ?
+		status_next_index_then_workdir(path_old, path_new, status, it) :
+		status_next_paired(path_old, path_new, status, it);
+}
+
+void git_status_iterator_free(git_status_iterator *it)
+{
+	if (it == NULL)
+		return;
+
+	git_diff_list_free(it->h2i);
+	git_diff_list_free(it->i2w);
+
+	git__free(it);
+}
+
+int git_status_foreach_ext(
+	git_repository *repo,
+	const git_status_options *opts,
+	git_status_cb callback,
+	void *payload)
+{
+	git_status_iterator *it;
+	const char *path_old, *path_new;
+	unsigned int status;
+	int error = 0;
+
+	if ((error = git_status_iterator_new_ext(&it, repo, opts)) < 0)
+		return error;
+
+	while ((error = git_status_next(&path_old, &path_new, &status, it)) == 0) {
+		if (callback(path_old, status, payload) != 0) {
+			error = GIT_EUSER;
+			break;
+		}
+	}
+
+	if (error == GIT_ITEROVER)
+		error = 0;
+
+	git_status_iterator_free(it);
+
+	return error;
+}
+
+#define GIT_STATUS_OPTIONS_DEFAULT { \
+	GIT_STATUS_OPTIONS_VERSION, \
+	GIT_STATUS_SHOW_INDEX_AND_WORKDIR, \
+	GIT_STATUS_OPT_INCLUDE_IGNORED | GIT_STATUS_OPT_INCLUDE_UNTRACKED | GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS \
+}
+
+int git_status_iterator_new(
+	git_status_iterator **it,
+	git_repository *repo)
+{
+	git_status_options opts = GIT_STATUS_OPTIONS_DEFAULT;
+
+	return git_status_iterator_new_ext(it, repo, &opts);
 }
 
 int git_status_foreach(
@@ -205,12 +376,7 @@ int git_status_foreach(
 	git_status_cb callback,
 	void *payload)
 {
-	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
-
-	opts.show  = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
-	opts.flags = GIT_STATUS_OPT_INCLUDE_IGNORED |
-		GIT_STATUS_OPT_INCLUDE_UNTRACKED |
-		GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS;
+	git_status_options opts = GIT_STATUS_OPTIONS_DEFAULT;
 
 	return git_status_foreach_ext(repo, &opts, callback, payload);
 }

--- a/src/status.h
+++ b/src/status.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_status_h__
+#define INCLUDE_status_h__
+
+#include "git2/types.h"
+
+struct git_status_iterator {
+	const git_status_options *opts;
+
+	git_diff_list *h2i;
+	size_t h2i_idx;
+	size_t h2i_len;
+
+	git_diff_list *i2w;
+	size_t i2w_idx;
+	size_t i2w_len;
+
+	int (*strcomp)(const char *, const char *);
+};
+
+#endif /* INCLUDE_status_h__ */


### PR DESCRIPTION
A long, long time ago we talked about adding rename support to status.  When we did, @arrbee mentioned that he would like to see status move to an iterator-based pattern (like `git_note`).

This adds an iterator for status and moves the existing `foreach` pattern over to use it.  The existing `foreach` pattern stayed the same for compatibility.  This means that there is no hope for rename support with the existing `foreach` pattern.  I could switch this out to `old_path` / `new_path` if somebody thought this was valuable, but I suspect that if we're going to do this, we should mark the old pattern as deprecated and not worry about it.

Thoughts?

Am I crazy?

Did I massively misunderstand the intentions here?

Assuming the latter is not a "yes" (we all know the answer to "am I crazy" is a yes, but that won't deter me), then I will layer some rename detection on top of this and try to figure out a not ugly way to match the `head2index new_path`s up with the `index2workdir old_path`s.
