### PR TITLE
Changed context_lines and interhunk_lines to uint32_t to match struct s_xdemitconf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,8 @@ v0.21 + 1
 
 * The THREADSAFE option to build libgit2 with threading support has
   been flipped to be on by default.
+
+* The context_lines and interhunk_lines fields in git_diff_options are
+  now uint32_t instead of uint16_t. This allows to set them to UINT_MAX,
+  in effect asking for "infinite" context e.g. to iterate over all the
+  unmodified lines of a diff.

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -377,8 +377,8 @@ typedef struct {
 
 	/* options controlling how to diff text is generated */
 
-	uint16_t    context_lines;    /**< defaults to 3 */
-	uint16_t    interhunk_lines;  /**< defaults to 0 */
+	uint32_t    context_lines;    /**< defaults to 3 */
+	uint32_t    interhunk_lines;  /**< defaults to 0 */
 	uint16_t    id_abbrev;       /**< default 'core.abbrev' or 7 if unset */
 	git_off_t   max_size;         /**< defaults to 512MB */
 	const char *old_prefix;       /**< defaults to "a" */

--- a/src/diff.c
+++ b/src/diff.c
@@ -439,7 +439,7 @@ static int diff_list_apply_options(
 	/* If not given explicit `opts`, check `diff.xyz` configs */
 	if (!opts) {
 		int context = git_config__get_int_force(cfg, "diff.context", 3);
-		diff->opts.context_lines = context >= 0 ? (uint16_t)context : 3;
+		diff->opts.context_lines = context >= 0 ? (uint32_t)context : 3;
 
 		/* add other defaults here */
 	}


### PR DESCRIPTION
This should provide an elegant way to solve #2656.

I ran all the unit tests.
