### PR TITLE
Expose patch serialization to git_buf

### DIFF
--- a/include/git2/patch.h
+++ b/include/git2/patch.h
@@ -234,17 +234,6 @@ GIT_EXTERN(int) git_patch_print(
 /**
  * Get the content of a patch as a single diff text.
  *
- * @param string Allocated string; caller must free.
- * @param patch A git_patch representing changes to one file
- * @return 0 on success, <0 on failure.
- */
-GIT_EXTERN(int) git_patch_to_str(
-	char **string,
-	git_patch *patch);
-
-/**
- * Get the content of a patch as a single diff text.
- *
  * @param out The git_buf to be filled in
  * @param patch A git_patch representing changes to one file
  * @return 0 on success, <0 on failure.

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -459,21 +459,3 @@ int git_patch_to_buf(
 {
 	return git_patch_print(patch, diff_print_to_buffer_cb, out);
 }
-
-/* print a git_patch to a char* */
-int git_patch_to_str(
-	char **string,
-	git_patch *patch)
-{
-	int error;
-	git_buf output = GIT_BUF_INIT;
-
-	if (!(error = git_patch_to_buf(&output, patch)))
-		*string = git_buf_detach(&output);
-	else {
-		git_buf_free(&output);
-		*string = NULL;
-	}
-
-	return error;
-}

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -853,7 +853,7 @@ void test_diff_blob__using_path_and_attributes(void)
 	size_t bin_len = 33;
 	const char *changed;
 	git_patch *p;
-	char *pout;
+	git_buf buf = GIT_BUF_INIT;
 
 	/* set up custom diff drivers and 'diff' attribute mappings for them */
 
@@ -951,7 +951,7 @@ void test_diff_blob__using_path_and_attributes(void)
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, nonbin, "zzz.normal", changed, strlen(changed), NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.normal b/zzz.normal\n"
 		"index 45141a7..75b0dbb 100644\n"
@@ -960,23 +960,23 @@ void test_diff_blob__using_path_and_attributes(void)
 		"@@ -1,0 +2,3 @@ Hello from the root\n"
 		"+More lines\n"
 		"+And more\n"
-		"+Go here\n", pout);
-	git__free(pout);
+		"+Go here\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, nonbin, "zzz.binary", changed, strlen(changed), NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.binary b/zzz.binary\n"
 		"index 45141a7..75b0dbb 100644\n"
-		"Binary files a/zzz.binary and b/zzz.binary differ\n", pout);
-	git__free(pout);
+		"Binary files a/zzz.binary and b/zzz.binary differ\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, nonbin, "zzz.alphary", changed, strlen(changed), NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.alphary b/zzz.alphary\n"
 		"index 45141a7..75b0dbb 100644\n"
@@ -985,13 +985,13 @@ void test_diff_blob__using_path_and_attributes(void)
 		"@@ -1,0 +2,3 @@ Hello from the root\n"
 		"+More lines\n"
 		"+And more\n"
-		"+Go here\n", pout);
-	git__free(pout);
+		"+Go here\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, nonbin, "zzz.numary", changed, strlen(changed), NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.numary b/zzz.numary\n"
 		"index 45141a7..75b0dbb 100644\n"
@@ -1000,8 +1000,8 @@ void test_diff_blob__using_path_and_attributes(void)
 		"@@ -1,0 +2,3 @@\n"
 		"+More lines\n"
 		"+And more\n"
-		"+Go here\n", pout);
-	git__free(pout);
+		"+Go here\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	/* "0123456789\n\x01\x02\x03\x04\x05\x06\x07\x08\x09\x00\n0123456789\n"
@@ -1012,17 +1012,17 @@ void test_diff_blob__using_path_and_attributes(void)
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, bin, "zzz.normal", changed, 37, NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.normal b/zzz.normal\n"
 		"index b435cd5..1604519 100644\n"
-		"Binary files a/zzz.normal and b/zzz.normal differ\n", pout);
-	git__free(pout);
+		"Binary files a/zzz.normal and b/zzz.normal differ\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, bin, "zzz.textary", changed, 37, NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.textary b/zzz.textary\n"
 		"index b435cd5..1604519 100644\n"
@@ -1030,13 +1030,13 @@ void test_diff_blob__using_path_and_attributes(void)
 		"+++ b/zzz.textary\n"
 		"@@ -3 +3 @@\n"
 		"-0123456789\n"
-		"+replace a line\n", pout);
-	git__free(pout);
+		"+replace a line\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, bin, "zzz.textalphary", changed, 37, NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.textalphary b/zzz.textalphary\n"
 		"index b435cd5..1604519 100644\n"
@@ -1044,13 +1044,13 @@ void test_diff_blob__using_path_and_attributes(void)
 		"+++ b/zzz.textalphary\n"
 		"@@ -3 +3 @@\n"
 		"-0123456789\n"
-		"+replace a line\n", pout);
-	git__free(pout);
+		"+replace a line\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
 	cl_git_pass(git_patch_from_blob_and_buffer(
 		&p, bin, "zzz.textnumary", changed, 37, NULL, &opts));
-	cl_git_pass(git_patch_to_str(&pout, p));
+	cl_git_pass(git_patch_to_buf(&buf, p));
 	cl_assert_equal_s(
 		"diff --git a/zzz.textnumary b/zzz.textnumary\n"
 		"index b435cd5..1604519 100644\n"
@@ -1058,10 +1058,11 @@ void test_diff_blob__using_path_and_attributes(void)
 		"+++ b/zzz.textnumary\n"
 		"@@ -3 +3 @@ 0123456789\n"
 		"-0123456789\n"
-		"+replace a line\n", pout);
-	git__free(pout);
+		"+replace a line\n", buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(p);
 
+	git_buf_free(&buf);
 	git_blob_free(nonbin);
 	git_blob_free(bin);
 }

--- a/tests/diff/diffiter.c
+++ b/tests/diff/diffiter.c
@@ -414,16 +414,16 @@ void test_diff_diffiter__iterate_and_generate_patch_text(void)
 
 	for (d = 0; d < num_d; ++d) {
 		git_patch *patch;
-		char *text;
+		git_buf buf = GIT_BUF_INIT;
 
 		cl_git_pass(git_patch_from_diff(&patch, diff, d));
 		cl_assert(patch != NULL);
 
-		cl_git_pass(git_patch_to_str(&text, patch));
+		cl_git_pass(git_patch_to_buf(&buf, patch));
 
-		cl_assert_equal_s(expected_patch_text[d], text);
+		cl_assert_equal_s(expected_patch_text[d], buf.ptr);
 
-		git__free(text);
+		git_buf_free(&buf);
 		git_patch_free(patch);
 	}
 

--- a/tests/diff/patch.c
+++ b/tests/diff/patch.c
@@ -141,7 +141,7 @@ void test_diff_patch__to_string(void)
 	git_tree *one, *another;
 	git_diff *diff;
 	git_patch *patch;
-	char *text;
+	git_buf buf = GIT_BUF_INIT;
 	const char *expected = "diff --git a/subdir.txt b/subdir.txt\ndeleted file mode 100644\nindex e8ee89e..0000000\n--- a/subdir.txt\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-Is it a bird?\n-Is it a plane?\n";
 
 	g_repo = cl_git_sandbox_init("status");
@@ -155,16 +155,16 @@ void test_diff_patch__to_string(void)
 
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
 
-	cl_git_pass(git_patch_to_str(&text, patch));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
 
-	cl_assert_equal_s(expected, text);
+	cl_assert_equal_s(expected, buf.ptr);
 
 	cl_assert_equal_sz(31, git_patch_size(patch, 0, 0, 0));
 	cl_assert_equal_sz(31, git_patch_size(patch, 1, 0, 0));
 	cl_assert_equal_sz(31 + 16, git_patch_size(patch, 1, 1, 0));
 	cl_assert_equal_sz(strlen(expected), git_patch_size(patch, 1, 1, 1));
 
-	git__free(text);
+	git_buf_free(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 	git_tree_free(another);
@@ -178,7 +178,7 @@ void test_diff_patch__config_options(void)
 	git_config *cfg;
 	git_diff *diff;
 	git_patch *patch;
-	char *text;
+	git_buf buf = GIT_BUF_INIT;
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	char *onefile = "staged_changes_modified_file";
 	const char *expected1 = "diff --git c/staged_changes_modified_file i/staged_changes_modified_file\nindex 70bd944..906ee77 100644\n--- c/staged_changes_modified_file\n+++ i/staged_changes_modified_file\n@@ -1 +1,2 @@\n staged_changes_modified_file\n+staged_changes_modified_file\n";
@@ -199,10 +199,10 @@ void test_diff_patch__config_options(void)
 
 	cl_assert_equal_i(1, (int)git_diff_num_deltas(diff));
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
-	cl_git_pass(git_patch_to_str(&text, patch));
-	cl_assert_equal_s(expected1, text);
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+	cl_assert_equal_s(expected1, buf.ptr);
 
-	git__free(text);
+	git_buf_clear(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -210,10 +210,10 @@ void test_diff_patch__config_options(void)
 
 	cl_assert_equal_i(1, (int)git_diff_num_deltas(diff));
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
-	cl_git_pass(git_patch_to_str(&text, patch));
-	cl_assert_equal_s(expected2, text);
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+	cl_assert_equal_s(expected2, buf.ptr);
 
-	git__free(text);
+	git_buf_clear(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -224,10 +224,10 @@ void test_diff_patch__config_options(void)
 
 	cl_assert_equal_i(1, (int)git_diff_num_deltas(diff));
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
-	cl_git_pass(git_patch_to_str(&text, patch));
-	cl_assert_equal_s(expected3, text);
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+	cl_assert_equal_s(expected3, buf.ptr);
 
-	git__free(text);
+	git_buf_clear(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -238,13 +238,14 @@ void test_diff_patch__config_options(void)
 
 	cl_assert_equal_i(1, (int)git_diff_num_deltas(diff));
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
-	cl_git_pass(git_patch_to_str(&text, patch));
-	cl_assert_equal_s(expected4, text);
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+	cl_assert_equal_s(expected4, buf.ptr);
 
-	git__free(text);
+	git_buf_clear(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
+	git_buf_free(&buf);
 	git_tree_free(one);
 	git_config_free(cfg);
 }
@@ -465,10 +466,10 @@ static void check_single_patch_stats(
 	cl_assert_equal_sz(dels, actual_dels);
 
 	if (expected != NULL) {
-		char *text;
-		cl_git_pass(git_patch_to_str(&text, patch));
-		cl_assert_equal_s(expected, text);
-		git__free(text);
+		git_buf buf = GIT_BUF_INIT;
+		cl_git_pass(git_patch_to_buf(&buf, patch));
+		cl_assert_equal_s(expected, buf.ptr);
+		git_buf_free(&buf);
 
 		cl_assert_equal_sz(
 			strlen(expected), git_patch_size(patch, 1, 1, 1));

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -584,7 +584,7 @@ void test_diff_rename__patch(void)
 	git_diff_find_options opts = GIT_DIFF_FIND_OPTIONS_INIT;
 	git_patch *patch;
 	const git_diff_delta *delta;
-	char *text;
+	git_buf buf = GIT_BUF_INIT;
 	const char *expected = "diff --git a/sixserving.txt b/ikeepsix.txt\nindex ad0a8e5..36020db 100644\n--- a/sixserving.txt\n+++ b/ikeepsix.txt\n@@ -1,3 +1,6 @@\n+I Keep Six Honest Serving-Men\n+=============================\n+\n I KEEP six honest serving-men\n  (They taught me all I knew);\n Their names are What and Why and When\n@@ -21,4 +24,4 @@ She sends'em abroad on her own affairs,\n One million Hows, two million Wheres,\n And seven million Whys!\n \n-                -- Rudyard Kipling\n+  -- Rudyard Kipling\n";
 
 	old_tree = resolve_commit_oid_to_tree(g_repo, sha0);
@@ -610,9 +610,9 @@ void test_diff_rename__patch(void)
 	cl_assert((delta = git_patch_get_delta(patch)) != NULL);
 	cl_assert_equal_i(GIT_DELTA_COPIED, (int)delta->status);
 
-	cl_git_pass(git_patch_to_str(&text, patch));
-	cl_assert_equal_s(expected, text);
-	git__free(text);
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+	cl_assert_equal_s(expected, buf.ptr);
+	git_buf_free(&buf);
 
 	git_patch_free(patch);
 

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -1375,7 +1375,7 @@ void test_diff_workdir__patience_diff(void)
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff = NULL;
 	git_patch *patch = NULL;
-	char *as_str = NULL;
+	git_buf buf = GIT_BUF_INIT;
 	const char *expected_normal = "diff --git a/test.txt b/test.txt\nindex 34a5acc..d52725f 100644\n--- a/test.txt\n+++ b/test.txt\n@@ -1,10 +1,7 @@\n When I wrote this\n I did not know\n-how to create\n-a patience diff\n I did not know\n how to create\n+a patience diff\n another problem\n-I did not know\n-how to create\n a minimal diff\n";
 	const char *expected_patience = "diff --git a/test.txt b/test.txt\nindex 34a5acc..d52725f 100644\n--- a/test.txt\n+++ b/test.txt\n@@ -1,10 +1,7 @@\n When I wrote this\n I did not know\n+I did not know\n how to create\n a patience diff\n-I did not know\n-how to create\n another problem\n-I did not know\n-how to create\n a minimal diff\n";
 
@@ -1397,10 +1397,10 @@ void test_diff_workdir__patience_diff(void)
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
 	cl_assert_equal_i(1, git_diff_num_deltas(diff));
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
-	cl_git_pass(git_patch_to_str(&as_str, patch));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
 
-	cl_assert_equal_s(expected_normal, as_str);
-	git__free(as_str);
+	cl_assert_equal_s(expected_normal, buf.ptr);
+	git_buf_clear(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -1409,10 +1409,12 @@ void test_diff_workdir__patience_diff(void)
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
 	cl_assert_equal_i(1, git_diff_num_deltas(diff));
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
-	cl_git_pass(git_patch_to_str(&as_str, patch));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
 
-	cl_assert_equal_s(expected_patience, as_str);
-	git__free(as_str);
+	cl_assert_equal_s(expected_patience, buf.ptr);
+	git_buf_clear(&buf);
+
+	git_buf_free(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 }


### PR DESCRIPTION
Returning library-allocated strings from libgit2 works fine on Linux, but may cause problems on Windows because there is no one C Runtime that everything links against. With libgit2 not exposing its own allocator, freeing the string is a gamble.

`git_patch_to_str` already serializes to a buffer, then returns the underlying memory. Expose the functionality directly, so callers can use the `git_buf_free` function to free the memory later.

Additional test cases exercising `git_patch_to_buf` are not required, because the existing `git_patch_to_str` tests will cover `git_patch_to_buf` as well.
