### PR TITLE
Don't scale insertions/deletions markers if its less than the requested width

### DIFF
--- a/src/diff_stats.c
+++ b/src/diff_stats.c
@@ -90,15 +90,16 @@ int git_diff_file_stats__full_to_buf(
 			goto on_error;
 
 		if (filestat->insertions || filestat->deletions) {
+			size_t total = filestat->insertions + filestat->deletions;
+
 			if (git_buf_putc(out, ' ') < 0)
 				goto on_error;
 
-			if (!width) {
+			if (!width || total <= width) {
 				if (git_buf_putcn(out, '+', filestat->insertions) < 0 ||
 					git_buf_putcn(out, '-', filestat->deletions) < 0)
 					goto on_error;
 			} else {
-				size_t total = filestat->insertions + filestat->deletions;
 				size_t full = (total * width + stats->max_filestat / 2) /
 					stats->max_filestat;
 				size_t plus = full * filestat->insertions / total;


### PR DESCRIPTION
As part of #2289 we added scaling to the `+` and `-` markers by taking a `width` parameter. If the total number of insertions and deletions is less than the `width`, there is no need to scale.
