### PR TITLE
travis: run valgrind only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,15 @@ matrix:
    - compiler: gcc
      env: COVERITY=1
      os: linux
+   - compiler: gcc
+     env:
+       - VALGRIND=1
+         OPTIONS="-DBUILD_CLAR=ON -DBUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Debug"
+     os: linux
  allow_failures:
-   - env: COVERITY=1
+   - env:
+     - COVERITY=1
+       VALGRIND=1
 
 install:
   - ./script/install-deps-${TRAVIS_OS_NAME}.sh
@@ -43,8 +50,8 @@ script:
 
 # Run Tests
 after_success:
- - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get -qq install valgrind; fi
- - if [ "$TRAVIS_OS_NAME" = "linux" ]; then valgrind --leak-check=full --show-reachable=yes --suppressions=./libgit2_clar.supp _build/libgit2_clar -ionline; fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" -a -n "$VALGRIND" ]; then sudo apt-get -qq install valgrind; fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" -a -n "$VALGRIND" ]; then valgrind --leak-check=full --show-reachable=yes --suppressions=./libgit2_clar.supp _build/libgit2_clar -ionline; fi
 
 # Only watch the development and master branches
 branches:


### PR DESCRIPTION
Instead of running valgrind on each job, half of which are in release
mode and don't have much usable information for valgrind, perform an
debug build as part of allowed_failures and run valgrind on that one,
which should speed up the feedback we get from the builds.
