### PR TITLE
Introduce GIT_MERGE_CONFIG_* for merge.ff settings

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -270,22 +270,23 @@ typedef enum {
 
 typedef enum {
 	/*
-	 * No configuration was found that suggests a behavior for merge.
+	 * No configuration was found that suggests a preferred behavior for
+	 * merge.
 	 */
-	GIT_MERGE_CONFIG_NONE = 0,
+	GIT_MERGE_PREFERENCE_NONE = 0,
 
 	/**
 	 * There is a `merge.ff=false` configuration setting, suggesting that
 	 * the user does not want to allow a fast-forward merge.
 	 */
-	GIT_MERGE_CONFIG_NO_FASTFORWARD = (1 << 0),
+	GIT_MERGE_PREFERENCE_NO_FASTFORWARD = (1 << 0),
 
 	/**
 	 * There is a `merge.ff=only` configuration setting, suggesting that
 	 * the user only wants fast-forward merges.
 	 */
-	GIT_MERGE_CONFIG_FASTFORWARD_ONLY = (1 << 1),
-} git_merge_config_t;
+	GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY = (1 << 1),
+} git_merge_preference_t;
 
 /**
  * Analyzes the given branch(es) and determines the opportunities for
@@ -299,7 +300,7 @@ typedef enum {
  */
 GIT_EXTERN(int) git_merge_analysis(
 	git_merge_analysis_t *analysis_out,
-	git_merge_config_t *config_out,
+	git_merge_preference_t *preference_out,
 	git_repository *repo,
 	const git_merge_head **their_heads,
 	size_t their_heads_len);

--- a/src/merge.c
+++ b/src/merge.c
@@ -2564,13 +2564,13 @@ done:
 	return error;
 }
 
-static int merge_config(git_merge_config_t *out, git_repository *repo)
+static int merge_preference(git_merge_preference_t *out, git_repository *repo)
 {
 	git_config *config;
 	const char *value;
 	int bool_value, error = 0;
 
-	*out = GIT_MERGE_CONFIG_NONE;
+	*out = GIT_MERGE_PREFERENCE_NONE;
 
 	if ((error = git_repository_config_snapshot(&config, repo)) < 0)
 		goto done;
@@ -2586,10 +2586,10 @@ static int merge_config(git_merge_config_t *out, git_repository *repo)
 
 	if (git_config_parse_bool(&bool_value, value) == 0) {
 		if (!bool_value)
-			*out |= GIT_MERGE_CONFIG_NO_FASTFORWARD;
+			*out |= GIT_MERGE_PREFERENCE_NO_FASTFORWARD;
 	} else {
 		if (strcasecmp(value, "only") == 0)
-			*out |= GIT_MERGE_CONFIG_FASTFORWARD_ONLY;
+			*out |= GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY;
 	}
 
 done:
@@ -2599,7 +2599,7 @@ done:
 
 int git_merge_analysis(
 	git_merge_analysis_t *analysis_out,
-	git_merge_config_t *config_out,
+	git_merge_preference_t *preference_out,
 	git_repository *repo,
 	const git_merge_head **their_heads,
 	size_t their_heads_len)
@@ -2607,7 +2607,7 @@ int git_merge_analysis(
 	git_merge_head *ancestor_head = NULL, *our_head = NULL;
 	int error = 0;
 
-	assert(analysis_out && config_out && repo && their_heads);
+	assert(analysis_out && preference_out && repo && their_heads);
 
 	if (their_heads_len != 1) {
 		giterr_set(GITERR_MERGE, "Can only merge a single branch");
@@ -2617,7 +2617,7 @@ int git_merge_analysis(
 
 	*analysis_out = GIT_MERGE_ANALYSIS_NONE;
 
-	if ((error = merge_config(config_out, repo)) < 0)
+	if ((error = merge_preference(preference_out, repo)) < 0)
 		goto done;
 
 	if (git_repository_head_unborn(repo)) {

--- a/tests/merge/workdir/analysis.c
+++ b/tests/merge/workdir/analysis.c
@@ -38,7 +38,7 @@ void test_merge_workdir_analysis__cleanup(void)
 
 static void analysis_from_branch(
 	git_merge_analysis_t *merge_analysis,
-	git_merge_config_t *merge_config,
+	git_merge_preference_t *merge_pref,
 	const char *branchname)
 {
 	git_buf refname = GIT_BUF_INIT;
@@ -50,7 +50,7 @@ static void analysis_from_branch(
 	cl_git_pass(git_reference_lookup(&their_ref, repo, git_buf_cstr(&refname)));
 	cl_git_pass(git_merge_head_from_ref(&their_head, repo, their_ref));
 
-	cl_git_pass(git_merge_analysis(merge_analysis, merge_config, repo, (const git_merge_head **)&their_head, 1));
+	cl_git_pass(git_merge_analysis(merge_analysis, merge_pref, repo, (const git_merge_head **)&their_head, 1));
 
 	git_buf_free(&refname);
 	git_merge_head_free(their_head);
@@ -60,9 +60,9 @@ static void analysis_from_branch(
 void test_merge_workdir_analysis__fastforward(void)
 {
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 
-	analysis_from_branch(&merge_analysis, &merge_config, FASTFORWARD_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, FASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_FASTFORWARD, (merge_analysis & GIT_MERGE_ANALYSIS_FASTFORWARD));
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_NORMAL, (merge_analysis & GIT_MERGE_ANALYSIS_NORMAL));
 }
@@ -70,40 +70,40 @@ void test_merge_workdir_analysis__fastforward(void)
 void test_merge_workdir_analysis__no_fastforward(void)
 {
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 
-	analysis_from_branch(&merge_analysis, &merge_config, NOFASTFORWARD_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, NOFASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_NORMAL, merge_analysis);
 }
 
 void test_merge_workdir_analysis__uptodate(void)
 {
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 
-	analysis_from_branch(&merge_analysis, &merge_config, UPTODATE_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, UPTODATE_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_UP_TO_DATE, merge_analysis);
 }
 
 void test_merge_workdir_analysis__uptodate_merging_prev_commit(void)
 {
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 
-	analysis_from_branch(&merge_analysis, &merge_config, PREVIOUS_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, PREVIOUS_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_UP_TO_DATE, merge_analysis);
 }
 
 void test_merge_workdir_analysis__unborn(void)
 {
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 	git_buf master = GIT_BUF_INIT;
 
 	git_buf_joinpath(&master, git_repository_path(repo), "refs/heads/master");
 	p_unlink(git_buf_cstr(&master));
 
-	analysis_from_branch(&merge_analysis, &merge_config, NOFASTFORWARD_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, NOFASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_FASTFORWARD, (merge_analysis & GIT_MERGE_ANALYSIS_FASTFORWARD));
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_UNBORN, (merge_analysis & GIT_MERGE_ANALYSIS_UNBORN));
 
@@ -114,27 +114,27 @@ void test_merge_workdir_analysis__fastforward_with_config_noff(void)
 {
 	git_config *config;
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 
 	git_repository_config(&config, repo);
 	git_config_set_string(config, "merge.ff", "false");
 
-	analysis_from_branch(&merge_analysis, &merge_config, FASTFORWARD_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, FASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_FASTFORWARD, (merge_analysis & GIT_MERGE_ANALYSIS_FASTFORWARD));
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_NORMAL, (merge_analysis & GIT_MERGE_ANALYSIS_NORMAL));
-	cl_assert_equal_i(GIT_MERGE_CONFIG_NO_FASTFORWARD, (merge_config & GIT_MERGE_CONFIG_NO_FASTFORWARD));
+	cl_assert_equal_i(GIT_MERGE_PREFERENCE_NO_FASTFORWARD, (merge_pref & GIT_MERGE_PREFERENCE_NO_FASTFORWARD));
 }
 
 void test_merge_workdir_analysis__no_fastforward_with_config_ffonly(void)
 {
 	git_config *config;
 	git_merge_analysis_t merge_analysis;
-	git_merge_config_t merge_config;
+	git_merge_preference_t merge_pref;
 
 	git_repository_config(&config, repo);
 	git_config_set_string(config, "merge.ff", "only");
 
-	analysis_from_branch(&merge_analysis, &merge_config, NOFASTFORWARD_BRANCH);
+	analysis_from_branch(&merge_analysis, &merge_pref, NOFASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_NORMAL, (merge_analysis & GIT_MERGE_ANALYSIS_NORMAL));
-	cl_assert_equal_i(GIT_MERGE_CONFIG_FASTFORWARD_ONLY, (merge_config & GIT_MERGE_CONFIG_FASTFORWARD_ONLY));
+	cl_assert_equal_i(GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY, (merge_pref & GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY));
 }


### PR DESCRIPTION
`git_merge_analysis` will now analyze the configuration as well, and return `GIT_MERGE_CONFIG_NO_FASTFORWARD` when `merge.ff=false` and `GIT_MERGE_CONFIG_FASTFORWARD_ONLY` when `merge.ff=true`
