### PR TITLE
Minor changes for rewrites

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -454,6 +454,9 @@ typedef enum {
 	GIT_DIFF_FIND_DONT_IGNORE_WHITESPACE = (1 << 13),
 	/** measure similarity only by comparing SHAs (fast and cheap) */
 	GIT_DIFF_FIND_EXACT_MATCH_ONLY = (1 << 14),
+
+	/** do not break rewrites unless they contribute to a rename */
+	GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY  = (1 << 15),
 } git_diff_find_t;
 
 /**

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -799,6 +799,9 @@ int git_diff_find_similar(
 
 		if (is_rename_target(diff, &opts, t, sigcache))
 			++num_tgts;
+
+		if ((tgt->flags & GIT_DIFF_FLAG__TO_SPLIT) != 0)
+			num_rewrites++;
 	}
 
 	/* if there are no candidate srcs or tgts, we're done */
@@ -1036,7 +1039,8 @@ find_best_matches:
 	if (num_rewrites > 0 || num_updates > 0)
 		error = apply_splits_and_deletes(
 			diff, diff->deltas.length - num_rewrites,
-			FLAG_SET(&opts, GIT_DIFF_BREAK_REWRITES));
+			FLAG_SET(&opts, GIT_DIFF_BREAK_REWRITES) &&
+			!FLAG_SET(&opts, GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY));
 
 cleanup:
 	git__free(tgt2src);

--- a/src/status.c
+++ b/src/status.c
@@ -284,8 +284,10 @@ int git_status_list_new(
 		diffopt.flags = diffopt.flags | GIT_DIFF_IGNORE_SUBMODULES;
 
 	if ((flags & GIT_STATUS_OPT_RENAMES_FROM_REWRITES) != 0)
-		findopt.flags = findopt.flags | GIT_DIFF_FIND_AND_BREAK_REWRITES |
-			GIT_DIFF_FIND_RENAMES_FROM_REWRITES;
+		findopt.flags = findopt.flags |
+			GIT_DIFF_FIND_AND_BREAK_REWRITES |
+			GIT_DIFF_FIND_RENAMES_FROM_REWRITES |
+			GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY;
 
 	if (show != GIT_STATUS_SHOW_WORKDIR_ONLY) {
 		if ((error = git_diff_tree_to_index(

--- a/tests-clar/status/renames.c
+++ b/tests-clar/status/renames.c
@@ -403,6 +403,47 @@ void test_status_renames__both_rename_from_rewrite(void)
 	git_index_free(index);
 }
 
+void test_status_renames__rewrites_only_for_renames(void)
+{
+	git_index *index;
+	git_status_list *statuslist;
+	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
+	struct status_entry expected[] = {
+		{ GIT_STATUS_WT_MODIFIED, "ikeepsix.txt", "ikeepsix.txt" },
+	};
+
+	opts.flags |= GIT_STATUS_OPT_INCLUDE_UNTRACKED;
+	opts.flags |= GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX;
+	opts.flags |= GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR;
+	opts.flags |= GIT_STATUS_OPT_RENAMES_FROM_REWRITES;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_rewritefile("renames/ikeepsix.txt",
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n" \
+		"This is enough content for the file to be rewritten.\n");
+
+	cl_git_pass(git_status_list_new(&statuslist, g_repo, &opts));
+	test_status(statuslist, expected, 1);
+	git_status_list_free(statuslist);
+
+	git_index_free(index);
+}
+
 void test_status_renames__both_casechange_one(void)
 {
 	git_index *index;


### PR DESCRIPTION
Commit `f676ed5` is to ensure that we always split rewrites.  Currently, if the only change is a rewrite, it does not get split in `git_diff_find_similar`.  (However it would be split if another rewrite - one impacting a rename - were to exist.)

Commit `d7c3a10` changes the behavior of `git_status` to more closely emulate `git-status(1)`, where rewrites will contribute to renames, but otherwise will not be shown.  That is to say if you were to completely rewrite file `c`, while renaming `a` to `b` and `b` to `a`, you expect the status:

```
#       renamed:    b -> a
#       renamed:    a -> b
#       modified:   c
```

(Currently we would display `c` as an add/delete pair.)
