### PR TITLE
netops: remove duplicate include

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -19,10 +19,6 @@
 #	endif
 #endif
 
-#ifdef __FreeBSD__
-#	include <netinet/in.h>
-#endif
-
 #ifdef GIT_SSL
 # include <openssl/ssl.h>
 # include <openssl/err.h>


### PR DESCRIPTION
9e9aee6 added an include <netinet/in.h> to fix the build on FreeBSD.
Sometime since then the same header is included ifndef _WIN32, so
remove the duplicate include.
