### PR TITLE
Allow port to be NULL if not present on URL to be parsed

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -709,11 +709,14 @@ int gitno_extract_url_parts(
 		GITERR_CHECK_ALLOC(*host);
 	}
 
-	if (u.field_set & (1 << UF_PORT))
+	if (u.field_set & (1 << UF_PORT)) {
 		*port = git__substrdup(_port, u.field_data[UF_PORT].len);
-	else
+		GITERR_CHECK_ALLOC(*port);
+	} else if (default_port) {
 		*port = git__strdup(default_port);
-	GITERR_CHECK_ALLOC(*port);
+		GITERR_CHECK_ALLOC(*port);
+	} else
+		*port = NULL;
 
 	if (u.field_set & (1 << UF_PATH)) {
 		*path = git__substrdup(_path, u.field_data[UF_PATH].len);


### PR DESCRIPTION
With the current version of `gitno_extract_url_parts` there is no way to find out if a user explicitely specified a port or if the default port was used.

Knowing this, however, might be useful for third party transports which rely on external tools where a different port can be specified optionally (e.g., by passing "-p", but, only if the user intentionally requests a different port in the URL).
