### PR TITLE
transport: let the progress output return an error

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -410,7 +410,7 @@ struct git_remote_callbacks {
 	 * progress side-band will be passed to this function (this is
 	 * the 'counting objects' output.
 	 */
-	void (*progress)(const char *str, int len, void *data);
+	int (*progress)(const char *str, int len, void *data);
 
 	/**
 	 * Completion is called when different parts of the download

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -170,7 +170,7 @@ typedef enum {
 	GIT_TRANSPORTFLAGS_NO_CHECK_CERT = 1
 } git_transport_flags_t;
 
-typedef void (*git_transport_message_cb)(const char *str, int len, void *data);
+typedef int (*git_transport_message_cb)(const char *str, int len, void *data);
 
 typedef struct git_transport git_transport;
 

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -509,7 +509,10 @@ int git_smart__download_pack(
 		if (pkt->type == GIT_PKT_PROGRESS) {
 			if (t->progress_cb) {
 				git_pkt_progress *p = (git_pkt_progress *) pkt;
-				t->progress_cb(p->data, p->len, t->message_cb_payload);
+				if (t->progress_cb(p->data, p->len, t->message_cb_payload)) {
+					giterr_set(GITERR_NET, "The fetch was cancelled by the user");
+					return GIT_EUSER;
+				}
 			}
 			git__free(pkt);
 		} else if (pkt->type == GIT_PKT_DATA) {


### PR DESCRIPTION
There are any number of issues that can come up in the progress
callback, and we should let the user cancel at that point as well.

/cc @arthurschreiber
