### PR TITLE
Rename the ssh credentials

### DIFF
--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -19,13 +19,13 @@ int git_cred_has_username(git_cred *cred)
 		ret = !!c->username;
 		break;
 	}
-	case GIT_CREDTYPE_SSH_KEYFILE_PASSPHRASE: {
-		git_cred_ssh_keyfile_passphrase *c = (git_cred_ssh_keyfile_passphrase *)cred;
+	case GIT_CREDTYPE_SSH_KEY: {
+		git_cred_ssh_key *c = (git_cred_ssh_key *)cred;
 		ret = !!c->username;
 		break;
 	}
-	case GIT_CREDTYPE_SSH_PUBLICKEY: {
-		git_cred_ssh_publickey *c = (git_cred_ssh_publickey *)cred;
+	case GIT_CREDTYPE_SSH_CUSTOM: {
+		git_cred_ssh_custom *c = (git_cred_ssh_custom *)cred;
 		ret = !!c->username;
 		break;
 	}
@@ -84,10 +84,10 @@ int git_cred_userpass_plaintext_new(
 	return 0;
 }
 
-static void ssh_keyfile_passphrase_free(struct git_cred *cred)
+static void ssh_key_free(struct git_cred *cred)
 {
-	git_cred_ssh_keyfile_passphrase *c =
-		(git_cred_ssh_keyfile_passphrase *)cred;
+	git_cred_ssh_key *c =
+		(git_cred_ssh_key *)cred;
 
 	git__free(c->username);
 	git__free(c->publickey);
@@ -104,9 +104,9 @@ static void ssh_keyfile_passphrase_free(struct git_cred *cred)
 	git__free(c);
 }
 
-static void ssh_publickey_free(struct git_cred *cred)
+static void ssh_custom_free(struct git_cred *cred)
 {
-	git_cred_ssh_publickey *c = (git_cred_ssh_publickey *)cred;
+	git_cred_ssh_custom *c = (git_cred_ssh_custom *)cred;
 
 	git__free(c->username);
 	git__free(c->publickey);
@@ -115,22 +115,22 @@ static void ssh_publickey_free(struct git_cred *cred)
 	git__free(c);
 }
 
-int git_cred_ssh_keyfile_passphrase_new(
+int git_cred_ssh_key_new(
 	git_cred **cred,
 	const char *username,
 	const char *publickey,
 	const char *privatekey,
 	const char *passphrase)
 {
-	git_cred_ssh_keyfile_passphrase *c;
+	git_cred_ssh_key *c;
 
 	assert(cred && privatekey);
 
-	c = git__calloc(1, sizeof(git_cred_ssh_keyfile_passphrase));
+	c = git__calloc(1, sizeof(git_cred_ssh_key));
 	GITERR_CHECK_ALLOC(c);
 
-	c->parent.credtype = GIT_CREDTYPE_SSH_KEYFILE_PASSPHRASE;
-	c->parent.free = ssh_keyfile_passphrase_free;
+	c->parent.credtype = GIT_CREDTYPE_SSH_KEY;
+	c->parent.free = ssh_key_free;
 
 	if (username) {
 		c->username = git__strdup(username);
@@ -154,7 +154,7 @@ int git_cred_ssh_keyfile_passphrase_new(
 	return 0;
 }
 
-int git_cred_ssh_publickey_new(
+int git_cred_ssh_custom_new(
 	git_cred **cred,
 	const char *username,
 	const char *publickey,
@@ -162,15 +162,15 @@ int git_cred_ssh_publickey_new(
 	git_cred_sign_callback sign_callback,
 	void *sign_data)
 {
-	git_cred_ssh_publickey *c;
+	git_cred_ssh_custom *c;
 
 	assert(cred);
 
-	c = git__calloc(1, sizeof(git_cred_ssh_publickey));
+	c = git__calloc(1, sizeof(git_cred_ssh_custom));
 	GITERR_CHECK_ALLOC(c);
 
-	c->parent.credtype = GIT_CREDTYPE_SSH_PUBLICKEY;
-	c->parent.free = ssh_publickey_free;
+	c->parent.credtype = GIT_CREDTYPE_SSH_CUSTOM;
+	c->parent.free = ssh_custom_free;
 
 	if (username) {
 		c->username = git__strdup(username);

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -249,15 +249,15 @@ static int _git_ssh_authenticate_session(
 			rc = libssh2_userauth_password(session, user, c->password);
 			break;
 		}
-		case GIT_CREDTYPE_SSH_KEYFILE_PASSPHRASE: {
-			git_cred_ssh_keyfile_passphrase *c = (git_cred_ssh_keyfile_passphrase *)cred;
+		case GIT_CREDTYPE_SSH_KEY: {
+			git_cred_ssh_key *c = (git_cred_ssh_key *)cred;
 			user = c->username ? c->username : user;
 			rc = libssh2_userauth_publickey_fromfile(
 				session, c->username, c->publickey, c->privatekey, c->passphrase);
 			break;
 		}
-		case GIT_CREDTYPE_SSH_PUBLICKEY: {
-			git_cred_ssh_publickey *c = (git_cred_ssh_publickey *)cred;
+		case GIT_CREDTYPE_SSH_CUSTOM: {
+			git_cred_ssh_custom *c = (git_cred_ssh_custom *)cred;
 
 			user = c->username ? c->username : user;
 			rc = libssh2_userauth_publickey(
@@ -349,8 +349,8 @@ static int _git_ssh_setup_conn(
 		if (t->owner->cred_acquire_cb(
 				&t->cred, t->owner->url, user,
 				GIT_CREDTYPE_USERPASS_PLAINTEXT |
-				GIT_CREDTYPE_SSH_KEYFILE_PASSPHRASE |
-				GIT_CREDTYPE_SSH_PUBLICKEY,
+				GIT_CREDTYPE_SSH_KEY |
+				GIT_CREDTYPE_SSH_CUSTOM,
 				t->owner->cred_acquire_payload) < 0)
 			goto on_error;
 

--- a/tests-clar/online/push.c
+++ b/tests-clar/online/push.c
@@ -47,12 +47,12 @@ static int cred_acquire_cb(
 	GIT_UNUSED(user_from_url);
 	GIT_UNUSED(payload);
 
-	if (GIT_CREDTYPE_SSH_KEYFILE_PASSPHRASE & allowed_types) {
+	if (GIT_CREDTYPE_SSH_KEY & allowed_types) {
 		if (!_remote_user || !_remote_ssh_pubkey || !_remote_ssh_key || !_remote_ssh_passphrase) {
 			printf("GITTEST_REMOTE_USER, GITTEST_REMOTE_SSH_PUBKEY, GITTEST_REMOTE_SSH_KEY and GITTEST_REMOTE_SSH_PASSPHRASE must be set\n");
 			return -1;
 		}
-		return git_cred_ssh_keyfile_passphrase_new(cred, _remote_user, _remote_ssh_pubkey, _remote_ssh_key, _remote_ssh_passphrase);
+		return git_cred_ssh_key_new(cred, _remote_user, _remote_ssh_pubkey, _remote_ssh_key, _remote_ssh_passphrase);
 	}
 
 	if (GIT_CREDTYPE_USERPASS_PLAINTEXT & allowed_types) {


### PR DESCRIPTION
The names from libssh2 are somewhat obtuse for us. We can simplify the
usual key/passphrase credential's name, as well as make clearer what the
custom signature function is.

---

If we're not going to let the user grab the libssh2 handle directly, then we need to make the functions names make sense within the context of the Git library.
