### PR TITLE
Fix tests sensitive to the global configuration.

### DIFF
--- a/tests/diff/iterator.c
+++ b/tests/diff/iterator.c
@@ -10,11 +10,13 @@ void test_diff_iterator__initialize(void)
 	 * cleanup function so that assertion failures don't result in a
 	 * missed cleanup.
 	 */
+	cl_fake_home();
 }
 
 void test_diff_iterator__cleanup(void)
 {
 	cl_git_sandbox_cleanup();
+	cl_fake_home_cleanup(NULL);
 }
 
 

--- a/tests/index/addall.c
+++ b/tests/index/addall.c
@@ -8,6 +8,7 @@ static git_repository *g_repo = NULL;
 
 void test_index_addall__initialize(void)
 {
+	cl_fake_home();
 }
 
 void test_index_addall__cleanup(void)
@@ -15,6 +16,7 @@ void test_index_addall__cleanup(void)
 	git_repository_free(g_repo);
 	g_repo = NULL;
 
+	cl_fake_home_cleanup(NULL);
 	cl_fixture_cleanup(TEST_DIR);
 }
 

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -9,11 +9,13 @@ static git_repository *g_repo = NULL;
 
 void test_status_ignore__initialize(void)
 {
+	cl_fake_home();
 }
 
 void test_status_ignore__cleanup(void)
 {
 	cl_git_sandbox_cleanup();
+	cl_fake_home_cleanup(NULL);
 }
 
 static void assert_ignored_(


### PR DESCRIPTION
These tests were inadvertently failing due to non-trivial ~/.gitconfig
settings which are not controlled by the test suite. Use a fake home
so that the walled garden is preserved.
