### PR TITLE
Improvements to git_transport extensibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,16 @@ v0.21 + 1
 
 * LF -> CRLF filter now runs when * text = auto (with Git for Windows 1.9.4)
 
+* The git_remote_set_transport function now sets a transport factory function,
+  rather than a pre-existing transport instance.
+
+* The git_clone_options struct no longer provides the ignore_cert_errors or
+  remote_name members for remote customization.
+
+  Instead, the git_clone_options struct has two new members, remote_cb and
+  remote_cb_payload, which allow the caller to completely override the remote
+  creation process. If needed, the caller can use this callback to give their
+  remote a name other than the default (origin) or disable cert checking.
+
+  The remote_callbacks member has been preserved for convenience, although it
+  is not used when a remote creation callback is supplied.

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -419,20 +419,19 @@ GIT_EXTERN(int) git_remote_list(git_strarray *out, git_repository *repo);
 GIT_EXTERN(void) git_remote_check_cert(git_remote *remote, int check);
 
 /**
- * Sets a custom transport for the remote. The caller can use this function
- * to bypass the automatic discovery of a transport by URL scheme (i.e.
- * http://, https://, git://) and supply their own transport to be used
- * instead. After providing the transport to a remote using this function,
- * the transport object belongs exclusively to that remote, and the remote will
- * free it when it is freed with git_remote_free.
+ * Sets a custom transport factory for the remote. The caller can use this
+ * function to override the transport used for this remote when performing
+ * network operations.
  *
  * @param remote the remote to configure
- * @param transport the transport object for the remote to use
+ * @param transport_cb the function to use to create a transport
+ * @param payload opaque parameter passed to transport_cb
  * @return 0 or an error code
  */
 GIT_EXTERN(int) git_remote_set_transport(
 	git_remote *remote,
-	git_transport *transport);
+	git_transport_cb transport_cb,
+	void *payload);
 
 /**
  * Argument to the completion callback which tells it which operation

--- a/src/remote.h
+++ b/src/remote.h
@@ -22,6 +22,8 @@ struct git_remote {
 	git_vector refs;
 	git_vector refspecs;
 	git_vector active_refspecs;
+	git_transport_cb transport_cb;
+	void *transport_cb_payload;
 	git_transport *transport;
 	git_repository *repo;
 	git_remote_callbacks callbacks;

--- a/src/transport.c
+++ b/src/transport.c
@@ -133,9 +133,10 @@ int git_transport_new(git_transport **out, git_remote *owner, const char *url)
 		return -1;
 	}
 
-	error = fn(&transport, owner, param);
-	if (error < 0)
+	if ((error = fn(&transport, owner, param)) < 0)
 		return error;
+
+	GITERR_CHECK_VERSION(transport, GIT_TRANSPORT_VERSION, "git_transport");
 
 	*out = transport;
 

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -110,12 +110,25 @@ void test_clone_nonetwork__fail_with_already_existing_but_non_empty_directory(vo
 	cl_git_fail(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 }
 
+int custom_origin_name_remote_create(
+	git_remote **out,
+	git_repository *repo,
+	const char *name,
+	const char *url,
+	void *payload)
+{
+	GIT_UNUSED(name);
+	GIT_UNUSED(payload);
+
+	return git_remote_create(out, repo, "my_origin", url);
+}
+
 void test_clone_nonetwork__custom_origin_name(void)
 {
-       g_options.remote_name = "my_origin";
-       cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
+	g_options.remote_cb = custom_origin_name_remote_create;
+	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 
-       cl_git_pass(git_remote_load(&g_remote, g_repo, "my_origin"));
+	cl_git_pass(git_remote_load(&g_remote, g_repo, "my_origin"));
 }
 
 void test_clone_nonetwork__defaults(void)

--- a/tests/clone/transport.c
+++ b/tests/clone/transport.c
@@ -1,0 +1,50 @@
+#include "clar_libgit2.h"
+
+#include "git2/clone.h"
+#include "git2/transport.h"
+#include "fileops.h"
+
+static int custom_transport(
+	git_transport **out,
+	git_remote *owner,
+	void *payload)
+{
+	*((int*)payload) = 1;
+
+	return git_transport_local(out, owner, payload);
+}
+
+static int custom_transport_remote_create(
+	git_remote **out,
+	git_repository *repo,
+	const char *name,
+	const char *url,
+	void *payload)
+{
+	int error;
+
+	if ((error = git_remote_create(out, repo, name, url)) < 0)
+		return error;
+
+	if ((error = git_remote_set_transport(*out, custom_transport, payload)) < 0)
+		return error;
+
+	return 0;
+}
+
+void test_clone_transport__custom_transport(void)
+{
+	git_repository *repo;
+	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+	int custom_transport_used = 0;
+
+	clone_opts.remote_cb = custom_transport_remote_create;
+	clone_opts.remote_cb_payload = &custom_transport_used;
+
+	cl_git_pass(git_clone(&repo, cl_fixture("testrepo.git"), "./custom_transport.git", &clone_opts));
+	git_repository_free(repo);
+
+	cl_git_pass(git_futils_rmdir_r("./custom_transport.git", NULL, GIT_RMDIR_REMOVE_FILES));
+
+	cl_assert(custom_transport_used == 1);
+}


### PR DESCRIPTION
`git_remote_set_transport` now takes a transport factory function pointer and payload, rather than a live transport object. This means that callers no longer have to worry about the strange programming model of creating a transport object, then handing off its ownership to the `git_remote`. (This is especially strange since the signature of the method to create a `git_transport` requires that the caller have the owning remote already created!) It also means that the transport factory function pointer and payload can be duplicated with the rest of the remote's data in `git_remote_dup`.

`git_clone_options` now allows the caller to set a transport factory function pointer and payload, so that the transport used for `git_clone` can be overridden by the caller. This was previously not possible with this function because the `git_remote` is created within the function rather than being passed in. We already have similar options for disabling SSH certificate verification, etc.

These are both breaking changes and are documented in the changelog.
