### PR TITLE
indexer: check the packfile trailer

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -630,7 +630,7 @@ int git_indexer_stream_finalize(git_indexer_stream *idx, git_transfer_progress *
 
 	/* Test for this before resolve_deltas(), as it plays with idx->off */
 	if (idx->off < idx->pack->mwf.size - 20) {
-		giterr_set(GITERR_INDEXER, "Indexing error: unexpected data at the end of the pack");
+		giterr_set(GITERR_INDEXER, "unexpected data at the end of the pack");
 		return -1;
 	}
 
@@ -646,7 +646,7 @@ int git_indexer_stream_finalize(git_indexer_stream *idx, git_transfer_progress *
 
 	git_hash_final(&trailer_hash, &idx->trailer);
 	if (git_oid_cmp(&file_hash, &trailer_hash)) {
-		giterr_set(GITERR_INDEXER, "Indexing error: packfile trailer mismatch");
+		giterr_set(GITERR_INDEXER, "packfile trailer mismatch");
 		return -1;
 	}
 
@@ -655,7 +655,7 @@ int git_indexer_stream_finalize(git_indexer_stream *idx, git_transfer_progress *
 			return -1;
 
 	if (stats->indexed_objects != stats->total_objects) {
-		giterr_set(GITERR_INDEXER, "Indexing error: early EOF");
+		giterr_set(GITERR_INDEXER, "early EOF");
 		return -1;
 	}
 


### PR DESCRIPTION
It has been bothering me since I wrote the original version that we don't check that the trailer is correct. Simply keeping back the last 20B out of the file on-disc causes problems, as the packfile layer expects the trailer to be there and won't let us read all of the objects, which is why (I now realise) my earlier attempt failed when the math seemed to work out.

So what we do instead is simply to write out everything but leave out the last 20B from what we hash, compare with what's on-disc and complain if it's not correct.
