### PR TITLE
Fixed active_refspecs field not initialized on new git_remote objects

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -163,6 +163,10 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 	if (fetch != NULL) {
 		if (add_refspec(remote, fetch, true) < 0)
 			goto on_error;
+
+		/* Move the data over to where the matching functions can find them */
+		if (dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs) < 0)
+			goto on_error;
 	}
 
 	if (!name)


### PR DESCRIPTION
This is a bug fix resulting from the investigation of #2670. I simply copy-pasted the piece of code from the implementation of `git_remote_load()`.

When creating a new remote, contrary to loading one from disk, `active_refspecs` is not populated. This means that if using the new remote to push, `git_remote_update_tips()` will be a no-op since it checks the refspecs passed during the push against the base ones i.e. `active_refspecs`. And therefore the local refs won't be created or updated after the push operation.

All the unit tests pass.
