### PR TITLE
Commit diff convenience

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -9,6 +9,7 @@
 
 #include "common.h"
 #include "types.h"
+#include "diff.h"
 #include "oid.h"
 #include "object.h"
 
@@ -350,6 +351,22 @@ GIT_EXTERN(int) git_commit_amend(
 	const char *message_encoding,
 	const char *message,
 	const git_tree *tree);
+
+/**
+ * Create a diff between a commit and one of its parents.
+ *
+ * The returned diff must be freed explicitly with `git_diff_free`.
+ *
+ * @param diff output pointer to a git_diff pointer to be allocated.
+ * @param commit the commit for the diff
+ * @param mainline the parent of the commit, if it is a merge
+ * @param opts structure with options to influence diff or NULL for defaults.
+ */
+GIT_EXTERN(int) git_commit_diff(
+	git_diff **diff,
+	const git_commit *commit,
+	unsigned int mainline,
+	const git_diff_options *opts);
 
 /** @} */
 GIT_END_DECL

--- a/src/commit.c
+++ b/src/commit.c
@@ -477,3 +477,60 @@ int git_commit_nth_gen_ancestor(
 	*ancestor = parent;
 	return 0;
 }
+
+int git_commit_diff(
+	git_diff **out,
+	const git_commit *commit,
+	unsigned int mainline,
+	const git_diff_options *opts)
+{
+	git_commit *parent = NULL;
+	git_diff *diff = NULL;
+	git_tree *old_tree = NULL, *new_tree = NULL;
+	char commit_oidstr[GIT_OID_HEXSZ + 1];
+	unsigned int parentcount;
+	int error;
+
+	assert(out && commit);
+
+	parentcount = git_commit_parentcount(commit);
+
+	if (parentcount > 1 && mainline == 0) {
+		git_oid_fmt(commit_oidstr, git_commit_id(commit));
+		commit_oidstr[GIT_OID_HEXSZ] = '\0';
+
+		giterr_set(GITERR_INVALID, "Mainline branch is not specified but %s is a merge commit", commit_oidstr);
+		return -1;
+	}
+
+	if (parentcount <= 1 && mainline != 0) {
+		git_oid_fmt(commit_oidstr, git_commit_id(commit));
+		commit_oidstr[GIT_OID_HEXSZ] = '\0';
+
+		giterr_set(GITERR_INVALID, "Mainline branch specified but %s is not a merge commit", commit_oidstr);
+		return -1;
+	}
+
+	if (parentcount > 0) {
+		if (parentcount > 1)
+			mainline--;
+
+		if ((error = git_commit_parent(&parent, commit, mainline)) < 0 ||
+			(error = git_commit_tree(&old_tree, parent)) < 0)
+			goto on_error;
+	}
+
+	if ((error = git_commit_tree(&new_tree, commit)) < 0 ||
+		(error = git_diff_tree_to_tree(&diff, git_commit_owner(commit),
+			old_tree, new_tree, opts)) < 0)
+		goto on_error;
+
+	*out = diff;
+
+on_error:
+	git_tree_free(old_tree);
+	git_tree_free(new_tree);
+	git_commit_free(parent);
+
+	return error;
+}

--- a/tests/commit/diff.c
+++ b/tests/commit/diff.c
@@ -1,0 +1,152 @@
+#include "clar_libgit2.h"
+#include "commit.h"
+#include "git2/commit.h"
+
+static git_repository *_repo;
+
+void test_commit_diff__initialize(void)
+{
+	cl_fixture_sandbox("testrepo.git");
+	cl_git_pass(git_repository_open(&_repo, "testrepo.git"));
+}
+
+void test_commit_diff__cleanup(void)
+{
+	git_repository_free(_repo);
+	_repo = NULL;
+
+	cl_fixture_cleanup("testrepo.git");
+}
+
+void test_commit_diff__single_parent(void)
+{
+	git_commit *commit;
+	git_diff *diff;
+	git_patch *patch;
+	git_oid oid;
+	git_buf buf = GIT_BUF_INIT;
+
+	git_oid_fromstr(&oid, "9fd738e8f7967c078dceed8190330fc8648ee56a");
+	cl_git_pass(git_commit_lookup(&commit, _repo, &oid));
+	cl_git_pass(git_commit_diff(&diff, commit, 0, NULL));
+	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+
+	cl_assert(strcmp(buf.ptr,
+		"diff --git a/new.txt b/new.txt\n" \
+		"index fa49b07..a71586c 100644\n" \
+		"--- a/new.txt\n" \
+		"+++ b/new.txt\n" \
+		"@@ -1 +1 @@\n" \
+		"-new file\n" \
+		"+my new file\n") == 0);
+
+	git_buf_free(&buf);
+	git_patch_free(patch);
+	git_diff_free(diff);
+	git_commit_free(commit);
+}
+
+void test_commit_diff__first_parent(void)
+{
+	git_commit *commit;
+	git_diff *diff;
+	git_patch *patch;
+	git_oid oid;
+	git_buf buf = GIT_BUF_INIT;
+
+	git_oid_fromstr(&oid, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
+	cl_git_pass(git_commit_lookup(&commit, _repo, &oid));
+	cl_git_pass(git_commit_diff(&diff, commit, 1, NULL));
+	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+
+	cl_assert(strcmp(buf.ptr,
+		"diff --git a/branch_file.txt b/branch_file.txt\n" \
+		"new file mode 100644\n" \
+		"index 0000000..45b983b\n" \
+		"--- /dev/null\n" \
+		"+++ b/branch_file.txt\n" \
+		"@@ -0,0 +1 @@\n" \
+		"+hi\n") == 0);
+
+	git_buf_free(&buf);
+	git_patch_free(patch);
+	git_diff_free(diff);
+	git_commit_free(commit);
+}
+
+void test_commit_diff__second_parent(void)
+{
+	git_commit *commit;
+	git_diff *diff;
+	git_patch *patch;
+	git_oid oid;
+	git_buf buf = GIT_BUF_INIT;
+
+	git_oid_fromstr(&oid, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
+	cl_git_pass(git_commit_lookup(&commit, _repo, &oid));
+	cl_git_pass(git_commit_diff(&diff, commit, 2, NULL));
+
+	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+
+	cl_assert(strcmp(buf.ptr,
+		"diff --git a/README b/README\n" \
+		"index 1385f26..a823312 100644\n" \
+		"--- a/README\n" \
+		"+++ b/README\n" \
+		"@@ -1 +1 @@\n" \
+		"-hey\n" \
+		"+hey there\n") == 0);
+
+	git_buf_free(&buf);
+	git_patch_free(patch);
+
+	cl_git_pass(git_patch_from_diff(&patch, diff, 1));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+
+	cl_assert(strcmp(buf.ptr,
+		"diff --git a/new.txt b/new.txt\n" \
+		"index fa49b07..a71586c 100644\n" \
+		"--- a/new.txt\n" \
+		"+++ b/new.txt\n" \
+		"@@ -1 +1 @@\n" \
+		"-new file\n" \
+		"+my new file\n") == 0);
+
+	git_buf_free(&buf);
+	git_patch_free(patch);
+	git_diff_free(diff);
+	git_commit_free(commit);
+}
+
+void test_commit_diff__root(void)
+{
+	git_commit *commit;
+	git_diff *diff;
+	git_patch *patch;
+	git_oid oid;
+	git_buf buf = GIT_BUF_INIT;
+
+	git_oid_fromstr(&oid, "8496071c1b46c854b31185ea97743be6a8774479");
+	cl_git_pass(git_commit_lookup(&commit, _repo, &oid));
+	cl_git_pass(git_commit_diff(&diff, commit, 0, NULL));
+	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+
+	cl_assert(strcmp(buf.ptr,
+		"diff --git a/README b/README\n" \
+		"new file mode 100644\n" \
+		"index 0000000..1385f26\n" \
+		"--- /dev/null\n" \
+		"+++ b/README\n" \
+		"@@ -0,0 +1 @@\n" \
+		"+hey\n") == 0);
+
+	git_buf_free(&buf);
+	git_patch_free(patch);
+	git_diff_free(diff);
+	git_commit_free(commit);
+}
+


### PR DESCRIPTION
Generating a series of a patches for a range of commits is a common operation i.e. `git format-patch` and `git cherry-pick`. This adds `git_commit_diff` which is a convenience wrapper around `git_diff_tree_to_tree` where the `old_tree` parameter is fixed to one of the commit's parents.
