### PR TITLE
config: a multiline var can start immediately

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1649,7 +1649,7 @@ static int is_multiline_var(const char *str)
 	}
 
 	/* An odd number means last backslash wasn't escaped, so it's multiline */
-	return (end > str) && (count & 1);
+	return count & 1;
 }
 
 static int parse_multiline_variable(struct reader *reader, git_buf *value, int in_quotes)

--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -90,3 +90,16 @@ void test_config_stress__trailing_backslash(void)
 	cl_assert_equal_s(path, str);
 	git_config_free(config);
 }
+
+void test_config_stress__complex(void)
+{
+	git_config *config;
+	const char *str;
+	const char *path = "./config-immediate-multiline";
+
+	cl_git_mkfile(path, "[imm]\n multi = \"\\\nfoo\"");
+	cl_git_pass(git_config_open_ondisk(&config, path));
+	cl_git_pass(git_config_get_string(&str, config, "imm.multi"));
+	cl_assert_equal_s(str, "foo");
+	git_config_free(config);
+}


### PR DESCRIPTION
In the check for multiline, we traverse the backslashes from the end
backwards and int the end assert that we haven't gone past the beginning
of the line. We make sure of this in the loop condition, but we also
check in the return value.

However, for certain configurations, a line in a multiline variable
might be empty to aid formatting. In that case, 'end' == 'start', since
we ended up looking at the first char which made it a multiline.

There is no need for the (end > start) check in the return, since the
loop guarantees we won't go further back than the first char in the
line, and we do accept the first char to be the final backslash.

This fixes #2483.
