### PR TITLE
Don't use read-write accounts for the tests

### DIFF
--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -11,7 +11,6 @@
 #define BB_REPO_URL "https://libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_PASS "https://libgit3:libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_WRONG_PASS "https://libgit3:wrong@bitbucket.org/libgit2/testgitrepository.git"
-#define ASSEMBLA_REPO_URL "https://libgit2:_Libgit2@git.assembla.com/libgit2-test-repos.git"
 
 static git_repository *g_repo;
 static git_clone_options g_options;
@@ -288,11 +287,6 @@ void test_online_clone__bitbucket_style(void)
 	cl_git_pass(git_clone(&g_repo, BB_REPO_URL_WITH_WRONG_PASS, "./foo", &g_options));
 	git_repository_free(g_repo); g_repo = NULL;
 	cl_fixture_cleanup("./foo");
-}
-
-void test_online_clone__assembla_style(void)
-{
-	cl_git_pass(git_clone(&g_repo, ASSEMBLA_REPO_URL, "./foo", NULL));
 }
 
 static int cancel_at_half(const git_transfer_progress *stats, void *payload)


### PR DESCRIPTION
Don't write out the passwords, but use read-only accounts to make sure these credentials cannot change what's in the repos.
