### PR TITLE
Maint fixes for ssl initing and ssh exposure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,17 +408,6 @@ IF (SONAME)
 ENDIF()
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libgit2.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libgit2.pc @ONLY)
 
-IF (LIBSSH2_FOUND)
-	SET(INCLUDE_LIBSSH2 "#include <libssh2.h>")
-	SET(GIT_SSH_PK_FUNC "typedef LIBSSH2_USERAUTH_PUBLICKEY_SIGN_FUNC((*git_cred_sign_callback));")
-	SET(GIT_SSH_KI_FUNC "typedef LIBSSH2_USERAUTH_KBDINT_RESPONSE_FUNC((*git_cred_ssh_interactive_callback));")
-ELSE ()
-	SET(GIT_SSH_PK_FUNC "typedef int (*git_cred_sign_callback)(void *, unsigned char **, size_t *, const unsigned char *, size_t, void **);")
-	SET(GIT_SSH_KI_FUNC "typedef int (*git_cred_ssh_interactive_callback)(const char *, int, const char *, int, int, const void *, void *, void **);")
-ENDIF ()
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/include/git2/transport.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/git2/transport.h @ONLY)
-
-
 IF (MSVC_IDE)
    # Precompiled headers
    SET_TARGET_PROPERTIES(git2 PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h /FIprecompiled.h")

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -11,8 +11,6 @@
 #include "net.h"
 #include "types.h"
 
-@INCLUDE_LIBSSH2@
-
 /**
  * @file git2/transport.h
  * @brief Git transport interfaces and functions
@@ -59,14 +57,19 @@ typedef struct {
 	char *password;
 } git_cred_userpass_plaintext;
 
+
 /*
- * This defines the callbacks for custom public key signatures and
- * keyboard-interactive authentication. It is replaced at build-time
- * with either the libssh2 signature or a dummy signature that's close
- * enough but with void pointers instead of libssh2 structures.
+ * If the user hasn't included libssh2.h before git2.h, we need to
+ * define a few types for the callback signatures.
  */
-@GIT_SSH_PK_FUNC@
-@GIT_SSH_KI_FUNC@
+#ifndef LIBSSH2_VERSION
+typedef struct _LIBSSH2_SESSION LIBSSH2_SESSION;
+typedef struct _LIBSSH2_USERAUTH_KBDINT_PROMPT LIBSSH2_USERAUTH_KBDINT_PROMPT;
+typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE LIBSSH2_USERAUTH_KBDINT_RESPONSE;
+#endif
+
+typedef int (*git_cred_sign_callback)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract);
+typedef int (*git_cred_ssh_interactive_callback)(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract);
 
 /**
  * A ssh key from disk


### PR DESCRIPTION
A couple of fixes which could go into a maint branch if we decided to go that way.

The ssh bit is a bit tricky. It will produce the right header for the version that's built, and it also fixes the signature in the non-ssh case to be compatible with the libssh2 one, so programs built with the header without ssh can still work if the shared object is replaced with one which does support ssh.

I'm torn between doing that and just making the user set a define if they're interested in using ssh, which is in practice what we already have, we'd just have to document it and choose a name for the define which is not one that we use internally.
