### PR TITLE
generate.py: Fix python3 unicode problem on Windows

### DIFF
--- a/tests/generate.py
+++ b/tests/generate.py
@@ -8,7 +8,7 @@
 
 from __future__ import with_statement
 from string import Template
-import re, fnmatch, os, codecs, pickle
+import re, fnmatch, os, codecs, pickle, sys
 
 class Module(object):
     class Template(object):
@@ -118,8 +118,12 @@ class Module(object):
             self.modified = True
             self.mtime = st.st_mtime
 
-            with open(path) as fp:
-                raw_content = fp.read()
+            if sys.version_info < (3, 0):
+                with open(path) as fp:
+                    raw_content = fp.read()
+            else:
+                with open(path, 'rb') as fp:
+                    raw_content = "".join(map(chr, fp.read()))
 
         except IOError:
             return False


### PR DESCRIPTION
generate.py: Fix python3 unicode problem on Windows.
The old way works with python2 on Windows and python2/3 on Linux.
