### PR TITLE
remote: delete git_remote_supported_url()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ v0.21 + 1
 * git_remote_delete() now accepts the repository and the remote's name
   instead of a loaded remote.
 
+* git_remote_supported_url() has been removed as it has become
+  essentially useless with rsync-style ssh paths.
+
 * The git_clone_options struct no longer provides the ignore_cert_errors or
   remote_name members for remote customization.
 

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -390,19 +390,6 @@ GIT_EXTERN(int) git_remote_fetch(
 		const char *reflog_message);
 
 /**
- *
- * Return whether the library supports a particular URL scheme
- *
- * Both the built-in and externally-registered transport lists are
- * searched for a transport which supports the scheme of the given
- * URL.
- *
- * @param url the url to check
- * @return 1 if the url is supported, 0 otherwise
-*/
-GIT_EXTERN(int) git_remote_supported_url(const char* url);
-
-/**
  * Get a list of the configured remotes for a repo
  *
  * The string array must be freed by the user.

--- a/src/transport.c
+++ b/src/transport.c
@@ -212,15 +212,6 @@ done:
 	return error;
 }
 
-int git_remote_supported_url(const char* url)
-{
-	git_transport_cb fn;
-	void *param;
-
-	/* The only error we expect is ENOTFOUND */
-	return !transport_find_fn(&fn, url, &param);
-}
-
 int git_transport_init(git_transport *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -91,26 +91,6 @@ void test_network_remote_remotes__error_when_no_push_available(void)
 	git_remote_free(r);
 }
 
-void test_network_remote_remotes__supported_urls(void)
-{
-	int ssh_supported = 0, https_supported = 0;
-
-#ifdef GIT_SSH
-	ssh_supported = 1;
-#endif
-
-#if defined(GIT_SSL) || defined(GIT_WINHTTP)
-	https_supported = 1;
-#endif
-
-	cl_assert(git_remote_supported_url("git://github.com/libgit2/libgit2"));
-	cl_assert(git_remote_supported_url("http://github.com/libgit2/libgit2"));
-
-	cl_assert_equal_i(ssh_supported, git_remote_supported_url("git@github.com:libgit2/libgit2.git"));
-	cl_assert_equal_i(ssh_supported, git_remote_supported_url("ssh://git@github.com/libgit2/libgit2.git"));
-	cl_assert_equal_i(https_supported, git_remote_supported_url("https://github.com/libgit2/libgit2.git"));
-}
-
 void test_network_remote_remotes__refspec_parsing(void)
 {
 	cl_assert_equal_s(git_refspec_src(_refspec), "refs/heads/*");


### PR DESCRIPTION
This function does not in fact tell us anything, as almost anything with
a colon in it is a valid rsync-style SSH path; it can not tell us that
we do not support ftp or afp or similar as those are still valid SSH
paths and we do support that.

From #2640 
