### PR TITLE
Add git_packbuilder_hash to query pack filename

### DIFF
--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -130,6 +130,16 @@ GIT_EXTERN(int) git_packbuilder_write(
 	git_transfer_progress_callback progress_cb,
 	void *progress_cb_payload);
 
+/**
+* Get the packfile's hash
+*
+* A packfile's name is derived from the sorted hashing of all object
+* names. This is only correct after the packfile has been written.
+*
+* @param pb The packbuilder object
+*/
+GIT_EXTERN(const git_oid *) git_packbuilder_hash(git_packbuilder *pb);
+
 typedef int (*git_packbuilder_foreach_cb)(void *buf, size_t size, void *payload);
 /**
  * Create the new pack and pass each object to the callback

--- a/tests-clar/pack/packbuilder.c
+++ b/tests-clar/pack/packbuilder.c
@@ -128,6 +128,18 @@ void test_pack_packbuilder__create_pack(void)
 	cl_assert_equal_s(hex, "5d410bdf97cf896f9007681b92868471d636954b");
 }
 
+void test_pack_packbuilder__get_hash(void)
+{
+	char hex[41]; hex[40] = '\0';
+
+	seed_packbuilder();
+
+	git_packbuilder_write(_packbuilder, ".", NULL, NULL);
+	git_oid_fmt(hex, git_packbuilder_hash(_packbuilder));
+
+	cl_assert_equal_s(hex, "80e61eb315239ef3c53033e37fee43b744d57122");
+}
+
 static git_transfer_progress stats;
 static int foreach_cb(void *buf, size_t len, void *payload)
 {


### PR DESCRIPTION
Adding a `git_packbuilder_hash` that exposes the written pack file hash from `git_indexer_hash`.

It appears that the `pack_oid` was supposed to contain this data?  But was instead used to keep the per-object hash?  Maybe I'm misreading this, though.
