### PR TITLE
Fix error in resolving a folder as a volume mount point

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -23,6 +23,10 @@
 #define IO_REPARSE_TAG_SYMLINK (0xA000000CL)
 #endif
 
+#ifndef VOLUME_NAME_GUID
+#define VOLUME_NAME_GUID	0x1
+#endif
+
 /* Options which we always provide to _wopen.
  *
  * _O_BINARY - Raw access; no translation of CR or LF characters


### PR DESCRIPTION
Assuming you have a repo cloned to the following directory structure:
C:\dir1\dir2\dir3\repo

Lets say that 'C:\dir1\dir2' is actually the mount point for a volume (and this is the only mount point for the volume).

When fetching from a remote, it will end up calling fileops.c::git_futils_mkdir().  This attempts to ascertain if 'C:\dir1\dir2' is a directory or not, which depends on the result from posix_w32.c::l_statw().

In the current implementation, the call to GetFinalPathNameByHandleW would return 'C:\dir1\dir2' and the following call to GetFileAttributesExW in l_statw() would be for the junction point.  This causes git_futils_mkdir() to fail (since S_ISDIR is not set).

This patch modifies getfinalpath_w() to return the full path from the volume root (i.e. \?\Volume{}) so GetFileAttributesExW can query for the metadata of the final target.
