### PR TITLE
Ensure reuc vector is always valid

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1283,8 +1283,9 @@ static int read_reuc(git_index *index, const char *buffer, size_t size)
 	size_t len;
 	int i;
 
-	/* This gets called multiple times, the vector might already be initialized */
-	if (index->reuc._alloc_size == 0 && git_vector_init(&index->reuc, 16, reuc_cmp) < 0)
+	/* If called multiple times, the vector might already be initialized */
+	if (index->reuc._alloc_size == 0 &&
+		git_vector_init(&index->reuc, 16, reuc_cmp) < 0)
 		return -1;
 
 	while (size) {
@@ -1294,11 +1295,8 @@ static int read_reuc(git_index *index, const char *buffer, size_t size)
 		if (size <= len)
 			return index_error_invalid("reading reuc entries");
 
-		lost = git__malloc(sizeof(git_index_reuc_entry));
+		lost = git__calloc(1, sizeof(git_index_reuc_entry));
 		GITERR_CHECK_ALLOC(lost);
-
-		if (git_vector_insert(&index->reuc, lost) < 0)
-			return -1;
 
 		/* read NUL-terminated pathname for entry */
 		lost->path = git__strdup(buffer);
@@ -1337,6 +1335,10 @@ static int read_reuc(git_index *index, const char *buffer, size_t size)
 			size -= 20;
 			buffer += 20;
 		}
+
+		/* entry was read successfully - insert into reuc vector */
+		if (git_vector_insert(&index->reuc, lost) < 0)
+			return -1;
 	}
 
 	/* entries are guaranteed to be sorted on-disk */


### PR DESCRIPTION
In theory, if there was a problem reading the REUC data, the `read_reuc()` routine could have left uninitialized and invalid data in the `git_index` vector.  This moves the line that inserts a new entry into the vector down to the bottom of the routine so we know all the content is already valid.  Also, per @linquize, this uses `calloc` to ensure no uninitialized data.
