### PR TITLE
Add GIT_BRANCH_LOCAL_AND_REMOTE to git_branch_t enum

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -84,7 +84,7 @@ typedef struct git_branch_iterator git_branch_iterator;
  * @param repo Repository where to find the branches.
  * @param list_flags Filtering flags for the branch
  * listing. Valid values are GIT_BRANCH_LOCAL, GIT_BRANCH_REMOTE
- * or a combination of the two.
+ * or GIT_BRANCH_ALL.
  *
  * @return 0 on success  or an error code
  */

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -193,6 +193,7 @@ typedef enum {
 typedef enum {
 	GIT_BRANCH_LOCAL = 1,
 	GIT_BRANCH_REMOTE = 2,
+	GIT_BRANCH_ALL = GIT_BRANCH_LOCAL|GIT_BRANCH_REMOTE,
 } git_branch_t;
 
 /** Valid modes for index and tree entries. */

--- a/tests/refs/branches/iterator.c
+++ b/tests/refs/branches/iterator.c
@@ -48,7 +48,7 @@ static void assert_retrieval(unsigned int flags, unsigned int expected_count)
 
 void test_refs_branches_iterator__retrieve_all_branches(void)
 {
-	assert_retrieval(GIT_BRANCH_LOCAL | GIT_BRANCH_REMOTE, 14);
+	assert_retrieval(GIT_BRANCH_ALL, 14);
 }
 
 void test_refs_branches_iterator__retrieve_remote_branches(void)
@@ -139,7 +139,7 @@ void test_refs_branches_iterator__mix_of_packed_and_loose(void)
 
 	r2 = cl_git_sandbox_init("testrepo2");
 
-	cl_git_pass(git_branch_iterator_new(&iter, r2, GIT_BRANCH_LOCAL | GIT_BRANCH_REMOTE));
+	cl_git_pass(git_branch_iterator_new(&iter, r2, GIT_BRANCH_ALL));
 	contains_branches(exp, iter);
 
 	git_branch_iterator_free(iter);


### PR DESCRIPTION
git_branch_t is an enum so requesting GIT_BRANCH_LOCAL | GIT_BRANCH_REMOTE is not possible as it is not a member of the enum (at least VS2013 C++ complains about it).

This fixes a regression introduced in commit a667ca8298193b3103c1dbdcb1f6c527e6e99eb2 (PR #1946).
