### PR TITLE
Bare repositories don't have indexes.

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -720,6 +720,12 @@ int git_repository_index__weakptr(git_index **out, git_repository *repo)
 
 	assert(out && repo);
 
+    if (repo->is_bare) {
+        giterr_set(GIT_EBAREREPO, "Bare repositories don't have an index");
+        *out = NULL;
+        return -1;
+    }
+
 	if (repo->_index == NULL) {
 		git_buf index_path = GIT_BUF_INIT;
 		git_index *index;


### PR DESCRIPTION
Fixes #2218.

Note that I don't know what I'm doing ;-). Maybe there's a rational reason to allow bare repos to have indexes, but I haven't (yet) found one.
