### PR TITLE
Fix diff output for renames and copies

### DIFF
--- a/src/diff_output.c
+++ b/src/diff_output.c
@@ -593,6 +593,8 @@ static int diff_patch_load(
 		delta->new_file.flags |= GIT_DIFF_FLAG__NO_DATA;
 		break;
 	case GIT_DELTA_MODIFIED:
+	case GIT_DELTA_COPIED:
+	case GIT_DELTA_RENAMED:
 		break;
 	case GIT_DELTA_UNTRACKED:
 		delta->old_file.flags |= GIT_DIFF_FLAG__NO_DATA;


### PR DESCRIPTION
@ben discovered a bug when looking at text diffs after using rename detection. The function that decides if data should be loaded for a given delta didn't know which sides of the diff to load for those cases and defaulted to loading no data, so no text diffs were availble.

This fixes that bug and adds a test that looks at the patch generated for diff entries that are COPIED or RENAMED.
