### PR TITLE
MidnightBSD may also not have strnlen

### DIFF
--- a/src/strnlen.h
+++ b/src/strnlen.h
@@ -7,7 +7,7 @@
 #ifndef INCLUDE_strlen_h__
 #define INCLUDE_strlen_h__
 
-#if defined(__MINGW32__) || defined(__sun) || defined(__APPLE__)
+#if defined(__MINGW32__) || defined(__sun) || defined(__APPLE__) || defined(__MidnightBSD__)
 #   define NO_STRNLEN
 #endif
 


### PR DESCRIPTION
Provide an implementation for `strnlen` on MidnightBSD (a fork/clone of FreeBSD).

I've been seeing these in the perl bindings test reports:

```
Can't load '/usr/home/cpan/pit/bare/conf/perl-5.14.0/.cpanplus/5.14.0/build/Git-Raw-0.35/blib/arch/auto/Git/Raw/Raw.so' for module Git::Raw: /usr/home/cpan/pit/bare/conf/perl-5.14.0/.cpanplus/5.14.0/build/Git-Raw-0.35/blib/arch/auto/Git/Raw/Raw.so: Undefined symbol "strnlen" at /usr/home/cpan/pit/bare/perl-5.14.0/lib/5.14.0/amd64-midnightbsd/DynaLoader.pm line 190.
 at /usr/home/cpan/pit/bare/conf/perl-5.14.0/.cpanplus/5.14.0/build/Git-Raw-0.35/blib/lib/Git/Raw/Blame.pm line 6
```
