### PR TITLE
Create directory for creating symlink

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -773,7 +773,8 @@ static int blob_content_to_link(
 		return error;
 
 	if (can_symlink) {
-		if ((error = p_symlink(git_buf_cstr(&linktarget), path)) < 0)
+		if ((error = git_futils_mkpath2file(path, 0755)) < 0 ||
+			(error = p_symlink(git_buf_cstr(&linktarget), path)) < 0)
 			giterr_set(GITERR_CHECKOUT, "Could not create symlink %s\n", path);
 	} else {
 		error = git_futils_fake_symlink(git_buf_cstr(&linktarget), path);


### PR DESCRIPTION
The problem: libgit2 failed to clone git://github.com/timburks/nu

When we checkout the repo, it fails to create /include/Nu/Nu.h, because /include/Nu directory does not exist.

So we should create parent directories for symlink if they do not exist.
