### PR TITLE
Fix bug popping ignore files during wd iteration

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -78,6 +78,8 @@ static int push_one_ignore(void *payload, git_buf *path)
 {
 	git_ignores *ign = payload;
 
+	ign->depth++;
+
 	return push_ignore_file(
 		ign->repo, ign, &ign->ign_path, path->ptr, GIT_IGNORE_FILE);
 }
@@ -108,6 +110,7 @@ int git_ignore__for_path(
 	ignores->repo = repo;
 	git_buf_init(&ignores->dir, 0);
 	ignores->ign_internal = NULL;
+	ignores->depth = 0;
 
 	/* Read the ignore_case flag */
 	if ((error = git_repository__cvar(
@@ -163,6 +166,8 @@ int git_ignore__push_dir(git_ignores *ign, const char *dir)
 	if (git_buf_joinpath(&ign->dir, ign->dir.ptr, dir) < 0)
 		return -1;
 
+	ign->depth++;
+
 	return push_ignore_file(
 		ign->repo, ign, &ign->ign_path, ign->dir.ptr, GIT_IGNORE_FILE);
 }
@@ -174,7 +179,7 @@ int git_ignore__pop_dir(git_ignores *ign)
 		const char *start, *end, *scan;
 		size_t keylen;
 
-		/* - ign->dir looks something like "a/b" (or "a/b/c/d")
+		/* - ign->dir looks something like "a/b/" (or "a/b/c/d/")
 		 * - file->key looks something like "0#a/b/.gitignore
 		 *
 		 * We are popping the last directory off ign->dir.  We also want to
@@ -191,9 +196,13 @@ int git_ignore__pop_dir(git_ignores *ign)
 		if (ign->dir.size >= keylen &&
 			!memcmp(ign->dir.ptr + ign->dir.size - keylen, start, keylen))
 			git_vector_pop(&ign->ign_path);
-
-		git_buf_rtruncate_at_char(&ign->dir, '/');
 	}
+
+	if (--ign->depth > 0) {
+		git_buf_rtruncate_at_char(&ign->dir, '/');
+		git_path_to_dir(&ign->dir);
+	}
+
 	return 0;
 }
 

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -29,6 +29,7 @@ typedef struct {
 	git_vector ign_path;
 	git_vector ign_global;
 	int ignore_case;
+	int depth;
 } git_ignores;
 
 extern int git_ignore__for_path(


### PR DESCRIPTION
There were a couple bugs in popping ignore files during iteration that could result in incorrect decisions being made and thus ignore files below the root either not being loaded correctly or not being popped at the right time.

One bug was an off-by-one in comparing the path of the .gitignore file with the path being exited during iteration. This would result in the ignore rules being applied even after the directory was exited.

The second bug was not correctly truncating the path being tracked during traversal if there were no ignores on the list (i.e. when you have no .gitignore at the root, but do have some in contained directories). This would result in some .gitignore files not being loaded (and creating a .gitignore at the root would generally work around this).
