### PR TITLE
Summarize empty messages

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -311,7 +311,10 @@ const char *git_commit_summary(git_commit *commit)
 				git_buf_putc(&summary, *msg);
 		}
 
-		commit->summary = git_buf_detach(&summary);
+		if (summary.asize == 0)
+			commit->summary = git__strdup("");
+		else
+			commit->summary = git_buf_detach(&summary);
 	}
 
 	return commit->summary;

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -72,4 +72,8 @@ void test_commit_commit__summary(void)
 	assert_commit_summary("Trailing spaces  are removed", "Trailing spaces  are removed  ");
 	assert_commit_summary("Trailing tabs", "Trailing tabs\t\n\nare removed");
 	assert_commit_summary("Trailing spaces", "Trailing spaces \n\nare removed");
+	assert_commit_summary("", "");
+	assert_commit_summary("", " ");
+	assert_commit_summary("", "\n");
+	assert_commit_summary("", "\n \n");
 }


### PR DESCRIPTION
When a commit message is empty or consists only of whitespace, the summary should be the empty string.  `git_buf_detach`ing an empty buffer returns NULL.  Duh.
