### PR TITLE
refdb: catch a directory disappearing

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -853,6 +853,9 @@ int git_path_direach(
 
 	if ((dir = opendir(path->ptr)) == NULL) {
 		giterr_set(GITERR_OS, "Failed to open directory '%s'", path->ptr);
+		if (errno == ENOENT)
+			return GIT_ENOTFOUND;
+
 		return -1;
 	}
 


### PR DESCRIPTION
If a directory disappears between the time we look up the entries of its
parent and the time when we go to look at it, we should ignore the error
and move forward.

This fixes #2046.

---

Unfortunately I don't know of any way we can reliably test this, as it's an issue that happens at at time when we cannot stop execution.
