### PR TITLE
improve test for index extension truncation

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1575,7 +1575,8 @@ static size_t read_extension(git_index *index, const char *buffer, size_t buffer
 
 	total_size = dest.extension_size + sizeof(struct index_extension);
 
-	if (buffer_size - total_size < INDEX_FOOTER_SIZE)
+	if (buffer_size < total_size ||
+		buffer_size - total_size < INDEX_FOOTER_SIZE)
 		return 0;
 
 	/* optional extension */
@@ -1661,7 +1662,7 @@ static int parse_index(git_index *index, const char *buffer, size_t buffer_size)
 
 		/* see if we have read any bytes from the extension */
 		if (extension_size == 0)
-			return index_error_invalid("extension size is zero");
+			return index_error_invalid("extension is truncated");
 
 		seek_forward(extension_size);
 	}


### PR DESCRIPTION
Both `buffer_size` and `total_size` are unsigned and we currently compare `buffer_size` (the length of the remaining buffer) to `total_size` (the size that we need to consume from the index to fill in this extension - the advertised length plus the length of the extension header) but when `buffer_size < total_size`, it will very rarely be true that `buffer_size - total_size < INDEX_FOOTER_SIZE`.  We should instead test that explicitly.
