### PR TITLE
Function-based options initializers

### DIFF
--- a/include/git2/blame.h
+++ b/include/git2/blame.h
@@ -83,6 +83,19 @@ typedef struct git_blame_options {
 #define GIT_BLAME_OPTIONS_INIT {GIT_BLAME_OPTIONS_VERSION}
 
 /**
+* Initializes a `git_blame_options` with default values. Equivalent to
+* creating an instance with GIT_BLAME_OPTIONS_INIT.
+*
+* @param opts the `git_blame_options` instance to initialize.
+* @param version the version of the struct; you should pass
+* `GIT_BLAME_OPTIONS_VERSION` here.
+* @return Zero on success; -1 on failure.
+*/
+GIT_EXTERN(int) git_blame_init_options(
+	git_blame_options* opts,
+	int version);
+
+/**
  * Structure that represents a blame hunk.
  *
  * - `lines_in_hunk` is the number of lines in this hunk

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -267,6 +267,19 @@ typedef struct git_checkout_opts {
 #define GIT_CHECKOUT_OPTS_INIT {GIT_CHECKOUT_OPTS_VERSION}
 
 /**
+* Initializes a `git_checkout_opts` with default values. Equivalent to
+* creating an instance with GIT_CHECKOUT_OPTS_INIT.
+*
+* @param opts the `git_checkout_opts` instance to initialize.
+* @param version the version of the struct; you should pass
+* `GIT_CHECKOUT_OPTS_VERSION` here.
+* @return Zero on success; -1 on failure.
+*/
+GIT_EXTERN(int) git_checkout_init_opts(
+	git_checkout_opts* opts,
+	int version);
+
+/**
  * Updates files in the index and the working tree to match the content of
  * the commit pointed at by HEAD.
  *

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -66,6 +66,19 @@ typedef struct git_clone_options {
 #define GIT_CLONE_OPTIONS_INIT {GIT_CLONE_OPTIONS_VERSION, {GIT_CHECKOUT_OPTS_VERSION, GIT_CHECKOUT_SAFE_CREATE}, GIT_REMOTE_CALLBACKS_INIT}
 
 /**
+* Initializes a `git_clone_options` with default values. Equivalent to
+* creating an instance with GIT_CLONE_OPTIONS_INIT.
+*
+* @param opts the `git_clone_options` instance to initialize.
+* @param version the version of the struct; you should pass
+* `GIT_CLONE_OPTIONS_VERSION` here.
+* @return Zero on success; -1 on failure.
+*/
+GIT_EXTERN(int) git_clone_init_options(
+	git_clone_options* opts,
+	int version);
+
+/**
  * Clone a remote repository.
  *
  * This version handles the simple case. If you'd like to create the

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -377,6 +377,19 @@ typedef struct {
 	{GIT_DIFF_OPTIONS_VERSION, 0, GIT_SUBMODULE_IGNORE_DEFAULT, {NULL,0}, NULL, NULL, 3}
 
 /**
+* Initializes a `git_diff_options` with default values. Equivalent to
+* creating an instance with GIT_DIFF_OPTIONS_INIT.
+*
+* @param opts the `git_diff_options` instance to initialize.
+* @param version the version of the struct; you should pass
+* `GIT_DIFF_OPTIONS_VERSION` here.
+* @return Zero on success; -1 on failure.
+*/
+GIT_EXTERN(int) git_diff_init_options(
+	git_diff_options* opts,
+	int version);
+
+/**
  * When iterating over a diff, callback that will be made per file.
  *
  * @param delta A pointer to the delta data for the file
@@ -603,6 +616,19 @@ typedef struct {
 
 #define GIT_DIFF_FIND_OPTIONS_VERSION 1
 #define GIT_DIFF_FIND_OPTIONS_INIT {GIT_DIFF_FIND_OPTIONS_VERSION}
+
+/**
+* Initializes a `git_diff_find_options` with default values. Equivalent to
+* creating an instance with GIT_DIFF_FIND_OPTIONS_INIT.
+*
+* @param opts the `git_diff_find_options` instance to initialize.
+* @param version the version of the struct; you should pass
+* `GIT_DIFF_FIND_OPTIONS_VERSION` here.
+* @return Zero on success; -1 on failure.
+*/
+GIT_EXTERN(int) git_diff_find_init_options(
+	git_diff_find_options* opts,
+	int version);
 
 /** @name Diff Generator Functions
  *

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -104,6 +104,18 @@ typedef struct {
 #define GIT_MERGE_TREE_OPTS_VERSION 1
 #define GIT_MERGE_TREE_OPTS_INIT {GIT_MERGE_TREE_OPTS_VERSION}
 
+/**
+ * Initializes a `git_merge_tree_opts` with default values. Equivalent to
+ * creating an instance with GIT_MERGE_TREE_OPTS_INIT.
+ *
+ * @param opts the `git_merge_tree_opts` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_MERGE_TREE_OPTS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_merge_tree_init_opts(
+	git_merge_tree_opts* opts,
+	int version);
 
 /**
  * Option flags for `git_merge`.
@@ -144,6 +156,18 @@ typedef struct {
 #define GIT_MERGE_OPTS_VERSION 1
 #define GIT_MERGE_OPTS_INIT {GIT_MERGE_OPTS_VERSION, 0, GIT_MERGE_TREE_OPTS_INIT, GIT_CHECKOUT_OPTS_INIT}
 
+/**
+ * Initializes a `git_merge_opts` with default values. Equivalent to creating
+ * an instance with GIT_MERGE_OPTS_INIT.
+ *
+ * @param opts the `git_merge_opts` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_MERGE_OPTS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_merge_init_opts(
+	git_merge_opts* opts,
+	int version);
 
 /**
  * Find a merge base between two commits

--- a/include/git2/push.h
+++ b/include/git2/push.h
@@ -39,6 +39,19 @@ typedef struct {
 #define GIT_PUSH_OPTIONS_VERSION 1
 #define GIT_PUSH_OPTIONS_INIT { GIT_PUSH_OPTIONS_VERSION }
 
+/**
+ * Initializes a `git_push_options` with default values. Equivalent to
+ * creating an instance with GIT_PUSH_OPTIONS_INIT.
+ *
+ * @param opts the `git_push_options` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_PUSH_OPTIONS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_push_init_options(
+	git_push_options* opts,
+	int version);
+
 /** Push network progress notification function */
 typedef int (*git_push_transfer_progress)(
 	unsigned int current,

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -495,6 +495,19 @@ struct git_remote_callbacks {
 #define GIT_REMOTE_CALLBACKS_INIT {GIT_REMOTE_CALLBACKS_VERSION}
 
 /**
+ * Initializes a `git_remote_callbacks` with default values. Equivalent to
+ * creating an instance with GIT_REMOTE_CALLBACKS_INIT.
+ *
+ * @param opts the `git_remote_callbacks` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_REMOTE_CALLBACKS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_remote_init_callbacks(
+	git_remote_callbacks* opts,
+	int version);
+
+/**
  * Set the callbacks for a remote
  *
  * Note that the remote keeps its own copy of the data and you need to

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -268,6 +268,19 @@ typedef struct {
 #define GIT_REPOSITORY_INIT_OPTIONS_INIT {GIT_REPOSITORY_INIT_OPTIONS_VERSION}
 
 /**
+ * Initializes a `git_repository_init_options` with default values. Equivalent
+ * to creating an instance with GIT_REPOSITORY_INIT_OPTIONS_INIT.
+ *
+ * @param opts the `git_repository_init_options` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_REPOSITORY_INIT_OPTIONS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_repository_init_init_options(
+	git_repository_init_options* opts,
+	int version);
+
+/**
  * Create a new Git repository in the given folder with extended controls.
  *
  * This will initialize a new git repository (creating the repo_path

--- a/include/git2/revert.h
+++ b/include/git2/revert.h
@@ -34,6 +34,19 @@ typedef struct {
 #define GIT_REVERT_OPTS_INIT {GIT_REVERT_OPTS_VERSION, 0, GIT_MERGE_TREE_OPTS_INIT, GIT_CHECKOUT_OPTS_INIT}
 
 /**
+ * Initializes a `git_revert_opts` with default values. Equivalent to
+ * creating an instance with GIT_REVERT_OPTS_INIT.
+ *
+ * @param opts the `git_revert_opts` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_REVERT_OPTS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_revert_init_opts(
+	git_revert_opts* opts,
+	int version);
+
+/**
  * Reverts the given commit against the given "our" commit, producing an
  * index that reflects the result of the revert.
  *

--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -175,6 +175,19 @@ typedef struct {
 #define GIT_STATUS_OPTIONS_INIT {GIT_STATUS_OPTIONS_VERSION}
 
 /**
+ * Initializes a `git_status_options` with default values. Equivalent to
+ * creating an instance with GIT_STATUS_OPTIONS_INIT.
+ *
+ * @param opts the `git_status_options` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_STATUS_OPTIONS_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_status_init_options(
+	git_status_options* opts,
+	int version);
+
+/**
  * A status entry, providing the differences between the file as it exists
  * in HEAD and the index, and providing the differences between the index
  * and the working directory.

--- a/include/git2/sys/config.h
+++ b/include/git2/sys/config.h
@@ -70,6 +70,19 @@ struct git_config_backend {
 #define GIT_CONFIG_BACKEND_INIT {GIT_CONFIG_BACKEND_VERSION}
 
 /**
+ * Initializes a `git_config_backend` with default values. Equivalent to
+ * creating an instance with GIT_CONFIG_BACKEND_INIT.
+ *
+ * @param opts the `git_config_backend` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_CONFIG_BACKEND_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_config_init_backend(
+	git_config_backend* backend,
+	int version);
+
+/**
  * Add a generic config file instance to an existing config
  *
  * Note that the configuration object will free the file

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -89,6 +89,19 @@ struct git_odb_backend {
 #define GIT_ODB_BACKEND_VERSION 1
 #define GIT_ODB_BACKEND_INIT {GIT_ODB_BACKEND_VERSION}
 
+/**
+ * Initializes a `git_odb_backend` with default values. Equivalent to
+ * creating an instance with GIT_ODB_BACKEND_INIT.
+ *
+ * @param opts the `git_odb_backend` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_ODB_BACKEND_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_odb_init_backend(
+	git_odb_backend* backend,
+	int version);
+
 GIT_EXTERN(void *) git_odb_backend_malloc(git_odb_backend *backend, size_t len);
 
 GIT_END_DECL

--- a/include/git2/sys/refdb_backend.h
+++ b/include/git2/sys/refdb_backend.h
@@ -159,6 +159,19 @@ struct git_refdb_backend {
 #define GIT_REFDB_BACKEND_INIT {GIT_REFDB_BACKEND_VERSION}
 
 /**
+ * Initializes a `git_refdb_backend` with default values. Equivalent to
+ * creating an instance with GIT_REFDB_BACKEND_INIT.
+ *
+ * @param opts the `git_refdb_backend` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_REFDB_BACKEND_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_refdb_init_backend(
+	git_refdb_backend* backend,
+	int version);
+
+/**
  * Constructors for default filesystem-based refdb backend
  *
  * Under normal usage, this is called for you when the repository is

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -280,6 +280,19 @@ struct git_transport {
 #define GIT_TRANSPORT_INIT {GIT_TRANSPORT_VERSION}
 
 /**
+ * Initializes a `git_transport` with default values. Equivalent to
+ * creating an instance with GIT_TRANSPORT_INIT.
+ *
+ * @param opts the `git_transport` instance to initialize.
+ * @param version the version of the struct; you should pass
+ *        `GIT_TRANSPORT_VERSION` here.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_transport_init(
+	git_transport* opts,
+	int version);
+
+/**
  * Function to use to create a transport from a URL. The transport database
  * is scanned to find a transport that implements the scheme of the URI (i.e.
  * git:// or http://) and a transport object is returned to the caller.

--- a/src/blame.c
+++ b/src/blame.c
@@ -476,3 +476,15 @@ int git_blame_buffer(
 	*out = blame;
 	return 0;
 }
+
+int git_blame_init_options(git_blame_options* opts, int version)
+{
+	if (version != GIT_BLAME_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_blame_options", version);
+		return -1;
+	} else {
+		git_blame_options o = GIT_BLAME_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2194,3 +2194,15 @@ int git_checkout_head(
 	assert(repo);
 	return git_checkout_tree(repo, NULL, opts);
 }
+
+int git_checkout_init_opts(git_checkout_opts* opts, int version)
+{
+	if (version != GIT_CHECKOUT_OPTS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_checkout_opts", version);
+		return -1;
+	} else {
+		git_checkout_opts o = GIT_CHECKOUT_OPTS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/clone.c
+++ b/src/clone.c
@@ -439,3 +439,15 @@ int git_clone(
 	*out = repo;
 	return error;
 }
+
+int git_clone_init_options(git_clone_options* opts, int version)
+{
+	if (version != GIT_CLONE_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_clone_options", version);
+		return -1;
+	} else {
+		git_clone_options o = GIT_CLONE_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/config.c
+++ b/src/config.c
@@ -1245,3 +1245,15 @@ cleanup:
 
 	return error;
 }
+
+int git_config_init_backend(git_config_backend* backend, int version)
+{
+	if (version != GIT_CONFIG_BACKEND_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_config_backend", version);
+		return -1;
+	} else {
+		git_config_backend b = GIT_CONFIG_BACKEND_INIT;
+		memcpy(backend, &b, sizeof(b));
+		return 0;
+	}
+}

--- a/src/diff.c
+++ b/src/diff.c
@@ -1413,3 +1413,27 @@ int git_diff__paired_foreach(
 
 	return error;
 }
+
+int git_diff_init_options(git_diff_options* opts, int version)
+{
+	if (version != GIT_DIFF_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_diff_options", version);
+		return -1;
+	} else {
+		git_diff_options o = GIT_DIFF_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}
+
+int git_diff_find_init_options(git_diff_find_options* opts, int version)
+{
+	if (version != GIT_DIFF_FIND_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_diff_find_options", version);
+		return -1;
+	} else {
+		git_diff_find_options o = GIT_DIFF_FIND_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/merge.c
+++ b/src/merge.c
@@ -2744,3 +2744,27 @@ void git_merge_head_free(git_merge_head *head)
 
 	git__free(head);
 }
+
+int git_merge_init_opts(git_merge_opts* opts, int version)
+{
+	if (version != GIT_MERGE_OPTS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_merge_opts", version);
+		return -1;
+	} else {
+		git_merge_opts o = GIT_MERGE_OPTS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}
+
+int git_merge_tree_init_opts(git_merge_tree_opts* opts, int version)
+{
+	if (version != GIT_MERGE_TREE_OPTS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_merge_tree_opts", version);
+		return -1;
+	} else {
+		git_merge_tree_opts o = GIT_MERGE_TREE_OPTS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/odb.c
+++ b/src/odb.c
@@ -1113,3 +1113,14 @@ int git_odb__error_ambiguous(const char *message)
 	return GIT_EAMBIGUOUS;
 }
 
+int git_odb_init_backend(git_odb_backend* backend, int version)
+{
+	if (version != GIT_ODB_BACKEND_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_odb_backend", version);
+		return -1;
+	} else {
+		git_odb_backend b = GIT_ODB_BACKEND_INIT;
+		memcpy(backend, &b, sizeof(b));
+		return 0;
+	}
+}

--- a/src/push.c
+++ b/src/push.c
@@ -705,3 +705,15 @@ void git_push_free(git_push *push)
 
 	git__free(push);
 }
+
+int git_push_init_options(git_push_options* opts, int version)
+{
+	if (version != GIT_PUSH_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_push_options", version);
+		return -1;
+	} else {
+		git_push_options o = GIT_PUSH_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -235,3 +235,15 @@ int git_refdb_ensure_log(git_refdb *db, const char *refname)
 
 	return db->backend->ensure_log(db->backend, refname);
 }
+
+int git_refdb_init_backend(git_refdb_backend* backend, int version)
+{
+	if (version != GIT_REFDB_BACKEND_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_refdb_backend", version);
+		return -1;
+	} else {
+		git_refdb_backend b = GIT_REFDB_BACKEND_INIT;
+		memcpy(backend, &b, sizeof(b));
+		return 0;
+	}
+}

--- a/src/remote.c
+++ b/src/remote.c
@@ -1731,3 +1731,15 @@ const git_refspec *git_remote_get_refspec(const git_remote *remote, size_t n)
 {
 	return git_vector_get(&remote->refspecs, n);
 }
+
+int git_remote_init_callbacks(git_remote_callbacks* opts, int version)
+{
+	if (version != GIT_REMOTE_CALLBACKS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_remote_callbacks", version);
+		return -1;
+	} else {
+		git_remote_callbacks o = GIT_REMOTE_CALLBACKS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/repository.c
+++ b/src/repository.c
@@ -2010,3 +2010,15 @@ int git_repository_is_shallow(git_repository *repo)
 		return error;
 	return st.st_size == 0 ? 0 : 1;
 }
+
+int git_repository_init_init_options(git_repository_init_options* opts, int version)
+{
+	if (version != GIT_REPOSITORY_INIT_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_repository_init_options", version);
+		return -1;
+	} else {
+		git_repository_init_options o = GIT_REPOSITORY_INIT_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/revert.c
+++ b/src/revert.c
@@ -218,3 +218,15 @@ done:
 
 	return error;
 }
+
+int git_revert_init_opts(git_revert_opts* opts, int version)
+{
+	if (version != GIT_REVERT_OPTS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_revert_opts", version);
+		return -1;
+	} else {
+		git_revert_opts o = GIT_REVERT_OPTS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/status.c
+++ b/src/status.c
@@ -495,3 +495,14 @@ int git_status_should_ignore(
 	return git_ignore_path_is_ignored(ignored, repo, path);
 }
 
+int git_status_init_options(git_status_options* opts, int version)
+{
+	if (version != GIT_STATUS_OPTIONS_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_status_options", version);
+		return -1;
+	} else {
+		git_status_options o = GIT_STATUS_OPTIONS_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/src/transport.c
+++ b/src/transport.c
@@ -217,3 +217,15 @@ int git_remote_supported_url(const char* url)
 
 	return fn != &git_transport_dummy;
 }
+
+int git_transport_init(git_transport* opts, int version)
+{
+	if (version != GIT_TRANSPORT_VERSION) {
+		giterr_set(GITERR_INVALID, "Invalid version %d for git_transport", version);
+		return -1;
+	} else {
+		git_transport o = GIT_TRANSPORT_INIT;
+		memcpy(opts, &o, sizeof(o));
+		return 0;
+	}
+}

--- a/tests/structinit/structinit.c
+++ b/tests/structinit/structinit.c
@@ -1,0 +1,120 @@
+#include "clar_libgit2.h"
+#include <git2/sys/config.h>
+#include <git2/sys/odb_backend.h>
+#include <git2/sys/refdb_backend.h>
+
+#define STRINGIFY(s) #s
+
+/* Checks two conditions for the specified structure:
+ *     1. That the initializers for the latest version produces the same
+ *        in-memory representation.
+ *     2. That the function-based initializer supports all versions from 1...n,
+ *        where n is the latest version (often represented by GIT_*_VERSION).
+ *
+ * Parameters:
+ *     structname: The name of the structure to test, e.g. git_blame_options.
+ *     structver: The latest version of the specified structure.
+ *     macroinit: The macro that initializes the latest version of the structure.
+ *     funcinitname: The function that initializes the structure. Must have the
+ *                   signature "int (structname* instance, int version)".
+ */
+#define CHECK_MACRO_FUNC_INIT_EQUAL(structname, structver, macroinit, funcinitname) \
+	structname structname##_macro_latest = macroinit; \
+	structname structname##_func_latest; \
+	cl_git_pass(funcinitname(&structname##_func_latest, structver)); \
+	cl_check_( \
+		memcmp(&structname##_macro_latest, &structname##_func_latest, \
+			sizeof(structname)) == 0, \
+		"Macro-based and function-based initializer for " STRINGIFY(structname) \
+			" are not equivalent."); \
+	\
+	int structname##_curr_ver = structver - 1; \
+	while (structname##_curr_ver > 0) \
+	{ \
+		structname macro; \
+		cl_git_pass(funcinitname(&macro, structname##_curr_ver)); \
+		structname##_curr_ver--; \
+	}
+
+void test_structinit_structinit__compare(void)
+{
+	/* blame */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_blame_options, GIT_BLAME_OPTIONS_VERSION, \
+		GIT_BLAME_OPTIONS_INIT, git_blame_init_options);
+
+	/* checkout */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_checkout_opts, GIT_CHECKOUT_OPTS_VERSION, \
+		GIT_CHECKOUT_OPTS_INIT, git_checkout_init_opts);
+
+	/* clone */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_clone_options, GIT_CLONE_OPTIONS_VERSION, \
+		GIT_CLONE_OPTIONS_INIT, git_clone_init_options);
+
+	/* diff */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_diff_options, GIT_DIFF_OPTIONS_VERSION, \
+		GIT_DIFF_OPTIONS_INIT, git_diff_init_options);
+
+	/* diff_find */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_diff_find_options, GIT_DIFF_FIND_OPTIONS_VERSION, \
+		GIT_DIFF_FIND_OPTIONS_INIT, git_diff_find_init_options);
+
+	/* merge_tree */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_merge_tree_opts, GIT_MERGE_TREE_OPTS_VERSION, \
+		GIT_MERGE_TREE_OPTS_INIT, git_merge_tree_init_opts);
+
+	/* merge */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_merge_opts, GIT_MERGE_OPTS_VERSION, \
+		GIT_MERGE_OPTS_INIT, git_merge_init_opts);
+
+	/* push */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_push_options, GIT_PUSH_OPTIONS_VERSION, \
+		GIT_PUSH_OPTIONS_INIT, git_push_init_options);
+
+	/* remote */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_remote_callbacks, GIT_REMOTE_CALLBACKS_VERSION, \
+		GIT_REMOTE_CALLBACKS_INIT, git_remote_init_callbacks);
+
+	/* repository_init */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_repository_init_options, GIT_REPOSITORY_INIT_OPTIONS_VERSION, \
+		GIT_REPOSITORY_INIT_OPTIONS_INIT, git_repository_init_init_options);
+
+	/* revert */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_revert_opts, GIT_REVERT_OPTS_VERSION, \
+		GIT_REVERT_OPTS_INIT, git_revert_init_opts);
+
+	/* status */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_status_options, GIT_STATUS_OPTIONS_VERSION, \
+		GIT_STATUS_OPTIONS_INIT, git_status_init_options);
+
+	/* transport */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_transport, GIT_TRANSPORT_VERSION, \
+		GIT_TRANSPORT_INIT, git_transport_init);
+
+	/* config_backend */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_config_backend, GIT_CONFIG_BACKEND_VERSION, \
+		GIT_CONFIG_BACKEND_INIT, git_config_init_backend);
+
+	/* odb_backend */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_odb_backend, GIT_ODB_BACKEND_VERSION, \
+		GIT_ODB_BACKEND_INIT, git_odb_init_backend);
+
+	/* refdb_backend */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_refdb_backend, GIT_REFDB_BACKEND_VERSION, \
+		GIT_REFDB_BACKEND_INIT, git_refdb_init_backend);
+}


### PR DESCRIPTION
In response to #1997, I've implemented a function-based `git_merge_opts` initializer, which would allow `GIT_MERGE_OPTS_INIT` to be used from C++. It would also allow for wrappers like libgit2sharp to use `GIT_MERGE_OPTS_INIT` directly via the function. I'd love some feedback on the interface before I implement them for other options structures, though!

I have the function return the options structure directly instead of taking a pointer to a structure that would be memcpy'd to, primarily because it means that `GIT_MERGE_OPTS_INIT` can be used in C++ the same way that C uses it. Returning a struct directly isn't particularly "C-like" though.

What do you think?
