### PR TITLE
Ensure filters (i.e. CRLF) are applied when checking out conflict content

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1761,10 +1761,12 @@ static int checkout_write_merge(
 	checkout_conflictdata *conflict)
 {
 	git_buf our_label = GIT_BUF_INIT, their_label = GIT_BUF_INIT,
-		path_suffixed = GIT_BUF_INIT, path_workdir = GIT_BUF_INIT;
+		path_suffixed = GIT_BUF_INIT, path_workdir = GIT_BUF_INIT,
+		in_data = GIT_BUF_INIT, out_data = GIT_BUF_INIT;
 	git_merge_file_options opts = GIT_MERGE_FILE_OPTIONS_INIT;
 	git_merge_file_result result = {0};
 	git_filebuf output = GIT_FILEBUF_INIT;
+	git_filter_list *fl = NULL;
 	int error = 0;
 
 	if (data->opts.checkout_strategy & GIT_CHECKOUT_CONFLICT_STYLE_DIFF3)
@@ -1810,13 +1812,27 @@ static int checkout_write_merge(
 		(error = checkout_safe_for_update_only(git_buf_cstr(&path_workdir), result.mode)) <= 0)
 		goto done;
 
+	if (!data->opts.disable_filters) {
+		if ((error = git_buf_put(&in_data, result.ptr, result.len)) < 0 ||
+			(error = git_filter_list_load(&fl, data->repo, NULL, git_buf_cstr(&path_workdir),
+				GIT_FILTER_TO_WORKTREE, GIT_FILTER_OPT_DEFAULT)) < 0 ||
+			(error = git_filter_list_apply_to_data(&out_data, fl, &in_data)) < 0)
+			goto done;
+	} else if ((error = git_buf_put(&out_data, result.ptr, result.len)) < 0)
+		goto done;
+
+
 	if ((error = git_futils_mkpath2file(path_workdir.ptr, 0755)) < 0 ||
-		(error = git_filebuf_open(&output, path_workdir.ptr, GIT_FILEBUF_DO_NOT_BUFFER, result.mode)) < 0 ||
-		(error = git_filebuf_write(&output, result.ptr, result.len)) < 0 ||
+		(error = git_filebuf_open(&output, git_buf_cstr(&path_workdir), GIT_FILEBUF_DO_NOT_BUFFER, result.mode)) < 0 ||
+		(error = git_filebuf_write(&output, out_data.ptr, out_data.size)) < 0 ||
 		(error = git_filebuf_commit(&output)) < 0)
 		goto done;
 
 done:
+	git_filter_list_free(fl);
+
+	git_buf_free(&out_data);
+	git_buf_free(&in_data);
 	git_buf_free(&our_label);
 	git_buf_free(&their_label);
 


### PR DESCRIPTION
Currently when we're writing out the content of a conflicted file via `git_checkout_index`, we're bypassing the filter mechanisms.

On Windows (with `core.autocrlf = true`), we end up with just line-feeds in the working directory, which in itself may cause more conflicts further down the line.
