### PR TITLE
hashsig: Export as a `sys` header

### DIFF
--- a/include/git2/sys/hashsig.h
+++ b/include/git2/sys/hashsig.h
@@ -4,10 +4,12 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_hashsig_h__
-#define INCLUDE_hashsig_h__
+#ifndef INCLUDE_sys_hashsig_h__
+#define INCLUDE_sys_hashsig_h__
 
-#include "common.h"
+#include "git2/common.h"
+
+GIT_BEGIN_DECL
 
 /**
  * Similarity signature of line hashes for a buffer
@@ -35,7 +37,7 @@ typedef enum {
  * @param buflen The length of the data at `buf`
  * @param generate_pairwise_hashes Should pairwise runs be hashed
  */
-extern int git_hashsig_create(
+GIT_EXTERN(int) git_hashsig_create(
 	git_hashsig **out,
 	const char *buf,
 	size_t buflen,
@@ -50,7 +52,7 @@ extern int git_hashsig_create(
  * This will return an error if the file doesn't contain enough data to
  * compute a valid signature.
  */
-extern int git_hashsig_create_fromfile(
+GIT_EXTERN(int) git_hashsig_create_fromfile(
 	git_hashsig **out,
 	const char *path,
 	git_hashsig_option_t opts);
@@ -58,15 +60,17 @@ extern int git_hashsig_create_fromfile(
 /**
  * Release memory for a content similarity signature
  */
-extern void git_hashsig_free(git_hashsig *sig);
+GIT_EXTERN(void) git_hashsig_free(git_hashsig *sig);
 
 /**
  * Measure similarity between two files
  *
  * @return <0 for error, [0 to 100] as similarity score
  */
-extern int git_hashsig_compare(
+GIT_EXTERN(int) git_hashsig_compare(
 	const git_hashsig *a,
 	const git_hashsig *b);
+
+GIT_END_DECL
 
 #endif

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -8,9 +8,9 @@
 
 #include "git2/config.h"
 #include "git2/blob.h"
+#include "git2/sys/hashsig.h"
 
 #include "diff.h"
-#include "hashsig.h"
 #include "path.h"
 #include "fileops.h"
 #include "config.h"

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -4,7 +4,7 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "hashsig.h"
+#include "git2/sys/hashsig.h"
 #include "fileops.h"
 #include "util.h"
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -22,7 +22,6 @@
 #include "tree.h"
 #include "merge_file.h"
 #include "blob.h"
-#include "hashsig.h"
 #include "oid.h"
 #include "index.h"
 #include "filebuf.h"
@@ -42,6 +41,7 @@
 #include "git2/tree.h"
 #include "git2/oidarray.h"
 #include "git2/sys/index.h"
+#include "git2/sys/hashsig.h"
 
 #define GIT_MERGE_INDEX_ENTRY_EXISTS(X)	((X).mode != 0)
 #define GIT_MERGE_INDEX_ENTRY_ISFILE(X) S_ISREG((X).mode)

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
 #include "buf_text.h"
-#include "hashsig.h"
+#include "git2/sys/hashsig.h"
 #include "fileops.h"
 
 #define TESTSTR "Have you seen that? Have you seeeen that??"

--- a/tests/merge/trees/treediff.c
+++ b/tests/merge/trees/treediff.c
@@ -3,7 +3,7 @@
 #include "merge.h"
 #include "../merge_helpers.h"
 #include "diff.h"
-#include "hashsig.h"
+#include "git2/sys/hashsig.h"
 
 static git_repository *repo;
 


### PR DESCRIPTION
As the name says. You never know when this stuff can come in handy, and @arrbee did such a nice job abstracting the API that it can be exported cleanly with no modifications.

Howe convenient!
