### PR TITLE
void *malloc(size_t) -> int malloc(void **, size_t)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .lock-wafbuild
 .waf*
 build/
+build_static/
 build-amiga/
 tests/tmp/
 msvc/Debug/

--- a/include/git2/blame.h
+++ b/include/git2/blame.h
@@ -106,7 +106,7 @@ typedef struct git_blame_hunk {
 	git_signature *final_signature;
 
 	git_oid orig_commit_id;
-	const char *orig_path;
+	char *orig_path;
 	uint16_t orig_start_line_number;
 	git_signature *orig_signature;
 

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -122,7 +122,7 @@ GIT_EXTERN(void) git_oid_pathfmt(char *out, const git_oid *id);
  * @return the c-string; NULL if memory is exhausted. Caller must
  *			deallocate the string with git__free().
  */
-GIT_EXTERN(char *) git_oid_allocfmt(const git_oid *id);
+GIT_EXTERN(int) git_oid_allocfmt(char **out, const git_oid *id);
 
 /**
  * Format a git_oid into a buffer as a hex format c-string.
@@ -228,7 +228,7 @@ typedef struct git_oid_shorten git_oid_shorten;
  *		be unique.
  *	@return a `git_oid_shorten` instance, NULL if OOM
  */
-GIT_EXTERN(git_oid_shorten *) git_oid_shorten_new(size_t min_length);
+GIT_EXTERN(int) git_oid_shorten_new(git_oid_shorten **out, size_t min_length);
 
 /**
  * Add a new OID to set of shortened OIDs and calculate

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -89,7 +89,7 @@ struct git_odb_backend {
 #define GIT_ODB_BACKEND_VERSION 1
 #define GIT_ODB_BACKEND_INIT {GIT_ODB_BACKEND_VERSION}
 
-GIT_EXTERN(void *) git_odb_backend_malloc(git_odb_backend *backend, size_t len);
+GIT_EXTERN(int) git_odb_backend_malloc(void **out, git_odb_backend *backend, size_t len);
 
 GIT_END_DECL
 

--- a/include/git2/sys/refs.h
+++ b/include/git2/sys/refs.h
@@ -19,7 +19,8 @@
  * @param peel the first non-tag object's OID, or NULL
  * @return the created git_reference or NULL on error
  */
-GIT_EXTERN(git_reference *) git_reference__alloc(
+GIT_EXTERN(int) git_reference__alloc(
+	git_reference **out,
 	const char *name,
 	const git_oid *oid,
 	const git_oid *peel);
@@ -31,7 +32,8 @@ GIT_EXTERN(git_reference *) git_reference__alloc(
  * @param target the target for a symbolic reference
  * @return the created git_reference or NULL on error
  */
-GIT_EXTERN(git_reference *) git_reference__alloc_symbolic(
+GIT_EXTERN(int) git_reference__alloc_symbolic(
+	git_reference **out,
 	const char *name,
 	const char *target);
 

--- a/src/array.h
+++ b/src/array.h
@@ -31,7 +31,7 @@
 	do { (a).size = (a).asize = 0; (a).ptr = NULL; } while (0)
 
 #define git_array_init_to_size(a, desired) \
-	do { (a).size = 0; (a).asize = desired; (a).ptr = git__calloc(desired, sizeof(*(a).ptr)); } while (0)
+	( (a).size = 0, (a).asize = desired, git__calloc(&(a).ptr, desired, sizeof(*(a).ptr)) )
 
 #define git_array_clear(a) \
 	do { git__free((a).ptr); git_array_init(a); } while (0)
@@ -46,8 +46,9 @@ GIT_INLINE(void *) git_array_grow(void *_a, size_t item_size)
 {
 	git_array_generic_t *a = _a;
 	uint32_t new_size = (a->size < 8) ? 8 : a->asize * 3 / 2;
-	char *new_array = git__realloc(a->ptr, new_size * item_size);
-	if (!new_array) {
+	char *new_array;
+	
+	if (git__realloc(&new_array, a->ptr, new_size * item_size) < 0) {
 		git_array_clear(*a);
 		return NULL;
 	} else {

--- a/src/bitvec.h
+++ b/src/bitvec.h
@@ -30,8 +30,7 @@ GIT_INLINE(int) git_bitvec_init(git_bitvec *bv, size_t capacity)
 
 	if (capacity >= 64) {
 		bv->length = (capacity / 64) + 1;
-		bv->u.words = git__calloc(bv->length, sizeof(uint64_t));
-		if (!bv->u.words)
+		if (git__calloc(&bv->u.words, bv->length, sizeof(uint64_t)) < 0)
 			return -1;
 	}
 

--- a/src/blame.h
+++ b/src/blame.h
@@ -85,7 +85,8 @@ struct git_blame {
 	git_off_t final_buf_size;
 };
 
-git_blame *git_blame__alloc(
+int git_blame__alloc(
+	git_blame **out,
 	git_repository *repo,
 	git_blame_options opts,
 	const char *path);

--- a/src/blame_git.h
+++ b/src/blame_git.h
@@ -15,6 +15,6 @@ int git_blame__get_origin(
 		git_commit *commit,
 		const char *path);
 void git_blame__free_entry(git_blame__entry *ent);
-void git_blame__like_git(git_blame *sb, uint32_t flags);
+int git_blame__like_git(git_blame *sb, uint32_t flags);
 
 #endif

--- a/src/blob.c
+++ b/src/blob.c
@@ -133,8 +133,8 @@ static int write_symlink(
 	ssize_t read_len;
 	int error;
 
-	link_data = git__malloc(link_size);
-	GITERR_CHECK_ALLOC(link_data);
+	if (git__malloc(&link_data, link_size) < 0)
+		return -1;
 
 	read_len = p_readlink(path, link_data, link_size);
 	if (read_len != (ssize_t)link_size) {
@@ -279,15 +279,9 @@ int git_blob_create_fromchunks(
 
 	assert(oid && repo && source_cb);
 
-	if ((error = git_buf_joinpath(
-			&path, git_repository_path(repo), GIT_OBJECTS_DIR "streamed")) < 0)
-		goto cleanup;
-
-	content = git__malloc(BUFFER_SIZE);
-	GITERR_CHECK_ALLOC(content);
-
-	if ((error = git_filebuf_open(
-			&file, git_buf_cstr(&path), GIT_FILEBUF_TEMPORARY, 0666)) < 0)
+	if ((error = git_buf_joinpath(&path, git_repository_path(repo), GIT_OBJECTS_DIR "streamed")) < 0 ||
+		(error = git__malloc(&content, BUFFER_SIZE)) < 0 ||
+		(error = git_filebuf_open(&file, git_buf_cstr(&path), GIT_FILEBUF_TEMPORARY, 0666)) < 0)
 		goto cleanup;
 
 	while (1) {

--- a/src/branch.c
+++ b/src/branch.c
@@ -162,8 +162,10 @@ int git_branch_iterator_new(
 {
 	branch_iter *iter;
 
-	iter = git__calloc(1, sizeof(branch_iter));
-	GITERR_CHECK_ALLOC(iter);
+	*out = NULL;
+
+	if (git__calloc(&iter, 1, sizeof(branch_iter)) < 0)
+		return -1;
 
 	iter->flags = list_flags;
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -63,9 +63,7 @@ int git_buf_try_grow(
 	/* round allocation up to multiple of 8 */
 	new_size = (new_size + 7) & ~7;
 
-	new_ptr = git__realloc(new_ptr, new_size);
-
-	if (!new_ptr) {
+	if (git__realloc(&new_ptr, new_ptr, new_size) < 0) {
 		if (mark_oom) {
 			if (buf->ptr) git__free(buf->ptr);
 			buf->ptr = git_buf__oom;

--- a/src/commit_list.h
+++ b/src/commit_list.h
@@ -38,11 +38,11 @@ typedef struct git_commit_list {
 	struct git_commit_list *next;
 } git_commit_list;
 
-git_commit_list_node *git_commit_list_alloc_node(git_revwalk *walk);
+int git_commit_list_alloc_node(git_commit_list_node **out, git_revwalk *walk);
 int git_commit_list_time_cmp(void *a, void *b);
 void git_commit_list_free(git_commit_list **list_p);
-git_commit_list *git_commit_list_insert(git_commit_list_node *item, git_commit_list **list_p);
-git_commit_list *git_commit_list_insert_by_date(git_commit_list_node *item, git_commit_list **list_p);
+int git_commit_list_insert(git_commit_list_node *item, git_commit_list **list_p);
+int git_commit_list_insert_by_date(git_commit_list_node *item, git_commit_list **list_p);
 int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit);
 git_commit_list_node *git_commit_list_pop(git_commit_list **stack);
 

--- a/src/config.c
+++ b/src/config.c
@@ -71,10 +71,10 @@ int git_config_new(git_config **out)
 {
 	git_config *cfg;
 
-	cfg = git__malloc(sizeof(git_config));
-	GITERR_CHECK_ALLOC(cfg);
+	*out = NULL;
 
-	memset(cfg, 0x0, sizeof(git_config));
+	if (git__calloc(&cfg, 1, sizeof(git_config)) < 0)
+		return -1;
 
 	if (git_vector_init(&cfg->files, 3, config_backend_cmp) < 0) {
 		git__free(cfg);
@@ -275,13 +275,9 @@ int git_config_add_backend(
 
 	GITERR_CHECK_VERSION(file, GIT_CONFIG_BACKEND_VERSION, "git_config_backend");
 
-	if ((result = file->open(file, level)) < 0)
+	if ((result = file->open(file, level)) < 0 ||
+		(result = git__calloc(&internal, 1, sizeof(file_internal))) < 0)
 		return result;
-
-	internal = git__malloc(sizeof(file_internal));
-	GITERR_CHECK_ALLOC(internal);
-
-	memset(internal, 0x0, sizeof(file_internal));
 
 	internal->file = file;
 	internal->level = level;
@@ -430,8 +426,8 @@ int git_config_iterator_new(git_config_iterator **out, const git_config *cfg)
 {
 	all_iter *iter;
 
-	iter = git__calloc(1, sizeof(all_iter));
-	GITERR_CHECK_ALLOC(iter);
+	if (git__calloc(&iter, 1, sizeof(all_iter)) < 0)
+		return -1;
 
 	iter->parent.free = all_iter_free;
 	iter->parent.next = all_iter_next;
@@ -452,8 +448,8 @@ int git_config_iterator_glob_new(git_config_iterator **out, const git_config *cf
 	if (regexp == NULL)
 		return git_config_iterator_new(out, cfg);
 
-	iter = git__calloc(1, sizeof(all_iter));
-	GITERR_CHECK_ALLOC(iter);
+	if (git__calloc(&iter, 1, sizeof(all_iter)) < 0)
+		return -1;
 
 	if ((result = regcomp(&iter->regex, regexp, REG_EXTENDED)) < 0) {
 		giterr_set_regex(&iter->regex, result);
@@ -860,11 +856,9 @@ int git_config_multivar_iterator_new(git_config_iterator **out, const git_config
 	git_config_iterator *inner = NULL;
 	int error;
 
-	if ((error = git_config_iterator_new(&inner, cfg)) < 0)
+	if ((error = git_config_iterator_new(&inner, cfg)) < 0 ||
+		(error = git__calloc(&iter, 1, sizeof(multivar_iter))) < 0)
 		return error;
-
-	iter = git__calloc(1, sizeof(multivar_iter));
-	GITERR_CHECK_ALLOC(iter);
 
 	if ((error = git_config__normalize_name(name, &iter->name)) < 0)
 		goto on_error;
@@ -1185,8 +1179,8 @@ int git_config__normalize_name(const char *in, char **out)
 
 	assert(in && out);
 
-	name = git__strdup(in);
-	GITERR_CHECK_ALLOC(name);
+	if (git__strdup(&name, in) < 0)
+		return -1;
 
 	fdot = strchr(name, '.');
 	ldot = strrchr(name, '.');

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -279,8 +279,9 @@ static int crlf_check(
 			return GIT_PASSTHROUGH;
 	}
 
-	*payload = git__malloc(sizeof(ca));
-	GITERR_CHECK_ALLOC(*payload);
+	if (git__malloc(payload, sizeof(ca)) < 0)
+		return -1;
+
 	memcpy(*payload, &ca, sizeof(ca));
 
 	return 0;
@@ -314,9 +315,14 @@ static void crlf_cleanup(
 	git__free(payload);
 }
 
-git_filter *git_crlf_filter_new(void)
+int git_crlf_filter_new(git_filter **out)
 {
-	struct crlf_filter *f = git__calloc(1, sizeof(struct crlf_filter));
+	struct crlf_filter *f;
+
+	if (git__calloc(&f, 1, sizeof(struct crlf_filter)) < 0) {
+		*out = NULL;
+		return -1;
+	}
 
 	f->f.version = GIT_FILTER_VERSION;
 	f->f.attributes = "crlf eol text";
@@ -326,5 +332,6 @@ git_filter *git_crlf_filter_new(void)
 	f->f.apply    = crlf_apply;
 	f->f.cleanup  = crlf_cleanup;
 
-	return (git_filter *)f;
+	*out = (git_filter *)f;
+	return 0;
 }

--- a/src/date.c
+++ b/src/date.c
@@ -1,7 +1,8 @@
 /*
- * GIT - The information manager from hell
+ * Copyright (C) the libgit2 contributors. All rights reserved.
  *
- * Copyright (C) Linus Torvalds, 2005
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
  */
 
 #include "common.h"

--- a/src/delta-apply.c
+++ b/src/delta-apply.c
@@ -74,8 +74,8 @@ int git__delta_apply(
 		return -1;
 	}
 
-	res_dp = git__malloc(res_sz + 1);
-	GITERR_CHECK_ALLOC(res_dp);
+	if (git__malloc(&res_dp, res_sz + 1) < 0)
+		return -1;
 
 	res_dp[res_sz] = '\0';
 	out->data = res_dp;

--- a/src/diff_driver.h
+++ b/src/diff_driver.h
@@ -12,7 +12,7 @@
 
 typedef struct git_diff_driver_registry git_diff_driver_registry;
 
-git_diff_driver_registry *git_diff_driver_registry_new(void);
+int git_diff_driver_registry_new(git_diff_driver_registry **out);
 void git_diff_driver_registry_free(git_diff_driver_registry *);
 
 typedef struct git_diff_driver git_diff_driver;

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -277,8 +277,8 @@ static int diff_file_content_load_workdir_symlink(
 	 */
 	alloc_len = (ssize_t)(fc->file->size * 2) + 1;
 
-	fc->map.data = git__calloc(alloc_len, sizeof(char));
-	GITERR_CHECK_ALLOC(fc->map.data);
+	if (git__calloc(fc->map.data, alloc_len, sizeof(char)) < 0)
+		return -1;
 
 	fc->flags |= GIT_DIFF_FLAG__FREE_DATA;
 

--- a/src/diff_patch.c
+++ b/src/diff_patch.c
@@ -100,9 +100,13 @@ static int diff_patch_init_from_diff(
 static int diff_patch_alloc_from_diff(
 	git_patch **out, git_diff *diff, size_t delta_index)
 {
+	git_patch *patch;
 	int error;
-	git_patch *patch = git__calloc(1, sizeof(git_patch));
-	GITERR_CHECK_ALLOC(patch);
+
+	if (git__calloc(&patch, 1, sizeof(git_patch)) < 0) {
+		*out = NULL;
+		return -1;
+	}
 
 	if (!(error = diff_patch_init_from_diff(patch, diff, delta_index))) {
 		patch->flags |= GIT_DIFF_PATCH_ALLOCATED;
@@ -380,8 +384,10 @@ static int diff_patch_with_delta_alloc(
 	size_t old_len = *old_path ? strlen(*old_path) : 0;
 	size_t new_len = *new_path ? strlen(*new_path) : 0;
 
-	*out = pd = git__calloc(1, sizeof(*pd) + old_len + new_len + 2);
-	GITERR_CHECK_ALLOC(pd);
+	if (git__calloc(&pd, 1, sizeof(*pd) + old_len + new_len + 2) < 0) {
+		*out = NULL;
+		return -1;
+	}
 
 	pd->patch.flags = GIT_DIFF_PATCH_ALLOCATED;
 
@@ -397,6 +403,7 @@ static int diff_patch_with_delta_alloc(
 	} else if (*old_path)
 		*new_path = &pd->paths[0];
 
+	*out = pd;
 	return 0;
 }
 

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -833,8 +833,10 @@ static int cp_link(const char *from, const char *to, size_t link_size)
 {
 	int error = 0;
 	ssize_t read_len;
-	char *link_data = git__malloc(link_size + 1);
-	GITERR_CHECK_ALLOC(link_data);
+	char *link_data;
+
+	if (git__malloc(&link_data, link_size + 1) < 0)
+		return -1;
 
 	read_len = p_readlink(from, link_data, link_size);
 	if (read_len != (ssize_t)link_size) {

--- a/src/filter.h
+++ b/src/filter.h
@@ -25,7 +25,7 @@ extern void git_filter_free(git_filter *filter);
  * Available filters
  */
 
-extern git_filter *git_crlf_filter_new(void);
-extern git_filter *git_ident_filter_new(void);
+extern int git_crlf_filter_new(git_filter **out);
+extern int git_ident_filter_new(git_filter **out);
 
 #endif

--- a/src/global.h
+++ b/src/global.h
@@ -15,11 +15,9 @@ typedef struct {
 	git_error error_t;
 } git_global_st;
 
-git_global_st *git__global_state(void);
+extern int git__global_state(git_global_st **out);
 
 extern git_mutex git__mwindow_mutex;
-
-#define GIT_GLOBAL (git__global_state())
 
 typedef void (*git_global_shutdown_fn)(void);
 

--- a/src/graph.c
+++ b/src/graph.c
@@ -89,7 +89,7 @@ static int mark_parents(git_revwalk *walk, git_commit_list_node *one,
 
 		/* Keep track of root commits, to make sure the path gets marked */
 		if (commit->out_degree == 0) {
-			if (git_commit_list_insert(commit, &roots) == NULL)
+			if (git_commit_list_insert(commit, &roots) < 0)
 				goto on_error;
 		}
 	}

--- a/src/hash/hash_win32.c
+++ b/src/hash/hash_win32.c
@@ -172,7 +172,7 @@ GIT_INLINE(void) hash_ctx_cryptoapi_cleanup(git_hash_ctx *ctx)
 
 GIT_INLINE(int) hash_ctx_cng_init(git_hash_ctx *ctx)
 {
-	if ((ctx->ctx.cng.hash_object = git__malloc(hash_prov.prov.cng.hash_object_size)) == NULL)
+	if (git__malloc(&ctx->ctx.cng.hash_object, hash_prov.prov.cng.hash_object_size) < 0)
 		return -1;
 
 	if (hash_prov.prov.cng.create_hash(hash_prov.prov.cng.handle, &ctx->ctx.cng.hash_handle, ctx->ctx.cng.hash_object, hash_prov.prov.cng.hash_object_size, NULL, 0, 0) < 0) {

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -224,17 +224,21 @@ static int hashsig_finalize_hashes(git_hashsig *sig)
 	return 0;
 }
 
-static git_hashsig *hashsig_alloc(git_hashsig_option_t opts)
+static int hashsig_alloc(git_hashsig **out, git_hashsig_option_t opts)
 {
-	git_hashsig *sig = git__calloc(1, sizeof(git_hashsig));
-	if (!sig)
-		return NULL;
+	git_hashsig *sig;
+	
+	*out = NULL;
+
+	if (git__calloc(&sig, 1, sizeof(git_hashsig)) < 0)
+		return -1;
 
 	hashsig_heap_init(&sig->mins, hashsig_cmp_min);
 	hashsig_heap_init(&sig->maxs, hashsig_cmp_max);
 	sig->opt = opts;
 
-	return sig;
+	*out = sig;
+	return 0;
 }
 
 int git_hashsig_create(
@@ -245,8 +249,12 @@ int git_hashsig_create(
 {
 	int error;
 	hashsig_in_progress prog;
-	git_hashsig *sig = hashsig_alloc(opts);
-	GITERR_CHECK_ALLOC(sig);
+	git_hashsig *sig;
+
+	*out = NULL;
+	
+	if (hashsig_alloc(&sig, opts) < 0)
+		return -1;
 
 	hashsig_in_progress_init(&prog, sig);
 
@@ -272,8 +280,12 @@ int git_hashsig_create_fromfile(
 	ssize_t buflen = 0;
 	int error = 0, fd;
 	hashsig_in_progress prog;
-	git_hashsig *sig = hashsig_alloc(opts);
-	GITERR_CHECK_ALLOC(sig);
+	git_hashsig *sig;
+
+	*out = NULL;
+	
+	if (hashsig_alloc(&sig, opts) < 0)
+		return -1;
 
 	if ((fd = git_futils_open_ro(path)) < 0) {
 		git__free(sig);

--- a/src/ident.c
+++ b/src/ident.c
@@ -112,14 +112,20 @@ static int ident_apply(
 		return ident_remove_id(to, from);
 }
 
-git_filter *git_ident_filter_new(void)
+int git_ident_filter_new(git_filter **out)
 {
-	git_filter *f = git__calloc(1, sizeof(git_filter));
+	git_filter *f;
+	
+	*out = NULL;
+
+	if (git__calloc(&f, 1, sizeof(git_filter)) < 0)
+		return -1;
 
 	f->version = GIT_FILTER_VERSION;
 	f->attributes = "+ident"; /* apply to files with ident attribute set */
 	f->shutdown = git_filter_free;
 	f->apply    = ident_apply;
 
-	return f;
+	*out = f;
+	return 0;
 }

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -33,10 +33,8 @@ static int parse_ignore_file(
 	scan = buffer;
 
 	while (!error && *scan) {
-		if (!match) {
-			match = git__calloc(1, sizeof(*match));
-			GITERR_CHECK_ALLOC(match);
-		}
+		if (!match && git__calloc(&match, 1, sizeof(*match)) < 0)
+			return -1;
 
 		match->flags = GIT_ATTR_FNMATCH_ALLOWSPACE | GIT_ATTR_FNMATCH_ALLOWNEG;
 

--- a/src/merge.h
+++ b/src/merge.h
@@ -140,7 +140,7 @@ int git_merge__bases_many(
  * Three-way tree differencing
  */
 
-git_merge_diff_list *git_merge_diff_list__alloc(git_repository *repo);
+int git_merge_diff_list__alloc(git_merge_diff_list **out, git_repository *repo);
 
 int git_merge_diff_list__find_differences(git_merge_diff_list *merge_diff_list,
 	const git_tree *ancestor_tree,

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -77,11 +77,11 @@ int git_merge_file_input_from_index_entry(
 		return 0;
 
 	if ((error = git_repository_odb(&odb, repo)) < 0 ||
-		(error = git_odb_read(&input->odb_object, odb, &entry->oid)) < 0)
+		(error = git_odb_read(&input->odb_object, odb, &entry->oid)) < 0 ||
+		(error = git__strdup(&input->path, entry->path)) < 0)
 		goto done;
 
 	input->mode = entry->mode;
-	input->path = git__strdup(entry->path);
 	input->mmfile.size = git_odb_object_size(input->odb_object);
 	input->mmfile.ptr = (char *)git_odb_object_data(input->odb_object);
 
@@ -108,11 +108,11 @@ int git_merge_file_input_from_diff_file(
 		return 0;
 
 	if ((error = git_repository_odb(&odb, repo)) < 0 ||
-		(error = git_odb_read(&input->odb_object, odb, &file->oid)) < 0)
+		(error = git_odb_read(&input->odb_object, odb, &file->oid)) < 0 ||
+		(error = git__strdup(&input->path, file->path)) < 0)
 		goto done;
 
 	input->mode = file->mode;
-	input->path = git__strdup(file->path);
 	input->mmfile.size = git_odb_object_size(input->odb_object);
 	input->mmfile.ptr = (char *)git_odb_object_data(input->odb_object);
 

--- a/src/object.c
+++ b/src/object.c
@@ -15,6 +15,7 @@
 #include "tree.h"
 #include "blob.h"
 #include "tag.h"
+#include "oid.h"
 
 static const int OBJECT_BASE_SIZE = 4096;
 
@@ -77,8 +78,8 @@ int git_object__from_odb_object(
 	}
 
 	/* Allocate and initialize base object */
-	object = git__calloc(1, object_size);
-	GITERR_CHECK_ALLOC(object);
+	if (git__calloc(&object, 1, object_size) < 0)
+		return -1;
 
 	git_oid_cpy(&object->cached.oid, &odb_obj->cached.oid);
 	object->cached.type = odb_obj->cached.type;
@@ -296,8 +297,7 @@ static int peel_error(int error, const git_oid *oid, git_otype type)
 
 	type_name = git_object_type2string(type);
 
-	git_oid_fmt(hex_oid, oid);
-	hex_oid[GIT_OID_HEXSZ] = '\0';
+	git_oid__fmtz(hex_oid, oid);
 
 	giterr_set(GITERR_OBJECT, "The git_object of id '%s' can not be "
 		"successfully peeled into a %s (git_otype=%i).", hex_oid, type_name, type);

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -558,8 +558,8 @@ static int pack_backend__writepack(struct git_odb_writepack **out,
 
 	backend = (struct pack_backend *)_backend;
 
-	writepack = git__calloc(1, sizeof(struct pack_writepack));
-	GITERR_CHECK_ALLOC(writepack);
+	if (git__calloc(&writepack, 1, sizeof(struct pack_writepack)) < 0)
+		return -1;
 
 	if (git_indexer_new(&writepack->indexer,
 		backend->pack_folder, 0, odb, progress_cb, progress_payload) < 0) {
@@ -598,8 +598,12 @@ static void pack_backend__free(git_odb_backend *_backend)
 
 static int pack_backend__alloc(struct pack_backend **out, size_t initial_size)
 {
-	struct pack_backend *backend = git__calloc(1, sizeof(struct pack_backend));
-	GITERR_CHECK_ALLOC(backend);
+	struct pack_backend *backend;
+
+	*out = NULL;
+
+	if (git__calloc(&backend, 1, sizeof(struct pack_backend)) < 0)
+		return -1;
 
 	if (git_vector_init(&backend->packs, initial_size, packfile_sort__cb) < 0) {
 		git__free(backend);
@@ -625,6 +629,8 @@ int git_odb_backend_one_pack(git_odb_backend **backend_out, const char *idx)
 {
 	struct pack_backend *backend = NULL;
 	struct git_pack_file *packfile = NULL;
+
+	*backend_out = NULL;
 
 	if (pack_backend__alloc(&backend, 1) < 0)
 		return -1;

--- a/src/offmap.h
+++ b/src/offmap.h
@@ -10,9 +10,9 @@
 #include "common.h"
 #include "git2/types.h"
 
-#define kmalloc git__malloc
-#define kcalloc git__calloc
-#define krealloc git__realloc
+#define kmalloc git__std_malloc
+#define kcalloc git__std_calloc
+#define krealloc git__std_realloc
 #define kfree git__free
 #include "khash.h"
 

--- a/src/oid.h
+++ b/src/oid.h
@@ -33,4 +33,15 @@ GIT_INLINE(int) git_oid__cmp(const git_oid *a, const git_oid *b)
 	return git_oid__hashcmp(a->id, b->id);
 }
 
+/**
+ * Format a git_oid into a hex string.
+ *
+ * @param out output hex string; must be pointing at the start of
+ *		the hex sequence and have at least the number of bytes
+ *		needed for an oid encoded in hex and a trailing NULL.
+ *      (41 bytes).
+ * @param id oid structure to format.
+ */
+void git_oid__fmtz(char *str, const git_oid *oid);
+
 #endif

--- a/src/oidmap.h
+++ b/src/oidmap.h
@@ -10,9 +10,9 @@
 #include "common.h"
 #include "git2/oid.h"
 
-#define kmalloc git__malloc
-#define kcalloc git__calloc
-#define krealloc git__realloc
+#define kmalloc git__std_malloc
+#define kcalloc git__std_calloc
+#define krealloc git__std_realloc
 #define kfree git__free
 #include "khash.h"
 

--- a/src/path.c
+++ b/src/path.c
@@ -950,10 +950,9 @@ int git_path_dirload(
 #endif
 
 		alloc_size = path_len + need_slash + de_len + 1 + alloc_extra;
-		if ((entry_path = git__calloc(alloc_size, 1)) == NULL) {
-			error = -1;
+
+		if ((error = git__calloc(&entry_path, alloc_size, 1)) < 0)
 			break;
-		}
 
 		if (path_len)
 			memcpy(entry_path, path, path_len);

--- a/src/pool.h
+++ b/src/pool.h
@@ -73,17 +73,19 @@ extern void git_pool_swap(git_pool *a, git_pool *b);
 /**
  * Allocate space for one or more items from a pool.
  */
-extern void *git_pool_malloc(git_pool *pool, uint32_t items);
+extern int git_pool_malloc(void **out, git_pool *pool, uint32_t items);
 
 /**
  * Allocate space and zero it out.
  */
-GIT_INLINE(void *) git_pool_mallocz(git_pool *pool, uint32_t items)
+GIT_INLINE(int) git_pool_calloc(void **out, git_pool *pool, uint32_t items)
 {
-	void *ptr = git_pool_malloc(pool, items);
-	if (ptr)
-		memset(ptr, 0, (size_t)items * (size_t)pool->item_size);
-	return ptr;
+	int error;
+
+	if ((error = git_pool_malloc(out, pool, items)) == 0)
+		memset(*out, 0, (size_t)items * (size_t)pool->item_size);
+
+	return error;
 }
 
 /**
@@ -91,28 +93,28 @@ GIT_INLINE(void *) git_pool_mallocz(git_pool *pool, uint32_t items)
  *
  * This is allowed only for pools with item_size == sizeof(char)
  */
-extern char *git_pool_strndup(git_pool *pool, const char *str, size_t n);
+extern int git_pool_strndup(char **out, git_pool *pool, const char *str, size_t n);
 
 /**
  * Allocate space and duplicate a string into it.
  *
  * This is allowed only for pools with item_size == sizeof(char)
  */
-extern char *git_pool_strdup(git_pool *pool, const char *str);
+extern int git_pool_strdup(char **out, git_pool *pool, const char *str);
 
 /**
  * Allocate space and duplicate a string into it, NULL is no error.
  *
  * This is allowed only for pools with item_size == sizeof(char)
  */
-extern char *git_pool_strdup_safe(git_pool *pool, const char *str);
+extern int git_pool_strdup_safe(char **out, git_pool *pool, const char *str);
 
 /**
  * Allocate space for the concatenation of two strings.
  *
  * This is allowed only for pools with item_size == sizeof(char)
  */
-extern char *git_pool_strcat(git_pool *pool, const char *a, const char *b);
+extern int git_pool_strcat(char **out, git_pool *pool, const char *a, const char *b);
 
 /**
  * Push a block back onto the free list for the pool.

--- a/src/pqueue.c
+++ b/src/pqueue.c
@@ -39,8 +39,8 @@ int git_pqueue_init(git_pqueue *q, size_t n, git_pqueue_cmp cmppri)
 	assert(q);
 
 	/* Need to allocate n+1 elements since element 0 isn't used. */
-	q->d = git__malloc((n + 1) * sizeof(void *));
-	GITERR_CHECK_ALLOC(q->d);
+	if (git__malloc(&q->d, (n + 1) * sizeof(void *)) < 0)
+		return -1;
 
 	q->size = 1;
 	q->avail = q->step = (n + 1); /* see comment above about n+1 */
@@ -124,8 +124,9 @@ int git_pqueue_insert(git_pqueue *q, void *d)
 	/* allocate more memory if necessary */
 	if (q->size >= q->avail) {
 		newsize = q->size + q->step;
-		tmp = git__realloc(q->d, sizeof(void *) * newsize);
-		GITERR_CHECK_ALLOC(tmp);
+
+		if (git__realloc(&tmp, q->d, sizeof(void *) * newsize) < 0)
+			return -1;
 
 		q->d = tmp;
 		q->avail = newsize;

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -24,8 +24,8 @@ int git_refdb_new(git_refdb **out, git_repository *repo)
 
 	assert(out && repo);
 
-	db = git__calloc(1, sizeof(*db));
-	GITERR_CHECK_ALLOC(db);
+	if (git__calloc(&db, 1, sizeof(*db)) < 0)
+		return -1;
 
 	db->repo = repo;
 

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -13,9 +13,9 @@
 
 #include <git2/sys/refdb_backend.h>
 
-git_reflog_entry *git_reflog_entry__alloc(void)
+int git_reflog_entry__alloc(git_reflog_entry **out)
 {
-	return git__calloc(1, sizeof(git_reflog_entry));
+	return git__calloc(out, 1, sizeof(git_reflog_entry));
 }
 
 void git_reflog_entry__free(git_reflog_entry *entry)
@@ -79,14 +79,12 @@ int git_reflog_append(git_reflog *reflog, const git_oid *new_oid, const git_sign
 
 	assert(reflog && new_oid && committer);
 
-	entry = git__calloc(1, sizeof(git_reflog_entry));
-	GITERR_CHECK_ALLOC(entry);
-
-	if ((git_signature_dup(&entry->committer, committer)) < 0)
+	if (git__calloc(&entry, 1, sizeof(git_reflog_entry)) < 0 ||
+		git_signature_dup(&entry->committer, committer) < 0)
 		goto cleanup;
 
 	if (msg != NULL) {
-		if ((entry->msg = git__strdup(msg)) == NULL)
+		if (git__strdup(&entry->msg, msg) < 0)
 			goto cleanup;
 
 		newline = strchr(msg, '\n');

--- a/src/refs.h
+++ b/src/refs.h
@@ -64,7 +64,7 @@ struct git_reference {
 	char name[0];
 };
 
-git_reference *git_reference__set_name(git_reference *ref, const char *name);
+int git_reference__set_name(git_reference **out, git_reference *ref, const char *name);
 
 int git_reference__normalize_name_lax(char *buffer_out, size_t out_size, const char *name);
 int git_reference__normalize_name(git_buf *buf, const char *name, unsigned int flags);

--- a/src/remote.h
+++ b/src/remote.h
@@ -33,7 +33,7 @@ struct git_remote {
 };
 
 const char* git_remote__urlfordirection(struct git_remote *remote, int direction);
-int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_url);
+int git_remote__get_http_proxy(char **proxy_url, git_remote *remote, bool use_ssl);
 
 git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refname);
 git_refspec *git_remote__matching_dst_refspec(git_remote *remote, const char *refname);

--- a/src/revert.c
+++ b/src/revert.c
@@ -9,6 +9,7 @@
 #include "repository.h"
 #include "filebuf.h"
 #include "merge.h"
+#include "oid.h"
 
 #include "git2/types.h"
 #include "git2/merge.h"
@@ -107,8 +108,7 @@ static int revert_seterr(git_commit *commit, const char *fmt)
 {
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 
-	git_oid_fmt(commit_oidstr, git_commit_id(commit));
-	commit_oidstr[GIT_OID_HEXSZ] = '\0';
+	git_oid__fmtz(commit_oidstr, git_commit_id(commit));
 
 	giterr_set(GITERR_REVERT, fmt, commit_oidstr);
 
@@ -184,8 +184,7 @@ int git_revert(
 	if ((error = git_repository__ensure_not_bare(repo, "revert")) < 0)
 		return error;
 
-	git_oid_fmt(commit_oidstr, git_commit_id(commit));
-	commit_oidstr[GIT_OID_HEXSZ] = '\0';
+	git_oid__fmtz(commit_oidstr, git_commit_id(commit));
 
 	if ((commit_msg = git_commit_summary(commit)) == NULL) {
 		error = -1;

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -896,7 +896,9 @@ int git_revparse(
 		const char *rstr;
 		revspec->flags = GIT_REVPARSE_RANGE;
 
-		lstr = git__substrdup(spec, dotdot - spec);
+		if (git__substrdup(&lstr, spec, dotdot - spec))
+			return -1;
+
 		rstr = dotdot + 2;
 		if (dotdot[2] == '.') {
 			revspec->flags |= GIT_REVPARSE_MERGE_BASE;

--- a/src/stash.c
+++ b/src/stash.c
@@ -35,15 +35,11 @@ static int retrieve_head(git_reference **out, git_repository *repo)
 
 static int append_abbreviated_oid(git_buf *out, const git_oid *b_commit)
 {
-	char *formatted_oid;
+	char formatted_oid[GIT_OID_HEXSZ];
 
-	formatted_oid = git_oid_allocfmt(b_commit);
-	GITERR_CHECK_ALLOC(formatted_oid);
+	git_oid_fmt(formatted_oid, b_commit);
 
-	git_buf_put(out, formatted_oid, 7);
-	git__free(formatted_oid);
-
-	return git_buf_oom(out) ? -1 : 0;
+	return git_buf_put(out, formatted_oid, 7);
 }
 
 static int append_commit_description(git_buf *out, git_commit* commit)

--- a/src/strmap.h
+++ b/src/strmap.h
@@ -9,9 +9,9 @@
 
 #include "common.h"
 
-#define kmalloc git__malloc
-#define kcalloc git__calloc
-#define krealloc git__realloc
+#define kmalloc git__std_malloc
+#define kcalloc git__std_calloc
+#define krealloc git__std_realloc
 #define kfree git__free
 #include "khash.h"
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -150,12 +150,8 @@ int git_transport_register(
 {
 	transport_definition *d;
 
-	d = git__calloc(sizeof(transport_definition), 1);
-	GITERR_CHECK_ALLOC(d);
-
-	d->prefix = git__strdup(prefix);
-
-	if (!d->prefix)
+	if (git__calloc(&d ,sizeof(transport_definition), 1) < 0 ||
+		git__strdup(&d->prefix, prefix) < 0)
 		goto on_error;
 
 	d->priority = priority;
@@ -168,8 +164,11 @@ int git_transport_register(
 	return 0;
 
 on_error:
-	git__free(d->prefix);
-	git__free(d);
+	if (d) {
+		git__free(d->prefix);
+		git__free(d);
+	}
+
 	return -1;
 }
 

--- a/src/tsort.c
+++ b/src/tsort.c
@@ -184,14 +184,14 @@ static int check_invariant(struct tsort_run *stack, ssize_t stack_curr)
 static int resize(struct tsort_store *store, size_t new_size)
 {
 	if (store->alloc < new_size) {
-		void **tempstore = git__realloc(store->storage, new_size * sizeof(void *));
+		void **tempstore;
 
 		/**
 		 * Do not propagate on OOM; this will abort the sort and
 		 * leave the array unsorted, but no error code will be
 		 * raised
 		 */
-		if (tempstore == NULL)
+		if (git__realloc(&tempstore, store->storage, new_size * sizeof(void *)) < 0)
 			return -1;
 
 		store->storage = tempstore;

--- a/src/win32/dir.c
+++ b/src/win32/dir.c
@@ -34,9 +34,9 @@ git__DIR *git__opendir(const char *dir)
 
 	dirlen = strlen(dir);
 
-	new = git__calloc(sizeof(*new) + dirlen + 1, 1);
-	if (!new)
+	if (git__calloc(&new, sizeof(*new) + dirlen + 1, 1) < 0)
 		return NULL;
+
 	memcpy(new->dir, dir, dirlen);
 
 	git_win32_path_from_c(filter_w, filter);

--- a/src/win32/error.c
+++ b/src/win32/error.c
@@ -60,9 +60,7 @@ char *git_win32_get_error_message(DWORD error_code)
 			goto on_error;
 		}
 
-		utf8_msg = git__malloc(utf8_size);
-
-		if (!utf8_msg)
+		if (git__malloc(&utf8_msg, utf8_size) < 0)
 			goto on_error;
 
 		if (!WideCharToMultiByte(CP_UTF8, dwFlags,

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -44,8 +44,9 @@ int git_win32__find_file(
 
 	/* allocate space for wchar_t path to file */
 	alloc_len = root->len + len + 2;
-	file_utf16 = git__calloc(alloc_len, sizeof(wchar_t));
-	GITERR_CHECK_ALLOC(file_utf16);
+
+	if (git__calloc(&file_utf16, alloc_len, sizeof(wchar_t)) < 0)
+		return -1;
 
 	/* append root + '\\' + filename as wchar_t */
 	memcpy(file_utf16, root->path, root->len * sizeof(wchar_t));

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -70,7 +70,7 @@ int git_zstream_deflatebuf(git_buf *out, const void *in, size_t in_len)
 	int error = 0;
 
 	if ((error = git_zstream_init(&zstream)) < 0)
-		goto done;
+		return error;
 
 	do {
 		if (out->asize - out->size < BUFFER_SIZE)
@@ -89,7 +89,6 @@ int git_zstream_deflatebuf(git_buf *out, const void *in, size_t in_len)
 	if (written < 0)
 		error = written;
 
-done:
 	git_zstream_free(&zstream);
 	return error;
 }

--- a/tests/blame/getters.c
+++ b/tests/blame/getters.c
@@ -17,12 +17,14 @@ void test_blame_getters__initialize(void)
 		{ 3, {{0}}, 13, NULL, {{0}}, "e", 0},
 	};
 
-	g_blame = git_blame__alloc(NULL, opts, "");
+	cl_git_pass(git_blame__alloc(&g_blame, NULL, opts, ""));
 
 	for (i=0; i<5; i++) {
-		git_blame_hunk *h = git__calloc(1, sizeof(git_blame_hunk));
+		git_blame_hunk *h;
+		
+		cl_git_pass(git__calloc(&h, 1, sizeof(git_blame_hunk)));
 		h->final_start_line_number = hunks[i].final_start_line_number;
-		h->orig_path = git__strdup(hunks[i].orig_path);
+		cl_git_pass(git__strdup(&h->orig_path, hunks[i].orig_path));
 		h->lines_in_hunk = hunks[i].lines_in_hunk;
 
 		git_vector_insert(&g_blame->hunks, h);

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -69,12 +69,12 @@ char *cl_getenv(const char *name)
 	if (alloc_len <= 0)
 		return NULL;
 
-	cl_assert(value_utf16 = git__calloc(alloc_len, sizeof(wchar_t)));
+	cl_git_pass(git__calloc(&value_utf16, alloc_len, sizeof(wchar_t)));
 
 	GetEnvironmentVariableW(name_utf16, value_utf16, alloc_len);
 
 	alloc_len = alloc_len * 4 + 1; /* worst case UTF16->UTF8 growth */
-	cl_assert(value_utf8 = git__calloc(alloc_len, 1));
+	cl_git_pass(git__calloc(&value_utf8, alloc_len, 1));
 
 	git__utf16_to_8(value_utf8, alloc_len, value_utf16);
 

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -51,9 +51,8 @@ void assert_commit_summary(const char *expected, const char *given)
 {
 	git_commit *dummy;
 
-	cl_assert(dummy = git__calloc(1, sizeof(struct git_commit)));
-
-	dummy->raw_message = git__strdup(given);
+	cl_git_pass(git__calloc(&dummy, 1, sizeof(struct git_commit)));
+	cl_git_pass(git__strdup(&dummy->raw_message, given));
 	cl_assert_equal_s(expected, git_commit_summary(dummy));
 
 	git_commit__free(dummy);

--- a/tests/commit/parse.c
+++ b/tests/commit/parse.c
@@ -270,8 +270,7 @@ static int parse_commit(git_commit **out, const char *buffer)
 	git_odb_object fake_odb_object;
 	int error;
 
-	commit = (git_commit*)git__malloc(sizeof(git_commit));
-	memset(commit, 0x0, sizeof(git_commit));
+	cl_git_pass(git__calloc(&commit, 1, sizeof(git_commit)));
 	commit->object.repo = g_repo;
 
 	memset(&fake_odb_object, 0x0, sizeof(git_odb_object));

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -112,8 +112,7 @@ void test_commit_write__root(void)
 	/* First we need to update HEAD so it points to our non-existant branch */
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_assert(git_reference_type(head) == GIT_REF_SYMBOLIC);
-	head_old = git__strdup(git_reference_symbolic_target(head));
-	cl_assert(head_old != NULL);
+	cl_git_pass(git__strdup(&head_old, git_reference_symbolic_target(head)));
 	git_reference_free(head);
 
 	cl_git_pass(git_reference_symbolic_create(&head, g_repo, "HEAD", branch_name, 1, NULL, NULL));

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -370,7 +370,7 @@ void test_core_buffer__7(void)
 
 	git_buf_free(&a);
 
-	b = git__strdup(fun);
+	cl_git_pass(git__strdup(&b, fun));
 	git_buf_attach(&a, b, 0);
 
 	cl_assert_equal_s(fun, a.ptr);
@@ -379,7 +379,7 @@ void test_core_buffer__7(void)
 
 	git_buf_free(&a);
 
-	b = git__strdup(fun);
+	cl_git_pass(git__strdup(&b, fun));
 	git_buf_attach(&a, b, strlen(fun) + 1);
 
 	cl_assert_equal_s(fun, a.ptr);

--- a/tests/core/dirent.c
+++ b/tests/core/dirent.c
@@ -206,7 +206,9 @@ void test_core_dirent__traverse_weird_filenames(void)
 /* test filename length limits */
 void test_core_dirent__length_limits(void)
 {
-	char *big_filename = (char *)git__malloc(FILENAME_MAX + 1);
+	char *big_filename;
+	
+	cl_git_pass(git__malloc(&big_filename, FILENAME_MAX + 1));
 	memset(big_filename, 'a', FILENAME_MAX + 1);
 	big_filename[FILENAME_MAX] = 0;
 

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -130,7 +130,9 @@ static void check_mode_at_line(
 void test_core_mkdir__chmods(void)
 {
 	struct stat st;
-	mode_t *old = git__malloc(sizeof(mode_t));
+	mode_t *old;
+	
+	cl_git_pass(git__malloc(&old, sizeof(mode_t)));
 	*old = p_umask(022);
 
 	cl_set_cleanup(cleanup_chmod_root, old);

--- a/tests/core/path.c
+++ b/tests/core/path.c
@@ -210,8 +210,9 @@ check_string_to_dir(
     const char* expected)
 {
 	size_t len = strlen(path);
-	char *buf = git__malloc(len + 2);
-	cl_assert(buf);
+	char *buf;
+	
+	cl_git_pass(git__malloc(&buf, len + 2));
 
 	strncpy(buf, path, len + 2);
 

--- a/tests/core/pool.c
+++ b/tests/core/pool.c
@@ -11,7 +11,7 @@ void test_core_pool__0(void)
 	cl_git_pass(git_pool_init(&p, 1, 4000));
 
 	for (i = 1; i < 10000; i *= 2) {
-		ptr = git_pool_malloc(&p, i);
+		cl_git_pass(git_pool_malloc(&ptr, &p, i));
 		cl_assert(ptr != NULL);
 		cl_assert(git_pool__ptr_in_pool(&p, ptr));
 		cl_assert(!git_pool__ptr_in_pool(&p, &i));
@@ -31,11 +31,12 @@ void test_core_pool__1(void)
 {
 	int i;
 	git_pool p;
+	void *out;
 
 	cl_git_pass(git_pool_init(&p, 1, 4000));
 
 	for (i = 2010; i > 0; i--)
-		cl_assert(git_pool_malloc(&p, i) != NULL);
+		cl_git_pass(git_pool_malloc(&out, &p, i));
 
 	/* with fixed page size, allocation must end up with these values */
 	cl_assert(git_pool__open_pages(&p) == 1);
@@ -46,7 +47,7 @@ void test_core_pool__1(void)
 	cl_git_pass(git_pool_init(&p, 1, 4100));
 
 	for (i = 2010; i > 0; i--)
-		cl_assert(git_pool_malloc(&p, i) != NULL);
+		cl_git_pass(git_pool_malloc(&out, &p, i));
 
 	/* with fixed page size, allocation must end up with these values */
 	cl_assert(git_pool__open_pages(&p) == 1);
@@ -69,7 +70,7 @@ void test_core_pool__2(void)
 	cl_git_pass(git_pool_init(&p, sizeof(git_oid), 100));
 
 	for (i = 1000; i < 10000; i++) {
-		oid = git_pool_malloc(&p, 1);
+		cl_git_pass(git_pool_malloc(&oid, &p, 1));
 		cl_assert(oid != NULL);
 
 		for (j = 0; j < 8; j++)
@@ -93,13 +94,13 @@ void test_core_pool__free_list(void)
 	cl_git_pass(git_pool_init(&p, 100, 100));
 
 	for (i = 0; i < 10; ++i) {
-		ptr = git_pool_malloc(&p, 1);
+		cl_git_pass(git_pool_malloc(&ptr, &p, 1));
 		cl_assert(ptr != NULL);
 	}
 	cl_assert_equal_i(10, (int)p.items);
 
 	for (i = 0; i < 50; ++i) {
-		ptrs[i] = git_pool_malloc(&p, 1);
+		cl_git_pass(git_pool_malloc(&ptrs[i], &p, 1));
 		cl_assert(ptrs[i] != NULL);
 	}
 	cl_assert_equal_i(60, (int)p.items);
@@ -111,13 +112,13 @@ void test_core_pool__free_list(void)
 	cl_assert_equal_i(60, (int)p.items);
 
 	for (i = 0; i < 50; ++i) {
-		ptrs[i] = git_pool_malloc(&p, 1);
+		cl_git_pass(git_pool_malloc(&ptrs[i], &p, 1));
 		cl_assert(ptrs[i] != NULL);
 	}
 	cl_assert_equal_i(60, (int)p.items);
 
 	for (i = 0; i < 111; ++i) {
-		ptr = git_pool_malloc(&p, 1);
+		cl_git_pass(git_pool_malloc(&ptr, &p, 1));
 		cl_assert(ptr != NULL);
 	}
 	cl_assert_equal_i(170, (int)p.items);
@@ -126,7 +127,7 @@ void test_core_pool__free_list(void)
 	cl_assert_equal_i(170, (int)p.items);
 
 	for (i = 0; i < 50; ++i) {
-		ptrs[i] = git_pool_malloc(&p, 1);
+		cl_git_pass(git_pool_malloc(&ptrs[i], &p, 1));
 		cl_assert(ptrs[i] != NULL);
 	}
 	cl_assert_equal_i(170, (int)p.items);
@@ -137,10 +138,12 @@ void test_core_pool__free_list(void)
 void test_core_pool__strndup_limit(void)
 {
 	git_pool p;
+	char *out;
 
 	cl_git_pass(git_pool_init(&p, 1, 100));
 	/* ensure 64 bit doesn't overflow */
-	cl_assert(git_pool_strndup(&p, "foo", (size_t)-1) == NULL);
+	cl_git_fail(git_pool_strndup(&out, &p, "foo", (size_t)-1));
+	cl_assert(out == NULL);
 	git_pool_clear(&p);
 }
 

--- a/tests/core/vector.c
+++ b/tests/core/vector.c
@@ -40,8 +40,8 @@ void test_core_vector__2(void)
 	git_vector x;
 	int *ptrs[2];
 
-	ptrs[0] = git__malloc(sizeof(int));
-	ptrs[1] = git__malloc(sizeof(int));
+	cl_git_pass(git__malloc(&ptrs[0], sizeof(int)));
+	cl_git_pass(git__malloc(&ptrs[1], sizeof(int)));
 
 	*ptrs[0] = 2;
 	*ptrs[1] = 1;
@@ -148,7 +148,9 @@ static int merge_structs(void **old_raw, void *new)
 
 static my_struct *alloc_struct(int value)
 {
-	my_struct *st = git__malloc(sizeof(my_struct));
+	my_struct *st;
+	
+	cl_git_pass(git__malloc(&st, sizeof(my_struct)));
 	st->content = value;
 	st->count = 0;
 	_struct_count++;

--- a/tests/filter/custom.c
+++ b/tests/filter/custom.c
@@ -102,8 +102,9 @@ static void bitflip_filter_free(git_filter *f)
 
 static git_filter *create_bitflip_filter(void)
 {
-	git_filter *filter = git__calloc(1, sizeof(git_filter));
-	cl_assert(filter);
+	git_filter *filter;
+	
+	cl_git_pass(git__calloc(&filter, 1, sizeof(git_filter)));
 
 	filter->version = GIT_FILTER_VERSION;
 	filter->attributes = "+bitflip";
@@ -153,8 +154,9 @@ static void reverse_filter_free(git_filter *f)
 
 static git_filter *create_reverse_filter(const char *attrs)
 {
-	git_filter *filter = git__calloc(1, sizeof(git_filter));
-	cl_assert(filter);
+	git_filter *filter;
+	
+	cl_git_pass(git__calloc(&filter, 1, sizeof(git_filter)));
 
 	filter->version = GIT_FILTER_VERSION;
 	filter->attributes = attrs;

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -109,10 +109,14 @@ void merge__dump_index_entries(git_vector *index_entries)
 
 	printf ("\nINDEX [%d]:\n", (int)index_entries->length);
 	for (i = 0; i < index_entries->length; i++) {
+		char id[GIT_OID_HEXSZ+1];
+
 		index_entry = index_entries->contents[i];
 
+		git_oid__fmtz(id, &index_entry->oid);
+
 		printf("%o ", index_entry->mode);
-		printf("%s ", git_oid_allocfmt(&index_entry->oid));
+		printf("%s ", id);
 		printf("%d ", git_index_entry_stage(index_entry));
 		printf("%s ", index_entry->path);
 		printf("\n");
@@ -140,15 +144,21 @@ void merge__dump_reuc(git_index *index)
 
 	printf ("\nREUC:\n");
 	for (i = 0; i < git_index_reuc_entrycount(index); i++) {
+		char id[GIT_OID_HEXSZ+1][3];
+
 		reuc = git_index_reuc_get_byindex(index, i);
+
+		git_oid__fmtz(id[0], &reuc->oid[0]);
+		git_oid__fmtz(id[1], &reuc->oid[1]);
+		git_oid__fmtz(id[2], &reuc->oid[2]);
 
 		printf("%s ", reuc->path);
 		printf("%o ", reuc->mode[0]);
-		printf("%s\n", git_oid_allocfmt(&reuc->oid[0]));
+		printf("%s\n", id[0]);
 		printf("          %o ", reuc->mode[1]);
-		printf("          %s\n", git_oid_allocfmt(&reuc->oid[1]));
+		printf("          %s\n", id[1]);
 		printf("          %o ", reuc->mode[2]);
-		printf("          %s ", git_oid_allocfmt(&reuc->oid[2]));
+		printf("          %s ", id[2]);
 		printf("\n");
 	}
 	printf("\n");

--- a/tests/merge/trees/treediff.c
+++ b/tests/merge/trees/treediff.c
@@ -40,7 +40,7 @@ static void test_find_differences(
     struct merge_index_conflict_data *treediff_conflict_data,
     size_t treediff_conflict_data_len)
 {
-    git_merge_diff_list *merge_diff_list = git_merge_diff_list__alloc(repo);
+    git_merge_diff_list *merge_diff_list;
     git_oid ancestor_oid, ours_oid, theirs_oid;
     git_tree *ancestor_tree, *ours_tree, *theirs_tree;
 
@@ -49,8 +49,8 @@ static void test_find_differences(
 	opts.target_limit = 1000;
 	opts.rename_threshold = 50;
 
-	opts.metric = git__malloc(sizeof(git_diff_similarity_metric));
-	cl_assert(opts.metric != NULL);
+	cl_git_pass(git_merge_diff_list__alloc(&merge_diff_list, repo));
+	cl_git_pass(git__malloc(&opts.metric, sizeof(git_diff_similarity_metric)));
 
 	opts.metric->file_signature = git_diff_find_similar__hashsig_for_file;
 	opts.metric->buffer_signature = git_diff_find_similar__hashsig_for_buf;

--- a/tests/network/urlparse.c
+++ b/tests/network/urlparse.c
@@ -141,7 +141,7 @@ void test_network_urlparse__encoded_username_password(void)
 
 void test_network_urlparse__connection_data_cross_host_redirect(void)
 {
-	conndata.host = git__strdup("bar.com");
+	cl_git_pass(git__strdup(&conndata.host, "bar.com"));
 	cl_git_fail_with(gitno_connection_data_from_url(&conndata,
 				"https://foo.com/bar/baz", NULL),
 			-1);

--- a/tests/object/cache.c
+++ b/tests/object/cache.c
@@ -212,7 +212,7 @@ void test_object_cache__threadmania(void)
 		cl_git_pass(git_repository_open(&g_repo, cl_fixture("testrepo.git")));
 
 		for (th = 0; th < THREADCOUNT; ++th) {
-			data = git__malloc(2 * sizeof(int));
+			cl_git_pass(git__malloc(&data, 2 * sizeof(int)));
 
 			((int *)data)[0] = th;
 			((int *)data)[1] = th % max_i;

--- a/tests/object/raw/compare.c
+++ b/tests/object/raw/compare.c
@@ -98,7 +98,7 @@ void test_object_raw_compare__compare_allocfmt_oids(void)
 
 	cl_git_pass(git_oid_fromstr(&in, exp));
 
-	out = git_oid_allocfmt(&in);
+	cl_git_pass(git_oid_allocfmt(&out, &in));
 	cl_assert(out);
 	cl_assert_equal_s(exp, out);
 	git__free(out);

--- a/tests/object/raw/short.c
+++ b/tests/object/raw/short.c
@@ -9,8 +9,7 @@ void test_object_raw_short__oid_shortener_no_duplicates(void)
 	git_oid_shorten *os;
 	int min_len;
 
-	os = git_oid_shorten_new(0);
-	cl_assert(os != NULL);
+	cl_git_pass(git_oid_shorten_new(&os, 0));
 
 	git_oid_shorten_add(os, "22596363b3de40b06f981fb85d82312e8c0ed511");
 	git_oid_shorten_add(os, "ce08fe4884650f067bd5703b6a59a8b3b3c99a09");
@@ -28,15 +27,15 @@ static int insert_sequential_oids(
 	int i, min_len = 0;
 	char numbuf[16];
 	git_oid oid;
-	char **oids = git__calloc(n, sizeof(char *));
-	cl_assert(oids != NULL);
+	char **oids;
+
+	cl_git_pass(git__calloc(&oids, n, sizeof(char *)));
 
 	for (i = 0; i < n; ++i) {
 		p_snprintf(numbuf, sizeof(numbuf), "%u", (unsigned int)i);
 		git_hash_buf(&oid, numbuf, strlen(numbuf));
 
-		oids[i] = git__malloc(GIT_OID_HEXSZ + 1);
-		cl_assert(oids[i]);
+		cl_git_pass(git__malloc(&oids[i], GIT_OID_HEXSZ + 1));
 		git_oid_nfmt(oids[i], GIT_OID_HEXSZ + 1, &oid);
 
 		min_len = git_oid_shorten_add(os, oids[i]);
@@ -72,8 +71,7 @@ void test_object_raw_short__oid_shortener_stresstest_git_oid_shorten(void)
 	int min_len = 0, found_collision;
 	char **oids;
 
-	os = git_oid_shorten_new(0);
-	cl_assert(os != NULL);
+	cl_git_pass(git_oid_shorten_new(&os, 0));
 
 	/*
 	 * Insert in the shortener 1000 unique SHA1 ids
@@ -125,8 +123,7 @@ void test_object_raw_short__oid_shortener_too_much_oids(void)
 	git_oid_shorten *os;
 	char **oids;
 
-	os = git_oid_shorten_new(0);
-	cl_assert(os != NULL);
+	cl_git_pass(git_oid_shorten_new(&os, 0));
 
 	cl_assert(insert_sequential_oids(&oids, os, MAX_OIDS, MAX_OIDS - 1) < 0);
 

--- a/tests/odb/backend/nonrefreshing.c
+++ b/tests/odb/backend/nonrefreshing.c
@@ -111,8 +111,8 @@ static int build_fake_backend(
 {
 	fake_backend *backend;
 
-	backend = git__calloc(1, sizeof(fake_backend));
-	GITERR_CHECK_ALLOC(backend);
+	if (git__calloc(&backend, 1, sizeof(fake_backend)) < 0)
+		return -1;
 
 	backend->parent.version = GIT_ODB_BACKEND_VERSION;
 

--- a/tests/odb/sorting.c
+++ b/tests/odb/sorting.c
@@ -10,9 +10,7 @@ static git_odb_backend *new_backend(size_t position)
 {
 	fake_backend *b;
 
-	b = git__calloc(1, sizeof(fake_backend));
-	if (b == NULL)
-		return NULL;
+	cl_git_pass(git__calloc(&b, 1, sizeof(fake_backend)));
 
 	b->base.version = GIT_ODB_BACKEND_VERSION;
 	b->position = position;

--- a/tests/online/push.c
+++ b/tests/online/push.c
@@ -97,7 +97,7 @@ static int record_push_status_cb(const char *ref, const char *msg, void *data)
 	git_vector *statuses = (git_vector *)data;
 	push_status *s;
 
-	cl_assert(s = git__malloc(sizeof(*s)));
+	cl_git_pass(git__malloc(&s, sizeof(*s)));
 	s->ref = ref;
 	s->success = (msg == NULL);
 	s->msg = msg;
@@ -191,7 +191,7 @@ static void verify_tracking_branches(git_remote *remote, expected_ref expected_r
 	git_buf ref_name = GIT_BUF_INIT;
 	git_vector actual_refs = GIT_VECTOR_INIT;
 	git_branch_iterator *iter;
-	char *actual_ref;
+	char *actual_ref, *name;
 	git_oid oid;
 	int failed = 0, error;
 	git_branch_t branch_type;
@@ -203,7 +203,8 @@ static void verify_tracking_branches(git_remote *remote, expected_ref expected_r
 	while ((error = git_branch_next(&ref, &branch_type, iter)) == 0) {
 		cl_assert_equal_i(branch_type, GIT_BRANCH_REMOTE);
 
-		cl_git_pass(git_vector_insert(&actual_refs, git__strdup(git_reference_name(ref))));
+		cl_git_pass(git__strdup(&name, git_reference_name(ref)));
+		cl_git_pass(git_vector_insert(&actual_refs, name));
 	}
 
 	cl_assert_equal_i(error, GIT_ITEROVER);

--- a/tests/online/push_util.c
+++ b/tests/online/push_util.c
@@ -30,13 +30,13 @@ int record_update_tips_cb(const char *refname, const git_oid *a, const git_oid *
 	updated_tip *t;
 	record_callbacks_data *record_data = (record_callbacks_data *)data;
 
-	cl_assert(t = git__malloc(sizeof(*t)));
+	cl_git_pass(git__malloc(&t, sizeof(*t)));
 
-	cl_assert(t->name = git__strdup(refname));
-	cl_assert(t->old_oid = git__malloc(sizeof(*t->old_oid)));
+	cl_git_pass(git__strdup(&t->name, refname));
+	cl_git_pass(git__malloc(&t->old_oid, sizeof(*t->old_oid)));
 	git_oid_cpy(t->old_oid, a);
 
-	cl_assert(t->new_oid = git__malloc(sizeof(*t->new_oid)));
+	cl_git_pass(git__malloc(&t->new_oid, sizeof(*t->new_oid)));
 	git_oid_cpy(t->new_oid, b);
 
 	git_vector_insert(&record_data->updated_tips, t);
@@ -110,7 +110,7 @@ failed:
 	git_buf_puts(&msg, "Expected and actual refs differ:\nEXPECTED:\n");
 
 	for(i = 0; i < expected_refs_len; i++) {
-		cl_assert(oid_str = git_oid_allocfmt(expected_refs[i].oid));
+		cl_git_pass(git_oid_allocfmt(&oid_str, expected_refs[i].oid));
 		cl_git_pass(git_buf_printf(&msg, "%s = %s\n", expected_refs[i].name, oid_str));
 		git__free(oid_str);
 	}
@@ -121,7 +121,7 @@ failed:
 		if (master_present && !strcmp(actual->name, "refs/heads/master"))
 			continue;
 
-		cl_assert(oid_str = git_oid_allocfmt(&actual->oid));
+		cl_git_pass(git_oid_allocfmt(&oid_str, &actual->oid));
 		cl_git_pass(git_buf_printf(&msg, "%s = %s\n", actual->name, oid_str));
 		git__free(oid_str);
 	}

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -59,7 +59,7 @@ static void seed_packbuilder(void)
 	cl_git_pass(git_revwalk_push_ref(_revwalker, "HEAD"));
 
 	while (git_revwalk_next(&oid, _revwalker) == 0) {
-		o = git__malloc(GIT_OID_RAWSZ);
+		git__malloc(&o, GIT_OID_RAWSZ);
 		cl_assert(o != NULL);
 		git_oid_cpy(o, &oid);
 		cl_git_pass(git_vector_insert(&_commits, o));

--- a/tests/refs/iterator.c
+++ b/tests/refs/iterator.c
@@ -142,7 +142,10 @@ void test_refs_iterator__foreach_can_cancel(void)
 static int refs_foreach_name_cb(const char *name, void *payload)
 {
 	git_vector *output = payload;
-	cl_git_pass(git_vector_insert(output, git__strdup(name)));
+	char *dup;
+
+	cl_git_pass(git__strdup(&dup, name));
+	cl_git_pass(git_vector_insert(output, dup));
 	return 0;
 }
 

--- a/tests/repo/message.c
+++ b/tests/repo/message.c
@@ -36,7 +36,7 @@ void test_repo_message__message(void)
 	len = git_repository_message(NULL, 0, _repo);
 	cl_assert(len > 0);
 
-	_actual = git__malloc(len + 1);
+	cl_git_pass(git__malloc(&_actual, len + 1));
 	cl_assert(_actual != NULL);
 
 	/* Test non truncation */

--- a/tests/reset/soft.c
+++ b/tests/reset/soft.c
@@ -2,6 +2,7 @@
 #include "posix.h"
 #include "reset_helpers.h"
 #include "path.h"
+#include "oid.h"
 #include "repo/repo_helpers.h"
 
 static git_repository *repo;
@@ -57,8 +58,7 @@ void test_reset_soft__resetting_to_the_commit_pointed_at_by_the_Head_does_not_ch
 	char raw_head_oid[GIT_OID_HEXSZ + 1];
 
 	cl_git_pass(git_reference_name_to_id(&oid, repo, "HEAD"));
-	git_oid_fmt(raw_head_oid, &oid);
-	raw_head_oid[GIT_OID_HEXSZ] = '\0';
+	git_oid__fmtz(raw_head_oid, &oid);
 
 	retrieve_target_from_oid(&target, repo, raw_head_oid);
 

--- a/tests/revwalk/mergebase.c
+++ b/tests/revwalk/mergebase.c
@@ -153,10 +153,7 @@ static void assert_mergebase_many(const char *expected_sha, int count, ...)
 	char *partial_oid;
 	git_object *object;
 
-	oids = git__malloc(count * sizeof(git_oid));
-	cl_assert(oids != NULL);
-
-	memset(oids, 0x0, count * sizeof(git_oid));
+	git__calloc(&oids, count, sizeof(git_oid));
 
 	va_start(ap, count);
 	

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -212,7 +212,7 @@ void test_stash_save__stashing_updates_the_reflog(void)
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
 
-	sha = git_oid_allocfmt(&stash_tip_oid);
+	cl_git_pass(git_oid_allocfmt(&sha, &stash_tip_oid));
 
 	assert_object_oid("refs/stash@{0}", sha, GIT_OBJ_COMMIT);
 	assert_object_oid("refs/stash@{1}", NULL, GIT_OBJ_COMMIT);

--- a/tests/submodule/modify.c
+++ b/tests/submodule/modify.c
@@ -172,7 +172,7 @@ void test_submodule_modify__edit_and_save(void)
 
 	cl_git_pass(git_submodule_lookup(&sm1, g_repo, "sm_changed_head"));
 
-	old_url = git__strdup(git_submodule_url(sm1));
+	git__strdup(&old_url, git_submodule_url(sm1));
 
 	/* modify properties of submodule */
 	cl_git_pass(git_submodule_set_url(sm1, SM_LIBGIT2_URL));


### PR DESCRIPTION
This was an exercise in discovering whether we could / should change the allocators to fit more with the standards we use for other things - returning an `int` status code and taking a pointer that will be set to the allocated memory.  I'm pushing this up more for discussion, at the moment, to see if we even want to continue down this path.

Note that I did this on win32 so it's pretty likely that Travis won't even build this successfully.  Also, I broke blame, so the tests there will fail miserably at the moment.

I think this was very valuable as a learning experience, as it required me to touch every allocation throughout the library.  My takeaway is that switching us over to free memory in the event of an allocation failure would generally not be ridiculously burdensome.

Additional takeaways:
1. We are good about checking the return codes from `*alloc`, generally.  (Yay!)  There were a few that we must have simply overlooked, but there was only one area that was systematically poor,.
2. Blame needs some better error handling.
3. `git_oid__fmtz` should probably exist, at least as an internal helper.

However, this didn't provide nearly the value that I had hoped.  In fact, I would say that it's an overall negative since there are now more unfun compiler warnings.

Anyway.  I did want to push this up for the sake of discussion, but I think that we should abandon this effort and keep `malloc` sane.  Certainly we should go fix up the problem areas that I noticed, though.
