### PR TITLE
Properly report failure when expanding a packfile

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -460,7 +460,7 @@ static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 
 	/* add the extra space we need at the end */
 	if (p_ftruncate(idx->pack->mwf.fd, current_size + size) < 0) {
-		giterr_system_set(errno);
+		giterr_set(GITERR_OS, "Failed to increase size of pack file '%s'", idx->pack->pack_name);
 		return -1;
 	}
 


### PR DESCRIPTION
This fix should be pretty obvious. The original code was trying to report an error to the user, but used the wrong function. It took a while to debug this failure without a meaningful user-level error message.
