### PR TITLE
SSH: Clone fails with errors: ERROR: Repository invalid & Early EOF

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -51,7 +51,7 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 		repo = strchr(url, '/');
 	} else {
 		repo = strchr(url, ':');
-		repo++;
+		if (repo) repo++;
 	}
 
 	if (!repo) {


### PR DESCRIPTION
I am trying to clone this repository using libgit2 (via objective-git): git@github.com:isaac/test.git

The problem seems to be in the ssh transport here: https://github.com/libgit2/libgit2/blob/ef6389ad504037e7a4311adbf14f1fa5a5aa4190/src/transports/ssh.c#L55

At this point the `repo` variable == ":isaac/test.git" which generates the errors: "ERROR: repository invalid." (SSH) & "Early EOF" (libgit2) - full libssh2 trace and libgit2 error here: https://gist.github.com/isaac/d169270043a4a3007e59

If I add this code @ line 55 it fixes the problem: `repo++;` - this removes the first character from the `repo` variable which makes it: "isaac/test.git" - after this the clone finishes as expected.

I would have opend a pull request for this error but my C skills are very lacking and I'm not sure if `repo++;` is the best solution for this issue.

Cheers,
Isaac
