### PR TITLE
qsort_r appeared in glibc 2.8

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -686,7 +686,8 @@ void git__qsort_r(
 	void *els, size_t nel, size_t elsize, git__sort_r_cmp cmp, void *payload)
 {
 #if defined(__MINGW32__) || defined(__OpenBSD__) || defined(AMIGA) || \
-	defined(__gnu_hurd__)
+	defined(__gnu_hurd__) || \
+	(__GLIBC__ == 2 && __GLIBC_MINOR__ < 8)
 	git__insertsort_r(els, nel, elsize, NULL, cmp, payload);
 #elif defined(GIT_WIN32)
 	git__qsort_r_glue glue = { cmp, payload };


### PR DESCRIPTION
Fall back to insert sort on ancient versions of glibc.  Tested on glibc 2.3.6 (Ubuntu 6.0.6).

This is in response to https://github.com/libgit2/libgit2/issues/1606 and similar to @arrbee's proposal therein except that we check for `__GLIBC__ == 2` in case glibc revs to 3.0.

(I don't think this will cause problems against people building and having `__GLIBC__ == 1`, because I don't think that's a thing, but if it is we can sort it out when somebody does that, which is to say never.)
