### PR TITLE
Merge checkout strategy

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -2186,8 +2186,6 @@ static int merge_normalize_checkout_opts(
 	const git_merge_head **their_heads)
 {
 	int error = 0;
-	unsigned int default_checkout_strategy = GIT_CHECKOUT_SAFE |
-		GIT_CHECKOUT_ALLOW_CONFLICTS;
 
 	GIT_UNUSED(repo);
 
@@ -2195,11 +2193,11 @@ static int merge_normalize_checkout_opts(
 		memcpy(checkout_opts, given_checkout_opts, sizeof(git_checkout_options));
 	else {
 		git_checkout_options default_checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+		default_checkout_opts.checkout_strategy =  GIT_CHECKOUT_SAFE |
+			GIT_CHECKOUT_ALLOW_CONFLICTS;
+
 		memcpy(checkout_opts, &default_checkout_opts, sizeof(git_checkout_options));
 	}
-
-	if (!checkout_opts->checkout_strategy)
-		checkout_opts->checkout_strategy = default_checkout_strategy;
 
 	/* TODO: for multiple ancestors in merge-recursive, this is "merged common ancestors" */
 	if (!checkout_opts->ancestor_label) {

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -86,7 +86,7 @@ static void set_core_autocrlf_to(git_repository *repo, bool value)
 	git_config_free(cfg);
 }
 
-static int merge_branch(int merge_file_favor, int checkout_strategy)
+static int merge_branch(void)
 {
 	git_oid their_oids[1];
 	git_merge_head *their_heads[1];
@@ -97,8 +97,7 @@ static int merge_branch(int merge_file_favor, int checkout_strategy)
 	cl_git_pass(git_oid_fromstr(&their_oids[0], MERGE_BRANCH_OID));
 	cl_git_pass(git_merge_head_from_id(&their_heads[0], repo, &their_oids[0]));
 
-	merge_opts.file_favor = merge_file_favor;
-	checkout_opts.checkout_strategy = checkout_strategy;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS;
 	error = git_merge(repo, (const git_merge_head **)their_heads, 1, &merge_opts, &checkout_opts);
 
 	git_merge_head_free(their_heads[0]);
@@ -214,7 +213,7 @@ static int merge_dirty_files(char *dirty_files[])
 
 	write_files(dirty_files);
 
-	error = merge_branch(0, 0);
+	error = merge_branch();
 
 	git_object_free(head_object);
 	git_reference_free(head);
@@ -237,7 +236,7 @@ static int merge_differently_filtered_files(char *files[])
 
 	cl_git_pass(git_index_write(repo_index));
 
-	error = merge_branch(0, 0);
+	error = merge_branch();
 
 	git_object_free(head_object);
 	git_reference_free(head);
@@ -248,7 +247,7 @@ static int merge_differently_filtered_files(char *files[])
 static int merge_staged_files(char *staged_files[])
 {	
 	stage_random_files(staged_files);
-	return merge_branch(0, 0);
+	return merge_branch();
 }
 
 void test_merge_workdir_dirty__unaffected_dirty_files_allowed(void)
@@ -271,7 +270,7 @@ void test_merge_workdir_dirty__unstaged_deletes_maintained(void)
 
 	cl_git_pass(p_unlink("merge-resolve/unchanged.txt"));
 
-	cl_git_pass(merge_branch(0, 0));
+	cl_git_pass(merge_branch());
 
 	git_object_free(head_object);
 	git_reference_free(head);
@@ -309,7 +308,7 @@ void test_merge_workdir_dirty__identical_staged_files_allowed(void)
 		stage_content(content);
 
 		git_index_write(repo_index);
-		cl_git_pass(merge_branch(0, 0));
+		cl_git_pass(merge_branch());
 	}
 }
 

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -92,7 +92,7 @@ void test_merge_workdir_simple__cleanup(void)
 	cl_git_sandbox_cleanup();
 }
 
-static void merge_simple_branch(int merge_file_favor, int checkout_strategy)
+static void merge_simple_branch(int merge_file_favor, int addl_checkout_strategy)
 {
 	git_oid their_oids[1];
 	git_merge_head *their_heads[1];
@@ -103,7 +103,9 @@ static void merge_simple_branch(int merge_file_favor, int checkout_strategy)
 	cl_git_pass(git_merge_head_from_id(&their_heads[0], repo, &their_oids[0]));
 
 	merge_opts.file_favor = merge_file_favor;
-	checkout_opts.checkout_strategy = checkout_strategy;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS |
+		addl_checkout_strategy;
+
 	cl_git_pass(git_merge(repo, (const git_merge_head **)their_heads, 1, &merge_opts, &checkout_opts));
 
 	git_merge_head_free(their_heads[0]);


### PR DESCRIPTION
@jamill rightly informed me that I was an idiot when it came to checkout strategy.  This fixes two issues in merge:
1. The default checkout strategy should _not_ be `SAFE_CREATE`, it should be `SAFE`.  With `SAFE_CREATE`, you could have an unstaged delete in your working directory, perform a merge (where the file was untouched by the merge) and we would check the file back out for you!  Using `SAFE` fixes that up, and we behave like git core.
2. We did not allow an checkout strategy of `NONE`.  I think that it is crazy that anybody would ever want this, because we would blow away their index with the merge result and then not touch the working directory.  But it's certainly theoretically possible, and moreso, I cringe when I was asked to better document the current behavior because I couldn't justify overwriting their perfectly legitimate (but bizarre) choice with my also perfectly legitimate choice.  A `NULL` checkout options struct remains unchanged.

Note that there may be fallout for a binding (@arthurschreiber) that has hooked up merge and _is_ providing a checkout options struct with a merge strategy of 0.
