### PR TITLE
Rename in-memory remote to anonymous and swap url and fetch order

### DIFF
--- a/examples/network/fetch.c
+++ b/examples/network/fetch.c
@@ -91,7 +91,7 @@ int fetch(git_repository *repo, int argc, char **argv)
 	// Figure out whether it's a named remote or a URL
 	printf("Fetching %s for repo %p\n", argv[1], repo);
 	if (git_remote_load(&remote, repo, argv[1]) < 0) {
-		if (git_remote_create_inmemory(&remote, repo, NULL, argv[1]) < 0)
+		if (git_remote_create_anonymous(&remote, repo, argv[1], NULL) < 0)
 			return -1;
 	}
 

--- a/examples/network/ls-remote.c
+++ b/examples/network/ls-remote.c
@@ -15,7 +15,7 @@ static int use_remote(git_repository *repo, char *name)
 	// Find the remote by name
 	error = git_remote_load(&remote, repo, name);
 	if (error < 0) {
-		error = git_remote_create_inmemory(&remote, repo, NULL, name);
+		error = git_remote_create_anonymous(&remote, repo, name, NULL);
 		if (error < 0)
 			goto cleanup;
 	}

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -62,10 +62,10 @@ GIT_EXTERN(int) git_remote_create_with_fetchspec(
 		const char *fetch);
 
 /**
- * Create a remote in memory
+ * Create an anonymous remote
  *
- * Create a remote with the given refspec in memory. You can use
- * this when you have a URL instead of a remote's name.  Note that in-memory
+ * Create a remote with the given url and refspec in memory. You can use
+ * this when you have a URL instead of a remote's name.  Note that anonymous
  * remotes cannot be converted to persisted remotes.
  *
  * The name, when provided, will be checked for validity.
@@ -73,15 +73,15 @@ GIT_EXTERN(int) git_remote_create_with_fetchspec(
  *
  * @param out pointer to the new remote object
  * @param repo the associated repository
- * @param fetch the fetch refspec to use for this remote.
  * @param url the remote repository's URL
+ * @param fetch the fetch refspec to use for this remote.
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_remote_create_inmemory(
+GIT_EXTERN(int) git_remote_create_anonymous(
 		git_remote **out,
 		git_repository *repo,
-		const char *fetch,
-		const char *url);
+		const char *url,
+		const char *fetch);
 
 /**
  * Get the information for a particular remote

--- a/src/remote.c
+++ b/src/remote.c
@@ -236,7 +236,7 @@ on_error:
 	return -1;
 }
 
-int git_remote_create_inmemory(git_remote **out, git_repository *repo, const char *fetch, const char *url)
+int git_remote_create_anonymous(git_remote **out, git_repository *repo, const char *url, const char *fetch)
 {
 	int error;
 	git_remote *remote;
@@ -502,7 +502,7 @@ int git_remote_save(const git_remote *remote)
 	assert(remote);
 
 	if (!remote->name) {
-		giterr_set(GITERR_INVALID, "Can't save an in-memory remote.");
+		giterr_set(GITERR_INVALID, "Can't save an anonymous remote.");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -1433,7 +1433,7 @@ static int rename_fetch_refspecs(
 		if (spec->push)
 			continue;
 
-		/* Every refspec is a problem refspec for an in-memory remote, OR */
+		/* Every refspec is a problem refspec for an anonymous remote, OR */
 		/* Does the dst part of the refspec follow the expected format? */
 		if (!remote->name ||
 			strcmp(git_buf_cstr(&base), spec->string)) {
@@ -1481,7 +1481,7 @@ int git_remote_rename(
 	assert(remote && new_name);
 
 	if (!remote->name) {
-		giterr_set(GITERR_INVALID, "Can't rename an in-memory remote.");
+		giterr_set(GITERR_INVALID, "Can't rename an anonymous remote.");
 		return GIT_EINVALIDSPEC;
 	}
 

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -30,7 +30,7 @@ static void connect_to_local_repository(const char *local_repository)
 {
 	git_buf_sets(&file_path_buf, cl_git_path_url(local_repository));
 
-	cl_git_pass(git_remote_create_inmemory(&remote, repo, NULL, git_buf_cstr(&file_path_buf)));
+	cl_git_pass(git_remote_create_anonymous(&remote, repo, git_buf_cstr(&file_path_buf), NULL));
 	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH));
 }
 
@@ -182,7 +182,7 @@ void test_network_remote_local__push_to_bare_remote(void)
 	}
 
 	/* Connect to the bare repo */
-	cl_git_pass(git_remote_create_inmemory(&localremote, repo, NULL, "./localbare.git"));
+	cl_git_pass(git_remote_create_anonymous(&localremote, repo, "./localbare.git", NULL));
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH));
 
 	/* Try to push */
@@ -222,7 +222,7 @@ void test_network_remote_local__push_to_bare_remote_with_file_url(void)
 	url = cl_git_path_url("./localbare.git");
 
 	/* Connect to the bare repo */
-	cl_git_pass(git_remote_create_inmemory(&localremote, repo, NULL, url));
+	cl_git_pass(git_remote_create_anonymous(&localremote, repo, url, NULL));
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH));
 
 	/* Try to push */
@@ -259,7 +259,7 @@ void test_network_remote_local__push_to_non_bare_remote(void)
 	}
 
 	/* Connect to the bare repo */
-	cl_git_pass(git_remote_create_inmemory(&localremote, repo, NULL, "./localnonbare"));
+	cl_git_pass(git_remote_create_anonymous(&localremote, repo, "./localnonbare", NULL));
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH));
 
 	/* Try to push */

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -66,7 +66,7 @@ void test_network_remote_remotes__error_when_no_push_available(void)
 	git_transport *t;
 	git_push *p;
 
-	cl_git_pass(git_remote_create_inmemory(&r, _repo, NULL, cl_fixture("testrepo.git")));
+	cl_git_pass(git_remote_create_anonymous(&r, _repo, cl_fixture("testrepo.git"), NULL));
 
 	cl_git_pass(git_transport_local(&t,r,NULL));
 
@@ -343,7 +343,7 @@ void test_network_remote_remotes__cannot_save_an_inmemory_remote(void)
 {
 	git_remote *remote;
 
-	cl_git_pass(git_remote_create_inmemory(&remote, _repo, NULL, "git://github.com/libgit2/libgit2"));
+	cl_git_pass(git_remote_create_anonymous(&remote, _repo, "git://github.com/libgit2/libgit2", NULL));
 
 	cl_assert_equal_p(NULL, git_remote_name(remote));
 
@@ -436,7 +436,7 @@ void test_network_remote_remotes__check_structure_version(void)
 
 	git_remote_free(_remote);
 	_remote = NULL;
-	cl_git_pass(git_remote_create_inmemory(&_remote, _repo, NULL, "test-protocol://localhost"));
+	cl_git_pass(git_remote_create_anonymous(&_remote, _repo, "test-protocol://localhost", NULL));
 
 	transport.version = 0;
 	cl_git_fail(git_remote_set_transport(_remote, &transport));
@@ -503,7 +503,7 @@ void test_network_remote_remotes__query_refspecs(void)
 	git_strarray array;
 	int i;
 
-	cl_git_pass(git_remote_create_inmemory(&remote, _repo, NULL, "git://github.com/libgit2/libgit2"));
+	cl_git_pass(git_remote_create_anonymous(&remote, _repo, "git://github.com/libgit2/libgit2", NULL));
 
 	for (i = 0; i < 3; i++) {
 		cl_git_pass(git_remote_add_fetch(remote, fetch_refspecs[i]));

--- a/tests/network/remote/rename.c
+++ b/tests/network/remote/rename.c
@@ -167,7 +167,7 @@ void test_network_remote_rename__cannot_rename_an_inmemory_remote(void)
 {
 	git_remote *remote;
 
-	cl_git_pass(git_remote_create_inmemory(&remote, _repo, NULL, "file:///blah"));
+	cl_git_pass(git_remote_create_anonymous(&remote, _repo, "file:///blah", NULL));
 	cl_git_fail(git_remote_rename(remote, "newname", NULL, NULL));
 
 	git_remote_free(remote);


### PR DESCRIPTION
The order in this function is the opposite to what
create_with_fetchspec() has, so change this one, as url-then-refspec is
what git does.
