### PR TITLE
signature: don't allow empty emails

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -70,9 +70,9 @@ int git_signature_new(git_signature **sig_out, const char *name, const char *ema
 	if (p->name == NULL || p->email == NULL)
 		return -1; /* oom */
 
-	if (p->name[0] == '\0') {
+	if (p->name[0] == '\0' || p->email[0] == '\0') {
 		git_signature_free(p);
-		return signature_error("Signature cannot have an empty name");
+		return signature_error("Signature cannot have an empty name or email");
 	}
 
 	p->when.time = time;

--- a/tests/commit/signature.c
+++ b/tests/commit/signature.c
@@ -56,8 +56,8 @@ void test_commit_signature__create_empties(void)
 
 	cl_git_fail(try_build_signature("", "emeric.fermas@gmail.com", 1234567890, 60));
 	cl_git_fail(try_build_signature("   ", "emeric.fermas@gmail.com", 1234567890, 60));
-	cl_git_pass(try_build_signature("nulltoken", "", 1234567890, 60));
-	cl_git_pass(try_build_signature("nulltoken", "  ", 1234567890, 60));
+	cl_git_fail(try_build_signature("nulltoken", "", 1234567890, 60));
+	cl_git_fail(try_build_signature("nulltoken", "  ", 1234567890, 60));
 }
 
 void test_commit_signature__create_one_char(void)


### PR DESCRIPTION
A signature is made up of a non-empty name and a non-empty email so
let's validate that. This also brings us more in line with git, which
also rejects ident with an empty email.
