### PR TITLE
Removing a completed starter project.

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -53,9 +53,6 @@ These are good small projects to get started with libgit2.
 * Submit a PR to clarify documentation! While we do try to document all of
   the APIs, your fresh eyes on the documentation will find areas that are
   confusing much more easily.
-* Add support for the symref protocol extension, so we don't guess
-  what the remote's default branch is
-  [#2006](https://github.com/libgit2/libgit2/issues/2006)
 
 If none of these appeal to you, take a look at our issues list to see if
 there are any unresolved issues you'd like to jump in on.


### PR DESCRIPTION
Removing the starter project for adding support for the symref
extension (#2006) from PROJECTS.md, as this seems to have been
completed with the merge of #2376.
