### PR TITLE
Do not merge: travis test

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -736,6 +736,3 @@ git_attr_rule *git_attr_cache__lookup_macro(
 	if (!git_strmap_valid_index(macros, pos))
 		return NULL;
 
-	return (git_attr_rule *)git_strmap_value_at(macros, pos);
-}
-


### PR DESCRIPTION
Travis appears to be marking build failures as green?  Hopefully this was just an intermittent problem.  This is a really horrible build failure to test that.
