### PR TITLE
index: check for valid filemodes on add

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1104,12 +1104,26 @@ int git_index_remove_bypath(git_index *index, const char *path)
 	return 0;
 }
 
+static bool valid_filemode(const int filemode)
+{
+	return (filemode == GIT_FILEMODE_BLOB ||
+		filemode == GIT_FILEMODE_BLOB_EXECUTABLE ||
+		filemode == GIT_FILEMODE_LINK ||
+		filemode == GIT_FILEMODE_COMMIT);
+}
+
+
 int git_index_add(git_index *index, const git_index_entry *source_entry)
 {
 	git_index_entry *entry = NULL;
 	int ret;
 
 	assert(index && source_entry && source_entry->path);
+
+	if (!valid_filemode(source_entry->mode)) {
+		giterr_set(GITERR_INDEX, "invalid filemode");
+		return -1;
+	}
 
 	if ((ret = index_entry_dup(&entry, source_entry)) < 0 ||
 		(ret = index_insert(index, &entry, 1)) < 0)

--- a/tests/index/filemodes.c
+++ b/tests/index/filemodes.c
@@ -152,3 +152,18 @@ void test_index_filemodes__trusted(void)
 
 	git_index_free(index);
 }
+
+void test_index_filemodes__invalid(void)
+{
+	git_index *index;
+	git_index_entry entry;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	entry.path = "foo";
+	entry.mode = GIT_OBJ_BLOB;
+	cl_git_fail(git_index_add(index, &entry));
+
+	entry.mode = GIT_FILEMODE_BLOB;
+	cl_git_pass(git_index_add(index, &entry));
+}


### PR DESCRIPTION
I noticed that we don't check for this, which can lead to invalid filemodes being written out to disk.
