### PR TITLE
[#2338] Don't use win32 mmap while still writing.

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -249,6 +249,16 @@ int git_futils_mv_withpath(const char *from, const char *to, const mode_t dirmod
 	return 0;
 }
 
+int git_futils_opt_mmap_ro(
+	git_map *out, git_file fd, git_off_t begin, size_t len, bool no_mmap)
+{
+#ifdef NO_MMAP_ALT
+	if (no_mmap)
+		return p_no_mmap(out, len, GIT_PROT_READ, GIT_MAP_SHARED, fd, begin);
+#endif
+	return git_futils_mmap_ro(out, fd, begin, len);
+}
+
 int git_futils_mmap_ro(git_map *out, git_file fd, git_off_t begin, size_t len)
 {
 	return p_mmap(out, len, GIT_PROT_READ, GIT_MAP_SHARED, fd, begin);

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -247,6 +247,13 @@ extern int git_futils_mmap_ro(
 	git_off_t begin,
 	size_t len);
 
+extern int git_futils_opt_mmap_ro(
+	git_map *out,
+	git_file fd,
+	git_off_t begin,
+	size_t len,
+	bool no_mmap);
+
 /**
  * Read-only map an entire file.
  *

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -514,7 +514,8 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_tran
 			return 0;
 
 		if (!idx->have_stream) {
-			error = git_packfile_unpack_header(&entry_size, &type, mwf, &w, &idx->off);
+			error = git_packfile_unpack_header_opt_mmap(
+				&entry_size, &type, mwf, &w, &idx->off, true);
 			if (error == GIT_EBUFS) {
 				idx->off = entry_start;
 				return 0;

--- a/src/map.h
+++ b/src/map.h
@@ -40,6 +40,19 @@ typedef struct { /* memory mapped buffer	*/
 	assert((prot & GIT_PROT_WRITE) || (prot & GIT_PROT_READ)); \
 	assert((flags & GIT_MAP_FIXED) == 0); } while (0)
 
+#ifdef NO_MMAP
+
+#define p_mmap p_no_mmap
+#define p_munmap p_no_munmap
+
+#elif defined(GIT_WIN32)
+
+#define NO_MMAP_ALT
+extern int p_no_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset);
+extern int p_no_munmap(git_map *map);
+
+#endif
+
 extern int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset);
 extern int p_munmap(git_map *map);
 

--- a/src/mwindow.h
+++ b/src/mwindow.h
@@ -38,6 +38,8 @@ typedef struct git_mwindow_ctl {
 int git_mwindow_contains(git_mwindow *win, git_off_t offset);
 void git_mwindow_free_all(git_mwindow_file *mwf);
 unsigned char *git_mwindow_open(git_mwindow_file *mwf, git_mwindow **cursor, git_off_t offset, size_t extra, unsigned int *left);
+unsigned char *git_mwindow_open_opt_mmap(git_mwindow_file *mwf,
+	git_mwindow **cursor, git_off_t offset, size_t extra, unsigned int *left, bool no_mmap);
 int git_mwindow_file_register(git_mwindow_file *mwf);
 void git_mwindow_file_deregister(git_mwindow_file *mwf);
 void git_mwindow_close(git_mwindow **w_cursor);

--- a/src/pack.h
+++ b/src/pack.h
@@ -120,6 +120,14 @@ int git_packfile_unpack_header(
 		git_mwindow **w_curs,
 		git_off_t *curpos);
 
+int git_packfile_unpack_header_opt_mmap(
+	size_t *size_p,
+	git_otype *type_p,
+	git_mwindow_file *mwf,
+	git_mwindow **w_curs,
+	git_off_t *curpos,
+	bool no_mmap);
+
 int git_packfile_resolve_header(
 		size_t *size_p,
 		git_otype *type_p,

--- a/src/posix.c
+++ b/src/posix.c
@@ -203,11 +203,11 @@ int p_write(git_file fd, const void *buf, size_t cnt)
 	return 0;
 }
 
-#ifdef NO_MMAP
-
 #include "map.h"
 
-int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
+#if defined(NO_MMAP) || defined(NO_MMAP_ALT)
+
+int p_no_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
 {
 	GIT_MMAP_VALIDATE(out, len, prot, flags);
 
@@ -231,7 +231,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	return 0;
 }
 
-int p_munmap(git_map *map)
+int p_no_munmap(git_map *map)
 {
 	assert(map != NULL);
 	free(map->data);

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -94,6 +94,11 @@ int p_munmap(git_map *map)
 
 	assert(map != NULL);
 
+#ifdef NO_MMAP_ALT
+	if (!map->fmh)
+		return p_no_munmap(map);
+#endif
+
 	if (map->data) {
 		if (!UnmapViewOfFile(map->data)) {
 			giterr_set(GITERR_OS, "Failed to munmap. Could not unmap view of file");


### PR DESCRIPTION
MSDN's page on CreateFileMapping cautions that file mappings are not
guaranteed to be coherent when used with regular WriteFile calls,
especially with remote filesystems.

In particular, attempting to work with a clone located on a network
share causes errors while cloning or fetching.

Resolve the problem by using the mmap emulation code already present
in the case of writes interspersed with reads; this code didn't really
benefit much from mmap since the entire stream was read (and verified
by decompressing).
