### PR TITLE
Provide the user with a more useful error code when a looking up a reference which name points to a namepace

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -165,7 +165,13 @@ int git_futils_readbuffer_updated(
 		return -1;
 	}
 
-	if (S_ISDIR(st.st_mode) || !git__is_sizet(st.st_size+1)) {
+
+	if (S_ISDIR(st.st_mode)) {
+		giterr_set(GITERR_INVALID, "requested file is a directory");
+		return GIT_ENOTFOUND;
+	}
+
+	if (!git__is_sizet(st.st_size+1)) {
 		giterr_set(GITERR_OS, "Invalid regular file stat for '%s'", path);
 		return -1;
 	}

--- a/tests-clar/refs/lookup.c
+++ b/tests-clar/refs/lookup.c
@@ -46,3 +46,15 @@ void test_refs_lookup__oid(void)
 	cl_git_pass(git_oid_fromstr(&expected, "1385f264afb75a56a5bec74243be9b367ba4ca08"));
 	cl_assert(git_oid_cmp(&tag, &expected) == 0);
 }
+
+void test_refs_lookup__namespace(void)
+{
+	int error;
+	git_reference *ref;
+
+	error = git_reference_lookup(&ref, g_repo, "refs/heads");
+	cl_assert_equal_i(error, GIT_ENOTFOUND);
+
+	error = git_reference_lookup(&ref, g_repo, "refs/heads/");
+	cl_assert_equal_i(error, GIT_EINVALIDSPEC);
+}


### PR DESCRIPTION
Relates to **[this comment](https://github.com/libgit2/libgit2/pull/1541#discussion_r4072173)**

Provided reference `refs/heads/foo/bar` exists, looking up for `refs/heads/foo` returns `GIT_ERROR` when `GIT_ENOTFOUND` may be more explicit.

Actually, on Windows, the code fails **[here](https://github.com/libgit2/libgit2/blob/development/src/fileops.c#L158)** with `errno = E_ACCESS` whereas, on Linux, the code runs a bit farther ans escapes **[here](https://github.com/libgit2/libgit2/blob/development/src/fileops.c#L163)**.
