### PR TITLE
Checkout should not recreate deleted files - with fix

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -183,6 +183,8 @@ typedef enum {
 	GIT_CHECKOUT_NOTIFY_UPDATED   = (1u << 2),
 	GIT_CHECKOUT_NOTIFY_UNTRACKED = (1u << 3),
 	GIT_CHECKOUT_NOTIFY_IGNORED   = (1u << 4),
+
+	GIT_CHECKOUT_NOTIFY_ALL       = 0x0FFFFu
 } git_checkout_notify_t;
 
 /** Checkout notification callback function */

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -220,8 +220,10 @@ static int checkout_action_no_wd(
 		action = CHECKOUT_ACTION_IF(SAFE_CREATE, UPDATE_BLOB, NONE);
 		break;
 	case GIT_DELTA_ADDED:    /* case 2 or 28 (and 5 but not really) */
-	case GIT_DELTA_MODIFIED: /* case 13 (and 35 but not really) */
 		action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+		break;
+	case GIT_DELTA_MODIFIED: /* case 13 (and 35 but not really) */
+		action = CHECKOUT_ACTION_IF(SAFE_CREATE, UPDATE_BLOB, CONFLICT);
 		break;
 	case GIT_DELTA_TYPECHANGE: /* case 21 (B->T) and 28 (T->B)*/
 		if (delta->new_file.mode == GIT_FILEMODE_TREE)

--- a/tests-clar/checkout/checkout_helpers.c
+++ b/tests-clar/checkout/checkout_helpers.c
@@ -91,3 +91,98 @@ void check_file_contents_nocr_at_line(
 {
 	check_file_contents_internal(path, expected, true, file, line, msg);
 }
+
+int checkout_count_callback(
+	git_checkout_notify_t why,
+	const char *path,
+	const git_diff_file *baseline,
+	const git_diff_file *target,
+	const git_diff_file *workdir,
+	void *payload)
+{
+	checkout_counts *ct = payload;
+
+	GIT_UNUSED(baseline); GIT_UNUSED(target); GIT_UNUSED(workdir);
+
+	if (why & GIT_CHECKOUT_NOTIFY_CONFLICT) {
+		ct->n_conflicts++;
+
+		if (ct->debug) {
+			if (workdir) {
+				if (baseline) {
+					if (target)
+						fprintf(stderr, "M %s (conflicts with M %s)\n",
+							workdir->path, target->path);
+					else
+						fprintf(stderr, "M %s (conflicts with D %s)\n",
+							workdir->path, baseline->path);
+				} else {
+					if (target)
+						fprintf(stderr, "Existing %s (conflicts with A %s)\n",
+							workdir->path, target->path);
+					else
+						fprintf(stderr, "How can an untracked file be a conflict (%s)\n", workdir->path);
+				}
+			} else {
+				if (baseline) {
+					if (target)
+						fprintf(stderr, "D %s (conflicts with M %s)\n",
+							target->path, baseline->path);
+					else
+						fprintf(stderr, "D %s (conflicts with D %s)\n",
+							baseline->path, baseline->path);
+				} else {
+					if (target)
+						fprintf(stderr, "How can an added file with no workdir be a conflict (%s)\n", target->path);
+					else
+						fprintf(stderr, "How can a nonexistent file be a conflict (%s)\n", path);
+				}
+			}
+		}
+	}
+
+	if (why & GIT_CHECKOUT_NOTIFY_DIRTY) {
+		ct->n_dirty++;
+
+		if (ct->debug) {
+			if (workdir)
+				fprintf(stderr, "M %s\n", workdir->path);
+			else
+				fprintf(stderr, "D %s\n", baseline->path);
+		}
+	}
+
+	if (why & GIT_CHECKOUT_NOTIFY_UPDATED) {
+		ct->n_updates++;
+
+		if (ct->debug) {
+			if (baseline) {
+				if (target)
+					fprintf(stderr, "update: M %s\n", path);
+				else
+					fprintf(stderr, "update: D %s\n", path);
+			} else {
+				if (target)
+					fprintf(stderr, "update: A %s\n", path);
+				else
+					fprintf(stderr, "update: this makes no sense %s\n", path);
+			}
+		}
+	}
+
+	if (why & GIT_CHECKOUT_NOTIFY_UNTRACKED) {
+		ct->n_untracked++;
+
+		if (ct->debug)
+			fprintf(stderr, "? %s\n", path);
+	}
+
+	if (why & GIT_CHECKOUT_NOTIFY_IGNORED) {
+		ct->n_ignored++;
+
+		if (ct->debug)
+			fprintf(stderr, "I %s\n", path);
+	}
+
+	return 0;
+}

--- a/tests-clar/checkout/checkout_helpers.h
+++ b/tests-clar/checkout/checkout_helpers.h
@@ -19,3 +19,20 @@ extern void check_file_contents_nocr_at_line(
 
 #define check_file_contents_nocr(PATH,EXP) \
 	check_file_contents_nocr_at_line(PATH,EXP,__FILE__,__LINE__,"String mismatch: " #EXP " != " #PATH)
+
+typedef struct {
+	int n_conflicts;
+	int n_dirty;
+	int n_updates;
+	int n_untracked;
+	int n_ignored;
+	int debug;
+} checkout_counts;
+
+extern int checkout_count_callback(
+	git_checkout_notify_t why,
+	const char *path,
+	const git_diff_file *baseline,
+	const git_diff_file *target,
+	const git_diff_file *workdir,
+	void *payload);


### PR DESCRIPTION
This contains @ethomson's failing test that checkout was incorrectly recreating a deleted file even in SAFE checkout mode, plus it has the fix for the problem and some extra new checkout test helpers that make it easier to look at exactly what checkout is doing.
