### PR TITLE
Speed up build under MSVC

### DIFF
--- a/src/win32/precompiled.h
+++ b/src/win32/precompiled.h
@@ -1,4 +1,5 @@
 #include "git2.h"
+#include "common.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -6,6 +7,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <fcntl.h>
+#include <time.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
I noticed the MSVC build getting slow, so I added a couple of things to the precompiled header, which sped up the build noticeably. Here's a couple of representative samples from my VM, using `msbuild /ds /m /t:libgit2_clar libgit2.sln` on a solution generated with `cmake -G "Visual Studio 11 Win64"`:
- Before: `Time Elapsed 00:03:14.73`
- After: `Time Elapsed 00:00:57.19`
