### PR TITLE
Check NULL before calling free

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -22,7 +22,7 @@ static void set_error(int error_class, char *string)
 {
 	git_error *error = &GIT_GLOBAL->error_t;
 
-	if (error->message != string)
+	if (error->message != string && error->message)
 		git__free(error->message);
 
 	error->message = string;


### PR DESCRIPTION
In TortoiseGit we're experiencing a significant number of crashes with free in errors.c, however, we don't know where exactly (the crashreports we have point to https://github.com/libgit2/libgit2/blob/master/src/errors.c#L74, but there is no `free` - but in set_error there is a `free`).

So: Might it be possible that error->message is uninitialized or error->message is NULL (the crashreports do not include any variable assignments)?

This PR assumes that it is NULL and tries to fix that.
