### PR TITLE
global: free the error message when exiting a thread

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -223,6 +223,9 @@ int init_error = 0;
 
 static void cb__free_status(void *st)
 {
+	git_global_st *state = (git_global_st *) st;
+	git__free(state->error_t.message);
+
 	git__free(st);
 }
 

--- a/tests/threads/basic.c
+++ b/tests/threads/basic.c
@@ -1,5 +1,6 @@
 #include "clar_libgit2.h"
 
+#include "thread_helpers.h"
 #include "cache.h"
 
 
@@ -33,4 +34,17 @@ void test_threads_basic__multiple_init(void)
 	git_threads_shutdown();
 	cl_git_pass(git_repository_open(&nested_repo, cl_fixture("testrepo.git")));
 	git_repository_free(nested_repo);
+}
+
+static void *set_error(void *dummy)
+{
+	giterr_set(GITERR_INVALID, "oh no, something happened!\n");
+
+	return dummy;
+}
+
+/* Set errors so we can check that we free it */
+void test_threads_basic__set_error(void)
+{
+	run_in_parallel(1, 4, set_error, NULL, NULL);
 }


### PR DESCRIPTION
When we free the global state at thread termination, we must also free
the error message in order not to leak the string once per thread.

---

Turns out we don't actually set an error message in our threaded tests, so we can't see this doing anything in the tests. I'll have to add that once I'm front a system with a working valgrind.
