### PR TITLE
Fix write_object.

### DIFF
--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -288,6 +288,7 @@ static int write_object(
 	git_odb_object *obj = NULL;
 	git_otype type;
 	unsigned char hdr[10], *zbuf = NULL;
+	void *delta_data = NULL;
 	void *data;
 	size_t hdr_len, zbuf_len = COMPRESS_BUFLEN, data_len;
 	ssize_t written;
@@ -295,10 +296,11 @@ static int write_object(
 
 	if (po->delta) {
 		if (po->delta_data)
-			data = po->delta_data;
-		else if ((error = get_delta(&data, pb->odb, po)) < 0)
+			delta_data = po->delta_data;
+		else if ((error = get_delta(&delta_data, pb->odb, po)) < 0)
 				goto done;
 
+		data = delta_data;
 		data_len = po->delta_size;
 		type = GIT_OBJ_REF_DELTA;
 	} else {
@@ -351,7 +353,7 @@ static int write_object(
 		}
 
 		if (po->delta)
-			git__free(data);
+			git__free(delta_data);
 	}
 
 	if (po->delta_data) {

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -70,7 +70,7 @@ int git_zstream_deflatebuf(git_buf *out, const void *in, size_t in_len)
 	int error = 0;
 
 	if ((error = git_zstream_init(&zstream)) < 0)
-		goto done;
+		return error;
 
 	do {
 		if (out->asize - out->size < BUFFER_SIZE)
@@ -89,7 +89,6 @@ int git_zstream_deflatebuf(git_buf *out, const void *in, size_t in_len)
 	if (written < 0)
 		error = written;
 
-done:
 	git_zstream_free(&zstream);
 	return error;
 }


### PR DESCRIPTION
Two bugs:
1. zstream free.
2. write_object free.

```
(64781,0x7fff77764180) malloc: *** error for object 0x7f8d7586843e: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
(64782,0x7fff77764180) malloc: *** error for object 0x7f8d7606b23e: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
```

```
(gdb) bt
#0  0x00007fff8f4e9d46 in __kill ()
#1  0x00007fff8d0d6f83 in abort ()
#2  0x00007fff8d0aa989 in free ()
#3  0x000000010051d869 in git__free [inlined] () at /Users/xtao/Work/code/pygit2_xt/vendor/libgit2/src/util.h:354
#4  0x000000010051d869 in write_one (status=<value temporarily unavailable, due to optimizations>, pb=0x100376a10, po=0x10077ea28, write_cb=0x100527b00 <foreach_cb>, cb_data=0x7fff5fbfe8f0) at src/pack-objects.c:354
#5  0x000000010051ece0 in write_pack (pb=0x100376a10, write_cb=0x100527b00 <foreach_cb>, cb_data=0x7fff5fbfe8f0) at src/pack-objects.c:620
#6  0x0000000100527df7 in local_download_pack (transport=0x10035cda0, repo=0x100340520, stats=0x100366718, progress_cb=0, progress_payload=0x0) at src/transports/local.c:540
#7  0x000000010050ed75 in git_remote_download (remote=0x100366640) at src/remote.c:827
#8  0x00000001004ba94a in Remote_fetch ()
#9  0x00000001000ec591 in call_function ()
#10 0x00000001000e8bbd in PyEval_EvalFrameEx ()
#11 0x00000001000eaa6f in PyEval_EvalCodeEx ()
#12 0x00000001000e1f37 in PyEval_EvalCode ()
#13 0x00000001001190ef in run_mod ()
#14 0x0000000100119079 in PyRun_FileExFlags ()
#15 0x0000000100117dd3 in PyRun_SimpleFileExFlags ()
#16 0x000000010011766e in PyRun_AnyFileExFlags ()
#17 0x0000000100133b85 in Py_Main ()
#18 0x0000000100000ead in main ()
```
