### PR TITLE
generate.py specifies encoding for test files

### DIFF
--- a/tests/generate.py
+++ b/tests/generate.py
@@ -118,7 +118,7 @@ class Module(object):
             self.modified = True
             self.mtime = st.st_mtime
 
-            with open(path) as fp:
+            with codecs.open(path, encoding='utf-8') as fp:
                 raw_content = fp.read()
 
         except IOError:


### PR DESCRIPTION
On many Windows machines, the default encoding is not utf-8. In the libgit2 repository, there are two files containing unicode characters encoded in utf-8. When generate.py attempts to load them using the wrong encoding, it crashes.

This happend on two machines, and fixes it on at least one (presumably on both).
