### PR TITLE
Fix some issues from the last Coverity scan

### DIFF
--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -232,14 +232,13 @@ int git_attr_file__parse_buffer(
 
 	while (!error && *scan) {
 		/* allocate rule if needed */
-		if (!rule) {
-			if (!(rule = git__calloc(1, sizeof(*rule)))) {
-				error = -1;
-				break;
-			}
-			rule->match.flags = GIT_ATTR_FNMATCH_ALLOWNEG |
-				GIT_ATTR_FNMATCH_ALLOWMACRO;
+		if (!rule && !(rule = git__calloc(1, sizeof(*rule)))) {
+			error = -1;
+			break;
 		}
+
+		rule->match.flags =
+			GIT_ATTR_FNMATCH_ALLOWNEG | GIT_ATTR_FNMATCH_ALLOWMACRO;
 
 		/* parse the next "pattern attr attr attr" line */
 		if (!(error = git_attr_fnmatch__parse(

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -176,10 +176,9 @@ static int attr_cache_lookup(
 		goto cleanup;
 
 	entry = attr_cache_lookup_entry(cache, relfile);
-	if (!entry) {
-		if ((error = attr_cache_make_entry(&entry, repo, relfile)) < 0)
-			goto cleanup;
-	} else if (entry->file[source] != NULL) {
+	if (!entry)
+		error = attr_cache_make_entry(&entry, repo, relfile);
+	else if (entry->file[source] != NULL) {
 		file = entry->file[source];
 		GIT_REFCOUNT_INC(file);
 	}
@@ -254,8 +253,7 @@ bool git_attr_cache__is_cached(
 	khiter_t pos;
 	git_attr_file_entry *entry;
 
-	if (!(cache = git_repository_attr_cache(repo)) ||
-		!(files = cache->files))
+	if (!cache || !(files = cache->files))
 		return false;
 
 	pos = git_strmap_lookup_index(files, filename);

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -32,9 +32,9 @@ static int parse_ignore_file(
 	}
 
 	while (!error && *scan) {
-		if (!match) {
-			match = git__calloc(1, sizeof(*match));
-			GITERR_CHECK_ALLOC(match);
+		if (!match && !(match = git__calloc(1, sizeof(*match)))) {
+			error = -1;
+			break;
 		}
 
 		match->flags = GIT_ATTR_FNMATCH_ALLOWSPACE | GIT_ATTR_FNMATCH_ALLOWNEG;

--- a/src/index.c
+++ b/src/index.c
@@ -1880,8 +1880,9 @@ static int parse_index(git_index *index, const char *buffer, size_t buffer_size)
 	git_oid checksum_calculated, checksum_expected;
 
 #define seek_forward(_increase) { \
-	if (_increase >= buffer_size) \
-		return index_error_invalid("ran out of data while parsing"); \
+	if (_increase >= buffer_size) { \
+		error = index_error_invalid("ran out of data while parsing"); \
+		goto done; } \
 	buffer += _increase; \
 	buffer_size -= _increase;\
 }


### PR DESCRIPTION
Fix some issues from the last coverity scan. Most of these are cases where an early return could bypass a call to `git_mutex_unlock` (with one change just to make two similar functions actually have parallel construction).
