### PR TITLE
Update bswap.h

### DIFF
--- a/src/bswap.h
+++ b/src/bswap.h
@@ -76,6 +76,10 @@ GIT_INLINE(uint16_t) default_swab16(uint16_t val)
 #define bswap32(x) _byteswap_ulong(x)
 #define bswap16(x) _byteswap_ushort(x)
 
+#else
+
+#include <arpa/inet.h>
+
 #endif
 
 #ifdef bswap32


### PR DESCRIPTION
Add htonl() and friends declarations on non-x86 arches.
