### PR TITLE
Solaris doesn't necessarily have stdint.h, use inttypes.h

### DIFF
--- a/deps/http-parser/http_parser.h
+++ b/deps/http-parser/http_parser.h
@@ -40,6 +40,8 @@ typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
 typedef SIZE_T size_t;
 typedef SSIZE_T ssize_t;
+#elif defined(__sun) || defined(__sun__)
+#include <sys/inttypes.h>
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
Found this failure:
http://ppm4.activestate.com/sun4-solaris-64/5.14/1400/J/JA/JACQUESG/Git-Raw-0.41.d/log-20140803T142004.txt

This is easy enough to fix, use `<sys/inttypes.h>` instead of `<stdint.h>`.

See:
http://wiki.opencsw.org/porting-faq#toc1
