### PR TITLE
Allow callers to set mode on packfile creation

### DIFF
--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -20,6 +20,7 @@ typedef struct git_indexer git_indexer;
  *
  * @param out where to store the indexer instance
  * @param path to the directory where the packfile should be stored
+ * @param mode permissions to use creating packfile or 0 for defaults
  * @param odb object database from which to read base objects when
  * fixing thin packs. Pass NULL if no thin pack is expected (an error
  * will be returned if there are bases missing)
@@ -29,6 +30,7 @@ typedef struct git_indexer git_indexer;
 GIT_EXTERN(int) git_indexer_new(
 		git_indexer **out,
 		const char *path,
+		unsigned int mode,
 		git_odb *odb,
 		git_transfer_progress_callback progress_cb,
 		void *progress_cb_payload);

--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -119,6 +119,7 @@ GIT_EXTERN(int) git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid
  *
  * @param pb The packbuilder
  * @param path to the directory where the packfile and index should be stored
+ * @param mode permissions to use creating a packfile or 0 for defaults
  * @param progress_cb function to call with progress information from the indexer (optional)
  * @param progress_cb_payload payload for the progress callback (optional)
  *
@@ -127,6 +128,7 @@ GIT_EXTERN(int) git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid
 GIT_EXTERN(int) git_packbuilder_write(
 	git_packbuilder *pb,
 	const char *path,
+	unsigned int mode,
 	git_transfer_progress_callback progress_cb,
 	void *progress_cb_payload);
 

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -558,7 +558,7 @@ static int pack_backend__writepack(struct git_odb_writepack **out,
 	GITERR_CHECK_ALLOC(writepack);
 
 	if (git_indexer_new(&writepack->indexer,
-		backend->pack_folder, odb, progress_cb, progress_payload) < 0) {
+		backend->pack_folder, 0, odb, progress_cb, progress_payload) < 0) {
 		git__free(writepack);
 		return -1;
 	}

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1248,6 +1248,7 @@ static int write_cb(void *buf, size_t len, void *payload)
 int git_packbuilder_write(
 	git_packbuilder *pb,
 	const char *path,
+	unsigned int mode,
 	git_transfer_progress_callback progress_cb,
 	void *progress_cb_payload)
 {
@@ -1258,7 +1259,7 @@ int git_packbuilder_write(
 	PREPARE_PACK;
 
 	if (git_indexer_new(
-		&indexer, path, pb->odb, progress_cb, progress_cb_payload) < 0)
+		&indexer, path, mode, pb->odb, progress_cb, progress_cb_payload) < 0)
 		return -1;
 
 	ctx.indexer = indexer;

--- a/tests-clar/pack/indexer.c
+++ b/tests-clar/pack/indexer.c
@@ -48,7 +48,7 @@ void test_pack_indexer__out_of_order(void)
 	git_indexer *idx;
 	git_transfer_progress stats;
 
-	cl_git_pass(git_indexer_new(&idx, ".", NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
 	cl_git_pass(git_indexer_append(idx, out_of_order_pack, out_of_order_pack_len, &stats));
 	cl_git_pass(git_indexer_commit(idx, &stats));
 
@@ -75,7 +75,7 @@ void test_pack_indexer__fix_thin(void)
 	git_oid_fromstr(&should_id, "e68fe8129b546b101aee9510c5328e7f21ca1d18");
 	cl_assert(!git_oid_cmp(&id, &should_id));
 
-	cl_git_pass(git_indexer_new(&idx, ".", odb, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, odb, NULL, NULL));
 	cl_git_pass(git_indexer_append(idx, thin_pack, thin_pack_len, &stats));
 	cl_git_pass(git_indexer_commit(idx, &stats));
 
@@ -108,7 +108,7 @@ void test_pack_indexer__fix_thin(void)
 
 		cl_git_pass(p_stat(name, &st));
 
-		cl_git_pass(git_indexer_new(&idx, ".", NULL, NULL, NULL));
+		cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
 		read = p_read(fd, buffer, sizeof(buffer));
 		cl_assert(read != -1);
 		p_close(fd);


### PR DESCRIPTION
Take a handy mode so that callers can create read/writeable packfiles.  Handy on Windows where deleting readonly files is disappointingly (but not surprisingly) painful.
