### PR TITLE
git_revparse_ext: should return a NULL reference  when the revparse expression doesn't lead to a reference

### DIFF
--- a/tests-clar/refs/revparse.c
+++ b/tests-clar/refs/revparse.c
@@ -738,4 +738,45 @@ void test_refs_revparse__ext_can_expand_short_reference_names(void)
 		"master",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 		"refs/heads/master");
+
+	test_object_and_ref(
+		"HEAD",
+		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
+		"refs/heads/master");
+
+    test_object_and_ref(
+		"tags/test",
+		"b25fa35b38051e4ae45d4222e795f9df2e43f1d1",
+        "refs/tags/test");
+}
+
+void test_refs_revparse__ext_returns_NULL_reference_when_expression_points_at_a_revision(void)
+{
+    test_object_and_ref(
+        "HEAD~3",
+        "4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
+        NULL);
+
+    test_object_and_ref(
+        "HEAD~0",
+        "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
+        NULL);
+
+    test_object_and_ref(
+        "HEAD^0",
+        "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
+        NULL);
+
+    test_object_and_ref(
+		"@{-1}@{0}",
+		"a4a7dce85cf63874e984719f4fdd239f5145052f",
+		NULL);
+}
+
+void test_refs_revparse__ext_returns_NULL_reference_when_expression_points_at_a_tree_content(void)
+{
+    test_object_and_ref(
+		"tags/test:readme.txt",
+		"0266163a49e280c4f5ed1e08facd36a2bd716bcf",
+        NULL);
 }


### PR DESCRIPTION
The following test fails:

``` c
void test_refs_revparse__ext_returns_NULL_reference_when_expression_doesnt_lead_to_a_reference(void)
{
    test_object_and_ref(
        "HEAD~3",
        "4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
        NULL);  // currently returns refs/heads/master
}
```

I believe the same issue arises when having `^` or `:` in the revparse expression.
