### PR TITLE
Allow Makefile.embed to be used when cross-compiling

### DIFF
--- a/Makefile.embed
+++ b/Makefile.embed
@@ -6,12 +6,12 @@ else
 	PREFIX=
 endif
 
-WIN32=0
+MINGW=0
 ifneq (,$(findstring MINGW32,$(PLATFORM)))
-	WIN32=1
+	MINGW=1
 endif
 ifneq (,$(findstring mingw,$(CROSS_COMPILE)))
-	WIN32=1
+	MINGW=1
 endif
 
 rm=rm -f
@@ -20,7 +20,7 @@ RANLIB=$(PREFIX)ranlib
 
 LIBNAME=libgit2.a
 
-ifeq ($(WIN32),1)
+ifeq ($(MINGW),1)
 	CC=gcc
 else
 	CC=cc
@@ -35,10 +35,10 @@ CFLAGS= -g $(DEFINES) -Wall -Wextra -O2 $(EXTRA_CFLAGS)
 
 SRCS = $(wildcard src/*.c) $(wildcard src/transports/*.c) $(wildcard src/xdiff/*.c) $(wildcard deps/http-parser/*.c) $(wildcard deps/zlib/*.c) src/hash/hash_generic.c
 
-ifeq ($(WIN32),1)
+ifeq ($(MINGW),1)
 	SRCS += $(wildcard src/win32/*.c) $(wildcard src/compat/*.c) deps/regex/regex.c
 	INCLUDES += -Ideps/regex
-	DEFINES += -DWIN32 -D_WIN32_WINNT=0x0501
+	DEFINES += -DWIN32 -D_WIN32_WINNT=0x0501 -D__USE_MINGW_ANSI_STDIO=1
 else
 	SRCS += $(wildcard src/unix/*.c) 
 	CFLAGS += -fPIC


### PR DESCRIPTION
This allows libgit2 to be cross-compiled (e.g. when building native rugged binaries for windows from Linux or OS X).

```
CROSS_COMPILE=i686-w64-mingw32 make -f Makefile.embed
```
