### PR TITLE
Null byte in hunk header

### DIFF
--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -373,10 +373,11 @@ static long diff_context_find(
 		!ctxt->match_line(ctxt->driver, ctxt->line.ptr, ctxt->line.size))
 		return -1;
 
-	git_buf_truncate(&ctxt->line, (size_t)out_size);
-	git_buf_copy_cstr(out, (size_t)out_size, &ctxt->line);
+	if (out_size > (long)ctxt->line.size)
+		out_size = ctxt->line.size;
+	memcpy(out, ctxt->line.ptr, (size_t)out_size);
 
-	return (long)ctxt->line.size;
+	return out_size;
 }
 
 void git_diff_find_context_init(

--- a/tests-clar/diff/diff_helpers.c
+++ b/tests-clar/diff/diff_helpers.c
@@ -70,8 +70,9 @@ int diff_hunk_cb(
 	diff_expects *e = payload;
 
 	GIT_UNUSED(delta);
-	GIT_UNUSED(header);
-	GIT_UNUSED(header_len);
+
+	/* confirm no NUL bytes in header text */
+	while (header_len--) cl_assert('\0' != *header++);
 
 	e->hunks++;
 	e->hunk_old_lines += range->old_lines;

--- a/tests-clar/diff/drivers.c
+++ b/tests-clar/diff/drivers.c
@@ -123,3 +123,34 @@ void test_diff_drivers__patterns(void)
 	git_tree_free(one);
 }
 
+void test_diff_drivers__long_lines(void)
+{
+	const char *base = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non nisi ligula. Ut viverra enim sed lobortis suscipit.\nPhasellus eget erat odio. Praesent at est iaculis, ultricies augue vel, dignissim risus. Suspendisse at nisi quis turpis fringilla rutrum id sit amet nulla.\nNam eget dolor fermentum, aliquet nisl at, convallis tellus. Pellentesque rhoncus erat enim, id porttitor elit euismod quis.\nMauris sollicitudin magna odio, non egestas libero vehicula ut. Etiam et quam velit. Fusce eget libero rhoncus, ultricies felis sit amet, egestas purus.\nAliquam in semper tellus. Pellentesque adipiscing rutrum velit, quis malesuada lacus consequat eget.\n";
+	git_index *idx;
+	git_diff_list *diff;
+	git_diff_patch *patch;
+	char *actual;
+	const char *expected = "diff --git a/longlines.txt b/longlines.txt\nindex c1ce6ef..0134431 100644\n--- a/longlines.txt\n+++ b/longlines.txt\n@@ -3,3 +3,5 @@ Phasellus eget erat odio. Praesent at est iaculis, ultricies augue vel, dignissi\n Nam eget dolor fermentum, aliquet nisl at, convallis tellus. Pellentesque rhoncus erat enim, id porttitor elit euismod quis.\n Mauris sollicitudin magna odio, non egestas libero vehicula ut. Etiam et quam velit. Fusce eget libero rhoncus, ultricies felis sit amet, egestas purus.\n Aliquam in semper tellus. Pellentesque adipiscing rutrum velit, quis malesuada lacus consequat eget.\n+newline\n+newline\n";
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+
+	cl_git_mkfile("empty_standard_repo/longlines.txt", base);
+	cl_git_pass(git_repository_index(&idx, g_repo));
+	cl_git_pass(git_index_add_bypath(idx, "longlines.txt"));
+	cl_git_pass(git_index_write(idx));
+	git_index_free(idx);
+
+	cl_git_append2file("empty_standard_repo/longlines.txt", "newline\nnewline\n");
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, NULL));
+	cl_assert_equal_sz(1, git_diff_num_deltas(diff));
+	cl_git_pass(git_diff_get_patch(&patch, NULL, diff, 0));
+	cl_git_pass(git_diff_patch_to_str(&actual, patch));
+
+	cl_assert_equal_s(expected, actual);
+
+	free(actual);
+	git_diff_patch_free(patch);
+	git_diff_list_free(diff);
+}
+


### PR DESCRIPTION
I'm not sure how it happens, but it seems that sometimes there is a null byte in the hunk header. For me, I have it happen on the following commit/file:

https://git.gnome.org/browse/gitg/diff/libgitg/tests/Makefile.am?id=23bc9feeb7b12a1d6cba2794806fd0297d244a00

@@ -2,7 +2,7 @@ AM_CPPFLAGS = -g -I$(top_srcdir) -I$(top_srcdir)/gitg -I$(top_srcdir)/libgitg $(

Basically, with libgit2 in this hunk header, the last ( is a null byte, then followed by a newline. The header_len reported by the hunk callback reports a length up and including the newline (and thus includes this null byte).
