### PR TITLE
Clarify when to use github issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ release its source code.
 * Mailing list: The libgit2 mailing list was
     traditionally hosted in Librelist but has been deprecated. We encourage you to 
     [use StackOverflow](http://stackoverflow.com/questions/tagged/libgit2) instead for any questions regarding
-    the library, and to or [open an issue](https://github.com/libgit2/libgit2/issues) 
+    the library, or [open an issue](https://github.com/libgit2/libgit2/issues) 
     on GitHub for bug reports.  The mailing list archives are still available at 
     <http://librelist.com/browser/libgit2/>.
 


### PR DESCRIPTION
Suggest that github issues are to be used for bug reports, while questions about usage should be directed to StackOverflow.
