### PR TITLE
test asserting checkout should not recreate deleted files

### DIFF
--- a/tests-clar/checkout/tree.c
+++ b/tests-clar/checkout/tree.c
@@ -442,6 +442,36 @@ void test_checkout_tree__checking_out_a_conflicting_content_change_returns_EMERG
 	assert_conflict("branch_file.txt", "hello\n", "5b5b025", "c47800c");
 }
 
+void test_checkout_tree__donot_update_deleted_file_by_default(void)
+{
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	git_oid old_id, new_id;
+	git_commit *old_commit = NULL, *new_commit = NULL;
+	git_index *index = NULL;
+
+	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_pass(git_oid_fromstr(&old_id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
+	cl_git_pass(git_commit_lookup(&old_commit, g_repo, &old_id));
+	cl_git_pass(git_reset(g_repo, (git_object *)old_commit, GIT_RESET_HARD));
+
+	cl_git_pass(p_unlink("testrepo/branch_file.txt"));
+	cl_git_pass(git_index_remove_bypath(index ,"branch_file.txt"));
+	cl_git_pass(git_index_write(index));
+
+	cl_assert(!git_path_exists("testrepo/branch_file.txt"));
+
+	cl_git_pass(git_oid_fromstr(&new_id, "099fabac3a9ea935598528c27f866e34089c2eff"));
+	cl_git_pass(git_commit_lookup(&new_commit, g_repo, &new_id));
+	cl_git_fail(git_checkout_tree(g_repo, (git_object *)new_commit, &opts));
+
+	git_commit_free(old_commit);
+	git_commit_free(new_commit);
+	git_index_free(index);
+}
+
 void test_checkout_tree__can_checkout_with_last_workdir_item_missing(void)
 {
 	git_index *index = NULL;


### PR DESCRIPTION
When you have a delete staged and you try to check out a tree that has a modification to that file, the file is unexpectedly recreated.

Core git:

```
>git rm a.txt
rm 'a.txt'

>git checkout 2ad1c5ac1d
error: Your local changes to the following files would be overwritten by checkout:
        a.txt
Please, commit your changes or stash them before you can switch branches.
Aborting
```

So I would expect a failure of some sort here?
