### PR TITLE
Parse config headers with quoted quotes

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -792,6 +792,11 @@ static int parse_section_header_ext(diskfile_backend *cfg, const char *line, con
 		}
 
 		switch (c) {
+		case 0:
+			set_parse_error(cfg, 0, "Unexpected end-of-line in section header");
+			git_buf_free(&buf);
+			return -1;
+
 		case '"':
 			++quote_marks;
 			continue;
@@ -801,6 +806,12 @@ static int parse_section_header_ext(diskfile_backend *cfg, const char *line, con
 
 			switch (c) {
 			case '"':
+				if (&line[rpos-1] == last_quote) {
+					set_parse_error(cfg, 0, "Missing closing quotation mark in section header");
+					git_buf_free(&buf);
+					return -1;
+				}
+
 			case '\\':
 				break;
 

--- a/tests-clar/config/read.c
+++ b/tests-clar/config/read.c
@@ -431,10 +431,10 @@ void test_config_read__simple_read_from_specific_level(void)
 	git_config_free(cfg);
 }
 
-static void clean_empty_config(void *unused)
+static void clean_test_config(void *unused)
 {
 	GIT_UNUSED(unused);
-	cl_fixture_cleanup("./empty");
+	cl_fixture_cleanup("./testconfig");
 }
 
 void test_config_read__can_load_and_parse_an_empty_config_file(void)
@@ -442,10 +442,21 @@ void test_config_read__can_load_and_parse_an_empty_config_file(void)
 	git_config *cfg;
 	int i;
 
-	cl_set_cleanup(&clean_empty_config, NULL);
-	cl_git_mkfile("./empty", "");
-	cl_git_pass(git_config_open_ondisk(&cfg, "./empty"));
+	cl_set_cleanup(&clean_test_config, NULL);
+	cl_git_mkfile("./testconfig", "");
+	cl_git_pass(git_config_open_ondisk(&cfg, "./testconfig"));
 	cl_assert_equal_i(GIT_ENOTFOUND, git_config_get_int32(&i, cfg, "nope.neither"));
+
+	git_config_free(cfg);
+}
+
+void test_config_read__corrupt_header(void)
+{
+	git_config *cfg;
+
+	cl_set_cleanup(&clean_test_config, NULL);
+	cl_git_mkfile("./testconfig", "[sneaky ] \"quoted closing quote mark\\\"");
+	cl_git_fail(git_config_open_ondisk(&cfg, "./testconfig"));
 
 	git_config_free(cfg);
 }


### PR DESCRIPTION
When parsing the config header line, we look for the first and last quote and read to the last quote.  If the last quote is quoted, however, we walk past the end of the string.  This stops parsing if the last quote was a quoted quote.
