### PR TITLE
Fix core.excludesfile named .gitignore

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -14,8 +14,7 @@ static int parse_ignore_file(
 {
 	int error = 0;
 	git_attr_fnmatch *match = NULL;
-	const char *scan = NULL;
-	char *context = NULL;
+	const char *scan = NULL, *context = NULL;
 	int ignore_case = false;
 
 	/* Prefer to have the caller pass in a git_ignores as the parsedata
@@ -25,10 +24,10 @@ static int parse_ignore_file(
 	else if (git_repository__cvar(&ignore_case, repo, GIT_CVAR_IGNORECASE) < 0)
 		return error;
 
-	if (ignores->key && git__suffixcmp(ignores->key, "/" GIT_IGNORE_FILE) == 0) {
+	if (ignores->key &&
+		git_path_root(ignores->key + 2) < 0 &&
+		git__suffixcmp(ignores->key, "/" GIT_IGNORE_FILE) == 0)
 		context = ignores->key + 2;
-		context[strlen(context) - strlen(GIT_IGNORE_FILE)] = '\0';
-	}
 
 	scan = buffer;
 
@@ -64,9 +63,6 @@ static int parse_ignore_file(
 	}
 
 	git__free(match);
-	/* restore file path used for context */
-	if (context)
-		context[strlen(context)] = '.'; /* first char of GIT_IGNORE_FILE */
 
 	return error;
 }

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -490,3 +490,24 @@ void clar__assert_equal_file(
 	clar__assert_equal(file, line, "mismatched file length", 1, "%"PRIuZ,
 		(size_t)expected_bytes, (size_t)total_bytes);
 }
+
+void cl_fake_home(git_buf *restore)
+{
+	git_buf path = GIT_BUF_INIT;
+
+	cl_git_pass(git_libgit2_opts(
+		GIT_OPT_GET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, restore));
+
+	cl_must_pass(p_mkdir("home", 0777));
+	cl_git_pass(git_path_prettify(&path, "home", NULL));
+	cl_git_pass(git_libgit2_opts(
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, path.ptr));
+	git_buf_free(&path);
+}
+
+void cl_fake_home_cleanup(git_buf *restore)
+{
+	cl_git_pass(git_libgit2_opts(
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, restore->ptr));
+	git_buf_free(restore);
+}

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -120,4 +120,7 @@ int cl_repo_get_bool(git_repository *repo, const char *cfg);
 
 void cl_repo_set_string(git_repository *repo, const char *cfg, const char *value);
 
+void cl_fake_home(git_buf *restore);
+void cl_fake_home_cleanup(git_buf *restore);
+
 #endif


### PR DESCRIPTION
Ignore rules with slashes in them are matched using `FNM_PATHNAME` and use the path to the `.gitignore` file from the root of the repository along with the path fragment (including slashes) in the ignore file itself.  Unfortunately, the relative path to the `.gitignore` file was being applied to the global `core.excludesfile` if that also happened to be named ".gitignore".

This fixes that with more precise matching and includes test for ignore rules with leading slashes (which were the primary example of this being broken in the real world).

This also backports an improvement to the file context logic from the threadsafe-iterators branch (i.e. PR #2108) so we don't rely on mutating the key of the attribute file name to generate the context path. Instead, the matching rule parser just expects a trailing filename and strips it off when it parses the rule.

This is an alternate fix for Issue #2266 to PR #2267  - sorry @robrix, once I wrote the tests, it was easier just to write the fix for this as well...
