### PR TITLE
Clean up warnings

### DIFF
--- a/deps/regex/regex.c
+++ b/deps/regex/regex.c
@@ -67,10 +67,17 @@
 #include "regex_internal.h"
 
 #include "regex_internal.c"
+
 #ifdef GAWK
-#define bool int
-#define true (1)
-#define false (0)
+# define bool int
+
+# ifndef true
+#  define true (1)
+# endif
+
+# ifndef false
+#  define false (0)
+# endif
 #endif
 #include "regcomp.c"
 #include "regexec.c"

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -7,10 +7,11 @@
 #ifndef INCLUDE_buffer_h__
 #define INCLUDE_buffer_h__
 
+#include <stdarg.h>
+
 #include "common.h"
 #include "git2/strarray.h"
 #include "git2/buffer.h"
-#include <stdarg.h>
 
 /* typedef struct {
  *  	char   *ptr;

--- a/src/common.h
+++ b/src/common.h
@@ -42,6 +42,8 @@
 # endif
 #define GIT_STDLIB_CALL
 
+# include <arpa/inet.h>
+
 #endif
 
 #include "git2/types.h"

--- a/src/merge.c
+++ b/src/merge.c
@@ -2306,8 +2306,8 @@ done:
 
 int git_merge__indexes(git_repository *repo, git_index *index_new)
 {
-	git_index *index_repo;
-	unsigned int index_repo_caps;
+	git_index *index_repo = NULL;
+	unsigned int index_repo_caps = 0;
 	git_vector paths = GIT_VECTOR_INIT;
 	size_t index_conflicts = 0, wd_conflicts = 0, conflicts, i;
 	char *path;

--- a/src/revert.c
+++ b/src/revert.c
@@ -20,14 +20,11 @@
 
 static int write_revert_head(
 	git_repository *repo,
-	const git_commit *commit,
 	const char *commit_oidstr)
 {
 	git_filebuf file = GIT_FILEBUF_INIT;
 	git_buf file_path = GIT_BUF_INIT;
 	int error = 0;
-
-	assert(repo && commit);
 
 	if ((error = git_buf_joinpath(&file_path, repo->path_repository, GIT_REVERT_HEAD_FILE)) >= 0 &&
 		(error = git_filebuf_open(&file, file_path.ptr, GIT_FILEBUF_FORCE, GIT_REVERT_FILE_MODE)) >= 0 &&
@@ -44,15 +41,12 @@ static int write_revert_head(
 
 static int write_merge_msg(
 	git_repository *repo,
-	const git_commit *commit,
 	const char *commit_oidstr,
 	const char *commit_msgline)
 {
 	git_filebuf file = GIT_FILEBUF_INIT;
 	git_buf file_path = GIT_BUF_INIT;
 	int error = 0;
-
-	assert(repo && commit);
 
 	if ((error = git_buf_joinpath(&file_path, repo->path_repository, GIT_MERGE_MSG_FILE)) < 0 ||
 		(error = git_filebuf_open(&file, file_path.ptr, GIT_FILEBUF_FORCE, GIT_REVERT_FILE_MODE)) < 0 ||
@@ -198,8 +192,8 @@ int git_revert(
 
 	if ((error = git_buf_printf(&their_label, "parent of %.7s... %s", commit_oidstr, commit_msg)) < 0 ||
 		(error = revert_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0 ||
-		(error = write_revert_head(repo, commit, commit_oidstr)) < 0 ||
-		(error = write_merge_msg(repo, commit, commit_oidstr, commit_msg)) < 0 ||
+		(error = write_revert_head(repo, commit_oidstr)) < 0 ||
+		(error = write_merge_msg(repo, commit_oidstr, commit_msg)) < 0 ||
 		(error = git_repository_head(&our_ref, repo)) < 0 ||
 		(error = git_reference_peel((git_object **)&our_commit, our_ref, GIT_OBJ_COMMIT)) < 0 ||
 		(error = git_revert_commit(&index_new, repo, commit, our_commit, opts.mainline, &opts.merge_tree_opts)) < 0 ||

--- a/src/win32/precompiled.h
+++ b/src/win32/precompiled.h
@@ -1,6 +1,3 @@
-#include "git2.h"
-#include "common.h"
-
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
@@ -9,6 +6,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <time.h>
+#include <stdarg.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -20,3 +18,6 @@
 #ifdef GIT_THREADS
  #include "win32/pthread.h"
 #endif
+
+#include "git2.h"
+#include "common.h"

--- a/tests/blame/harder.c
+++ b/tests/blame/harder.c
@@ -36,6 +36,8 @@ void test_blame_harder__m(void)
 	/* TODO */
 	git_blame_options opts = GIT_BLAME_OPTIONS_INIT;
 
+	GIT_UNUSED(opts);
+
 	opts.flags = GIT_BLAME_TRACK_COPIES_SAME_FILE;
 }
 
@@ -43,6 +45,8 @@ void test_blame_harder__m(void)
 void test_blame_harder__c(void)
 {
 	git_blame_options opts = GIT_BLAME_OPTIONS_INIT;
+
+	GIT_UNUSED(opts);
 
 	/* Attribute the first hunk in b.txt to (E), since it was cut/pasted from
 	 * a.txt in (D).
@@ -54,6 +58,8 @@ void test_blame_harder__cc(void)
 {
 	git_blame_options opts = GIT_BLAME_OPTIONS_INIT;
 
+	GIT_UNUSED(opts);
+
 	/* Attribute the second hunk in b.txt to (E), since it was copy/pasted from
 	 * a.txt in (C).
 	 */
@@ -63,6 +69,8 @@ void test_blame_harder__cc(void)
 void test_blame_harder__ccc(void)
 {
 	git_blame_options opts = GIT_BLAME_OPTIONS_INIT;
+
+	GIT_UNUSED(opts);
 	
 	/* Attribute the third hunk in b.txt to (E).  This hunk was deleted from
 	 * a.txt in (D), but reintroduced in (B).

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -60,7 +60,6 @@ int merge_commits_from_branches(
 	git_commit *our_commit, *their_commit;
 	git_oid our_oid, their_oid;
 	git_buf branch_buf = GIT_BUF_INIT;
-	int error;
 
 	git_buf_printf(&branch_buf, "%s%s", GIT_REFS_HEADS_DIR, ours_name);
 	cl_git_pass(git_reference_name_to_id(&our_oid, repo, branch_buf.ptr));

--- a/tests/merge/trees/commits.c
+++ b/tests/merge/trees/commits.c
@@ -29,28 +29,6 @@ void test_merge_trees_commits__cleanup(void)
 	cl_git_sandbox_cleanup();
 }
 
-static void merge_commits(
-	git_index **out,
-	git_repository *repo,
-	const char *our_oidstr,
-	const char *their_oidstr,
-	const git_merge_tree_opts *opts)
-{
-	git_oid our_oid, their_oid;
-	git_commit *our_commit, *their_commit;
-
-	cl_git_pass(git_oid_fromstr(&our_oid, our_oidstr));
-	cl_git_pass(git_oid_fromstr(&their_oid, their_oidstr));
-
-	cl_git_pass(git_commit_lookup(&our_commit, repo, &our_oid));
-	cl_git_pass(git_commit_lookup(&their_commit, repo, &their_oid));
-
-	cl_git_pass(git_merge_commits(out, repo, our_commit, their_commit, opts));
-
-	git_commit_free(our_commit);
-	git_commit_free(their_commit);
-}
-
 void test_merge_trees_commits__automerge(void)
 {
 	git_index *index;

--- a/tests/refs/branches/create.c
+++ b/tests/refs/branches/create.c
@@ -74,3 +74,4 @@ void test_refs_branches_create__creating_a_branch_with_an_invalid_name_returns_E
 	cl_assert_equal_i(GIT_EINVALIDSPEC,
 		git_branch_create(&branch, repo, "inv@{id", target, 0));
 }
+


### PR DESCRIPTION
Clean up some warnings:
- `hton*` not declared when not using `bswap.h`
- Unused variable removed
- Unused function removed
- No newline at end of `tests/refs/branches/create.c`
- Include `stdarg.h` before trying to redefine `va_copy`
- Added `GIT_UNUSED` in the blame harder tests
