### PR TITLE
Fill ref->peel all zeros in packed_parse_oid()

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -114,6 +114,7 @@ static int packed_parse_oid(
 
 	git_oid_cpy(&ref->oid, &id);
 
+	memset(&ref->peel, 0, sizeof(git_oid));
 	ref->flags = 0;
 
 	*ref_out = ref;


### PR DESCRIPTION
Fix crashes that relies on checking zero oid
