### PR TITLE
Make tests pass if XDG config exists

### DIFF
--- a/tests-clar/config/global.c
+++ b/tests-clar/config/global.c
@@ -6,18 +6,21 @@ void test_config_global__initialize(void)
 {
 	git_buf path = GIT_BUF_INIT;
 
-	cl_must_pass(p_mkdir("home", 0777));
+	cl_assert_equal_i(0, p_mkdir("home", 0777));
 	cl_git_pass(git_path_prettify(&path, "home", NULL));
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, path.ptr));
 
-	cl_must_pass(p_mkdir("xdg", 0777));
-	cl_git_pass(git_path_prettify(&path, "xdg", NULL));
+	cl_assert_equal_i(0, p_mkdir("xdg", 0777));
+	cl_assert_equal_i(0, p_mkdir("xdg/git", 0777));
+	cl_git_pass(git_path_prettify(&path, "xdg/git", NULL));
+	cl_git_pass(git_libgit2_opts(
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, path.ptr));
+
+	cl_assert_equal_i(0, p_mkdir("etc", 0777));
+	cl_git_pass(git_path_prettify(&path, "etc", NULL));
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, path.ptr));
-
-	cl_git_pass(git_libgit2_opts(
-		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, NULL));
 
 	git_buf_free(&path);
 }
@@ -26,6 +29,11 @@ void test_config_global__cleanup(void)
 {
 	cl_git_pass(git_futils_rmdir_r("home", NULL, GIT_RMDIR_REMOVE_FILES));
 	cl_git_pass(git_futils_rmdir_r("xdg", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_git_pass(git_futils_rmdir_r("etc", NULL, GIT_RMDIR_REMOVE_FILES));
+
+	git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, NULL);
+	git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, NULL);
+	git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, NULL);
 }
 
 void test_config_global__open_global(void)
@@ -48,10 +56,7 @@ void test_config_global__open_xdg(void)
 	const char *val, *str = "teststring";
 	const char *key = "this.variable";
 
-	p_setenv("XDG_CONFIG_HOME", "xdg", 1);
-
-	cl_must_pass(p_mkdir("xdg/git/", 0777));
-	cl_git_mkfile("xdg/git/config", "");
+	cl_git_mkfile("xdg/git/config", "# XDG config\n[core]\n  test = 1\n");
 
 	cl_git_pass(git_config_open_default(&cfg));
 	cl_git_pass(git_config_open_level(&xdg, cfg, GIT_CONFIG_LEVEL_XDG));


### PR DESCRIPTION
These tests check that the XDG config is not in use but due to some mistakes in how the tests were set up, if you are actually using the XDG config path, the tests would fail. This fixes that and actually isolates the tests from the system XDG setup.

Obviously the Travis test environment isn't using the XDG config or the tests would never be passing in the first place.
