### PR TITLE
CMakeLists: fix zlib linker setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,17 +136,15 @@ IF(WIN32 OR AMIGA)
 ENDIF()
 
 # Optional external dependency: zlib
-IF(NOT ZLIB_LIBRARY)
-	# It's optional, but FIND_PACKAGE gives a warning that looks more like an
-	# error.
-	FIND_PACKAGE(ZLIB QUIET)
-ENDIF()
+# It's optional, but FIND_PACKAGE gives a warning that looks more like an
+# error.
+FIND_PACKAGE(ZLIB QUIET)
 IF (ZLIB_FOUND)
 	INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIRS})
 	LINK_LIBRARIES(${ZLIB_LIBRARIES})
 	# Fake the message CMake would have shown
 	MESSAGE("-- Found zlib: ${ZLIB_LIBRARY}")
-ELSEIF (NOT ZLIB_LIBRARY)
+ELSE()
 	MESSAGE( "zlib was not found; using bundled 3rd-party sources." )
 	INCLUDE_DIRECTORIES(deps/zlib)
 	ADD_DEFINITIONS(-DNO_VIZ -DSTDC -DNO_GZIP)


### PR DESCRIPTION
b53671a (Search for zlib unconditional, 2012-12-18) changed things
around to always (even on windows, that's what the subject refers to)
call FIND_PACKAGE(ZLIB).

However, it did not correctly handle the case where ZLIB_LIBRARY is
cached, either by the user setting it manually or by an earlier
search.  In that case, the IF(ZLIB_FOUND) would not trigger (that
variable is not cached) and we'd instead use the built-in version.

000e689 (CMake: don't try to use bundled zlib when the system's path
is in the cache, 2013-05-12) tried to fix that, but it actually made
the problem worse: now with ZLIB_LIBRARY cached, _neither_ of the
blocks would execute, resulting in a linker error for me when trying
to build such a doubly-configured setup.

To fix the issue, we just trust CMake to do the right thing.  If
ZLIB_LIBRARY is set (either from user or cache) then the find_library
in FindZLIB.cmake will use that instead of searching again.  So we can
unconditionally (for real this time) call FIND_PACKAGE(ZLIB), and just
check its result.
