### PR TITLE
revwalk: don't try to find merge bases when there can be none

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -205,6 +205,12 @@ int git_merge__bases_many(git_commit_list **out, git_revwalk *walk, git_commit_l
 	git_commit_list *result = NULL, *tmp = NULL;
 	git_pqueue list;
 
+	/* If there's only the one commit, there can be no merge bases */
+	if (twos->length == 0) {
+		*out = NULL;
+		return 0;
+	}
+
 	/* if the commit is repeated, we have a our merge base already */
 	git_vector_foreach(twos, i, two) {
 		if (one == two)

--- a/src/revwalk.h
+++ b/src/revwalk.h
@@ -32,7 +32,8 @@ struct git_revwalk {
 	int (*enqueue)(git_revwalk *, git_commit_list_node *);
 
 	unsigned walking:1,
-		first_parent: 1;
+		first_parent: 1,
+		did_hide: 1;
 	unsigned int sorting;
 
 	/* merge base calculation */


### PR DESCRIPTION
As a way to speed up the cases where we need to hide some commits, we
find out what the merge bases are so we know to stop marking commits as
uninteresting and avoid walking down a potentially very large amount of
commits which we will never see. There are however two oversights in
current code.

The merge-base finding algorithm fails to recognize that if it is only
given one commit, there can be no merge base. It instead walks down the
whole ancestor chain needlessly. Make it return an empty list
immediately in this situation.

The revwalk does not know whether the user has asked to hide any commits
at all. In situation where the user pushes multiple commits but doesn't
hide any, the above fix wouldn't do the trick. Keep track of whether the
user wants to hide any commits and only run the merge-base finding
algorithm when it's needed.

---

This is the cause for http://stackoverflow.com/questions/22539288/performance-issue-while-iterating-through-repos-commits and why we can't have nice things.
