### PR TITLE
Fix Windows warnings and missing prototypes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -154,7 +154,7 @@ static int find_internal_file_by_level(
 	} else {
 		git_vector_foreach(&cfg->files, i, internal) {
 			if (internal->level == level)
-				pos = i;
+				pos = (int)i;
 		}
 	}
 
@@ -189,7 +189,7 @@ static void try_remove_existing_file_internal(
 
 	git_vector_foreach(&cfg->files, i, internal) {
 		if (internal->level == level)
-			pos = i;
+			pos = (int)i;
 	}
 
 	if (pos == -1)

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -331,7 +331,7 @@ int git_diff_driver_content_is_binary(
 }
 
 static int diff_context_line__simple(
-	git_diff_driver *driver, const char *line, long line_len)
+	git_diff_driver *driver, const char *line, size_t line_len)
 {
 	GIT_UNUSED(driver);
 	GIT_UNUSED(line_len);
@@ -339,7 +339,7 @@ static int diff_context_line__simple(
 }
 
 static int diff_context_line__pattern_match(
-	git_diff_driver *driver, const char *line, long line_len)
+	git_diff_driver *driver, const char *line, size_t line_len)
 {
 	size_t i;
 

--- a/src/diff_driver.h
+++ b/src/diff_driver.h
@@ -31,7 +31,7 @@ typedef long (*git_diff_find_context_fn)(
 	const char *, long, char *, long, void *);
 
 typedef int (*git_diff_find_context_line)(
-	git_diff_driver *, const char *, long);
+	git_diff_driver *, const char *, size_t);
 
 typedef struct {
 	git_diff_driver *driver;

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -711,7 +711,7 @@ int git_diff_find_similar(
 	git_vector_foreach(&diff->deltas, i, to) {
 		size_t tried_sources = 0;
 
-		match_targets[i].idx = i;
+		match_targets[i].idx = (uint32_t)i;
 		match_targets[i].similarity = 0;
 
 		/* skip things that are not rename targets */
@@ -744,8 +744,8 @@ int git_diff_find_similar(
 				match_sources[j].similarity < (uint32_t)similarity) {
 				match_targets[i].similarity = (uint32_t)similarity;
 				match_sources[j].similarity = (uint32_t)similarity;
-				match_targets[i].idx = j;
-				match_sources[j].idx = i;
+				match_targets[i].idx = (uint32_t)j;
+				match_sources[j].idx = (uint32_t)i;
 			}
 		}
 	}

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -674,7 +674,7 @@ static int ensure_left_hand_identifier_is_not_known_yet(git_object *object, git_
 int revparse__ext(
 	git_object **object_out,
 	git_reference **reference_out,
-	int *identifier_len_out,
+	size_t *identifier_len_out,
 	git_repository *repo,
 	const char *spec)
 {
@@ -832,7 +832,8 @@ int git_revparse_ext(
 	git_repository *repo,
 	const char *spec)
 {
-	int error, identifier_len;
+	int error;
+	size_t identifier_len;
 	git_object *obj = NULL;
 	git_reference *ref = NULL;
 
@@ -841,6 +842,7 @@ int git_revparse_ext(
 
 	*object_out = obj;
 	*reference_out = ref;
+	GIT_UNUSED(identifier_len);
 
 	return 0;
 

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -19,6 +19,8 @@
 #include <winhttp.h>
 #pragma comment(lib, "winhttp")
 
+#include <strsafe.h>
+
 /* For UuidCreate */
 #pragma comment(lib, "rpcrt4")
 

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -5,6 +5,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 #include "../posix.h"
+#include "../fileops.h"
 #include "path.h"
 #include "utf-conv.h"
 #include "repository.h"

--- a/tests-clar/refs/iterator.c
+++ b/tests-clar/refs/iterator.c
@@ -66,7 +66,7 @@ void test_refs_iterator__list(void)
 	} while (!error);
 
 	git_reference_iterator_free(iter);
-	cl_assert_equal_i(output.length, ARRAY_SIZE(refnames));
+	cl_assert_equal_sz(output.length, ARRAY_SIZE(refnames));
 
 	git_vector_sort(&output);
 


### PR DESCRIPTION
This fixes problems with missing function prototypes and 64-bit data issues on Windows.

I'm really only opening this as a PR so I can check the Travis results before merging... :kissing_cat: 
