### PR TITLE
There is no "z" size specifier on MSVC

### DIFF
--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -49,9 +49,11 @@
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #	define PRIuZ "Iu"
 #	define PRIxZ "Ix"
+#	define PRIdZ "Id"
 #else
 #	define PRIuZ "zu"
 #	define PRIxZ "zx"
+#	define PRIdZ "zd"
 #endif
 
 /* Micosoft Visual C/C++ */

--- a/src/tree-cache.c
+++ b/src/tree-cache.c
@@ -278,7 +278,7 @@ static void write_tree(git_buf *out, git_tree_cache *tree)
 {
 	size_t i;
 
-	git_buf_printf(out, "%s%c%zd %"PRIuZ"\n", tree->name, 0, tree->entry_count, tree->children_count);
+	git_buf_printf(out, "%s%c%"PRIdZ" %"PRIuZ"\n", tree->name, 0, tree->entry_count, tree->children_count);
 
 	if (tree->entry_count != -1)
 		git_buf_put(out, (const char *) &tree->oid, GIT_OID_RAWSZ);


### PR DESCRIPTION
See http://msdn.microsoft.com/en-us/library/tcxf1dw6.aspx and https://stackoverflow.com/questions/6655410/why-doesnt-zd-printf-format-work-in-vs2010
