### PR TITLE
Add "as_path" parameters to blob and buffer diff APIs

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -983,7 +983,9 @@ GIT_EXTERN(int) git_diff_patch_to_str(
  * `GIT_DIFF_FORCE_TEXT` of course).
  *
  * @param old_blob Blob for old side of diff, or NULL for empty blob
+ * @param old_as_path Treat old blob as if it had this filename; can be NULL
  * @param new_blob Blob for new side of diff, or NULL for empty blob
+ * @param new_as_path Treat new blob as if it had this filename; can be NULL
  * @param options Options for diff, or NULL for default options
  * @param file_cb Callback for "file"; made once if there is a diff; can be NULL
  * @param hunk_cb Callback for each hunk in diff; can be NULL
@@ -993,7 +995,9 @@ GIT_EXTERN(int) git_diff_patch_to_str(
  */
 GIT_EXTERN(int) git_diff_blobs(
 	const git_blob *old_blob,
+	const char *old_as_path,
 	const git_blob *new_blob,
+	const char *new_as_path,
 	const git_diff_options *options,
 	git_diff_file_cb file_cb,
 	git_diff_hunk_cb hunk_cb,
@@ -1010,14 +1014,18 @@ GIT_EXTERN(int) git_diff_blobs(
  *
  * @param out The generated patch; NULL on error
  * @param old_blob Blob for old side of diff, or NULL for empty blob
+ * @param old_as_path Treat old blob as if it had this filename; can be NULL
  * @param new_blob Blob for new side of diff, or NULL for empty blob
+ * @param new_as_path Treat new blob as if it had this filename; can be NULL
  * @param options Options for diff, or NULL for default options
  * @return 0 on success or error code < 0
  */
 GIT_EXTERN(int) git_diff_patch_from_blobs(
 	git_diff_patch **out,
 	const git_blob *old_blob,
+	const char *old_as_path,
 	const git_blob *new_blob,
+	const char *new_as_path,
 	const git_diff_options *opts);
 
 /**
@@ -1033,8 +1041,10 @@ GIT_EXTERN(int) git_diff_patch_from_blobs(
  * the reverse, with GIT_DELTA_REMOVED and blob content removed.
  *
  * @param old_blob Blob for old side of diff, or NULL for empty blob
+ * @param old_as_path Treat old blob as if it had this filename; can be NULL
  * @param buffer Raw data for new side of diff, or NULL for empty
  * @param buffer_len Length of raw data for new side of diff
+ * @param buffer_as_path Treat buffer as if it had this filename; can be NULL
  * @param options Options for diff, or NULL for default options
  * @param file_cb Callback for "file"; made once if there is a diff; can be NULL
  * @param hunk_cb Callback for each hunk in diff; can be NULL
@@ -1044,8 +1054,10 @@ GIT_EXTERN(int) git_diff_patch_from_blobs(
  */
 GIT_EXTERN(int) git_diff_blob_to_buffer(
 	const git_blob *old_blob,
+	const char *old_as_path,
 	const char *buffer,
 	size_t buffer_len,
+	const char *buffer_as_path,
 	const git_diff_options *options,
 	git_diff_file_cb file_cb,
 	git_diff_hunk_cb hunk_cb,
@@ -1062,16 +1074,20 @@ GIT_EXTERN(int) git_diff_blob_to_buffer(
  *
  * @param out The generated patch; NULL on error
  * @param old_blob Blob for old side of diff, or NULL for empty blob
+ * @param old_as_path Treat old blob as if it had this filename; can be NULL
  * @param buffer Raw data for new side of diff, or NULL for empty
  * @param buffer_len Length of raw data for new side of diff
+ * @param buffer_as_path Treat buffer as if it had this filename; can be NULL
  * @param options Options for diff, or NULL for default options
  * @return 0 on success or error code < 0
  */
 GIT_EXTERN(int) git_diff_patch_from_blob_and_buffer(
 	git_diff_patch **out,
 	const git_blob *old_blob,
-	const char *buf,
-	size_t buflen,
+	const char *old_as_path,
+	const char *buffer,
+	size_t buffer_len,
+	const char *buffer_as_path,
 	const git_diff_options *opts);
 
 

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -18,23 +18,23 @@
 static bool diff_file_content_binary_by_size(git_diff_file_content *fc)
 {
 	/* if we have diff opts, check max_size vs file size */
-	if ((fc->file.flags & DIFF_FLAGS_KNOWN_BINARY) == 0 &&
+	if ((fc->file->flags & DIFF_FLAGS_KNOWN_BINARY) == 0 &&
 		fc->opts_max_size > 0 &&
-		fc->file.size > fc->opts_max_size)
-		fc->file.flags |= GIT_DIFF_FLAG_BINARY;
+		fc->file->size > fc->opts_max_size)
+		fc->file->flags |= GIT_DIFF_FLAG_BINARY;
 
-	return ((fc->file.flags & GIT_DIFF_FLAG_BINARY) != 0);
+	return ((fc->file->flags & GIT_DIFF_FLAG_BINARY) != 0);
 }
 
 static void diff_file_content_binary_by_content(git_diff_file_content *fc)
 {
-	if ((fc->file.flags & DIFF_FLAGS_KNOWN_BINARY) != 0)
+	if ((fc->file->flags & DIFF_FLAGS_KNOWN_BINARY) != 0)
 		return;
 
 	switch (git_diff_driver_content_is_binary(
 		fc->driver, fc->map.data, fc->map.len)) {
-	case 0: fc->file.flags |= GIT_DIFF_FLAG_NOT_BINARY; break;
-	case 1: fc->file.flags |= GIT_DIFF_FLAG_BINARY; break;
+	case 0: fc->file->flags |= GIT_DIFF_FLAG_NOT_BINARY; break;
+	case 1: fc->file->flags |= GIT_DIFF_FLAG_BINARY; break;
 	default: break;
 	}
 }
@@ -48,38 +48,39 @@ static int diff_file_content_init_common(
 		fc->opts_max_size = opts->max_size ?
 			opts->max_size : DIFF_MAX_FILESIZE;
 
-	if (!fc->driver) {
-		if (git_diff_driver_lookup(&fc->driver, fc->repo, "") < 0)
-			return -1;
+	if (fc->src == GIT_ITERATOR_TYPE_EMPTY)
 		fc->src = GIT_ITERATOR_TYPE_TREE;
-	}
+
+	if (!fc->driver &&
+		git_diff_driver_lookup(&fc->driver, fc->repo, fc->file->path) < 0)
+		return -1;
 
 	/* give driver a chance to modify options */
 	git_diff_driver_update_options(&fc->opts_flags, fc->driver);
 
 	/* make sure file is conceivable mmap-able */
-	if ((git_off_t)((size_t)fc->file.size) != fc->file.size)
-		fc->file.flags |= GIT_DIFF_FLAG_BINARY;
+	if ((git_off_t)((size_t)fc->file->size) != fc->file->size)
+		fc->file->flags |= GIT_DIFF_FLAG_BINARY;
 	/* check if user is forcing text diff the file */
 	else if (fc->opts_flags & GIT_DIFF_FORCE_TEXT) {
-		fc->file.flags &= ~GIT_DIFF_FLAG_BINARY;
-		fc->file.flags |= GIT_DIFF_FLAG_NOT_BINARY;
+		fc->file->flags &= ~GIT_DIFF_FLAG_BINARY;
+		fc->file->flags |= GIT_DIFF_FLAG_NOT_BINARY;
 	}
 	/* check if user is forcing binary diff the file */
 	else if (fc->opts_flags & GIT_DIFF_FORCE_BINARY) {
-		fc->file.flags &= ~GIT_DIFF_FLAG_NOT_BINARY;
-		fc->file.flags |= GIT_DIFF_FLAG_BINARY;
+		fc->file->flags &= ~GIT_DIFF_FLAG_NOT_BINARY;
+		fc->file->flags |= GIT_DIFF_FLAG_BINARY;
 	}
 
 	diff_file_content_binary_by_size(fc);
 
-	if ((fc->file.flags & GIT_DIFF_FLAG__NO_DATA) != 0) {
-		fc->file.flags |= GIT_DIFF_FLAG__LOADED;
+	if ((fc->flags & GIT_DIFF_FLAG__NO_DATA) != 0) {
+		fc->flags |= GIT_DIFF_FLAG__LOADED;
 		fc->map.len  = 0;
 		fc->map.data = "";
 	}
 
-	if ((fc->file.flags & GIT_DIFF_FLAG__LOADED) != 0)
+	if ((fc->flags & GIT_DIFF_FLAG__LOADED) != 0)
 		diff_file_content_binary_by_content(fc);
 
 	return 0;
@@ -92,15 +93,14 @@ int git_diff_file_content__init_from_diff(
 	bool use_old)
 {
 	git_diff_delta *delta = git_vector_get(&diff->deltas, delta_index);
-	git_diff_file *file = use_old ? &delta->old_file : &delta->new_file;
 	bool has_data = true;
 
 	memset(fc, 0, sizeof(*fc));
 	fc->repo = diff->repo;
+	fc->file = use_old ? &delta->old_file : &delta->new_file;
 	fc->src  = use_old ? diff->old_src : diff->new_src;
-	memcpy(&fc->file, file, sizeof(fc->file));
 
-	if (git_diff_driver_lookup(&fc->driver, fc->repo, file->path) < 0)
+	if (git_diff_driver_lookup(&fc->driver, fc->repo, fc->file->path) < 0)
 		return -1;
 
 	switch (delta->status) {
@@ -122,7 +122,7 @@ int git_diff_file_content__init_from_diff(
 	}
 
 	if (!has_data)
-		fc->file.flags |= GIT_DIFF_FLAG__NO_DATA;
+		fc->flags |= GIT_DIFF_FLAG__NO_DATA;
 
 	return diff_file_content_init_common(fc, &diff->opts);
 }
@@ -131,21 +131,24 @@ int git_diff_file_content__init_from_blob(
 	git_diff_file_content *fc,
 	git_repository *repo,
 	const git_diff_options *opts,
-	const git_blob *blob)
+	const git_blob *blob,
+	git_diff_file *as_file)
 {
 	memset(fc, 0, sizeof(*fc));
 	fc->repo = repo;
+	fc->file = as_file;
 	fc->blob = blob;
 
 	if (!blob) {
-		fc->file.flags |= GIT_DIFF_FLAG__NO_DATA;
+		fc->flags |= GIT_DIFF_FLAG__NO_DATA;
 	} else {
-		fc->file.flags |= GIT_DIFF_FLAG__LOADED | GIT_DIFF_FLAG_VALID_OID;
-		fc->file.size = git_blob_rawsize(blob);
-		fc->file.mode = 0644;
-		git_oid_cpy(&fc->file.oid, git_blob_id(blob));
+		fc->flags |= GIT_DIFF_FLAG__LOADED;
+		fc->file->flags |= GIT_DIFF_FLAG_VALID_OID;
+		fc->file->size = git_blob_rawsize(blob);
+		fc->file->mode = GIT_FILEMODE_BLOB;
+		git_oid_cpy(&fc->file->oid, git_blob_id(blob));
 
-		fc->map.len = (size_t)fc->file.size;
+		fc->map.len  = (size_t)fc->file->size;
 		fc->map.data = (char *)git_blob_rawcontent(blob);
 	}
 
@@ -157,18 +160,21 @@ int git_diff_file_content__init_from_raw(
 	git_repository *repo,
 	const git_diff_options *opts,
 	const char *buf,
-	size_t buflen)
+	size_t buflen,
+	git_diff_file *as_file)
 {
 	memset(fc, 0, sizeof(*fc));
 	fc->repo = repo;
+	fc->file = as_file;
 
 	if (!buf) {
-		fc->file.flags |= GIT_DIFF_FLAG__NO_DATA;
+		fc->flags |= GIT_DIFF_FLAG__NO_DATA;
 	} else {
-		fc->file.flags |= GIT_DIFF_FLAG__LOADED | GIT_DIFF_FLAG_VALID_OID;
-		fc->file.size = buflen;
-		fc->file.mode = 0644;
-		git_odb_hash(&fc->file.oid, buf, buflen, GIT_OBJ_BLOB);
+		fc->flags |= GIT_DIFF_FLAG__LOADED;
+		fc->file->flags |= GIT_DIFF_FLAG_VALID_OID;
+		fc->file->size = buflen;
+		fc->file->mode = GIT_FILEMODE_BLOB;
+		git_odb_hash(&fc->file->oid, buf, buflen, GIT_OBJ_BLOB);
 
 		fc->map.len  = buflen;
 		fc->map.data = (char *)buf;
@@ -190,7 +196,7 @@ static int diff_file_content_commit_to_str(
 		unsigned int sm_status = 0;
 		const git_oid *sm_head;
 
-		if ((error = git_submodule_lookup(&sm, fc->repo, fc->file.path)) < 0 ||
+		if ((error = git_submodule_lookup(&sm, fc->repo, fc->file->path)) < 0 ||
 			(error = git_submodule_status(&sm_status, sm)) < 0) {
 			/* GIT_EEXISTS means a "submodule" that has not been git added */
 			if (error == GIT_EEXISTS)
@@ -199,25 +205,25 @@ static int diff_file_content_commit_to_str(
 		}
 
 		/* update OID if we didn't have it previously */
-		if ((fc->file.flags & GIT_DIFF_FLAG_VALID_OID) == 0 &&
+		if ((fc->file->flags & GIT_DIFF_FLAG_VALID_OID) == 0 &&
 			((sm_head = git_submodule_wd_id(sm)) != NULL ||
 			 (sm_head = git_submodule_head_id(sm)) != NULL))
 		{
-			git_oid_cpy(&fc->file.oid, sm_head);
-			fc->file.flags |= GIT_DIFF_FLAG_VALID_OID;
+			git_oid_cpy(&fc->file->oid, sm_head);
+			fc->file->flags |= GIT_DIFF_FLAG_VALID_OID;
 		}
 
 		if (GIT_SUBMODULE_STATUS_IS_WD_DIRTY(sm_status))
 			status = "-dirty";
 	}
 
-	git_oid_tostr(oid, sizeof(oid), &fc->file.oid);
+	git_oid_tostr(oid, sizeof(oid), &fc->file->oid);
 	if (git_buf_printf(&content, "Subproject commit %s%s\n", oid, status) < 0)
 		return -1;
 
 	fc->map.len  = git_buf_len(&content);
 	fc->map.data = git_buf_detach(&content);
-	fc->file.flags |= GIT_DIFF_FLAG__FREE_DATA;
+	fc->flags |= GIT_DIFF_FLAG__FREE_DATA;
 
 	return 0;
 }
@@ -227,27 +233,27 @@ static int diff_file_content_load_blob(git_diff_file_content *fc)
 	int error = 0;
 	git_odb_object *odb_obj = NULL;
 
-	if (git_oid_iszero(&fc->file.oid))
+	if (git_oid_iszero(&fc->file->oid))
 		return 0;
 
-	if (fc->file.mode == GIT_FILEMODE_COMMIT)
+	if (fc->file->mode == GIT_FILEMODE_COMMIT)
 		return diff_file_content_commit_to_str(fc, false);
 
 	/* if we don't know size, try to peek at object header first */
-	if (!fc->file.size) {
+	if (!fc->file->size) {
 		git_odb *odb;
 		size_t len;
 		git_otype type;
 
 		if (!(error = git_repository_odb__weakptr(&odb, fc->repo))) {
 			error = git_odb__read_header_or_object(
-				&odb_obj, &len, &type, odb, &fc->file.oid);
+				&odb_obj, &len, &type, odb, &fc->file->oid);
 			git_odb_free(odb);
 		}
 		if (error)
 			return error;
 
-		fc->file.size = len;
+		fc->file->size = len;
 	}
 
 	if (diff_file_content_binary_by_size(fc))
@@ -259,11 +265,11 @@ static int diff_file_content_load_blob(git_diff_file_content *fc)
 		git_odb_object_free(odb_obj);
 	} else {
 		error = git_blob_lookup(
-			(git_blob **)&fc->blob, fc->repo, &fc->file.oid);
+			(git_blob **)&fc->blob, fc->repo, &fc->file->oid);
 	}
 
 	if (!error) {
-		fc->file.flags |= GIT_DIFF_FLAG__FREE_BLOB;
+		fc->flags |= GIT_DIFF_FLAG__FREE_BLOB;
 		fc->map.data = (void *)git_blob_rawcontent(fc->blob);
 		fc->map.len  = (size_t)git_blob_rawsize(fc->blob);
 	}
@@ -279,16 +285,16 @@ static int diff_file_content_load_workdir_symlink(
 	/* link path on disk could be UTF-16, so prepare a buffer that is
 	 * big enough to handle some UTF-8 data expansion
 	 */
-	alloc_len = (ssize_t)(fc->file.size * 2) + 1;
+	alloc_len = (ssize_t)(fc->file->size * 2) + 1;
 
 	fc->map.data = git__calloc(alloc_len, sizeof(char));
 	GITERR_CHECK_ALLOC(fc->map.data);
 
-	fc->file.flags |= GIT_DIFF_FLAG__FREE_DATA;
+	fc->flags |= GIT_DIFF_FLAG__FREE_DATA;
 
 	read_len = p_readlink(git_buf_cstr(path), fc->map.data, alloc_len);
 	if (read_len < 0) {
-		giterr_set(GITERR_OS, "Failed to read symlink '%s'", fc->file.path);
+		giterr_set(GITERR_OS, "Failed to read symlink '%s'", fc->file->path);
 		return -1;
 	}
 
@@ -307,28 +313,28 @@ static int diff_file_content_load_workdir_file(
 	if (fd < 0)
 		return fd;
 
-	if (!fc->file.size &&
-		!(fc->file.size = git_futils_filesize(fd)))
+	if (!fc->file->size &&
+		!(fc->file->size = git_futils_filesize(fd)))
 		goto cleanup;
 
 	if (diff_file_content_binary_by_size(fc))
 		goto cleanup;
 
 	if ((error = git_filters_load(
-			&filters, fc->repo, fc->file.path, GIT_FILTER_TO_ODB)) < 0)
+			&filters, fc->repo, fc->file->path, GIT_FILTER_TO_ODB)) < 0)
 		goto cleanup;
 	/* error >= is a filter count */
 
 	if (error == 0) {
 		if (!(error = git_futils_mmap_ro(
-				&fc->map, fd, 0, (size_t)fc->file.size)))
-			fc->file.flags |= GIT_DIFF_FLAG__UNMAP_DATA;
+				&fc->map, fd, 0, (size_t)fc->file->size)))
+			fc->flags |= GIT_DIFF_FLAG__UNMAP_DATA;
 		else /* fall through to try readbuffer below */
 			giterr_clear();
 	}
 
 	if (error != 0) {
-		error = git_futils_readbuffer_fd(&raw, fd, (size_t)fc->file.size);
+		error = git_futils_readbuffer_fd(&raw, fd, (size_t)fc->file->size);
 		if (error < 0)
 			goto cleanup;
 
@@ -340,7 +346,7 @@ static int diff_file_content_load_workdir_file(
 		if (!error) {
 			fc->map.len  = git_buf_len(&filtered);
 			fc->map.data = git_buf_detach(&filtered);
-			fc->file.flags |= GIT_DIFF_FLAG__FREE_DATA;
+			fc->flags |= GIT_DIFF_FLAG__FREE_DATA;
 		}
 
 		git_buf_free(&raw);
@@ -359,26 +365,26 @@ static int diff_file_content_load_workdir(git_diff_file_content *fc)
 	int error = 0;
 	git_buf path = GIT_BUF_INIT;
 
-	if (fc->file.mode == GIT_FILEMODE_COMMIT)
+	if (fc->file->mode == GIT_FILEMODE_COMMIT)
 		return diff_file_content_commit_to_str(fc, true);
 
-	if (fc->file.mode == GIT_FILEMODE_TREE)
+	if (fc->file->mode == GIT_FILEMODE_TREE)
 		return 0;
 
 	if (git_buf_joinpath(
-			&path, git_repository_workdir(fc->repo), fc->file.path) < 0)
+			&path, git_repository_workdir(fc->repo), fc->file->path) < 0)
 		return -1;
 
-	if (S_ISLNK(fc->file.mode))
+	if (S_ISLNK(fc->file->mode))
 		error = diff_file_content_load_workdir_symlink(fc, &path);
 	else
 		error = diff_file_content_load_workdir_file(fc, &path);
 
 	/* once data is loaded, update OID if we didn't have it previously */
-	if (!error && (fc->file.flags & GIT_DIFF_FLAG_VALID_OID) == 0) {
+	if (!error && (fc->file->flags & GIT_DIFF_FLAG_VALID_OID) == 0) {
 		error = git_odb_hash(
-			&fc->file.oid, fc->map.data, fc->map.len, GIT_OBJ_BLOB);
-		fc->file.flags |= GIT_DIFF_FLAG_VALID_OID;
+			&fc->file->oid, fc->map.data, fc->map.len, GIT_OBJ_BLOB);
+		fc->file->flags |= GIT_DIFF_FLAG_VALID_OID;
 	}
 
 	git_buf_free(&path);
@@ -389,10 +395,10 @@ int git_diff_file_content__load(git_diff_file_content *fc)
 {
 	int error = 0;
 
-	if ((fc->file.flags & GIT_DIFF_FLAG__LOADED) != 0)
+	if ((fc->flags & GIT_DIFF_FLAG__LOADED) != 0)
 		return 0;
 
-	if (fc->file.flags & GIT_DIFF_FLAG_BINARY)
+	if ((fc->file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 		return 0;
 
 	if (fc->src == GIT_ITERATOR_TYPE_WORKDIR)
@@ -402,7 +408,7 @@ int git_diff_file_content__load(git_diff_file_content *fc)
 	if (error)
 		return error;
 
-	fc->file.flags |= GIT_DIFF_FLAG__LOADED;
+	fc->flags |= GIT_DIFF_FLAG__LOADED;
 
 	diff_file_content_binary_by_content(fc);
 
@@ -411,26 +417,26 @@ int git_diff_file_content__load(git_diff_file_content *fc)
 
 void git_diff_file_content__unload(git_diff_file_content *fc)
 {
-	if (fc->file.flags & GIT_DIFF_FLAG__FREE_DATA) {
+	if (fc->flags & GIT_DIFF_FLAG__FREE_DATA) {
 		git__free(fc->map.data);
 		fc->map.data = "";
 		fc->map.len  = 0;
-		fc->file.flags &= ~GIT_DIFF_FLAG__FREE_DATA;
+		fc->flags &= ~GIT_DIFF_FLAG__FREE_DATA;
 	}
-	else if (fc->file.flags & GIT_DIFF_FLAG__UNMAP_DATA) {
+	else if (fc->flags & GIT_DIFF_FLAG__UNMAP_DATA) {
 		git_futils_mmap_free(&fc->map);
 		fc->map.data = "";
 		fc->map.len  = 0;
-		fc->file.flags &= ~GIT_DIFF_FLAG__UNMAP_DATA;
+		fc->flags &= ~GIT_DIFF_FLAG__UNMAP_DATA;
 	}
 
-	if (fc->file.flags & GIT_DIFF_FLAG__FREE_BLOB) {
+	if (fc->flags & GIT_DIFF_FLAG__FREE_BLOB) {
 		git_blob_free((git_blob *)fc->blob);
 		fc->blob = NULL;
-		fc->file.flags &= ~GIT_DIFF_FLAG__FREE_BLOB;
+		fc->flags &= ~GIT_DIFF_FLAG__FREE_BLOB;
 	}
 
-	fc->file.flags &= ~GIT_DIFF_FLAG__LOADED;
+	fc->flags &= ~GIT_DIFF_FLAG__LOADED;
 }
 
 void git_diff_file_content__clear(git_diff_file_content *fc)

--- a/src/diff_file.h
+++ b/src/diff_file.h
@@ -15,8 +15,9 @@
 /* expanded information for one side of a delta */
 typedef struct {
 	git_repository *repo;
-	git_diff_file file;
+	git_diff_file *file;
 	git_diff_driver *driver;
+	uint32_t flags;
 	uint32_t opts_flags;
 	git_off_t opts_max_size;
 	git_iterator_type_t src;
@@ -34,14 +35,16 @@ extern int git_diff_file_content__init_from_blob(
 	git_diff_file_content *fc,
 	git_repository *repo,
 	const git_diff_options *opts,
-	const git_blob *blob);
+	const git_blob *blob,
+	git_diff_file *as_file);
 
 extern int git_diff_file_content__init_from_raw(
 	git_diff_file_content *fc,
 	git_repository *repo,
 	const git_diff_options *opts,
 	const char *buf,
-	size_t buflen);
+	size_t buflen,
+	git_diff_file *as_file);
 
 /* this loads the blob/file-on-disk as needed */
 extern int git_diff_file_content__load(git_diff_file_content *fc);

--- a/src/diff_patch.c
+++ b/src/diff_patch.c
@@ -64,12 +64,12 @@ static void diff_patch_update_binary(git_diff_patch *patch)
 	if ((patch->delta->flags & DIFF_FLAGS_KNOWN_BINARY) != 0)
 		return;
 
-	if ((patch->ofile.file.flags & GIT_DIFF_FLAG_BINARY) != 0 ||
-		(patch->nfile.file.flags & GIT_DIFF_FLAG_BINARY) != 0)
+	if ((patch->ofile.file->flags & GIT_DIFF_FLAG_BINARY) != 0 ||
+		(patch->nfile.file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 		patch->delta->flags |= GIT_DIFF_FLAG_BINARY;
 
-	else if ((patch->ofile.file.flags & DIFF_FLAGS_NOT_BINARY) != 0 &&
-			 (patch->nfile.file.flags & DIFF_FLAGS_NOT_BINARY) != 0)
+	else if ((patch->ofile.file->flags & DIFF_FLAGS_NOT_BINARY) != 0 &&
+			 (patch->nfile.file->flags & DIFF_FLAGS_NOT_BINARY) != 0)
 		patch->delta->flags |= GIT_DIFF_FLAG_NOT_BINARY;
 }
 
@@ -143,42 +143,42 @@ static int diff_patch_load(git_diff_patch *patch, git_diff_output *output)
 		output && !output->hunk_cb && !output->data_cb)
 		return 0;
 
-#define DIFF_FLAGS_KNOWN_DATA (GIT_DIFF_FLAG__NO_DATA|GIT_DIFF_FLAG_VALID_OID)
-
 	incomplete_data =
-		((patch->ofile.file.flags & DIFF_FLAGS_KNOWN_DATA) != 0 &&
-		 (patch->nfile.file.flags & DIFF_FLAGS_KNOWN_DATA) != 0);
+		(((patch->ofile.flags & GIT_DIFF_FLAG__NO_DATA) != 0 ||
+		  (patch->ofile.file->flags & GIT_DIFF_FLAG_VALID_OID) != 0) &&
+		 ((patch->nfile.flags & GIT_DIFF_FLAG__NO_DATA) != 0 ||
+		  (patch->nfile.file->flags & GIT_DIFF_FLAG_VALID_OID) != 0));
 
 	/* always try to load workdir content first because filtering may
 	 * need 2x data size and this minimizes peak memory footprint
 	 */
 	if (patch->ofile.src == GIT_ITERATOR_TYPE_WORKDIR) {
 		if ((error = git_diff_file_content__load(&patch->ofile)) < 0 ||
-			(patch->ofile.file.flags & GIT_DIFF_FLAG_BINARY) != 0)
+			(patch->ofile.file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 			goto cleanup;
 	}
 	if (patch->nfile.src == GIT_ITERATOR_TYPE_WORKDIR) {
 		if ((error = git_diff_file_content__load(&patch->nfile)) < 0 ||
-			(patch->nfile.file.flags & GIT_DIFF_FLAG_BINARY) != 0)
+			(patch->nfile.file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 			goto cleanup;
 	}
 
 	/* once workdir has been tried, load other data as needed */
 	if (patch->ofile.src != GIT_ITERATOR_TYPE_WORKDIR) {
 		if ((error = git_diff_file_content__load(&patch->ofile)) < 0 ||
-			(patch->ofile.file.flags & GIT_DIFF_FLAG_BINARY) != 0)
+			(patch->ofile.file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 			goto cleanup;
 	}
 	if (patch->nfile.src != GIT_ITERATOR_TYPE_WORKDIR) {
 		if ((error = git_diff_file_content__load(&patch->nfile)) < 0 ||
-			(patch->nfile.file.flags & GIT_DIFF_FLAG_BINARY) != 0)
+			(patch->nfile.file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 			goto cleanup;
 	}
 
 	/* if we were previously missing an oid, update MODIFIED->UNMODIFIED */
 	if (incomplete_data &&
-		patch->ofile.file.mode == patch->nfile.file.mode &&
-		git_oid_equal(&patch->ofile.file.oid, &patch->nfile.file.oid) &&
+		patch->ofile.file->mode == patch->nfile.file->mode &&
+		git_oid_equal(&patch->ofile.file->oid, &patch->nfile.file->oid) &&
 		patch->delta->status == GIT_DELTA_MODIFIED) /* not RENAMED/COPIED! */
 		patch->delta->status = GIT_DELTA_UNMODIFIED;
 
@@ -193,7 +193,7 @@ cleanup:
 			patch->delta->status != GIT_DELTA_UNMODIFIED &&
 			(patch->ofile.map.len || patch->nfile.map.len) &&
 			(patch->ofile.map.len != patch->nfile.map.len ||
-			 !git_oid_equal(&patch->ofile.file.oid, &patch->nfile.file.oid)))
+			 !git_oid_equal(&patch->ofile.file->oid, &patch->nfile.file->oid)))
 			patch->flags |= GIT_DIFF_PATCH_DIFFABLE;
 
 		patch->flags |= GIT_DIFF_PATCH_LOADED;
@@ -312,25 +312,30 @@ int git_diff_foreach(
 typedef struct {
 	git_diff_patch patch;
 	git_diff_delta delta;
+	char paths[GIT_FLEX_ARRAY];
 } diff_patch_with_delta;
 
 static int diff_single_generate(diff_patch_with_delta *pd, git_xdiff_output *xo)
 {
 	int error = 0;
 	git_diff_patch *patch = &pd->patch;
-	bool has_old = ((patch->ofile.file.flags & GIT_DIFF_FLAG__NO_DATA) == 0);
-	bool has_new = ((patch->nfile.file.flags & GIT_DIFF_FLAG__NO_DATA) == 0);
+	bool has_old = ((patch->ofile.flags & GIT_DIFF_FLAG__NO_DATA) == 0);
+	bool has_new = ((patch->nfile.flags & GIT_DIFF_FLAG__NO_DATA) == 0);
 
 	pd->delta.status = has_new ?
 		(has_old ? GIT_DELTA_MODIFIED : GIT_DELTA_ADDED) :
 		(has_old ? GIT_DELTA_DELETED : GIT_DELTA_UNTRACKED);
 
-	if (git_oid_equal(&patch->nfile.file.oid, &patch->ofile.file.oid))
+	if (git_oid_equal(&patch->nfile.file->oid, &patch->ofile.file->oid))
 		pd->delta.status = GIT_DELTA_UNMODIFIED;
 
 	patch->delta = &pd->delta;
 
 	diff_patch_init_common(patch);
+
+	if (pd->delta.status == GIT_DELTA_UNMODIFIED &&
+		!(patch->ofile.opts_flags & GIT_DIFF_INCLUDE_UNMODIFIED))
+		return error;
 
 	error = diff_patch_file_callback(patch, (git_diff_output *)xo);
 
@@ -347,7 +352,9 @@ static int diff_patch_from_blobs(
 	diff_patch_with_delta *pd,
 	git_xdiff_output *xo,
 	const git_blob *old_blob,
+	const char *old_path,
 	const git_blob *new_blob,
+	const char *new_path,
 	const git_diff_options *opts)
 {
 	int error = 0;
@@ -357,29 +364,61 @@ static int diff_patch_from_blobs(
 
 	GITERR_CHECK_VERSION(opts, GIT_DIFF_OPTIONS_VERSION, "git_diff_options");
 
-	pd->patch.delta = &pd->delta;
-
-	if (!repo) /* return two NULL items as UNMODIFIED delta */
-		return 0;
-
 	if (opts && (opts->flags & GIT_DIFF_REVERSE) != 0) {
-		const git_blob *swap = old_blob;
-		old_blob = new_blob;
-		new_blob = swap;
+		const git_blob *tmp_blob;
+		const char *tmp_path;
+		tmp_blob = old_blob; old_blob = new_blob; new_blob = tmp_blob;
+		tmp_path = old_path; old_path = new_path; new_path = tmp_path;
 	}
 
+	pd->patch.delta = &pd->delta;
+
+	pd->delta.old_file.path = old_path;
+	pd->delta.new_file.path = new_path;
+
 	if ((error = git_diff_file_content__init_from_blob(
-			&pd->patch.ofile, repo, opts, old_blob)) < 0 ||
+			&pd->patch.ofile, repo, opts, old_blob, &pd->delta.old_file)) < 0 ||
 		(error = git_diff_file_content__init_from_blob(
-			&pd->patch.nfile, repo, opts, new_blob)) < 0)
+			&pd->patch.nfile, repo, opts, new_blob, &pd->delta.new_file)) < 0)
 		return error;
 
 	return diff_single_generate(pd, xo);
 }
 
+static int diff_patch_with_delta_alloc(
+	diff_patch_with_delta **out,
+	const char **old_path,
+	const char **new_path)
+{
+	diff_patch_with_delta *pd;
+	size_t old_len = *old_path ? strlen(*old_path) : 0;
+	size_t new_len = *new_path ? strlen(*new_path) : 0;
+
+	*out = pd = git__calloc(1, sizeof(*pd) + old_len + new_len + 2);
+	GITERR_CHECK_ALLOC(pd);
+
+	pd->patch.flags = GIT_DIFF_PATCH_ALLOCATED;
+
+	if (*old_path) {
+		memcpy(&pd->paths[0], *old_path, old_len);
+		*old_path = &pd->paths[0];
+	} else if (*new_path)
+		*old_path = &pd->paths[old_len + 1];
+
+	if (*new_path) {
+		memcpy(&pd->paths[old_len + 1], *new_path, new_len);
+		*new_path = &pd->paths[old_len + 1];
+	} else if (*old_path)
+		*new_path = &pd->paths[0];
+
+	return 0;
+}
+
 int git_diff_blobs(
 	const git_blob *old_blob,
+	const char *old_path,
 	const git_blob *new_blob,
+	const char *new_path,
 	const git_diff_options *opts,
 	git_diff_file_cb file_cb,
 	git_diff_hunk_cb hunk_cb,
@@ -397,7 +436,13 @@ int git_diff_blobs(
 		(git_diff_output *)&xo, opts, file_cb, hunk_cb, data_cb, payload);
 	git_xdiff_init(&xo, opts);
 
-	error = diff_patch_from_blobs(&pd, &xo, old_blob, new_blob, opts);
+	if (!old_path && new_path)
+		old_path = new_path;
+	else if (!new_path && old_path)
+		new_path = old_path;
+
+	error = diff_patch_from_blobs(
+		&pd, &xo, old_blob, old_path, new_blob, new_path, opts);
 
 	git_diff_patch_free((git_diff_patch *)&pd);
 
@@ -407,7 +452,9 @@ int git_diff_blobs(
 int git_diff_patch_from_blobs(
 	git_diff_patch **out,
 	const git_blob *old_blob,
+	const char *old_path,
 	const git_blob *new_blob,
+	const char *new_path,
 	const git_diff_options *opts)
 {
 	int error = 0;
@@ -417,16 +464,18 @@ int git_diff_patch_from_blobs(
 	assert(out);
 	*out = NULL;
 
-	pd = git__calloc(1, sizeof(*pd));
-	GITERR_CHECK_ALLOC(pd);
-	pd->patch.flags = GIT_DIFF_PATCH_ALLOCATED;
+	if (diff_patch_with_delta_alloc(&pd, &old_path, &new_path) < 0)
+		return -1;
 
 	memset(&xo, 0, sizeof(xo));
 
 	diff_output_to_patch((git_diff_output *)&xo, &pd->patch);
 	git_xdiff_init(&xo, opts);
 
-	if (!(error = diff_patch_from_blobs(pd, &xo, old_blob, new_blob, opts)))
+	error = diff_patch_from_blobs(
+		pd, &xo, old_blob, old_path, new_blob, new_path, opts);
+
+	if (!error)
 		*out = (git_diff_patch *)pd;
 	else
 		git_diff_patch_free((git_diff_patch *)pd);
@@ -438,8 +487,10 @@ static int diff_patch_from_blob_and_buffer(
 	diff_patch_with_delta *pd,
 	git_xdiff_output *xo,
 	const git_blob *old_blob,
+	const char *old_path,
 	const char *buf,
 	size_t buflen,
+	const char *buf_path,
 	const git_diff_options *opts)
 {
 	int error = 0;
@@ -450,28 +501,36 @@ static int diff_patch_from_blob_and_buffer(
 
 	pd->patch.delta = &pd->delta;
 
-	if (!repo && !buf) /* return two NULL items as UNMODIFIED delta */
-		return 0;
-
 	if (opts && (opts->flags & GIT_DIFF_REVERSE) != 0) {
+		pd->delta.old_file.path = buf_path;
+		pd->delta.new_file.path = old_path;
+
 		if (!(error = git_diff_file_content__init_from_raw(
-				&pd->patch.ofile, repo, opts, buf, buflen)))
+				&pd->patch.ofile, repo, opts, buf, buflen, &pd->delta.old_file)))
 			error = git_diff_file_content__init_from_blob(
-				&pd->patch.nfile, repo, opts, old_blob);
+				&pd->patch.nfile, repo, opts, old_blob, &pd->delta.new_file);
 	} else {
+		pd->delta.old_file.path = old_path;
+		pd->delta.new_file.path = buf_path;
+
 		if (!(error = git_diff_file_content__init_from_blob(
-				&pd->patch.ofile, repo, opts, old_blob)))
+				&pd->patch.ofile, repo, opts, old_blob, &pd->delta.old_file)))
 			error = git_diff_file_content__init_from_raw(
-				&pd->patch.nfile, repo, opts, buf, buflen);
+				&pd->patch.nfile, repo, opts, buf, buflen, &pd->delta.new_file);
 	}
+
+	if (error < 0)
+		return error;
 
 	return diff_single_generate(pd, xo);
 }
 
 int git_diff_blob_to_buffer(
 	const git_blob *old_blob,
+	const char *old_path,
 	const char *buf,
 	size_t buflen,
+	const char *buf_path,
 	const git_diff_options *opts,
 	git_diff_file_cb file_cb,
 	git_diff_hunk_cb hunk_cb,
@@ -489,8 +548,13 @@ int git_diff_blob_to_buffer(
 		(git_diff_output *)&xo, opts, file_cb, hunk_cb, data_cb, payload);
 	git_xdiff_init(&xo, opts);
 
+	if (!old_path && buf_path)
+		old_path = buf_path;
+	else if (!buf_path && old_path)
+		buf_path = old_path;
+
 	error = diff_patch_from_blob_and_buffer(
-		&pd, &xo, old_blob, buf, buflen, opts);
+		&pd, &xo, old_blob, old_path, buf, buflen, buf_path, opts);
 
 	git_diff_patch_free((git_diff_patch *)&pd);
 
@@ -500,8 +564,10 @@ int git_diff_blob_to_buffer(
 int git_diff_patch_from_blob_and_buffer(
 	git_diff_patch **out,
 	const git_blob *old_blob,
+	const char *old_path,
 	const char *buf,
 	size_t buflen,
+	const char *buf_path,
 	const git_diff_options *opts)
 {
 	int error = 0;
@@ -511,17 +577,18 @@ int git_diff_patch_from_blob_and_buffer(
 	assert(out);
 	*out = NULL;
 
-	pd = git__calloc(1, sizeof(*pd));
-	GITERR_CHECK_ALLOC(pd);
-	pd->patch.flags = GIT_DIFF_PATCH_ALLOCATED;
+	if (diff_patch_with_delta_alloc(&pd, &old_path, &buf_path) < 0)
+		return -1;
 
 	memset(&xo, 0, sizeof(xo));
 
 	diff_output_to_patch((git_diff_output *)&xo, &pd->patch);
 	git_xdiff_init(&xo, opts);
 
-	if (!(error = diff_patch_from_blob_and_buffer(
-			pd, &xo, old_blob, buf, buflen, opts)))
+	error = diff_patch_from_blob_and_buffer(
+		pd, &xo, old_blob, old_path, buf, buflen, buf_path, opts);
+
+	if (!error)
 		*out = (git_diff_patch *)pd;
 	else
 		git_diff_patch_free((git_diff_patch *)pd);


### PR DESCRIPTION
This adds parameters to the four functions that allow for blob-to-blob and blob-to-buffer differencing (either via callbacks or by making a `git_diff_patch object`).  These parameters let you say that filename we should pretend the blob has while doing the diff. If you pass NULL, there should be no change from the existing behavior, which is to skip using attributes for file type checks and just look at content.  With the parameters, you can plug into the new diff driver functionality and get binary or non-binary behavior, plus function context regular expressions, etc.

**This changes the public APIs:** `git_diff_blobs`, `git_diff_blob_to_buffer`, `git_diff_patch_from_blobs` and `git_diff_patch_from_blob_and_buffer`

This commit also fixes things so that the `git_diff_delta` that is generated by these functions will actually be populated with the data that we know about the blobs (or buffers) so you can use it appropriately.  It also fixes a bug in generating patches from the `git_diff_patch` objects created via these functions.

Lastly, there is one other behavior change that may matter.  If there is no difference between the two blobs, these functions no longer generate any diff callbacks / patches unless you have passed in `GIT_DIFF_INCLUDE_UNMODIFIED`.  This is pretty natural, but could potentially change the behavior of existing usage.
