### PR TITLE
Add GIT_DIFF_FIND_REMOVE_UNMODIFIED flag and fix copy detection bug

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -525,14 +525,14 @@ typedef enum {
 	 */
 	GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY  = (1u << 15),
 
-	/** Delete any UNMODIFIED records after find_similar is done.
+	/** Remove any UNMODIFIED deltas after find_similar is done.
 	 *
 	 * Using GIT_DIFF_FIND_COPIES_FROM_UNMODIFIED to emulate the
 	 * --find-copies-harder behavior requires building a diff with the
 	 * GIT_DIFF_INCLUDE_UNMODIFIED flag.  If you do not want UNMODIFIED
 	 * records in the final result, pass this flag to have them removed.
 	 */
-	GIT_DIFF_FIND_DELETE_UNMODIFIED = (1u << 16),
+	GIT_DIFF_FIND_REMOVE_UNMODIFIED = (1u << 16),
 } git_diff_find_t;
 
 /**

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -746,7 +746,7 @@ static bool is_rename_source(
 	case GIT_DELTA_UNMODIFIED:
 		if (!FLAG_SET(opts, GIT_DIFF_FIND_COPIES_FROM_UNMODIFIED))
 			return false;
-		if (FLAG_SET(opts, GIT_DIFF_FIND_DELETE_UNMODIFIED))
+		if (FLAG_SET(opts, GIT_DIFF_FIND_REMOVE_UNMODIFIED))
 			delta->flags |= GIT_DIFF_FLAG__TO_DELETE;
 		break;
 

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -1365,7 +1365,7 @@ void test_diff_rename__can_delete_unmodified_deltas(void)
 	cl_assert_equal_i(1, exp.file_status[GIT_DELTA_MODIFIED]);
 	cl_assert_equal_i(3, exp.file_status[GIT_DELTA_UNMODIFIED]);
 
-	opts.flags = GIT_DIFF_FIND_ALL | GIT_DIFF_FIND_DELETE_UNMODIFIED;
+	opts.flags = GIT_DIFF_FIND_ALL | GIT_DIFF_FIND_REMOVE_UNMODIFIED;
 	cl_git_pass(git_diff_find_similar(diff, &opts));
 
 	memset(&exp, 0, sizeof(exp));


### PR DESCRIPTION
When doing copy detection, it is often necessary to include `UNMODIFIED` records in the `git_diff` so they are available as source records for `GIT_DIFF_FIND_COPIES_FROM_UNMODIFIED`. Yet in the final diff, often you will not want to have these `UNMODIFIED` records.

This PR adds a new flag (`GIT_DIFF_FIND_REMOVE_UNMODIFIED`) which causes these `UNMODIFIED` records to be removed from the diff list after the rename/copy detection phase is over.

In developing this, I found a bug where the right side of a split delta (i.e. a `MODIFIED` record that has changed so much that `GIT_DIFF_FIND_AND_BREAK_REWRITES` will cause it to be split into a `DELETED` and `ADDED` pair) was never being considered a valid target for a `COPIED` record, even though it should be possible to split into a `DELETED` / `COPIED` pair. The first commit in this PR adds a test for that case and fixes the bug.
