### PR TITLE
Don't lose our elements when calling git_vector_set()

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -327,8 +327,10 @@ int git_vector_resize_to(git_vector *v, size_t new_length)
 
 int git_vector_set(void **old, git_vector *v, size_t position, void *value)
 {
-	if (git_vector_resize_to(v, position + 1) < 0)
-		return -1;
+	if (position + 1 > v->length) {
+		if (git_vector_resize_to(v, position + 1) < 0)
+			return -1;
+	}
 
 	if (old != NULL)
 		*old = v->contents[position];


### PR DESCRIPTION
Turns out that if you call `git_vector_set` with `position < length`, that is you are not appending an element or setting the last element, it will actually lose your stuff!
