### PR TITLE
Add lax parsing for commit and tag objects

### DIFF
--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -33,17 +33,18 @@ GIT_BEGIN_DECL
  * The special value 'GIT_OBJ_ANY' may be passed to let
  * the method guess the object's type.
  *
- * @param object pointer to the looked-up object
+ * @param out Pointer in which to store the looked-up object (must be
+ *            freed by the caller when done)
  * @param repo the repository to look up the object
  * @param id the unique identifier for the object
  * @param type the type of the object
  * @return 0 or an error code
  */
 GIT_EXTERN(int) git_object_lookup(
-		git_object **object,
-		git_repository *repo,
-		const git_oid *id,
-		git_otype type);
+	git_object **out,
+	git_repository *repo,
+	const git_oid *id,
+	git_otype type);
 
 /**
  * Lookup a reference to one of the objects in a repository,
@@ -65,7 +66,8 @@ GIT_EXTERN(int) git_object_lookup(
  * The special value 'GIT_OBJ_ANY' may be passed to let
  * the method guess the object's type.
  *
- * @param object_out pointer where to store the looked-up object
+ * @param out Pointer in which to store the looked-up object (must be
+ *            freed by the caller when done)
  * @param repo the repository to look up the object
  * @param id a short identifier for the object
  * @param len the length of the short identifier
@@ -73,28 +75,56 @@ GIT_EXTERN(int) git_object_lookup(
  * @return 0 or an error code
  */
 GIT_EXTERN(int) git_object_lookup_prefix(
-		git_object **object_out,
-		git_repository *repo,
-		const git_oid *id,
-		size_t len,
-		git_otype type);
+	git_object **out,
+	git_repository *repo,
+	const git_oid *id,
+	size_t len,
+	git_otype type);
 
 
 /**
  * Lookup an object that represents a tree entry.
  *
- * @param out buffer that receives a pointer to the object (which must be freed
- *            by the caller)
+ * @param out Pointer in which to store the looked-up object (must be
+ *            freed by the caller when done)
  * @param treeish root object that can be peeled to a tree
  * @param path relative path from the root object to the desired object
  * @param type type of object desired
  * @return 0 on success, or an error code
  */
 GIT_EXTERN(int) git_object_lookup_bypath(
-		git_object **out,
-		const git_object *treeish,
-		const char *path,
-		git_otype type);
+	git_object **out,
+	const git_object *treeish,
+	const char *path,
+	git_otype type);
+
+/**
+ * Look up object by partial or full OID and type, trying to return the
+ * object even if a parse error is encountered.
+ *
+ * Unlike other APIs to look up objects, this tries to return a
+ * `git_object` even if the data is not well-formatted, so long as the
+ * basic object type can still be determined from the raw data.
+ *
+ * If the object does not parse correctly, this will still return an error
+ * code, but it will also set the `out` parameter to an object with as
+ * much data filled in as possible.  The resulting object may return NULL
+ * for properties that should not be NULL or other strange things.
+ *
+ * @param out Pointer in which to store the looked-up object (must be
+ *            freed by the caller when done)
+ * @param repo the repository to look up the object
+ * @param id a short identifier for the object
+ * @param len the length of the short identifier
+ * @param type the type of the object
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_object_lookup_lax(
+	git_object **out,
+	git_repository *repo,
+	const git_oid *id,
+	size_t len,
+	git_otype type);
 
 /**
  * Get the id (SHA1) of a repository object
@@ -169,12 +199,13 @@ GIT_EXTERN(void) git_object_free(git_object *object);
 GIT_EXTERN(const char *) git_object_type2string(git_otype type);
 
 /**
- * Convert a string object type representation to it's git_otype.
+ * Convert a string object type representation to its git_otype.
  *
- * @param str the string to convert.
- * @return the corresponding git_otype.
+ * @param str The string to convert.
+ * @param len Length of str (or 0 for unspecified but NUL-terminated input)
+ * @return The corresponding `git_otype` of `GIT_OBJ_BAD` if no match.
  */
-GIT_EXTERN(git_otype) git_object_string2type(const char *str);
+GIT_EXTERN(git_otype) git_object_string2type(const char *str, size_t len);
 
 /**
  * Determine if the given git_otype is a valid loose object type.

--- a/src/commit.h
+++ b/src/commit.h
@@ -17,7 +17,7 @@
 struct git_commit {
 	git_object object;
 
-	git_array_t(git_oid) parent_ids;
+	git_oid_array parent_ids;
 	git_oid tree_id;
 
 	git_signature *author;

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -240,7 +240,7 @@ static int diff_file_content_load_blob(git_diff_file_content *fc)
 
 	if (odb_obj != NULL) {
 		error = git_object__from_odb_object(
-			(git_object **)&fc->blob, fc->repo, odb_obj, GIT_OBJ_BLOB);
+			(git_object **)&fc->blob, fc->repo, odb_obj, GIT_OBJ_BLOB, true);
 		git_odb_object_free(odb_obj);
 	} else {
 		error = git_blob_lookup(

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -508,7 +508,7 @@ static int similarity_sig(
 		if (info->odb_obj != NULL)
 			error = git_object__from_odb_object(
 				(git_object **)&info->blob, info->repo,
-				info->odb_obj, GIT_OBJ_BLOB);
+				info->odb_obj, GIT_OBJ_BLOB, true);
 		else
 			error = git_blob_lookup(&info->blob, info->repo, &file->id);
 

--- a/src/object.h
+++ b/src/object.h
@@ -7,6 +7,9 @@
 #ifndef INCLUDE_object_h__
 #define INCLUDE_object_h__
 
+#include "common.h"
+#include "array.h"
+
 /** Base git object for inheritance */
 struct git_object {
 	git_cached_obj cached;
@@ -17,15 +20,49 @@ struct git_object {
 void git_object__free(void *object);
 
 int git_object__from_odb_object(
-	git_object **object_out,
+	git_object **out,
 	git_repository *repo,
 	git_odb_object *odb_obj,
-	git_otype type);
+	git_otype type,
+	bool lax);
 
 int git_object__resolve_to_type(git_object **obj, git_otype type);
 
-int git_oid__parse(git_oid *oid, const char **buffer_out, const char *buffer_end, const char *header);
-
 void git_oid__writebuf(git_buf *buf, const char *header, const git_oid *oid);
 
+enum {
+	GIT_PARSE_BODY_OPTIONAL = -2,
+	GIT_PARSE_BODY = -1,
+	GIT_PARSE_MODE_OPTIONAL = 0,
+	GIT_PARSE_OID = 1,
+	GIT_PARSE_OID_ARRAY = 2,
+	GIT_PARSE_OTYPE = 3,
+	GIT_PARSE_SIGNATURE = 4,
+	GIT_PARSE_TO_EOL = 5,
+};
+
+typedef git_array_t(git_oid) git_oid_array;
+
+typedef struct {
+	const char *tag;
+	size_t taglen;
+	int type;
+	union {
+		git_oid *id;
+		git_otype *otype;
+		char **text;
+		git_signature **sig;
+		git_oid_array *ids;
+		const char **body;
+	} value;
+} git_object_parse_t;
+
+/* parse tagged lines followed by blank line and message body */
+int git_object__parse_lines(
+	git_otype type,
+	git_object_parse_t *parse,
+	const char *buf,
+	const char *buf_end);
+
 #endif
+

--- a/src/odb.c
+++ b/src/odb.c
@@ -778,7 +778,7 @@ int git_odb_read(git_odb_object **out, git_odb *db, const git_oid *id)
 	}
 
 	if (error && error != GIT_PASSTHROUGH) {
-		if (!reads)
+		if (!reads || error == GIT_ENOTFOUND)
 			return git_odb__error_notfound("no match for id", id);
 		return error;
 	}

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -129,7 +129,7 @@ static size_t get_object_header(obj_hdr *hdr, unsigned char *data)
 	typename[used] = 0;
 	if (used == 0)
 		return 0;
-	hdr->type = git_object_string2type(typename);
+	hdr->type = git_object_string2type(typename, used);
 	used++; /* consume the space */
 
 	/*

--- a/src/oid.c
+++ b/src/oid.c
@@ -122,32 +122,6 @@ char *git_oid_tostr(char *out, size_t n, const git_oid *oid)
 	return out;
 }
 
-int git_oid__parse(
-	git_oid *oid, const char **buffer_out,
-	const char *buffer_end, const char *header)
-{
-	const size_t sha_len = GIT_OID_HEXSZ;
-	const size_t header_len = strlen(header);
-
-	const char *buffer = *buffer_out;
-
-	if (buffer + (header_len + sha_len + 1) > buffer_end)
-		return -1;
-
-	if (memcmp(buffer, header, header_len) != 0)
-		return -1;
-
-	if (buffer[header_len + sha_len] != '\n')
-		return -1;
-
-	if (git_oid_fromstr(oid, buffer + header_len) < 0)
-		return -1;
-
-	*buffer_out = buffer + (header_len + sha_len + 1);
-
-	return 0;
-}
-
 void git_oid__writebuf(git_buf *buf, const char *header, const git_oid *oid)
 {
 	char hex_oid[GIT_OID_HEXSZ];

--- a/src/signature.h
+++ b/src/signature.h
@@ -12,6 +12,7 @@
 #include "repository.h"
 #include <time.h>
 
+void git_signature__clear(git_signature *sig);
 int git_signature__parse(git_signature *sig, const char **buffer_out, const char *buffer_end, const char *header, char ender);
 void git_signature__writebuf(git_buf *buf, const char *header, const git_signature *sig);
 

--- a/src/util.h
+++ b/src/util.h
@@ -322,6 +322,12 @@ GIT_INLINE(bool) git__iswildcard(int c)
 	return (c == '*' || c == '?' || c == '[');
 }
 
+GIT_INLINE(bool) git__iseol(const char *ptr, size_t len)
+{
+	char c = *ptr;
+	return (c == '\n' || (c == '\r' && len > 1 && *(ptr + 1) == '\n'));
+}
+
 /*
  * Parse a string value as a boolean, just like Core Git does.
  *

--- a/tests/object/raw/type2string.c
+++ b/tests/object/raw/type2string.c
@@ -23,17 +23,17 @@ void test_object_raw_type2string__convert_type_to_string(void)
 
 void test_object_raw_type2string__convert_string_to_type(void)
 {
-	cl_assert(git_object_string2type(NULL) == GIT_OBJ_BAD);
-	cl_assert(git_object_string2type("") == GIT_OBJ_BAD);
-	cl_assert(git_object_string2type("commit") == GIT_OBJ_COMMIT);
-	cl_assert(git_object_string2type("tree") == GIT_OBJ_TREE);
-	cl_assert(git_object_string2type("blob") == GIT_OBJ_BLOB);
-	cl_assert(git_object_string2type("tag") == GIT_OBJ_TAG);
-	cl_assert(git_object_string2type("OFS_DELTA") == GIT_OBJ_OFS_DELTA);
-	cl_assert(git_object_string2type("REF_DELTA") == GIT_OBJ_REF_DELTA);
+	cl_assert(git_object_string2type(NULL, 0) == GIT_OBJ_BAD);
+	cl_assert(git_object_string2type("", 0) == GIT_OBJ_BAD);
+	cl_assert(git_object_string2type("commit", 0) == GIT_OBJ_COMMIT);
+	cl_assert(git_object_string2type("tree", 0) == GIT_OBJ_TREE);
+	cl_assert(git_object_string2type("blob", 0) == GIT_OBJ_BLOB);
+	cl_assert(git_object_string2type("tag", 0) == GIT_OBJ_TAG);
+	cl_assert(git_object_string2type("OFS_DELTA", 0) == GIT_OBJ_OFS_DELTA);
+	cl_assert(git_object_string2type("REF_DELTA", 0) == GIT_OBJ_REF_DELTA);
 
-	cl_assert(git_object_string2type("CoMmIt") == GIT_OBJ_BAD);
-	cl_assert(git_object_string2type("hohoho") == GIT_OBJ_BAD);
+	cl_assert(git_object_string2type("CoMmIt", 0) == GIT_OBJ_BAD);
+	cl_assert(git_object_string2type("hohoho", 0) == GIT_OBJ_BAD);
 }
 
 void test_object_raw_type2string__check_type_is_loose(void)

--- a/tests/odb/loose.c
+++ b/tests/odb/loose.c
@@ -24,7 +24,7 @@ static void write_object_files(object_data *d)
 
 static void cmp_objects(git_rawobj *o, object_data *d)
 {
-	cl_assert(o->type == git_object_string2type(d->type));
+	cl_assert(o->type == git_object_string2type(d->type, 0));
 	cl_assert(o->len == d->dlen);
 
 	if (o->len > 0)


### PR DESCRIPTION
This is a proposal for dealing with the fact that Git (and other Git implementations) sometimes create objects in the ODB that fail to pass libgit2's parsing rules. This is designed to give a way to get the `git_object` as best as possible, even if it appears to be non-compliant.

This changes the behavior of object parsing for commits and tags so that even when bad data is found inside the object, we will continue to try to parse as much of the object as we can. The existing functions (`git_object_lookup` for example) still delete the partially parsed object before returning an error, but this also adds a new function `git_object_lookup_lax` that will still return the error code, but will also return the object with the partial data (if we got far enough along in the parsing process to even create the base object).

I'm not sure if this is the right solution, and certainly the implementation is way more intrusive than it has to be, but I've been playing around with this code for a few days (mostly off and on) and I thought I should get some feedback before spending more time on it.
