### PR TITLE
Allow for backend optimization of git_odb_exists queries

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -185,11 +185,15 @@ GIT_EXTERN(int) git_odb_read_header(size_t *len_out, git_otype *type_out, git_od
  *
  * @param db database to be searched for the given object.
  * @param id the object to search for.
+ * @param confirm_not_exist true if this existence call is simply
+ *   verifying that the object does not already exist in the object
+ *   database (allowing for an optimization opportunity in custom
+ *   backends)
  * @return
  * - 1, if the object was found
  * - 0, otherwise
  */
-GIT_EXTERN(int) git_odb_exists(git_odb *db, const git_oid *id);
+GIT_EXTERN(int) git_odb_exists(git_odb *db, const git_oid *id, int confirm_not_exist);
 
 /**
  * Refresh the object database to load newly added files.

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -87,7 +87,8 @@ struct git_odb_backend {
 
 	int (* exists)(
 			struct git_odb_backend *,
-			const git_oid *);
+			const git_oid *,
+			int);
 
 	int (* refresh)(struct git_odb_backend *);
 

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -44,7 +44,7 @@ static int filter_ref__cb(git_remote_head *head, void *payload)
 		return 0;
 
 	/* If we have the object, mark it so we don't ask for it */
-	if (git_odb_exists(p->odb, &head->oid))
+	if (git_odb_exists(p->odb, &head->oid, 0))
 		head->local = 1;
 	else
 		p->remote->need_pack = 1;

--- a/src/odb.c
+++ b/src/odb.c
@@ -526,7 +526,7 @@ void git_odb_free(git_odb *db)
 	GIT_REFCOUNT_DEC(db, odb_free);
 }
 
-int git_odb_exists(git_odb *db, const git_oid *id)
+int git_odb_exists(git_odb *db, const git_oid *id, int confirm_not_exist)
 {
 	git_odb_object *object;
 	size_t i;
@@ -546,7 +546,7 @@ attempt_lookup:
 		git_odb_backend *b = internal->backend;
 
 		if (b->exists != NULL)
-			found = b->exists(b, id);
+			found = b->exists(b, id, confirm_not_exist);
 	}
 
 	if (!found && !refreshed) {
@@ -752,7 +752,7 @@ int git_odb_write(
 	assert(oid && db);
 
 	git_odb_hash(oid, data, len, type);
-	if (git_odb_exists(db, oid))
+	if (git_odb_exists(db, oid, 1))
 		return 0;
 
 	for (i = 0; i < db->backends.length && error < 0; ++i) {

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -662,7 +662,7 @@ static int loose_backend__read_prefix(
 	return error;
 }
 
-static int loose_backend__exists(git_odb_backend *backend, const git_oid *oid)
+static int loose_backend__exists(git_odb_backend *backend, const git_oid *oid, int confirm_not_exist)
 {
 	git_buf object_path = GIT_BUF_INIT;
 	int error;

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -418,7 +418,7 @@ static int pack_backend__read_prefix(
 	return error;
 }
 
-static int pack_backend__exists(git_odb_backend *backend, const git_oid *oid)
+static int pack_backend__exists(git_odb_backend *backend, const git_oid *oid, int confirm_not_exist)
 {
 	struct git_pack_entry e;
 	return pack_entry_find(&e, (struct pack_backend *)backend, oid) == 0;

--- a/src/push.c
+++ b/src/push.c
@@ -301,7 +301,7 @@ static int revwalk(git_vector *commits, git_push *push)
 			if (git_oid_iszero(&spec->roid))
 				continue;
 
-			if (!git_odb_exists(push->repo->_odb, &spec->roid)) {
+			if (!git_odb_exists(push->repo->_odb, &spec->roid, 0)) {
 				giterr_clear();
 				error = GIT_ENONFASTFORWARD;
 				goto on_error;

--- a/src/refs.c
+++ b/src/refs.c
@@ -368,7 +368,7 @@ int git_reference_create(
 	if ((error = git_repository_odb__weakptr(&odb, repo)) < 0)
 		return error;
 	
-	if (!git_odb_exists(odb, oid)) {
+	if (!git_odb_exists(odb, oid, 0)) {
 		giterr_set(GITERR_REFERENCE,
 			"Target OID for the reference doesn't exist on the repository");
 		return -1;

--- a/src/remote.c
+++ b/src/remote.c
@@ -856,7 +856,7 @@ int git_remote_update_tips(git_remote *remote)
 			continue;
 		}
 
-		if (autotag && !git_odb_exists(odb, &head->oid))
+		if (autotag && !git_odb_exists(odb, &head->oid, 0))
 			continue;
 
 		if (git_vector_insert(&update_heads, head) < 0)

--- a/src/repository.c
+++ b/src/repository.c
@@ -1331,7 +1331,7 @@ int git_repository_head_detached(git_repository *repo)
 		return 0;
 	}
 
-	exists = git_odb_exists(odb, git_reference_target(ref));
+	exists = git_odb_exists(odb, git_reference_target(ref), 0);
 
 	git_reference_free(ref);
 	return exists;

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -265,7 +265,7 @@ static int local_push_copy_object(
 	git_oid remote_odb_obj_oid;
 
 	/* Object already exists in the remote ODB; do nothing and return 0*/
-	if (git_odb_exists(remote_odb, &obj->id))
+	if (git_odb_exists(remote_odb, &obj->id, 1))
 		return 0;
 
 	if ((error = git_odb_read(&odb_obj, local_odb, &obj->id)) < 0)
@@ -506,7 +506,7 @@ static int local_download_pack(
 		git_commit *commit;
 
 		/* Skip commits we already have */
-		if (git_odb_exists(odb, &oid)) continue;
+		if (git_odb_exists(odb, &oid, 0)) continue;
 
 		if (!git_object_lookup((git_object**)&commit, t->repo, &oid, GIT_OBJ_COMMIT)) {
 			const git_oid *tree_oid = git_commit_tree_id(commit);


### PR DESCRIPTION
In particular, for some backends it is more expensive to repeatedly do existence queries that will fail than it is to write objects which will only rarely be written twice.  This patch adds a "confirm_not_exists" query to git_odb_exists, so that libgit2 can tell the backend that it is only checking for existence in order to avoid duplicating content by an unnecessary write.