### PR TITLE
Fix incorrect precedence within git_repository_is_empty()

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1495,26 +1495,20 @@ static int repo_contains_no_reference(git_repository *repo)
 int git_repository_is_empty(git_repository *repo)
 {
 	git_reference *head = NULL;
-	int error;
+	int is_empty = 0;
 
 	if (git_reference_lookup(&head, repo, GIT_HEAD_FILE) < 0)
 		return -1;
 
-	if (git_reference_type(head) != GIT_REF_SYMBOLIC) {
-		error = -1;
-		goto cleanup;
-	}
+	if (git_reference_type(head) == GIT_REF_SYMBOLIC)
+		is_empty =
+			(strcmp(git_reference_symbolic_target(head),
+					GIT_REFS_HEADS_DIR "master") == 0) &&
+			repo_contains_no_reference(repo);
 
-	if (!(error = (strcmp(
-		git_reference_symbolic_target(head),
-		GIT_REFS_HEADS_DIR "master") == 0)))
-			goto cleanup;
-
-	error = repo_contains_no_reference(repo);
-
-cleanup:
 	git_reference_free(head);
-	return error < 0 ? -1 : error;
+
+	return is_empty;
 }
 
 const char *git_repository_path(git_repository *repo)


### PR DESCRIPTION
The correct logic checks whether HEAD is symbolic, assigns the result of that check to `error`, then fails if it's zero (i.e., HEAD is not symbolic).
#1728 introduced a subtle change to the precedence, causing it to assign the result of `git_reference_type()` to `error`. Since all of the `git_ref_t` values are non-negative, `git_repository_is_empty()` could bail out with an erroneously positive value.

This was caught (unintentionally) by surprising unit test failures in libgit2/objective-git#238.

@ivoire @vmg
