### PR TITLE
commit: safer commit creation with reference update

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -254,7 +254,8 @@ GIT_EXTERN(int) git_commit_nth_gen_ancestor(
  *	is not direct, it will be resolved to a direct reference.
  *	Use "HEAD" to update the HEAD of the current branch and
  *	make it point to this commit. If the reference doesn't
- *	exist yet, it will be created.
+ *	exist yet, it will be created. If it does exist, the first
+ *	parent must be the tip of this branch.
  *
  * @param author Signature with author and author time of commit
  *
@@ -329,7 +330,7 @@ GIT_EXTERN(int) git_commit_create_v(
  *
  * The `update_ref` value works as in the regular `git_commit_create()`,
  * updating the ref to point to the newly rewritten commit.  If you want
- * to amend a commit that is not currently the HEAD of the branch and then
+ * to amend a commit that is not currently the tip of the branch and then
  * rewrite the following commits to reach a ref, pass this as NULL and
  * update the rest of the commit chain and ref separately.
  *

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -38,6 +38,10 @@ void test_commit_commit__create_unexisting_update_ref(void)
 	cl_git_pass(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
 				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
 
+	/* fail because the parent isn't the tip of the branch anymore */
+	cl_git_fail(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
+				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+
 	cl_git_pass(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
 	cl_assert(!git_oid_cmp(&oid, git_reference_target(ref)));
 

--- a/tests/object/commit/commitstagedfile.c
+++ b/tests/object/commit/commitstagedfile.c
@@ -175,6 +175,10 @@ void test_object_commit_commitstagedfile__amend_commit(void)
 	cl_git_pass(git_commit_amend(
 		&new_oid, old_commit, "HEAD", NULL, NULL, NULL, "Initial commit", NULL));
 
+	/* fail because the commit isn't the tip of the branch anymore */
+	cl_git_fail(git_commit_amend(
+		&new_oid, old_commit, "HEAD", NULL, NULL, NULL, "Initial commit", NULL));
+
 	cl_git_pass(git_commit_lookup(&new_commit, repo, &new_oid));
 
 	cl_assert_equal_i(0, git_commit_parentcount(new_commit));
@@ -182,6 +186,7 @@ void test_object_commit_commitstagedfile__amend_commit(void)
 	assert_commit_is_head(new_commit);
 
 	git_commit_free(old_commit);
+
 	old_commit = new_commit;
 
 	/* let's amend the tree of that last commit */
@@ -191,6 +196,10 @@ void test_object_commit_commitstagedfile__amend_commit(void)
 	cl_git_pass(git_index_write_tree(&tree_oid, index));
 	cl_git_pass(git_tree_lookup(&tree, repo, &tree_oid));
 	cl_assert_equal_i(2, git_tree_entrycount(tree));
+
+	/* fail to amend on a ref which does not exist */
+	cl_git_fail_with(GIT_ENOTFOUND, git_commit_amend(
+		&new_oid, old_commit, "refs/heads/nope", NULL, NULL, NULL, "Initial commit", tree));
 
 	cl_git_pass(git_commit_amend(
 		&new_oid, old_commit, "HEAD", NULL, NULL, NULL, "Initial commit", tree));


### PR DESCRIPTION
The current version of the commit creation and amend function are unsafe
to use when passing the update_ref parameter, as they do not check that
the reference at the moment of update points to what the user expects.

Make sure that we're moving history forward when we ask the library to
update the reference for us by checking that the first parent of the new
commit is the current value of the reference. We also make sure that the
ref we're updating hasn't moved between the read and the write.

Similarly, when amending a commit, make sure that the current tip of the
branch is the commit we're amending.
