### PR TITLE
preload configuration paths

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -627,6 +627,20 @@ static git_futils_dirs_guess_cb git_futils__dir_guess[GIT_FUTILS_DIR__MAX] = {
 	git_futils_guess_xdg_dirs,
 };
 
+int git_futils_dirs_global_init(void)
+{
+	git_futils_dir_t i;
+	git_buf *path;
+	int error = 0;
+
+	for (i = 0; i < GIT_FUTILS_DIR__MAX; i++) {
+		if ((error = git_futils_dirs_get(&path, i)) < 0)
+			break;
+	}
+
+	return error;
+}
+
 static int git_futils_check_selector(git_futils_dir_t which)
 {
 	if (which < GIT_FUTILS_DIR__MAX)

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -310,6 +310,13 @@ typedef enum {
 } git_futils_dir_t;
 
 /**
+ * Configures global data for configuration file search paths.
+ *
+ * @return 0 on success, <0 on failure
+ */
+extern int git_futils_dirs_global_init(void);
+
+/**
  * Get the search path for global/system/xdg files
  *
  * @param out pointer to git_buf containing search path

--- a/src/global.c
+++ b/src/global.c
@@ -65,10 +65,8 @@ int git_threads_init(void)
 		return -1;
 
 	/* Initialize any other subsystems that have global state */
-	if ((error = git_hash_global_init()) >= 0)
-		_tls_init = 1;
-
-	if (error == 0)
+	if ((error = git_hash_global_init()) >= 0 &&
+		(error = git_futils_dirs_global_init()) >= 0)
 		_tls_init = 1;
 
 	GIT_MEMORY_BARRIER;
@@ -127,7 +125,8 @@ int git_threads_init(void)
 	pthread_key_create(&_tls_key, &cb__free_status);
 
 	/* Initialize any other subsystems that have global state */
-	if ((error = git_hash_global_init()) >= 0)
+	if ((error = git_hash_global_init()) >= 0 &&
+		(error = git_futils_dirs_global_init()) >= 0)
 		_tls_init = 1;
 
 	GIT_MEMORY_BARRIER;


### PR DESCRIPTION
Set some defaults when compiled with `THREADSAFE` so that we don't storm through the lazy initializers all at once.

Obsoletes https://github.com/libgit2/libgit2/pull/1720
