### PR TITLE
Make config reading continue after hitting a missing include file.

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1280,11 +1280,18 @@ static int config_parse(git_strmap *values, diskfile_backend *cfg_file, struct r
 
 				r->file_path = git_buf_detach(&path);
 				git_buf_init(&r->buffer, 0);
-				if (git_futils_readbuffer_updated(&r->buffer, r->file_path, &r->file_mtime,
-									    &r->file_size, NULL) == 0) {
+				result = git_futils_readbuffer_updated(&r->buffer, r->file_path, &r->file_mtime,
+									    &r->file_size, NULL);
+
+				if (result == 0) {
 					result = config_parse(values, cfg_file, r, level, depth+1);
 					r = git_array_get(cfg_file->readers, index);
 				}
+				else if (result == GIT_ENOTFOUND) {
+					giterr_clear();
+					result = 0;
+				}
+
 				git_buf_free(&r->buffer);
 
 				if (result < 0)

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -92,12 +92,13 @@ void test_config_include__missing(void)
 	git_config *cfg;
 	const char *str;
 
-	cl_git_mkfile("included", "[include]\npath = nonexistentfile\n[foo]\nbar = baz");
+	cl_git_mkfile("including", "[include]\npath = nonexistentfile\n[foo]\nbar = baz");
 
-	cl_git_pass(git_config_open_ondisk(&cfg, "included"));
+	giterr_clear();
+	cl_git_pass(git_config_open_ondisk(&cfg, "including"));
+	cl_assert(giterr_last() == NULL);
 	cl_git_pass(git_config_get_string(&str, cfg, "foo.bar"));
 	cl_assert_equal_s(str, "baz");
 
 	git_config_free(cfg);
-	unlink("included");
 }


### PR DESCRIPTION
For example, if you have

[include]
path = foo

and foo didn't exist, git_config_open_ondisk() would just give up
on the rest of the file.  Now it ignores the unresolved include
without error and continues reading the rest of the file.
