### PR TITLE
examples/diff: Add minimal, patience diff options.

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -28,10 +28,6 @@ These are good small projects to get started with libgit2.
   core Git command and add a missing command-line option.  There are many
   gaps right now and this helps demonstrate how to use the library.  Here
   are some specific ideas:
-    * Add the `--minimal` flag to `examples/diff.c` since the `libgit2`
-      diff API now has a flag to support it
-    * Add the `--patience` flag to `examples/diff.c` since it is also now
-      supported.
     * Add the `--shortstat` flag to `examples/diff.c` based on the work
       that was done to add `--numstat` already.
     * Fix the `examples/diff.c` implementation of the `-B`

--- a/examples/diff.c
+++ b/examples/diff.c
@@ -234,6 +234,10 @@ static void parse_opts(struct opts *o, int argc, char *argv[])
 			o->diffopts.flags |= GIT_DIFF_INCLUDE_IGNORED;
 		else if (!strcmp(a, "--untracked"))
 			o->diffopts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
+		else if (!strcmp(a, "--patience"))
+			o->diffopts.flags |= GIT_DIFF_PATIENCE;
+		else if (!strcmp(a, "--minimal"))
+			o->diffopts.flags |= GIT_DIFF_MINIMAL;
 		else if (!strcmp(a, "--numstat"))
 			o->numstat = 1;
 		else if (match_uint16_arg(


### PR DESCRIPTION
- Add minimal, patience diff options to diff example. libgit2
  `diff_xdiff.git_xdiff_init` already supports these flags, so
  no additional change is necessary.
- Remove minimal and patience flag addition from project list.
