### PR TITLE
Update readme to point to the currently maintained Erlang bindings. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Here are the bindings to libgit2 that are currently available:
 * Delphi
     * GitForDelphi <https://github.com/libgit2/GitForDelphi>
 * Erlang
-    * Geef <https://github.com/schacon/geef>
+    * Geef <https://github.com/carlosmn/geef>
 * Go
     * go-git <https://github.com/str1ngs/go-git>
 * GObject


### PR DESCRIPTION
Namely: https://github.com/carlosmn/geef

The readme was linking to a repository that hadn't been updated in two years. Carlos's is being actively developed.  
