### PR TITLE
config: allow setting  empty string as value

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1293,6 +1293,9 @@ static char *escape_value(const char *ptr)
 	assert(ptr);
 
 	len = strlen(ptr);
+	if (!len)
+		return git__calloc(1, sizeof(char));
+
 	git_buf_grow(&buf, len);
 
 	while (*ptr != '\0') {

--- a/tests-clar/config/write.c
+++ b/tests-clar/config/write.c
@@ -242,3 +242,20 @@ void test_config_write__can_set_a_value_to_NULL(void)
 
     cl_git_sandbox_cleanup();
 }
+
+void test_config_write__can_set_an_empty_value(void)
+{
+	git_repository *repository;
+	git_config *config;
+	const char * str;
+
+	repository = cl_git_sandbox_init("testrepo.git");
+	cl_git_pass(git_repository_config(&config, repository));
+
+	cl_git_pass(git_config_set_string(config, "core.somevar", ""));
+	cl_git_pass(git_config_get_string(&str, config, "core.somevar"));
+	cl_assert_equal_s(str, "");
+
+	git_config_free(config);
+	cl_git_sandbox_cleanup();
+}


### PR DESCRIPTION
I was writing some submodule tests for Rugged and I noticed that I can't set the url for a submodule to `""`.

I'm not that familiar with `git_buf` and there may be something obvious that I'm missing...

`git_config_set_string(config, "config.section", "")` fails when
escaping the value.

The buffer in `escape_value` is allocated without NULL-termination. And
in case of empty string - 0 is passed for buffer size in `git_buf_grow`.

`git_buf_detach` returns NULL when the allocated size is 0 and that
leads to an error return in `GITERR_CHECK_ALLOC` called after
`escape_value`.
