### PR TITLE
OSX 10.8 + Valgrind

### DIFF
--- a/tests-clar/valgrind-supp-mac.txt
+++ b/tests-clar/valgrind-supp-mac.txt
@@ -154,3 +154,31 @@
 	fun:printf
 	fun:clar_print_init
 }
+{
+	molo-1
+	Memcheck:Leak
+	fun:malloc_zone_malloc
+	...
+	fun:_objc_init
+}
+{
+	molo-2
+	Memcheck:Leak
+	fun:malloc_zone_calloc
+	...
+	fun:_objc_init
+}
+{
+	molo-3
+	Memcheck:Leak
+	fun:malloc
+	...
+	fun:_objc_init
+}
+{
+	molo-4
+	Memcheck:Leak
+	fun:malloc
+	...
+	fun:dyld_register_image_state_change_handler
+}


### PR DESCRIPTION
Finally dug into the suppressions file to make Valgrind useful on OSX 10.8 again. This requires Valgrind 3.8.1 (earlier versions just refuse to run). I recorded [some output](https://gist.github.com/ben/e62ad3febcfa7daaf977), it's much more usable now.
