### PR TITLE
Introduce git_merge_head_id

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -376,6 +376,15 @@ GIT_EXTERN(int) git_merge_head_from_id(
 	const git_oid *id);
 
 /**
+ * Gets the commit ID that the given `git_merge_head` refers to.
+ *
+ * @param id pointer to commit id to be filled in
+ * @param head the given merge head
+ */
+GIT_EXTERN(const git_oid *) git_merge_head_id(
+	const git_merge_head *head);
+
+/**
  * Frees a `git_merge_head`.
  *
  * @param head merge head to free

--- a/src/merge.c
+++ b/src/merge.c
@@ -2736,6 +2736,14 @@ int git_merge_head_from_fetchhead(
 	return merge_head_init(out, repo, branch_name, remote_url, oid);
 }
 
+const git_oid *git_merge_head_id(
+	const git_merge_head *head)
+{
+	assert(head);
+
+	return &head->oid;
+}
+
 void git_merge_head_free(git_merge_head *head)
 {
 	if (head == NULL)

--- a/tests/merge/workdir/setup.c
+++ b/tests/merge/workdir/setup.c
@@ -881,6 +881,33 @@ void test_merge_workdir_setup__two_remotes(void)
 	git_merge_head_free(their_heads[3]);
 }
 
+void test_merge_workdir_setup__id_from_head(void)
+{
+	git_oid expected_id;
+	const git_oid *id;
+	git_reference *ref;
+	git_merge_head *heads[3];
+
+	cl_git_pass(git_oid_fromstr(&expected_id, OCTO1_OID));
+	cl_git_pass(git_merge_head_from_fetchhead(&heads[0], repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH, "http://remote.url/repo.git", &expected_id));
+	id = git_merge_head_id(heads[0]);
+	cl_assert_equal_i(1, git_oid_equal(id, &expected_id));
+
+	cl_git_pass(git_merge_head_from_id(&heads[1], repo, &expected_id));
+	id = git_merge_head_id(heads[1]);
+	cl_assert_equal_i(1, git_oid_equal(id, &expected_id));
+
+	cl_git_pass(git_reference_lookup(&ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
+	cl_git_pass(git_merge_head_from_ref(&heads[2], repo, ref));
+	id = git_merge_head_id(heads[2]);
+	cl_assert_equal_i(1, git_oid_equal(id, &expected_id));
+
+	git_reference_free(ref);
+	git_merge_head_free(heads[0]);
+	git_merge_head_free(heads[1]);
+	git_merge_head_free(heads[2]);
+}
+
 struct merge_head_cb_data {
 	const char **oid_str;
 	unsigned int len;


### PR DESCRIPTION
Callers (especially bindings) may want to know if they can fast-forward, by creating a `git_merge_head` and then inquiring about the merge status.  Having a way to get the ID back out of the merge head is useful in the case where you want to perform that fast-forward.  Otherwise, users would have to lug around both the merge head and the ID that it was created from.
