### PR TITLE
Bring Valgrind back!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 # Run Tests
 after_success:
  - sudo apt-get -qq install valgrind
- - valgrind --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -ionline
+ - valgrind --leak-check=full --show-reachable=yes --suppressions=./libgit2_clar.supp _build/libgit2_clar -ionline
 
 # Only watch the development branch
 branches:


### PR DESCRIPTION
**Before:**

```
$ valgrind --leak-check=full --show-reachable=yes --suppressions=../libgit2_clar.supp ./libgit2_clar -ionline
valgrind: ./libgit2_clar: No such file or directory
```

**Now:**

```
==14138== 
==14138== HEAP SUMMARY:
==14138==     in use at exit: 207,812 bytes in 5,105 blocks
==14138==   total heap usage: 799,051 allocs, 793,946 frees, 2,190,994,460 bytes allocated
==14138== 
==14138== LEAK SUMMARY:
==14138==    definitely lost: 0 bytes in 0 blocks
==14138==    indirectly lost: 0 bytes in 0 blocks
==14138==      possibly lost: 0 bytes in 0 blocks
==14138==    still reachable: 0 bytes in 0 blocks
==14138==         suppressed: 207,812 bytes in 5,105 blocks
==14138== 
==14138== For counts of detected and suppressed errors, rerun with: -v
==14138== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 12740 from 16)
```
