### PR TITLE
Treewalker

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -907,11 +907,12 @@ static int tree_walk(
 				return -1;
 
 			error = tree_walk(subtree, callback, path, payload, preorder);
+			git_tree_free(subtree);
+
 			if (error != 0)
 				break;
 
 			git_buf_truncate(path, path_len);
-			git_tree_free(subtree);
 		}
 
 		if (!preorder && callback(path->ptr, entry, payload) < 0) {


### PR DESCRIPTION
This fixes two bugs in git_tree_walk:
- in preorder mode, if the callback returns >0 for the last entry the walker encounters, that value would be returned as the return value of git_tree_walk.I don't think that was intentional, as you expect a "git_error_code" from git_tree_walk; the instruction to skip is also not an error, but just a message to the walker.
- on returning from tree_walk on a subtree that returned an error code, we would leak the subtree.
