### PR TITLE
Do not redefine WC_ERR_INVALID_CHARS

### DIFF
--- a/src/win32/error.c
+++ b/src/win32/error.c
@@ -12,7 +12,9 @@
 # include <winhttp.h>
 #endif
 
+#ifndef WC_ERR_INVALID_CHARS
 #define WC_ERR_INVALID_CHARS	0x80
+#endif
 
 char *git_win32_get_error_message(DWORD error_code)
 {


### PR DESCRIPTION
WC_ERR_INVALID_CHARS might be already defined by the Windows SDK.

Signed-off-by: Sven Strickroth email@cs-ware.de
