### PR TITLE
Don't bail on parsing commits with an invalid timezone

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -174,8 +174,10 @@ int git_signature__parse(git_signature *sig, const char **buffer_out,
 			tz_start = time_end + 1;
 
 			if ((tz_start[0] != '-' && tz_start[0] != '+') ||
-				git__strtol32(&offset, tz_start + 1, &tz_end, 10) < 0)
-				return signature_error("malformed timezone");
+				git__strtol32(&offset, tz_start + 1, &tz_end, 10) < 0) {
+				//malformed timezone, just assume it's zero
+				offset = 0;
+			}
 
 			hours = offset / 100;
 			mins = offset % 100;


### PR DESCRIPTION
git doesn't do that, and it's not something that's usually
actionable to fix. if you have a git repository with one bad
timezone in the history, it's too late to change it most likely.
