### PR TITLE
signature: extend trimming to more whitespace

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -35,11 +35,11 @@ static bool contains_angle_brackets(const char *input)
 
 static char *extract_trimmed(const char *ptr, size_t len)
 {
-	while (len && ptr[0] == ' ') {
+	while (len && git__isspace(ptr[0])) {
 		ptr++; len--;
 	}
 
-	while (len && ptr[len - 1] == ' ') {
+	while (len && git__isspace(ptr[len - 1])) {
 		len--;
 	}
 

--- a/tests-clar/commit/signature.c
+++ b/tests-clar/commit/signature.c
@@ -31,6 +31,8 @@ static void assert_name_and_email(
 void test_commit_signature__leading_and_trailing_spaces_are_trimmed(void)
 {
 	assert_name_and_email("nulltoken", "emeric.fermas@gmail.com", "  nulltoken ", "   emeric.fermas@gmail.com     ");
+	assert_name_and_email("nulltoken", "emeric.fermas@gmail.com", "  nulltoken ", "   emeric.fermas@gmail.com  \n");
+	assert_name_and_email("nulltoken", "emeric.fermas@gmail.com", " \t nulltoken \n", " \n  emeric.fermas@gmail.com  \n");
 }
 
 void test_commit_signature__angle_brackets_in_names_are_not_supported(void)


### PR DESCRIPTION
There are all sorts of misconfiguration in the wild. We already rely on the
signature constructor to trim SP. Extend the logic to use
`isspace` to decide whether a character should be trimmed.
