### PR TITLE
Add rename from rewrites to status

### DIFF
--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -107,7 +107,7 @@ typedef enum {
  * - GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX indicates that rename detection
  *   should be processed between the head and the index and enables
  *   the GIT_STATUS_INDEX_RENAMED as a possible status flag.
- * - GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR indicates tha rename
+ * - GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR indicates that rename
  *   detection should be run between the index and the working directory
  *   and enabled GIT_STATUS_WT_RENAMED as a possible status flag.
  * - GIT_STATUS_OPT_SORT_CASE_SENSITIVELY overrides the native case
@@ -116,6 +116,8 @@ typedef enum {
  * - GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY overrides the native case
  *   sensitivity for the file system and forces the output to be in
  *   case-insensitive order
+ * - GIT_STATUS_OPT_RENAMES_FROM_REWRITES indicates that rename detection
+ *   should include rewritten files
  *
  * Calling `git_status_foreach()` is like calling the extended version
  * with: GIT_STATUS_OPT_INCLUDE_IGNORED, GIT_STATUS_OPT_INCLUDE_UNTRACKED,
@@ -134,6 +136,7 @@ typedef enum {
 	GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR = (1u << 8),
 	GIT_STATUS_OPT_SORT_CASE_SENSITIVELY    = (1u << 9),
 	GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY  = (1u << 10),
+	GIT_STATUS_OPT_RENAMES_FROM_REWRITES    = (1u << 11),
 } git_status_opt_t;
 
 #define GIT_STATUS_OPT_DEFAULTS \

--- a/src/status.c
+++ b/src/status.c
@@ -225,24 +225,6 @@ static git_status_list *git_status_list_alloc(git_index *index)
 	return status;
 }
 
-/*
-static int newfile_cmp(const void *a, const void *b)
-{
-	const git_diff_delta *delta_a = a;
-	const git_diff_delta *delta_b = b;
-
-	return git__strcmp(delta_a->new_file.path, delta_b->new_file.path);
-}
-
-static int newfile_casecmp(const void *a, const void *b)
-{
-	const git_diff_delta *delta_a = a;
-	const git_diff_delta *delta_b = b;
-
-	return git__strcasecmp(delta_a->new_file.path, delta_b->new_file.path);
-}
-*/
-
 int git_status_list_new(
 	git_status_list **out,
 	git_repository *repo,
@@ -251,7 +233,7 @@ int git_status_list_new(
 	git_index *index = NULL;
 	git_status_list *status = NULL;
 	git_diff_options diffopt = GIT_DIFF_OPTIONS_INIT;
-	git_diff_find_options findopts_i2w = GIT_DIFF_FIND_OPTIONS_INIT;
+	git_diff_find_options findopt = GIT_DIFF_FIND_OPTIONS_INIT;
 	git_tree *head = NULL;
 	git_status_show_t show =
 		opts ? opts->show : GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
@@ -284,6 +266,7 @@ int git_status_list_new(
 	}
 
 	diffopt.flags = GIT_DIFF_INCLUDE_TYPECHANGE;
+	findopt.flags = GIT_DIFF_FIND_FOR_UNTRACKED;
 
 	if ((flags & GIT_STATUS_OPT_INCLUDE_UNTRACKED) != 0)
 		diffopt.flags = diffopt.flags | GIT_DIFF_INCLUDE_UNTRACKED;
@@ -300,7 +283,9 @@ int git_status_list_new(
 	if ((flags & GIT_STATUS_OPT_EXCLUDE_SUBMODULES) != 0)
 		diffopt.flags = diffopt.flags | GIT_DIFF_IGNORE_SUBMODULES;
 
-	findopts_i2w.flags |= GIT_DIFF_FIND_FOR_UNTRACKED;
+	if ((flags & GIT_STATUS_OPT_RENAMES_FROM_REWRITES) != 0)
+		findopt.flags = findopt.flags | GIT_DIFF_FIND_AND_BREAK_REWRITES |
+			GIT_DIFF_FIND_RENAMES_FROM_REWRITES;
 
 	if (show != GIT_STATUS_SHOW_WORKDIR_ONLY) {
 		if ((error = git_diff_tree_to_index(
@@ -308,7 +293,7 @@ int git_status_list_new(
 			goto done;
 
 		if ((flags & GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX) != 0 &&
-			(error = git_diff_find_similar(status->head2idx, NULL)) < 0)
+			(error = git_diff_find_similar(status->head2idx, &findopt)) < 0)
 			goto done;
 	}
 
@@ -318,7 +303,7 @@ int git_status_list_new(
 			goto done;
 
 		if ((flags & GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR) != 0 &&
-			(error = git_diff_find_similar(status->idx2wd, &findopts_i2w)) < 0)
+			(error = git_diff_find_similar(status->idx2wd, &findopt)) < 0)
 			goto done;
 	}
 


### PR DESCRIPTION
Add rename from rewrites to status; core git enables this by default.  eg:

```
% git status
# On branch master
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#       renamed:    b.txt -> a.txt
#       renamed:    a.txt -> b.txt
#
```

This adds a flag `GIT_STATUS_OPT_RENAMES_FROM_REWRITES` that causes diffs to break rewrites and perform rename detection on it.

Some new test cases indicate another bug:  paired foreach was not joining deltas when there was a rename in the index->workdir diff.  We always sorted index to rename deltas on new name, which will cause these deltas not to get paired because we sort head->index by the new (index) path and index->workdir by the new (workdir) path.

This change temporarily resorts the index->workdir diff list by the index (old) path so that we can track a rename in the workdir from head->index->workdir.
