### PR TITLE
Check for EWOULDBLOCK as well as EAGAIN on write.

### DIFF
--- a/src/posix.c
+++ b/src/posix.c
@@ -189,7 +189,7 @@ int p_write(git_file fd, const void *buf, size_t cnt)
 		r = write(fd, b, cnt);
 #endif
 		if (r < 0) {
-			if (errno == EINTR || errno == EAGAIN)
+			if (errno == EINTR || GIT_ISBLOCKED(errno))
 				continue;
 			return -1;
 		}

--- a/src/posix.h
+++ b/src/posix.h
@@ -29,6 +29,15 @@
 #define O_CLOEXEC 0
 #endif
 
+/* Determine whether an errno value indicates that a read or write failed
+ * because the descriptor is blocked.
+ */
+#if defined(EWOULDBLOCK)
+#define GIT_ISBLOCKED(e) ((e) == EAGAIN || (e) == EWOULDBLOCK)
+#else
+#define GIT_ISBLOCKED(e) ((e) == EAGAIN)
+#endif
+
 typedef int git_file;
 
 /**


### PR DESCRIPTION
On some systems, notably HP PA-RISC systems running Linux or HP-UX,
EWOULDBLOCK and EAGAIN are not the same value.  POSIX (and these OSes) allow
EWOULDBLOCK to occur on write(2) (and send(2), etc.), so check explicitly
for this case as well as EAGAIN.  On most systems, where they are the same,
the compiler will simply optimize this check out and it will have no effect.

I don't actually have access to a PA-RISC system to test this on, so I haven't tested this except on Debian sid/amd64, where this works fine.
