### PR TITLE
Insert extern function 'oid_str_free' for free OID string that allocated...

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -123,6 +123,7 @@ GIT_EXTERN(void) git_oid_pathfmt(char *out, const git_oid *id);
  *			deallocate the string with git__free().
  */
 GIT_EXTERN(char *) git_oid_allocfmt(const git_oid *id);
+GIT_EXTERN(void) oid_str_free(char* str);
 
 /**
  * Format a git_oid into a buffer as a hex format c-string.

--- a/src/oid.c
+++ b/src/oid.c
@@ -114,6 +114,11 @@ char *git_oid_allocfmt(const git_oid *oid)
 	return str;
 }
 
+void oid_str_free(char* str)
+{
+  git__free(str);
+}
+
 char *git_oid_tostr(char *out, size_t n, const git_oid *oid)
 {
 	if (!out || n == 0)


### PR DESCRIPTION
This change made sice my application crush .
My application compiled on  win64 machine debug version.
My application use pygit2 (that use libgit2).
pygit2 allocate oid string using git_oid_allocfmt but free it by itself because git__free is not extern function.
As result of that beffer allocate and free with different compiled code.
To Solve that i insert new API ' oid_str_free' and call it form pygit2 instead free.
