### PR TITLE
Remove "ignore" state from the git.git-authors

### DIFF
--- a/git.git-authors
+++ b/git.git-authors
@@ -28,9 +28,6 @@
 #   his/her consent on a patch-by-patch basis.
 # "???" means the person is a prominent contributor who has
 #   not yet made his/her standpoint clear.
-# "ign" means the authors consent is ignored for the purpose
-#   of libification. This is because the author has contributed
-#   to areas that aren't interesting for the library.
 #
 # Please try to keep the list alphabetically ordered. It will
 # help in case we get all 600-ish git.git authors on it.
@@ -61,7 +58,6 @@ ok	Linus Torvalds <torvalds@linux-foundation.org>
 ok	Lukas Sandström <lukass@etek.chalmers.se>
 ok	Matthieu Moy <Matthieu.Moy@imag.fr>
 ok	Michael Haggerty <mhagger@alum.mit.edu>
-ign	Mike McCormack <mike@codeweavers.com> (imap-send)
 ok	Nicolas Pitre <nico@fluxnic.net> <nico@cam.org>
 ok	Paolo Bonzini <bonzini@gnu.org>
 ok	Paul Kocher <paul@cryptography.com>
@@ -70,7 +66,6 @@ ok	Petr Onderka <gsvick@gmail.com>
 ok	Pierre Habouzit <madcoder@debian.org>
 ok	Pieter de Bie <pdebie@ai.rug.nl>
 ok	René Scharfe <rene.scharfe@lsrfire.ath.cx>
-ign	Robert Shearman <rob@codeweavers.com> (imap-send)
 ok	Sebastian Schuberth <sschuberth@gmail.com>
 ok	Shawn O. Pearce <spearce@spearce.org>
 ok	Steffen Prohaska <prohaska@zib.de>


### PR DESCRIPTION
Remove the "ignore" state for authors.  I'm not sure what the original thinking here was, but it doesn't make much sense.

These people were added based on the state of git.git when their names were added.  They may have made subsequent contributions which should _not_ be ignored.  Further, whether a change is "interestingness" is a strange judgement call.

The whole damn thing doesn't make any sense; somebody is either of the "always ok", "never ok" or "always ask".
