### PR TITLE
Flip THREADSAFE's default to ON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,6 @@ v0.21 + 1
 
 * Introduce git_note_author() and git_note_committer() to get the author
   and committer information on a git_note, respectively.
+
+* The THREADSAFE option to build libgit2 with threading support has
+  been flipped to be on by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ INCLUDE(AddCFlagIfSupported)
 #
 OPTION( SONAME				"Set the (SO)VERSION of the target"		ON  )
 OPTION( BUILD_SHARED_LIBS	"Build Shared Library (OFF for Static)"	ON  )
-OPTION( THREADSAFE			"Build libgit2 as threadsafe"			OFF )
+OPTION( THREADSAFE			"Build libgit2 as threadsafe"			ON )
 OPTION( BUILD_CLAR			"Build Tests using the Clar suite"		ON  )
 OPTION( BUILD_EXAMPLES		"Build library usage example apps"		OFF )
 OPTION( TAGS				"Generate tags"							OFF )

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following CMake variables are declared:
 - `INCLUDE_INSTALL_DIR`: Where to install headers to.
 - `BUILD_SHARED_LIBS`: Build libgit2 as a Shared Library (defaults to ON)
 - `BUILD_CLAR`: Build [Clar](https://github.com/vmg/clar)-based test suite (defaults to ON)
-- `THREADSAFE`: Build libgit2 with threading support (defaults to OFF)
+- `THREADSAFE`: Build libgit2 with threading support (defaults to ON)
 - `STDCALL`: Build libgit2 as `stdcall`. Turn off for `cdecl` (Windows; defaults to ON)
 
 Compiler and linker options


### PR DESCRIPTION
Threads are here to stay; and for a while now, users have had to call
the initialization function which sets up threads and crypto regardless
of whether the library was built threadsafe or not.
