### PR TITLE
Fixed GIT_REMOTE_DOWNLOAD_TAGS_ALL to behave like git 1.9.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,3 +118,7 @@ v0.21 + 1
 
 * git_status_file now takes an exact path. Use git_status_list_new if
   pathspec searching is needed.
+
+* The fetch behavior of remotes with autotag set to GIT_REMOTE_DOWNLOAD_TAGS_ALL
+  has been changed to match git 1.9.0 and later. In this mode, libgit2 now
+  fetches all tags in addition to whatever else needs to be fetched.

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -28,15 +28,15 @@ static int maybe_want(git_remote *remote, git_remote_head *head, git_odb *odb, g
 
 	if (remote->download_tags == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {
 		/*
-		 * If tagopt is --tags, then we only use the default
-		 * tags refspec and ignore the remote's
+		 * If tagopt is --tags, always request tags
+		 * in addition to the remote's refspecs
 		 */
 		if (git_refspec_src_matches(tagspec, head->name))
 			match = 1;
-		else
-			return 0;
-	} else if (git_remote__matching_refspec(remote, head->name))
-			match = 1;
+	}
+
+	if (!match && git_remote__matching_refspec(remote, head->name))
+		match = 1;
 
 	if (!match)
 		return 0;

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -171,7 +171,7 @@ void test_network_remote_local__tagopt(void)
 	git_remote_set_autotag(remote, GIT_REMOTE_DOWNLOAD_TAGS_ALL);
 	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
 
-	cl_git_fail(git_reference_lookup(&ref, repo, "refs/remotes/tagopt/master"));
+	cl_git_pass(git_reference_lookup(&ref, repo, "refs/remotes/tagopt/master"));
 	cl_git_pass(git_reference_lookup(&ref, repo, "refs/tags/hard_tag"));
 	git_reference_free(ref);
 


### PR DESCRIPTION
This should fix #2672.
