### PR TITLE
fix tests on FreeBSD

### DIFF
--- a/tests-clar/core/posix.c
+++ b/tests-clar/core/posix.c
@@ -1,5 +1,7 @@
 #ifndef _WIN32
 # include <arpa/inet.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
 #else
 # include <ws2tcpip.h>
 # ifdef _MSC_VER


### PR DESCRIPTION
238b761 introduced a test for posix behaviour, but on FreeBSD some
of the structs and constants used aren't defined in <arpa/inet.h>.
Include the appropriate headers to get the tests working again on
FreeBSD.
