### PR TITLE
Fix warnings in thread-utils.h when building without -DTHREADSAFE=ON

### DIFF
--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -183,8 +183,8 @@ GIT_INLINE(int64_t) git_atomic64_add(git_atomic64 *a, int64_t addend)
 
 /* Pthreads Mutex */
 #define git_mutex unsigned int
-#define git_mutex_init(a) 0
-#define git_mutex_lock(a) 0
+static int git_mutex_init(git_mutex* mutex) { GIT_UNUSED(mutex); return 0; }
+static int git_mutex_lock(git_mutex* mutex) { GIT_UNUSED(mutex); return 0; }
 #define git_mutex_unlock(a) (void)0
 #define git_mutex_free(a) (void)0
 

--- a/tests/path/core.c
+++ b/tests/path/core.c
@@ -16,8 +16,6 @@ static void test_make_relative(
 
 void test_path_core__make_relative(void)
 {
-	git_buf buf = GIT_BUF_INIT;
-
 	test_make_relative("foo.c", "/path/to/foo.c", "/path/to", 0);
 	test_make_relative("bar/foo.c", "/path/to/bar/foo.c", "/path/to", 0);
 	test_make_relative("foo.c", "/path/to/foo.c", "/path/to/", 0);


### PR DESCRIPTION
The compiler was generating a bunch of warnings for
git_mutex_init and git_mutex_lock when GIT_THREADS
was not defined (i.e. when not using -DTHREADSAFE=ON).

Also remove an unused variable from tests/path/core.c.
