### PR TITLE
Plug configuration file search paths tests leaks

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -618,7 +618,7 @@ static git_futils_dirs_guess_cb git_futils__dir_guess[GIT_FUTILS_DIR__MAX] = {
 	git_futils_guess_template_dirs,
 };
 
-static void git_futils_dirs_global_shutdown(void)
+void git_futils_dirs_global_shutdown(void)
 {
 	int i;
 	for (i = 0; i < GIT_FUTILS_DIR__MAX; ++i)

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -399,4 +399,9 @@ extern int git_futils_filestamp_check(
 extern void git_futils_filestamp_set(
 	git_futils_filestamp *tgt, const git_futils_filestamp *src);
 
+/**
+ * Free the configuration file search paths.
+ */
+extern void git_futils_dirs_global_shutdown(void);
+
 #endif /* INCLUDE_fileops_h__ */

--- a/tests-clar/repo/config.c
+++ b/tests-clar/repo/config.c
@@ -46,6 +46,8 @@ void test_repo_config__open_missing_global(void)
 	git_config_free(global);
 	git_config_free(config);
 	git_repository_free(repo);
+
+	git_futils_dirs_global_shutdown();
 }
 
 void test_repo_config__open_missing_global_with_separators(void)
@@ -73,6 +75,8 @@ void test_repo_config__open_missing_global_with_separators(void)
 	git_config_free(global);
 	git_config_free(config);
 	git_repository_free(repo);
+
+	git_futils_dirs_global_shutdown();
 }
 
 #include "repository.h"
@@ -100,6 +104,8 @@ void test_repo_config__read_no_configs(void)
 	cl_git_pass(git_repository__cvar(&val, repo, GIT_CVAR_ABBREV));
 	cl_assert_equal_i(GIT_ABBREV_DEFAULT, val);
 	git_repository_free(repo);
+
+	git_futils_dirs_global_shutdown();
 
 	/* with just system */
 
@@ -197,4 +203,6 @@ void test_repo_config__read_no_configs(void)
 
 	cl_assert(!git_path_exists("empty_standard_repo/.git/config"));
 	cl_assert(!git_path_exists("alternate/3/.gitconfig"));
+
+	git_futils_dirs_global_shutdown();
 }

--- a/tests-clar/repo/open.c
+++ b/tests-clar/repo/open.c
@@ -322,6 +322,8 @@ void test_repo_open__no_config(void)
 	git_config_free(config);
 	git_repository_free(repo);
 	cl_fixture_cleanup("empty_standard_repo");
+
+	git_futils_dirs_global_shutdown();
 }
 
 void test_repo_open__force_bare(void)


### PR DESCRIPTION
This one might be a bit controversial as it artificially exposes a previously static function for the sole purpose of avoiding to pollute the valgrind log with leaks from tests.

Feel free to ignore if it isn't worth it.
