### PR TITLE
Const up members of git_merge_file_result

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -177,13 +177,13 @@ typedef struct {
 	 * The path that the resultant merge file should use, or NULL if a
 	 * filename conflict would occur.
 	 */
-	char *path;
+	const char *path;
 
 	/** The mode that the resultant merge file should use.  */
 	unsigned int mode;
 
 	/** The contents of the merge. */
-	unsigned char *ptr;
+	const char *ptr;
 
 	/** The length of the merge contents. */
 	size_t len;

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -272,8 +272,8 @@ void git_merge_file_result_free(git_merge_file_result *result)
 	if (result == NULL)
 		return;
 
-	git__free(result->path);
+	git__free((char *)result->path);
 
 	/* xdiff uses malloc() not git_malloc, so we use free(), not git_free() */
-	free(result->ptr);
+	free((char *)result->ptr);
 }


### PR DESCRIPTION
@arthurschreiber noticed that I had been very sloppy when I made `git_merge_file_result` a public structure and the members should have been decorated as `const`.  Also, that we use `char *` for strings, not `unsigned char *`.  It's almost as if I've been living in a cave and writing code in bizarre languages lately!
