### PR TITLE
Switch default calling convention to cdecl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,16 +30,13 @@ OPTION( ENABLE_TRACE		"Enables tracing support"				OFF )
 OPTION( LIBGIT2_FILENAME	"Name of the produced binary" OFF )
 
 IF(MSVC)
-	# This option is only availalbe when building with MSVC. By default,
-	# libgit2 is build using the stdcall calling convention, as that's what
-	# the CLR expects by default and how the Windows API is built.
+	# This option is only availalbe when building with MSVC. By default, libgit2
+	# is build using the cdecl calling convention, which is useful if you're
+	# writing C. However, the CLR and Win32 API both expect stdcall.
 	#
-	# If you are writing a C or C++ program and want to link to libgit2, you
-	# have to either:
-	# - Add /Gz to the compiler options of _your_ program / library.
-	# - Turn this off by invoking CMake with the "-DSTDCALL=Off" argument.
-	#
-	OPTION( STDCALL			"Build libgit2 with the __stdcall convention"	ON  )
+	# If you are writing a CLR program and want to link to libgit2, you'll want
+	# to turn this on by invoking CMake with the "-DSTDCALL=ON" argument.
+	OPTION( STDCALL			"Build libgit2 with the __stdcall convention"	OFF  )
 
 	# This option must match the settings used in your program, in particular if you
 	# are linking statically


### PR DESCRIPTION
As reported in #1714, having the default calling convention set to `__stdcall` means that the library seems broken on Windows – a trivial program with the default compiler settings _won't link_. It was decided to work this way back in #356 because .NET, but my gut tells me the majority of .NET users are probably using libgit2sharp rather than P/Invoking directly into the library. @scunz made this point [back in #885](https://github.com/libgit2/libgit2/pull/885#issuecomment-7891981).

This PR switches the default to `__cdecl`, but retains the ability to use the other convention. This means that bindings that want `__stdcall` will need to specify `-DSTDCALL=ON` in their build scripts. Here's an incomplete list of bindings that will need PR's to fix them:
- [ ] [Libgit2Sharp](/libgit2/libgit2sharp) - [#468](https://github.com/libgit2/libgit2sharp/pull/468)
- [ ] [GitForDelphi](/jasonpenny/GitForDelphi) (?)
- [ ] Others?
