### PR TITLE
remote: relax the url rules

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -272,12 +272,6 @@ int git_remote_load(git_remote **out, git_repository *repo, const char *name)
 	if ((error = git_config_get_string(&val, config, git_buf_cstr(&buf))) < 0)
 		goto cleanup;
 
-	if (strlen(val) == 0) {
-		giterr_set(GITERR_INVALID, "Malformed remote '%s' - missing URL", name);
-		error = -1;
-		goto cleanup;
-	}
-
 	remote->repo = repo;
 	remote->url = git__strdup(val);
 	GITERR_CHECK_ALLOC(remote->url);

--- a/tests-clar/network/remote/remotes.c
+++ b/tests-clar/network/remote/remotes.c
@@ -361,13 +361,15 @@ void test_network_remote_remotes__tagopt(void)
 	git_config_free(cfg);
 }
 
-void test_network_remote_remotes__cannot_load_with_an_empty_url(void)
+void test_network_remote_remotes__can_load_with_an_empty_url(void)
 {
 	git_remote *remote = NULL;
 
-	cl_git_fail(git_remote_load(&remote, _repo, "empty-remote-url"));
-	cl_assert(giterr_last()->klass == GITERR_INVALID);
-	cl_assert_equal_p(remote, NULL);
+	cl_git_pass(git_remote_load(&remote, _repo, "empty-remote-url"));
+
+	cl_git_fail(git_remote_connect(remote, GIT_DIRECTION_FETCH));
+
+	git_remote_free(remote);
 }
 
 void test_network_remote_remotes__check_structure_version(void)


### PR DESCRIPTION
Accept any value for the remote's url, including an empty string which
we used to reject as invalid configuration.

This is not quite what git does (although it has its own problems with
such configurations) and it makes it harder to fix the issue, by not
letting the user modify it.

As we already need to check for a valid URL when we try to connect to
the network, let that perform the check, as we don't need to do it
anywhere else.
