### PR TITLE
Allow backend consumers to specify file mode

### DIFF
--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -40,10 +40,18 @@ GIT_EXTERN(int) git_odb_backend_pack(git_odb_backend **out, const char *objects_
  * @param objects_dir the Git repository's objects directory
  * @param compression_level zlib compression level to use
  * @param do_fsync whether to do an fsync() after writing (currently ignored)
+ * @param dir_mode permissions to use creating a directory or 0 for defaults
+ * @param file_mode permissions to use creating a file or 0 for defaults
  *
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_odb_backend_loose(git_odb_backend **out, const char *objects_dir, int compression_level, int do_fsync);
+GIT_EXTERN(int) git_odb_backend_loose(
+	git_odb_backend **out,
+	const char *objects_dir,
+	int compression_level,
+	int do_fsync,
+	mode_t dir_mode,
+	mode_t file_mode);
 
 /**
  * Create a backend out of a single packfile

--- a/src/odb.c
+++ b/src/odb.c
@@ -492,7 +492,7 @@ static int add_default_backends(
 #endif
 
 	/* add the loose object backend */
-	if (git_odb_backend_loose(&loose, objects_dir, -1, 0) < 0 ||
+	if (git_odb_backend_loose(&loose, objects_dir, -1, 0, 0, 0) < 0 ||
 		add_backend_internal(db, loose, GIT_LOOSE_PRIORITY, as_alternates, inode) < 0)
 		return -1;
 


### PR DESCRIPTION
I spin up a loose object backend to do some temporary work and then want to delete that.  Windows is apparently deficient about how it allows one to delete files - if they're set readonly, it's problematic.  Thus, I would like to be able to have the loose object backend just create files that are read/write.
