### PR TITLE
'del' instead of 'delete' for the poor C++ users

### DIFF
--- a/include/git2/sys/refdb_backend.h
+++ b/include/git2/sys/refdb_backend.h
@@ -103,7 +103,7 @@ struct git_refdb_backend {
 	 * Deletes the given reference from the refdb.  A refdb implementation
 	 * must provide this function.
 	 */
-	int (*delete)(git_refdb_backend *backend, const char *ref_name);
+	int (*del)(git_refdb_backend *backend, const char *ref_name);
 
 	/**
 	 * Suggests that the given refdb compress or optimize its references.

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -201,5 +201,5 @@ int git_refdb_rename(
 int git_refdb_delete(struct git_refdb *db, const char *ref_name)
 {
 	assert(db && db->backend);
-	return db->backend->delete(db->backend, ref_name);
+	return db->backend->del(db->backend, ref_name);
 }

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1096,7 +1096,7 @@ int git_refdb_backend_fs(
 	backend->parent.lookup = &refdb_fs_backend__lookup;
 	backend->parent.iterator = &refdb_fs_backend__iterator;
 	backend->parent.write = &refdb_fs_backend__write;
-	backend->parent.delete = &refdb_fs_backend__delete;
+	backend->parent.del = &refdb_fs_backend__delete;
 	backend->parent.rename = &refdb_fs_backend__rename;
 	backend->parent.compress = &refdb_fs_backend__compress;
 	backend->parent.free = &refdb_fs_backend__free;


### PR DESCRIPTION
If somebody were crazy enough to want to create their own refdb backend from C++ then we should pity them, since their task is hard enough without us stomping on their reserved words.

Moving `delete` to `del` matches the name used by config.
