### PR TITLE
Add -DLIBICONV_PLUG for cmake when using a iconv in Mac OS X.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ OPTION( USE_SSH				"Link with libssh to enable SSH support" ON )
 
 IF(APPLE)
 	SET( USE_ICONV ON )
+	ADD_DEFINITIONS(-DLIBICONV_PLUG)
 ENDIF()
 
 IF(MSVC)


### PR DESCRIPTION
Or it will not able to find correct symbols (`iconv`, `iconv_open`, `iconv_close`) for `libiconv.dylib`.
