### PR TITLE
Move yield to the tests and enable for FreeBSD

### DIFF
--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -53,12 +53,6 @@ typedef struct {
 
 #endif
 
-#if defined(GIT_WIN32)
-#define git_thread_yield() Sleep(0)
-#else
-#define git_thread_yield() sched_yield()
-#endif
-
 /* Pthreads Mutex */
 #define git_mutex pthread_mutex_t
 #define git_mutex_init(a)	pthread_mutex_init(a, NULL)
@@ -186,7 +180,6 @@ GIT_INLINE(int64_t) git_atomic64_add(git_atomic64 *a, int64_t addend)
 #define git_thread unsigned int
 #define git_thread_create(thread, attr, start_routine, arg) 0
 #define git_thread_join(id, status) (void)0
-#define git_thread_yield() (void)0
 
 /* Pthreads Mutex */
 #define git_mutex unsigned int

--- a/tests/threads/diff.c
+++ b/tests/threads/diff.c
@@ -1,6 +1,20 @@
 #include "clar_libgit2.h"
 #include "thread_helpers.h"
 
+#ifdef GIT_THREADS
+
+# if defined(GIT_WIN32)
+#  define git_thread_yield() Sleep(0)
+# elif defined(__FreeBSD__) || defined(__MidnightBSD__) || defined(__DragonFly__)
+#  define git_thread_yield() pthread_yield()
+# else
+#  define git_thread_yield() sched_yield()
+# endif
+
+#else
+# define git_thread_yield() (void)0
+#endif
+
 static git_repository *_repo;
 static git_tree *_a, *_b;
 static git_atomic _counts[4];


### PR DESCRIPTION
Move the definition of git_thread_yield() to the test which needs it and
add the correct definition for it for FreeBSD and derivatives.

Original patch adding FreeBSD and derivatives by @jacquesg.

This supersedes #2317.
