### PR TITLE
submodule: check alloc and name presence

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1025,6 +1025,7 @@ static int submodule_get(
 
 	if (!git_strmap_valid_index(smcfg, pos)) {
 		sm = submodule_alloc(repo, name);
+		GITERR_CHECK_ALLOC(sm);
 
 		/* insert value at name - if another thread beats us to it, then use
 		 * their record and release our own.
@@ -1101,8 +1102,10 @@ static int submodule_load_from_config(
 
 	namestart = key + strlen("submodule.");
 	property  = strrchr(namestart, '.');
-	if (property == NULL)
+
+	if (!property || (property == namestart))
 		return 0;
+
 	property++;
 	is_path = (strcasecmp(property, "path") == 0);
 

--- a/tests-clar/resources/submodules/gitmodules
+++ b/tests-clar/resources/submodules/gitmodules
@@ -1,3 +1,6 @@
 [submodule "testrepo"]
 	path = testrepo
 	url = 
+[submodule ""]
+	path = testrepo
+	url = 


### PR DESCRIPTION
Having the following invalid config in `.gitmodules` leads to a segfault when running the tests:

```
[submodule ""]
  path = testrepo
```

The segfault is:

```
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x0000000000000010

VM Regions Near 0x10:
-->
    __TEXT                 00000001060d9000-000000010634d000 [ 2512K] r-x/rwx SM=COW  /Users/USER/*

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libgit2_clar                        0x000000010616beef submodule_get + 239 (submodule.c:1032)
1   libgit2_clar                        0x000000010616dbdb submodule_load_from_config + 411 (submodule.c:1112)
2   libgit2_clar                        0x00000001060f31af file_foreach + 399 (config_file.c:273)
3   libgit2_clar                        0x000000010616efcb git_config_file_foreach + 75 (config_file.h:45)
4   libgit2_clar                        0x000000010616ac03 load_submodule_config + 323 (submodule.c:1370)
5   libgit2_clar                        0x000000010616a95c git_submodule_lookup + 124 (submodule.c:110)
6   libgit2_clar                        0x00000001060fe887 maybe_modified_submodule + 135 (diff.c:608)
7   libgit2_clar                        0x00000001060fe189 maybe_modified + 937 (diff.c:712)
8   libgit2_clar                        0x00000001060fcd64 handle_matched_item + 36 (diff.c:1034)
9   libgit2_clar                        0x00000001060fbd53 git_diff__from_iterators + 691 (diff.c:1103)
10  libgit2_clar                        0x00000001060fd503 git_diff_index_to_workdir + 419 (diff.c:1215)
11  libgit2_clar                        0x00000001061dcd34 test_diff_submodules__unmodified_submodule + 132 (submodules.c:75)
12  libgit2_clar                        0x0000000106192bf7 clar_run_test + 103 (clar.c:161)
13  libgit2_clar                        0x0000000106191bdb clar_run_suite + 459 (clar.c:223)
14  libgit2_clar                        0x0000000106191324 clar_test + 180 (clar.c:339)
15  libgit2_clar                        0x000000010619033a main + 42 (main.c:14)
16  libdyld.dylib                       0x00007fff8fb397e1 start + 1

Thread 0 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x0000000000000000  rcx: 0x786cc94261c9a402  rdx: 0x00007fff59b26334
  rdi: 0x00007fa480c0b610  rsi: 0x00000001063605e8  rbp: 0x00007fff59b26370  rsp: 0x00007fff59b26330
   r8: 0x0000000000000005   r9: 0x0000000059961c75  r10: 0x0000000000000000  r11: 0x0000000059961c75
  r12: 0x0000000000000000  r13: 0x0000000000000000  r14: 0x0000000000000000  r15: 0x0000000000000000
  rip: 0x000000010616beef  rfl: 0x0000000000010202  cr2: 0x0000000000000010
Logical CPU: 4

```

So I added a small check in `submodule_get` to see if there is a config subsection with the submodule name before doing anything.

I also added `GITERR_CHECK_ALLOC` just in case something else pops up.
