### PR TITLE
pack: return the correct final offset

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -744,7 +744,7 @@ cleanup:
 		git__free(obj->data);
 
 	if (elem)
-		*obj_offset = elem->offset;
+		*obj_offset = curpos;
 
 	git_array_clear(chain);
 	return error;


### PR DESCRIPTION
The callers of git_packfile_unpack() expect the obj_offset argument to
be set to the beginning of the next object. We were mistakenly returning
the the offset of the object's data, which causes the CRC function to
try to use the wrong offset.

Set obj_offset to curpos instead of elem->offset to point to the next
element and bring back expected behaviour.

---

This is one for backporting too @vmg 
