### PR TITLE
Use time(2) to get the time

### DIFF
--- a/src/date.c
+++ b/src/date.c
@@ -823,15 +823,13 @@ static void pending_number(struct tm *tm, int *num)
 }
 
 static git_time_t approxidate_str(const char *date,
-									const struct timeval *tv,
-									int *error_ret)
+	time_t time_sec,
+	int *error_ret)
 {
 	int number = 0;
 	int touched = 0;
 	struct tm tm = {0}, now;
-	time_t time_sec;
 
-	time_sec = tv->tv_sec;
 	p_localtime_r(&time_sec, &tm);
 	now = tm;
 
@@ -861,7 +859,7 @@ static git_time_t approxidate_str(const char *date,
 
 int git__date_parse(git_time_t *out, const char *date)
 {
-	struct timeval tv;
+	time_t time_sec;
 	git_time_t timestamp;
 	int offset, error_ret=0;
 
@@ -870,7 +868,9 @@ int git__date_parse(git_time_t *out, const char *date)
 		return 0;
 	}
 
-	p_gettimeofday(&tv, NULL);
-	*out = approxidate_str(date, &tv, &error_ret);
+	if (time(&time_sec) == -1)
+		return -1;
+
+	*out = approxidate_str(date, time_sec, &error_ret);
    return error_ret;
 }

--- a/src/posix.h
+++ b/src/posix.h
@@ -71,16 +71,12 @@ typedef int GIT_SOCKET;
 
 #define p_localtime_r localtime_r
 #define p_gmtime_r gmtime_r
-#define p_gettimeofday gettimeofday
 
 #else
 
 typedef SOCKET GIT_SOCKET;
-struct timezone;
 extern struct tm * p_localtime_r (const time_t *timer, struct tm *result);
 extern struct tm * p_gmtime_r (const time_t *timer, struct tm *result);
-extern int p_gettimeofday(struct timeval *tv, struct timezone *tz);
-
 
 #endif
 

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -518,56 +518,6 @@ p_gmtime_r (const time_t *timer, struct tm *result)
 	return result;
 }
 
-#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
-#define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
-#else
-#define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
-#endif
-
-#ifndef _TIMEZONE_DEFINED
-#define _TIMEZONE_DEFINED
-struct timezone
-{
-	int  tz_minuteswest; /* minutes W of Greenwich */
-	int  tz_dsttime;     /* type of dst correction */
-};
-#endif
-
-int p_gettimeofday(struct timeval *tv, struct timezone *tz)
-{
-	FILETIME ft;
-	unsigned __int64 tmpres = 0;
-	static int tzflag;
-
-	if (NULL != tv)
-	{
-		GetSystemTimeAsFileTime(&ft);
-
-		tmpres |= ft.dwHighDateTime;
-		tmpres <<= 32;
-		tmpres |= ft.dwLowDateTime;
-
-		/*converting file time to unix epoch*/
-		tmpres /= 10;  /*convert into microseconds*/
-		tmpres -= DELTA_EPOCH_IN_MICROSECS;
-		tv->tv_sec = (long)(tmpres / 1000000UL);
-		tv->tv_usec = (long)(tmpres % 1000000UL);
-	}
-
-	if (NULL != tz)
-	{
-		 if (!tzflag)
-		{
-			_tzset();
-			tzflag++;
-		}
-		tz->tz_minuteswest = _timezone / 60;
-		tz->tz_dsttime = _daylight;
-	}
-
-	return 0;
-}
-
 int p_inet_pton(int af, const char* src, void* dst)
 {
 	union {


### PR DESCRIPTION
We didn't use the added precision in `gettimeofday`, so remove it.
This prevents us from having an unnecessary reimplementation on
win32.
