### PR TITLE
allow (ignore) bare slash in gitignore

### DIFF
--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -397,7 +397,8 @@ int git_attr_fnmatch__parse(
 
 	*base = scan;
 
-	spec->length = scan - pattern;
+	if ((spec->length = scan - pattern) == 0)
+		return GIT_ENOTFOUND;
 
 	if (pattern[spec->length - 1] == '/') {
 		spec->length--;

--- a/src/pool.c
+++ b/src/pool.c
@@ -194,6 +194,11 @@ char *git_pool_strndup(git_pool *pool, const char *str, size_t n)
 
 	assert(pool && str && pool->item_size == sizeof(char));
 
+	if (n + 1 == 0) {
+		giterr_set_oom();
+		return NULL;
+	}
+
 	if ((ptr = git_pool_malloc(pool, (uint32_t)(n + 1))) != NULL) {
 		memcpy(ptr, str, n);
 		*(((char *)ptr) + n) = '\0';

--- a/tests-clar/attr/ignore.c
+++ b/tests-clar/attr/ignore.c
@@ -34,6 +34,27 @@ void test_attr_ignore__honor_temporary_rules(void)
 	assert_is_ignored(true, "NewFolder/NewFolder/File.txt");
 }
 
+void test_attr_ignore__allow_root(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "/");
+
+	assert_is_ignored(false, "File.txt");
+	assert_is_ignored(false, "NewFolder");
+	assert_is_ignored(false, "NewFolder/NewFolder");
+	assert_is_ignored(false, "NewFolder/NewFolder/File.txt");
+}
+
+void test_attr_ignore__ignore_root(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "/\n\n/NewFolder\n/NewFolder/NewFolder");
+
+	assert_is_ignored(false, "File.txt");
+	assert_is_ignored(true, "NewFolder");
+	assert_is_ignored(true, "NewFolder/NewFolder");
+	assert_is_ignored(true, "NewFolder/NewFolder/File.txt");
+}
+
+
 void test_attr_ignore__skip_gitignore_directory(void)
 {
 	cl_git_rewritefile("attr/.git/info/exclude", "/NewFolder\n/NewFolder/NewFolder");

--- a/tests-clar/core/pool.c
+++ b/tests-clar/core/pool.c
@@ -133,3 +133,13 @@ void test_core_pool__free_list(void)
 
 	git_pool_clear(&p);
 }
+
+void test_core_pool__strndup_limit(void)
+{
+	git_pool p;
+
+	cl_git_pass(git_pool_init(&p, 1, 100));
+	cl_assert(git_pool_strndup(&p, "foo", -1) == NULL);
+	git_pool_clear(&p);
+}
+


### PR DESCRIPTION
If you have a forward slash (`/'`) by itself on a line, the `.gitignore` parser crashes.

When parsing lines, when we find a trailing `/`, we try to truncate it by decrementing the length of the string by one.  (https://github.com/libgit2/libgit2/blob/development/src/attr_file.c#L403).  However, in the case of a bare slash, this will set the strings length to uint32_t's max value.

We then try to `git_pool_strndup` uint32_t's max value bytes.  At which point we try to `git_pool_malloc` one more byte (https://github.com/libgit2/libgit2/blob/development/src/pool.c#L197) for a total of zero bytes, which succeeds.  At which point we try to `memcpy` uint32_t's max value of bytes into some region that was expected to contain 0 bytes.
