### PR TITLE
Resend POST requests for Kerberos in WinHTTP

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -952,7 +952,7 @@ static int winhttp_stream_write_chunked(
 		}
 
 		/* If we are using Negotiate, POST requests with a body may fail with ERROR_WINHTTP_RESEND_REQUEST
-		 * We first send a zero-length request to get a 401 without writing the body twice */
+		 * We first send an empty request to get a 401 without writing the body twice */
 		if (t->cred &&
 			t->cred->credtype == GIT_CREDTYPE_DEFAULT &&
 			t->auth_mechanism == GIT_WINHTTP_AUTH_NEGOTIATE &&
@@ -968,7 +968,7 @@ static int winhttp_stream_write_chunked(
 			}
 
 			if (!WinHttpWriteData(s->request,
-				"0\r\n\r\n", 5,
+				"4\r\n0000\r\n0\r\n\r\n", 14,
 				&bytes_written)) {
 				giterr_set(GITERR_OS, "Failed to write empty request");
 				return -1;
@@ -1179,7 +1179,7 @@ static int winhttp_action(
 	}
 
 	/* If we are using Negotiate, POST requests with a body may fail with ERROR_WINHTTP_RESEND_REQUEST
-	 * We first send a zero-length request to get a 401 without writing the body twice
+	 * We first send an empty request to get a 401 without writing the body twice
 	 * WinHttp only allows the resent content length to differ if using Transfer-Encoding: chunked */
 	if (t->cred &&
 		t->cred->credtype == GIT_CREDTYPE_DEFAULT &&


### PR DESCRIPTION
I'm trying to use LibGit2Sharp to connect to an Apache server that uses mod_auth_kerb for authentication, and I'm getting the error "Failed to receive response: The request must be resent".  It seems that the way WinHttp handles Kerberos authentication involves sending the request twice, which works fine for GET requests that have no body but fails for POST requests because it doesn’t store a copy of the request body to resend.  

The workaround I’m using here is to send an initial empty POST when using Negotiate, which should trigger the 401 early and allow the actual request to succeed without having to write the body twice.  I think this may be unnecessary in some cases, but I don’t see a way to tell whether it’s required and the extra empty POST appears to be harmless if it succeeds.  

I’m fairly new to both Kerberos and WinHttp, so I apologize in advance if I’ve done something completely crazy and I welcome suggestions for other solutions to my problem.  
