### PR TITLE
Added support for setting transport flags (No check SSL cert) to git_clo...

### DIFF
--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -51,6 +51,8 @@ GIT_BEGIN_DECL
  * - `cred_acquire_cb` is a callback to be used if credentials are required
  *   during the initial fetch.
  * - `cred_acquire_payload` is the payload for the above callback.
+ * - `transport_flags` is flags used to create transport if no transport is
+ *   provided.
  * - `transport` is a custom transport to be used for the initial fetch.  NULL
  *   means use the transport autodetected from the URL.
  * - `remote_callbacks` may be used to specify custom progress callbacks for
@@ -75,6 +77,7 @@ typedef struct git_clone_options {
 	const char *push_spec;
 	git_cred_acquire_cb cred_acquire_cb;
 	void *cred_acquire_payload;
+    git_transport_flags_t transport_flags;
 	git_transport *transport;
 	git_remote_callbacks *remote_callbacks;
 	git_remote_autotag_option_t remote_autotag;

--- a/src/clone.c
+++ b/src/clone.c
@@ -336,6 +336,10 @@ static int create_and_configure_origin(
 	    (error = git_remote_set_pushurl(origin, options->pushurl)) < 0)
 		goto on_error;
 
+	if (options->transport_flags == GIT_TRANSPORTFLAGS_NO_CHECK_CERT) {
+        git_remote_check_cert(origin, 0);
+    }
+
 	if ((error = git_remote_save(origin)) < 0)
 		goto on_error;
 


### PR DESCRIPTION
As issue #1147, I was unable to git_clone a repository from github that used https, because it complained that the SSL certificate is invalid, so I added an option to git_clone to set the transport flags that will be used during the clone.

More specifically, it checks to see if the transport flags == `GIT_TRANSPORTFLAGS_NO_CHECK_CERT` and if so it calls `git_remote_check_cert(origin, 0))` to set the correct options.
