### PR TITLE
fix git_branch_set_upstream for local branches

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -521,7 +521,8 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 		goto on_error;
 
 	if (local) {
-		if (git_buf_puts(&value, git_reference_name(branch)) < 0)
+		git_buf_clear(&value);
+		if (git_buf_puts(&value, git_reference_name(upstream)) < 0)
 			goto on_error;
 	} else {
 		/* Get the remoe-tracking branch's refname in its repo */

--- a/tests-clar/refs/branches/upstream.c
+++ b/tests-clar/refs/branches/upstream.c
@@ -103,6 +103,7 @@ void test_refs_branches_upstream__set_unset_upstream(void)
 
 	repository = cl_git_sandbox_init("testrepo.git");
 
+	/* remote */
 	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/test"));
 	cl_git_pass(git_branch_set_upstream(branch, "test/master"));
 
@@ -112,6 +113,17 @@ void test_refs_branches_upstream__set_unset_upstream(void)
 	cl_git_pass(git_config_get_string(&value, config, "branch.test.merge"));
 	cl_assert_equal_s(value, "refs/heads/master");
 
+	/* local */
+	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/test"));
+	cl_git_pass(git_branch_set_upstream(branch, "master"));
+
+	cl_git_pass(git_repository_config(&config, repository));
+	cl_git_pass(git_config_get_string(&value, config, "branch.test.remote"));
+	cl_assert_equal_s(value, ".");
+	cl_git_pass(git_config_get_string(&value, config, "branch.test.merge"));
+	cl_assert_equal_s(value, "refs/heads/master");
+
+	/* unset */
 	cl_git_pass(git_branch_set_upstream(branch, NULL));
 	cl_git_fail_with(git_config_get_string(&value, config, "branch.test.merge"), GIT_ENOTFOUND);
 	cl_git_fail_with(git_config_get_string(&value, config, "branch.test.remote"), GIT_ENOTFOUND);


### PR DESCRIPTION
Currently git_branch_set_upstream when passed a local branch
creates invalid configuration, for ex. if we setup branch
'tracking_master' to track local 'master' libgit2 generates
the following config

```
[branch "track_master"]
  remote = .
  merge = .refs/heads/track_master
```

The merge value is invalid and calling git_branch_upstream on
'tracking_master' results in invalid reference error.

It should do:

```
[branch "track_master"]
  remote = .
  merge = refs/heads/master
```
