### PR TITLE
allow checkout to proceed when a dir to be removed is in use (win32)

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -134,6 +134,9 @@ typedef enum {
 	/** Treat pathspec as simple list of exact match file paths */
 	GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH = (1u << 13),
 
+	/** Ignore directories in use, they will be left empty */
+	GIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES = (1u << 18),
+
 	/**
 	 * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
 	 */

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -955,6 +955,9 @@ static int checkout_remove_the_old(
 	uint32_t flg = GIT_RMDIR_EMPTY_PARENTS |
 		GIT_RMDIR_REMOVE_FILES | GIT_RMDIR_REMOVE_BLOCKERS;
 
+	if (data->opts.checkout_strategy & GIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES)
+		flg |= GIT_RMDIR_SKIP_NONEMPTY;
+
 	git_buf_truncate(&data->path, data->workdir_len);
 
 	git_vector_foreach(&data->diff->deltas, i, delta) {

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -444,7 +444,7 @@ static int futils__rmdir_recurs_foreach(void *opaque, git_buf *path)
 
 		if (data->error < 0) {
 			if ((data->flags & GIT_RMDIR_SKIP_NONEMPTY) != 0 &&
-				(errno == ENOTEMPTY || errno == EEXIST))
+				(errno == ENOTEMPTY || errno == EEXIST || errno == EBUSY))
 				data->error = 0;
 			else
 				futils__error_cannot_rmdir(path->ptr, NULL);
@@ -480,7 +480,7 @@ static int futils__rmdir_empty_parent(void *opaque, git_buf *path)
 		if (en == ENOENT || en == ENOTDIR) {
 			giterr_clear();
 			error = 0;
-		} else if (en == ENOTEMPTY || en == EEXIST) {
+		} else if (en == ENOTEMPTY || en == EEXIST || en == EBUSY) {
 			giterr_clear();
 			error = GIT_ITEROVER;
 		} else {

--- a/tests-clar/checkout/tree.c
+++ b/tests-clar/checkout/tree.c
@@ -526,3 +526,66 @@ void test_checkout_tree__can_write_to_empty_dirs(void)
 
 	git_object_free(obj);
 }
+
+void test_checkout_tree__fails_when_dir_in_use(void)
+{
+#ifdef GIT_WIN32
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	git_oid oid;
+	git_object *obj = NULL;
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/dir"));
+	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
+
+	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
+
+	cl_assert(git_path_isfile("testrepo/a/b.txt"));
+
+	git_object_free(obj);
+
+	cl_git_pass(p_chdir("testrepo/a"));
+
+	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/master"));
+	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
+
+	cl_git_fail(git_checkout_tree(g_repo, obj, &opts));
+
+	cl_git_pass(p_chdir("../.."));
+
+	cl_assert(git_path_is_empty_dir("testrepo/a"));
+#endif
+}
+
+void test_checkout_tree__can_continue_when_dir_in_use(void)
+{
+#ifdef GIT_WIN32
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	git_oid oid;
+	git_object *obj = NULL;
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE |
+		GIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES;
+
+	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/dir"));
+	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
+
+	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
+
+	cl_assert(git_path_isfile("testrepo/a/b.txt"));
+
+	git_object_free(obj);
+
+	cl_git_pass(p_chdir("testrepo/a"));
+
+	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/master"));
+	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
+
+	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
+
+	cl_git_pass(p_chdir("../.."));
+
+	cl_assert(git_path_is_empty_dir("testrepo/a"));
+#endif
+}


### PR DESCRIPTION
On win32, one may not remove a directory that is the current working directory of any process.  (Or the parent thereof.)  Thus, if somebody is to execute a checkout that would remove an in-use directory, we will fail halfway through the checkout.

The most likely culprit here is that somebody has their shell open to that directory.

Core git will prompt the user here, allowing them to retry or to simply continue without removing the directory:

```
Deletion of directory 'foo' failed. Should I try again? (y/n) y
Deletion of directory 'foo' failed. Should I try again? (y/n) y
Deletion of directory 'foo' failed. Should I try again? (y/n) y
Deletion of directory 'foo' failed. Should I try again? (y/n) n
Switched to branch 'd'    
```

To cope, add a `GIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES` that will simply leave in-use directories on-disk.  Some plumbing to `rmdir` is required to make this work, and to disambiguate the cases where win32 `rmdir` returns `EACCES` (that is to say, _all_ cases return `EACCES`, unfortunately.)

Note that this is worsened by the fact that it is non-obvious that we remove directories that would be added back.  Imagine that two branches exist that have files beneath the same directory but no files in common.  Eg, branch A has `dir/A` and branch B has `dir/B`.  We will remove `dir` (since it would be left empty from removal of `dir/A`) then add it back for `dir/B`.  This implementation detail is not obvious to the user, who expects that they should be able to be in the directory when this checkout occurs.
