### PR TITLE
refs: add git_reference_is_tag

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -442,6 +442,15 @@ GIT_EXTERN(int) git_reference_is_branch(git_reference *ref);
  */
 GIT_EXTERN(int) git_reference_is_remote(git_reference *ref);
 
+/**
+ * Check if a reference is a tag
+ *
+ * @param ref A git reference
+ *
+ * @return 1 when the reference lives in the refs/tags
+ * namespace; 0 otherwise.
+ */
+GIT_EXTERN(int) git_reference_is_tag(git_reference *ref);
 
 typedef enum {
 	GIT_REF_FORMAT_NORMAL = 0,

--- a/src/refs.c
+++ b/src/refs.c
@@ -952,6 +952,17 @@ int git_reference_is_remote(git_reference *ref)
 	return git_reference__is_remote(ref->name);
 }
 
+int git_reference__is_tag(const char *ref_name)
+{
+	return git__prefixcmp(ref_name, GIT_REFS_TAGS_DIR) == 0;
+}
+
+int git_reference_is_tag(git_reference *ref)
+{
+	assert(ref);
+	return git_reference__is_tag(ref->name);
+}
+
 static int peel_error(int error, git_reference *ref, const char* msg)
 {
 	giterr_set(

--- a/src/refs.h
+++ b/src/refs.h
@@ -67,6 +67,7 @@ int git_reference__update_terminal(git_repository *repo, const char *ref_name, c
 int git_reference__is_valid_name(const char *refname, unsigned int flags);
 int git_reference__is_branch(const char *ref_name);
 int git_reference__is_remote(const char *ref_name);
+int git_reference__is_tag(const char *ref_name);
 
 /**
  * Lookup a reference by name and try to resolve to an OID.

--- a/tests-clar/refs/read.c
+++ b/tests-clar/refs/read.c
@@ -255,6 +255,22 @@ void test_refs_read__can_determine_if_a_reference_is_a_local_branch(void)
 	assert_is_branch("refs/tags/e90810b", false);
 }
 
+static void assert_is_tag(const char *name, bool expected_tagness)
+{
+	git_reference *reference;
+	cl_git_pass(git_reference_lookup(&reference, g_repo, name));
+	cl_assert_equal_i(expected_tagness, git_reference_is_tag(reference));
+	git_reference_free(reference);
+}
+
+void test_refs_read__can_determine_if_a_reference_is_a_tag(void)
+{
+	assert_is_tag("refs/tags/e90810b", true);
+	assert_is_tag("refs/tags/test", true);
+	assert_is_tag("refs/heads/packed", false);
+	assert_is_tag("refs/remotes/test/master", false);
+}
+
 void test_refs_read__invalid_name_returns_EINVALIDSPEC(void)
 {
 	git_reference *reference;


### PR DESCRIPTION
Add `git_reference_is_tag`. 

The check is needed sometimes and it's strange using `git_reference_is_branch` for branches and then using prefix comparison for tags. 
