### PR TITLE
cygwin also doesn't have qsort_r

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -612,7 +612,7 @@ void git__qsort_r(
 #if defined(__MINGW32__) || defined(AMIGA) || \
 	defined(__OpenBSD__) || defined(__NetBSD__) || \
 	defined(__gnu_hurd__) || defined(__ANDROID_API__) || \
-	defined(__sun) || \
+	defined(__sun) || defined(__CYGWIN__) || \
 	(__GLIBC__ == 2 && __GLIBC_MINOR__ < 8)
 	git__insertsort_r(els, nel, elsize, NULL, cmp, payload);
 #elif defined(GIT_WIN32)


### PR DESCRIPTION
Found this on the cygwin mailing list:

http://cygwin.com/ml/cygwin/2014-02/msg00122.html

I have also seen it in the `Git::Raw` bindings:

```
g++  --shared  -Wl,--enable-auto-import -Wl,--export-all-symbols -Wl,--enable-auto-image-base -fstack-protector Raw.o deps/libgit2/deps/http-parser/http_parser.o deps/libgit2/deps/zlib/adler32.o deps/libgit2/deps/zlib/crc32.o deps/libgit2/deps/zlib/deflate.o deps/libgit2/deps/zlib/inffast.o deps/libgit2/deps/zlib/inflate.o deps/libgit2/deps/zlib/inftrees.o deps/libgit2/deps/zlib/trees.o deps/libgit2/deps/zlib/zutil.o deps/libgit2/src/attr.o deps/libgit2/src/attr_file.o deps/libgit2/src/attrcache.o deps/libgit2/src/blame.o deps/libgit2/src/blame_git.o deps/libgit2/src/blob.o deps/libgit2/src/branch.o deps/libgit2/src/buf_text.o deps/libgit2/src/buffer.o deps/libgit2/src/cache.o deps/libgit2/src/checkout.o deps/libgit2/src/cherrypick.o deps/libgit2/src/clone.o deps/libgit2/src/commit.o deps/libgit2/src/commit_list.o deps/libgit2/src/config.o deps/libgit2/src/config_cache.o deps/libgit2/src/config_file.o deps/libgit2/src/crlf.o deps/libgit2/src/date.o deps/libgit2/src/delta-apply.o deps/libgit2/src/delta.o deps/libgit2/src/diff.o deps/libgit2/src/diff_driver.o deps/libgit2/src/diff_file.o deps/libgit2/src/diff_patch.o deps/libgit2/src/diff_print.o deps/libgit2/src/diff_stats.o deps/libgit2/src/diff_tform.o deps/libgit2/src/diff_xdiff.o deps/libgit2/src/errors.o deps/libgit2/src/fetch.o deps/libgit2/src/fetchhead.o deps/libgit2/src/filebuf.o deps/libgit2/src/fileops.o deps/libgit2/src/filter.o deps/libgit2/src/fnmatch.o deps/libgit2/src/global.o deps/libgit2/src/graph.o deps/libgit2/src/hash.o deps/libgit2/src/hashsig.o deps/libgit2/src/ident.o deps/libgit2/src/ignore.o deps/libgit2/src/index.o deps/libgit2/src/indexer.o deps/libgit2/src/iterator.o deps/libgit2/src/merge.o deps/libgit2/src/merge_file.o deps/libgit2/src/message.o deps/libgit2/src/mwindow.o deps/libgit2/src/netops.o deps/libgit2/src/notes.o deps/libgit2/src/object.o deps/libgit2/src/object_api.o deps/libgit2/src/odb.o deps/libgit2/src/odb_loose.o deps/libgit2/src/odb_mempack.o deps/libgit2/src/odb_pack.o deps/libgit2/src/oid.o deps/libgit2/src/pack-objects.o deps/libgit2/src/pack.o deps/libgit2/src/path.o deps/libgit2/src/pathspec.o deps/libgit2/src/pool.o deps/libgit2/src/posix.o deps/libgit2/src/pqueue.o deps/libgit2/src/push.o deps/libgit2/src/refdb.o deps/libgit2/src/refdb_fs.o deps/libgit2/src/reflog.o deps/libgit2/src/refs.o deps/libgit2/src/refspec.o deps/libgit2/src/remote.o deps/libgit2/src/repository.o deps/libgit2/src/reset.o deps/libgit2/src/revert.o deps/libgit2/src/revparse.o deps/libgit2/src/revwalk.o deps/libgit2/src/settings.o deps/libgit2/src/sha1_lookup.o deps/libgit2/src/signature.o deps/libgit2/src/sortedcache.o deps/libgit2/src/stash.o deps/libgit2/src/status.o deps/libgit2/src/strmap.o deps/libgit2/src/submodule.o deps/libgit2/src/sysdir.o deps/libgit2/src/tag.o deps/libgit2/src/thread-utils.o deps/libgit2/src/trace.o deps/libgit2/src/transport.o deps/libgit2/src/tree-cache.o deps/libgit2/src/tree.o deps/libgit2/src/tsort.o deps/libgit2/src/util.o deps/libgit2/src/vector.o deps/libgit2/src/zstream.o deps/libgit2/src/transports/cred.o deps/libgit2/src/transports/cred_helpers.o deps/libgit2/src/transports/git.o deps/libgit2/src/transports/http.o deps/libgit2/src/transports/local.o deps/libgit2/src/transports/smart.o deps/libgit2/src/transports/smart_pkt.o deps/libgit2/src/transports/smart_protocol.o deps/libgit2/src/transports/ssh.o deps/libgit2/src/transports/winhttp.o deps/libgit2/src/xdiff/xdiffi.o deps/libgit2/src/xdiff/xemit.o deps/libgit2/src/xdiff/xhistogram.o deps/libgit2/src/xdiff/xmerge.o deps/libgit2/src/xdiff/xpatience.o deps/libgit2/src/xdiff/xprepare.o deps/libgit2/src/xdiff/xutils.o deps/libgit2/src/hash/hash_generic.o deps/libgit2/src/unix/map.o deps/libgit2/src/unix/realpath.o  -o blib/arch/auto/Git/Raw/Raw.dll  \
  /usr/lib/perl5/5.14/x86_64-cygwin-threads/CORE/cygperl5_14.dll -lssl -lcrypto -lpthread   \

deps/libgit2/src/util.o:util.c:(.text+0xd11): undefined reference to `qsort_r'
deps/libgit2/src/util.o:util.c:(.text+0xd11): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `qsort_r'
/usr/bin/ld: deps/libgit2/src/util.o: bad reloc address 0x0 in section `.pdata'
```
