### PR TITLE
don't double free pkt

### DIFF
--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -261,7 +261,7 @@ static int wait_while_ack(gitno_buffer *buf)
 		    (pkt->status != GIT_ACK_CONTINUE ||
 		     pkt->status != GIT_ACK_COMMON)) {
 			git__free(pkt);
-			break;
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
libgit2sharp has a use case that exercises this code path, but I could not make it happen myself.

@nulltoken do you have any insight into how this got triggered in that test?  I tried setting fetch specs to none, then to all, but it did not happen for me...!
