### PR TITLE
netops: error out on url without a path

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -717,6 +717,9 @@ int gitno_extract_url_parts(
 	if (u.field_set & (1 << UF_PATH)) {
 		*path = git__substrdup(_path, u.field_data[UF_PATH].len);
 		GITERR_CHECK_ALLOC(*path);
+	} else {
+		giterr_set(GITERR_NET, "invalid url, missing path");
+		return GIT_EINVALIDSPEC;
 	}
 
 	if (u.field_set & (1 << UF_USERINFO)) {

--- a/tests/network/urlparse.c
+++ b/tests/network/urlparse.c
@@ -33,6 +33,24 @@ void test_network_urlparse__trivial(void)
 	cl_assert_equal_p(pass, NULL);
 }
 
+void test_network_urlparse__root(void)
+{
+	cl_git_pass(gitno_extract_url_parts(&host, &port, &path, &user, &pass,
+				"http://example.com/", "8080"));
+	cl_assert_equal_s(host, "example.com");
+	cl_assert_equal_s(port, "8080");
+	cl_assert_equal_s(path, "/");
+	cl_assert_equal_p(user, NULL);
+	cl_assert_equal_p(pass, NULL);
+}
+
+void test_network_urlparse__just_hostname(void)
+{
+	cl_git_fail_with(GIT_EINVALIDSPEC,
+			 gitno_extract_url_parts(&host, &port, &path, &user, &pass,
+						 "http://example.com", "8080"));
+}
+
 void test_network_urlparse__encoded_password(void)
 {
 	cl_git_pass(gitno_extract_url_parts(&host, &port, &path, &user, &pass,


### PR DESCRIPTION
In order to connect to a remote server, we need to provide a path to the
repository we're interested in. Consider the lack of path in the url an
error.

This should fix #2458 and supersede #2242.

@vmg I think this is another one for maint.
