### PR TITLE
Update text=auto / core.autocrlf=false behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@ v0.21 + 1
 * Use a map for the treebuilder, making insertion O(1)
 
 * LF -> CRLF filter refuses to handle mixed-EOL files
+
+* LF -> CRLF filter now runs when * text = auto (with Git for Windows 1.9.4)
+

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -286,7 +286,8 @@ static int crlf_check(
 		if (error < 0)
 			return error;
 
-		if (ca.auto_crlf == GIT_AUTO_CRLF_FALSE)
+		if (ca.crlf_action == GIT_CRLF_GUESS &&
+			ca.auto_crlf == GIT_AUTO_CRLF_FALSE)
 			return GIT_PASSTHROUGH;
 
 		if (ca.auto_crlf == GIT_AUTO_CRLF_INPUT &&

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -279,8 +279,13 @@ void test_checkout_crlf__autocrlf_false_text_auto_attr(void)
 
 	git_checkout_head(g_repo, &opts);
 
-	check_file_contents("./crlf/all-lf", ALL_LF_TEXT_RAW);
-	check_file_contents("./crlf/all-crlf", ALL_CRLF_TEXT_RAW);
+	if (GIT_EOL_NATIVE == GIT_EOL_CRLF) {
+		check_file_contents("./crlf/all-lf", ALL_LF_TEXT_AS_CRLF);
+		check_file_contents("./crlf/all-crlf", ALL_CRLF_TEXT_AS_CRLF);
+	} else {
+		check_file_contents("./crlf/all-lf", ALL_LF_TEXT_RAW);
+		check_file_contents("./crlf/all-crlf", ALL_CRLF_TEXT_RAW);
+	}
 }
 
 void test_checkout_crlf__autocrlf_true_text_auto_attr(void)


### PR DESCRIPTION
Git for Windows 1.9.4 changed the behavior when the text=auto attribute is specified and core.autocrlf=false.  Previous observed behavior would _not_ filter files when going into the working directory, the new behavior _does_ filter.  Update our behavior to match.

With Git for Windows 1.9.2:

```
C:\Temp\TestRepo> git config --get core.autocrlf

C:\Temp\TestRepo>type .gitattributes
* text=auto

C:\Temp\TestRepo>git --version
git version 1.9.2.msysgit.0

C:\Temp\TestRepo>del foo.txt

C:\Temp\TestRepo>git checkout HEAD foo.txt

C:\Temp\TestRepo>HexDump.exe /C foo.txt
00000000  61 73 64 66 0a 61 73 64  66 0a 61 73 64 66 0a 73  |asdf.asdf.asdf.s|
00000010  61 64 66 0a 66 6f 6f 0a  66 6f 6f 0a 62 61 72 0a  |adf.foo.foo.bar.|
00000020  62 61 72 0a 62 61 72 0a                           |bar.bar.|
00000028
```

After upgrading to Git for Windows 1.9.4:

```
C:\Temp\TestRepo> git config --get core.autocrlf

C:\Temp\TestRepos\Foo019>type .gitattributes
* text=auto

C:\Temp\TestRepos\Foo019>git --version
git version 1.9.4.msysgit.0

C:\Temp\TestRepos\Foo019>del foo.txt

C:\Temp\TestRepos\Foo019>git checkout HEAD foo.txt

C:\Temp\TestRepos\Foo019>HexDump.exe /C foo.txt
00000000  61 73 64 66 0d 0a 61 73  64 66 0d 0a 61 73 64 66  |asdf..asdf..asdf|
00000010  0d 0a 73 61 64 66 0d 0a  66 6f 6f 0d 0a 66 6f 6f  |..sadf..foo..foo|
00000020  0d 0a 62 61 72 0d 0a 62  61 72 0d 0a 62 61 72 0d  |..bar..bar..bar.|
00000030  0a                                                |.|
00000031
```

Sigh.
