### PR TITLE
Win32: Supply _O_NOINHERIT when calling _wopen

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -19,6 +19,15 @@
 # define FILE_NAME_NORMALIZED 0
 #endif
 
+/* Options which we always provide to _wopen.
+ *
+ * _O_BINARY - Raw access; no translation of CR or LF characters
+ * _O_NOINHERIT - Do not mark the created handle as inheritable by child processes.
+ *    The Windows default is 'not inheritable', but the CRT's default (following
+ *    POSIX convention) is 'inheritable'. We have no desire for our handles to be
+ *    inheritable on Windows, so specify the flag to get default behavior back. */
+#define STANDARD_OPEN_FLAGS (_O_BINARY | _O_NOINHERIT)
+
 /* GetFinalPathNameByHandleW signature */
 typedef DWORD(WINAPI *PFGetFinalPathNameByHandleW)(HANDLE, LPWSTR, DWORD, DWORD);
 
@@ -317,7 +326,7 @@ int p_open(const char *path, int flags, ...)
 		va_end(arg_list);
 	}
 
-	return _wopen(buf, flags | _O_BINARY, mode);
+	return _wopen(buf, flags | STANDARD_OPEN_FLAGS, mode);
 }
 
 int p_creat(const char *path, mode_t mode)
@@ -327,7 +336,7 @@ int p_creat(const char *path, mode_t mode)
 	if (utf8_to_16_with_errno(buf, path) < 0)
 		return -1;
 
-	return _wopen(buf, _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY, mode);
+	return _wopen(buf, _O_WRONLY | _O_CREAT | _O_TRUNC | STANDARD_OPEN_FLAGS, mode);
 }
 
 int p_getcwd(char *buffer_out, size_t size)


### PR DESCRIPTION
We have a build system which can build Git repositories. The workflow is:
1. Clone the repository.
2. Build the repository, by spawning a child process to do the build -- MSBuild.exe.

We found that if you ask the build system to build two Git repositories simultaneously, it doesn't work. Here is why -- the clone kicks off for both builds simultaneously. Inevitably one of the clones finishes before the other one. The guy who finished first calls MSBuild.exe to start step 2 of the workflow above. This happens while the other clone (the slower clone) is still in progress.

We found that the open handle to the pack file for the slower clone is actually duplicated into the MSBuild.exe child process. (On Windows, a 'handle' is the official word for 'file descriptor'). This is undesirable, and causes the slower clone to fail, because now it can't do things it wants to do to the pack file, because this other process has it open also. How did this happen?

On Windows, handles are normally _not_ inheritable. You have to ask for this behavior by jumping through a couple of hoops. But it turns out that the C runtime library (which provides `_wopen`) defaults to jumping through these hoops. Presumably this is to be more like POSIX. The fix is to specify the `_O_NOINHERIT` flag to `_wopen` so that this doesn't happen.

I can't think of any reason why we would want for our handles to be inheritable on Windows.
