### PR TITLE
Fix compiler warning (git_off_t cast to size_t).

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -427,15 +427,19 @@ static void hash_partially(git_indexer *idx, const uint8_t *data, size_t size)
 static int write_at(git_indexer *idx, const void *data, git_off_t offset, size_t size)
 {
 	git_file fd = idx->pack->mwf.fd;
-	long page_size = git__page_size();
-	git_off_t page_start, page_offset;
+	size_t page_size;
+	size_t page_offset;
+	git_off_t page_start;
 	unsigned char *map_data;
 	git_map map;
 	int error;
 
+	if ((error = git__page_size(&page_size)) < 0)
+		return error;
+
 	/* the offset needs to be at the beginning of the a page boundary */
-	page_start = (offset / page_size) * page_size;
-	page_offset = offset - page_start;
+	page_offset = offset % page_size;
+	page_start = offset - page_offset;
 
 	if ((error = p_mmap(&map, page_offset + size, GIT_PROT_WRITE, GIT_MAP_SHARED, fd, page_start)) < 0)
 		return error;

--- a/src/map.h
+++ b/src/map.h
@@ -42,6 +42,5 @@ typedef struct { /* memory mapped buffer	*/
 
 extern int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset);
 extern int p_munmap(git_map *map);
-extern long git__page_size(void);
 
 #endif /* INCLUDE_map_h__ */

--- a/src/pool.c
+++ b/src/pool.c
@@ -1,4 +1,5 @@
 #include "pool.h"
+#include "posix.h"
 #ifndef GIT_WIN32
 #include <unistd.h>
 #endif
@@ -305,17 +306,10 @@ uint32_t git_pool__system_page_size(void)
 	static uint32_t size = 0;
 
 	if (!size) {
-#ifdef GIT_WIN32
-		SYSTEM_INFO info;
-		GetSystemInfo(&info);
-		size = (uint32_t)info.dwPageSize;
-#elif defined(__amigaos4__)
-		size = (uint32_t)4096; /* 4K as there is no global value we can query */
-#else
-		size = (uint32_t)sysconf(_SC_PAGE_SIZE);
-#endif
-
-		size -= 2 * sizeof(void *); /* allow space for malloc overhead */
+		size_t page_size;
+		if (git__page_size(&page_size) < 0)
+			page_size = 4096;
+		size = page_size - 2 * sizeof(void *); /* allow space for malloc overhead */
 	}
 
 	return size;

--- a/src/pool.h
+++ b/src/pool.h
@@ -143,8 +143,6 @@ extern uint32_t git_pool__full_pages(git_pool *pool);
 
 extern bool git_pool__ptr_in_pool(git_pool *pool, void *ptr);
 
-extern uint32_t git_pool__system_page_size(void);
-
 extern uint32_t git_pool__suggest_items_per_page(uint32_t item_size);
 
 #endif

--- a/src/posix.c
+++ b/src/posix.c
@@ -207,10 +207,11 @@ int p_write(git_file fd, const void *buf, size_t cnt)
 
 #include "map.h"
 
-long git__page_size(void)
+int git__page_size(size_t *page_size)
 {
 	/* dummy; here we don't need any alignment anyway */
-	return 4096;
+	*page_size = 4096;
+	return 0;
 }
 
 

--- a/src/posix.h
+++ b/src/posix.h
@@ -66,6 +66,8 @@ extern int p_creat(const char *path, mode_t mode);
 extern int p_getcwd(char *buffer_out, size_t size);
 extern int p_rename(const char *from, const char *to);
 
+extern int git__page_size(size_t *page_size);
+
 #ifndef GIT_WIN32
 
 #define p_stat(p,b) stat(p, b)

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -13,9 +13,15 @@
 #include <unistd.h>
 #include <errno.h>
 
-long git__page_size(void)
+int git__page_size(size_t *page_size)
 {
-	return sysconf(_SC_PAGE_SIZE);
+	long sc_page_size = sysconf(_SC_PAGE_SIZE);
+	if (sc_page_size < 0) {
+		giterr_set_str(GITERR_OS, "Can't determine system page size");
+		return -1;
+	}
+	*page_size = (size_t) sc_page_size;
+	return 0;
 }
 
 int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -23,9 +23,10 @@ static DWORD get_page_size(void)
 	return page_size;
 }
 
-long git__page_size(void)
+int git__page_size(size_t *page_size)
 {
-	return (long)get_page_size();
+	*page_size = get_page_size();
+	return 0;
 }
 
 int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)


### PR DESCRIPTION
Use size_t for page size, instead of long. Check result of sysconf.
Use size_t for page offset so no cast to size_t (second arg to p_mmap).
Use mod instead div/mult pair, so no cast to size_t is necessary.

@carlosmn: another minor compiler fix for #2352.
