### PR TITLE
When auto follow tags, FETCH_HEAD should list only newly followed tags

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -1065,15 +1065,19 @@ static int update_tips_for_spec(
 		if (autotag && !git_odb_exists(odb, &head->oid))
 			continue;
 
-		if (git_vector_insert(&update_heads, head) < 0)
+		if (!autotag && git_vector_insert(&update_heads, head) < 0)
 			goto on_error;
 
 		error = git_reference_name_to_id(&old, remote->repo, refname.ptr);
 		if (error < 0 && error != GIT_ENOTFOUND)
 			goto on_error;
 
-		if (error == GIT_ENOTFOUND)
+		if (error == GIT_ENOTFOUND) {
 			memset(&old, 0, GIT_OID_RAWSZ);
+
+			if (autotag && git_vector_insert(&update_heads, head) < 0)
+				goto on_error;
+		}
 
 		if (!git_oid__cmp(&old, &head->oid))
 			continue;

--- a/tests/fetchhead/fetchhead_data.h
+++ b/tests/fetchhead/fetchhead_data.h
@@ -16,6 +16,11 @@
 	"8f50ba15d49353813cc6e20298002c0d17b0a9ee\tnot-for-merge\ttag 'commit_tree' of git://github.com/libgit2/TestGitRepository\n" \
 	"6e0c7bdb9b4ed93212491ee778ca1c65047cab4e\tnot-for-merge\ttag 'nearly-dangling' of git://github.com/libgit2/TestGitRepository\n"
 
+#define FETCH_HEAD_WILDCARD_DATA2 \
+	"49322bb17d3acc9146f98c97d078513228bbf3c0\t\tbranch 'master' of git://github.com/libgit2/TestGitRepository\n" \
+	"0966a434eb1a025db6b71485ab63a3bfbea520b6\tnot-for-merge\tbranch 'first-merge' of git://github.com/libgit2/TestGitRepository\n" \
+	"42e4e7c5e507e113ebbb7801b16b52cf867b7ce1\tnot-for-merge\tbranch 'no-parent' of git://github.com/libgit2/TestGitRepository\n" \
+
 #define FETCH_HEAD_NO_MERGE_DATA \
 	"0966a434eb1a025db6b71485ab63a3bfbea520b6\tnot-for-merge\tbranch 'first-merge' of git://github.com/libgit2/TestGitRepository\n" \
 	"49322bb17d3acc9146f98c97d078513228bbf3c0\tnot-for-merge\tbranch 'master' of git://github.com/libgit2/TestGitRepository\n" \
@@ -25,6 +30,16 @@
 	"8f50ba15d49353813cc6e20298002c0d17b0a9ee\tnot-for-merge\ttag 'commit_tree' of git://github.com/libgit2/TestGitRepository\n" \
 	"6e0c7bdb9b4ed93212491ee778ca1c65047cab4e\tnot-for-merge\ttag 'nearly-dangling' of git://github.com/libgit2/TestGitRepository\n"
 
+#define FETCH_HEAD_NO_MERGE_DATA2 \
+	"0966a434eb1a025db6b71485ab63a3bfbea520b6\tnot-for-merge\tbranch 'first-merge' of git://github.com/libgit2/TestGitRepository\n" \
+	"49322bb17d3acc9146f98c97d078513228bbf3c0\tnot-for-merge\tbranch 'master' of git://github.com/libgit2/TestGitRepository\n" \
+	"42e4e7c5e507e113ebbb7801b16b52cf867b7ce1\tnot-for-merge\tbranch 'no-parent' of git://github.com/libgit2/TestGitRepository\n" \
+
+#define FETCH_HEAD_NO_MERGE_DATA3 \
+	"0966a434eb1a025db6b71485ab63a3bfbea520b6\tnot-for-merge\tbranch 'first-merge' of git://github.com/libgit2/TestGitRepository\n" \
+	"49322bb17d3acc9146f98c97d078513228bbf3c0\tnot-for-merge\tbranch 'master' of git://github.com/libgit2/TestGitRepository\n" \
+	"42e4e7c5e507e113ebbb7801b16b52cf867b7ce1\tnot-for-merge\tbranch 'no-parent' of git://github.com/libgit2/TestGitRepository\n" \
+	"8f50ba15d49353813cc6e20298002c0d17b0a9ee\tnot-for-merge\ttag 'commit_tree' of git://github.com/libgit2/TestGitRepository\n" \
 
 #define FETCH_HEAD_EXPLICIT_DATA \
 	"0966a434eb1a025db6b71485ab63a3bfbea520b6\t\tbranch 'first-merge' of git://github.com/libgit2/TestGitRepository\n"

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -67,6 +67,11 @@ static void fetchhead_test_fetch(const char *fetchspec, const char *expected_fet
 void test_online_fetchhead__wildcard_spec(void)
 {
 	fetchhead_test_clone();
+	fetchhead_test_fetch(NULL, FETCH_HEAD_WILDCARD_DATA2);
+	cl_git_pass(git_tag_delete(g_repo, "annotated_tag"));
+	cl_git_pass(git_tag_delete(g_repo, "blob"));
+	cl_git_pass(git_tag_delete(g_repo, "commit_tree"));
+	cl_git_pass(git_tag_delete(g_repo, "nearly-dangling"));
 	fetchhead_test_fetch(NULL, FETCH_HEAD_WILDCARD_DATA);
 }
 
@@ -87,5 +92,12 @@ void test_online_fetchhead__no_merges(void)
 	cl_git_pass(git_config_delete_entry(config, "branch.master.merge"));
 	git_config_free(config);
 
+	fetchhead_test_fetch(NULL, FETCH_HEAD_NO_MERGE_DATA2);
+	cl_git_pass(git_tag_delete(g_repo, "annotated_tag"));
+	cl_git_pass(git_tag_delete(g_repo, "blob"));
+	cl_git_pass(git_tag_delete(g_repo, "commit_tree"));
+	cl_git_pass(git_tag_delete(g_repo, "nearly-dangling"));
 	fetchhead_test_fetch(NULL, FETCH_HEAD_NO_MERGE_DATA);
+	cl_git_pass(git_tag_delete(g_repo, "commit_tree"));
+	fetchhead_test_fetch(NULL, FETCH_HEAD_NO_MERGE_DATA3);
 }


### PR DESCRIPTION
When auto follow tags, FETCH_HEAD should list only newly followed tags.
