### PR TITLE
Fix broken build when MSVC SDL checks is enabled

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -292,7 +292,7 @@ int git_commit_nth_gen_ancestor(
 	const git_commit *commit,
 	unsigned int n)
 {
-	git_commit *current, *parent;
+	git_commit *current, *parent = NULL;
 	int error;
 
 	assert(ancestor && commit);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -296,7 +296,7 @@ cleanup:
 
 static int config_set(git_config_backend *cfg, const char *name, const char *value)
 {
-	cvar_t *var = NULL, *old_var;
+	cvar_t *var = NULL, *old_var = NULL;
 	diskfile_backend *b = (diskfile_backend *)cfg;
 	char *key, *esc_value = NULL;
 	khiter_t pos;

--- a/src/object.c
+++ b/src/object.c
@@ -117,7 +117,7 @@ int git_object_lookup_prefix(
 {
 	git_object *object = NULL;
 	git_odb *odb = NULL;
-	git_odb_object *odb_obj;
+	git_odb_object *odb_obj = NULL;
 	int error = 0;
 
 	assert(repo && object_out && id);

--- a/src/push.c
+++ b/src/push.c
@@ -180,7 +180,7 @@ int git_push_update_tips(git_push *push)
 	git_buf remote_ref_name = GIT_BUF_INIT;
 	size_t i, j;
 	git_refspec *fetch_spec;
-	push_spec *push_spec;
+	push_spec *push_spec = NULL;
 	git_reference *remote_ref;
 	push_status *status;
 	int error = 0;

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -21,8 +21,8 @@ int git_smart__store_refs(transport_smart *t, int flushes)
 	gitno_buffer *buf = &t->buffer;
 	git_vector *refs = &t->refs;
 	int error, flush = 0, recvd;
-	const char *line_end;
-	git_pkt *pkt;
+	const char *line_end = NULL;
+	git_pkt *pkt = NULL;
 	git_pkt_ref *ref;
 	size_t i;
 
@@ -135,7 +135,7 @@ int git_smart__detect_caps(git_pkt_ref *pkt, transport_smart_caps *caps)
 static int recv_pkt(git_pkt **out, gitno_buffer *buf)
 {
 	const char *ptr = buf->data, *line_end = ptr;
-	git_pkt *pkt;
+	git_pkt *pkt = NULL;
 	int pkt_type, error = 0, ret;
 
 	do {
@@ -640,8 +640,8 @@ static int add_push_report_sideband_pkt(git_push *push, git_pkt_data *data_pkt)
 
 static int parse_report(gitno_buffer *buf, git_push *push)
 {
-	git_pkt *pkt;
-	const char *line_end;
+	git_pkt *pkt = NULL;
+	const char *line_end = NULL;
 	int error, recvd;
 
 	for (;;) {

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -893,7 +893,7 @@ static int winhttp_connect(
 	wchar_t *ua = L"git/1.0 (libgit2 " WIDEN(LIBGIT2_VERSION) L")";
 	wchar_t host[GIT_WIN_PATH];
 	int32_t port;
-	const char *default_port;
+	const char *default_port = "80";
 	int ret;
 
 	if (!git__prefixcmp(url, prefix_http)) {


### PR DESCRIPTION
Fix broken build when MSVC SDL checks is enabled
Mostly initialize local variables.
