### PR TITLE
refs: remove the _with_log differentiation

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -89,37 +89,9 @@ GIT_EXTERN(int) git_reference_dwim(git_reference **out, git_repository *repo, co
  * This function will return an error if a reference already exists with the
  * given name unless `force` is true, in which case it will be overwritten.
  *
- * @param out Pointer to the newly created reference
- * @param repo Repository where that reference will live
- * @param name The name of the reference
- * @param target The target of the reference
- * @param force Overwrite existing references
- * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
- */
-GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repository *repo, const char *name, const char *target, int force);
-
-/**
- * Create a new symbolic reference and update the reflog with a given
- * message.
- *
- * A symbolic reference is a reference name that refers to another
- * reference name.  If the other name moves, the symbolic name will move,
- * too.  As a simple example, the "HEAD" reference might refer to
- * "refs/heads/master" while on the "master" branch of a repository.
- *
- * The symbolic reference will be created in the repository and written to
- * the disk.  The generated reference object must be freed by the user.
- *
- * Valid reference names must follow one of two patterns:
- *
- * 1. Top-level names must contain only capital letters and underscores,
- *    and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
- * 2. Names prefixed with "refs/" can be almost anything.  You must avoid
- *    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
- *    sequences ".." and "@{" which have special meaning to revparse.
- *
- * This function will return an error if a reference already exists with the
- * given name unless `force` is true, in which case it will be overwritten.
+ * The signature and message for the reflog will be ignored if the
+ * reference does not belong in the standard set (HEAD, branches and
+ * remote-tracking branches) and and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference will live
@@ -127,18 +99,10 @@ GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repositor
  * @param target The target of the reference
  * @param force Overwrite existing references
  * @param signature The identity that will used to populate the reflog entry
- * @param log_message The one line long message that has to be appended
- * to the reflog
- * @return 0 on success, EEXISTS, EINVALIDSPEC or an error code
+ * @param log_message The one line long message to be appended to the reflog
+ * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_reference_symbolic_create_with_log(
-	git_reference **out,
-	git_repository *repo,
-	const char *name,
-	const char *target,
-	int force,
-	const git_signature *signature,
-	const char *log_message);
+GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const git_signature *signature, const char *log_message);
 
 /**
  * Create a new direct reference.
@@ -163,57 +127,21 @@ GIT_EXTERN(int) git_reference_symbolic_create_with_log(
  * This function will return an error if a reference already exists with the
  * given name unless `force` is true, in which case it will be overwritten.
  *
+ * The signature and message for the reflog will be ignored if the
+ * reference does not belong in the standard set (HEAD, branches and
+ * remote-tracking branches) and and it does not have a reflog.
+ *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference will live
  * @param name The name of the reference
  * @param id The object id pointed to by the reference.
  * @param force Overwrite existing references
- * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
- */
-GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force);
-
-/**
- * Create a new direct reference and update the reflog with a given
- * message.
- *
- * A direct reference (also called an object id reference) refers directly
- * to a specific object id (a.k.a. OID or SHA) in the repository.  The id
- * permanently refers to the object (although the reference itself can be
- * moved).  For example, in libgit2 the direct ref "refs/tags/v0.17.0"
- * refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.
- *
- * The direct reference will be created in the repository and written to
- * the disk.  The generated reference object must be freed by the user.
- *
- * Valid reference names must follow one of two patterns:
- *
- * 1. Top-level names must contain only capital letters and underscores,
- *    and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
- * 2. Names prefixed with "refs/" can be almost anything.  You must avoid
- *    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
- *    sequences ".." and "@{" which have special meaning to revparse.
- *
- * This function will return an error if a reference already exists with the
- * given name unless `force` is true, in which case it will be overwritten.
- *
- * @param out Pointer to the newly created reference
- * @param repo Repository where that reference will live
- * @param name The name of the reference
- * @param id The object id pointed to by the reference.
  * @param force Overwrite existing references
  * @param signature The identity that will used to populate the reflog entry
- * @param log_message The one line long message that has to be appended
- * to the reflog
- * @return 0 on success, EEXISTS, EINVALIDSPEC or an error code
+ * @param log_message The one line long message to be appended to the reflog
+ * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_reference_create_with_log(
-	git_reference **out,
-	git_repository *repo,
-	const char *name,
-	const git_oid *id,
-	int force,
-	const git_signature *signature,
-	const char *log_message);
+GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force, const git_signature *signature, const char *log_message);
 
 /**
  * Get the OID pointed to by a direct reference.
@@ -307,35 +235,18 @@ GIT_EXTERN(git_repository *) git_reference_owner(const git_reference *ref);
  * The target name will be checked for validity.
  * See `git_reference_create_symbolic()` for rules about valid names.
  *
- * @param out Pointer to the newly created reference
- * @param ref The reference
- * @param target The new target for the reference
- * @return 0 on success, GIT_EINVALIDSPEC or an error code
- */
-GIT_EXTERN(int) git_reference_symbolic_set_target(
-	git_reference **out,
-	git_reference *ref,
-	const char *target);
-
-/**
- * Create a new reference with the same name as the given reference but a
- * different symbolic target  and update the reflog with a given message.
- *
- * The reference must be a symbolic reference, otherwise this will fail.
- *
- * The new reference will be written to disk, overwriting the given reference.
- *
- * The target name will be checked for validity.
- * See `git_reference_create_symbolic()` for rules about valid names.
+ * The signature and message for the reflog will be ignored if the
+ * reference does not belong in the standard set (HEAD, branches and
+ * remote-tracking branches) and and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param ref The reference
  * @param target The new target for the reference
  * @param signature The identity that will used to populate the reflog entry
- * @param log_message The one line long message that has to be appended
- * @return 0 on success, EINVALIDSPEC or an error code
+ * @param log_message The one line long message to be appended to the reflog
+ * @return 0 on success, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_reference_symbolic_set_target_with_log(
+GIT_EXTERN(int) git_reference_symbolic_set_target(
 	git_reference **out,
 	git_reference *ref,
 	const char *target,
@@ -349,33 +260,18 @@ GIT_EXTERN(int) git_reference_symbolic_set_target_with_log(
  *
  * The new reference will be written to disk, overwriting the given reference.
  *
- * @param out Pointer to the newly created reference
- * @param ref The reference
- * @param id The new target OID for the reference
- * @return 0 or an error code
- */
-GIT_EXTERN(int) git_reference_set_target(
-	git_reference **out,
-	git_reference *ref,
-	const git_oid *id);
-
-/**
- * Create a new reference with the same name as the given reference but a
- * different OID target and update the reflog with a given message.
- *
- * The reference must be a direct reference, otherwise this will fail.
- *
- * The new reference will be written to disk, overwriting the given reference.
+ * The signature and message for the reflog will be ignored if the
+ * reference does not belong in the standard set (HEAD, branches and
+ * remote-tracking branches) and and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param ref The reference
  * @param id The new target OID for the reference
  * @param signature The identity that will used to populate the reflog entry
- * @param log_message The one line long message that has to be appended
- * to the reflog
+ * @param log_message The one line long message to be appended to the reflog
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_reference_set_target_with_log(
+GIT_EXTERN(int) git_reference_set_target(
 	git_reference **out,
 	git_reference *ref,
 	const git_oid *id,

--- a/src/branch.c
+++ b/src/branch.c
@@ -72,7 +72,7 @@ int git_branch_create(
 		goto cleanup;
 
 	error = git_reference_create(&branch, repository,
-		git_buf_cstr(&canonical_branch_name), git_commit_id(commit), force);
+		git_buf_cstr(&canonical_branch_name), git_commit_id(commit), force, NULL, NULL);
 
 	if (!error)
 		*ref_out = branch;

--- a/src/commit.c
+++ b/src/commit.c
@@ -112,7 +112,7 @@ int git_commit_create_from_oids(
 	git_buf_free(&commit);
 
 	if (update_ref != NULL)
-		return git_reference__update_terminal(repo, update_ref, oid);
+		return git_reference__update_terminal(repo, update_ref, oid, NULL, NULL);
 
 	return 0;
 

--- a/src/push.c
+++ b/src/push.c
@@ -241,7 +241,7 @@ int git_push_update_tips(git_push *push)
 				giterr_clear();
 			else
 				goto on_error;
-		} else if ((error = git_reference_create(NULL, push->remote->repo, git_buf_cstr(&remote_ref_name), &push_spec->loid, 1)) < 0)
+		} else if ((error = git_reference_create(NULL, push->remote->repo, git_buf_cstr(&remote_ref_name), &push_spec->loid, 1, NULL, NULL)) < 0)
 			goto on_error;
 	}
 

--- a/src/refs.h
+++ b/src/refs.h
@@ -68,7 +68,7 @@ git_reference *git_reference__set_name(git_reference *ref, const char *name);
 
 int git_reference__normalize_name_lax(char *buffer_out, size_t out_size, const char *name);
 int git_reference__normalize_name(git_buf *buf, const char *name, unsigned int flags);
-int git_reference__update_terminal(git_repository *repo, const char *ref_name, const git_oid *oid);
+int git_reference__update_terminal(git_repository *repo, const char *ref_name, const git_oid *oid, const git_signature *signature, const char *log_message);
 int git_reference__is_valid_name(const char *refname, unsigned int flags);
 int git_reference__is_branch(const char *ref_name);
 int git_reference__is_remote(const char *ref_name);

--- a/src/remote.c
+++ b/src/remote.c
@@ -1027,7 +1027,7 @@ static int update_tips_for_spec(git_remote *remote, git_refspec *spec, git_vecto
 			continue;
 
 		/* In autotag mode, don't overwrite any locally-existing tags */
-		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, !autotag);
+		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, !autotag, NULL, NULL);
 		if (error < 0 && error != GIT_EEXISTS)
 			goto on_error;
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -1863,11 +1863,11 @@ int git_repository_set_head(
 
 	if (!error) {
 		if (git_reference_is_branch(ref))
-			error = git_reference_symbolic_create(&new_head, repo, GIT_HEAD_FILE, git_reference_name(ref), 1);
+			error = git_reference_symbolic_create(&new_head, repo, GIT_HEAD_FILE, git_reference_name(ref), 1, NULL, NULL);
 		else
 			error = git_repository_set_head_detached(repo, git_reference_target(ref));
 	} else if (looks_like_a_branch(refname))
-		error = git_reference_symbolic_create(&new_head, repo, GIT_HEAD_FILE, refname, 1);
+		error = git_reference_symbolic_create(&new_head, repo, GIT_HEAD_FILE, refname, 1, NULL, NULL);
 
 	git_reference_free(ref);
 	git_reference_free(new_head);
@@ -1891,7 +1891,7 @@ int git_repository_set_head_detached(
 	if ((error = git_object_peel(&peeled, object, GIT_OBJ_COMMIT)) < 0)
 		goto cleanup;
 
-	error = git_reference_create(&new_head, repo, GIT_HEAD_FILE, git_object_id(peeled), 1);
+	error = git_reference_create(&new_head, repo, GIT_HEAD_FILE, git_object_id(peeled), 1, NULL, NULL);
 
 cleanup:
 	git_object_free(object);
@@ -1916,7 +1916,7 @@ int git_repository_detach_head(
 	if ((error = git_object_lookup(&object, repo, git_reference_target(old_head), GIT_OBJ_COMMIT)) < 0)
 		goto cleanup;
 
-	error = git_reference_create(&new_head, repo, GIT_HEAD_FILE, git_reference_target(old_head), 1);
+	error = git_reference_create(&new_head, repo, GIT_HEAD_FILE, git_reference_target(old_head), 1, NULL, NULL);
 
 cleanup:
 	git_object_free(object);

--- a/src/reset.c
+++ b/src/reset.c
@@ -131,7 +131,7 @@ int git_reset(
 
 	/* move HEAD to the new target */
 	if ((error = git_reference__update_terminal(repo, GIT_HEAD_FILE,
-		git_object_id(commit))) < 0)
+		git_object_id(commit), NULL, NULL)) < 0)
 		goto cleanup;
 
 	if (reset_type == GIT_RESET_HARD) {

--- a/src/stash.c
+++ b/src/stash.c
@@ -417,7 +417,7 @@ static int update_reflog(
 	if ((error = git_reference_ensure_log(repo, GIT_REFS_STASH_FILE)) < 0)
 		return error;
 
-	error = git_reference_create_with_log(&stash, repo, GIT_REFS_STASH_FILE, w_commit_oid, 1, stasher, message);
+	error = git_reference_create(&stash, repo, GIT_REFS_STASH_FILE, w_commit_oid, 1, stasher, message);
 
 	git_reference_free(stash);
 
@@ -628,7 +628,7 @@ int git_stash_drop(
 		entry = git_reflog_entry_byindex(reflog, 0);
 
 		git_reference_free(stash);
-		if ((error = git_reference_create(&stash, repo, GIT_REFS_STASH_FILE, &entry->oid_cur, 1) < 0))
+		if ((error = git_reference_create(&stash, repo, GIT_REFS_STASH_FILE, &entry->oid_cur, 1, NULL, NULL) < 0))
 			goto cleanup;
 
 		/* We need to undo the writing that we just did */

--- a/src/tag.c
+++ b/src/tag.c
@@ -271,7 +271,7 @@ static int git_tag_create__internal(
 	} else
 		git_oid_cpy(oid, git_object_id(target));
 
-	error = git_reference_create(&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite);
+	error = git_reference_create(&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL, NULL);
 
 cleanup:
 	git_reference_free(new_ref);
@@ -376,7 +376,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 		return -1;
 	}
 
-	error = git_reference_create(&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite);
+	error = git_reference_create(&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL, NULL);
 
 	git_reference_free(new_ref);
 	git_buf_free(&ref_name);

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -315,7 +315,7 @@ static int local_push_update_remote_ref(
 	if (lref) {
 		/* Create or update a ref */
 		if ((error = git_reference_create(NULL, remote_repo, rref, loid,
-				!git_oid_iszero(roid))) < 0)
+				!git_oid_iszero(roid), NULL, NULL)) < 0)
 			return error;
 	} else {
 		/* Delete a ref */

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -484,7 +484,7 @@ void assert_conflict(
 
 	/* Make HEAD point to this branch */
 	cl_git_pass(git_reference_symbolic_create(
-		&head, g_repo, "HEAD", git_reference_name(branch), 1));
+		&head, g_repo, "HEAD", git_reference_name(branch), 1, NULL, NULL));
 	git_reference_free(head);
 	git_reference_free(branch);
 

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -116,7 +116,7 @@ void test_commit_write__root(void)
 	cl_assert(head_old != NULL);
 	git_reference_free(head);
 
-	cl_git_pass(git_reference_symbolic_create(&head, g_repo, "HEAD", branch_name, 1));
+	cl_git_pass(git_reference_symbolic_create(&head, g_repo, "HEAD", branch_name, 1, NULL, NULL));
 
 	cl_git_pass(git_commit_create_v(
 		&commit_id, /* out id */

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -945,7 +945,7 @@ void test_diff_rename__rejected_match_can_match_others(void)
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_git_pass(git_reference_symbolic_set_target(
-		&selfsimilar, head, "refs/heads/renames_similar"));
+		&selfsimilar, head, "refs/heads/renames_similar", NULL, NULL));
 	cl_git_pass(git_checkout_head(g_repo, &opts));
 	cl_git_pass(git_repository_index(&index, g_repo));
 
@@ -1030,7 +1030,7 @@ void test_diff_rename__rejected_match_can_match_others_two(void)
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_git_pass(git_reference_symbolic_set_target(
-		&selfsimilar, head, "refs/heads/renames_similar_two"));
+		&selfsimilar, head, "refs/heads/renames_similar_two", NULL, NULL));
 	cl_git_pass(git_checkout_head(g_repo, &opts));
 	cl_git_pass(git_repository_index(&index, g_repo));
 
@@ -1088,7 +1088,7 @@ void test_diff_rename__rejected_match_can_match_others_three(void)
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_git_pass(git_reference_symbolic_set_target(
-		&selfsimilar, head, "refs/heads/renames_similar_two"));
+		&selfsimilar, head, "refs/heads/renames_similar_two", NULL, NULL));
 	cl_git_pass(git_checkout_head(g_repo, &opts));
 	cl_git_pass(git_repository_index(&index, g_repo));
 

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -87,7 +87,7 @@ int merge_branches(git_merge_result **result, git_repository *repo, const char *
 
 	head_checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
 
-	cl_git_pass(git_reference_symbolic_create(&head_ref, repo, "HEAD", ours_branch, 1));
+	cl_git_pass(git_reference_symbolic_create(&head_ref, repo, "HEAD", ours_branch, 1, NULL, NULL));
 	cl_git_pass(git_checkout_head(repo, &head_checkout_opts));
 
 	cl_git_pass(git_reference_lookup(&theirs_ref, repo, theirs_branch));

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -406,7 +406,7 @@ void test_merge_workdir_simple__directory_file(void)
 		{ 0100644, "f5504f36e6f4eb797a56fc5bac6c6c7f32969bf2", 3, "file-5/new" },
 	};
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, GIT_REFS_HEADS_DIR OURS_DIRECTORY_FILE, 1));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, GIT_REFS_HEADS_DIR OURS_DIRECTORY_FILE, 1, NULL, NULL));
 	cl_git_pass(git_reference_name_to_id(&head_commit_id, repo, GIT_HEAD_FILE));
 	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_commit_id));
 	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD));

--- a/tests/merge/workdir/trivial.c
+++ b/tests/merge/workdir/trivial.c
@@ -42,7 +42,7 @@ static int merge_trivial(const char *ours, const char *theirs, bool automerge)
 	opts.merge_tree_opts.automerge_flags |= automerge ? 0 : GIT_MERGE_AUTOMERGE_NONE;
 
 	git_buf_printf(&branch_buf, "%s%s", GIT_REFS_HEADS_DIR, ours);
-	cl_git_pass(git_reference_symbolic_create(&our_ref, repo, "HEAD", branch_buf.ptr, 1));
+	cl_git_pass(git_reference_symbolic_create(&our_ref, repo, "HEAD", branch_buf.ptr, 1, NULL, NULL));
 
 	cl_git_pass(git_checkout_head(repo, &checkout_opts));
 

--- a/tests/refs/branches/delete.c
+++ b/tests/refs/branches/delete.c
@@ -14,7 +14,7 @@ void test_refs_branches_delete__initialize(void)
 	cl_git_pass(git_repository_open(&repo, "testrepo.git"));
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0));
+	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL, NULL));
 }
 
 void test_refs_branches_delete__cleanup(void)

--- a/tests/refs/branches/ishead.c
+++ b/tests/refs/branches/ishead.c
@@ -98,9 +98,9 @@ void test_refs_branches_ishead__only_direct_references_are_considered(void)
 	git_repository_free(repo);
 	repo = cl_git_sandbox_init("testrepo.git");
 
-	cl_git_pass(git_reference_symbolic_create(&linked, repo, "refs/heads/linked", "refs/heads/master", 0));
-	cl_git_pass(git_reference_symbolic_create(&super, repo, "refs/heads/super", "refs/heads/linked", 0));
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/heads/super", 1));
+	cl_git_pass(git_reference_symbolic_create(&linked, repo, "refs/heads/linked", "refs/heads/master", 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&super, repo, "refs/heads/super", "refs/heads/linked", 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/heads/super", 1, NULL, NULL));
 
 	cl_assert_equal_i(false, git_branch_is_head(linked));
 	cl_assert_equal_i(false, git_branch_is_head(super));

--- a/tests/refs/branches/iterator.c
+++ b/tests/refs/branches/iterator.c
@@ -12,7 +12,7 @@ void test_refs_branches_iterator__initialize(void)
 	cl_git_pass(git_repository_open(&repo, "testrepo.git"));
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0));
+	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL, NULL));
 }
 
 void test_refs_branches_iterator__cleanup(void)
@@ -113,7 +113,7 @@ void test_refs_branches_iterator__retrieve_remote_symbolic_HEAD_when_present(voi
 	};
 
 	git_reference_free(fake_remote);
-	cl_git_pass(git_reference_symbolic_create(&fake_remote, repo, "refs/remotes/nulltoken/HEAD", "refs/remotes/nulltoken/master", 0));
+	cl_git_pass(git_reference_symbolic_create(&fake_remote, repo, "refs/remotes/nulltoken/HEAD", "refs/remotes/nulltoken/master", 0, NULL, NULL));
 
 	assert_retrieval(GIT_BRANCH_REMOTE, 3);
 

--- a/tests/refs/crashes.c
+++ b/tests/refs/crashes.c
@@ -7,7 +7,7 @@ void test_refs_crashes__double_free(void)
 	const char *REFNAME = "refs/heads/xxx";
 
 	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
-	cl_git_pass(git_reference_symbolic_create(&ref, repo, REFNAME, "refs/heads/master", 0));
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, REFNAME, "refs/heads/master", 0, NULL, NULL));
 	cl_git_pass(git_reference_lookup(&ref2, repo, REFNAME));
 	cl_git_pass(git_reference_delete(ref));
 	git_reference_free(ref);

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -32,7 +32,7 @@ void test_refs_create__symbolic(void)
 	git_oid_fromstr(&id, current_master_tip);
 
 	/* Create and write the new symbolic reference */
-	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0));
+	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0, NULL, NULL));
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
@@ -73,7 +73,7 @@ void test_refs_create__deep_symbolic(void)
 
 	git_oid_fromstr(&id, current_master_tip);
 
-	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0));
+	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0, NULL, NULL));
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
 	cl_git_pass(git_reference_resolve(&resolved_ref, looked_up_ref));
 	cl_assert(git_oid_cmp(&id, git_reference_target(resolved_ref)) == 0);
@@ -95,7 +95,7 @@ void test_refs_create__oid(void)
 	git_oid_fromstr(&id, current_master_tip);
 
 	/* Create and write the new object id reference */
-	cl_git_pass(git_reference_create(&new_reference, g_repo, new_head, &id, 0));
+	cl_git_pass(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL, NULL));
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head));
@@ -130,7 +130,7 @@ void test_refs_create__oid_unknown(void)
 	git_oid_fromstr(&id, "deadbeef3f795b2b4353bcce3a527ad0a4f7f644");
 
 	/* Create and write the new object id reference */
-	cl_git_fail(git_reference_create(&new_reference, g_repo, new_head, &id, 0));
+	cl_git_fail(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL, NULL));
 
 	/* Ensure the reference can't be looked-up... */
 	cl_git_fail(git_reference_lookup(&looked_up_ref, g_repo, new_head));
@@ -144,10 +144,10 @@ void test_refs_create__propagate_eexists(void)
 
 	/* Make sure it works for oid and for symbolic both */
 	git_oid_fromstr(&oid, current_master_tip);
-	error = git_reference_create(&ref, g_repo, current_head_target, &oid, false);
+	error = git_reference_create(&ref, g_repo, current_head_target, &oid, false, NULL, NULL);
 	cl_assert(error == GIT_EEXISTS);
 
-	error = git_reference_symbolic_create(&ref, g_repo, "HEAD", current_head_target, false);
+	error = git_reference_symbolic_create(&ref, g_repo, "HEAD", current_head_target, false, NULL, NULL);
 	cl_assert(error == GIT_EEXISTS);
 }
 
@@ -161,8 +161,8 @@ void test_refs_create__creating_a_reference_with_an_invalid_name_returns_EINVALI
 	git_oid_fromstr(&id, current_master_tip);
 
 	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_create(
-		&new_reference, g_repo, name, &id, 0));
+		&new_reference, g_repo, name, &id, 0, NULL, NULL));
 
 	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(
-		&new_reference, g_repo, name, current_head_target, 0));
+		&new_reference, g_repo, name, current_head_target, 0, NULL, NULL));
 }

--- a/tests/refs/createwithlog.c
+++ b/tests/refs/createwithlog.c
@@ -35,7 +35,7 @@ void test_refs_createwithlog__creating_a_direct_reference_adds_a_reflog_entry(vo
 	cl_git_pass(git_signature_now(&signature, "foo", "foo@bar"));
 
 	cl_git_pass(
-		git_reference_create_with_log(&reference, g_repo, name, &id, 0, signature, message));
+		git_reference_create(&reference, g_repo, name, &id, 0, signature, message));
 
 	cl_git_pass(git_reflog_read(&reflog, g_repo, name));
 	cl_assert_equal_sz(1, git_reflog_entrycount(reflog));

--- a/tests/refs/delete.c
+++ b/tests/refs/delete.c
@@ -66,7 +66,7 @@ void test_refs_delete__packed_only(void)
 	git_oid_fromstr(&id, current_master_tip);
 
 	/* Create and write the new object id reference */
-	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &id, 0));
+	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &id, 0, NULL, NULL));
 	git_reference_free(ref);
 
 	/* Lookup the reference */

--- a/tests/refs/foreachglob.c
+++ b/tests/refs/foreachglob.c
@@ -12,7 +12,7 @@ void test_refs_foreachglob__initialize(void)
 	cl_git_pass(git_repository_open(&repo, "testrepo.git"));
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0));
+	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL, NULL));
 }
 
 void test_refs_foreachglob__cleanup(void)

--- a/tests/refs/overwrite.c
+++ b/tests/refs/overwrite.c
@@ -27,8 +27,8 @@ void test_refs_overwrite__symbolic(void)
 	git_reference *ref, *branch_ref;
 
 	/* The target needds to exist and we need to check the name has changed */
-	cl_git_pass(git_reference_symbolic_create(&branch_ref, g_repo, ref_branch_name, ref_master_name, 0));
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_branch_name, 0));
+	cl_git_pass(git_reference_symbolic_create(&branch_ref, g_repo, ref_branch_name, ref_master_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_branch_name, 0, NULL, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place*/
@@ -38,8 +38,8 @@ void test_refs_overwrite__symbolic(void)
 	git_reference_free(ref);
 
 	/* Ensure we can't create it unless we force it to */
-	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0));
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1));
+	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1, NULL, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place */
@@ -63,7 +63,7 @@ void test_refs_overwrite__object_id(void)
 	git_reference_free(ref);
 
 	/* Create it */
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_test_name));
@@ -72,8 +72,8 @@ void test_refs_overwrite__object_id(void)
 	git_reference_free(ref);
 
 	/* Ensure we can't overwrite unless we force it */
-	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0));
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1));
+	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1, NULL, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it has been overwritten */
@@ -94,10 +94,10 @@ void test_refs_overwrite__object_id_with_symbolic(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
 	git_reference_free(ref);
-	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0));
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1));
+	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1, NULL, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place */
@@ -120,11 +120,11 @@ void test_refs_overwrite__symbolic_with_object_id(void)
 	git_reference_free(ref);
 
 	/* Create the symbolic ref */
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
 	git_reference_free(ref);
 	/* It shouldn't overwrite unless we tell it to */
-	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0));
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1));
+	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1, NULL, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place */

--- a/tests/refs/pack.c
+++ b/tests/refs/pack.c
@@ -93,11 +93,11 @@ void test_refs_pack__symbolic(void)
 	for (i = 0; i < 100; ++i) {
 		snprintf(name, sizeof(name), "refs/heads/symbolic-%03d", i);
 		cl_git_pass(git_reference_symbolic_create(
-			&ref, g_repo, name, "refs/heads/master", 0));
+			&ref, g_repo, name, "refs/heads/master", 0, NULL, NULL));
 		git_reference_free(ref);
 
 		snprintf(name, sizeof(name), "refs/heads/direct-%03d", i);
-		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0));
+		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL, NULL));
 		git_reference_free(ref);
 	}
 

--- a/tests/refs/reflog/reflog.c
+++ b/tests/refs/reflog/reflog.c
@@ -82,7 +82,7 @@ void test_refs_reflog_reflog__append_then_read(void)
 
 	/* Create a new branch pointing at the HEAD */
 	git_oid_fromstr(&oid, current_master_tip);
-	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &oid, 0));
+	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &oid, 0, NULL, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_signature_now(&committer, "foo", "foo@bar"));
@@ -189,11 +189,11 @@ void test_refs_reflog_reflog__write_only_std_locations(void)
 
 	git_oid_fromstr(&id, current_master_tip);
 
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/foo", &id, 1));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/foo", &id, 1, NULL, NULL));
 	git_reference_free(ref);
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1, NULL, NULL));
 	git_reference_free(ref);
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/notes/foo", &id, 1));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/notes/foo", &id, 1, NULL, NULL));
 	git_reference_free(ref);
 
 	assert_has_reflog(true, "refs/heads/foo");
@@ -210,7 +210,7 @@ void test_refs_reflog_reflog__write_when_explicitly_active(void)
 	git_oid_fromstr(&id, current_master_tip);
 	git_reference_ensure_log(g_repo, "refs/tags/foo");
 
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1, NULL, NULL));
 	git_reference_free(ref);
 	assert_has_reflog(true, "refs/tags/foo");
 }

--- a/tests/refs/rename.c
+++ b/tests/refs/rename.c
@@ -268,15 +268,15 @@ void test_refs_rename__overwrite(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	/* Create loose references */
-	cl_git_pass(git_reference_create(&ref_one, g_repo, ref_one_name, &id, 0));
-	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0));
+	cl_git_pass(git_reference_create(&ref_one, g_repo, ref_one_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0, NULL, NULL));
 
 	/* Pack everything */
 	cl_git_pass(git_repository_refdb(&refdb, g_repo));
 	cl_git_pass(git_refdb_compress(refdb));
 
 	/* Attempt to create illegal reference */
-	cl_git_fail(git_reference_create(&ref_one_new, g_repo, ref_one_name_new, &id, 0));
+	cl_git_fail(git_reference_create(&ref_one_new, g_repo, ref_one_name_new, &id, 0, NULL, NULL));
 
 	/* Illegal reference couldn't be created so this is supposed to fail */
 	cl_git_fail(git_reference_lookup(&ref_one_new, g_repo, ref_one_name_new));
@@ -301,7 +301,7 @@ void test_refs_rename__prefix(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	/* Create loose references */
-	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0));
+	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0, NULL, NULL));
 
 	/* An existing reference... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, ref_two_name));
@@ -334,7 +334,7 @@ void test_refs_rename__move_up(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	/* Create loose references */
-	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name_new, &id, 0));
+	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name_new, &id, 0, NULL, NULL));
 	git_reference_free(ref_two);
 
 	/* An existing reference... */

--- a/tests/refs/revparse.c
+++ b/tests/refs/revparse.c
@@ -596,7 +596,8 @@ void test_refs_revparse__issue_994(void)
 		repo,
 		"refs/remotes/origin/bim_with_3d@11296",
 		git_reference_target(head),
-		0));
+		0,
+		NULL, NULL));
 
 	cl_git_pass(git_revparse_single(&target, repo, "origin/bim_with_3d@11296"));
 	git_object_free(target);

--- a/tests/refs/settargetwithlog.c
+++ b/tests/refs/settargetwithlog.c
@@ -38,7 +38,7 @@ void test_refs_settargetwithlog__updating_a_direct_reference_adds_a_reflog_entry
 
 	cl_git_pass(git_signature_now(&signature, "foo", "foo@bar"));
 
-	cl_git_pass(git_reference_set_target_with_log(
+	cl_git_pass(git_reference_set_target(
 		&reference_out, reference, &target_id, signature, message));
 
 	cl_git_pass(git_reflog_read(&reflog, g_repo, br2_name));

--- a/tests/refs/setter.c
+++ b/tests/refs/setter.c
@@ -34,7 +34,7 @@ void test_refs_setter__update_direct(void)
 	cl_git_pass(git_reference_lookup(&test_ref, g_repo, ref_test_name));
 	cl_assert(git_reference_type(test_ref) == GIT_REF_OID);
 
-	cl_git_pass(git_reference_set_target(&new_ref, test_ref, &id));
+	cl_git_pass(git_reference_set_target(&new_ref, test_ref, &id, NULL, NULL));
 
 	git_reference_free(test_ref);
 	git_reference_free(new_ref);
@@ -53,7 +53,7 @@ void test_refs_setter__update_symbolic(void)
 	cl_assert(git_reference_type(head) == GIT_REF_SYMBOLIC);
 	cl_assert(strcmp(git_reference_symbolic_target(head), ref_master_name) == 0);
 
-	cl_git_pass(git_reference_symbolic_set_target(&new_head, head, ref_test_name));
+	cl_git_pass(git_reference_symbolic_set_target(&new_head, head, ref_test_name, NULL, NULL));
 	git_reference_free(new_head);
 	git_reference_free(head);
 
@@ -73,7 +73,7 @@ void test_refs_setter__cant_update_direct_with_symbolic(void)
 	cl_assert(git_reference_type(ref) == GIT_REF_OID);
 	git_oid_cpy(&id, git_reference_target(ref));
 
-	cl_git_fail(git_reference_symbolic_set_target(&new, ref, ref_name));
+	cl_git_fail(git_reference_symbolic_set_target(&new, ref, ref_name, NULL, NULL));
 
 	git_reference_free(ref);
 }
@@ -90,10 +90,10 @@ void test_refs_setter__cant_update_symbolic_with_direct(void)
 	git_reference_free(ref);
 
 	/* Create the symbolic ref */
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
 
 	/* Can't set an OID on a direct ref */
-	cl_git_fail(git_reference_set_target(&new, ref, &id));
+	cl_git_fail(git_reference_set_target(&new, ref, &id, NULL, NULL));
 
 	git_reference_free(ref);
 }

--- a/tests/refs/unicode.c
+++ b/tests/refs/unicode.c
@@ -24,7 +24,7 @@ void test_refs_unicode__create_and_lookup(void)
 	/* Create the reference */
 	cl_git_pass(git_reference_lookup(&ref0, repo, master));
 	cl_git_pass(git_reference_create(
-		&ref1, repo, REFNAME, git_reference_target(ref0), 0));
+		&ref1, repo, REFNAME, git_reference_target(ref0), 0, NULL, NULL));
 	cl_assert_equal_s(REFNAME, git_reference_name(ref1));
 	git_reference_free(ref0);
 

--- a/tests/refs/update.c
+++ b/tests/refs/update.c
@@ -22,5 +22,5 @@ void test_refs_update__updating_the_target_of_a_symref_with_an_invalid_name_retu
 	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
 	git_reference_free(head);
 
-	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(&head, g_repo, GIT_HEAD_FILE, "refs/heads/inv@{id", 1));
+	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(&head, g_repo, GIT_HEAD_FILE, "refs/heads/inv@{id", 1, NULL, NULL));
 }

--- a/tests/repo/head.c
+++ b/tests/repo/head.c
@@ -26,7 +26,7 @@ void test_repo_head__head_detached(void)
 	cl_assert_equal_i(true, git_repository_head_detached(repo));
 
 	/* take the reop back to it's original state */
-	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master", 1));
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master", 1, NULL, NULL));
 	git_reference_free(ref);
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
@@ -44,7 +44,7 @@ void test_repo_head__unborn_head(void)
 
 
 	/* take the repo back to it's original state */
-	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master", 1));
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master", 1, NULL, NULL));
 	cl_assert(git_repository_head_unborn(repo) == 0);
 
 	git_reference_free(ref);
@@ -156,7 +156,7 @@ void test_repo_head__detach_head_Fails_if_HEAD_and_point_to_a_non_commitish(void
 {
 	git_reference *head;
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/tags/point_to_blob", 1));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/tags/point_to_blob", 1, NULL, NULL));
 
 	cl_git_fail(git_repository_detach_head(repo));
 

--- a/tests/repo/repo_helpers.c
+++ b/tests/repo/repo_helpers.c
@@ -7,7 +7,7 @@ void make_head_unborn(git_repository* repo, const char *target)
 {
 	git_reference *head;
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, target, 1));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, target, 1, NULL, NULL));
 	git_reference_free(head);
 }
 

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -174,7 +174,7 @@ void test_stash_save__cannot_stash_against_an_unborn_branch(void)
 {
 	git_reference *head;
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, "HEAD", "refs/heads/unborn", 1));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, "HEAD", "refs/heads/unborn", 1, NULL, NULL));
 
 	cl_assert_equal_i(GIT_EUNBORNBRANCH,
 		git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -108,7 +108,7 @@ void test_submodule_lookup__lookup_even_with_unborn_head(void)
 
 	/* put us on an unborn branch */
 	cl_git_pass(git_reference_symbolic_create(
-		&head, g_repo, "HEAD", "refs/heads/garbage", 1));
+		&head, g_repo, "HEAD", "refs/heads/garbage", 1, NULL, NULL));
 	git_reference_free(head);
 
 	/* lookup existing */

--- a/tests/threads/refdb.c
+++ b/tests/threads/refdb.c
@@ -58,7 +58,7 @@ void test_threads_refdb__iterator(void)
 
 	for (r = 0; r < 200; ++r) {
 		snprintf(name, sizeof(name), "refs/heads/direct-%03d", r);
-		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0));
+		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL, NULL));
 		git_reference_free(ref);
 	}
 
@@ -102,7 +102,7 @@ static void *create_refs(void *arg)
 
 	for (i = 0; i < 10; ++i) {
 		snprintf(name, sizeof(name), "refs/heads/thread-%03d-%02d", *id, i);
-		cl_git_pass(git_reference_create(&ref[i], g_repo, name, &head, 0));
+		cl_git_pass(git_reference_create(&ref[i], g_repo, name, &head, 0, NULL, NULL));
 
 		if (i == 5) {
 			git_refdb *refdb;
@@ -165,7 +165,7 @@ void test_threads_refdb__edit_while_iterate(void)
 
 	for (r = 0; r < 50; ++r) {
 		snprintf(name, sizeof(name), "refs/heads/starter-%03d", r);
-		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0));
+		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL, NULL));
 		git_reference_free(ref);
 	}
 


### PR DESCRIPTION
Any well-behaved program should write a descriptive message to the
reflog whenever it updates a reference. Let's make this more prominent
by removing the version without the reflog parameters.

---

As mentioned in #1920 , let's always expose the reflog message as function arguments to encourage useful messages in the reflog.
