### PR TITLE
fixes issues with objective-git

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -7,11 +7,11 @@
 #ifndef INCLUDE_git_merge_h__
 #define INCLUDE_git_merge_h__
 
-#include "git2/common.h"
-#include "git2/types.h"
-#include "git2/oid.h"
-#include "git2/checkout.h"
-#include "git2/index.h"
+#include "common.h"
+#include "types.h"
+#include "oid.h"
+#include "checkout.h"
+#include "index.h"
 
 /**
  * @file git2/merge.h


### PR DESCRIPTION
The standard process to include the objective-git Framework on an OSX project would not compile because of this. Please include this fix as all other header files do not follow the "git2/*" convention.
