### PR TITLE
Introduce git_reference_shorthand

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -493,6 +493,21 @@ GIT_EXTERN(int) git_reference_peel(
  */
 GIT_EXTERN(int) git_reference_is_valid_name(const char *refname);
 
+/**
+ * Get the reference's short name
+ *
+ * This will transform the reference name into a name "human-readable"
+ * version. If no shortname is appropriate, it will return the full
+ * name.
+ *
+ * The memory is owned by the reference and must not be freed.
+ *
+ * @param ref a reference
+ * @return the human-readable version of the name
+ */
+GIT_EXTERN(const char *) git_reference_shorthand(git_reference *ref);
+
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/refs.c
+++ b/src/refs.c
@@ -1016,3 +1016,20 @@ int git_reference_is_valid_name(
 		refname,
 		GIT_REF_FORMAT_ALLOW_ONELEVEL);
 }
+
+const char *git_reference_shorthand(git_reference *ref)
+{
+	const char *name = ref->name;
+
+	if (!git__prefixcmp(name, GIT_REFS_HEADS_DIR))
+		return name + strlen(GIT_REFS_HEADS_DIR);
+	else if (!git__prefixcmp(name, GIT_REFS_TAGS_DIR))
+		return name + strlen(GIT_REFS_TAGS_DIR);
+	else if (!git__prefixcmp(name, GIT_REFS_REMOTES_DIR))
+		return name + strlen(GIT_REFS_REMOTES_DIR);
+	else if (!git__prefixcmp(name, GIT_REFS_DIR))
+		return name + strlen(GIT_REFS_DIR);
+
+	/* No shorthands are avaiable, so just return the name */
+	return name;
+}

--- a/tests-clar/refs/shorthand.c
+++ b/tests-clar/refs/shorthand.c
@@ -1,0 +1,27 @@
+#include "clar_libgit2.h"
+
+#include "repository.h"
+
+void assert_shorthand(git_repository *repo, const char *refname, const char *shorthand)
+{
+	git_reference *ref;
+
+	cl_git_pass(git_reference_lookup(&ref, repo, refname));
+	cl_assert_equal_s(git_reference_shorthand(ref), shorthand);
+	git_reference_free(ref);
+}
+
+void test_refs_shorthand__0(void)
+{
+	git_repository *repo;
+
+	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
+
+
+	assert_shorthand(repo, "refs/heads/master", "master");
+	assert_shorthand(repo, "refs/tags/test", "test");
+	assert_shorthand(repo, "refs/remotes/test/master", "test/master");
+	assert_shorthand(repo, "refs/notes/fanout", "notes/fanout");
+
+	git_repository_free(repo);
+}


### PR DESCRIPTION
Generate a shorthand name out of the full refname.

---

I'm sure the name can be made better, maybe `_short_name`?

Current git's representation of remote-tracking branches is currently split between the old way of including `remotes/` which `gitk` and `name-rev` show, and `branch` and `log` not including it. I went with the latter as it's the newer one and how one talks about remote-tracking branches anyway.
