### PR TITLE
travis: fix allowed failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
          OPTIONS="-DBUILD_CLAR=ON -DBUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Debug"
      os: linux
  allow_failures:
-   - env:
+   env:
      - COVERITY=1
-       VALGRIND=1
+     - VALGRIND=1
 
 install:
   - ./script/install-deps-${TRAVIS_OS_NAME}.sh


### PR DESCRIPTION
The other PR made the allowed_failures into a single node with two env variables instead of two different nodes. This should let us have allowed failures back.
