### PR TITLE
odb: Error when streaming in less|more bytes than declared

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -238,6 +238,9 @@ GIT_EXTERN(int) git_odb_open_wstream(git_odb_stream **out, git_odb *db, size_t s
 /**
  * Write to an odb stream
  *
+ * This method will fail as soon as the total number of
+ * received bytes exceeds the size declared with `git_odb_open_wstream()`
+ *
  * @param stream the stream
  * @param buffer the data to write
  * @param len the buffer's length
@@ -250,6 +253,9 @@ GIT_EXTERN(int) git_odb_stream_write(git_odb_stream *stream, const char *buffer,
  *
  * The object will take its final name and will be available to the
  * odb.
+ *
+ * This method will fail if the total number of received bytes
+ * differs from the size declared with `git_odb_open_wstream()`
  *
  * @param out pointer to store the resulting object's id
  * @param stream the stream

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -78,6 +78,9 @@ struct git_odb_stream {
 	unsigned int mode;
 	void *hash_ctx;
 
+	size_t declared_size;
+	size_t received_bytes;
+
 	/**
 	 * Write at most `len` bytes into `buffer` and advance the
 	 * stream.
@@ -93,9 +96,13 @@ struct git_odb_stream {
 	 * Store the contents of the stream as an object with the id
 	 * specified in `oid`.
 	 *
-	 * This method will *not* be invoked by libgit2 if the object pointed at
-	 * by `oid` already exists in any backend. Libgit2 will however take care
-	 * of properly disposing the stream through a call to `free()`.
+	 * This method will *not* be invoked by libgit2 when:
+	 *  - the object pointed at by `oid` already exists in any backend.
+	 * 	- the total number of received bytes differs from the size declared
+	 *    with `git_odb_open_wstream()`
+	 *
+	 * Libgit2 will however take care of properly disposing the stream through
+	 * a call to `free()`.
 	 */
 	int (*finalize_write)(git_odb_stream *stream, const git_oid *oid);
 

--- a/tests-clar/odb/streamwrite.c
+++ b/tests-clar/odb/streamwrite.c
@@ -1,0 +1,56 @@
+#include "clar_libgit2.h"
+#include "git2/odb_backend.h"
+
+static git_repository *repo;
+static git_odb *odb;
+static git_odb_stream *stream;
+
+void test_odb_streamwrite__initialize(void)
+{
+	repo = cl_git_sandbox_init("testrepo.git");
+	cl_git_pass(git_repository_odb(&odb, repo));
+
+	cl_git_pass(git_odb_open_wstream(&stream, odb, 14, GIT_OBJ_BLOB));
+	cl_assert_equal_sz(14, stream->declared_size);
+}
+
+void test_odb_streamwrite__cleanup(void)
+{
+	git_odb_stream_free(stream);
+	git_odb_free(odb);
+	cl_git_sandbox_cleanup();
+}
+
+void test_odb_streamwrite__can_accept_chunks(void)
+{
+	git_oid oid;
+
+	cl_git_pass(git_odb_stream_write(stream, "deadbeef", 8));
+	cl_assert_equal_sz(8, stream->received_bytes);
+
+	cl_git_pass(git_odb_stream_write(stream, "deadbeef", 6));
+	cl_assert_equal_sz(8 + 6, stream->received_bytes);
+
+	cl_git_pass(git_odb_stream_finalize_write(&oid, stream));
+}
+
+void test_odb_streamwrite__can_detect_missing_bytes(void)
+{
+	git_oid oid;
+
+	cl_git_pass(git_odb_stream_write(stream, "deadbeef", 8));
+	cl_assert_equal_sz(8, stream->received_bytes);
+
+	cl_git_pass(git_odb_stream_write(stream, "deadbeef", 4));
+	cl_assert_equal_sz(8 + 4, stream->received_bytes);
+
+	cl_git_fail(git_odb_stream_finalize_write(&oid, stream));
+}
+
+void test_odb_streamwrite__can_detect_additional_bytes(void)
+{
+	cl_git_pass(git_odb_stream_write(stream, "deadbeef", 8));
+	cl_assert_equal_sz(8, stream->received_bytes);
+
+	cl_git_fail(git_odb_stream_write(stream, "deadbeef", 7));
+}


### PR DESCRIPTION
- Make `git_odb_stream_write()` fail when receiving more bytes than expected
- Make `git_odb_stream_finalize_write()` fail when the number of received bytes differs from what was expected
