### PR TITLE
Fixed missing error check on call to git_remote_download

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -857,11 +857,14 @@ int git_remote_fetch(
 	if ((error = git_remote_connect(remote, GIT_DIRECTION_FETCH)) != 0)
 		return error;
 
-	if ((error = git_remote_download(remote)) != 0)
-		return error;
+	error = git_remote_download(remote);
 
 	/* We don't need to be connected anymore */
 	git_remote_disconnect(remote);
+
+	/* If the download failed, return the error */
+	if (error != 0)
+		return error;
 
 	/* Default reflog message */
 	if (reflog_message)


### PR DESCRIPTION
Fixed missing error check on call to git_remote_download in git_remote_fetch. Moved error check to statement following git_remote_disconnect so that the disconnect happens regardless of the result of the download call.

I believe whatever I did wrong in the previous pull request with respect to the libgit2 version has been fixed.

Best,

Brian
