### PR TITLE
git_repository_state_cleanup() should remove rebase-merge/, rebase-apply/ and BISECT_LOG

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1966,7 +1966,9 @@ int git_repository__cleanup_files(git_repository *repo, const char *files[], siz
 
 		if ((error = git_buf_joinpath(&path, repo->path_repository, files[i])) < 0 ||
 			(git_path_isfile(git_buf_cstr(&path)) &&
-			(error = p_unlink(git_buf_cstr(&path))) < 0))
+			(error = p_unlink(git_buf_cstr(&path))) < 0) ||
+			(git_path_isdir(git_buf_cstr(&path)) &&
+			(error = git_futils_rmdir_r(git_buf_cstr(&path), NULL, GIT_RMDIR_REMOVE_FILES | GIT_RMDIR_REMOVE_BLOCKERS)) < 0))
 			goto done;
 	}
 
@@ -1982,6 +1984,9 @@ static const char *state_files[] = {
 	GIT_MERGE_MSG_FILE,
 	GIT_REVERT_HEAD_FILE,
 	GIT_CHERRY_PICK_HEAD_FILE,
+	GIT_BISECT_LOG_FILE,
+	GIT_REBASE_MERGE_DIR,
+	GIT_REBASE_APPLY_DIR,
 };
 
 int git_repository_state_cleanup(git_repository *repo)

--- a/tests/repo/state.c
+++ b/tests/repo/state.c
@@ -45,52 +45,70 @@ void test_repo_state__merge(void)
 {
 	setup_simple_state(GIT_MERGE_HEAD_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_MERGE);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__revert(void)
 {
 	setup_simple_state(GIT_REVERT_HEAD_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_REVERT);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__cherry_pick(void)
 {
 	setup_simple_state(GIT_CHERRY_PICK_HEAD_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_CHERRY_PICK);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__bisect(void)
 {
 	setup_simple_state(GIT_BISECT_LOG_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_BISECT);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__rebase_interactive(void)
 {
 	setup_simple_state(GIT_REBASE_MERGE_INTERACTIVE_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_REBASE_INTERACTIVE);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__rebase_merge(void)
 {
 	setup_simple_state(GIT_REBASE_MERGE_DIR "whatever");
 	assert_repo_state(GIT_REPOSITORY_STATE_REBASE_MERGE);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__rebase(void)
 {
 	setup_simple_state(GIT_REBASE_APPLY_REBASING_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_REBASE);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__apply_mailbox(void)
 {
 	setup_simple_state(GIT_REBASE_APPLY_APPLYING_FILE);
 	assert_repo_state(GIT_REPOSITORY_STATE_APPLY_MAILBOX);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 
 void test_repo_state__apply_mailbox_or_rebase(void)
 {
 	setup_simple_state(GIT_REBASE_APPLY_DIR "whatever");
 	assert_repo_state(GIT_REPOSITORY_STATE_APPLY_MAILBOX_OR_REBASE);
+	cl_git_pass(git_repository_state_cleanup(_repo));
+	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }


### PR DESCRIPTION
We didn't have any test cases for `git_repository_state_cleanup()`. Turns out that we actually didn't cleanup the `rebase-merge/` or `rebase-apply/` directories. Ditto for the `BISECT_LOG` file.
