### PR TITLE
Move typedef of git_blame to type.h to fix missing docs

### DIFF
--- a/include/git2/blame.h
+++ b/include/git2/blame.h
@@ -128,10 +128,6 @@ typedef struct git_blame_hunk {
 	char boundary;
 } git_blame_hunk;
 
-
-/* Opaque structure to hold blame results */
-typedef struct git_blame git_blame;
-
 /**
  * Gets the number of hunks that exist in the blame structure.
  */

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -152,6 +152,9 @@ typedef struct git_note git_note;
 /** Representation of a git packbuilder */
 typedef struct git_packbuilder git_packbuilder;
 
+/* Opaque structure to hold blame results */
+typedef struct git_blame git_blame;
+
 /** Time in a signature */
 typedef struct git_time {
 	git_time_t time; /**< time in seconds from epoch */


### PR DESCRIPTION
Currently `git_blame` is typedef'd in its own header (`include/git2/blame.h`) while other opaques are typedef'd in `include/git2/types.h`. This prevents it from showing up in the types array in the docurium output json. Moving it fixes the issue. 
