### PR TITLE
Refactor git_cache to use an rwlock

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -30,7 +30,7 @@ typedef struct {
 
 typedef struct {
 	git_oidmap *map;
-	git_mutex   lock;
+	git_rwlock  lock;
 	ssize_t     used_memory;
 } git_cache;
 


### PR DESCRIPTION
This is super low-hanging fruit to reduce contention when many threads are trying to read from the cache simultaneously.

Before this change, 10–20 threads hitting the cache hard resulted in a trace where literally _tens_ of seconds (not to be confused with milliseconds) were being spent in `git_cache_get`. It's now a rounding error.

/cc @arrbee 
