### PR TITLE
Ignore core.safecrlf=warn until we have a warn infrastructure

### DIFF
--- a/src/config_cache.c
+++ b/src/config_cache.c
@@ -51,6 +51,12 @@ static git_cvar_map _cvar_map_autocrlf[] = {
 	{GIT_CVAR_STRING, "input", GIT_AUTO_CRLF_INPUT}
 };
 
+static git_cvar_map _cvar_map_safecrlf[] = {
+	{GIT_CVAR_FALSE, NULL, GIT_SAFE_CRLF_FALSE},
+	{GIT_CVAR_TRUE, NULL, GIT_SAFE_CRLF_FAIL},
+	{GIT_CVAR_STRING, "warn", GIT_SAFE_CRLF_WARN}
+};
+
 /*
  * Generic map for integer values
  */
@@ -68,7 +74,7 @@ static struct map_data _cvar_maps[] = {
 	{"core.trustctime", NULL, 0, GIT_TRUSTCTIME_DEFAULT },
 	{"core.abbrev", _cvar_map_int, 1, GIT_ABBREV_DEFAULT },
 	{"core.precomposeunicode", NULL, 0, GIT_PRECOMPOSE_DEFAULT },
-	{"core.safecrlf", NULL, 0, GIT_SAFE_CRLF_DEFAULT},
+	{"core.safecrlf", _cvar_map_safecrlf, ARRAY_SIZE(_cvar_map_safecrlf), GIT_SAFE_CRLF_DEFAULT},
 	{"core.logallrefupdates", NULL, 0, GIT_LOGALLREFUPDATES_DEFAULT },
 };
 

--- a/tests/filter/crlf.c
+++ b/tests/filter/crlf.c
@@ -196,3 +196,44 @@ void test_filter_crlf__no_safecrlf(void)
 	git_buf_free(&out);
 }
 
+void test_filter_crlf__safecrlf_warn(void)
+{
+	git_filter_list *fl;
+	git_filter *crlf;
+	git_buf in = {0}, out = GIT_BUF_INIT;
+
+	cl_repo_set_string(g_repo, "core.safecrlf", "warn");
+
+	cl_git_pass(git_filter_list_new(
+		&fl, g_repo, GIT_FILTER_TO_ODB, 0));
+
+	crlf = git_filter_lookup(GIT_FILTER_CRLF);
+	cl_assert(crlf != NULL);
+
+	cl_git_pass(git_filter_list_push(fl, crlf, NULL));
+
+	/* Normalized \r\n succeeds with safecrlf=warn */
+	in.ptr = "Normal\r\nCRLF\r\nline-endings.\r\n";
+	in.size = strlen(in.ptr);
+
+	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	cl_assert_equal_s("Normal\nCRLF\nline-endings.\n", out.ptr);
+
+	/* Mix of line endings succeeds with safecrlf=warn */
+	in.ptr = "Mixed\nup\r\nLF\nand\r\nCRLF\nline-endings.\r\n";
+	in.size = strlen(in.ptr);
+
+	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	/* TODO: check for warning */
+	cl_assert_equal_s("Mixed\nup\nLF\nand\nCRLF\nline-endings.\n", out.ptr);
+
+	/* Normalized \n is reversible, so does not fail with safecrlf=warn */
+	in.ptr = "Normal\nLF\nonly\nline-endings.\n";
+	in.size = strlen(in.ptr);
+
+	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	cl_assert_equal_s(in.ptr, out.ptr);
+
+	git_filter_list_free(fl);
+	git_buf_free(&out);
+}


### PR DESCRIPTION
Ouch. :(
