### PR TITLE
branch: move from foreach to an iterator

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -66,33 +66,41 @@ GIT_EXTERN(int) git_branch_create(
  */
 GIT_EXTERN(int) git_branch_delete(git_reference *branch);
 
-typedef int (*git_branch_foreach_cb)(
-	const char *branch_name,
-	git_branch_t branch_type,
-	void *payload);
+/** Iterator type for branches */
+typedef struct git_branch_iterator git_branch_iterator;
 
 /**
- * Loop over all the branches and issue a callback for each one.
+ * Create an iterator which loops over the requested branches.
  *
- * If the callback returns a non-zero value, this will stop looping.
- *
+ * @param out the iterator
  * @param repo Repository where to find the branches.
- *
  * @param list_flags Filtering flags for the branch
  * listing. Valid values are GIT_BRANCH_LOCAL, GIT_BRANCH_REMOTE
  * or a combination of the two.
  *
- * @param branch_cb Callback to invoke per found branch.
- *
- * @param payload Extra parameter to callback function.
- *
- * @return 0 on success, GIT_EUSER on non-zero callback, or error code
+ * @return 0 on success  or an error code
  */
-GIT_EXTERN(int) git_branch_foreach(
+GIT_EXTERN(int) git_branch_iterator_new(
+	git_branch_iterator **out,
 	git_repository *repo,
-	unsigned int list_flags,
-	git_branch_foreach_cb branch_cb,
-	void *payload);
+	unsigned int list_flags);
+
+/**
+ * Retrieve the next branch from the iterator
+ *
+ * @param out the reference
+ * @param out_type the type of branch (local or remote-tracking)
+ * @param iter the branch iterator
+ * @return 0 on success, GIT_ITEROVER if there are no more branches or an error code.
+ */
+GIT_EXTERN(int) git_branch_next(git_reference **out, unsigned int *out_type, git_branch_iterator *iter);
+
+/**
+ * Free a branch iterator
+ *
+ * @param iter the iterator to free
+ */
+GIT_EXTERN(void) git_branch_iterator_free(git_branch_iterator *iter);
 
 /**
  * Move/rename an existing local branch reference.

--- a/src/branch.c
+++ b/src/branch.c
@@ -124,48 +124,66 @@ on_error:
 	return error;
 }
 
-int git_branch_foreach(
-	git_repository *repo,
-	unsigned int list_flags,
-	git_branch_foreach_cb callback,
-	void *payload)
-{
+typedef struct {
 	git_reference_iterator *iter;
+	unsigned int flags;
+} branch_iter;
+
+int git_branch_next(git_reference **out, unsigned int *out_type, git_branch_iterator *_iter)
+{
+	branch_iter *iter = (branch_iter *) _iter;
 	git_reference *ref;
-	int error = 0;
+	int error;
 
-	if (git_reference_iterator_new(&iter, repo) < 0)
-		return -1;
+	while ((error = git_reference_next(&ref, iter->iter)) == 0) {
+		if ((iter->flags & GIT_BRANCH_LOCAL) &&
+		    !git__prefixcmp(ref->name, GIT_REFS_HEADS_DIR)) {
+			*out = ref;
+			*out_type = GIT_BRANCH_LOCAL;
 
-	while ((error = git_reference_next(&ref, iter)) == 0) {
-		if (list_flags & GIT_BRANCH_LOCAL &&
-		    git__prefixcmp(ref->name, GIT_REFS_HEADS_DIR) == 0) {
-			if (callback(ref->name + strlen(GIT_REFS_HEADS_DIR),
-					GIT_BRANCH_LOCAL, payload)) {
-				error = GIT_EUSER;
-			}
+			return 0;
+		} else  if ((iter->flags & GIT_BRANCH_REMOTE) &&
+			    !git__prefixcmp(ref->name, GIT_REFS_REMOTES_DIR)) {
+			*out = ref;
+			*out_type = GIT_BRANCH_REMOTE;
+
+			return 0;
+		} else {
+			git_reference_free(ref);
 		}
-
-		if (list_flags & GIT_BRANCH_REMOTE &&
-		    git__prefixcmp(ref->name, GIT_REFS_REMOTES_DIR) == 0) {
-			if (callback(ref->name + strlen(GIT_REFS_REMOTES_DIR),
-					GIT_BRANCH_REMOTE, payload)) {
-				error = GIT_EUSER;
-			}
-		}
-
-		git_reference_free(ref);
-
-		/* check if the callback has cancelled iteration */
-		if (error == GIT_EUSER)
-			break;
 	}
 
-	if (error == GIT_ITEROVER)
-		error = 0;
-
-	git_reference_iterator_free(iter);
 	return error;
+}
+
+int git_branch_iterator_new(
+	git_branch_iterator **out,
+	git_repository *repo,
+	unsigned int list_flags)
+{
+	branch_iter *iter;
+
+	iter = git__calloc(1, sizeof(branch_iter));
+	GITERR_CHECK_ALLOC(iter);
+
+	iter->flags = list_flags;
+
+	if (git_reference_iterator_new(&iter->iter, repo) < 0) {
+		git__free(iter);
+		return -1;
+	}
+
+	*out = (git_branch_iterator *) iter;
+
+	return 0;
+}
+
+void git_branch_iterator_free(git_branch_iterator *_iter)
+{
+	branch_iter *iter = (branch_iter *) _iter;
+
+	git_reference_iterator_free(iter->iter);
+	git__free(iter);
 }
 
 int git_branch_move(


### PR DESCRIPTION
Create a git_branch_iterator type which is equivalent to the foreach but
lets us write loops instead of callbacks.

Since the introduction of git_reference_shorthand(), the added value of
passing the name is reduced.
