### PR TITLE
git_commit_author returns a signature which git_signature_dup can't copy

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -66,12 +66,6 @@ int git_signature_new(git_signature **sig_out, const char *name, const char *ema
 	p->name = extract_trimmed(name, strlen(name));
 	p->email = extract_trimmed(email, strlen(email));
 
-	if (p->name == NULL || p->email == NULL ||
-		p->name[0] == '\0' || p->email[0] == '\0') {
-		git_signature_free(p);
-		return signature_error("Empty name or email");
-	}
-		
 	p->when.time = time;
 	p->when.offset = offset;
 

--- a/tests-clar/commit/signature.c
+++ b/tests-clar/commit/signature.c
@@ -49,13 +49,13 @@ void test_commit_signature__angle_brackets_in_email_are_not_supported(void)
 
 void test_commit_signature__create_empties(void)
 {
-   // can not create a signature with empty name or email
+   // can create a signature with empty name or email
 	cl_git_pass(try_build_signature("nulltoken", "emeric.fermas@gmail.com", 1234567890, 60));
 
-	cl_git_fail(try_build_signature("", "emeric.fermas@gmail.com", 1234567890, 60));
-	cl_git_fail(try_build_signature("   ", "emeric.fermas@gmail.com", 1234567890, 60));
-	cl_git_fail(try_build_signature("nulltoken", "", 1234567890, 60));
-	cl_git_fail(try_build_signature("nulltoken", "  ", 1234567890, 60));
+	cl_git_pass(try_build_signature("", "emeric.fermas@gmail.com", 1234567890, 60));
+	cl_git_pass(try_build_signature("   ", "emeric.fermas@gmail.com", 1234567890, 60));
+	cl_git_pass(try_build_signature("nulltoken", "", 1234567890, 60));
+	cl_git_pass(try_build_signature("nulltoken", "  ", 1234567890, 60));
 }
 
 void test_commit_signature__create_one_char(void)
@@ -74,6 +74,6 @@ void test_commit_signature__create_zero_char(void)
 {
    // creating a zero character signature
 	git_signature *sign;
-	cl_git_fail(git_signature_new(&sign, "", "x@y.z", 1234567890, 60));
-	cl_assert(sign == NULL);
+	cl_git_pass(git_signature_new(&sign, "", "x@y.z", 1234567890, 60));
+	cl_assert(sign != NULL);
 }


### PR DESCRIPTION
We're running into a situation where `git_commit_author` returns a non-NULL signature but `git_signature_dup` returns `NULL` for it because it has an empty name.

This is less than great. They should at least be consistent. But more importantly, this repository has a commit with an empty author name and libgit2 should be cool with that.
