### PR TITLE
ssh: store error message immediately after a failed agent call

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -292,6 +292,10 @@ static int ssh_agent_auth(LIBSSH2_SESSION *session, git_cred_ssh_key *c) {
 	}
 
 shutdown:
+
+	if (rc != LIBSSH2_ERROR_NONE)
+		ssh_error(session, "error authenticating");
+
 	libssh2_agent_disconnect(agent);
 	libssh2_agent_free(agent);
 
@@ -305,6 +309,7 @@ static int _git_ssh_authenticate_session(
 	int rc;
 
 	do {
+		giterr_clear();
 		switch (cred->credtype) {
 		case GIT_CREDTYPE_USERPASS_PLAINTEXT: {
 			git_cred_userpass_plaintext *c = (git_cred_userpass_plaintext *)cred;
@@ -361,7 +366,8 @@ static int _git_ssh_authenticate_session(
                 return GIT_EAUTH;
 
 	if (rc != LIBSSH2_ERROR_NONE) {
-		ssh_error(session, "Failed to authenticate SSH session");
+		if (!giterr_last())
+			ssh_error(session, "Failed to authenticate SSH session");
 		return -1;
 	}
 


### PR DESCRIPTION
When the call to the agent fails, we must retrieve the error message
just after the function call, as other calls may overwrite it.

As the agent authentication is the only one which has a teardown and
there does not seem to be a way to get the error message from a stored
error number, this tries to introduce some small changes to store the
error from the agent.

Clearing the error at the beginning of the loop lets us know whether the
agent has already set the libgit2 error message and we should skip it,
or if we should set it.

This should fix #2547 though it's feels like a kludge. But it's probably not that bad, since the API we should have would have a lot more interaction with the user to let them choose which identity to use, so this needs to get replaced anyway.
