### PR TITLE
[factor] Join typedef and struct definitions in single file.

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -421,15 +421,14 @@ typedef int (*git_diff_file_cb)(
 /**
  * Structure describing a hunk of a diff.
  */
-typedef struct git_diff_hunk git_diff_hunk;
-struct git_diff_hunk {
+typedef struct git_diff_hunk {
 	int    old_start;     /**< Starting line number in old_file */
 	int    old_lines;     /**< Number of lines in old_file */
 	int    new_start;     /**< Starting line number in new_file */
 	int    new_lines;     /**< Number of lines in new_file */
 	size_t header_len;    /**< Number of bytes in header text */
 	char   header[128];   /**< Header text, NUL-byte terminated */
-};
+} git_diff_hunk;
 
 /**
  * When iterating over a diff, callback that will be made per hunk.
@@ -469,8 +468,7 @@ typedef enum {
 /**
  * Structure describing a line (or data span) of a diff.
  */
-typedef struct git_diff_line git_diff_line;
-struct git_diff_line {
+typedef struct git_diff_line {
 	char   origin;       /**< A git_diff_line_t value */
 	int    old_lineno;   /**< Line number in old file or -1 for added line */
 	int    new_lineno;   /**< Line number in new file or -1 for deleted line */
@@ -478,7 +476,7 @@ struct git_diff_line {
 	size_t content_len;  /**< Number of bytes of data */
 	git_off_t content_offset; /**< Offset in the original file to the content */
 	const char *content; /**< Pointer to diff text, not NUL-byte terminated */
-};
+} git_diff_line;
 
 /**
  * When iterating over a diff, callback that will be made per text diff

--- a/src/diff_patch.c
+++ b/src/diff_patch.c
@@ -14,12 +14,11 @@
 #include "fileops.h"
 
 /* cached information about a hunk in a diff */
-typedef struct diff_patch_hunk diff_patch_hunk;
-struct diff_patch_hunk {
+typedef struct diff_patch_hunk {
 	git_diff_hunk hunk;
 	size_t line_start;
 	size_t line_count;
-};
+} diff_patch_hunk;
 
 struct git_patch {
 	git_refcount rc;

--- a/src/fetchhead.h
+++ b/src/fetchhead.h
@@ -9,14 +9,12 @@
 
 #include "vector.h"
 
-struct git_fetchhead_ref {
+typedef struct git_fetchhead_ref {
 	git_oid oid;
 	unsigned int is_merge;
 	char *ref_name;
 	char *remote_url;
-};
-
-typedef struct git_fetchhead_ref git_fetchhead_ref;
+} git_fetchhead_ref;
 
 int git_fetchhead_ref_create(
 	git_fetchhead_ref **fetchhead_ref_out,

--- a/src/filebuf.h
+++ b/src/filebuf.h
@@ -25,11 +25,12 @@
 #define GIT_FILELOCK_EXTENSION ".lock\0"
 #define GIT_FILELOCK_EXTLENGTH 6
 
+typedef struct git_filebuf git_filebuf;
 struct git_filebuf {
 	char *path_original;
 	char *path_lock;
 
-	int (*write)(struct git_filebuf *file, void *source, size_t len);
+	int (*write)(git_filebuf *file, void *source, size_t len);
 
 	bool compute_digest;
 	git_hash_ctx digest;
@@ -46,8 +47,6 @@ struct git_filebuf {
 	bool do_not_buffer;
 	int last_error;
 };
-
-typedef struct git_filebuf git_filebuf;
 
 #define GIT_FILEBUF_INIT {0}
 

--- a/src/netops.h
+++ b/src/netops.h
@@ -14,34 +14,28 @@
 # include <openssl/ssl.h>
 #endif
 
-struct gitno_ssl {
+typedef struct gitno_ssl {
 #ifdef GIT_SSL
 	SSL *ssl;
 #else
 	size_t dummy;
 #endif
-};
-
-typedef struct gitno_ssl gitno_ssl;
+} gitno_ssl;
 
 /* Represents a socket that may or may not be using SSL */
-struct gitno_socket {
+typedef struct gitno_socket {
 	GIT_SOCKET socket;
 	gitno_ssl ssl;
-};
+} gitno_socket;
 
-typedef struct gitno_socket gitno_socket;
-
-struct gitno_buffer {
+typedef struct gitno_buffer {
 	char *data;
 	size_t len;
 	size_t offset;
 	gitno_socket *socket;
 	int (*recv)(struct gitno_buffer *buffer);
 	void *cb_data;
-};
-
-typedef struct gitno_buffer gitno_buffer;
+} gitno_buffer;
 
 /* Flags to gitno_connect */
 enum {

--- a/src/tree-cache.h
+++ b/src/tree-cache.h
@@ -11,7 +11,7 @@
 #include "common.h"
 #include "git2/oid.h"
 
-struct git_tree_cache {
+typedef struct {
 	struct git_tree_cache *parent;
 	struct git_tree_cache **children;
 	size_t children_count;
@@ -20,9 +20,7 @@ struct git_tree_cache {
 	git_oid oid;
 	size_t namelen;
 	char name[GIT_FLEX_ARRAY];
-};
-
-typedef struct git_tree_cache git_tree_cache;
+} git_tree_cache;
 
 int git_tree_cache_read(git_tree_cache **tree, const char *buffer, size_t buffer_size);
 void git_tree_cache_invalidate_path(git_tree_cache *tree, const char *path);


### PR DESCRIPTION
It was already the dominant style by far (70:14), so I converted the missing ones. It is DRYer (only use the name type 2 times instead of 3), and removes the question: "should I typedef before or after the struct definition?".

The related question on my mind is: should we use unnamed struct typedefs `typedef struct {} S` or or named ones `typedef struct S {} S`?

Both styles have about an equal number of occurrences on the codebase, but on the public includes there are 3x more named.

I think unnamed is better because:
- makes it impossible to use `struct S` and forces use of just `S`. So we decide to someday transform a struct into, say, an int, no problem.
- DRYer: write the identifier only once instead of twice.

The only problem is that it is a backwards incompatible change if someone used `struct S` from the outside... but they shouldn't have in the first place!

We should also clarify which one to use on the CONVENTIONS.
