### PR TITLE
don't include ignored as rename candidates

### DIFF
--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -590,10 +590,12 @@ static bool is_rename_target(
 		return false;
 
 	case GIT_DELTA_UNTRACKED:
-	case GIT_DELTA_IGNORED:
 		if (!FLAG_SET(opts, GIT_DIFF_FIND_FOR_UNTRACKED))
 			return false;
 		break;
+
+	case GIT_DELTA_IGNORED:
+		return false;
 
 	default: /* all other status values should be checked */
 		break;


### PR DESCRIPTION
I don't think that we should ever consider IGNORED as rename targets - even when we're coming with untracked for index -> workdir comparisons.

In particular, if you have some process with an exclusive lock on a file such that it could not be read by libgit2, but you have thoughtfully put that file in your `.gitignore`, then disappointingly rename detection will always fail because that file could not be read.

I suggest that it should not have ever been attempted to be read in the first place.

I don't think there's a need for a flag here to turn these on, it seems like this is _never_ useful.
