### PR TITLE
HTTP: handle "relative" redirects

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -609,6 +609,9 @@ int gitno_connection_data_from_url(
 		data->use_ssl = true;
 	}
 
+	if (url[0] == '/')
+		default_port = data->use_ssl ? "443" : "80";
+
 	if (!default_port) {
 		giterr_set(GITERR_NET, "Unrecognized URL prefix");
 		goto cleanup;
@@ -617,6 +620,13 @@ int gitno_connection_data_from_url(
 	error = gitno_extract_url_parts(
 		&data->host, &data->port, &data->user, &data->pass,
 		url, default_port);
+
+	if (url[0] == '/') {
+		/* Relative redirect; reuse original host name and port */
+		git__free(data->host);
+		data->host = original_host;
+		original_host = NULL;
+	}
 
 	if (!error) {
 		const char *path = strchr(url, '/');

--- a/tests-clar/network/urlparse.c
+++ b/tests-clar/network/urlparse.c
@@ -125,6 +125,34 @@ void test_network_urlparse__connection_data_http_downgrade(void)
 			-1);
 }
 
+void test_network_urlparse__connection_data_relative_redirect(void)
+{
+	cl_git_pass(gitno_connection_data_from_url(&conndata,
+				"http://foo.com/bar/baz/biff", NULL));
+	cl_git_pass(gitno_connection_data_from_url(&conndata,
+				"/zap/baz/biff?bam", NULL));
+	cl_assert_equal_s(conndata.host, "foo.com");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/zap/baz/biff?bam");
+	cl_assert_equal_p(conndata.user, NULL);
+	cl_assert_equal_p(conndata.pass, NULL);
+	cl_assert_equal_i(conndata.use_ssl, false);
+}
+
+void test_network_urlparse__connection_data_relative_redirect_ssl(void)
+{
+	cl_git_pass(gitno_connection_data_from_url(&conndata,
+				"https://foo.com/bar/baz/biff", NULL));
+	cl_git_pass(gitno_connection_data_from_url(&conndata,
+				"/zap/baz/biff?bam", NULL));
+	cl_assert_equal_s(conndata.host, "foo.com");
+	cl_assert_equal_s(conndata.port, "443");
+	cl_assert_equal_s(conndata.path, "/zap/baz/biff?bam");
+	cl_assert_equal_p(conndata.user, NULL);
+	cl_assert_equal_p(conndata.pass, NULL);
+	cl_assert_equal_i(conndata.use_ssl, true);
+}
+
 /* Run this under valgrind */
 void test_network_urlparse__connection_data_cleanup(void)
 {


### PR DESCRIPTION
This allows the URL-parsing machinery to correctly handle redirect locations that begin with `/`, in addition to the protocol-prefixed URLs that were already handled. This should correct failures such as [this](https://travis-ci.org/libgit2/libgit2/jobs/12068704#L827).
