### PR TITLE
pull userdiff pattern updates from git.git

### DIFF
--- a/src/userdiff.h
+++ b/src/userdiff.h
@@ -45,13 +45,13 @@ typedef struct {
 static git_diff_driver_definition builtin_defs[] = {
 
 IPATTERN("ada",
-	 "!^(.*[ \t])?(is new|renames|is separate)([ \t].*)?$\n"
+	 "!^(.*[ \t])?(is[ \t]+new|renames|is[ \t]+separate)([ \t].*)?$\n"
 	 "!^[ \t]*with[ \t].*$\n"
 	 "^[ \t]*((procedure|function)[ \t]+.*)$\n"
 	 "^[ \t]*((package|protected|task)[ \t]+.*)$",
 	 /* -- */
 	 "[a-zA-Z][a-zA-Z0-9_]*"
-	 "|[0-9][-+0-9#_.eE]"
+	 "|[-+]?[0-9][0-9#_.aAbBcCdDeEfF]*([eE][+-]?[0-9_]+)?"
 	 "|=>|\\.\\.|\\*\\*|:=|/=|>=|<=|<<|>>|<>"),
 
 IPATTERN("fortran",


### PR DESCRIPTION
There have been a few updates since the userdiff patterns were copied from upstream git. This brings it up to date.

I just made "moral equivalent" commits and credited the originals. If you prefer, we can faux-cherry-pick the originals and leave the original authors in the author field. Both authors are listed as `ok` in the `git.git-authors` file.

I notice that libgit2's php pattern has forked, and you've grown a javascript pattern. Maybe those could be contributed back upstream to git? Hint, hint. :)

/cc @arrbee 
