### PR TITLE
Optionally disable building against the system zlib even if it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ OPTION( ANDROID				"Build for android NDK"	 				OFF )
 
 OPTION( USE_ICONV			"Link with and use iconv library" 		OFF )
 OPTION( USE_SSH				"Link with libssh to enable SSH support" ON )
+OPTION( USE_ZLIB			"Link with and use zlib if available"	ON  )
 OPTION( VALGRIND			"Configure build for valgrind"			OFF )
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -167,7 +168,10 @@ ENDIF()
 # Optional external dependency: zlib
 # It's optional, but FIND_PACKAGE gives a warning that looks more like an
 # error.
+IF (NOT USE_ZLIB)
 FIND_PACKAGE(ZLIB QUIET)
+ENDIF()
+
 IF (ZLIB_FOUND)
 	INCLUDE_DIRECTORIES(${ZLIB_INCLUDE_DIRS})
 	LINK_LIBRARIES(${ZLIB_LIBRARIES})
@@ -179,7 +183,11 @@ IF (ZLIB_FOUND)
 	# Fake the message CMake would have shown
 	MESSAGE("-- Found zlib: ${ZLIB_LIBRARY}")
 ELSE()
-	MESSAGE( "zlib was not found; using bundled 3rd-party sources." )
+	IF (USE_ZLIB)
+		MESSAGE( "zlib was not found; using bundled 3rd-party sources." )
+	ELSE()
+		MESSAGE( "zlib support disabled; using bundled 3rd-party sources." )
+	ENDIF()
 	INCLUDE_DIRECTORIES(deps/zlib)
 	ADD_DEFINITIONS(-DNO_VIZ -DSTDC -DNO_GZIP)
 	FILE(GLOB SRC_ZLIB deps/zlib/*.c deps/zlib/*.h)


### PR DESCRIPTION
Rationale:
1. When building a static libgit2 one may not want to link against dynamic system libraries that may not be available on machines other than the build machine.
2. Furthermore if only a dynamic library of zlib is available, linking against a static libgit2 requires that the application or other library using libgit2 has to link against zlib.
3. Bindings for other languages i.e. perl/ruby/python build dynamically loadable modules which link against libgit2. Sometimes one may not want to deploy both the dynamically loadable module and a dynamic version of libgit2. Tying the module to the static version of libgit2 not only solves some deployment issues, but also eliminates problems where the incorrect libgit2 library may be loaded (incorrectly setting LD_LIBRARY_PATH and friends etc.) 
