### PR TITLE
Rename tests

### DIFF
--- a/tests-clar/diff/rename.c
+++ b/tests-clar/diff/rename.c
@@ -1093,6 +1093,57 @@ void test_diff_rename__rejected_match_can_match_others_three(void)
 	git_reference_free(selfsimilar);
 }
 
+void test_diff_rename__can_rename_from_rewrite(void)
+{
+	git_index *index;
+	git_tree *tree;
+	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+	git_diff_list *diff;
+	git_diff_options diffopts = GIT_DIFF_OPTIONS_INIT;
+	git_diff_find_options findopts = GIT_DIFF_FIND_OPTIONS_INIT;
+
+	/* Both cannot be renames from a.txt */
+	unsigned int status[] = { GIT_DELTA_RENAMED, GIT_DELTA_RENAMED };
+	const char *sources[] = { "ikeepsix.txt", "songof7cities.txt" };
+	const char *targets[] = { "songof7cities.txt", "this-is-a-rename.txt" };
+	struct rename_expected expect = { 2, status, sources, targets };
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_pass(p_rename("renames/songof7cities.txt", "renames/this-is-a-rename.txt"));
+	cl_git_pass(p_rename("renames/ikeepsix.txt", "renames/songof7cities.txt"));
+
+	cl_git_pass(git_index_remove_bypath(index, "ikeepsix.txt"));
+
+	cl_git_pass(git_index_add_bypath(index, "songof7cities.txt"));
+	cl_git_pass(git_index_add_bypath(index, "this-is-a-rename.txt"));
+
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(
+		git_revparse_single((git_object **)&tree, g_repo, "HEAD^{tree}"));
+
+	cl_git_pass(
+		git_diff_tree_to_index(&diff, g_repo, tree, index, &diffopts));
+	
+	findopts.flags |= GIT_DIFF_FIND_AND_BREAK_REWRITES |
+		GIT_DIFF_FIND_REWRITES |
+		GIT_DIFF_FIND_RENAMES_FROM_REWRITES;
+
+	cl_git_pass(git_diff_find_similar(diff, &findopts));
+
+	cl_git_pass(
+		git_diff_foreach(diff, test_names_expected, NULL, NULL, &expect));
+
+	cl_assert(expect.idx == expect.len);
+
+	git_diff_list_free(diff);
+	git_tree_free(tree);
+	git_index_free(index);
+}
+
 void test_diff_rename__case_changes_are_split(void)
 {
 	git_index *index;


### PR DESCRIPTION
Two failing rename tests:  these cases both expect behavior like core git.

I hate writing failing tests and not providing a patch to fix it, but I haven't had a chance to investigate this any further.  I think this is the opposite case of a previous failure - just with an opposite sort file sort order.

My approach would be to sort by similarities and evict entries once they're matched?  But I'm not certain that this is the superior approach.  My hope is that @arrbee could share some insight?
