### PR TITLE
Convert gitdir paths to posix on Windows

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -289,16 +289,20 @@ static int read_gitfile(git_buf *path_out, const char *file_path)
 		return -1;
 
 	git_buf_rtrim(&file);
+	/* apparently on Windows, some people use backslashes in paths */
+	git_path_mkposix(file.ptr);
 
 	if (git_buf_len(&file) <= prefix_len ||
 		memcmp(git_buf_cstr(&file), GIT_FILE_CONTENT_PREFIX, prefix_len) != 0)
 	{
-		giterr_set(GITERR_REPOSITORY, "The `.git` file at '%s' is malformed", file_path);
+		giterr_set(GITERR_REPOSITORY,
+			"The `.git` file at '%s' is malformed", file_path);
 		error = -1;
 	}
 	else if ((error = git_path_dirname_r(path_out, file_path)) >= 0) {
 		const char *gitlink = git_buf_cstr(&file) + prefix_len;
 		while (*gitlink && git__isspace(*gitlink)) gitlink++;
+
 		error = git_path_prettify_dir(
 			path_out, gitlink, git_buf_cstr(path_out));
 	}


### PR DESCRIPTION
Apparently, a `.git` file with `gitdir: <path>` on Windows is allowed to use backslashes in the path.  Who knew?
