### PR TITLE
Be more careful with user-supplied buffers

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -967,16 +967,19 @@ void git_config_iterator_free(git_config_iterator *iter)
 
 int git_config_find_global(git_buf *path)
 {
+	git_buf_sanitize(path);
 	return git_sysdir_find_global_file(path, GIT_CONFIG_FILENAME_GLOBAL);
 }
 
 int git_config_find_xdg(git_buf *path)
 {
+	git_buf_sanitize(path);
 	return git_sysdir_find_xdg_file(path, GIT_CONFIG_FILENAME_XDG);
 }
 
 int git_config_find_system(git_buf *path)
 {
+	git_buf_sanitize(path);
 	return git_sysdir_find_system_file(path, GIT_CONFIG_FILENAME_SYSTEM);
 }
 

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -597,9 +597,9 @@ int git_diff_print_callback__to_file_handle(
 }
 
 /* print a git_patch to a git_buf */
-int git_patch_to_buf(
-	git_buf *out,
-	git_patch *patch)
+int git_patch_to_buf(git_buf *out, git_patch *patch)
 {
+	assert(out && patch);
+	git_buf_sanitize(out);
 	return git_patch_print(patch, git_diff_print_callback__to_buf, out);
 }

--- a/src/filter.c
+++ b/src/filter.c
@@ -578,6 +578,9 @@ int git_filter_list_apply_to_data(
 	git_buf *dbuffer[2], local = GIT_BUF_INIT;
 	unsigned int si = 0;
 
+	git_buf_sanitize(tgt);
+	git_buf_sanitize(src);
+
 	if (!fl)
 		return filter_list_out_buffer_from_raw(tgt, src->ptr, src->size);
 
@@ -613,7 +616,7 @@ int git_filter_list_apply_to_data(
 			/* PASSTHROUGH means filter decided not to process the buffer */
 			error = 0;
 		} else if (!error) {
-			git_buf_shorten(dbuffer[di], 0); /* force NUL termination */
+			git_buf_sanitize(dbuffer[di]); /* force NUL termination */
 			si = di; /* swap buffers */
 		} else {
 			tgt->size = 0;

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1276,6 +1276,7 @@ int git_packbuilder_foreach(git_packbuilder *pb, int (*cb)(void *buf, size_t siz
 int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb)
 {
 	PREPARE_PACK;
+	git_buf_sanitize(buf);
 	return write_pack(pb, &write_pack_buf, buf);
 }
 

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -641,7 +641,9 @@ int git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *ur
 {
 	int error = 0;
 
-	assert(url);
+	assert(out && repo && url);
+
+	git_buf_sanitize(out);
 
 	if (git_path_is_relative(url)) {
 		if (!(error = get_url_base(out, repo)))

--- a/tests/object/blob/filter.c
+++ b/tests/object/blob/filter.c
@@ -112,7 +112,7 @@ void test_object_blob_filter__to_odb(void)
 	git_config *cfg;
 	int i;
 	git_blob *blob;
-	git_buf out = GIT_BUF_INIT;
+	git_buf out = GIT_BUF_INIT, zeroed;
 
 	cl_git_pass(git_repository_config(&cfg, g_repo));
 	cl_assert(cfg);
@@ -127,12 +127,19 @@ void test_object_blob_filter__to_odb(void)
 	for (i = 0; i < CRLF_NUM_TEST_OBJECTS; i++) {
 		cl_git_pass(git_blob_lookup(&blob, g_repo, &g_crlf_oids[i]));
 
+		/* try once with allocated blob */
 		cl_git_pass(git_filter_list_apply_to_blob(&out, fl, blob));
-
 		cl_assert_equal_sz(g_crlf_filtered[i].size, out.size);
-
 		cl_assert_equal_i(
 			0, memcmp(out.ptr, g_crlf_filtered[i].ptr, out.size));
+
+		/* try again with zeroed blob */
+		memset(&zeroed, 0, sizeof(zeroed));
+		cl_git_pass(git_filter_list_apply_to_blob(&zeroed, fl, blob));
+		cl_assert_equal_sz(g_crlf_filtered[i].size, zeroed.size);
+		cl_assert_equal_i(
+			0, memcmp(zeroed.ptr, g_crlf_filtered[i].ptr, zeroed.size));
+		git_buf_free(&zeroed);
 
 		git_blob_free(blob);
 	}


### PR DESCRIPTION
Proposed fix for #2333 
1. Add missing calls to `git_buf_sanitize` on public APIs
2. Fix places where `git_buf` APIs could incorrectly write NUL terminators into invalid buffers
3. Change behavior of `git_buf_sanitize` to NUL terminate a buffer if it can
4. Change `git_buf_shorten` to just use `git_buf_truncate` or `git_buf_clear`
5. Adds tests of filtering code with zeroed (i.e. unsanitized) buffer which was segfaulting
