### PR TITLE
tag: Introduce git_tag_annotation_create()

### DIFF
--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -178,6 +178,37 @@ GIT_EXTERN(int) git_tag_create(
 	int force);
 
 /**
+ * Create a new tag in the object database pointing to a git_object
+ *
+ * The message will not be cleaned up. This can be achieved
+ * through `git_message_prettify()`.
+ *
+ * @param oid Pointer where to store the OID of the
+ * newly created tag
+ *
+ * @param repo Repository where to store the tag
+ *
+ * @param tag_name Name for the tag
+ *
+ * @param target Object to which this tag points. This object
+ * must belong to the given `repo`.
+ *
+ * @param tagger Signature of the tagger for this tag, and
+ * of the tagging time
+ *
+ * @param message Full message for this tag
+ *
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) git_tag_annotation_create(
+	git_oid *oid,
+	git_repository *repo,
+	const char *tag_name,
+	const git_object *target,
+	const git_signature *tagger,
+	const char *message);
+
+/**
  * Create a new tag in the repository from a buffer
  *
  * @param oid Pointer where to store the OID of the newly created tag

--- a/src/tag.c
+++ b/src/tag.c
@@ -291,6 +291,19 @@ int git_tag_create(
 	return git_tag_create__internal(oid, repo, tag_name, target, tagger, message, allow_ref_overwrite, 1);
 }
 
+int git_tag_annotation_create(
+	git_oid *oid,
+	git_repository *repo,
+	const char *tag_name,
+	const git_object *target,
+	const git_signature *tagger,
+	const char *message)
+{
+	assert(oid && repo && tag_name && target && tagger && message);
+
+	return write_tag_annotation(oid, repo, tag_name, target, tagger, message);
+}
+
 int git_tag_create_lightweight(
 	git_oid *oid,
 	git_repository *repo,


### PR DESCRIPTION
While working on libgit2/libgit2sharp#429, it's been noted that there's currently no way to create a tag annotation in the odb without creating a reference.

This PR exposes a new function which just does this.

This will eventually be bound in LibGit2Sharp.as `ObjectDatabase.CreateTag()`
