### PR TITLE
winhttp: Prevent swallowing of url parsing error

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -1116,9 +1116,9 @@ static int winhttp_action(
 	int ret = -1;
 
 	if (!t->connection)
-		if (gitno_connection_data_from_url(&t->connection_data, url, NULL) < 0 ||
-			 winhttp_connect(t, url) < 0)
-			return -1;
+		if ((ret = gitno_connection_data_from_url(&t->connection_data, url, NULL)) < 0 ||
+			 (ret = winhttp_connect(t, url)) < 0)
+			return ret;
 
 	if (winhttp_stream_alloc(t, &s) < 0)
 		return -1;

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -463,3 +463,9 @@ void test_online_clone__ssh_cannot_change_username(void)
 
 	cl_git_fail(git_clone(&g_repo, "ssh://git@github.com/libgit2/TestGitRepository", "./foo", &g_options));
 }
+
+void test_online_clone__url_with_no_path_returns_EINVALIDSPEC(void)
+{
+	cl_git_fail_with(git_clone(&g_repo, "http://github.com", "./foo", &g_options),
+		GIT_EINVALIDSPEC);
+}


### PR DESCRIPTION
This has been discovered while working on release LibGit2Sharp v0.19 (cf. libgit2/libgit2sharp#798).

Test `CloneFixture::CloningAnUrlWithoutPathThrows()` was passing on Mono, but failing on Windows, returning a generic error code instead of `GIT_EINVALIDREFSPEC`.

This fix the issue by propagating up to caller the parsing error.
