### PR TITLE
No need to find merge base.

### DIFF
--- a/src/revwalk.h
+++ b/src/revwalk.h
@@ -32,8 +32,7 @@ struct git_revwalk {
 	int (*enqueue)(git_revwalk *, git_commit_list_node *);
 
 	unsigned walking:1,
-		first_parent: 1,
-		did_hide: 1;
+		first_parent: 1;
 	unsigned int sorting;
 
 	/* merge base calculation */


### PR DESCRIPTION
As discussed in https://github.com/libgit2/libgit2/issues/2227, finding merge-base does not help in getting performance improvement. In this PR, I have done following changes:
1) Do not call `git_merge__bases_many` in `prepare_walk`
2) Do not call `enqueue` for an uninteresting node.
3) Do not call `process_parent_commits` for an uninteresting nodes (parent of an uninteresting nodes are also uninteresting).
4) Add some more tests for revwalk.
