### PR TITLE
license clarification + formatting all over

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Check the [contribution guidelines](CONTRIBUTING.md).
 License
 ==================================
 `libgit2` is under GPL2 **with linking exemption**. This means you
-can can link to and use the library from any program, proprietary or open source; paid
+can link to and use the library from any program, proprietary or open source; paid
 or gratis.  However, you cannot modify libgit2 and distribute it without
 supplying the source.
 


### PR DESCRIPTION
There are commercial open source applications, hence proprietary seems to be a better term.

Also:
- Trimmed header `=`'s to match text length
- made libgit2 stand out everywhere
- pretty printing links
- irc link for those with the correct setup
