### PR TITLE
git_remote_ls() crashes before connect is called

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -699,6 +699,11 @@ int git_remote_ls(const git_remote_head ***out, size_t *size, git_remote *remote
 {
 	assert(remote);
 
+	if (!remote->transport) {
+		giterr_set(GITERR_NET, "No transport bound to this remote");
+		return -1;
+	}
+
 	return remote->transport->ls(out, size, remote->transport);
 }
 
@@ -1941,6 +1946,8 @@ int git_remote_default_branch(git_buf *out, git_remote *remote)
 	const git_oid *head_id;
 	size_t heads_len, i;
 	int error;
+
+	assert(out);
 
 	if ((error = git_remote_ls(&heads, &heads_len, remote)) < 0)
 		return error;

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -55,6 +55,17 @@ void test_network_remote_local__retrieve_advertised_references(void)
 	cl_assert_equal_i(refs_len, 28);
 }
 
+void test_network_remote_local__retrieve_advertised_before_connect(void)
+{
+	const git_remote_head **refs;
+	size_t refs_len = 0;
+
+	git_buf_sets(&file_path_buf, cl_git_path_url(cl_fixture("testrepo.git")));
+
+	cl_git_pass(git_remote_create_anonymous(&remote, repo, git_buf_cstr(&file_path_buf), NULL));
+	cl_git_fail(git_remote_ls(&refs, &refs_len, remote));
+}
+
 void test_network_remote_local__retrieve_advertised_references_after_disconnect(void)
 {
 	const git_remote_head **refs;


### PR DESCRIPTION
The possibility exists that the user may call `git_remote_ls` before `git_remote_connect`. Currently we're crashing as we're dereferencing `remote->transport` without first checking its validity.
