### PR TITLE
Add support for setting the SSL CA location

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -136,7 +136,8 @@ typedef enum {
 	GIT_OPT_ENABLE_CACHING,
 	GIT_OPT_GET_CACHED_MEMORY,
 	GIT_OPT_GET_TEMPLATE_PATH,
-	GIT_OPT_SET_TEMPLATE_PATH
+	GIT_OPT_SET_TEMPLATE_PATH,
+	GIT_OPT_SET_SSL_CERT_LOCATIONS,
 } git_libgit2_opt_t;
 
 /**
@@ -220,6 +221,17 @@ typedef enum {
  *		> Set the default template path.
  *		>
  *		> - `path` directory of template.
+ *
+ *	* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)
+ *
+ *		> Set the SSL certificate-authority locations.
+ *		>
+ *		> - `file` is the location of a file containing several
+ *		>   certificates concatenated together.
+ *		> - `path` is the location of a directory holding several
+ *		>   certificates, one per file.
+ *		>
+ * 		> Either parameter may be `NULL`, but not both.
  *
  * @param option Option key
  * @param ... value to set the option


### PR DESCRIPTION
This is a re-worked version of pull request #2583. As discussed there, the only logical way to set the OpenSSL CA cert location is through `git_libgit2_opts`, since this is a global setting that affets the whole library. While it would be nice to have a separate OpenSSL context per connection that pulls its settings from the config variables `sslcainfo` and `sslcapath`, doing this doesn't seem to be possible.
