### PR TITLE
Strict/lax commit API

### DIFF
--- a/include/git2/sys/commit.h
+++ b/include/git2/sys/commit.h
@@ -25,8 +25,9 @@ GIT_BEGIN_DECL
  *
  * See documentation for `git_commit_create()` for information about the
  * parameters, as the meaning is identical excepting that `tree` and
- * `parents` now take `git_oid`.  This is a dangerous API in that the
- * `parents` list of `git_oid`s in not checked for validity.
+ * `parents` now take `git_oid`.  This is a dangerous API in that nor
+ * the `tree`, neither the `parents` list of `git_oid`s are checked for
+ * validity.
  */
 GIT_EXTERN(int) git_commit_create_from_oids(
 	git_oid *oid,

--- a/src/commit.c
+++ b/src/commit.c
@@ -96,7 +96,6 @@ int git_commit_create_from_oids(
 	git_odb *odb;
 
 	assert(oid && repo && tree && parent_count >= 0);
-	assert(git_object_owner((const git_object *)tree) == repo);
 
 	git_oid__writebuf(&commit, "tree ", tree);
 


### PR DESCRIPTION
This makes:
-  `git_commit_create()` more strict. The passed tree must be owned by the repo.
- `git_commit_create_from_oids()` more lax. The passed tree_oid can now be a plain simple oid.
