### PR TITLE
ref: free the last ref when cancelling git_branch_foreach()

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -132,18 +132,17 @@ int git_branch_foreach(
 {
 	git_reference_iterator *iter;
 	git_reference *ref;
-	int error;
+	int error = 0;
 
 	if (git_reference_iterator_new(&iter, repo) < 0)
 		return -1;
 
-	while ((error = git_reference_next(&ref, iter)) == 0) {
+	while (!error && (error = git_reference_next(&ref, iter)) == 0) {
 		if (list_flags & GIT_BRANCH_LOCAL &&
 		    git__prefixcmp(ref->name, GIT_REFS_HEADS_DIR) == 0) {
 			if (callback(ref->name + strlen(GIT_REFS_HEADS_DIR),
 					GIT_BRANCH_LOCAL, payload)) {
 				error = GIT_EUSER;
-				break;
 			}
 		}
 
@@ -152,7 +151,6 @@ int git_branch_foreach(
 			if (callback(ref->name + strlen(GIT_REFS_REMOTES_DIR),
 					GIT_BRANCH_REMOTE, payload)) {
 				error = GIT_EUSER;
-				break;
 			}
 		}
 

--- a/tests-clar/refs/branches/foreach.c
+++ b/tests-clar/refs/branches/foreach.c
@@ -122,7 +122,7 @@ void test_refs_branches_foreach__retrieve_remote_symbolic_HEAD_when_present(void
 	cl_git_pass(git_branch_foreach(repo, GIT_BRANCH_REMOTE, contains_branch_list_cb, &exp));
 
 	assert_branch_has_been_found(exp, "nulltoken/HEAD");
-	assert_branch_has_been_found(exp, "nulltoken/HEAD");
+	assert_branch_has_been_found(exp, "nulltoken/master");
 }
 
 static int branch_list_interrupt_cb(


### PR DESCRIPTION
Also fixed an assert typo on nulltoken's HEAD
