### PR TITLE
Fix submodule_is_config_only's return value

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -339,7 +339,7 @@ static bool submodule_is_config_only(
 
 	git_submodule_free(sm);
 
-	return false;
+	return rval;
 }
 
 static int checkout_action_with_wd(


### PR DESCRIPTION
I think this was the original intent in https://github.com/libgit2/libgit2/commit/591e8295. Not sure how to properly exercise the code path in a test though.
