### PR TITLE
Round up pool alloc sizes for alignment

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -146,7 +146,7 @@ GIT_INLINE(void) pool_remove_page(
 void *git_pool_malloc(git_pool *pool, uint32_t items)
 {
 	git_pool_page *scan = pool->open, *prev;
-	uint32_t size = items * pool->item_size;
+	uint32_t size = ((items * pool->item_size) + 7) & ~7;
 	void *ptr = NULL;
 
 	pool->has_string_alloc = 0;

--- a/tests/core/pool.c
+++ b/tests/core/pool.c
@@ -38,19 +38,19 @@ void test_core_pool__1(void)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert(git_pool__open_pages(&p) == 1);
-	cl_assert(git_pool__full_pages(&p) == 505);
+	cl_assert_equal_i(1, git_pool__open_pages(&p));
+	cl_assert_equal_i(507, git_pool__full_pages(&p));
 
 	git_pool_clear(&p);
 
-	cl_git_pass(git_pool_init(&p, 1, 4100));
+	cl_git_pass(git_pool_init(&p, 1, 4120));
 
 	for (i = 2010; i > 0; i--)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert(git_pool__open_pages(&p) == 1);
-	cl_assert(git_pool__full_pages(&p) == 492);
+	cl_assert_equal_i(1, git_pool__open_pages(&p));
+	cl_assert_equal_i(492, git_pool__full_pages(&p));
 
 	git_pool_clear(&p);
 }


### PR DESCRIPTION
To make sure that items returned from pool allocations are aligned on nice boundaries, this rounds up all pool allocation sizes to a multiple of 8.  This adds a small amount of overhead to each item.

The rounding up could be made optional with an extra parameter to the pool initialization that turned on rounding only for pools where item alignment actually matters, but I think for the extra code and complexity that would be involved, that it makes sense just to burn a little bit of extra memory and enable this all the time.
