### PR TITLE
Don't bail out after failing to read submodule configs.

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1269,7 +1269,7 @@ static int load_submodule_config(git_repository *repo)
 
 	/* add submodule information from index */
 
-	if ((error = load_submodule_config_from_index(repo, &gitmodules_oid)) < 0)        
+	if ((error = load_submodule_config_from_index(repo, &gitmodules_oid)) < 0)
 		goto cleanup;
 
 	/* add submodule information from HEAD */


### PR DESCRIPTION
:warning: Not ready to merge

As the config may only exist in only one of (or neither of?) the HEAD
or the index.

This fixes dirty submodule diffs for me.

/cc @jspahrsummers @arrbee
