### PR TITLE
netops: return GIT_ECERTIFICATE when it fails the basic tests

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -276,7 +276,7 @@ static int verify_server_cert(gitno_ssl *ssl, const char *host)
 
 	if (SSL_get_verify_result(ssl->ssl) != X509_V_OK) {
 		giterr_set(GITERR_SSL, "The SSL certificate is invalid");
-		return -1;
+		return GIT_ECERTIFICATE;
 	}
 
 	/* Try to parse the host as an IP address to see if it is */


### PR DESCRIPTION
When we first ask OpenSSL to verify the certfiicate itself (rather
than the HTTPS specifics), we should also return
GIT_ECERTIFICATE. Otherwise, the caller would consider this as a failed
operation rather than a failed validation and not call the user's own
validation.

---

We really need to figure out the creation of a test CA and certs and http-hosting repos so we can automatically test this.
