### PR TITLE
Add O_CLOEXEC to open calls

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -61,9 +61,11 @@ int git_futils_creat_locked(const char *path, const mode_t mode)
 	wchar_t buf[GIT_WIN_PATH];
 
 	git__utf8_to_16(buf, GIT_WIN_PATH, path);
-	fd = _wopen(buf, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY | O_EXCL, mode);
+	fd = _wopen(buf, O_WRONLY | O_CREAT | O_TRUNC |
+		O_EXCL | O_BINARY | O_CLOEXEC, mode);
 #else
-	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY | O_EXCL, mode);
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC |
+		O_EXCL | O_BINARY | O_CLOEXEC, mode);
 #endif
 
 	if (fd < 0) {

--- a/src/posix.c
+++ b/src/posix.c
@@ -111,12 +111,12 @@ int p_open(const char *path, int flags, ...)
 		va_end(arg_list);
 	}
 
-	return open(path, flags | O_BINARY, mode);
+	return open(path, flags | O_BINARY | O_CLOEXEC, mode);
 }
 
 int p_creat(const char *path, mode_t mode)
 {
-	return open(path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, mode);
+	return open(path, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY | O_CLOEXEC, mode);
 }
 
 int p_getcwd(char *buffer_out, size_t size)

--- a/src/posix.h
+++ b/src/posix.h
@@ -25,6 +25,9 @@
 #if !defined(O_BINARY)
 #define O_BINARY 0
 #endif
+#if !defined(O_CLOEXEC)
+#define O_CLOEXEC 0
+#endif
 
 typedef int git_file;
 


### PR DESCRIPTION
Just going through and cleaning up old issues. This addresses the request in #1329 to add `O_CLOEXEC` to open calls in the library to make things easier for library users that want to call `execv`, etc. Seems to me like there is no reason not to do this...
