### PR TITLE
Tests for index on case-insensitive filesystems

### DIFF
--- a/tests-clar/diff/rename.c
+++ b/tests-clar/diff/rename.c
@@ -811,3 +811,34 @@ void test_diff_rename__from_deleted_to_split(void)
 
 	git_buf_free(&c1);
 }
+
+void test_diff_rename__case_changes_are_split(void)
+{
+	git_index *index;
+	git_tree *tree;
+	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+	git_diff_list *diff = NULL;
+	diff_expects exp;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_pass(
+		git_revparse_single((git_object **)&tree, g_repo, "HEAD^{tree}"));
+
+	cl_git_pass(p_rename("renames/ikeepsix.txt", "renames/IKEEPSIX.txt"));
+
+	cl_git_pass(git_index_remove_bypath(index, "ikeepsix.txt"));
+	cl_git_pass(git_index_add_bypath(index, "IKEEPSIX.txt"));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, tree, index, NULL));
+
+	memset(&exp, 0, sizeof(exp));
+	cl_git_pass(git_diff_foreach(
+		diff, diff_file_cb, diff_hunk_cb, diff_line_cb, &exp));
+	cl_assert_equal_i(2, exp.files);
+	cl_assert_equal_i(1, exp.file_status[GIT_DELTA_DELETED]);
+	cl_assert_equal_i(1, exp.file_status[GIT_DELTA_ADDED]);
+
+	git_index_free(index);
+}


### PR DESCRIPTION
Just adding some tests that fail on a case-insensitive filesystem that I would expect to pass (based on the behavior of core git / git for windows.)
