### PR TITLE
Fixed memory leak in git_tag_delete()

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -406,8 +406,9 @@ int git_tag_delete(git_repository *repo, const char *tag_name)
 	if (error < 0)
 		return error;
 
-	if ((error = git_reference_delete(tag_ref)) == 0)
-		git_reference_free(tag_ref);
+	error = git_reference_delete(tag_ref);
+
+	git_reference_free(tag_ref);
 
 	return error;
 }


### PR DESCRIPTION
This should fix #2630
