### PR TITLE
Expose git_buf_put.

### DIFF
--- a/include/git2/buffer.h
+++ b/include/git2/buffer.h
@@ -105,6 +105,17 @@ GIT_EXTERN(int) git_buf_grow(git_buf *buffer, size_t target_size);
 GIT_EXTERN(int) git_buf_set(
 	git_buf *buffer, const void *data, size_t datalen);
 
+/**
+ * Append buffer to a copy of some raw data.
+ *
+ * @param buffer The buffer to set
+ * @param data The data to copy into the buffer
+ * @param datalen The length of the data to copy into the buffer
+ * @return 0 on success, -1 on allocation failure
+ */
+GIT_EXTERN(int) git_buf_put(
+	git_buf *buffer, const void *data, size_t datalen);
+
 GIT_END_DECL
 
 /** @} */

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -149,7 +149,7 @@ int git_buf_putc(git_buf *buf, char c)
 	return 0;
 }
 
-int git_buf_put(git_buf *buf, const char *data, size_t len)
+int git_buf_put(git_buf *buf, const void *data, size_t len)
 {
 	ENSURE_SIZE(buf, buf->size + len + 1);
 	memmove(buf->ptr + buf->size, data, len);

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -90,7 +90,6 @@ GIT_INLINE(bool) git_buf_oom(const git_buf *buf)
  */
 int git_buf_sets(git_buf *buf, const char *string);
 int git_buf_putc(git_buf *buf, char c);
-int git_buf_put(git_buf *buf, const char *data, size_t len);
 int git_buf_puts(git_buf *buf, const char *string);
 int git_buf_printf(git_buf *buf, const char *format, ...) GIT_FORMAT_PRINTF(2, 3);
 int git_buf_vprintf(git_buf *buf, const char *format, va_list ap);


### PR DESCRIPTION
Use git_buf_put to handle memory allocation in pygit2.
Please review :-)
