### PR TITLE
Add git_commit_amend API

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -242,8 +242,8 @@ GIT_EXTERN(int) git_commit_nth_gen_ancestor(
 /**
  * Create new commit in the repository from a list of `git_object` pointers
  *
- * The message will not be cleaned up automatically. You can do that with
- * the `git_message_prettify()` function.
+ * The message will **not** be cleaned up automatically. You can do that
+ * with the `git_message_prettify()` function.
  *
  * @param id Pointer in which to store the OID of the newly created commit
  *
@@ -291,20 +291,20 @@ GIT_EXTERN(int) git_commit_create(
 	const char *message_encoding,
 	const char *message,
 	const git_tree *tree,
-	int parent_count,
+	size_t parent_count,
 	const git_commit *parents[]);
 
 /**
  * Create new commit in the repository using a variable argument list.
  *
- * The message will be cleaned up from excess whitespace and it will be made
- * sure that the last line ends with a '\n'.
+ * The message will **not** be cleaned up automatically. You can do that
+ * with the `git_message_prettify()` function.
  *
  * The parents for the commit are specified as a variable list of pointers
  * to `const git_commit *`. Note that this is a convenience method which may
  * not be safe to export for certain languages or compilers
  *
- * All other parameters remain the same at `git_commit_create()`.
+ * All other parameters remain the same as `git_commit_create()`.
  *
  * @see git_commit_create
  */
@@ -317,8 +317,39 @@ GIT_EXTERN(int) git_commit_create_v(
 	const char *message_encoding,
 	const char *message,
 	const git_tree *tree,
-	int parent_count,
+	size_t parent_count,
 	...);
+
+/**
+ * Amend an existing commit by replacing only non-NULL values.
+ *
+ * This creates a new commit that is exactly the same as the old commit,
+ * except that any non-NULL values will be updated.  The new commit has
+ * the same parents as the old commit.
+ *
+ * The `update_ref` value works as in the regular `git_commit_create()`,
+ * updating the ref to point to the newly rewritten commit.  If you want
+ * to amend a commit that is not currently the HEAD of the branch and then
+ * rewrite the following commits to reach a ref, pass this as NULL and
+ * update the rest of the commit chain and ref separately.
+ *
+ * Unlike `git_commit_create()`, the `author`, `committer`, `message`,
+ * `message_encoding`, and `tree` parameters can be NULL in which case this
+ * will use the values from the original `commit_to_amend`.
+ *
+ * All parameters have the same meanings as in `git_commit_create()`.
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_amend(
+	git_oid *id,
+	const git_commit *commit_to_amend,
+	const char *update_ref,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/sys/commit.h
+++ b/include/git2/sys/commit.h
@@ -21,16 +21,18 @@
 GIT_BEGIN_DECL
 
 /**
- * Create new commit in the repository from a list of `git_oid` values
+ * Create new commit in the repository from a list of `git_oid` values.
  *
  * See documentation for `git_commit_create()` for information about the
  * parameters, as the meaning is identical excepting that `tree` and
  * `parents` now take `git_oid`.  This is a dangerous API in that nor
  * the `tree`, neither the `parents` list of `git_oid`s are checked for
  * validity.
+ *
+ * @see git_commit_create
  */
 GIT_EXTERN(int) git_commit_create_from_ids(
-	git_oid *oid,
+	git_oid *id,
 	git_repository *repo,
 	const char *update_ref,
 	const git_signature *author,
@@ -38,8 +40,40 @@ GIT_EXTERN(int) git_commit_create_from_ids(
 	const char *message_encoding,
 	const char *message,
 	const git_oid *tree,
-	int parent_count,
+	size_t parent_count,
 	const git_oid *parents[]);
+
+/**
+ * Callback function to return parents for commit.
+ *
+ * This is invoked with the count of the number of parents processed so far
+ * along with the user supplied payload.  This should return a git_oid of
+ * the next parent or NULL if all parents have been provided.
+ */
+typedef const git_oid *(*git_commit_parent_callback)(size_t idx, void *payload);
+
+/**
+ * Create a new commit in the repository with an callback to supply parents.
+ *
+ * See documentation for `git_commit_create()` for information about the
+ * parameters, as the meaning is identical excepting that `tree` takes a
+ * `git_oid` and doesn't check for validity, and `parent_cb` is invoked
+ * with `parent_payload` and should return `git_oid` values or NULL to
+ * indicate that all parents are accounted for.
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_from_callback(
+	git_oid *id,
+	git_repository *repo,
+	const char *update_ref,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_oid *tree,
+	git_commit_parent_callback parent_cb,
+	void *parent_payload);
 
 /** @} */
 GIT_END_DECL

--- a/src/signature.c
+++ b/src/signature.c
@@ -230,6 +230,8 @@ void git_signature__writebuf(git_buf *buf, const char *header, const git_signatu
 	int offset, hours, mins;
 	char sign;
 
+	assert(buf && sig);
+
 	offset = sig->when.offset;
 	sign = (sig->when.offset < 0) ? '-' : '+';
 

--- a/tests/object/commit/commitstagedfile.c
+++ b/tests/object/commit/commitstagedfile.c
@@ -132,3 +132,79 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	git_tree_free(tree);
 	git_index_free(index);
 }
+
+static void assert_commit_tree_has_n_entries(git_commit *c, int count)
+{
+	git_tree *tree;
+	cl_git_pass(git_commit_tree(&tree, c));
+	cl_assert_equal_i(count, git_tree_entrycount(tree));
+	git_tree_free(tree);
+}
+
+static void assert_commit_is_head_(git_commit *c, const char *file, int line)
+{
+	git_commit *head;
+	cl_git_pass(git_revparse_single((git_object **)&head, repo, "HEAD"));
+	clar__assert(git_oid_equal(git_commit_id(c), git_commit_id(head)), file, line, "Commit is not the HEAD", NULL, 1);
+	git_commit_free(head);
+}
+#define assert_commit_is_head(C) assert_commit_is_head_((C),__FILE__,__LINE__)
+
+void test_object_commit_commitstagedfile__amend_commit(void)
+{
+	git_index *index;
+	git_oid old_oid, new_oid, tree_oid;
+	git_commit *old_commit, *new_commit;
+	git_tree *tree;
+
+	/* make a commit */
+
+	cl_git_mkfile("treebuilder/myfile", "This is a file\n");
+	cl_git_pass(git_repository_index(&index, repo));
+	cl_git_pass(git_index_add_bypath(index, "myfile"));
+	cl_repo_commit_from_index(&old_oid, repo, NULL, 0, "first commit");
+
+	cl_git_pass(git_commit_lookup(&old_commit, repo, &old_oid));
+
+	cl_assert_equal_i(0, git_commit_parentcount(old_commit));
+	assert_commit_tree_has_n_entries(old_commit, 1);
+	assert_commit_is_head(old_commit);
+
+	/* let's amend the message of the HEAD commit */
+
+	cl_git_pass(git_commit_amend(
+		&new_oid, old_commit, "HEAD", NULL, NULL, NULL, "Initial commit", NULL));
+
+	cl_git_pass(git_commit_lookup(&new_commit, repo, &new_oid));
+
+	cl_assert_equal_i(0, git_commit_parentcount(new_commit));
+	assert_commit_tree_has_n_entries(new_commit, 1);
+	assert_commit_is_head(new_commit);
+
+	git_commit_free(old_commit);
+	old_commit = new_commit;
+
+	/* let's amend the tree of that last commit */
+
+	cl_git_mkfile("treebuilder/anotherfile", "This is another file\n");
+	cl_git_pass(git_index_add_bypath(index, "anotherfile"));
+	cl_git_pass(git_index_write_tree(&tree_oid, index));
+	cl_git_pass(git_tree_lookup(&tree, repo, &tree_oid));
+	cl_assert_equal_i(2, git_tree_entrycount(tree));
+
+	cl_git_pass(git_commit_amend(
+		&new_oid, old_commit, "HEAD", NULL, NULL, NULL, "Initial commit", tree));
+	git_tree_free(tree);
+
+	cl_git_pass(git_commit_lookup(&new_commit, repo, &new_oid));
+
+	cl_assert_equal_i(0, git_commit_parentcount(new_commit));
+	assert_commit_tree_has_n_entries(new_commit, 2);
+	assert_commit_is_head(new_commit);
+
+	/* cleanup */
+
+	git_commit_free(old_commit);
+	git_commit_free(new_commit);
+	git_index_free(index);
+}


### PR DESCRIPTION
This adds an API to amend an existing commit, basically a shorthand for creating a new commit that fills in missing parameters from the values of an existing commit.

As part of this, I also added a new `include/git2/sys` API to create a commit using a callback to get the parents (`git_commit_create_from_callback`). Since we have several different commit creation functions that mostly differ only in the way that the parents are represented (array of `git_commit *`, array of `git_oid *`, `va_list` of `git_commit *`), this allowed me to rewrite all the commit creation APIs so that temporary allocations are no longer needed.
