### PR TITLE
Generate cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,32 @@ IF (SONAME)
 ENDIF()
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libgit2.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libgit2.pc @ONLY)
 
+
+# Create LibGit2Config.cmake which makes it trivial to use libgit2 with cmake
+IF (${CMAKE_VERSION} VERSION_GREATER "2.8.8")
+    INCLUDE(CMakePackageConfigHelpers)
+    # Write LibGit2ConfigVersion.cmake
+    WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_BINARY_DIR}/LIBGIT2CONFIGVERSION.CMAKE
+                                    VERSION ${LIBGIT2_VERSION_STRING}
+                                    COMPATIBILITY SameMajorVersion
+    )
+    # Create the CMake Config files
+    CONFIGURE_PACKAGE_CONFIG_FILE(LibGit2Config.cmake.in
+                                ${CMAKE_BINARY_DIR}/LibGit2Config.cmake
+                                INSTALL_DESTINATION ${LIB_INSTALL_DIR}/cmake/LibGit2
+                                PATH_VARS LIB_INSTALL_DIR INCLUDE_INSTALL_DIR
+    )
+    INSTALL(FILES ${CMAKE_BINARY_DIR}/LibGit2Config.cmake
+                ${CMAKE_BINARY_DIR}/LibGit2ConfigVersion.cmake
+            DESTINATION ${LIB_INSTALL_DIR}/cmake/LibGit2
+    )
+    INSTALL(EXPORT LibGit2Export FILE LibGit2Targets.cmake
+            DESTINATION ${LIB_INSTALL_DIR}/cmake/LibGit2
+            NAMESPACE LibGit2::
+    )
+ENDIF()
+
+
 IF (MSVC_IDE)
    # Precompiled headers
    SET_TARGET_PROPERTIES(git2 PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h /FIprecompiled.h")
@@ -391,7 +417,7 @@ IF (MSVC_IDE)
 ENDIF ()
 
 # Install
-INSTALL(TARGETS git2
+INSTALL(TARGETS git2 EXPORT LibGit2Export
 	RUNTIME DESTINATION ${BIN_INSTALL_DIR}
 	LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 	ARCHIVE DESTINATION ${LIB_INSTALL_DIR}

--- a/LibGit2Config.cmake.in
+++ b/LibGit2Config.cmake.in
@@ -1,0 +1,33 @@
+@PACKAGE_INIT@
+
+# Config file for LibGit2
+# The following variables are defined:
+# LibGit2_FOUND        - True if LibGit2 has been found.
+# LibGit2_INCLUDE_DIRS - The include directory.
+# LibGit2_LIBRARY_DIRS - The libraries directory.
+# LibGit2_LIBRARIES    - Libraries needed to use Git2.
+
+########## The LibGit2 version ##########
+set(LibGit2_VERSION_MAJOR @LIBGIT2_VERSION_MAJOR@)
+set(LibGit2_VERSION_MINOR @LIBGIT2_VERSION_MINOR@)
+set(LibGit2_VERSION_PATCH @LIBGIT2_VERSION_REV@)
+set(LibGit2_VERSION       @LIBGIT2_VERSION_STRING@)
+#########################################
+
+########## Install dirs ##########
+set_and_check(LibGit2_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set_and_check(LibGit2_LIBRARY_DIRS "@PACKAGE_LIB_INSTALL_DIR@")
+##################################
+
+########## The LibGit2 libraries ##########
+# Load the exported targets.
+include("${CMAKE_CURRENT_LIST_DIR}/LibGit2Targets.cmake")
+set(LibGit2_LIBRARIES        LibGit2::git2)
+###########################################
+
+# The following variables are kept for compatibility purpose
+set(LIBGIT2_INCLUDE_DIR ${LibGit2_INCLUDE_DIRS})
+set(LIBGIT2_LIBRARY_DIRS ${LibGit2_LIBRARY_DIRS})
+set(LIBGIT2_FOUND ${LibGit2_FOUND})
+set(LIBGIT2_LIBRARIES ${LibGit2_LIBRARIES})
+


### PR DESCRIPTION
With this using libgit2 from cmake becomes trivial.
It is then enough to use find_package(LibGit2) without any Find*.cmake
files.
