### PR TITLE
Fix resolving relative windows network paths

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -242,8 +242,8 @@ int git_path_root(const char *path)
 
 #ifdef GIT_WIN32
 	/* Are we dealing with a windows network path? */
-	else if ((path[0] == '/' && path[1] == '/') ||
-		(path[0] == '\\' && path[1] == '\\'))
+	else if ((path[0] == '/' && path[1] == '/' && path[2] != '/') ||
+		(path[0] == '\\' && path[1] == '\\' && path[2] != '\\'))
 	{
 		offset += 2;
 

--- a/tests-clar/core/path.c
+++ b/tests-clar/core/path.c
@@ -538,7 +538,6 @@ void test_core_path__15_resolve_relative(void)
 	assert_resolve_relative(&buf, "a/b/", "a/b/.");
 
 	assert_resolve_relative(&buf, "/a/b/c", "///a/b/c");
-	assert_resolve_relative(&buf, "/a/b/c", "//a/b/c");
 	assert_resolve_relative(&buf, "/", "////");
 	assert_resolve_relative(&buf, "/a", "///a");
 	assert_resolve_relative(&buf, "/", "///.");
@@ -564,6 +563,21 @@ void test_core_path__15_resolve_relative(void)
 
 	cl_git_pass(git_buf_sets(&buf, "////.."));
 	cl_git_fail(git_path_resolve_relative(&buf, 0));
+
+	/* things that start with Windows network paths */
+#ifdef GIT_WIN32
+	assert_resolve_relative(&buf, "//a/b/c", "//a/b/c");
+	assert_resolve_relative(&buf, "//a/", "//a/b/..");
+	assert_resolve_relative(&buf, "//a/b/c", "//a/Q/../b/x/y/../../c");
+
+	cl_git_pass(git_buf_sets(&buf, "//a/b/../.."));
+	cl_git_fail(git_path_resolve_relative(&buf, 0));
+#else
+	assert_resolve_relative(&buf, "/a/b/c", "//a/b/c");
+	assert_resolve_relative(&buf, "/a/", "//a/b/..");
+	assert_resolve_relative(&buf, "/a/b/c", "//a/Q/../b/x/y/../../c");
+	assert_resolve_relative(&buf, "/", "//a/b/../..");
+#endif
 
 	git_buf_free(&buf);
 }


### PR DESCRIPTION
PR #1825 had a small problem with some of the test cases on Windows where some of the new test data looked like a network path (i.e. something starting with `\\drive\`) and was therefore giving different results on Windows.

This PR expands the tests to explicitly cover various network path cases and also fixes a possible bug in the network path recognition code where a path starting with `\\\` was being considered a network path, where I think we should be looking for `\\` followed by a non-slash character.

I'm opening this as a PR just to get some confirmation that this new behavior for Windows network paths makes sense and that it will be okay to not accept `\\\` as a valid network path.
