### PR TITLE
remote: correctly interpret tagopt '--tags'

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -34,10 +34,16 @@ static int filter_ref__cb(git_remote_head *head, void *payload)
 
 	if (!p->found_head && strcmp(head->name, GIT_HEAD_FILE) == 0)
 		p->found_head = 1;
-	else if (git_remote__matching_refspec(p->remote, head->name))
+	else if (p->remote->download_tags == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {
+		/*
+		 * If tagopt is --tags, then we only use the default
+		 * tags refspec and ignore the remote's
+		 */
+		if (git_refspec_src_matches(p->tagspec, head->name))
 			match = 1;
-	else if (p->remote->download_tags == GIT_REMOTE_DOWNLOAD_TAGS_ALL &&
-		 git_refspec_src_matches(p->tagspec, head->name))
+		else
+			return 0;
+	} else if (git_remote__matching_refspec(p->remote, head->name))
 			match = 1;
 
 	if (!match)

--- a/tests-clar/network/remote/local.c
+++ b/tests-clar/network/remote/local.c
@@ -141,3 +141,20 @@ void test_network_remote_local__shorthand_fetch_refspec1(void)
 
 	cl_git_fail(git_reference_lookup(&ref, repo, "refs/tags/hard_tag"));
 }
+
+void test_network_remote_local__tagopt(void)
+{
+	git_reference *ref;
+
+	connect_to_local_repository(cl_fixture("testrepo.git"));
+	git_remote_set_autotag(remote, GIT_REMOTE_DOWNLOAD_TAGS_ALL);
+
+	cl_git_pass(git_remote_download(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote));
+
+
+	cl_git_fail(git_reference_lookup(&ref, repo, "refs/remotes/master"));
+
+	cl_git_pass(git_reference_lookup(&ref, repo, "refs/tags/hard_tag"));
+	git_reference_free(ref);
+}


### PR DESCRIPTION
When tagopt is set to '--tags', we should only take the default tags
refspec into account and ignore any configured ones.

Bring the code into compliance.
