### PR TITLE
The "common.h" should be included before "config.h".

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "repository.h"
 #include "fileops.h"
 #include "config.h"

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -1,4 +1,5 @@
 #include "git2/ignore.h"
+#include "common.h"
 #include "ignore.h"
 #include "attr.h"
 #include "path.h"

--- a/src/remote.c
+++ b/src/remote.c
@@ -10,6 +10,7 @@
 #include "git2/oid.h"
 #include "git2/net.h"
 
+#include "common.h"
 #include "config.h"
 #include "repository.h"
 #include "remote.h"


### PR DESCRIPTION
When building libgit2 for ia32 architecture on a x64 machine under Windows, including "config.h" without a "common.h" would result in the following error:

```
C:\Program Files\Microsoft SDKs\Windows\v7.1\include\winbase.h(2288): error C2373: 'InterlockedIncrement' : redefinition; different type modifiers [C:\cygwin\home\zcbenz\codes\git-utils\build\libgit2.vcxproj]
C:\Program Files\Microsoft SDKs\Windows\v7.1\include\winbase.h(2295): error C2373: 'InterlockedDecrement' : redefinition; different type modifiers [C:\cygwin\home\zcbenz\codes\git-utils\build\libgit2.vcxproj]
C:\Program Files\Microsoft SDKs\Windows\v7.1\include\winbase.h(2303): error C2373: 'InterlockedExchange' : redefinition; different type modifiers [C:\cygwin\home\zcbenz\codes\git-utils\build\libgit2.vcxproj]
C:\Program Files\Microsoft SDKs\Windows\v7.1\include\winbase.h(2314): error C2373: 'InterlockedExchangeAdd' : redefinition; different type modifiers [C:\cygwin\home\zcbenz\codes\git-utils\build\libgit2.vcxproj]
```
