### PR TITLE
Switch description and message reporting in `clar__assert_equal_file`

### DIFF
--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -471,7 +471,7 @@ void clar__assert_equal_file(
 				buf, sizeof(buf), "file content mismatch at byte %d",
 				(int)(total_bytes + pos));
 			p_close(fd);
-			clar__fail(file, line, buf, path, 1);
+			clar__fail(file, line, path, buf, 1);
 		}
 
 		expected_data += bytes;


### PR DESCRIPTION
`clar__fail` will dup the description, but not the error message, on the assumption that the description was something that you crafted as a nice message but the error message is a string constant that will never get freed.  `clar__assert_equal_file` should behave with that assumption in mind.

Before:

```
1) Failure:
rebase::merge::first_next [..\tests\rebase\merge.c:36]
  4á╧☺`^É½♥
  rebase/.git/rebase-merge/current
```

After:

```
1) Failure:
rebase::merge::first_next [..\tests\rebase\merge.c:36]
  rebase/.git/rebase-merge/current
  file content mismatch at byte 0
```
