### PR TITLE
Make `git_credtype_t` a bitfield

### DIFF
--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -118,6 +118,8 @@ GIT_EXTERN(int) git_cred_ssh_keyfile_passphrase_new(
 /**
  * Creates a new ssh public key credential object.
  * The supplied credential parameter will be internally duplicated.
+ * You're supposed to sign the data `sign_fn` will provide you with
+ * the user's private key.
  *
  * @param out The newly created credential object.
  * @param username username to use to authenticate
@@ -131,9 +133,9 @@ GIT_EXTERN(int) git_cred_ssh_publickey_new(
 	git_cred **out,
 	const char *username,
 	const char *publickey,
-    size_t publickey_len,
-    git_cred_sign_callback sign_fn,
-    void *sign_data);
+	size_t publickey_len,
+	git_cred_sign_callback sign_fn,
+	void *sign_data);
 
 /**
  * Signature of a function which acquires a credential object.


### PR DESCRIPTION
This gives `git_credtype_t` correct values for or-ing.

Right now client code would get `GIT_CREDTYPE_SSH_PUBLICKEY` (3) for `GIT_CREDTYPE_USERPASS_PLAINTEXT`|`GIT_CREDTYPE_SSH_KEYFILE_PASSPHRASE` (1|2), which would throw them into trying to understand how `git_cred_ssh_publickey_new` is to be used ;-).

Fixes #1852.
