### PR TITLE
message: don't assume the comment char

### DIFF
--- a/include/git2/message.h
+++ b/include/git2/message.h
@@ -29,12 +29,14 @@ GIT_BEGIN_DECL
  *
  * @param message The message to be prettified.
  *
- * @param strip_comments Non-zero to remove lines starting with "#", 0 to
- *     leave them in.
+ * @param strip_comments Non-zero to remove comment lines, 0 to leave them in.
+ *
+ * @param comment_char Comment character. Lines starting with this character
+ * are considered to be comments and removed if `strip_comments` is non-zero.
  *
  * @return 0 or an error code.
  */
-GIT_EXTERN(int) git_message_prettify(git_buf *out, const char *message, int strip_comments);
+GIT_EXTERN(int) git_message_prettify(git_buf *out, const char *message, int strip_comments, char comment_char);
 
 /** @} */
 GIT_END_DECL

--- a/src/message.c
+++ b/src/message.c
@@ -21,7 +21,7 @@ static size_t line_length_without_trailing_spaces(const char *line, size_t len)
 
 /* Greatly inspired from git.git "stripspace" */
 /* see https://github.com/git/git/blob/497215d8811ac7b8955693ceaad0899ecd894ed2/builtin/stripspace.c#L4-67 */
-int git_message_prettify(git_buf *message_out, const char *message, int strip_comments)
+int git_message_prettify(git_buf *message_out, const char *message, int strip_comments, char comment_char)
 {
 	const size_t message_len = strlen(message);
 
@@ -40,7 +40,7 @@ int git_message_prettify(git_buf *message_out, const char *message, int strip_co
 			line_length = message_len - i;
 		}
 
-		if (strip_comments && line_length && message[i] == '#')
+		if (strip_comments && line_length && message[i] == comment_char)
 			continue;
 
 		rtrimmed_line_length = line_length_without_trailing_spaces(message + i, line_length);

--- a/tests/object/commit/commitstagedfile.c
+++ b/tests/object/commit/commitstagedfile.c
@@ -112,7 +112,7 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	cl_git_pass(git_tree_lookup(&tree, repo, &tree_oid));
 
 	memset(&buffer, 0, sizeof(git_buf));
-	cl_git_pass(git_message_prettify(&buffer, "Initial commit", 0));
+	cl_git_pass(git_message_prettify(&buffer, "Initial commit", 0, '#'));
 
 	cl_git_pass(git_commit_create_v(
 		&commit_oid,

--- a/tests/object/message.c
+++ b/tests/object/message.c
@@ -6,7 +6,7 @@ static void assert_message_prettifying(char *expected_output, char *input, int s
 {
 	git_buf prettified_message = GIT_BUF_INIT;
 
-	git_message_prettify(&prettified_message, input, strip_comments);
+	git_message_prettify(&prettified_message, input, strip_comments, '#');
 	cl_assert_equal_s(expected_output, git_buf_cstr(&prettified_message));
 
 	git_buf_free(&prettified_message);
@@ -175,25 +175,25 @@ void test_object_message__message_prettify(void)
 	git_buf buffer;
 
 	memset(&buffer, 0, sizeof(buffer));
-	cl_git_pass(git_message_prettify(&buffer, "", 0));
+	cl_git_pass(git_message_prettify(&buffer, "", 0, '#'));
 	cl_assert_equal_s(buffer.ptr, "");
 	git_buf_free(&buffer);
-	cl_git_pass(git_message_prettify(&buffer, "", 1));
+	cl_git_pass(git_message_prettify(&buffer, "", 1, '#'));
 	cl_assert_equal_s(buffer.ptr, "");
 	git_buf_free(&buffer);
 
-	cl_git_pass(git_message_prettify(&buffer, "Short", 0));
+	cl_git_pass(git_message_prettify(&buffer, "Short", 0, '#'));
 	cl_assert_equal_s("Short\n", buffer.ptr);
 	git_buf_free(&buffer);
-	cl_git_pass(git_message_prettify(&buffer, "Short", 1));
+	cl_git_pass(git_message_prettify(&buffer, "Short", 1, '#'));
 	cl_assert_equal_s("Short\n", buffer.ptr);
 	git_buf_free(&buffer);
 
-	cl_git_pass(git_message_prettify(&buffer, "This is longer\nAnd multiline\n# with some comments still in\n", 0));
+	cl_git_pass(git_message_prettify(&buffer, "This is longer\nAnd multiline\n# with some comments still in\n", 0, '#'));
 	cl_assert_equal_s(buffer.ptr, "This is longer\nAnd multiline\n# with some comments still in\n");
 	git_buf_free(&buffer);
 
-	cl_git_pass(git_message_prettify(&buffer, "This is longer\nAnd multiline\n# with some comments still in\n", 1));
+	cl_git_pass(git_message_prettify(&buffer, "This is longer\nAnd multiline\n# with some comments still in\n", 1, '#'));
 	cl_assert_equal_s(buffer.ptr, "This is longer\nAnd multiline\n");
 	git_buf_free(&buffer);
 }


### PR DESCRIPTION
The comment char is configurable and we need to provide a way for the
user to specify which comment char they chose for their message.

---

We need to do this at some point. This would be particularly relevant for enterprisey places where they feel the strange need to prefix everything with an issue number and think about what they're doing next.
