### PR TITLE
Bare naked merge and rebase

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -192,6 +192,26 @@ GIT_EXTERN(int) git_merge_trees(
 	const git_merge_tree_opts *opts);
 
 /**
+ * Merge two commits, producing a `git_index` that reflects the result of
+ * the merge.
+ *
+ * The returned index must be freed explicitly with `git_index_free`.
+ *
+ * @param out pointer to store the index result in
+ * @param repo repository that contains the given trees
+ * @param our_commit the commit that reflects the destination tree
+ * @param their_commit the commit to merge in to `our_commit`
+ * @param opts the merge tree options (or null for defaults)
+ * @return zero on success, -1 on failure.
+ */
+GIT_EXTERN(int) git_merge_commits(
+	git_index **out,
+	git_repository *repo,
+	const git_commit *our_commit,
+	const git_commit *their_commit,
+	const git_merge_tree_opts *opts);
+
+/**
  * Merges the given commits into HEAD, producing a new commit.
  *
  * @param out the results of the merge

--- a/include/git2/revert.h
+++ b/include/git2/revert.h
@@ -34,13 +34,36 @@ typedef struct {
 #define GIT_REVERT_OPTS_INIT {GIT_REVERT_OPTS_VERSION, 0, GIT_MERGE_TREE_OPTS_INIT, GIT_CHECKOUT_OPTS_INIT}
 
 /**
-* Reverts the given commits, producing changes in the working directory.
-*
-* @param repo the repository to revert
-* @param commits the commits to revert
-* @param commits_len the number of commits to revert
-* @param flags merge flags
-*/
+ * Reverts the given commit against the given "our" commit, producing an
+ * index that reflects the result of the revert.
+ *
+ * The returned index must be freed explicitly with `git_index_free`.
+ *
+ * @param out pointer to store the index result in
+ * @param repo the repository that contains the given commits
+ * @param revert_commit the commit to revert
+ * @param our_commit the commit to revert against (eg, HEAD)
+ * @param mainline the parent of the revert commit, if it is a merge
+ * @param merge_tree_opts the merge tree options (or null for defaults)
+ * @return zero on success, -1 on failure.
+ */
+int git_revert_commit(
+	git_index **out,
+	git_repository *repo,
+	git_commit *revert_commit,
+	git_commit *our_commit,
+	unsigned int mainline,
+	const git_merge_tree_opts *merge_tree_opts);
+
+/**
+ * Reverts the given commit, producing changes in the working directory.
+ *
+ * @param repo the repository to revert
+ * @param commits the commits to revert
+ * @param commits_len the number of commits to revert
+ * @param flags merge flags
+ * @return zero on success, -1 on failure.
+ */
 GIT_EXTERN(int) git_revert(
 	git_repository *repo,
 	git_commit *commit,

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -52,6 +52,34 @@ int merge_trees_from_branches(
 	return 0;
 }
 
+int merge_commits_from_branches(
+	git_index **index, git_repository *repo,
+	const char *ours_name, const char *theirs_name,
+	git_merge_tree_opts *opts)
+{
+	git_commit *our_commit, *their_commit;
+	git_oid our_oid, their_oid;
+	git_buf branch_buf = GIT_BUF_INIT;
+	int error;
+
+	git_buf_printf(&branch_buf, "%s%s", GIT_REFS_HEADS_DIR, ours_name);
+	cl_git_pass(git_reference_name_to_id(&our_oid, repo, branch_buf.ptr));
+	cl_git_pass(git_commit_lookup(&our_commit, repo, &our_oid));
+
+	git_buf_clear(&branch_buf);
+	git_buf_printf(&branch_buf, "%s%s", GIT_REFS_HEADS_DIR, theirs_name);
+	cl_git_pass(git_reference_name_to_id(&their_oid, repo, branch_buf.ptr));
+	cl_git_pass(git_commit_lookup(&their_commit, repo, &their_oid));
+
+	cl_git_pass(git_merge_commits(index, repo, our_commit, their_commit, opts));
+
+	git_buf_free(&branch_buf);
+	git_commit_free(our_commit);
+	git_commit_free(their_commit);
+
+	return 0;
+}
+
 int merge_branches(git_merge_result **result, git_repository *repo, const char *ours_branch, const char *theirs_branch, git_merge_opts *opts)
 {
 	git_reference *head_ref, *theirs_ref;

--- a/tests/merge/merge_helpers.h
+++ b/tests/merge/merge_helpers.h
@@ -44,6 +44,11 @@ int merge_trees_from_branches(
 	const char *ours_name, const char *theirs_name,
 	git_merge_tree_opts *opts);
 
+int merge_commits_from_branches(
+	git_index **index, git_repository *repo,
+	const char *ours_name, const char *theirs_name,
+	git_merge_tree_opts *opts);
+
 int merge_branches(git_merge_result **result, git_repository *repo,
 	const char *ours_branch, const char *theirs_branch, git_merge_opts *opts);
 

--- a/tests/merge/trees/commits.c
+++ b/tests/merge/trees/commits.c
@@ -1,0 +1,164 @@
+#include "clar_libgit2.h"
+#include "git2/repository.h"
+#include "git2/merge.h"
+#include "merge.h"
+#include "../merge_helpers.h"
+
+static git_repository *repo;
+
+#define TEST_REPO_PATH "merge-resolve"
+
+#define AUTOMERGEABLE_MERGED_FILE \
+	"this file is changed in master\n" \
+	"this file is automergeable\n" \
+	"this file is automergeable\n" \
+	"this file is automergeable\n" \
+	"this file is automergeable\n" \
+	"this file is automergeable\n" \
+	"this file is automergeable\n" \
+	"this file is automergeable\n" \
+	"this file is changed in branch\n"
+
+void test_merge_trees_commits__initialize(void)
+{
+	repo = cl_git_sandbox_init(TEST_REPO_PATH);
+}
+
+void test_merge_trees_commits__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+static void merge_commits(
+	git_index **out,
+	git_repository *repo,
+	const char *our_oidstr,
+	const char *their_oidstr,
+	const git_merge_tree_opts *opts)
+{
+	git_oid our_oid, their_oid;
+	git_commit *our_commit, *their_commit;
+
+	cl_git_pass(git_oid_fromstr(&our_oid, our_oidstr));
+	cl_git_pass(git_oid_fromstr(&their_oid, their_oidstr));
+
+	cl_git_pass(git_commit_lookup(&our_commit, repo, &our_oid));
+	cl_git_pass(git_commit_lookup(&their_commit, repo, &their_oid));
+
+	cl_git_pass(git_merge_commits(out, repo, our_commit, their_commit, opts));
+
+	git_commit_free(our_commit);
+	git_commit_free(their_commit);
+}
+
+void test_merge_trees_commits__automerge(void)
+{
+	git_index *index;
+	const git_index_entry *entry;
+	git_merge_tree_opts opts = GIT_MERGE_TREE_OPTS_INIT;
+	git_blob *blob;
+
+	struct merge_index_entry merge_index_entries[] = {
+		{ 0100644, "233c0919c998ed110a4b6ff36f353aec8b713487", 0,  "added-in-master.txt" },
+		{ 0100644, "f2e1550a0c9e53d5811175864a29536642ae3821", 0,  "automergeable.txt" },
+		{ 0100644, "4eb04c9e79e88f6640d01ff5b25ca2a60764f216", 0,  "changed-in-branch.txt" },
+		{ 0100644, "11deab00b2d3a6f5a3073988ac050c2d7b6655e2", 0,  "changed-in-master.txt" },
+
+		{ 0100644, "d427e0b2e138501a3d15cc376077a3631e15bd46", 1, "conflicting.txt" },
+		{ 0100644, "4e886e602529caa9ab11d71f86634bd1b6e0de10", 2, "conflicting.txt" },
+		{ 0100644, "2bd0a343aeef7a2cf0d158478966a6e587ff3863", 3, "conflicting.txt" },
+
+		{ 0100644, "c8f06f2e3bb2964174677e91f0abead0e43c9e5d", 0,  "unchanged.txt" },
+	};
+
+	struct merge_reuc_entry merge_reuc_entries[] = {
+		{ "automergeable.txt", 0100644, 0100644, 0100644, \
+			"6212c31dab5e482247d7977e4f0dd3601decf13b", \
+			"ee3fa1b8c00aff7fe02065fdb50864bb0d932ccf", \
+			"058541fc37114bfc1dddf6bd6bffc7fae5c2e6fe" },
+		{ "removed-in-branch.txt", 0100644, 0100644, 0, \
+			"dfe3f22baa1f6fce5447901c3086bae368de6bdd", \
+			"dfe3f22baa1f6fce5447901c3086bae368de6bdd", \
+			"" },
+		{ "removed-in-master.txt", 0100644, 0, 0100644, \
+			"5c3b68a71fc4fa5d362fd3875e53137c6a5ab7a5", \
+			"", \
+			"5c3b68a71fc4fa5d362fd3875e53137c6a5ab7a5" },
+	};
+
+	cl_git_pass(merge_commits_from_branches(&index, repo, "master", "branch", &opts));
+
+	cl_assert(merge_test_index(index, merge_index_entries, 8));
+	cl_assert(merge_test_reuc(index, merge_reuc_entries, 3));
+
+	cl_assert((entry = git_index_get_bypath(index, "automergeable.txt", 0)) != NULL);
+	cl_assert(entry->file_size == strlen(AUTOMERGEABLE_MERGED_FILE));
+
+	cl_git_pass(git_object_lookup((git_object **)&blob, repo, &entry->oid, GIT_OBJ_BLOB));
+	cl_assert(memcmp(git_blob_rawcontent(blob), AUTOMERGEABLE_MERGED_FILE, (size_t)entry->file_size) == 0);
+
+	git_index_free(index);
+	git_blob_free(blob);
+}
+
+void test_merge_trees_commits__no_ancestor(void)
+{
+	git_index *index;
+	git_merge_tree_opts opts = GIT_MERGE_TREE_OPTS_INIT;
+
+	struct merge_index_entry merge_index_entries[] = {
+		{ 0100644, "233c0919c998ed110a4b6ff36f353aec8b713487", 0, "added-in-master.txt" },
+		{ 0100644, "ee3fa1b8c00aff7fe02065fdb50864bb0d932ccf", 2, "automergeable.txt" },
+		{ 0100644, "d07ec190c306ec690bac349e87d01c4358e49bb2", 3, "automergeable.txt" },
+		{ 0100644, "ab6c44a2e84492ad4b41bb6bac87353e9d02ac8b", 0, "changed-in-branch.txt" },
+		{ 0100644, "11deab00b2d3a6f5a3073988ac050c2d7b6655e2", 0, "changed-in-master.txt" },
+		{ 0100644, "4e886e602529caa9ab11d71f86634bd1b6e0de10", 2, "conflicting.txt" },
+		{ 0100644, "4b253da36a0ae8bfce63aeabd8c5b58429925594", 3, "conflicting.txt" },
+		{ 0100644, "ef58fdd8086c243bdc81f99e379acacfd21d32d6", 0, "new-in-unrelated1.txt" },
+		{ 0100644, "948ba6e701c1edab0c2d394fb7c5538334129793", 0, "new-in-unrelated2.txt" },
+		{ 0100644, "dfe3f22baa1f6fce5447901c3086bae368de6bdd", 0, "removed-in-branch.txt" },
+		{ 0100644, "c8f06f2e3bb2964174677e91f0abead0e43c9e5d", 0, "unchanged.txt" },
+	};
+
+	cl_git_pass(merge_commits_from_branches(&index, repo, "master", "unrelated", &opts));
+
+	cl_assert(merge_test_index(index, merge_index_entries, 11));
+
+	git_index_free(index);
+}
+
+
+void test_merge_trees_commits__df_conflict(void)
+{
+	git_index *index;
+	git_merge_tree_opts opts = GIT_MERGE_TREE_OPTS_INIT;
+
+	struct merge_index_entry merge_index_entries[] = {
+		{ 0100644, "49130a28ef567af9a6a6104c38773fedfa5f9742", 2, "dir-10" },
+		{ 0100644, "6c06dcd163587c2cc18be44857e0b71116382aeb", 3, "dir-10" },
+		{ 0100644, "43aafd43bea779ec74317dc361f45ae3f532a505", 0, "dir-6" },
+		{ 0100644, "a031a28ae70e33a641ce4b8a8f6317f1ab79dee4", 3, "dir-7" },
+		{ 0100644, "5012fd565b1393bdfda1805d4ec38ce6619e1fd1", 1, "dir-7/file.txt" },
+		{ 0100644, "a5563304ddf6caba25cb50323a2ea6f7dbfcadca", 2, "dir-7/file.txt" },
+		{ 0100644, "e9ad6ec3e38364a3d07feda7c4197d4d845c53b5", 0, "dir-8" },
+		{ 0100644, "3ef4d30382ca33fdeba9fda895a99e0891ba37aa", 2, "dir-9" },
+		{ 0100644, "fc4c636d6515e9e261f9260dbcf3cc6eca97ea08", 1, "dir-9/file.txt" },
+		{ 0100644, "76ab0e2868197ec158ddd6c78d8a0d2fd73d38f9", 3, "dir-9/file.txt" },
+		{ 0100644, "5c2411f8075f48a6b2fdb85ebc0d371747c4df15", 0, "file-1/new" },
+		{ 0100644, "a39a620dae5bc8b4e771cd4d251b7d080401a21e", 1, "file-2" },
+		{ 0100644, "d963979c237d08b6ba39062ee7bf64c7d34a27f8", 2, "file-2" },
+		{ 0100644, "5c341ead2ba6f2af98ce5ec3fe84f6b6d2899c0d", 0, "file-2/new" },
+		{ 0100644, "9efe7723802d4305142eee177e018fee1572c4f4", 0, "file-3/new" },
+		{ 0100644, "bacac9b3493509aa15e1730e1545fc0919d1dae0", 1, "file-4" },
+		{ 0100644, "7663fce0130db092936b137cabd693ec234eb060", 3, "file-4" },
+		{ 0100644, "e49f917b448d1340b31d76e54ba388268fd4c922", 0, "file-4/new" },
+		{ 0100644, "cab2cf23998b40f1af2d9d9a756dc9e285a8df4b", 2, "file-5/new" },
+		{ 0100644, "f5504f36e6f4eb797a56fc5bac6c6c7f32969bf2", 3, "file-5/new" },
+	};
+
+	cl_git_pass(merge_trees_from_branches(&index, repo, "df_side1", "df_side2", &opts));
+
+	cl_assert(merge_test_index(index, merge_index_entries, 20));
+
+	git_index_free(index);
+}

--- a/tests/revert/bare.c
+++ b/tests/revert/bare.c
@@ -1,0 +1,107 @@
+#include "clar.h"
+#include "clar_libgit2.h"
+
+#include "buffer.h"
+#include "fileops.h"
+#include "git2/revert.h"
+
+#include "../merge/merge_helpers.h"
+
+#define TEST_REPO_PATH "revert"
+
+static git_repository *repo;
+
+// Fixture setup and teardown
+void test_revert_bare__initialize(void)
+{
+	repo = cl_git_sandbox_init(TEST_REPO_PATH);
+}
+
+void test_revert_bare__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_revert_bare__automerge(void)
+{
+	git_commit *head_commit, *revert_commit;
+	git_oid head_oid, revert_oid;
+	git_index *index;
+
+	struct merge_index_entry merge_index_entries[] = {
+		{ 0100644, "caf99de3a49827117bb66721010eac461b06a80c", 0, "file1.txt" },
+		{ 0100644, "0ab09ea6d4c3634bdf6c221626d8b6f7dd890767", 0, "file2.txt" },
+		{ 0100644, "f4e107c230d08a60fb419d19869f1f282b272d9c", 0, "file3.txt" },
+		{ 0100644, "0f5bfcf58c558d865da6be0281d7795993646cee", 0, "file6.txt" },
+	};
+
+	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
+	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_oid));
+
+	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
+	cl_git_pass(git_commit_lookup(&revert_commit, repo, &revert_oid));
+
+	cl_git_pass(git_revert_commit(&index, repo, revert_commit, head_commit, 0, NULL));
+	cl_assert(merge_test_index(index, merge_index_entries, 4));
+
+	git_commit_free(revert_commit);
+	git_commit_free(head_commit);
+	git_index_free(index);
+}
+
+void test_revert_bare__conflicts(void)
+{
+	git_reference *head_ref;
+	git_commit *head_commit, *revert_commit;
+	git_oid revert_oid;
+	git_index *index;
+
+	struct merge_index_entry merge_index_entries[] = {
+		{ 0100644, "7731926a337c4eaba1e2187d90ebfa0a93659382", 1, "file1.txt" },
+		{ 0100644, "4b8fcff56437e60f58e9a6bc630dd242ebf6ea2c", 2, "file1.txt" },
+		{ 0100644, "3a3ef367eaf3fe79effbfb0a56b269c04c2b59fe", 3, "file1.txt" },
+		{ 0100644, "0ab09ea6d4c3634bdf6c221626d8b6f7dd890767", 0, "file2.txt" },
+		{ 0100644, "f4e107c230d08a60fb419d19869f1f282b272d9c", 0, "file3.txt" },
+		{ 0100644, "0f5bfcf58c558d865da6be0281d7795993646cee", 0, "file6.txt" },
+	};
+
+	git_oid_fromstr(&revert_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
+
+	cl_git_pass(git_repository_head(&head_ref, repo));
+	cl_git_pass(git_reference_peel((git_object **)&head_commit, head_ref, GIT_OBJ_COMMIT));
+
+	cl_git_pass(git_commit_lookup(&revert_commit, repo, &revert_oid));
+	cl_git_pass(git_revert_commit(&index, repo, revert_commit, head_commit, 0, NULL));
+
+	cl_assert(git_index_has_conflicts(index));
+	cl_assert(merge_test_index(index, merge_index_entries, 6));
+
+	git_commit_free(revert_commit);
+	git_commit_free(head_commit);
+	git_reference_free(head_ref);
+	git_index_free(index);
+}
+
+void test_revert_bare__orphan(void)
+{
+	git_commit *head_commit, *revert_commit;
+	git_oid head_oid, revert_oid;
+	git_index *index;
+
+	struct merge_index_entry merge_index_entries[] = {
+		{ 0100644, "296a6d3be1dff05c5d1f631d2459389fa7b619eb", 0, "file-mainline.txt" },
+	};
+
+	git_oid_fromstr(&head_oid, "39467716290f6df775a91cdb9a4eb39295018145");
+	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_oid));
+
+	git_oid_fromstr(&revert_oid, "ebb03002cee5d66c7732dd06241119fe72ab96a5");
+	cl_git_pass(git_commit_lookup(&revert_commit, repo, &revert_oid));
+
+	cl_git_pass(git_revert_commit(&index, repo, revert_commit, head_commit, 0, NULL));
+	cl_assert(merge_test_index(index, merge_index_entries, 1));
+
+	git_commit_free(revert_commit);
+	git_commit_free(head_commit);
+	git_index_free(index);
+}

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -13,13 +13,13 @@ static git_repository *repo;
 static git_index *repo_index;
 
 // Fixture setup and teardown
-void test_revert_revert__initialize(void)
+void test_revert_workdir__initialize(void)
 {
 	repo = cl_git_sandbox_init(TEST_REPO_PATH);
 	git_repository_index(&repo_index, repo);
 }
 
-void test_revert_revert__cleanup(void)
+void test_revert_workdir__cleanup(void)
 {
 	git_index_free(repo_index);
 	cl_git_sandbox_cleanup();
@@ -27,7 +27,7 @@ void test_revert_revert__cleanup(void)
 
 /* git reset --hard 72333f47d4e83616630ff3b0ffe4c0faebcc3c45
  * git revert --no-commit d1d403d22cbe24592d725f442835cf46fe60c8ac */
-void test_revert_revert__automerge(void)
+void test_revert_workdir__automerge(void)
 {
 	git_commit *head, *commit;
 	git_oid head_oid, revert_oid;
@@ -54,7 +54,7 @@ void test_revert_revert__automerge(void)
 }
 
 /* git revert --no-commit 72333f47d4e83616630ff3b0ffe4c0faebcc3c45 */
-void test_revert_revert__conflicts(void)
+void test_revert_workdir__conflicts(void)
 {
 	git_reference *head_ref;
 	git_commit *head, *commit;
@@ -114,7 +114,7 @@ void test_revert_revert__conflicts(void)
 /* git reset --hard 39467716290f6df775a91cdb9a4eb39295018145
  * git revert --no-commit ebb03002cee5d66c7732dd06241119fe72ab96a5
 */
-void test_revert_revert__orphan(void)
+void test_revert_workdir__orphan(void)
 {
 	git_commit *head, *commit;
 	git_oid head_oid, revert_oid;
@@ -139,7 +139,7 @@ void test_revert_revert__orphan(void)
 
 /* git reset --hard 72333f47d4e83616630ff3b0ffe4c0faebcc3c45
  * git revert --no-commit d1d403d22cbe24592d725f442835cf46fe60c8ac */
-void test_revert_revert__conflict_use_ours(void)
+void test_revert_workdir__conflict_use_ours(void)
 {
 	git_commit *head, *commit;
 	git_oid head_oid, revert_oid;
@@ -182,7 +182,7 @@ void test_revert_revert__conflict_use_ours(void)
 /* git reset --hard cef56612d71a6af8d8015691e4865f7fece905b5
  * git revert --no-commit 55568c8de5322ff9a95d72747a239cdb64a19965
  */
-void test_revert_revert__rename_1_of_2(void)
+void test_revert_workdir__rename_1_of_2(void)
 {
 	git_commit *head, *commit;
 	git_oid head_oid, revert_oid;
@@ -216,7 +216,7 @@ void test_revert_revert__rename_1_of_2(void)
 
 /* git reset --hard 55568c8de5322ff9a95d72747a239cdb64a19965
  * git revert --no-commit HEAD~1 */
-void test_revert_revert__rename(void)
+void test_revert_workdir__rename(void)
 {
 	git_commit *head, *commit;
 	git_oid head_oid, revert_oid;
@@ -250,7 +250,7 @@ void test_revert_revert__rename(void)
 }
 
 /* git revert --no-commit HEAD */
-void test_revert_revert__head(void)
+void test_revert_workdir__head(void)
 {
 	git_reference *head;
 	git_commit *commit;
@@ -275,7 +275,7 @@ void test_revert_revert__head(void)
 	git_commit_free(commit);
 }
 
-void test_revert_revert__nonmerge_fails_mainline_specified(void)
+void test_revert_workdir__nonmerge_fails_mainline_specified(void)
 {
 	git_reference *head;
 	git_commit *commit;
@@ -295,7 +295,7 @@ void test_revert_revert__nonmerge_fails_mainline_specified(void)
 
 /* git reset --hard 5acdc74af27172ec491d213ee36cea7eb9ef2579
  * git revert HEAD */
-void test_revert_revert__merge_fails_without_mainline_specified(void)
+void test_revert_workdir__merge_fails_without_mainline_specified(void)
 {
 	git_commit *head;
 	git_oid head_oid;
@@ -313,7 +313,7 @@ void test_revert_revert__merge_fails_without_mainline_specified(void)
 
 /* git reset --hard 5acdc74af27172ec491d213ee36cea7eb9ef2579
  * git revert HEAD -m1 --no-commit */
-void test_revert_revert__merge_first_parent(void)
+void test_revert_workdir__merge_first_parent(void)
 {
 	git_commit *head;
 	git_oid head_oid;
@@ -338,7 +338,7 @@ void test_revert_revert__merge_first_parent(void)
 	git_commit_free(head);
 }
 
-void test_revert_revert__merge_second_parent(void)
+void test_revert_workdir__merge_second_parent(void)
 {
 	git_commit *head;
 	git_oid head_oid;


### PR DESCRIPTION
Add `revert_commit` and `merge_commits` that are lovely helper methods that provide revert and merge support for bare repositories.
