### PR TITLE
Clarify behavior of index/workdir operations on a case insensitive platforms

### DIFF
--- a/tests-clar/clar_libgit2.h
+++ b/tests-clar/clar_libgit2.h
@@ -5,6 +5,10 @@
 #include <git2.h>
 #include "common.h"
 
+#if (defined(GIT_WIN32) || defined(__APPLE__))
+#define CASE_INSENSITIVE_FILESYSTEM 1
+#endif
+
 /**
  * Replace for `clar_must_pass` that passes the last library error as the
  * test failure message.

--- a/tests-clar/repo/init.c
+++ b/tests-clar/repo/init.c
@@ -223,8 +223,6 @@ void test_repo_init__detect_filemode(void)
 #endif
 }
 
-#define CASE_INSENSITIVE_FILESYSTEM (defined GIT_WIN32 || defined __APPLE__)
-
 void test_repo_init__detect_ignorecase(void)
 {
 #if CASE_INSENSITIVE_FILESYSTEM

--- a/tests-clar/status/worktree.c
+++ b/tests-clar/status/worktree.c
@@ -683,7 +683,6 @@ void test_status_worktree__file_status_honors_case_ignorecase_regarding_untracke
 
 	repo = cl_git_sandbox_reopen();
 
-	/* Actually returns GIT_STATUS_IGNORED on Windows */
 	cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
 
 	cl_git_pass(git_repository_index(&index, repo));
@@ -692,7 +691,6 @@ void test_status_worktree__file_status_honors_case_ignorecase_regarding_untracke
 	cl_git_pass(git_index_write(index));
 	git_index_free(index);
 
-	/* Actually returns GIT_STATUS_IGNORED on Windows */
 	cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
 }
 

--- a/tests-clar/status/worktree.c
+++ b/tests-clar/status/worktree.c
@@ -675,30 +675,30 @@ void test_status_worktree__file_status_honors_core_ignorecase_false(void)
 
 void test_status_worktree__file_status_honors_case_ignorecase_regarding_untracked_files(void)
 {
-    git_repository *repo = cl_git_sandbox_init("status");
-    unsigned int status;
-    git_index *index;
+	git_repository *repo = cl_git_sandbox_init("status");
+	unsigned int status;
+	git_index *index;
 
-    cl_repo_set_bool(repo, "core.ignorecase", false);
+	cl_repo_set_bool(repo, "core.ignorecase", false);
 
 	repo = cl_git_sandbox_reopen();
 
-    /* Actually returns GIT_STATUS_IGNORED on Windows */
-    cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
+	/* Actually returns GIT_STATUS_IGNORED on Windows */
+	cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
 
-    cl_git_pass(git_repository_index(&index, repo));
+	cl_git_pass(git_repository_index(&index, repo));
 
-    cl_git_pass(git_index_add_bypath(index, "new_file"));
-    cl_git_pass(git_index_write(index));
-    git_index_free(index);
+	cl_git_pass(git_index_add_bypath(index, "new_file"));
+	cl_git_pass(git_index_write(index));
+	git_index_free(index);
 
-    /* Actually returns GIT_STATUS_IGNORED on Windows */
-    cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
+	/* Actually returns GIT_STATUS_IGNORED on Windows */
+	cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
 }
 
 void test_status_worktree__simple_delete(void)
 {
-    git_repository *repo = cl_git_sandbox_init("renames");
+	git_repository *repo = cl_git_sandbox_init("renames");
 	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
 	int count;
 

--- a/tests-clar/status/worktree.c
+++ b/tests-clar/status/worktree.c
@@ -694,6 +694,37 @@ void test_status_worktree__file_status_honors_case_ignorecase_regarding_untracke
 	cl_git_fail_with(git_status_file(&status, repo, "NEW_FILE"), GIT_ENOTFOUND);
 }
 
+void test_status_worktree__file_status_honors_case_ignorecase_on_case_insensitive_platforms(void)
+{
+#ifdef CASE_INSENSITIVE_FILESYSTEM
+	git_repository *repo = cl_git_sandbox_init("status");
+	unsigned int status;
+	git_index *index;
+
+	cl_repo_set_bool(repo, "core.ignorecase", true);
+
+	repo = cl_git_sandbox_reopen();
+
+	cl_git_pass(git_status_file(&status, repo, "NEW_FILE"));
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, status);
+
+	cl_git_pass(git_status_file(&status, repo, "new_file"));
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, status);
+
+	cl_git_pass(git_repository_index(&index, repo));
+
+	cl_git_pass(git_index_add_bypath(index, "new_file"));
+	cl_git_pass(git_index_write(index));
+	git_index_free(index);
+
+	cl_git_pass(git_status_file(&status, repo, "new_file"));
+	cl_assert_equal_i(GIT_STATUS_INDEX_NEW, status);
+
+	cl_git_pass(git_status_file(&status, repo, "NEW_FILE"));
+	cl_assert_equal_i(GIT_STATUS_INDEX_NEW, status);
+#endif
+}
+
 void test_status_worktree__simple_delete(void)
 {
 	git_repository *repo = cl_git_sandbox_init("renames");


### PR DESCRIPTION
This **[LibGit2Sharp test](https://github.com/libgit2/libgit2sharp/blob/vNext/LibGit2Sharp.Tests/StageFixture.cs#L156-L181)** doesn't pass any longer when being run against f2c4188.

The failing test has been stripped down to put this issue under the bright light of Clar.
