### PR TITLE
caps: Rename to features to avoid confusion

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -98,26 +98,26 @@ GIT_EXTERN(void) git_libgit2_version(int *major, int *minor, int *rev);
  * was compiled
  */
 typedef enum {
-	GIT_HAS_THREADS	= (1 << 0),
-	GIT_HAS_HTTPS = (1 << 1),
-	GIT_HAS_SSH = (1 << 2),
+	GIT_FEATURE_THREADS	= (1 << 0),
+	GIT_FEATURE_HTTPS = (1 << 1),
+	GIT_FEATURE_SSH = (1 << 2),
 } git_feature_t;
 
 /**
  * Query compile time options for libgit2.
  *
- * @return A combination of GIT_HAS_* values.
+ * @return A combination of GIT_FEATURE_* values.
  *
- * - GIT_HAS_THREADS
+ * - GIT_FEATURE_THREADS
  *   Libgit2 was compiled with thread support. Note that thread support is
  *   still to be seen as a 'work in progress' - basic object lookups are
  *   believed to be threadsafe, but other operations may not be.
  *
- * - GIT_HAS_HTTPS
+ * - GIT_FEATURE_HTTPS
  *   Libgit2 supports the https:// protocol. This requires the openssl
  *   library to be found when compiling libgit2.
  *
- * - GIT_HAS_SSH
+ * - GIT_FEATURE_SSH
  *   Libgit2 supports the SSH protocol for network operations. This requires
  *   the openssh to be found when compiling libgit2
  */

--- a/src/settings.c
+++ b/src/settings.c
@@ -21,13 +21,13 @@ int git_libgit2_features()
 {
 	return 0
 #ifdef GIT_THREADS
-		| GIT_HAS_THREADS
+		| GIT_FEATURE_THREADS
 #endif
 #if defined(GIT_SSL) || defined(GIT_WINHTTP)
-		| GIT_HAS_HTTPS
+		| GIT_FEATURE_HTTPS
 #endif
 #if defined(GIT_SSH)
-		| GIT_HAS_SSH
+		| GIT_FEATURE_SSH
 #endif
 	;
 }

--- a/tests/core/features.c
+++ b/tests/core/features.c
@@ -12,20 +12,20 @@ void test_core_features__0(void)
 	caps = git_libgit2_features();
 
 #ifdef GIT_THREADS
-	cl_assert((caps & GIT_HAS_THREADS) != 0);
+	cl_assert((caps & GIT_FEATURE_THREADS) != 0);
 #else
-	cl_assert((caps & GIT_HAS_THREADS) == 0);
+	cl_assert((caps & GIT_FEATURE_THREADS) == 0);
 #endif
 
 #if defined(GIT_SSL) || defined(GIT_WINHTTP)
-	cl_assert((caps & GIT_HAS_HTTPS) != 0);
+	cl_assert((caps & GIT_FEATURE_HTTPS) != 0);
 #else
-	cl_assert((caps & GIT_HAS_HTTPS) == 0);
+	cl_assert((caps & GIT_FEATURE_HTTPS) == 0);
 #endif
 
 #if defined(GIT_SSH)
-	cl_assert((caps & GIT_HAS_SSH) != 0);
+	cl_assert((caps & GIT_FEATURE_SSH) != 0);
 #else
-	cl_assert((caps & GIT_HAS_SSH) == 0);
+	cl_assert((caps & GIT_FEATURE_SSH) == 0);
 #endif
 }


### PR DESCRIPTION
Git already has a very clear concept of "capabilities" (i.e. the ones that the network protocol supports, such as out of band packets and so on). Calling our own build flag check "capabilities" too makes this confusing, and worse of it all, gives us identifiers like `GIT_CAP_HTTPS` and `GIT_CAP_OFS_DELTA` that are 100% unrelated, and yet have the same prefix.

Let's rename our own build features as "features" because it's a much more appropriate name.
