### PR TITLE
qsort_r is broken on HURD, avoid

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -685,7 +685,8 @@ static int GIT_STDLIB_CALL git__qsort_r_glue_cmp(
 void git__qsort_r(
 	void *els, size_t nel, size_t elsize, git__sort_r_cmp cmp, void *payload)
 {
-#if defined(__MINGW32__) || defined(__OpenBSD__) || defined(AMIGA)
+#if defined(__MINGW32__) || defined(__OpenBSD__) || defined(AMIGA) || \
+	defined(__gnu_hurd__)
 	git__insertsort_r(els, nel, elsize, NULL, cmp, payload);
 #elif defined(GIT_WIN32)
 	git__qsort_r_glue glue = { cmp, payload };


### PR DESCRIPTION
Turns out that the `qsort_r` in libc on GNU HURD is damaged in a way that I don't really want to debug, and we should avoid using it.

(What is it the kids say?  "For the lulz"?  That's the one, then.)
