### PR TITLE
Add git_submodule_resolve_url()

### DIFF
--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -272,6 +272,16 @@ GIT_EXTERN(const char *) git_submodule_path(git_submodule *submodule);
 GIT_EXTERN(const char *) git_submodule_url(git_submodule *submodule);
 
 /**
+ * Resolve a submodule url relative to the given repository.
+ *
+ * @param out buffer to store the absolute submodule url in
+ * @param repository Pointer to repository object
+ * @param url Relative url
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *url);
+
+/**
 * Get the branch for the submodule.
 *
 * @param submodule Pointer to submodule object

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -229,16 +229,7 @@ int git_submodule_add_setup(
 	}
 
 	/* resolve parameters */
-
-	if (url[0] == '.' && (url[1] == '/' || (url[1] == '.' && url[2] == '/'))) {
-		if (!(error = lookup_head_remote(&real_url, repo)))
-			error = git_path_apply_relative(&real_url, url);
-	} else if (strchr(url, ':') != NULL || url[0] == '/') {
-		error = git_buf_sets(&real_url, url);
-	} else {
-		giterr_set(GITERR_SUBMODULE, "Invalid format for submodule URL");
-		error = -1;
-	}
+	error = git_submodule_resolve_url(&real_url, repo, url);
 	if (error)
 		goto cleanup;
 
@@ -531,6 +522,25 @@ const char *git_submodule_url(git_submodule *submodule)
 {
 	assert(submodule);
 	return submodule->url;
+}
+
+int git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *url)
+{
+	assert(url);
+
+	int error = 0;
+
+	if (url[0] == '.' && (url[1] == '/' || (url[1] == '.' && url[2] == '/'))) {
+		if (!(error = lookup_head_remote(out, repo)))
+			error = git_path_apply_relative(out, url);
+	} else if (strchr(url, ':') != NULL || url[0] == '/') {
+		error = git_buf_sets(out, url);
+	} else {
+		giterr_set(GITERR_SUBMODULE, "Invalid format for submodule URL");
+		error = -1;
+	}
+
+	return error;
 }
 
 const char *git_submodule_branch(git_submodule *submodule)


### PR DESCRIPTION
I'm implementing `git clone --recursive` in libgit2sharp (libgit2/libgit2sharp#640) and need a way to resolve relative submodule urls. As a quick hack, I wrote it in the binding, but @ben [agreed that it belongs to libgit2](https://github.com/libgit2/libgit2sharp/pull/640#discussion-diff-10219274).

I'm not sure if it's best to expose the function directly, as I did here. What do you think?

See also #2174 which should be fixed to make this one useful.

Please review my changes very carefully because this is my first C code with dynamic memory management.
