### PR TITLE
Bump required CMake version to 2.8.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # > cmake --build . --target install
 
 PROJECT(libgit2 C)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.3)
 
 # Add find modules to the path
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/")


### PR DESCRIPTION
`CMAKE_CURRENT_LIST_DIR` used in https://github.com/libgit2/libgit2/commit/5c8d5eac35794391c935e273612744a0684beb29 requires at least 2.8.3, fails with 2.6
