### PR TITLE
preserve windows error numbers as well

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -74,6 +74,30 @@ void giterr_set(int error_class, const char *string, ...);
 int giterr_set_regex(const regex_t *regex, int error_code);
 
 /**
+ * Gets the system error code for this thread.
+ */
+GIT_INLINE(int) giterr_system_last(void)
+{
+#ifdef GIT_WIN32
+	return GetLastError();
+#else
+	return errno;
+#endif
+}
+
+/**
+ * Sets the system error code for this thread.
+ */
+GIT_INLINE(void) giterr_system_set(int code)
+{
+#ifdef GIT_WIN32
+	SetLastError(code);
+#else
+	errno = code;
+#endif
+}
+
+/**
  * Check a versioned structure for validity
  */
 GIT_INLINE(int) giterr__check_version(const void *structure, unsigned int expected_max, const char *name)

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -343,11 +343,11 @@ int git_futils_mkdir(
 
 		/* make directory */
 		if (p_mkdir(make_path.ptr, mode) < 0) {
-			int tmp_errno = errno;
+			int tmp_errno = giterr_system_last();
 
 			/* ignore error if directory already exists */
 			if (p_stat(make_path.ptr, &st) < 0 || !S_ISDIR(st.st_mode)) {
-				errno = tmp_errno;
+				giterr_system_set(tmp_errno);
 				giterr_set(GITERR_OS, "Failed to make directory '%s'", make_path.ptr);
 				goto done;
 			}


### PR DESCRIPTION
Propagate the system error code on windows when a failure occurs, not just on unix.

Fixes https://github.com/libgit2/libgit2/issues/1787 - now when we try to `mkdir` a long path, the error message is Windows error code 206:

> ERROR_FILENAME_EXCED_RANGE
> 206 (0xCE)
> The filename or extension is too long.
