### PR TITLE
Make iterators use GIT_ITEROVER & smart advance

### DIFF
--- a/src/notes.c
+++ b/src/notes.c
@@ -647,18 +647,12 @@ int git_note_next(
 	const git_index_entry *item;
 
 	if ((error = git_iterator_current(&item, it)) < 0)
-		goto exit;
+		return error;
 
-	if (item != NULL) {
-		git_oid_cpy(note_id, &item->oid);
-		error = process_entry_path(item->path, annotated_id);
+	git_oid_cpy(note_id, &item->oid);
 
-		if (error >= 0)
-			error = git_iterator_advance(NULL, it);
-	} else {
-		error = GIT_ITEROVER;
-	}
+	if (!(error = process_entry_path(item->path, annotated_id)))
+		git_iterator_advance(NULL, it);
 
-exit:
 	return error;
 }

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1143,9 +1143,7 @@ static int load_submodule_config_from_index(
 		(error = git_iterator_for_index(&i, index, 0, NULL, NULL)) < 0)
 		return error;
 
-	error = git_iterator_current(&entry, i);
-
-	while (!error && entry != NULL) {
+	while (!(error = git_iterator_advance(&entry, i))) {
 
 		if (S_ISGITLINK(entry->mode)) {
 			error = submodule_load_from_index(repo, entry);
@@ -1158,9 +1156,10 @@ static int load_submodule_config_from_index(
 			if (strcmp(entry->path, GIT_MODULES_FILE) == 0)
 				git_oid_cpy(gitmodules_oid, &entry->oid);
 		}
-
-		error = git_iterator_advance(&entry, i);
 	}
+
+	if (error == GIT_ITEROVER)
+		error = 0;
 
 	git_iterator_free(i);
 
@@ -1183,9 +1182,7 @@ static int load_submodule_config_from_head(
 		return error;
 	}
 
-	error = git_iterator_current(&entry, i);
-
-	while (!error && entry != NULL) {
+	while (!(error = git_iterator_advance(&entry, i))) {
 
 		if (S_ISGITLINK(entry->mode)) {
 			error = submodule_load_from_head(repo, entry->path, &entry->oid);
@@ -1199,9 +1196,10 @@ static int load_submodule_config_from_head(
 				git_oid_iszero(gitmodules_oid))
 				git_oid_cpy(gitmodules_oid, &entry->oid);
 		}
-
-		error = git_iterator_advance(&entry, i);
 	}
+
+	if (error == GIT_ITEROVER)
+		error = 0;
 
 	git_iterator_free(i);
 	git_tree_free(head);

--- a/tests-clar/submodule/status.c
+++ b/tests-clar/submodule/status.c
@@ -370,12 +370,9 @@ void test_submodule_status__iterator(void)
 
 	cl_git_pass(git_iterator_for_workdir(&iter, g_repo,
 		GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
-	cl_git_pass(git_iterator_current(&entry, iter));
 
-	for (i = 0; entry; ++i) {
+	for (i = 0; !git_iterator_advance(&entry, iter); ++i)
 		cl_assert_equal_s(expected[i], entry->path);
-		cl_git_pass(git_iterator_advance(&entry, iter));
-	}
 
 	git_iterator_free(iter);
 


### PR DESCRIPTION
1. internal iterators now return `GIT_ITEROVER` when you go past the
   last item in the iteration.
2. `git_iterator_advance` will "advance" to the first item in the
   iteration if it is called immediately after creating the
   iterator, which allows a simpler idiom for basic iteration.
3. if `git_iterator_advance` encounters an error reading data (e.g.
   a missing tree or an unreadable file), it returns the error
   but also attempts to advance past the invalid data to prevent
   an infinite loop.

Updated all tests and internal usage of iterators to account for these new behaviors.
