### PR TITLE
Add R bindings to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Here are the bindings to libgit2 that are currently available:
     * GitPowerShell <https://github.com/ethomson/gitpowershell>
 * Python
     * pygit2 <https://github.com/libgit2/pygit2>
+* R
+    * git2r <https://github.com/ropensci/git2r>
 * Ruby
     * Rugged <https://github.com/libgit2/rugged>
 * Vala


### PR DESCRIPTION
The `git2r` package gives access to Git repositories from R using libgit2.
