### PR TITLE
Don't reset need_pack

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -44,7 +44,6 @@ static int maybe_want(git_remote *remote, git_remote_head *head, git_odb *odb, g
 	/* If we have the object, mark it so we don't ask for it */
 	if (git_odb_exists(odb, &head->oid)) {
 		head->local = 1;
-		remote->need_pack = 0;
 	}
 	else
 		remote->need_pack = 1;
@@ -106,6 +105,8 @@ cleanup:
 int git_fetch_negotiate(git_remote *remote)
 {
 	git_transport *t = remote->transport;
+
+    remote->need_pack = 0;
 
 	if (filter_wants(remote) < 0) {
 		giterr_set(GITERR_NET, "Failed to filter the reference list for wants");


### PR DESCRIPTION
While looping over multiple heads, an up-to-date head will clobber the `remote->need_pack` setting, preventing the rest of the machinery from building and downloading a pack-file, breaking fetches.
