### PR TITLE
Add high(est) config level for application specific config files

### DIFF
--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -44,6 +44,10 @@ typedef enum {
 	 */
 	GIT_CONFIG_LEVEL_LOCAL = 4,
 
+	/** Application specific configuration file; freely defined by applications
+	 */
+	GIT_CONFIG_LEVEL_APP = 5,
+
 	/** Represents the highest level available config file (i.e. the most
 	 * specific config file available that actually is loaded)
 	 */


### PR DESCRIPTION
Some tools use an extra level to maintain an application specific config files on top of the normal ones. Revision 16adc9fade52b49e2bc13cb52407cc0025a93c8b broke this.
