### PR TITLE
Dirty submodules do not correctly appear in diffs

### DIFF
--- a/src/diff_patch.c
+++ b/src/diff_patch.c
@@ -10,6 +10,7 @@
 #include "diff_driver.h"
 #include "diff_patch.h"
 #include "diff_xdiff.h"
+#include "fileops.h"
 
 /* cached information about a single span in a diff */
 typedef struct diff_patch_line diff_patch_line;
@@ -175,9 +176,12 @@ static int diff_patch_load(git_diff_patch *patch, git_diff_output *output)
 			goto cleanup;
 	}
 
-	/* if we were previously missing an oid, update MODIFIED->UNMODIFIED */
+	/* if previously missing an oid, and now that we have it the two sides
+	 * are the same (and not submodules), update MODIFIED -> UNMODIFIED
+	 */
 	if (incomplete_data &&
 		patch->ofile.file->mode == patch->nfile.file->mode &&
+		patch->ofile.file->mode != GIT_FILEMODE_COMMIT &&
 		git_oid_equal(&patch->ofile.file->oid, &patch->nfile.file->oid) &&
 		patch->delta->status == GIT_DELTA_MODIFIED) /* not RENAMED/COPIED! */
 		patch->delta->status = GIT_DELTA_UNMODIFIED;

--- a/tests-clar/diff/submodules.c
+++ b/tests-clar/diff/submodules.c
@@ -47,8 +47,10 @@ static void check_diff_patches(git_diff_list *diff, const char **expected)
 	for (d = 0; d < num_d; ++d, git_diff_patch_free(patch)) {
 		cl_git_pass(git_diff_get_patch(&patch, &delta, diff, d));
 
-		if (delta->status == GIT_DELTA_UNMODIFIED && expected[d] == NULL)
+		if (delta->status == GIT_DELTA_UNMODIFIED) {
+			cl_assert(expected[d] == NULL);
 			continue;
+		}
 
 		if (expected[d] && !strcmp(expected[d], "<SKIP>"))
 			continue;


### PR DESCRIPTION
**:warning: NOT READY TO MERGE :warning:**

@arrbee Looks like the `diff::submodules` tests were written to skip unmodified deltas, which is why we missed the bug with dirty submodule diffs.

Calling `git_submodule_reload_all()` before `check_diff_patches()` seems to fix the failure in the `dirty_submodule` test, but that begs a couple questions:
1. Why is submodule status cached in the first place?
2. If the caching is important, when are the appropriate points to automatically reload submodules? It would be unfortunate to put this burden on the caller.

Reloading does _not_ fix the `submod2_index_to_wd` test. Not sure what the right answer is there.
