### PR TITLE
Fix return value in git_config_get_multivar

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -535,6 +535,7 @@ int git_config_get_multivar(
 	file_internal *internal;
 	git_config_backend *file;
 	int ret = GIT_ENOTFOUND;
+	int err;
 	size_t i;
 
 	/*
@@ -547,9 +548,15 @@ int git_config_get_multivar(
 			continue;
 		file = internal->file;
 
-		ret = file->get_multivar(file, name, regexp, cb, payload);
-		if (ret < 0 && ret != GIT_ENOTFOUND)
-			return ret;
+		err = file->get_multivar(file, name, regexp, cb, payload);
+		switch (err) {
+			case GIT_OK:
+				ret = GIT_OK;
+			case GIT_ENOTFOUND:
+				break;
+			default:
+				return err;
+		}
 	}
 
 	return (ret == GIT_ENOTFOUND) ? config_error_notfound(name) : 0;


### PR DESCRIPTION
If there is not an error, the return value was always the return value of the last call to `file->get_multivar`

With this commit `GIT_ENOTFOUND` is only returned if all the calls to `file-get_multivar` return `GIT_ENOTFOUND`.
