### PR TITLE
revparse: Free left side of invalid range revspecs

### DIFF
--- a/src/revparse.c
+++ b/src/revparse.c
@@ -913,7 +913,7 @@ int git_revparse(
 		}
 
 		error = git_revparse_single(&revspec->from, repo, lstr);
-		if (error == 0)
+		if (!error)
 			error = git_revparse_single(&revspec->to, repo, rstr);
 
 		git__free((void*)lstr);


### PR DESCRIPTION
This fixes a small memory leak in git_revparse where early returns on
errors from git_revparse_single cause a free() on the (reallocated) left
side of the revspec to be skipped.
