### PR TITLE
Export `git_oid_tostr_s` instead of `_allocfmt`

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -116,13 +116,17 @@ GIT_EXTERN(void) git_oid_nfmt(char *out, size_t n, const git_oid *id);
 GIT_EXTERN(void) git_oid_pathfmt(char *out, const git_oid *id);
 
 /**
- * Format a git_oid into a newly allocated c-string.
+ * Format a git_oid into a statically allocated c-string.
+ *
+ * The c-string is owned by the library and should not be freed
+ * by the user. If libgit2 is built with thread support, the string
+ * will be stored in TLS (i.e. one buffer per thread) to allow for
+ * concurrent calls of the function.
  *
  * @param id the oid structure to format
- * @return the c-string; NULL if memory is exhausted. Caller must
- *			deallocate the string with git__free().
+ * @return the c-string
  */
-GIT_EXTERN(char *) git_oid_allocfmt(const git_oid *id);
+GIT_EXTERN(char *) git_oid_tostr_s(const git_oid *oid);
 
 /**
  * Format a git_oid into a buffer as a hex format c-string.

--- a/src/global.h
+++ b/src/global.h
@@ -13,6 +13,7 @@
 typedef struct {
 	git_error *last_error;
 	git_error error_t;
+	char oid_fmt[41];
 } git_global_st;
 
 #ifdef GIT_SSL

--- a/src/oid.c
+++ b/src/oid.c
@@ -8,6 +8,7 @@
 #include "common.h"
 #include "git2/oid.h"
 #include "repository.h"
+#include "global.h"
 #include <string.h>
 #include <limits.h>
 
@@ -97,6 +98,13 @@ void git_oid_pathfmt(char *str, const git_oid *oid)
 	*str++ = '/';
 	for (i = 1; i < sizeof(oid->id); i++)
 		str = fmt_one(str, oid->id[i]);
+}
+
+char *git_oid_tostr_s(const git_oid *oid)
+{
+	char *str = GIT_GLOBAL->oid_fmt;
+	git_oid_nfmt(str, GIT_OID_HEXSZ + 1, oid);
+	return str;
 }
 
 char *git_oid_allocfmt(const git_oid *oid)

--- a/src/oid.h
+++ b/src/oid.h
@@ -9,6 +9,17 @@
 
 #include "git2/oid.h"
 
+/**
+ * Format a git_oid into a newly allocated c-string.
+ *
+ * The c-string is owned by the caller and needs to be manually freed.
+ *
+ * @param id the oid structure to format
+ * @return the c-string; NULL if memory is exhausted. Caller must
+ *			deallocate the string with git__free().
+ */
+char *git_oid_allocfmt(const git_oid *id);
+
 GIT_INLINE(int) git_oid__hashcmp(const unsigned char *sha1, const unsigned char *sha2)
 {
 	int i;

--- a/tests/object/raw/compare.c
+++ b/tests/object/raw/compare.c
@@ -90,7 +90,7 @@ void test_object_raw_compare__compare_fmt_oids(void)
 	cl_assert_equal_s(exp, out);
 }
 
-void test_object_raw_compare__compare_allocfmt_oids(void)
+void test_object_raw_compare__compare_static_oids(void)
 {
 	const char *exp = "16a0123456789abcdef4b775213c23a8bd74f5e0";
 	git_oid in;
@@ -98,10 +98,9 @@ void test_object_raw_compare__compare_allocfmt_oids(void)
 
 	cl_git_pass(git_oid_fromstr(&in, exp));
 
-	out = git_oid_allocfmt(&in);
+	out = git_oid_tostr_s(&in);
 	cl_assert(out);
 	cl_assert_equal_s(exp, out);
-	git__free(out);
 }
 
 void test_object_raw_compare__compare_pathfmt_oids(void)

--- a/tests/online/push_util.c
+++ b/tests/online/push_util.c
@@ -110,9 +110,8 @@ failed:
 	git_buf_puts(&msg, "Expected and actual refs differ:\nEXPECTED:\n");
 
 	for(i = 0; i < expected_refs_len; i++) {
-		cl_assert(oid_str = git_oid_allocfmt(expected_refs[i].oid));
+		oid_str = git_oid_tostr_s(expected_refs[i].oid);
 		cl_git_pass(git_buf_printf(&msg, "%s = %s\n", expected_refs[i].name, oid_str));
-		git__free(oid_str);
 	}
 
 	git_buf_puts(&msg, "\nACTUAL:\n");
@@ -121,9 +120,8 @@ failed:
 		if (master_present && !strcmp(actual->name, "refs/heads/master"))
 			continue;
 
-		cl_assert(oid_str = git_oid_allocfmt(&actual->oid));
+		oid_str = git_oid_tostr_s(&actual->oid);
 		cl_git_pass(git_buf_printf(&msg, "%s = %s\n", actual->name, oid_str));
-		git__free(oid_str);
 	}
 
 	cl_fail(git_buf_cstr(&msg));

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -227,18 +227,12 @@ void test_stash_save__can_stash_against_a_detached_head(void)
 
 void test_stash_save__stashing_updates_the_reflog(void)
 {
-	char *sha;
-
 	assert_object_oid("refs/stash@{0}", NULL, GIT_OBJ_COMMIT);
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
 
-	sha = git_oid_allocfmt(&stash_tip_oid);
-
-	assert_object_oid("refs/stash@{0}", sha, GIT_OBJ_COMMIT);
+	assert_object_oid("refs/stash@{0}", git_oid_tostr_s(&stash_tip_oid), GIT_OBJ_COMMIT);
 	assert_object_oid("refs/stash@{1}", NULL, GIT_OBJ_COMMIT);
-
-	git__free(sha);
 }
 
 void test_stash_save__cannot_stash_when_there_are_no_local_change(void)


### PR DESCRIPTION
The old `allocfmt` is of no use to callers, as they are not able to free
the returned buffer. Export a new API that returns a static string that
doesn't need to be freed.

Supersedes https://github.com/libgit2/libgit2/pull/2524, fixes #2493
