### PR TITLE
relative url support for  git_submodule_add_setup

### DIFF
--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -1,0 +1,115 @@
+#include "clar_libgit2.h"
+#include "posix.h"
+#include "path.h"
+#include "submodule_helpers.h"
+
+static git_repository *g_repo = NULL;
+
+static void assert_submodule_url(const char* name, const char *url);
+
+void test_submodule_add__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_submodule_add__url_absolute(void)
+{
+	g_repo = setup_fixture_submod2();
+	git_submodule *sm;
+
+	/* re-add existing submodule */
+	cl_assert_equal_i(
+		GIT_EEXISTS,
+		git_submodule_add_setup(NULL, g_repo, "whatever", "sm_unchanged", 1));
+
+	/* add a submodule using a gitlink */
+
+	cl_git_pass(
+		git_submodule_add_setup(&sm, g_repo, "https://github.com/libgit2/libgit2.git", "sm_libgit2", 1)
+		);
+	git_submodule_free(sm);
+
+	cl_assert(git_path_isfile("submod2/" "sm_libgit2" "/.git"));
+
+	cl_assert(git_path_isdir("submod2/.git/modules"));
+	cl_assert(git_path_isdir("submod2/.git/modules/" "sm_libgit2"));
+	cl_assert(git_path_isfile("submod2/.git/modules/" "sm_libgit2" "/HEAD"));
+	assert_submodule_url("sm_libgit2", "https://github.com/libgit2/libgit2.git");
+
+	/* add a submodule not using a gitlink */
+
+	cl_git_pass(
+		git_submodule_add_setup(&sm, g_repo, "https://github.com/libgit2/libgit2.git", "sm_libgit2b", 0)
+		);
+	git_submodule_free(sm);
+
+	cl_assert(git_path_isdir("submod2/" "sm_libgit2b" "/.git"));
+	cl_assert(git_path_isfile("submod2/" "sm_libgit2b" "/.git/HEAD"));
+	cl_assert(!git_path_exists("submod2/.git/modules/" "sm_libgit2b"));
+	assert_submodule_url("sm_libgit2b", "https://github.com/libgit2/libgit2.git");
+}
+
+void test_submodule_add__url_relative(void) {
+	git_submodule *sm;
+	git_remote *remote;
+	
+	/* default remote url is https://github.com/libgit2/false.git */
+	g_repo = cl_git_sandbox_init("testrepo2");
+	
+	/* make sure we're not defaulting to origin - rename origin -> test_remote */
+	cl_git_pass(git_remote_load(&remote, g_repo, "origin"));
+	cl_git_pass(git_remote_rename(remote, "test_remote", NULL, NULL));
+	cl_git_fail(git_remote_load(&remote, g_repo, "origin"));
+	git_remote_free(remote);
+
+	cl_git_pass(
+		git_submodule_add_setup(&sm, g_repo, "../TestGitRepository", "TestGitRepository", 1)
+		);
+	git_submodule_free(sm);
+		
+	assert_submodule_url("TestGitRepository", "https://github.com/libgit2/TestGitRepository");
+}
+
+void test_submodule_add__url_relative_to_origin(void) {
+	git_submodule *sm;
+	
+	/* default remote url is https://github.com/libgit2/false.git */
+	g_repo = cl_git_sandbox_init("testrepo2");
+
+	cl_git_pass(
+		git_submodule_add_setup(&sm, g_repo, "../TestGitRepository", "TestGitRepository", 1)
+		);
+	git_submodule_free(sm);
+		
+	assert_submodule_url("TestGitRepository", "https://github.com/libgit2/TestGitRepository");
+}
+
+void test_submodule_add__url_relative_to_workdir(void) {
+	git_submodule *sm;
+
+	/* In this repo, HEAD (master) has no remote tracking branc h*/
+	g_repo = cl_git_sandbox_init("testrepo");
+
+	cl_git_pass(
+		git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1)
+		);
+	git_submodule_free(sm);
+		
+	assert_submodule_url("TestGitRepository", git_repository_workdir(g_repo));
+}
+
+static void assert_submodule_url(const char* name, const char *url)
+{
+	git_config *cfg;
+	const char *s;
+	git_buf key = GIT_BUF_INIT;
+
+	cl_git_pass(git_repository_config(&cfg, g_repo));
+
+	cl_git_pass(git_buf_printf(&key, "submodule.%s.url", name));
+	cl_git_pass(git_config_get_string(&s, cfg, git_buf_cstr(&key)));
+	cl_assert_equal_s(s, url);
+
+	git_config_free(cfg);
+	git_buf_free(&key);
+}

--- a/tests/submodule/modify.c
+++ b/tests/submodule/modify.c
@@ -7,83 +7,10 @@ static git_repository *g_repo = NULL;
 
 #define SM_LIBGIT2_URL "https://github.com/libgit2/libgit2.git"
 #define SM_LIBGIT2     "sm_libgit2"
-#define SM_LIBGIT2B    "sm_libgit2b"
-
-#define SM_RELATIVE_URL "../TestGitRepository"
-#define SM_RELATIVE_RESOLVED_URL "https://github.com/libgit2/TestGitRepository"
-#define SM_RELATIVE "TestGitRepository"
 
 void test_submodule_modify__initialize(void)
 {
 	g_repo = setup_fixture_submod2();
-}
-
-void test_submodule_modify__add(void)
-{
-	git_submodule *sm;
-	git_config *cfg;
-	const char *s;
-
-	/* re-add existing submodule */
-	cl_assert_equal_i(
-		GIT_EEXISTS,
-		git_submodule_add_setup(NULL, g_repo, "whatever", "sm_unchanged", 1));
-
-	/* add a submodule using a gitlink */
-
-	cl_git_pass(
-		git_submodule_add_setup(&sm, g_repo, SM_LIBGIT2_URL, SM_LIBGIT2, 1)
-		);
-	git_submodule_free(sm);
-
-	cl_assert(git_path_isfile("submod2/" SM_LIBGIT2 "/.git"));
-
-	cl_assert(git_path_isdir("submod2/.git/modules"));
-	cl_assert(git_path_isdir("submod2/.git/modules/" SM_LIBGIT2));
-	cl_assert(git_path_isfile("submod2/.git/modules/" SM_LIBGIT2 "/HEAD"));
-
-	cl_git_pass(git_repository_config(&cfg, g_repo));
-	cl_git_pass(
-		git_config_get_string(&s, cfg, "submodule." SM_LIBGIT2 ".url"));
-	cl_assert_equal_s(s, SM_LIBGIT2_URL);
-	git_config_free(cfg);
-
-	/* add a submodule not using a gitlink */
-
-	cl_git_pass(
-		git_submodule_add_setup(&sm, g_repo, SM_LIBGIT2_URL, SM_LIBGIT2B, 0)
-		);
-	git_submodule_free(sm);
-
-	cl_assert(git_path_isdir("submod2/" SM_LIBGIT2B "/.git"));
-	cl_assert(git_path_isfile("submod2/" SM_LIBGIT2B "/.git/HEAD"));
-	cl_assert(!git_path_exists("submod2/.git/modules/" SM_LIBGIT2B));
-
-	cl_git_pass(git_repository_config(&cfg, g_repo));
-	cl_git_pass(
-		git_config_get_string(&s, cfg, "submodule." SM_LIBGIT2B ".url"));
-	cl_assert_equal_s(s, SM_LIBGIT2_URL);
-	git_config_free(cfg);
-}
-
-void test_submodule_modify__add_with_relative_url(void) {
-	git_submodule *sm;
-	git_config *cfg;
-	const char *s;
-
-	git_repository* repo;
-	/* setup_fixture_submod2 does not work here because it does not set up origin configuration */
-	cl_git_pass(git_clone(&repo, SM_LIBGIT2_URL, "./sandbox/submodules_cloned", NULL));
-
-	cl_git_pass(
-		git_submodule_add_setup(&sm, repo, SM_RELATIVE_URL, SM_RELATIVE, 1)
-		);
-
-	cl_git_pass(git_repository_config(&cfg, repo));
-	cl_git_pass(
-		git_config_get_string(&s, cfg, "submodule." SM_RELATIVE ".url"));
-	cl_assert_equal_s(s, SM_RELATIVE_RESOLVED_URL);
-	git_config_free(cfg);
 }
 
 static int delete_one_config(const git_config_entry *entry, void *payload)


### PR DESCRIPTION
In git.git, you can clone a repository (e.g. `git clone git@github.com:libgit2/libgit2.git`) and then do `git submodule add ../libgit2sharp.git`. As this test points out, relative urls do not work in libgit2.

The problem is located in [lookup_head_remote](https://github.com/libgit2/libgit2/blame/development/src/submodule.c#L1455). It gets `HEAD` reference without resolving it, then tries to get the tracking branch of it - which obviously fails, because there is no tracking branch for `HEAD`. It might be a mistake to not dereference `HEAD`, but strangely, the method explicitly checks that `HEAD` is not a direct reference. Why that?

I tried to fix this by using `git_reference_lookup_resolved` and removing the first "Cannot resolve relative URL when HEAD is not symbolic" test, but then the same check fails for the resolved remote reference.

The top of the method summarizes:

```
/* 1. resolve HEAD -> refs/heads/BRANCH
 * 2. lookup config branch.BRANCH.remote -> ORIGIN
 * 3. lookup remote.ORIGIN.url
 */
```

but I think the method does something more compilcated. Honestly, I don't understand the method. Maybe @arrbee can look into this as he originally wrote the code.
