### PR TITLE
merge setup

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -23,13 +23,13 @@
 GIT_BEGIN_DECL
 
 /**
- * Flags for tree_many diff options.  A combination of these flags can be
- * passed in via the `flags` value in the `git_diff_tree_many_options`.
+ * Flags for `git_mrege_tree` options.  A combination of these flags can be
+ * passed in via the `flags` vlaue in the `git_merge_tree_opts`.
  */
 typedef enum {
 	/** Detect renames */
 	GIT_MERGE_TREE_FIND_RENAMES = (1 << 0),
-} git_merge_tree_flags;
+} git_merge_tree_flag_t;
 
 /**
  * Automerge options for `git_merge_trees_opts`.
@@ -44,7 +44,7 @@ typedef enum {
 
 typedef struct {
 	unsigned int version;
-	git_merge_tree_flags flags;
+	git_merge_tree_flag_t flags;
 
 	/** Similarity to consider a file renamed (default 50) */
 	unsigned int rename_threshold;
@@ -94,6 +94,57 @@ GIT_EXTERN(int) git_merge_base_many(
 	git_repository *repo,
 	const git_oid input_array[],
 	size_t length);
+
+/**
+ * Creates a `git_merge_head` from the given reference
+ *
+ * @param out pointer to store the git_merge_head result in
+ * @param repo repository that contains the given reference
+ * @param ref reference to use as a merge input
+ * @return zero on success, -1 on failure.
+ */
+GIT_EXTERN(int) git_merge_head_from_ref(
+	git_merge_head **out,
+	git_repository *repo,
+	git_reference *ref);
+
+/**
+ * Creates a `git_merge_head` from the given fetch head data
+ *
+ * @param out pointer to store the git_merge_head result in
+ * @param repo repository that contains the given commit
+ * @param branch_name name of the (remote) branch
+ * @param remote_url url of the remote
+ * @param oid the commit object id to use as a merge input
+ * @return zero on success, -1 on failure.
+ */
+GIT_EXTERN(int) git_merge_head_from_fetchhead(
+	git_merge_head **out,
+	git_repository *repo,
+	const char *branch_name,
+	const char *remote_url,
+	const git_oid *oid);
+
+/**
+ * Creates a `git_merge_head` from the given commit id
+ *
+ * @param out pointer to store the git_merge_head result in
+ * @param repo repository that contains the given commit
+ * @param oid the commit object id to use as a merge input
+ * @return zero on success, -1 on failure.
+ */
+GIT_EXTERN(int) git_merge_head_from_oid(
+	git_merge_head **out,
+	git_repository *repo,
+	const git_oid *oid);
+
+/**
+ * Frees a `git_merge_head`
+ *
+ * @param the merge head to free
+ */
+GIT_EXTERN(void) git_merge_head_free(
+	git_merge_head *head);
 
 /**
  * Merge two trees, producing a `git_index` that reflects the result of

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -168,6 +168,9 @@ typedef struct git_reference git_reference;
 /** Iterator for references */
 typedef struct git_reference_iterator  git_reference_iterator;
 
+/** Merge heads, the input to merge */
+typedef struct git_merge_head git_merge_head;
+
 
 /** Basic type of any Git reference. */
 typedef enum {

--- a/src/merge.h
+++ b/src/merge.h
@@ -107,11 +107,24 @@ typedef struct {
 	git_delta_t their_status;
 } git_merge_diff;
 
+/** Internal structure for merge inputs */
+struct git_merge_head {
+	char *ref_name;
+	char *remote_url;
+
+	git_oid oid;
+	git_commit *commit;
+};
+
 int git_merge__bases_many(
 	git_commit_list **out,
 	git_revwalk *walk,
 	git_commit_list_node *one,
 	git_vector *twos);
+
+/*
+ * Three-way tree differencing
+ */
 
 git_merge_diff_list *git_merge_diff_list__alloc(git_repository *repo);
 
@@ -123,5 +136,14 @@ int git_merge_diff_list__find_differences(git_merge_diff_list *merge_diff_list,
 int git_merge_diff_list__find_renames(git_repository *repo, git_merge_diff_list *merge_diff_list, const git_merge_tree_opts *opts);
 
 void git_merge_diff_list__free(git_merge_diff_list *diff_list);
+
+/* Merge metadata setup */
+
+int git_merge__setup(
+	git_repository *repo,
+	const git_merge_head *our_head,
+	const git_merge_head *their_heads[],
+	size_t their_heads_len,
+	unsigned int flags);
 
 #endif

--- a/tests-clar/merge/workdir/setup.c
+++ b/tests-clar/merge/workdir/setup.c
@@ -8,28 +8,28 @@
 static git_repository *repo;
 static git_index *repo_index;
 
-#define TEST_REPO_PATH "testrepo"
-#define TEST_INDEX_PATH TEST_REPO_PATH "/.git/index"
+#define TEST_REPO_PATH		"merge-resolve"
+#define TEST_INDEX_PATH TEST_REPO_PATH	"/.git/index"
 
-#define ORIG_HEAD                   "bd593285fc7fe4ca18ccdbabf027f5d689101452"
+#define ORIG_HEAD			"bd593285fc7fe4ca18ccdbabf027f5d689101452"
 
-#define THEIRS_SIMPLE_BRANCH        "branch"
-#define THEIRS_SIMPLE_OID           "7cb63eed597130ba4abb87b3e544b85021905520"
+#define THEIRS_SIMPLE_BRANCH	"branch"
+#define THEIRS_SIMPLE_OID	"7cb63eed597130ba4abb87b3e544b85021905520"
 
-#define OCTO1_BRANCH                "octo1"
-#define OCTO1_OID                   "16f825815cfd20a07a75c71554e82d8eede0b061"
+#define OCTO1_BRANCH		"octo1"
+#define OCTO1_OID			"16f825815cfd20a07a75c71554e82d8eede0b061"
 
-#define OCTO2_BRANCH                "octo2"
-#define OCTO2_OID                   "158dc7bedb202f5b26502bf3574faa7f4238d56c"
+#define OCTO2_BRANCH		"octo2"
+#define OCTO2_OID			"158dc7bedb202f5b26502bf3574faa7f4238d56c"
 
-#define OCTO3_BRANCH                "octo3"
-#define OCTO3_OID                   "50ce7d7d01217679e26c55939eef119e0c93e272"
+#define OCTO3_BRANCH		"octo3"
+#define OCTO3_OID			"50ce7d7d01217679e26c55939eef119e0c93e272"
 
-#define OCTO4_BRANCH                "octo4"
-#define OCTO4_OID                   "54269b3f6ec3d7d4ede24dd350dd5d605495c3ae"
+#define OCTO4_BRANCH		"octo4"
+#define OCTO4_OID			"54269b3f6ec3d7d4ede24dd350dd5d605495c3ae"
 
-#define OCTO5_BRANCH                "octo5"
-#define OCTO5_OID                   "e4f618a2c3ed0669308735727df5ebf2447f022f"
+#define OCTO5_BRANCH		"octo5"
+#define OCTO5_OID			"e4f618a2c3ed0669308735727df5ebf2447f022f"
 
 // Fixture setup and teardown
 void test_merge_workdir_setup__initialize(void)
@@ -44,6 +44,22 @@ void test_merge_workdir_setup__cleanup(void)
 	cl_git_sandbox_cleanup();
 }
 
+static bool test_file_contents(const char *filename, const char *expected)
+{
+	git_buf file_path_buf = GIT_BUF_INIT, file_buf = GIT_BUF_INIT;
+	bool equals;
+	
+	git_buf_printf(&file_path_buf, "%s/%s", git_repository_path(repo), filename);
+	
+	cl_git_pass(git_futils_readbuffer(&file_buf, file_path_buf.ptr));
+	equals = (strcmp(file_buf.ptr, expected) == 0);
+
+	git_buf_free(&file_path_buf);
+	git_buf_free(&file_buf);
+	
+	return equals;
+}
+
 static void write_file_contents(const char *filename, const char *output)
 {
 	git_buf file_path_buf = GIT_BUF_INIT;
@@ -53,6 +69,816 @@ static void write_file_contents(const char *filename, const char *output)
 	cl_git_rewritefile(file_path_buf.ptr, output);
 
 	git_buf_free(&file_path_buf);
+}
+
+/* git merge --no-ff octo1 */
+void test_merge_workdir_setup__one_branch(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_merge_head *our_head, *their_heads[1];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 1, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branch '" OCTO1_BRANCH "'\n"));
+
+	git_reference_free(octo1_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+}
+
+/* git merge --no-ff 16f825815cfd20a07a75c71554e82d8eede0b061 */
+void test_merge_workdir_setup__one_oid(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_merge_head *our_head, *their_heads[1];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[0], repo, &octo1_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 1, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge commit '" OCTO1_OID "'\n"));
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+}
+
+/* git merge octo1 octo2 */
+void test_merge_workdir_setup__two_branches(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_merge_head *our_head, *their_heads[2];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 2, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "' and '" OCTO2_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+}
+
+/* git merge octo1 octo2 octo3 */
+void test_merge_workdir_setup__three_branches(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_reference *octo3_ref;
+	git_merge_head *our_head, *their_heads[3];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+	
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_reference_lookup(&octo3_ref, repo, GIT_REFS_HEADS_DIR OCTO3_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[2], repo, octo3_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "', '" OCTO2_BRANCH "' and '" OCTO3_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	git_reference_free(octo3_ref);
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+/* git merge 16f825815cfd20a07a75c71554e82d8eede0b061 158dc7bedb202f5b26502bf3574faa7f4238d56c 50ce7d7d01217679e26c55939eef119e0c93e272 */
+void test_merge_workdir_setup__three_oids(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_oid octo2_oid;
+	git_oid octo3_oid;
+	git_merge_head *our_head, *their_heads[3];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[0], repo, &octo1_oid));
+	
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[1], repo, &octo2_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo3_oid, OCTO3_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[2], repo, &octo3_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge commit '" OCTO1_OID "'; commit '" OCTO2_OID "'; commit '" OCTO3_OID "'\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+/* git merge octo1 158dc7bedb202f5b26502bf3574faa7f4238d56c */
+void test_merge_workdir_setup__branches_and_oids_1(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_oid octo2_oid;
+	git_merge_head *our_head, *their_heads[2];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[1], repo, &octo2_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 2, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branch '" OCTO1_BRANCH "'; commit '" OCTO2_OID "'\n"));
+	
+	git_reference_free(octo1_ref);
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+}
+
+/* git merge octo1 158dc7bedb202f5b26502bf3574faa7f4238d56c octo3 54269b3f6ec3d7d4ede24dd350dd5d605495c3ae */
+void test_merge_workdir_setup__branches_and_oids_2(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_oid octo2_oid;
+	git_reference *octo3_ref;
+	git_oid octo4_oid;
+	git_merge_head *our_head, *their_heads[4];
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+	
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[1], repo, &octo2_oid));
+
+	cl_git_pass(git_reference_lookup(&octo3_ref, repo, GIT_REFS_HEADS_DIR OCTO3_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[2], repo, octo3_ref));
+	
+	cl_git_pass(git_oid_fromstr(&octo4_oid, OCTO4_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[3], repo, &octo4_oid));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 4, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n" OCTO4_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "' and '" OCTO3_BRANCH "'; commit '" OCTO2_OID "'; commit '" OCTO4_OID "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo3_ref);
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+	git_merge_head_free(their_heads[3]);
+}
+
+/* git merge 16f825815cfd20a07a75c71554e82d8eede0b061 octo2 50ce7d7d01217679e26c55939eef119e0c93e272 octo4 */
+void test_merge_workdir_setup__branches_and_oids_3(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_reference *octo2_ref;
+	git_oid octo3_oid;
+	git_reference *octo4_ref;
+	git_merge_head *our_head, *their_heads[4];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[0], repo, &octo1_oid));
+
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_oid_fromstr(&octo3_oid, OCTO3_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[2], repo, &octo3_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo4_ref, repo, GIT_REFS_HEADS_DIR OCTO4_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[3], repo, octo4_ref));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 4, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n" OCTO4_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge commit '" OCTO1_OID "'; branches '" OCTO2_BRANCH "' and '" OCTO4_BRANCH "'; commit '" OCTO3_OID "'\n"));
+	
+	git_reference_free(octo2_ref);
+	git_reference_free(octo4_ref);
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+	git_merge_head_free(their_heads[3]);
+}
+
+/* git merge 16f825815cfd20a07a75c71554e82d8eede0b061 octo2 50ce7d7d01217679e26c55939eef119e0c93e272 octo4 octo5 */
+void test_merge_workdir_setup__branches_and_oids_4(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_reference *octo2_ref;
+	git_oid octo3_oid;
+	git_reference *octo4_ref;
+	git_reference *octo5_ref;
+	git_merge_head *our_head, *their_heads[5];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[0], repo, &octo1_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+	
+	cl_git_pass(git_oid_fromstr(&octo3_oid, OCTO3_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[2], repo, &octo3_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo4_ref, repo, GIT_REFS_HEADS_DIR OCTO4_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[3], repo, octo4_ref));
+
+	cl_git_pass(git_reference_lookup(&octo5_ref, repo, GIT_REFS_HEADS_DIR OCTO5_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[4], repo, octo5_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 5, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n" OCTO4_OID "\n" OCTO5_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge commit '" OCTO1_OID "'; branches '" OCTO2_BRANCH "', '" OCTO4_BRANCH "' and '" OCTO5_BRANCH "'; commit '" OCTO3_OID "'\n"));
+	
+	git_reference_free(octo2_ref);
+	git_reference_free(octo4_ref);
+	git_reference_free(octo5_ref);
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+	git_merge_head_free(their_heads[3]);
+	git_merge_head_free(their_heads[4]);
+}
+
+/* git merge octo1 octo1 octo1 */
+void test_merge_workdir_setup__three_same_branches(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_1_ref;
+	git_reference *octo1_2_ref;
+	git_reference *octo1_3_ref;
+	git_merge_head *our_head, *their_heads[3];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_1_ref));
+	
+	cl_git_pass(git_reference_lookup(&octo1_2_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo1_2_ref));
+	
+	cl_git_pass(git_reference_lookup(&octo1_3_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[2], repo, octo1_3_ref));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO1_OID "\n" OCTO1_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "', '" OCTO1_BRANCH "' and '" OCTO1_BRANCH "'\n"));
+	
+	git_reference_free(octo1_1_ref);
+	git_reference_free(octo1_2_ref);
+	git_reference_free(octo1_3_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+/* git merge 16f825815cfd20a07a75c71554e82d8eede0b061 16f825815cfd20a07a75c71554e82d8eede0b061 16f825815cfd20a07a75c71554e82d8eede0b061 */
+void test_merge_workdir_setup__three_same_oids(void)
+{
+	git_oid our_oid;
+	git_oid octo1_1_oid;
+	git_oid octo1_2_oid;
+	git_oid octo1_3_oid;
+	git_merge_head *our_head, *their_heads[3];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_oid_fromstr(&octo1_1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[0], repo, &octo1_1_oid));
+	
+	cl_git_pass(git_oid_fromstr(&octo1_2_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[1], repo, &octo1_2_oid));
+	
+	cl_git_pass(git_oid_fromstr(&octo1_3_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_oid(&their_heads[2], repo, &octo1_3_oid));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO1_OID "\n" OCTO1_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge commit '" OCTO1_OID "'; commit '" OCTO1_OID "'; commit '" OCTO1_OID "'\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+static int create_remote_tracking_branch(const char *branch_name, const char *oid_str)
+{
+	int error = 0;
+
+	git_buf remotes_path = GIT_BUF_INIT,
+		origin_path = GIT_BUF_INIT,
+		filename = GIT_BUF_INIT,
+		data = GIT_BUF_INIT;
+
+	if ((error = git_buf_puts(&remotes_path, git_repository_path(repo))) < 0 ||
+		(error = git_buf_puts(&remotes_path, GIT_REFS_REMOTES_DIR)) < 0)
+		goto done;
+
+	if (!git_path_exists(git_buf_cstr(&remotes_path)) &&
+		(error = p_mkdir(git_buf_cstr(&remotes_path), 0777)) < 0)
+		goto done;
+
+	if ((error = git_buf_puts(&origin_path, git_buf_cstr(&remotes_path))) < 0 ||
+		(error = git_buf_puts(&origin_path, "origin")) < 0)
+		goto done;
+
+	if (!git_path_exists(git_buf_cstr(&origin_path)) &&
+		(error = p_mkdir(git_buf_cstr(&origin_path), 0777)) < 0)
+		goto done;
+
+	if ((error = git_buf_puts(&filename, git_buf_cstr(&origin_path))) < 0 ||
+		(error = git_buf_puts(&filename, "/")) < 0 ||
+		(error = git_buf_puts(&filename, branch_name)) < 0 ||
+		(error = git_buf_puts(&data, oid_str)) < 0 ||
+		(error = git_buf_puts(&data, "\n")) < 0)
+		goto done;
+
+	cl_git_rewritefile(git_buf_cstr(&filename), git_buf_cstr(&data));
+
+done:
+	git_buf_free(&remotes_path);
+	git_buf_free(&origin_path);
+	git_buf_free(&filename);
+	git_buf_free(&data);
+
+	return error;
+}
+
+/* git merge refs/remotes/origin/octo1 */
+void test_merge_workdir_setup__remote_tracking_one_branch(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_merge_head *our_head, *their_heads[1];
+
+	cl_git_pass(create_remote_tracking_branch(OCTO1_BRANCH, OCTO1_OID));
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 1, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge remote-tracking branch 'refs/remotes/origin/" OCTO1_BRANCH "'\n"));
+
+	git_reference_free(octo1_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+}
+
+/* git merge refs/remotes/origin/octo1 refs/remotes/origin/octo2 */
+void test_merge_workdir_setup__remote_tracking_two_branches(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_merge_head *our_head, *their_heads[2];
+
+	cl_git_pass(create_remote_tracking_branch(OCTO1_BRANCH, OCTO1_OID));
+	cl_git_pass(create_remote_tracking_branch(OCTO2_BRANCH, OCTO2_OID));
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 2, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge remote-tracking branches 'refs/remotes/origin/" OCTO1_BRANCH "' and 'refs/remotes/origin/" OCTO2_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+}
+
+/* git merge refs/remotes/origin/octo1 refs/remotes/origin/octo2 refs/remotes/origin/octo3 */
+void test_merge_workdir_setup__remote_tracking_three_branches(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_reference *octo3_ref;
+	git_merge_head *our_head, *their_heads[3];
+
+	cl_git_pass(create_remote_tracking_branch(OCTO1_BRANCH, OCTO1_OID));
+	cl_git_pass(create_remote_tracking_branch(OCTO2_BRANCH, OCTO2_OID));
+	cl_git_pass(create_remote_tracking_branch(OCTO3_BRANCH, OCTO3_OID));
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+	
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_reference_lookup(&octo3_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO3_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[2], repo, octo3_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge remote-tracking branches 'refs/remotes/origin/" OCTO1_BRANCH "', 'refs/remotes/origin/" OCTO2_BRANCH "' and 'refs/remotes/origin/" OCTO3_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	git_reference_free(octo3_ref);
+
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+/* git merge octo1 refs/remotes/origin/octo2 */
+void test_merge_workdir_setup__normal_branch_and_remote_tracking_branch(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_merge_head *our_head, *their_heads[2];
+
+	cl_git_pass(create_remote_tracking_branch(OCTO2_BRANCH, OCTO2_OID));
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 2, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branch '" OCTO1_BRANCH "', remote-tracking branch 'refs/remotes/origin/" OCTO2_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+}
+
+/* git merge refs/remotes/origin/octo1 octo2 */
+void test_merge_workdir_setup__remote_tracking_branch_and_normal_branch(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_merge_head *our_head, *their_heads[2];
+
+	cl_git_pass(create_remote_tracking_branch(OCTO1_BRANCH, OCTO1_OID));
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 2, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branch '" OCTO2_BRANCH "', remote-tracking branch 'refs/remotes/origin/" OCTO1_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+}
+
+/* git merge octo1 refs/remotes/origin/octo2 octo3 refs/remotes/origin/octo4 */
+void test_merge_workdir_setup__two_remote_tracking_branch_and_two_normal_branches(void)
+{
+	git_oid our_oid;
+	git_reference *octo1_ref;
+	git_reference *octo2_ref;
+	git_reference *octo3_ref;
+	git_reference *octo4_ref;
+	git_merge_head *our_head, *their_heads[4];
+
+	cl_git_pass(create_remote_tracking_branch(OCTO2_BRANCH, OCTO2_OID));
+	cl_git_pass(create_remote_tracking_branch(OCTO4_BRANCH, OCTO4_OID));
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+	
+	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[0], repo, octo1_ref));
+
+	cl_git_pass(git_reference_lookup(&octo2_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO2_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[1], repo, octo2_ref));
+
+	cl_git_pass(git_reference_lookup(&octo3_ref, repo, GIT_REFS_HEADS_DIR OCTO3_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[2], repo, octo3_ref));
+
+	cl_git_pass(git_reference_lookup(&octo4_ref, repo, GIT_REFS_REMOTES_DIR "origin/" OCTO4_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&their_heads[3], repo, octo4_ref));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 4, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n" OCTO4_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "' and '" OCTO3_BRANCH "', remote-tracking branches 'refs/remotes/origin/" OCTO2_BRANCH "' and 'refs/remotes/origin/" OCTO4_BRANCH "'\n"));
+	
+	git_reference_free(octo1_ref);
+	git_reference_free(octo2_ref);
+	git_reference_free(octo3_ref);
+	git_reference_free(octo4_ref);
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+	git_merge_head_free(their_heads[3]);
+}
+
+/* git pull origin branch octo1 */
+void test_merge_workdir_setup__pull_one(void)
+{
+	git_oid our_oid;
+	git_oid octo1_1_oid;
+	git_merge_head *our_head, *their_heads[1];
+
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[0], repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH, "http://remote.url/repo.git", &octo1_1_oid));
+	
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 1, 0));
+	
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branch 'octo1' of http://remote.url/repo.git\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+}
+
+/* git pull origin octo1 octo2 */
+void test_merge_workdir_setup__pull_two(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_oid octo2_oid;
+	git_merge_head *our_head, *their_heads[2];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[0], repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH, "http://remote.url/repo.git", &octo1_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[1], repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH, "http://remote.url/repo.git", &octo2_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 2, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "' and '" OCTO2_BRANCH "' of http://remote.url/repo.git\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+}
+
+/* git pull origin octo1 octo2 octo3 */
+void test_merge_workdir_setup__pull_three(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_oid octo2_oid;
+	git_oid octo3_oid;
+	git_merge_head *our_head, *their_heads[3];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[0], repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH, "http://remote.url/repo.git", &octo1_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[1], repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH, "http://remote.url/repo.git", &octo2_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo3_oid, OCTO3_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[2], repo, GIT_REFS_HEADS_DIR OCTO3_BRANCH, "http://remote.url/repo.git", &octo3_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "', '" OCTO2_BRANCH "' and '" OCTO3_BRANCH "' of http://remote.url/repo.git\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+void test_merge_workdir_setup__three_remotes(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_oid octo2_oid;
+	git_oid octo3_oid;
+	git_merge_head *our_head, *their_heads[3];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[0], repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH, "http://remote.first/repo.git", &octo1_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[1], repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH, "http://remote.second/repo.git", &octo2_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo3_oid, OCTO3_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[2], repo, GIT_REFS_HEADS_DIR OCTO3_BRANCH, "http://remote.third/repo.git", &octo3_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 3, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branch '" OCTO1_BRANCH "' of http://remote.first/repo.git, branch '" OCTO2_BRANCH "' of http://remote.second/repo.git, branch '" OCTO3_BRANCH "' of http://remote.third/repo.git\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+}
+
+void test_merge_workdir_setup__two_remotes(void)
+{
+	git_oid our_oid;
+	git_oid octo1_oid;
+	git_oid octo2_oid;
+	git_oid octo3_oid;
+	git_oid octo4_oid;
+	git_merge_head *our_head, *their_heads[4];
+	
+	cl_git_pass(git_oid_fromstr(&our_oid, ORIG_HEAD));
+	cl_git_pass(git_merge_head_from_oid(&our_head, repo, &our_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo1_oid, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[0], repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH, "http://remote.first/repo.git", &octo1_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo2_oid, OCTO2_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[1], repo, GIT_REFS_HEADS_DIR OCTO2_BRANCH, "http://remote.second/repo.git", &octo2_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo3_oid, OCTO3_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[2], repo, GIT_REFS_HEADS_DIR OCTO3_BRANCH, "http://remote.first/repo.git", &octo3_oid));
+
+	cl_git_pass(git_oid_fromstr(&octo4_oid, OCTO4_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&their_heads[3], repo, GIT_REFS_HEADS_DIR OCTO4_BRANCH, "http://remote.second/repo.git", &octo4_oid));
+
+	cl_git_pass(git_merge__setup(repo, our_head, (const git_merge_head **)their_heads, 4, 0));
+
+	cl_assert(test_file_contents(GIT_MERGE_HEAD_FILE, OCTO1_OID "\n" OCTO2_OID "\n" OCTO3_OID "\n" OCTO4_OID "\n"));
+	cl_assert(test_file_contents(GIT_ORIG_HEAD_FILE, ORIG_HEAD "\n"));
+	cl_assert(test_file_contents(GIT_MERGE_MODE_FILE, ""));
+	cl_assert(test_file_contents(GIT_MERGE_MSG_FILE, "Merge branches '" OCTO1_BRANCH "' and '" OCTO3_BRANCH "' of http://remote.first/repo.git, branches '" OCTO2_BRANCH "' and '" OCTO4_BRANCH "' of http://remote.second/repo.git\n"));
+	
+	git_merge_head_free(our_head);
+	git_merge_head_free(their_heads[0]);
+	git_merge_head_free(their_heads[1]);
+	git_merge_head_free(their_heads[2]);
+	git_merge_head_free(their_heads[3]);
 }
 
 struct merge_head_cb_data {


### PR DESCRIPTION
This is the next pull request to add merge functionality:  setup the various merge metadata files when you start a merge.  My goal is to not necessarily expose this publicly.  Thus this is sort of an odd PR that doesn't add any functionality.  However it seemed like a logical chunk of code to bring over.

This PR writes the following files:
- `ORIG_HEAD`, simply the current oid of `HEAD` for when you begin a merge.
- `MERGE_HEAD`, simply the oids of each "head" being merged in to the current branch
- `MERGE_MODE`, any flags to the merge, for example "no-ff" for no-fast-forward.
- `MERGE_MSG`, a description of the items being merged in, in a really ridiculous format.

I went for strict compatibility with core git on the `MERGE_MSG` file, despite the fact that it probably isn't necessarily . I don't think that anybody should expect the `MERGE_MSG` file to follow a particular format, however we do _try_ to parse that file and decorate commit messages based on the contents.

This introduces a new opaque type (`git_merge_head`) which is intended to be used as the input to merge.  This provides data about the commit being merged in, as well as where it comes from (in a textual description.)  This textual data is used for writing both the `MERGE_MSG` file, and is expected to be used later in the merge process when writing conflicts.  (The diff3 file contains the branch name / description in the markers, in some conflicts, files are written with the branch name appended.)
