### PR TITLE
indexer: remove the stream infix

### DIFF
--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -13,10 +13,10 @@
 
 GIT_BEGIN_DECL
 
-typedef struct git_indexer_stream git_indexer_stream;
+typedef struct git_indexer git_indexer;
 
 /**
- * Create a new streaming indexer instance
+ * Create a new indexer instance
  *
  * @param out where to store the indexer instance
  * @param path to the directory where the packfile should be stored
@@ -26,8 +26,8 @@ typedef struct git_indexer_stream git_indexer_stream;
  * @param progress_cb function to call with progress information
  * @param progress_cb_payload payload for the progress callback
  */
-GIT_EXTERN(int) git_indexer_stream_new(
-		git_indexer_stream **out,
+GIT_EXTERN(int) git_indexer_new(
+		git_indexer **out,
 		const char *path,
 		git_odb *odb,
 		git_transfer_progress_callback progress_cb,
@@ -41,7 +41,7 @@ GIT_EXTERN(int) git_indexer_stream_new(
  * @param size the size of the data in bytes
  * @param stats stat storage
  */
-GIT_EXTERN(int) git_indexer_stream_add(git_indexer_stream *idx, const void *data, size_t size, git_transfer_progress *stats);
+GIT_EXTERN(int) git_indexer_append(git_indexer *idx, const void *data, size_t size, git_transfer_progress *stats);
 
 /**
  * Finalize the pack and index
@@ -50,7 +50,7 @@ GIT_EXTERN(int) git_indexer_stream_add(git_indexer_stream *idx, const void *data
  *
  * @param idx the indexer
  */
-GIT_EXTERN(int) git_indexer_stream_finalize(git_indexer_stream *idx, git_transfer_progress *stats);
+GIT_EXTERN(int) git_indexer_commit(git_indexer *idx, git_transfer_progress *stats);
 
 /**
  * Get the packfile's hash
@@ -60,14 +60,14 @@ GIT_EXTERN(int) git_indexer_stream_finalize(git_indexer_stream *idx, git_transfe
  *
  * @param idx the indexer instance
  */
-GIT_EXTERN(const git_oid *) git_indexer_stream_hash(const git_indexer_stream *idx);
+GIT_EXTERN(const git_oid *) git_indexer_hash(const git_indexer *idx);
 
 /**
  * Free the indexer and its resources
  *
  * @param idx the indexer to free
  */
-GIT_EXTERN(void) git_indexer_stream_free(git_indexer_stream *idx);
+GIT_EXTERN(void) git_indexer_free(git_indexer *idx);
 
 GIT_END_DECL
 

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -116,7 +116,7 @@ struct git_odb_stream {
 struct git_odb_writepack {
 	git_odb_backend *backend;
 
-	int (*add)(git_odb_writepack *writepack, const void *data, size_t size, git_transfer_progress *stats);
+	int (*append)(git_odb_writepack *writepack, const void *data, size_t size, git_transfer_progress *stats);
 	int (*commit)(git_odb_writepack *writepack, git_transfer_progress *stats);
 	void (*free)(git_odb_writepack *writepack);
 };

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -35,7 +35,7 @@ struct tree_walk_context {
 };
 
 struct pack_write_context {
-	git_indexer_stream *indexer;
+	git_indexer *indexer;
 	git_transfer_progress *stats;
 };
 
@@ -1242,7 +1242,7 @@ int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb)
 static int write_cb(void *buf, size_t len, void *payload)
 {
 	struct pack_write_context *ctx = payload;
-	return git_indexer_stream_add(ctx->indexer, buf, len, ctx->stats);
+	return git_indexer_append(ctx->indexer, buf, len, ctx->stats);
 }
 
 int git_packbuilder_write(
@@ -1251,13 +1251,13 @@ int git_packbuilder_write(
 	git_transfer_progress_callback progress_cb,
 	void *progress_cb_payload)
 {
-	git_indexer_stream *indexer;
+	git_indexer *indexer;
 	git_transfer_progress stats;
 	struct pack_write_context ctx;
 
 	PREPARE_PACK;
 
-	if (git_indexer_stream_new(
+	if (git_indexer_new(
 		&indexer, path, pb->odb, progress_cb, progress_cb_payload) < 0)
 		return -1;
 
@@ -1265,12 +1265,12 @@ int git_packbuilder_write(
 	ctx.stats = &stats;
 
 	if (git_packbuilder_foreach(pb, write_cb, &ctx) < 0 ||
-		git_indexer_stream_finalize(indexer, &stats) < 0) {
-		git_indexer_stream_free(indexer);
+		git_indexer_commit(indexer, &stats) < 0) {
+		git_indexer_free(indexer);
 		return -1;
 	}
 
-	git_indexer_stream_free(indexer);
+	git_indexer_free(indexer);
 	return 0;
 }
 

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -459,7 +459,7 @@ static int foreach_cb(void *buf, size_t len, void *payload)
 	foreach_data *data = (foreach_data*)payload;
 
 	data->stats->received_bytes += len;
-	return data->writepack->add(data->writepack, buf, len, data->stats);
+	return data->writepack->append(data->writepack, buf, len, data->stats);
 }
 
 static int local_download_pack(

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -408,7 +408,7 @@ static int no_sideband(transport_smart *t, struct git_odb_writepack *writepack, 
 			return GIT_EUSER;
 		}
 
-		if (writepack->add(writepack, buf->data, buf->offset, stats) < 0)
+		if (writepack->append(writepack, buf->data, buf->offset, stats) < 0)
 			return -1;
 
 		gitno_consume_n(buf, buf->offset);
@@ -523,7 +523,7 @@ int git_smart__download_pack(
 			git__free(pkt);
 		} else if (pkt->type == GIT_PKT_DATA) {
 			git_pkt_data *p = (git_pkt_data *) pkt;
-			error = writepack->add(writepack, p->data, p->len, stats);
+			error = writepack->append(writepack, p->data, p->len, stats);
 
 			git__free(pkt);
 			if (error < 0)

--- a/tests-clar/pack/indexer.c
+++ b/tests-clar/pack/indexer.c
@@ -45,23 +45,23 @@ unsigned int base_obj_len = 2;
 
 void test_pack_indexer__out_of_order(void)
 {
-	git_indexer_stream *idx;
+	git_indexer *idx;
 	git_transfer_progress stats;
 
-	cl_git_pass(git_indexer_stream_new(&idx, ".", NULL, NULL, NULL));
-	cl_git_pass(git_indexer_stream_add(idx, out_of_order_pack, out_of_order_pack_len, &stats));
-	cl_git_pass(git_indexer_stream_finalize(idx, &stats));
+	cl_git_pass(git_indexer_new(&idx, ".", NULL, NULL, NULL));
+	cl_git_pass(git_indexer_append(idx, out_of_order_pack, out_of_order_pack_len, &stats));
+	cl_git_pass(git_indexer_commit(idx, &stats));
 
 	cl_assert_equal_i(stats.total_objects, 3);
 	cl_assert_equal_i(stats.received_objects, 3);
 	cl_assert_equal_i(stats.indexed_objects, 3);
 
-	git_indexer_stream_free(idx);
+	git_indexer_free(idx);
 }
 
 void test_pack_indexer__fix_thin(void)
 {
-	git_indexer_stream *idx;
+	git_indexer *idx;
 	git_transfer_progress stats;
 	git_repository *repo;
 	git_odb *odb;
@@ -75,9 +75,9 @@ void test_pack_indexer__fix_thin(void)
 	git_oid_fromstr(&should_id, "e68fe8129b546b101aee9510c5328e7f21ca1d18");
 	cl_assert(!git_oid_cmp(&id, &should_id));
 
-	cl_git_pass(git_indexer_stream_new(&idx, ".", odb, NULL, NULL));
-	cl_git_pass(git_indexer_stream_add(idx, thin_pack, thin_pack_len, &stats));
-	cl_git_pass(git_indexer_stream_finalize(idx, &stats));
+	cl_git_pass(git_indexer_new(&idx, ".", odb, NULL, NULL));
+	cl_git_pass(git_indexer_append(idx, thin_pack, thin_pack_len, &stats));
+	cl_git_pass(git_indexer_commit(idx, &stats));
 
 	cl_assert_equal_i(stats.total_objects, 2);
 	cl_assert_equal_i(stats.received_objects, 2);
@@ -85,9 +85,9 @@ void test_pack_indexer__fix_thin(void)
 	cl_assert_equal_i(stats.local_objects, 1);
 
 	git_oid_fromstr(&should_id, "11f0f69b334728fdd8bc86b80499f22f29d85b15");
-	cl_assert(!git_oid_cmp(git_indexer_stream_hash(idx), &should_id));
+	cl_assert(!git_oid_cmp(git_indexer_hash(idx), &should_id));
 
-	git_indexer_stream_free(idx);
+	git_indexer_free(idx);
 	git_odb_free(odb);
 	git_repository_free(repo);
 
@@ -110,19 +110,19 @@ void test_pack_indexer__fix_thin(void)
 		cl_git_pass(p_stat(name, &st));
 		left = st.st_size;
 
-		cl_git_pass(git_indexer_stream_new(&idx, ".", NULL, NULL, NULL));
+		cl_git_pass(git_indexer_new(&idx, ".", NULL, NULL, NULL));
 		read = p_read(fd, buffer, sizeof(buffer));
 		cl_assert(read != -1);
 		p_close(fd);
 
-		cl_git_pass(git_indexer_stream_add(idx, buffer, read, &stats));
-		cl_git_pass(git_indexer_stream_finalize(idx, &stats));
+		cl_git_pass(git_indexer_append(idx, buffer, read, &stats));
+		cl_git_pass(git_indexer_commit(idx, &stats));
 
 		cl_assert_equal_i(stats.total_objects, 3);
 		cl_assert_equal_i(stats.received_objects, 3);
 		cl_assert_equal_i(stats.indexed_objects, 3);
 		cl_assert_equal_i(stats.local_objects, 0);
 
-		git_indexer_stream_free(idx);
+		git_indexer_free(idx);
 	}
 }


### PR DESCRIPTION
It was there to keep it apart from the one which read in from a file on
disk. This other indexer does not exist anymore, so there is no need for
anything other than git_indexer to refer to it.

While here, rename _add() function to _append() and _finalize() to
_commit(). The former change is cosmetic, while the latter avoids
talking about "finalizing", which OO languages use to mean something
completely different.
