### PR TITLE
git_checkout_index: checkout other indexes

### DIFF
--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -171,7 +171,7 @@ int git_cherry_pick(
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 	const char *commit_msg, *commit_summary;
 	git_buf their_label = GIT_BUF_INIT;
-	git_index *index_new = NULL, *index_repo = NULL;
+	git_index *index_new = NULL;
 	int error = 0;
 
 	assert(repo && commit);
@@ -196,12 +196,10 @@ int git_cherry_pick(
 		(error = git_repository_head(&our_ref, repo)) < 0 ||
 		(error = git_reference_peel((git_object **)&our_commit, our_ref, GIT_OBJ_COMMIT)) < 0 ||
 		(error = git_cherry_pick_commit(&index_new, repo, commit, our_commit, opts.mainline, &opts.merge_opts)) < 0 ||
-		(error = git_merge__indexes(repo, index_new)) < 0 ||
-		(error = git_repository_index(&index_repo, repo)) < 0 ||
-		(error = git_merge__append_conflicts_to_merge_msg(repo, index_repo)) < 0 ||
-		(error = git_checkout_index(repo, index_repo, &opts.checkout_opts)) < 0)
+		(error = git_merge__check_result(repo, index_new)) < 0 ||
+		(error = git_merge__append_conflicts_to_merge_msg(repo, index_new)) < 0 ||
+		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0)
 		goto on_error;
-
 	goto done;
 
 on_error:
@@ -209,7 +207,6 @@ on_error:
 
 done:
 	git_index_free(index_new);
-	git_index_free(index_repo);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);
 	git_buf_free(&their_label);

--- a/src/merge.h
+++ b/src/merge.h
@@ -149,7 +149,7 @@ int git_merge__setup(
 	const git_merge_head *heads[],
 	size_t heads_len);
 
-int git_merge__indexes(git_repository *repo, git_index *index_new);
+int git_merge__check_result(git_repository *repo, git_index *index_new);
 
 int git_merge__append_conflicts_to_merge_msg(git_repository *repo, git_index *index);
 

--- a/src/revert.c
+++ b/src/revert.c
@@ -174,7 +174,7 @@ int git_revert(
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 	const char *commit_msg;
 	git_buf their_label = GIT_BUF_INIT;
-	git_index *index_new = NULL, *index_repo = NULL;
+	git_index *index_new = NULL;
 	int error;
 
 	assert(repo && commit);
@@ -199,10 +199,9 @@ int git_revert(
 		(error = git_repository_head(&our_ref, repo)) < 0 ||
 		(error = git_reference_peel((git_object **)&our_commit, our_ref, GIT_OBJ_COMMIT)) < 0 ||
 		(error = git_revert_commit(&index_new, repo, commit, our_commit, opts.mainline, &opts.merge_opts)) < 0 ||
-		(error = git_merge__indexes(repo, index_new)) < 0 ||
-		(error = git_repository_index(&index_repo, repo)) < 0 ||
-		(error = git_merge__append_conflicts_to_merge_msg(repo, index_repo)) < 0 ||
-		(error = git_checkout_index(repo, index_repo, &opts.checkout_opts)) < 0)
+		(error = git_merge__check_result(repo, index_new)) < 0 ||
+		(error = git_merge__append_conflicts_to_merge_msg(repo, index_new)) < 0 ||
+		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0)
 		goto on_error;
 
 	goto done;
@@ -212,7 +211,6 @@ on_error:
 
 done:
 	git_index_free(index_new);
-	git_index_free(index_repo);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);
 	git_buf_free(&their_label);

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -97,7 +97,7 @@ static int merge_branch(void)
 	cl_git_pass(git_oid_fromstr(&their_oids[0], MERGE_BRANCH_OID));
 	cl_git_pass(git_merge_head_from_id(&their_heads[0], repo, &their_oids[0]));
 
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	error = git_merge(repo, (const git_merge_head **)their_heads, 1, &merge_opts, &checkout_opts);
 
 	git_merge_head_free(their_heads[0]);


### PR DESCRIPTION
Modify `git_checkout_index` such that it can check out other `git_index`s (that are not necessarily the repository index).  This allows `checkout_index` to use the repository's index for stat cache information instead of the index data being checked out.  `git_merge` and friends now check out their indexes directly instead of trying to blend it into the running index.

This prevents an annoying bug for people who have CRLF-damaged repositories.  Consider a file being deleted in the merge result:  when computing the resultant index (to check out) we would remove that file from the repository's index (and its resultant stat cache).  We can then not use the stat cache to determine if the file has been modified (on disk) and must fall back to comparing the workdir file to HEAD.  If the libgit2 filter(s) were to behave differently than how the file is written, we will (erroneously) block the checkout.

Obsoletes #2383
