### PR TITLE
remote: accept a repository and remote name for deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ v0.21 + 1
   path of the programs to execute for receive-pack and upload-pack on
   the server, git_transport_ssh_with_paths.
 
+* git_remote_delete() now accepts the repository and the remote's name
+  instead of a loaded remote.
+
 * The git_clone_options struct no longer provides the ignore_cert_errors or
   remote_name members for remote customization.
 

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -596,10 +596,11 @@ GIT_EXTERN(int) git_remote_is_valid_name(const char *remote_name);
 * All remote-tracking branches and configuration settings
 * for the remote will be removed.
 *
-* @param remote A valid remote
+* @param repo the repository in which to act
+* @param name the name of the remove to delete
 * @return 0 on success, or an error code.
 */
-GIT_EXTERN(int) git_remote_delete(git_remote *remote);
+GIT_EXTERN(int) git_remote_delete(git_repository *repo, const char *name);
 
 /**
  * Retrieve the name of the remote's default branch

--- a/src/remote.c
+++ b/src/remote.c
@@ -1902,29 +1902,15 @@ static int remove_remote_tracking(git_repository *repo, const char *remote_name)
 	return error;
 }
 
-int git_remote_delete(git_remote *remote)
+int git_remote_delete(git_repository *repo, const char *name)
 {
 	int error;
-	git_repository *repo;
 
-	assert(remote);
+	assert(repo && name);
 
-	if (!remote->name) {
-		giterr_set(GITERR_INVALID, "Can't delete an anonymous remote.");
-		return -1;
-	}
-
-	repo = git_remote_owner(remote);
-
-	if ((error = remove_branch_config_related_entries(repo,
-		git_remote_name(remote))) < 0)
-		return error;
-
-	if ((error = remove_remote_tracking(repo, git_remote_name(remote))) < 0)
-		return error;
-
-	if ((error = rename_remote_config_section(
-		repo, git_remote_name(remote), NULL)) < 0)
+	if ((error = remove_branch_config_related_entries(repo, name)) < 0 ||
+	    (error = remove_remote_tracking(repo, name)) < 0 ||
+	    (error = rename_remote_config_section(repo, name, NULL)) < 0)
 		return error;
 
 	return 0;

--- a/tests/network/remote/delete.c
+++ b/tests/network/remote/delete.c
@@ -3,38 +3,23 @@
 
 #include "repository.h"
 
-static git_remote *_remote;
 static git_repository *_repo;
 
 void test_network_remote_delete__initialize(void)
 {
 	_repo = cl_git_sandbox_init("testrepo.git");
-
-	cl_git_pass(git_remote_load(&_remote, _repo, "test"));
 }
 
 void test_network_remote_delete__cleanup(void)
 {
-	git_remote_free(_remote);
 	cl_git_sandbox_cleanup();
-}
-
-void test_network_remote_delete__cannot_delete_an_anonymous_remote(void)
-{
-	git_remote *remote;
-
-	cl_git_pass(git_remote_create_anonymous(&remote, _repo, "git://github.com/libgit2/libgit2", NULL));
-
-	cl_git_fail(git_remote_delete(remote));
-
-	git_remote_free(remote);
 }
 
 void test_network_remote_delete__remove_remote_tracking_branches(void)
 {
 	git_reference *ref;
 
-	cl_git_pass(git_remote_delete(_remote));
+	cl_git_pass(git_remote_delete(_repo, "test"));
 	cl_git_fail_with(GIT_ENOTFOUND, git_reference_lookup(&ref, _repo, "refs/remotes/test/master"));
 }
 
@@ -42,7 +27,7 @@ void test_network_remote_delete__remove_remote_configuration_settings(void)
 {
 	cl_assert(count_config_entries_match(_repo, "remote\\.test\\.+") > 0);
 
-	cl_git_pass(git_remote_delete(_remote));
+	cl_git_pass(git_remote_delete(_repo, "test"));
 
 	cl_assert_equal_i(0, count_config_entries_match(_repo, "remote\\.test\\.+"));
 }
@@ -52,7 +37,7 @@ void test_network_remote_delete__remove_branch_upstream_configuration_settings(v
 	assert_config_entry_existence(_repo, "branch.mergeless.remote", true);
 	assert_config_entry_existence(_repo, "branch.master.remote", true);
 
-	cl_git_pass(git_remote_delete(_remote));
+	cl_git_pass(git_remote_delete(_repo, "test"));
 
 	assert_config_entry_existence(_repo, "branch.mergeless.remote", false);
 	assert_config_entry_existence(_repo, "branch.mergeless.merge", false);


### PR DESCRIPTION
We don't need the remote loaded, and the function extracted both of
these from the git_remote in order to do its work, so let's remote a
step and not ask for the loaded remote at all.

This fixes #2390.
