### PR TITLE
tree: allow retrieval of raw attributes

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -199,6 +199,17 @@ GIT_EXTERN(git_otype) git_tree_entry_type(const git_tree_entry *entry);
 GIT_EXTERN(git_filemode_t) git_tree_entry_filemode(const git_tree_entry *entry);
 
 /**
+ * Get the raw UNIX file attributes of a tree entry
+ *
+ * This function does not perform any normalization and is only useful
+ * if you need to be able to recreate the original tree object.
+ *
+ * @param entry a tree entry
+ * @return filemode as an integer
+ */
+
+GIT_EXTERN(git_filemode_t) git_tree_entry_filemode_raw(const git_tree_entry *entry);
+/**
  * Compare two tree entries
  *
  * @param e1 first tree entry

--- a/src/tree.c
+++ b/src/tree.c
@@ -237,7 +237,12 @@ void git_tree__free(void *_tree)
 
 git_filemode_t git_tree_entry_filemode(const git_tree_entry *entry)
 {
-	return (git_filemode_t)entry->attr;
+	return normalize_filemode(entry->attr);
+}
+
+git_filemode_t git_tree_entry_filemode_raw(const git_tree_entry *entry)
+{
+	return entry->attr;
 }
 
 const char *git_tree_entry_name(const git_tree_entry *entry)
@@ -385,8 +390,6 @@ int git_tree__parse(void *_tree, git_odb_object *odb_obj)
 
 		if (git__strtol32(&attr, buffer, &buffer, 8) < 0 || !buffer)
 			return tree_error("Failed to parse tree. Can't parse filemode", NULL);
-
-		attr = normalize_filemode(attr); /* make sure to normalize the filemode */
 
 		if (*buffer++ != ' ')
 			return tree_error("Failed to parse tree. Object is corrupted", NULL);

--- a/tests-clar/object/tree/attributes.c
+++ b/tests-clar/object/tree/attributes.c
@@ -107,7 +107,8 @@ void test_object_tree_attributes__normalize_600(void)
 	cl_git_pass(git_tree_lookup(&tree, repo, &id));
 
 	entry = git_tree_entry_byname(tree, "ListaTeste.xml");
-	cl_assert_equal_i(entry->attr, GIT_FILEMODE_BLOB);
+	cl_assert_equal_i(git_tree_entry_filemode(entry), GIT_FILEMODE_BLOB);
+	cl_assert_equal_i(git_tree_entry_filemode_raw(entry), 0100600);
 
 	git_tree_free(tree);
 	cl_git_sandbox_cleanup();


### PR DESCRIPTION
When a tool needs to recreate the tree object (for example an
interface to another VCS), it needs to use the raw attributes,
forgoing any normalization.

---

This is some production code that turns out I never pushed upstream. It introduces extra computation every time we ask for the normalized version, though it shouldn't be bad enough to warrant caching.
