### PR TITLE
odb: Straighten oid prefix handling

### DIFF
--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -641,10 +641,12 @@ static int loose_backend__read_prefix(
 {
 	int error = 0;
 
+	assert(len <= GIT_OID_HEXSZ);
+
 	if (len < GIT_OID_MINPREFIXLEN)
 		error = git_odb__error_ambiguous("prefix length too short");
 
-	else if (len >= GIT_OID_HEXSZ) {
+	else if (len == GIT_OID_HEXSZ) {
 		/* We can fall back to regular read method */
 		error = loose_backend__read(buffer_p, len_p, type_p, backend, short_oid);
 		if (!error)


### PR DESCRIPTION
The size of the prefix cannot exceed 40 nibbles (`GIT_OID_HEXSZ`)
