### PR TITLE
Fix mkstemp open flags.

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -578,7 +578,7 @@ int p_mkstemp(char *tmp_path)
 		return -1;
 #endif
 
-	return p_open(tmp_path, O_RDWR | O_CREAT | O_EXCL, 0744); //-V536
+	return p_open(tmp_path, O_RDWR | O_CREAT | O_EXCL, 0600); //-V536
 }
 
 int p_access(const char* path, mode_t mode)


### PR DESCRIPTION
@carlosmn: make sure that the temporary file is truncated.
