### PR TITLE
Skip test_blame_simple__trivial_libgit2 if not in libgit2 repo

### DIFF
--- a/tests/blame/simple.c
+++ b/tests/blame/simple.c
@@ -141,9 +141,8 @@ void test_blame_simple__trivial_libgit2(void)
 		git_repository_is_shallow(g_repo) ||
 		git_revparse_single(&obj, g_repo, "359fc2d") < 0)
 	{
-		printf("NOT INSIDE VALID LIBGIT2 REPO; skipping blame test\n");
 		giterr_clear();
-		return;
+		cl_skip("not inside valid libgit2 repo");
 	}
 
 	git_oid_cpy(&opts.newest_commit, git_object_id(obj));

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -555,6 +555,16 @@ void cl_set_cleanup(void (*cleanup)(void *), void *opaque)
 	_clar.local_cleanup_payload = opaque;
 }
 
+const char *clar_active_suite(void)
+{
+	return _clar.active_suite;
+}
+
+const char *clar_active_test(void)
+{
+	return _clar.active_test;
+}
+
 #include "clar/sandbox.h"
 #include "clar/fixtures.h"
 #include "clar/fs.h"

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -16,6 +16,8 @@ void clar_test_shutdown(void);
 int clar_test(int argc, char *argv[]);
 
 const char *clar_sandbox_path(void);
+const char *clar_active_suite(void);
+const char *clar_active_test(void);
 
 void cl_set_cleanup(void (*cleanup)(void *), void *opaque);
 void cl_fs_cleanup(void);

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -65,6 +65,8 @@ void clar__assert_equal_file(
 	const char *file,
 	int line);
 
+#define cl_skip(reason) do { printf("skipping %s::%s; %s\n", clar_active_suite(), clar_active_test(), reason); return; } while (0)
+
 /*
  * Some utility macros for building long strings
  */

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -200,15 +200,10 @@ void test_online_clone__cred_callback_failure_return_code_is_tunnelled(void)
 	const char *remote_url = cl_getenv("GITTEST_REMOTE_URL");
 	const char *remote_user = cl_getenv("GITTEST_REMOTE_USER");
 
-	if (!remote_url) {
-		printf("GITTEST_REMOTE_URL unset; skipping clone test\n");
-		return;
-	}
-
-	if (!remote_user) {
-		printf("GITTEST_REMOTE_USER unset; skipping clone test\n");
-		return;
-	}
+	if (!remote_url)
+		cl_skip("GITTEST_REMOTE_URL unset");
+	if (!remote_user)
+		cl_skip("GITTEST_REMOTE_USER unset");
 
 	g_options.remote_callbacks.credentials = cred_failure_cb;
 


### PR DESCRIPTION
The `test_blame_simple__trivial_libgit2` test relies on being run from within the libgit2 repository to leverage having a longer history to play with, but some bundled versions of libgit2 don't have the whole libgit2 history.  This just skips that test if the repository can't be opened successfully.

Fixes #2199 
