### PR TITLE
Correct C90 warnings

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -183,6 +183,7 @@ int git_threads_init(void)
 
 void git_threads_shutdown(void)
 {
+	void *ptr = NULL;
 	pthread_once_t new_once = PTHREAD_ONCE_INIT;
 
 	if (git_atomic_dec(&git__n_inits) > 0) return;
@@ -190,7 +191,7 @@ void git_threads_shutdown(void)
 	/* Shut down any subsystems that have global state */
 	git__shutdown();
 
-	void *ptr = pthread_getspecific(_tls_key);
+	ptr = pthread_getspecific(_tls_key);
 	pthread_setspecific(_tls_key, NULL);
 	git__free(ptr);
 

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -102,14 +102,13 @@ void test_repo_open__gitlinked(void)
 
 void test_repo_open__from_git_new_workdir(void)
 {
+#ifndef GIT_WIN32
 	/* The git-new-workdir script that ships with git sets up a bunch of
 	 * symlinks to create a second workdir that shares the object db with
 	 * another checkout.  Libgit2 can open a repo that has been configured
 	 * this way.
 	 */
-	cl_git_sandbox_init("empty_standard_repo");
 
-#ifndef GIT_WIN32
 	git_repository *repo2;
 	git_buf link_tgt = GIT_BUF_INIT, link = GIT_BUF_INIT, body = GIT_BUF_INIT;
 	const char **scan;
@@ -121,6 +120,8 @@ void test_repo_open__from_git_new_workdir(void)
 	static const char *copies[] = {
 		"HEAD", NULL
 	};
+
+	cl_git_sandbox_init("empty_standard_repo");
 
 	cl_git_pass(p_mkdir("alternate", 0777));
 	cl_git_pass(p_mkdir("alternate/.git", 0777));


### PR DESCRIPTION
This fixes 2 warnings I picked up on the gcc build. Not really issues, but keeps the build clean.
