### PR TITLE
[WIP] Reload config in git_submodule_lookup() if not found

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -113,11 +113,17 @@ int git_submodule_lookup(
 
 	assert(repo && name);
 
-	if ((error = load_submodule_config(repo)) < 0)
+	if (repo->submodules) {
+		pos = git_strmap_lookup_index(repo->submodules, name);
+		if (git_strmap_valid_index(repo->submodules, pos)) {
+			goto found;
+		}
+	}
+
+	if ((error = git_submodule_reload_all(repo)) < 0)
 		return error;
 
 	pos = git_strmap_lookup_index(repo->submodules, name);
-
 	if (!git_strmap_valid_index(repo->submodules, pos)) {
 		error = GIT_ENOTFOUND;
 
@@ -141,6 +147,7 @@ int git_submodule_lookup(
 		return error;
 	}
 
+found:
 	if (sm_ptr)
 		*sm_ptr = git_strmap_value_at(repo->submodules, pos);
 


### PR DESCRIPTION
If the submodule config is already in memory, and we can’t find the desired name in there, check back on disk for it. This is especially important when diffing, since it’s possible that further changes could have occurred since the configuration was reloaded.

Of course, this change is based on my limited knowledge of how libgit2 handles cache invalidation. If this should be handled at the application level by reloading all submodules before diffing, that'd be acceptable as well (though not ideal), and I can close this.

**To do:**
- [ ] Add a test that exposes the original issue

/cc @joshaber @arrbee 
