### PR TITLE
remote: rename _load() to _lookup()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ v0.21 + 1
   resfpecs to be the active list, similarly to how git fetch accepts a
   list on the command-line.
 
+* Rename git_remote_load() to git_remote_lookup() to bring it in line
+  with the rest of the lookup functions.
+
 * Introduce git_merge_bases() and the git_oidarray type to expose all
   merge bases between two commits.
 

--- a/examples/network/fetch.c
+++ b/examples/network/fetch.c
@@ -90,7 +90,7 @@ int fetch(git_repository *repo, int argc, char **argv)
 
 	// Figure out whether it's a named remote or a URL
 	printf("Fetching %s for repo %p\n", argv[1], repo);
-	if (git_remote_load(&remote, repo, argv[1]) < 0) {
+	if (git_remote_lookup(&remote, repo, argv[1]) < 0) {
 		if (git_remote_create_anonymous(&remote, repo, argv[1], NULL) < 0)
 			return -1;
 	}

--- a/examples/network/ls-remote.c
+++ b/examples/network/ls-remote.c
@@ -13,7 +13,7 @@ static int use_remote(git_repository *repo, char *name)
 	git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
 
 	// Find the remote by name
-	error = git_remote_load(&remote, repo, name);
+	error = git_remote_lookup(&remote, repo, name);
 	if (error < 0) {
 		error = git_remote_create_anonymous(&remote, repo, name, NULL);
 		if (error < 0)

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -94,7 +94,7 @@ GIT_EXTERN(int) git_remote_create_anonymous(
  * @param name the remote's name
  * @return 0, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_remote_load(git_remote **out, git_repository *repo, const char *name);
+GIT_EXTERN(int) git_remote_lookup(git_remote **out, git_repository *repo, const char *name);
 
 /**
  * Save a remote to its repository's configuration

--- a/src/branch.c
+++ b/src/branch.c
@@ -360,7 +360,7 @@ int git_branch_upstream_name(
 	}
 
 	if (strcmp(".", remote_name) != 0) {
-		if ((error = git_remote_load(&remote, repo, remote_name)) < 0)
+		if ((error = git_remote_lookup(&remote, repo, remote_name)) < 0)
 			goto cleanup;
 
 		refspec = git_remote__matching_refspec(remote, merge_name);
@@ -411,7 +411,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 
 	/* Find matching remotes */
 	for (i = 0; i < remote_list.count; i++) {
-		if ((error = git_remote_load(&remote, repo, remote_list.strings[i])) < 0)
+		if ((error = git_remote_lookup(&remote, repo, remote_list.strings[i])) < 0)
 			continue;
 
 		fetchspec = git_remote__matching_dst_refspec(remote, refname);
@@ -556,7 +556,7 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 			goto on_error;
 	} else {
 		/* Get the remoe-tracking branch's refname in its repo */
-		if (git_remote_load(&remote, repo, git_buf_cstr(&value)) < 0)
+		if (git_remote_lookup(&remote, repo, git_buf_cstr(&value)) < 0)
 			goto on_error;
 
 		fetchspec = git_remote__matching_dst_refspec(remote, git_reference_name(upstream));

--- a/src/remote.c
+++ b/src/remote.c
@@ -186,7 +186,7 @@ static int ensure_remote_doesnot_exist(git_repository *repo, const char *name)
 	int error;
 	git_remote *remote;
 
-	error = git_remote_load(&remote, repo, name);
+	error = git_remote_lookup(&remote, repo, name);
 
 	if (error == GIT_ENOTFOUND)
 		return 0;
@@ -350,7 +350,7 @@ static int get_optional_config(
 	return error;
 }
 
-int git_remote_load(git_remote **out, git_repository *repo, const char *name)
+int git_remote_lookup(git_remote **out, git_repository *repo, const char *name)
 {
 	git_remote *remote;
 	git_buf buf = GIT_BUF_INIT;
@@ -1677,7 +1677,7 @@ int git_remote_rename(git_strarray *out, git_repository *repo, const char *name,
 
 	assert(out && repo && name && new_name);
 
-	if ((error = git_remote_load(&remote, repo, name)) < 0)
+	if ((error = git_remote_lookup(&remote, repo, name)) < 0)
 		return error;
 
 	if ((error = ensure_remote_name_is_valid(new_name)) < 0)
@@ -2010,7 +2010,7 @@ static int remove_remote_tracking(git_repository *repo, const char *remote_name)
 	size_t i, count;
 
 	/* we want to use what's on the config, regardless of changes to the instance in memory */
-	if ((error = git_remote_load(&remote, repo, remote_name)) < 0)
+	if ((error = git_remote_lookup(&remote, repo, remote_name)) < 0)
 		return error;
 
 	count = git_remote_refspec_count(remote);

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1876,7 +1876,7 @@ static int lookup_head_remote(git_remote **remote, git_repository *repo)
 
 	/* lookup remote of remote tracking branch name */
 	if (!(error = lookup_head_remote_key(&remote_name, repo)))
-		error = git_remote_load(remote, repo, remote_name.ptr);
+		error = git_remote_lookup(remote, repo, remote_name.ptr);
 
 	git_buf_free(&remote_name);
 
@@ -1890,7 +1890,7 @@ static int lookup_default_remote(git_remote **remote, git_repository *repo)
 
 	/* if that failed, use 'origin' instead */
 	if (error == GIT_ENOTFOUND)
-		error = git_remote_load(remote, repo, "origin");
+		error = git_remote_lookup(remote, repo, "origin");
 
 	if (error == GIT_ENOTFOUND)
 		giterr_set(

--- a/tests/clone/local.c
+++ b/tests/clone/local.c
@@ -171,7 +171,7 @@ void test_clone_local__standard_unc_paths_are_written_git_style(void)
 	cl_git_pass(git_style_unc_path(&git_unc, "localhost", path));
 
 	cl_git_pass(git_clone(&repo, unc.ptr, "./clone.git", &opts));
-	cl_git_pass(git_remote_load(&remote, repo, "origin"));
+	cl_git_pass(git_remote_lookup(&remote, repo, "origin"));
 
 	cl_assert_equal_s(git_unc.ptr, git_remote_url(remote));
 
@@ -198,7 +198,7 @@ void test_clone_local__git_style_unc_paths(void)
 	cl_git_pass(git_style_unc_path(&git_unc, "localhost", path));
 
 	cl_git_pass(git_clone(&repo, git_unc.ptr, "./clone.git", &opts));
-	cl_git_pass(git_remote_load(&remote, repo, "origin"));
+	cl_git_pass(git_remote_lookup(&remote, repo, "origin"));
 
 	cl_assert_equal_s(git_unc.ptr, git_remote_url(remote));
 

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -128,14 +128,14 @@ void test_clone_nonetwork__custom_origin_name(void)
 	g_options.remote_cb = custom_origin_name_remote_create;
 	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 
-	cl_git_pass(git_remote_load(&g_remote, g_repo, "my_origin"));
+	cl_git_pass(git_remote_lookup(&g_remote, g_repo, "my_origin"));
 }
 
 void test_clone_nonetwork__defaults(void)
 {
 	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", NULL));
 	cl_assert(g_repo);
-	cl_git_pass(git_remote_load(&g_remote, g_repo, "origin"));
+	cl_git_pass(git_remote_lookup(&g_remote, g_repo, "origin"));
 }
 
 void test_clone_nonetwork__cope_with_already_existing_directory(void)

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -331,7 +331,7 @@ void test_fetchhead_nonetwork__unborn_with_upstream(void)
 	cl_git_pass(git_clone(&repo, "./test1", "./repowithunborn", NULL));
 
 	/* Simulate someone pushing to it by changing to one that has stuff */
-	cl_git_pass(git_remote_load(&remote, repo, "origin"));
+	cl_git_pass(git_remote_lookup(&remote, repo, "origin"));
 	cl_git_pass(git_remote_set_url(remote, cl_fixture("testrepo.git")));
 	cl_git_pass(git_remote_save(remote));
 

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -137,7 +137,7 @@ void test_network_fetchlocal__multi_remotes(void)
 
 	cl_set_cleanup(&cleanup_sandbox, NULL);
 	callbacks.transfer_progress = transfer_cb;
-	cl_git_pass(git_remote_load(&test, repo, "test"));
+	cl_git_pass(git_remote_lookup(&test, repo, "test"));
 	cl_git_pass(git_remote_set_url(test, cl_git_fixture_url("testrepo.git")));
 	git_remote_set_callbacks(test, &callbacks);
 	cl_git_pass(git_remote_connect(test, GIT_DIRECTION_FETCH));
@@ -148,7 +148,7 @@ void test_network_fetchlocal__multi_remotes(void)
 	cl_assert_equal_i(32, (int)refnames.count);
 	git_strarray_free(&refnames);
 
-	cl_git_pass(git_remote_load(&test2, repo, "test_with_pushurl"));
+	cl_git_pass(git_remote_lookup(&test2, repo, "test_with_pushurl"));
 	cl_git_pass(git_remote_set_url(test2, cl_git_fixture_url("testrepo.git")));
 	git_remote_set_callbacks(test2, &callbacks);
 	cl_git_pass(git_remote_connect(test2, GIT_DIRECTION_FETCH));

--- a/tests/network/remote/createthenload.c
+++ b/tests/network/remote/createthenload.c
@@ -16,7 +16,7 @@ void test_network_remote_createthenload__initialize(void)
 	cl_git_pass(git_config_set_string(_config, "remote.origin.url", url));
 	git_config_free(_config);
 
-	cl_git_pass(git_remote_load(&_remote, _repo, "origin"));
+	cl_git_pass(git_remote_lookup(&_remote, _repo, "origin"));
 }
 
 void test_network_remote_createthenload__cleanup(void)

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -11,7 +11,7 @@ void test_network_remote_remotes__initialize(void)
 {
 	_repo = cl_git_sandbox_init("testrepo.git");
 
-	cl_git_pass(git_remote_load(&_remote, _repo, "test"));
+	cl_git_pass(git_remote_lookup(&_remote, _repo, "test"));
 
 	_refspec = git_remote_get_refspec(_remote, 0);
 	cl_assert(_refspec != NULL);
@@ -38,7 +38,7 @@ void test_network_remote_remotes__parsing(void)
 	cl_assert_equal_s(git_remote__urlfordirection(_remote, GIT_DIRECTION_PUSH),
 					  "git://github.com/libgit2/libgit2");
 
-	cl_git_pass(git_remote_load(&_remote2, _repo, "test_with_pushurl"));
+	cl_git_pass(git_remote_lookup(&_remote2, _repo, "test_with_pushurl"));
 	cl_assert_equal_s(git_remote_name(_remote2), "test_with_pushurl");
 	cl_assert_equal_s(git_remote_url(_remote2), "git://github.com/libgit2/fetchlibgit2");
 	cl_assert_equal_s(git_remote_pushurl(_remote2), "git://github.com/libgit2/pushlibgit2");
@@ -63,7 +63,7 @@ void test_network_remote_remotes__pushurl(void)
 void test_network_remote_remotes__error_when_not_found(void)
 {
 	git_remote *r;
-	cl_git_fail_with(git_remote_load(&r, _repo, "does-not-exist"), GIT_ENOTFOUND);
+	cl_git_fail_with(git_remote_lookup(&r, _repo, "does-not-exist"), GIT_ENOTFOUND);
 
 	cl_assert(giterr_last() != NULL);
 	cl_assert(giterr_last()->klass == GITERR_CONFIG);
@@ -181,7 +181,7 @@ void test_network_remote_remotes__save(void)
 	_remote = NULL;
 
 	/* Load it from config and make sure everything matches */
-	cl_git_pass(git_remote_load(&_remote, _repo, "upstream"));
+	cl_git_pass(git_remote_lookup(&_remote, _repo, "upstream"));
 
 	cl_git_pass(git_remote_get_fetch_refspecs(&array, _remote));
 	cl_assert_equal_i(2, (int)array.count);
@@ -204,7 +204,7 @@ void test_network_remote_remotes__save(void)
 	git_remote_free(_remote);
 	_remote = NULL;
 
-	cl_git_pass(git_remote_load(&_remote, _repo, "upstream"));
+	cl_git_pass(git_remote_lookup(&_remote, _repo, "upstream"));
 	cl_assert(git_remote_pushurl(_remote) == NULL);
 }
 
@@ -241,7 +241,7 @@ void test_network_remote_remotes__missing_refspecs(void)
 
 	cl_git_pass(git_repository_config(&cfg, _repo));
 	cl_git_pass(git_config_set_string(cfg, "remote.specless.url", "http://example.com"));
-	cl_git_pass(git_remote_load(&_remote, _repo, "specless"));
+	cl_git_pass(git_remote_lookup(&_remote, _repo, "specless"));
 
 	git_config_free(cfg);
 }
@@ -302,7 +302,7 @@ void test_network_remote_remotes__loading_a_missing_remote_returns_ENOTFOUND(voi
 	git_remote_free(_remote);
 	_remote = NULL;
 
-	cl_assert_equal_i(GIT_ENOTFOUND, git_remote_load(&_remote, _repo, "just-left-few-minutes-ago"));
+	cl_assert_equal_i(GIT_ENOTFOUND, git_remote_lookup(&_remote, _repo, "just-left-few-minutes-ago"));
 }
 
 void test_network_remote_remotes__loading_with_an_invalid_name_returns_EINVALIDSPEC(void)
@@ -310,7 +310,7 @@ void test_network_remote_remotes__loading_with_an_invalid_name_returns_EINVALIDS
 	git_remote_free(_remote);
 	_remote = NULL;
 
-	cl_assert_equal_i(GIT_EINVALIDSPEC, git_remote_load(&_remote, _repo, "Inv@{id"));
+	cl_assert_equal_i(GIT_EINVALIDSPEC, git_remote_lookup(&_remote, _repo, "Inv@{id"));
 }
 
 /*
@@ -333,7 +333,7 @@ void test_network_remote_remotes__add(void)
 	git_remote_free(_remote);
 	_remote = NULL;
 
-	cl_git_pass(git_remote_load(&_remote, _repo, "addtest"));
+	cl_git_pass(git_remote_lookup(&_remote, _repo, "addtest"));
 	cl_assert_equal_i(GIT_REMOTE_DOWNLOAD_TAGS_AUTO, git_remote_autotag(_remote));
 
 	_refspec = git_vector_get(&_remote->refspecs, 0);
@@ -407,7 +407,7 @@ void test_network_remote_remotes__can_load_with_an_empty_url(void)
 {
 	git_remote *remote = NULL;
 
-	cl_git_pass(git_remote_load(&remote, _repo, "empty-remote-url"));
+	cl_git_pass(git_remote_lookup(&remote, _repo, "empty-remote-url"));
 
 	cl_assert(remote->url == NULL);
 	cl_assert(remote->pushurl == NULL);
@@ -424,7 +424,7 @@ void test_network_remote_remotes__can_load_with_only_an_empty_pushurl(void)
 {
 	git_remote *remote = NULL;
 
-	cl_git_pass(git_remote_load(&remote, _repo, "empty-remote-pushurl"));
+	cl_git_pass(git_remote_lookup(&remote, _repo, "empty-remote-pushurl"));
 
 	cl_assert(remote->url == NULL);
 	cl_assert(remote->pushurl == NULL);
@@ -439,7 +439,7 @@ void test_network_remote_remotes__returns_ENOTFOUND_when_neither_url_nor_pushurl
 	git_remote *remote = NULL;
 
 	cl_git_fail_with(
-		git_remote_load(&remote, _repo, "no-remote-url"), GIT_ENOTFOUND);
+		git_remote_lookup(&remote, _repo, "no-remote-url"), GIT_ENOTFOUND);
 }
 
 void assert_cannot_create_remote(const char *name, int expected_error)

--- a/tests/network/remote/rename.c
+++ b/tests/network/remote/rename.c
@@ -74,7 +74,7 @@ void test_network_remote_rename__renaming_a_remote_without_a_fetchrefspec_doesnt
 	cl_git_pass(git_repository_config__weakptr(&config, _repo));
 	cl_git_pass(git_config_delete_entry(config, "remote.test.fetch"));
 
-	cl_git_pass(git_remote_load(&remote, _repo, "test"));
+	cl_git_pass(git_remote_lookup(&remote, _repo, "test"));
 	git_remote_free(remote);
 
 	assert_config_entry_existence(_repo, "remote.test.fetch", false);
@@ -94,7 +94,7 @@ void test_network_remote_rename__renaming_a_remote_notifies_of_non_default_fetch
 
 	cl_git_pass(git_repository_config__weakptr(&config, _repo));
 	cl_git_pass(git_config_set_string(config, "remote.test.fetch", "+refs/*:refs/*"));
-	cl_git_pass(git_remote_load(&remote, _repo, "test"));
+	cl_git_pass(git_remote_lookup(&remote, _repo, "test"));
 	git_remote_free(remote);
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
@@ -132,14 +132,14 @@ void test_network_remote_rename__renamed_name_is_persisted(void)
 	git_repository *another_repo;
 	git_strarray problems = {0};
 
-	cl_git_fail(git_remote_load(&renamed, _repo, "just/renamed"));
+	cl_git_fail(git_remote_lookup(&renamed, _repo, "just/renamed"));
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
 	git_strarray_free(&problems);
 
 	cl_git_pass(git_repository_open(&another_repo, "testrepo.git"));
-	cl_git_pass(git_remote_load(&renamed, _repo, "just/renamed"));
+	cl_git_pass(git_remote_lookup(&renamed, _repo, "just/renamed"));
 
 	git_remote_free(renamed);
 	git_repository_free(another_repo);

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -46,7 +46,7 @@ void test_online_clone__network_full(void)
 
 	cl_git_pass(git_clone(&g_repo, LIVE_REPO_URL, "./foo", &g_options));
 	cl_assert(!git_repository_is_bare(g_repo));
-	cl_git_pass(git_remote_load(&origin, g_repo, "origin"));
+	cl_git_pass(git_remote_lookup(&origin, g_repo, "origin"));
 
 	cl_assert_equal_i(GIT_REMOTE_DOWNLOAD_TAGS_AUTO, origin->download_tags);
 
@@ -61,7 +61,7 @@ void test_online_clone__network_bare(void)
 
 	cl_git_pass(git_clone(&g_repo, LIVE_REPO_URL, "./foo", &g_options));
 	cl_assert(git_repository_is_bare(g_repo));
-	cl_git_pass(git_remote_load(&origin, g_repo, "origin"));
+	cl_git_pass(git_remote_lookup(&origin, g_repo, "origin"));
 
 	git_remote_free(origin);
 }

--- a/tests/online/fetch.c
+++ b/tests/online/fetch.c
@@ -120,7 +120,7 @@ void test_online_fetch__doesnt_retrieve_a_pack_when_the_repository_is_up_to_date
 
 	cl_git_pass(git_repository_open(&_repository, "./fetch/lg2"));
 
-	cl_git_pass(git_remote_load(&remote, _repository, "origin"));
+	cl_git_pass(git_remote_lookup(&remote, _repository, "origin"));
 	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH));
 
 	cl_assert_equal_i(false, invoked);

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -42,7 +42,7 @@ static void fetchhead_test_fetch(const char *fetchspec, const char *expected_fet
 	int equals = 0;
 	git_strarray array, *active_refs = NULL;
 
-	cl_git_pass(git_remote_load(&remote, g_repo, "origin"));
+	cl_git_pass(git_remote_lookup(&remote, g_repo, "origin"));
 	git_remote_set_autotag(remote, GIT_REMOTE_DOWNLOAD_TAGS_AUTO);
 
 	if(fetchspec != NULL) {

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -358,7 +358,7 @@ void test_repo_init__extended_1(void)
 	cl_assert_equal_s("refs/heads/development", git_reference_symbolic_target(ref));
 	git_reference_free(ref);
 
-	cl_git_pass(git_remote_load(&remote, _repo, "origin"));
+	cl_git_pass(git_remote_lookup(&remote, _repo, "origin"));
 	cl_assert_equal_s("origin", git_remote_name(remote));
 	cl_assert_equal_s(opts.origin_url, git_remote_url(remote));
 	git_remote_free(remote);

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -97,7 +97,7 @@ void test_submodule_add__url_relative(void)
 	cl_git_pass(git_remote_rename(&problems, g_repo, "origin", "test_remote"));
 	cl_assert_equal_i(0, problems.count);
 	git_strarray_free(&problems);
-	cl_git_fail(git_remote_load(&remote, g_repo, "origin"));
+	cl_git_fail(git_remote_lookup(&remote, g_repo, "origin"));
 
 	cl_git_pass(
 		git_submodule_add_setup(&sm, g_repo, "../TestGitRepository", "TestGitRepository", 1)


### PR DESCRIPTION
This brings it in line with the rest of the lookup functions.
