### PR TITLE
Ignore files that disappear while iterating

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -902,8 +902,16 @@ int git_path_dirload_with_stat(
 		git_buf_truncate(&full, prefix_len);
 
 		if ((error = git_buf_joinpath(&full, full.ptr, ps->path)) < 0 ||
-			(error = git_path_lstat(full.ptr, &ps->st)) < 0)
+			(error = git_path_lstat(full.ptr, &ps->st)) < 0) {
+			if (error == GIT_ENOTFOUND) {
+				giterr_clear();
+				error = 0;
+				git_vector_remove(contents, i--);
+				continue;
+			}
+
 			break;
+		}
 
 		if (S_ISDIR(ps->st.st_mode)) {
 			if ((error = git_buf_joinpath(&full, full.ptr, ".git")) < 0)


### PR DESCRIPTION
On occasion, files can disappear while we're iterating the filesystem, between calls to `readdir` and `stat`.  Let's pretend those didn't exist in the first place.
