### PR TITLE
Remove ignored files from the working directory if they were stashed

### DIFF
--- a/src/stash.c
+++ b/src/stash.c
@@ -465,7 +465,8 @@ static int ensure_there_are_changes_to_stash(
 static int reset_index_and_workdir(
 	git_repository *repo,
 	git_commit *commit,
-	bool remove_untracked)
+	bool remove_untracked,
+	bool remove_ignored)
 {
 	git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
 
@@ -473,6 +474,9 @@ static int reset_index_and_workdir(
 
 	if (remove_untracked)
 		opts.checkout_strategy |= GIT_CHECKOUT_REMOVE_UNTRACKED;
+
+	if (remove_ignored)
+		opts.checkout_strategy |= GIT_CHECKOUT_REMOVE_IGNORED;
 
 	return git_checkout_tree(repo, (git_object *)commit, &opts);
 }
@@ -532,7 +536,8 @@ int git_stash_save(
 	if ((error = reset_index_and_workdir(
 		repo,
 		((flags & GIT_STASH_KEEP_INDEX) != 0) ? i_commit : b_commit,
-		(flags & GIT_STASH_INCLUDE_UNTRACKED) != 0)) < 0)
+		(flags & GIT_STASH_INCLUDE_UNTRACKED) != 0,
+		(flags & GIT_STASH_INCLUDE_IGNORED) != 0)) < 0)
 		goto cleanup;
 
 cleanup:

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -159,6 +159,8 @@ void test_stash_save__can_include_untracked_and_ignored_files(void)
 	assert_blob_oid("refs/stash^3:who", NULL);
 	assert_blob_oid("refs/stash^3:when", "b6ed15e81e2593d7bb6265eb4a991d29dc3e628b");
 	assert_blob_oid("refs/stash^3:just.ignore", "78925fb1236b98b37a35e9723033e627f97aa88b");
+
+	cl_assert(!git_path_exists("stash/just.ignore"));
 }
 
 #define MESSAGE "Look Ma! I'm on TV!"


### PR DESCRIPTION
Ignored files that were stashed during `git_stash_save` were not removed as per the stash API.

This PR removes the files and fixes the test case.
