### PR TITLE
ssh: provide a factory function for setting ssh paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ v0.21 + 1
 * The git_remote_set_transport function now sets a transport factory function,
   rather than a pre-existing transport instance.
 
+* A factory function for ssh has been added which allows to change the
+  path of the programs to execute for receive-pack and upload-pack on
+  the server, git_transport_ssh_with_paths.
+
 * The git_clone_options struct no longer provides the ignore_cert_errors or
   remote_name members for remote customization.
 

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -336,6 +336,22 @@ GIT_EXTERN(int) git_transport_init(
  */
 GIT_EXTERN(int) git_transport_new(git_transport **out, git_remote *owner, const char *url);
 
+/**
+ * Create an ssh transport with custom git command paths
+ *
+ * This is a factory function suitable for setting as the transport
+ * callback in a remote (or for a clone in the options).
+ *
+ * The payload argument must be a strarray pointer with the paths for
+ * the `git-upload-pack` and `git-receive-pack` at index 0 and 1.
+ *
+ * @param out the resulting transport
+ * @param owner the owning remote
+ * @param payload a strarray with the paths
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *payload);
+
 /* Signature of a function which creates a transport */
 typedef int (*git_transport_cb)(git_transport **out, git_remote *owner, void *param);
 

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -34,5 +34,8 @@ export GITTEST_REMOTE_SSH_PUBKEY="$HOME/.ssh/id_rsa.pub"
 export GITTEST_REMOTE_SSH_PASSPHRASE=""
 
 if [ -e ./libgit2_clar ]; then
-    ./libgit2_clar -sonline::push -sonline::clone::cred_callback_failure
+    ./libgit2_clar -sonline::push -sonline::clone::cred_callback_failure &&
+    rm -rf $HOME/_temp/test.git &&
+    git init --bare $HOME/_temp/test.git && # create an empty one
+    ./libgit2_clar -sonline::clone::ssh_with_paths
 fi


### PR DESCRIPTION
git allows you to set which paths to use for the git server programs
when connecting over ssh; and we want to provide something similar.

We do this by providing a factory function which can be set as the
remote's transport callback which will set the given paths upon
creation.
