### PR TITLE
Make examples/status.c compile on Windows

### DIFF
--- a/examples/status.c
+++ b/examples/status.c
@@ -13,7 +13,11 @@
  */
 
 #include "common.h"
+#ifdef _WIN32
+#define sleep(a) Sleep(a * 1000)
+#else
 #include <unistd.h>
+#endif
 
 /**
  * This example demonstrates the use of the libgit2 status APIs,


### PR DESCRIPTION
On Linux, use `sleep(seconds)`
On Windows, use `Sleep(milliseconds)`
