### PR TITLE
thread: fix segfault on Windows 64 bits

### DIFF
--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -24,8 +24,10 @@ int pthread_join(pthread_t thread, void **value_ptr)
 	DWORD ret = WaitForSingleObject(thread, INFINITE);
 
 	if (ret == WAIT_OBJECT_0) {
-		if (value_ptr != NULL)
+		if (value_ptr != NULL) {
+			*value_ptr = NULL;
 			GetExitCodeThread(thread, (void *)value_ptr);
+		}
 		CloseHandle(thread);
 		return 0;
 	}


### PR DESCRIPTION
`lpExitCode` is a pointer to a long. A long is 32 bits wide on Windows.

It means that on Windows 64bits, `GetExitCodeThread()` doesn't set/clear the high-order bytes of the 64 bits memory space pointed at by `value_ptr`.
