### PR TITLE
Make ** pattern eat trailing slash

### DIFF
--- a/src/fnmatch.c
+++ b/src/fnmatch.c
@@ -62,6 +62,8 @@ p_fnmatchx(const char *pattern, const char *string, int flags, size_t recurs)
 							flags &= ~FNM_PATHNAME;
 							while (c == '*')
 								c = *++pattern;
+							if (c == '/')
+								c = *++pattern;
 						}
 
 						if (*string == '.' && (flags & FNM_PERIOD) &&

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -81,6 +81,24 @@ void test_attr_ignore__full_paths(void)
 	assert_is_ignored(false, "Folder/Middle/More/More/Contained/Not/Happy/Child");
 }
 
+void test_attr_ignore__more_starstar_cases(void)
+{
+	cl_must_pass(p_unlink("attr/.gitignore"));
+	cl_git_mkfile(
+		"attr/dir/.gitignore",
+		"sub/**/*.html\n");
+
+	assert_is_ignored(false, "aaa.html");
+	assert_is_ignored(false, "dir");
+	assert_is_ignored(false, "dir/sub");
+	assert_is_ignored(true,  "dir/sub/sub2/aaa.html");
+	assert_is_ignored(true,  "dir/sub/aaa.html");
+	assert_is_ignored(false, "dir/aaa.html");
+	assert_is_ignored(false, "sub");
+	assert_is_ignored(false, "sub/aaa.html");
+	assert_is_ignored(false, "sub/sub2/aaa.html");
+}
+
 void test_attr_ignore__leading_stars(void)
 {
 	cl_git_rewritefile(


### PR DESCRIPTION
This allows `foo/**/*.html` to match `foo/file.html`

Fixes #2316 
