### PR TITLE
Seamless support for NTLM/Kerberos auth on Windows

### DIFF
--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -185,7 +185,8 @@ GIT_EXTERN(int) git_cred_default_new(git_cred **out);
  *                          remote url, or NULL if not included.
  * - allowed_types: A bitmask stating which cred types are OK to return.
  * - payload: The payload provided when specifying this callback.
- * - returns 0 for success or non-zero to indicate an error
+ * - returns 0 for success, < 0 to indicate an error, > 0 to indicate
+ *       no credential was acquired
  */
 typedef int (*git_cred_acquire_cb)(
 	git_cred **cred,


### PR DESCRIPTION
@ethomson recently added support for "default credentials" on Windows. The disadvantage was that the caller had to explictly opt-in to this support by using a credential callback that would call `git_cred_default_new`.

This change modifies the contract for credential callbacks to permit them to 'pass.' This is generally useful; for example, a callback may be invoked with a certain set of allowed credential types. If the callback doesn't know how to supply a credential meeting any of those types, it has to error out right now, which errors out the entire network operation. Better to let the credential callback simply say "Sorry, I couldn't help you."

Next, the WinHTTP transport adds a fallback credential callback that runs if the user-provided credential callback is absent or passes. The fallback credential callback will seamlessly supply default credentials under a certain set of conditions: the target must have advertised Windows integrated authentication through a `WWW-Authenticate` header in a 401, and the target URI must be in one of the following Internet Explorer 'zones': My Computer, Intranet, or Trusted.

The check for the second criterion uses COM. This is ugly but is not really any worse than using WinHTTP in the first place. It just happens that this particular set of APIs (`IInternetSecurityManager`) doesn't have a non-COM API surface. Since the WinHTTP transport currently only builds on MSVC, we don't have to worry about MinGW.
