### PR TITLE
Fix assert when receiving uncommon sideband packet

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -435,6 +435,8 @@ static int write_at(git_indexer *idx, const void *data, git_off_t offset, size_t
 	git_map map;
 	int error;
 
+	assert(data && size);
+
 	/* the offset needs to be at the beginning of the a page boundary */
 	page_start = (offset / page_size) * page_size;
 	page_offset = offset - page_start;
@@ -452,6 +454,9 @@ static int write_at(git_indexer *idx, const void *data, git_off_t offset, size_t
 static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 {
 	git_off_t current_size = idx->pack->mwf.size;
+
+	if (!size)
+		return 0;
 
 	/* add the extra space we need at the end */
 	if (p_ftruncate(idx->pack->mwf.fd, current_size + size) < 0) {

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -592,7 +592,9 @@ int git_smart__download_pack(
 				}
 			} else if (pkt->type == GIT_PKT_DATA) {
 				git_pkt_data *p = (git_pkt_data *) pkt;
-				error = writepack->append(writepack, p->data, p->len, stats);
+
+				if (p->len)
+					error = writepack->append(writepack, p->data, p->len, stats);
 			} else if (pkt->type == GIT_PKT_FLUSH) {
 				/* A flush indicates the end of the packfile */
 				git__free(pkt);


### PR DESCRIPTION
If during pack download, we receive a 5-byte packet equal to "0005\x1", then a packet of type GIT_PKT_DATA is created with length 0. When we try to append this packet to a pack file, a long chain of invoked functions ends up failing to handle the no-op case of zero length. We should guard against this any time one of these functions might be invoked with a zero length.

Stack trace:

```
libgit2_clar!_wassert+0x108
libgit2_clar!p_mmap+0x99 [x:\libgit2\src\win32\map.c @ 42]
libgit2_clar!write_at+0xcf [x:\libgit2\src\indexer.c @ 442]
libgit2_clar!append_to_pack+0x96 [x:\libgit2\src\indexer.c @ 463]
libgit2_clar!git_indexer_append+0xc6 [x:\libgit2\src\indexer.c @ 476]
libgit2_clar!pack_backend__writepack_append+0x77 [x:\libgit2\src\odb_pack.c @ 542]
libgit2_clar!git_smart__download_pack+0x30d [x:\libgit2\src\transports\smart_protocol.c @ 595]
libgit2_clar!git_fetch_download_pack+0x85 [x:\libgit2\src\fetch.c @ 139]
libgit2_clar!git_remote_download+0xe3 [x:\libgit2\src\remote.c @ 840]
libgit2_clar!git_remote_fetch+0x70 [x:\libgit2\src\remote.c @ 854]
libgit2_clar!git_clone_into+0x192 [x:\libgit2\src\clone.c @ 353]
libgit2_clar!git_clone+0x2bd [x:\libgit2\src\clone.c @ 430]
```
