### PR TITLE
sched_yield() yields the process on FreeBSD and derivatives

### DIFF
--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -50,7 +50,11 @@ typedef git_atomic git_atomic_ssize;
 #if defined(GIT_WIN32)
 #define git_thread_yield() Sleep(0)
 #else
+#if defined(__FreeBSD__) || defined(__MidnightBSD__) || defined(__DragonFly__)
+#define git_thread_yield() pthread_yield()
+#else
 #define git_thread_yield() sched_yield()
+#endif
 #endif
 
 /* Pthreads Mutex */


### PR DESCRIPTION
Found this gotcha a few months ago in our codebase...

http://www.unix.com/man-page/freebsd/2/sched_yield/
