### PR TITLE
Make the default repository config getter return a snapshot

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -401,9 +401,14 @@ GIT_EXTERN(int) git_repository_is_bare(git_repository *repo);
 /**
  * Get the configuration file for this repository.
  *
- * If a configuration file has not been set, the default
- * config set for the repository will be returned, including
- * global and system configurations (if they are available).
+ * If no configuration has been set, the default config set for the
+ * repository will be returned, including global and system
+ * configurations (if they are available).
+ *
+ * This configuration will refresh before each lookup and is not safe
+ * to use in a threaded context. It is recommended to use
+ * `git_repository_config()` unless you intend to write to the
+ * configuration.
  *
  * The configuration file must be freed once it's no longer
  * being used by the user.
@@ -412,14 +417,20 @@ GIT_EXTERN(int) git_repository_is_bare(git_repository *repo);
  * @param repo A repository object
  * @return 0, or an error code
  */
-GIT_EXTERN(int) git_repository_config(git_config **out, git_repository *repo);
+GIT_EXTERN(int) git_repository_config_writable(git_config **out, git_repository *repo);
 
 /**
  * Get a snapshot of the repository's configuration
  *
- * Convenience function to take a snapshot from the repository's
- * configuration.  The contents of this snapshot will not change,
- * even if the underlying config files are modified.
+ * The contents are refreshed before returning, but the configuration
+ * values of this snapshot will not change.
+ *
+ * If no configuration has been set, the default config set for the
+ * repository will be returned, including global and system
+ * configurations (if they are available).
+ *
+ * The returned configuration object is safe to use in a threaded
+ * context.
  *
  * The configuration file must be freed once it's no longer
  * being used by the user.
@@ -428,7 +439,7 @@ GIT_EXTERN(int) git_repository_config(git_config **out, git_repository *repo);
  * @param repo the repository
  * @return 0, or an error code
  */
-GIT_EXTERN(int) git_repository_config_snapshot(git_config **out, git_repository *repo);
+GIT_EXTERN(int) git_repository_config(git_config **out, git_repository *repo);
 
 /**
  * Get the Object Database for this repository.

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -364,7 +364,7 @@ int git_attr_cache__do_init(git_repository *repo)
 		return -1;
 	}
 
-	if ((ret = git_repository_config_snapshot(&cfg, repo)) < 0)
+	if ((ret = git_repository_config(&cfg, repo)) < 0)
 		goto cancel;
 
 	/* cache config settings for attributes and ignores */

--- a/src/branch.c
+++ b/src/branch.c
@@ -341,7 +341,7 @@ int git_branch_upstream_name(
 	if (!git_reference__is_branch(refname))
 		return not_a_local_branch(refname);
 
-	if ((error = git_repository_config_snapshot(&config, repo)) < 0)
+	if ((error = git_repository_config(&config, repo)) < 0)
 		return error;
 
 	if ((error = retrieve_upstream_configuration(

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1935,12 +1935,11 @@ static int checkout_data_init(
 					GIT_DIR_MODE, GIT_MKDIR_VERIFY_DIR)) < 0)
 		goto cleanup;
 
-	/* refresh config and index content unless NO_REFRESH is given */
+	/* refresh index content unless NO_REFRESH is given */
 	if ((data->opts.checkout_strategy & GIT_CHECKOUT_NO_REFRESH) == 0) {
 		git_config *cfg;
 
-		if ((error = git_repository_config__weakptr(&cfg, repo)) < 0 ||
-			(error = git_config_refresh(cfg)) < 0)
+		if ((error = git_repository_config__weakptr(&cfg, repo)) < 0)
 			goto cleanup;
 
 		/* if we are checking out the index, don't reload,

--- a/src/diff.c
+++ b/src/diff.c
@@ -406,7 +406,7 @@ static int diff_list_apply_options(
 		diff->opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
 
 	/* load config values that affect diff behavior */
-	if ((val = git_repository_config_snapshot(&cfg, repo)) < 0)
+	if ((val = git_repository_config(&cfg, repo)) < 0)
 		return val;
 
 	if (!git_config__cvar(&val, cfg, GIT_CVAR_SYMLINKS) && val)

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -239,7 +239,7 @@ static int git_diff_driver_load(
 	memcpy(drv->name, driver_name, namelen);
 
 	/* if you can't read config for repo, just use default driver */
-	if (git_repository_config_snapshot(&cfg, repo) < 0) {
+	if (git_repository_config(&cfg, repo) < 0) {
 		giterr_clear();
 		goto done;
 	}

--- a/src/merge.c
+++ b/src/merge.c
@@ -2572,7 +2572,7 @@ static int merge_preference(git_merge_preference_t *out, git_repository *repo)
 
 	*out = GIT_MERGE_PREFERENCE_NONE;
 
-	if ((error = git_repository_config_snapshot(&config, repo)) < 0)
+	if ((error = git_repository_config(&config, repo)) < 0)
 		goto done;
 
 	if ((error = git_config_get_string(&value, config, "merge.ff")) < 0) {

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -90,7 +90,7 @@ static int packbuilder_config(git_packbuilder *pb)
 	int ret;
 	int64_t val;
 
-	if ((ret = git_repository_config_snapshot(&config, pb->repo)) < 0)
+	if ((ret = git_repository_config(&config, pb->repo)) < 0)
 		return ret;
 
 #define config_get(KEY,DST,DFLT) do { \

--- a/src/remote.c
+++ b/src/remote.c
@@ -356,7 +356,7 @@ int git_remote_load(git_remote **out, git_repository *repo, const char *name)
 	if ((error = ensure_remote_name_is_valid(name)) < 0)
 		return error;
 
-	if ((error = git_repository_config_snapshot(&config, repo)) < 0)
+	if ((error = git_repository_config(&config, repo)) < 0)
 		return error;
 
 	remote = git__malloc(sizeof(git_remote));

--- a/src/repository.c
+++ b/src/repository.c
@@ -462,7 +462,7 @@ int git_repository_open_ext(
 	else {
 		git_config *config = NULL;
 
-		if ((error = git_repository_config_snapshot(&config, repo)) < 0 ||
+		if ((error = git_repository_config(&config, repo)) < 0 ||
 			(error = load_config_data(repo, config)) < 0 ||
 			(error = load_workdir(repo, config, &parent)) < 0)
 			git_repository_free(repo);
@@ -616,7 +616,7 @@ int git_repository_config__weakptr(git_config **out, git_repository *repo)
 	return error;
 }
 
-int git_repository_config(git_config **out, git_repository *repo)
+int git_repository_config_writable(git_config **out, git_repository *repo)
 {
 	if (git_repository_config__weakptr(out, repo) < 0)
 		return -1;
@@ -625,7 +625,7 @@ int git_repository_config(git_config **out, git_repository *repo)
 	return 0;
 }
 
-int git_repository_config_snapshot(git_config **out, git_repository *repo)
+int git_repository_config(git_config **out, git_repository *repo)
 {
 	int error;
 	git_config *weak;

--- a/src/signature.c
+++ b/src/signature.c
@@ -144,7 +144,7 @@ int git_signature_default(git_signature **out, git_repository *repo)
 	git_config *cfg;
 	const char *user_name, *user_email;
 
-	if ((error = git_repository_config_snapshot(&cfg, repo)) < 0)
+	if ((error = git_repository_config(&cfg, repo)) < 0)
 		return error;
 
 	if (!(error = git_config_get_string(&user_name, cfg, "user.name")) &&

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -797,7 +797,7 @@ int git_submodule_init(git_submodule *sm, int overwrite)
 		return -1;
 	}
 
-	if ((error = git_repository_config(&cfg, sm->repo)) < 0)
+	if ((error = git_repository_config__weakptr(&cfg, sm->repo)) < 0)
 		return error;
 
 	/* write "submodule.NAME.url" */

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -157,7 +157,7 @@ void test_attr_ignore__expand_tilde_to_homedir(void)
 	/* construct fake home with fake global excludes */
 	cl_git_mkfile("home/globalexclude", "# found me\n*.global_with_tilde\n");
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_string(cfg, "core.excludesfile", "~/globalexclude"));
 	git_config_free(cfg);
 

--- a/tests/checkout/conflict.c
+++ b/tests/checkout/conflict.c
@@ -71,7 +71,7 @@ void test_checkout_conflict__initialize(void)
 		"* text eol=lf\n");
 
 	/* Ensure that the user's merge.conflictstyle doesn't interfere */
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_string(cfg, "merge.conflictstyle", "merge"));
 	git_config_free(cfg);
 }

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -398,7 +398,7 @@ void cl_repo_commit_from_index(
 void cl_repo_set_bool(git_repository *repo, const char *cfg, int value)
 {
 	git_config *config;
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_set_bool(config, cfg, value != 0));
 	git_config_free(config);
 }
@@ -417,7 +417,7 @@ int cl_repo_get_bool(git_repository *repo, const char *cfg)
 void cl_repo_set_string(git_repository *repo, const char *cfg, const char *value)
 {
 	git_config *config;
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_set_string(config, cfg, value));
 	git_config_free(config);
 }

--- a/tests/config/rename.c
+++ b/tests/config/rename.c
@@ -7,7 +7,7 @@ static git_config *g_config = NULL;
 void test_config_rename__initialize(void)
 {
     g_repo = cl_git_sandbox_init("testrepo.git");
-	cl_git_pass(git_repository_config(&g_config, g_repo));
+	cl_git_pass(git_repository_config_writable(&g_config, g_repo));
 }
 
 void test_config_rename__cleanup(void)
@@ -54,6 +54,7 @@ void test_config_rename__prevent_overwrite(void)
 
 	cl_git_pass(git_config_rename_section(
 		g_repo, "branch.track-local", "branch.local-track"));
+
 
 	cl_git_pass(git_config_get_entry(
 		&ce, g_config, "branch.local-track.remote"));

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -281,7 +281,7 @@ void test_config_write__can_set_an_empty_value(void)
 	const char * str;
 
 	repository = cl_git_sandbox_init("testrepo.git");
-	cl_git_pass(git_repository_config(&config, repository));
+	cl_git_pass(git_repository_config_writable(&config, repository));
 
 	cl_git_pass(git_config_set_string(config, "core.somevar", ""));
 	cl_git_pass(git_config_get_string(&str, config, "core.somevar"));

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -796,7 +796,7 @@ void test_diff_blob__using_path_and_attributes(void)
 
 	/* set up custom diff drivers and 'diff' attribute mappings for them */
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_bool(cfg, "diff.iam_binary.binary", 1));
 	cl_git_pass(git_config_set_bool(cfg, "diff.iam_text.binary", 0));
 	cl_git_pass(git_config_set_string(

--- a/tests/diff/drivers.c
+++ b/tests/diff/drivers.c
@@ -101,7 +101,7 @@ void test_diff_drivers__patterns(void)
 
 	/* let's define that driver */
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_bool(cfg, "diff.kipling0.binary", 1));
 	git_config_free(cfg);
 
@@ -121,7 +121,7 @@ void test_diff_drivers__patterns(void)
 	git_diff_driver_registry_free(g_repo->diff_drivers);
 	g_repo->diff_drivers = NULL;
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_bool(cfg, "diff.kipling0.binary", 0));
 	cl_git_pass(git_config_set_string(cfg, "diff.kipling0.xfuncname", "^H.*$"));
 	git_config_free(cfg);

--- a/tests/diff/patch.c
+++ b/tests/diff/patch.c
@@ -188,7 +188,7 @@ void test_diff_patch__config_options(void)
 	const char *expected4 = "diff --git staged_changes_modified_file staged_changes_modified_file\nindex 70bd9443ada0..906ee7711f4f 100644\n--- staged_changes_modified_file\n+++ staged_changes_modified_file\n@@ -1 +1,2 @@\n staged_changes_modified_file\n+staged_changes_modified_file\n";
 
 	g_repo = cl_git_sandbox_init("status");
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	one = resolve_commit_oid_to_tree(g_repo, one_sha);
 	opts.pathspec.count = 1;
 	opts.pathspec.strings = &onefile;

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -1426,7 +1426,7 @@ void test_diff_rename__matches_config_behavior(void)
 	tree2 = resolve_commit_oid_to_tree(g_repo, sha2);
 
 	diffopts.flags |= GIT_DIFF_INCLUDE_UNMODIFIED;
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 
 	/* diff.renames = false; no rename detection should happen */
 	cl_git_pass(git_config_set_bool(cfg, "diff.renames", false));
@@ -1508,7 +1508,7 @@ void test_diff_rename__can_override_thresholds_when_obeying_config(void)
 	diffopts.flags |= GIT_DIFF_INCLUDE_UNMODIFIED;
 	opts.flags = GIT_DIFF_FIND_BY_CONFIG;
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_string(cfg, "diff.renames", "copies"));
 	git_config_free(cfg);
 
@@ -1563,7 +1563,7 @@ void test_diff_rename__by_config_doesnt_mess_with_whitespace_settings(void)
 	diffopts.flags |= GIT_DIFF_INCLUDE_UNMODIFIED;
 	opts.flags = GIT_DIFF_FIND_BY_CONFIG;
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_string(cfg, "diff.renames", "copies"));
 	git_config_free(cfg);
 

--- a/tests/diff/submodules.c
+++ b/tests/diff/submodules.c
@@ -417,7 +417,7 @@ void test_diff_submodules__diff_ignore_options(void)
 	git_diff_free(diff);
 
 	opts.ignore_submodules = 0;
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(git_config_set_bool(cfg, "diff.ignoreSubmodules", false));
 
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));

--- a/tests/diff/tree.c
+++ b/tests/diff/tree.c
@@ -455,7 +455,7 @@ static void set_config_int(git_repository *repo, const char *name, int value)
 {
 	git_config *cfg;
 
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_int32(cfg, name, value));
 	git_config_free(cfg);
 }

--- a/tests/merge/files.c
+++ b/tests/merge/files.c
@@ -22,7 +22,7 @@ void test_merge_files__initialize(void)
 	git_repository_index(&repo_index, repo);
 
 	/* Ensure that the user's merge.conflictstyle doesn't interfere */
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "merge.conflictstyle", "merge"));
 	git_config_free(cfg);
 }

--- a/tests/merge/workdir/analysis.c
+++ b/tests/merge/workdir/analysis.c
@@ -116,8 +116,8 @@ void test_merge_workdir_analysis__fastforward_with_config_noff(void)
 	git_merge_analysis_t merge_analysis;
 	git_merge_preference_t merge_pref;
 
-	git_repository_config(&config, repo);
-	git_config_set_string(config, "merge.ff", "false");
+	git_repository_config_writable(&config, repo);
+	cl_git_pass(git_config_set_string(config, "merge.ff", "false"));
 
 	analysis_from_branch(&merge_analysis, &merge_pref, FASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_FASTFORWARD, (merge_analysis & GIT_MERGE_ANALYSIS_FASTFORWARD));
@@ -131,8 +131,8 @@ void test_merge_workdir_analysis__no_fastforward_with_config_ffonly(void)
 	git_merge_analysis_t merge_analysis;
 	git_merge_preference_t merge_pref;
 
-	git_repository_config(&config, repo);
-	git_config_set_string(config, "merge.ff", "only");
+	git_repository_config_writable(&config, repo);
+	cl_git_pass(git_config_set_string(config, "merge.ff", "only"));
 
 	analysis_from_branch(&merge_analysis, &merge_pref, NOFASTFORWARD_BRANCH);
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_NORMAL, (merge_analysis & GIT_MERGE_ANALYSIS_NORMAL));

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -80,7 +80,7 @@ static void set_core_autocrlf_to(git_repository *repo, bool value)
 {
 	git_config *cfg;
 
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_bool(cfg, "core.autocrlf", value));
 
 	git_config_free(cfg);

--- a/tests/merge/workdir/renames.c
+++ b/tests/merge/workdir/renames.c
@@ -22,7 +22,7 @@ void test_merge_workdir_renames__initialize(void)
 	repo = cl_git_sandbox_init(TEST_REPO_PATH);
 
 	/* Ensure that the user's merge.conflictstyle doesn't interfere */
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "merge.conflictstyle", "merge"));
 	git_config_free(cfg);
 }

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -81,7 +81,7 @@ void test_merge_workdir_simple__initialize(void)
 	git_repository_index(&repo_index, repo);
 
 	/* Ensure that the user's merge.conflictstyle doesn't interfere */
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "merge.conflictstyle", "merge"));
 	git_config_free(cfg);
 }
@@ -115,7 +115,7 @@ static void set_core_autocrlf_to(git_repository *repo, bool value)
 {
 	git_config *cfg;
 
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_bool(cfg, "core.autocrlf", value));
 
 	git_config_free(cfg);
@@ -349,7 +349,7 @@ void test_merge_workdir_simple__diff3_from_config(void)
 		REMOVED_IN_MASTER_REUC_ENTRY
 	};
 
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_set_string(config, "merge.conflictstyle", "diff3"));
 
 	merge_simple_branch(0, 0);
@@ -389,7 +389,7 @@ void test_merge_workdir_simple__merge_overrides_config(void)
 		REMOVED_IN_MASTER_REUC_ENTRY
 	};
 
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_set_string(config, "merge.conflictstyle", "diff3"));
 
 	merge_simple_branch(0, GIT_CHECKOUT_CONFLICT_STYLE_MERGE);

--- a/tests/network/remote/createthenload.c
+++ b/tests/network/remote/createthenload.c
@@ -11,7 +11,7 @@ void test_network_remote_createthenload__initialize(void)
 
 	cl_git_pass(git_repository_open(&_repo, "testrepo.git"));
 
-	cl_git_pass(git_repository_config(&_config, _repo));
+	cl_git_pass(git_repository_config_writable(&_config, _repo));
 	cl_git_pass(git_config_set_string(_config, "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"));
 	cl_git_pass(git_config_set_string(_config, "remote.origin.url", url));
 	git_config_free(_config);

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -262,7 +262,7 @@ void test_network_remote_remotes__missing_refspecs(void)
 	git_remote_free(_remote);
 	_remote = NULL;
 
-	cl_git_pass(git_repository_config(&cfg, _repo));
+	cl_git_pass(git_repository_config_writable(&cfg, _repo));
 	cl_git_pass(git_config_set_string(cfg, "remote.specless.url", "http://example.com"));
 	cl_git_pass(git_remote_load(&_remote, _repo, "specless"));
 
@@ -278,7 +278,7 @@ void test_network_remote_remotes__list(void)
 	cl_assert(list.count == 5);
 	git_strarray_free(&list);
 
-	cl_git_pass(git_repository_config(&cfg, _repo));
+	cl_git_pass(git_repository_config_writable(&cfg, _repo));
 
 	/* Create a new remote */
 	cl_git_pass(git_config_set_string(cfg, "remote.specless.url", "http://example.com"));
@@ -380,22 +380,27 @@ void test_network_remote_remotes__tagopt(void)
 	const char *opt;
 	git_config *cfg;
 
-	cl_git_pass(git_repository_config(&cfg, _repo));
-
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_ALL);
 	cl_git_pass(git_remote_save(_remote));
+
+	cl_git_pass(git_repository_config(&cfg, _repo));
 	cl_git_pass(git_config_get_string(&opt, cfg, "remote.test.tagopt"));
 	cl_assert_equal_s("--tags", opt);
+	git_config_free(cfg);
 
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_NONE);
 	cl_git_pass(git_remote_save(_remote));
+
+	cl_git_pass(git_repository_config(&cfg, _repo));
 	cl_git_pass(git_config_get_string(&opt, cfg, "remote.test.tagopt"));
 	cl_assert_equal_s("--no-tags", opt);
+	git_config_free(cfg);
 
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_AUTO);
 	cl_git_pass(git_remote_save(_remote));
-	cl_assert(git_config_get_string(&opt, cfg, "remote.test.tagopt") == GIT_ENOTFOUND);
 
+	cl_git_pass(git_repository_config(&cfg, _repo));
+	cl_assert(git_config_get_string(&opt, cfg, "remote.test.tagopt") == GIT_ENOTFOUND);
 	git_config_free(cfg);
 }
 

--- a/tests/notes/notesref.c
+++ b/tests/notes/notesref.c
@@ -38,7 +38,7 @@ void test_notes_notesref__config_corenotesref(void)
 	cl_git_pass(git_signature_now(&_sig, "alice", "alice@example.com"));
 	cl_git_pass(git_oid_fromstr(&oid, "8496071c1b46c854b31185ea97743be6a8774479"));
 
-	cl_git_pass(git_repository_config(&_cfg, _repo));
+	cl_git_pass(git_repository_config_writable(&_cfg, _repo));
 
 	cl_git_pass(git_config_set_string(_cfg, "core.notesRef", "refs/notes/mydefaultnotesref"));
 

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -82,7 +82,7 @@ void test_online_fetchhead__no_merges(void)
 
 	fetchhead_test_clone();
 
-	cl_git_pass(git_repository_config(&config, g_repo));
+	cl_git_pass(git_repository_config_writable(&config, g_repo));
 	cl_git_pass(git_config_delete_entry(config, "branch.master.remote"));
 	cl_git_pass(git_config_delete_entry(config, "branch.master.merge"));
 	git_config_free(config);

--- a/tests/refs/branches/create.c
+++ b/tests/refs/branches/create.c
@@ -120,7 +120,7 @@ void test_refs_branches_create__default_reflog_message(void)
 	git_signature *sig;
 	git_config *cfg;
 
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "user.name", "Foo Bar"));
 	cl_git_pass(git_config_set_string(cfg, "user.email", "foo@example.com"));
 	git_config_free(cfg);

--- a/tests/refs/branches/move.c
+++ b/tests/refs/branches/move.c
@@ -220,7 +220,7 @@ void test_refs_branches_move__default_reflog_message(void)
 	git_signature *sig;
 	git_config *cfg;
 
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "user.name", "Foo Bar"));
 	cl_git_pass(git_config_set_string(cfg, "user.email", "foo@example.com"));
 	git_config_free(cfg);

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -113,26 +113,33 @@ void test_refs_branches_upstream__set_unset_upstream(void)
 	cl_git_pass(git_config_get_string(&value, config, "branch.test.merge"));
 	cl_assert_equal_s(value, "refs/heads/master");
 
+	git_config_free(config);
 	git_reference_free(branch);
 
 	/* local */
 	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/test"));
 	cl_git_pass(git_branch_set_upstream(branch, "master"));
 
+	cl_git_pass(git_repository_config(&config, repository));
 	cl_git_pass(git_config_get_string(&value, config, "branch.test.remote"));
 	cl_assert_equal_s(value, ".");
 	cl_git_pass(git_config_get_string(&value, config, "branch.test.merge"));
 	cl_assert_equal_s(value, "refs/heads/master");
+	git_config_free(config);
 
 	/* unset */
 	cl_git_pass(git_branch_set_upstream(branch, NULL));
+	cl_git_pass(git_repository_config(&config, repository));
 	cl_git_fail_with(git_config_get_string(&value, config, "branch.test.merge"), GIT_ENOTFOUND);
 	cl_git_fail_with(git_config_get_string(&value, config, "branch.test.remote"), GIT_ENOTFOUND);
 
+	git_config_free(config);
 	git_reference_free(branch);
 
 	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/master"));
 	cl_git_pass(git_branch_set_upstream(branch, NULL));
+
+	cl_git_pass(git_repository_config(&config, repository));
 	cl_git_fail_with(git_config_get_string(&value, config, "branch.master.merge"), GIT_ENOTFOUND);
 	cl_git_fail_with(git_config_get_string(&value, config, "branch.master.remote"), GIT_ENOTFOUND);
 

--- a/tests/refs/reflog/reflog.c
+++ b/tests/refs/reflog/reflog.c
@@ -302,7 +302,7 @@ void test_refs_reflog_reflog__logallrefupdates_bare_set_false(void)
 {
 	git_config *config;
 
-	cl_git_pass(git_repository_config(&config, g_repo));
+	cl_git_pass(git_repository_config_writable(&config, g_repo));
 	cl_git_pass(git_config_set_bool(config, "core.logallrefupdates", false));
 	git_config_free(config);
 
@@ -313,7 +313,7 @@ void test_refs_reflog_reflog__logallrefupdates_bare_unset(void)
 {
 	git_config *config;
 
-	cl_git_pass(git_repository_config(&config, g_repo));
+	cl_git_pass(git_repository_config_writable(&config, g_repo));
 	cl_git_pass(git_config_delete_entry(config, "core.logallrefupdates"));
 	git_config_free(config);
 
@@ -328,7 +328,7 @@ void test_refs_reflog_reflog__logallrefupdates_nonbare_set_false(void)
 	g_repo = cl_git_sandbox_init("testrepo");
 
 
-	cl_git_pass(git_repository_config(&config, g_repo));
+	cl_git_pass(git_repository_config_writable(&config, g_repo));
 	cl_git_pass(git_config_set_bool(config, "core.logallrefupdates", false));
 	git_config_free(config);
 

--- a/tests/repo/config.c
+++ b/tests/repo/config.c
@@ -44,7 +44,7 @@ void test_repo_config__can_open_global_when_there_is_no_file(void)
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, path.ptr));
 
 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_open_level(
 		&global, config, GIT_CONFIG_LEVEL_GLOBAL));
 
@@ -73,7 +73,7 @@ void test_repo_config__can_open_missing_global_with_separators(void)
 	git_buf_free(&path);
 
 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_open_level(
 		&global, config, GIT_CONFIG_LEVEL_GLOBAL));
 

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -138,7 +138,7 @@ void test_repo_init__reinit_too_recent_bare_repo(void)
 
 	/* Initialize the repository */
 	cl_git_pass(git_repository_init(&_repo, "reinit.git", 1));
-	git_repository_config(&config, _repo);
+	git_repository_config_writable(&config, _repo);
 
 	/*
 	 * Hack the config of the repository to make it look like it has
@@ -257,8 +257,8 @@ void test_repo_init__reinit_doesnot_overwrite_ignorecase(void)
 	cl_git_pass(git_repository_init(&_repo, "not.overwrite.git", 1));
 
 	/* Change the "core.ignorecase" config value to something unlikely */
-	git_repository_config(&config, _repo);
-	git_config_set_int32(config, "core.ignorecase", 42);
+	cl_git_pass(git_repository_config_writable(&config, _repo));
+	cl_git_pass(git_config_set_int32(config, "core.ignorecase", 42));
 	git_config_free(config);
 	git_repository_free(_repo);
 	_repo = NULL;
@@ -576,7 +576,7 @@ void test_repo_init__init_with_initial_commit(void)
 	/* Make sure we're ready to use git_signature_default :-) */
 	{
 		git_config *cfg, *local;
-		cl_git_pass(git_repository_config(&cfg, _repo));
+		cl_git_pass(git_repository_config_writable(&cfg, _repo));
 		cl_git_pass(git_config_open_level(&local, cfg, GIT_CONFIG_LEVEL_LOCAL));
 		cl_git_pass(git_config_set_string(local, "user.name", "Test User"));
 		cl_git_pass(git_config_set_string(local, "user.email", "t@example.com"));

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -318,7 +318,7 @@ void test_repo_open__no_config(void)
 	git_buf_free(&path);
 
 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 
 	cl_git_pass(git_config_set_string(config, "test.set", "42"));
 

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -21,7 +21,7 @@ void test_revert_workdir__initialize(void)
 	git_repository_index(&repo_index, repo);
 
 	/* Ensure that the user's merge.conflictstyle doesn't interfere */
-	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_repository_config_writable(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "merge.conflictstyle", "merge"));
 	git_config_free(cfg);
 }
@@ -321,7 +321,7 @@ void test_revert_workdir__again_after_edit_two(void)
 		{ 0100644, "21a96a98ed84d45866e1de6e266fd3a61a4ae9dc", 3, "file.txt" },
 	};
 
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_writable(&config, repo));
 	cl_git_pass(git_config_set_bool(config, "core.autocrlf", 0));
 
 	cl_git_pass(git_oid_fromstr(&head_commit_oid, "e34ef1afe54eb526fd92eec66084125f340f1d65"));

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -388,7 +388,7 @@ void test_status_ignore__leading_slash_ignores(void)
 	cl_git_mkfile("home/.gitignore", "/ignore_me\n");
 	{
 		git_config *cfg;
-		cl_git_pass(git_repository_config(&cfg, g_repo));
+		cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 		cl_git_pass(git_config_set_string(
 			cfg, "core.excludesfile", "~/.gitignore"));
 		git_config_free(cfg);

--- a/tests/submodule/modify.c
+++ b/tests/submodule/modify.c
@@ -33,7 +33,7 @@ void test_submodule_modify__init(void)
 	const char *str;
 
 	/* erase submodule data from .git/config */
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_writable(&cfg, g_repo));
 	cl_git_pass(
 		git_config_foreach_match(cfg, "submodule\\..*", delete_one_config, cfg));
 	git_config_free(cfg);


### PR DESCRIPTION
You should always use a snapshot, with the sole exception of writing to
the configuration.

Any reads that are not against a snapshot have race conditions, both in
terms of returned values as well as dangling pointers.

This may be a bit controversial, but the thing to remember is that any time you're not using the snapshot, you're opening yourself to segfaults and inconsistent views of the configuration.
