### PR TITLE
revwalk: more sensible array handling

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -48,7 +48,7 @@ static int mark_uninteresting(git_revwalk *walk, git_commit_list_node *commit)
 
 	assert(commit);
 
-	git_array_alloc(pending);
+	git_array_init_to_size(pending, 2);
 	GITERR_CHECK_ARRAY(pending);
 
 	do {
@@ -67,7 +67,7 @@ static int mark_uninteresting(git_revwalk *walk, git_commit_list_node *commit)
 		tmp = git_array_pop(pending);
 		commit = tmp ? *tmp : NULL;
 
-	} while (git_array_size(pending) > 0);
+	} while (commit != NULL);
 
 	git_array_clear(pending);
 


### PR DESCRIPTION
Instead of using a sentinel empty value to detect the last commit, let's
check for when we get a NULL from popping the stack, which lets us know
when we're done.

The current code causes us to read uninitialized data, although only on
RHEL/CentOS 6 in release mode. This is a readability win overall.

---

This should fix libgit2/rugged#384
