### PR TITLE
Fixed a couple Clang warnings

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1145,12 +1145,16 @@ static int checkout_conflict_append_remove(
 	checkout_data *data = payload;
 	const char *name;
 
+	assert(ancestor || ours || theirs);
+
 	if (ancestor)
 		name = git__strdup(ancestor->path);
 	else if (ours)
 		name = git__strdup(ours->path);
 	else if (theirs)
 		name = git__strdup(theirs->path);
+	else
+		abort();
 
 	GITERR_CHECK_ALLOC(name);
 

--- a/tests/status/worktree_init.c
+++ b/tests/status/worktree_init.c
@@ -127,7 +127,6 @@ void test_status_worktree_init__bracket_in_filename(void)
 	git_index *index;
 	status_entry_single result;
 	unsigned int status_flags;
-	int error;
 
 	#define FILE_WITH_BRACKET "LICENSE[1].md"
 	#define FILE_WITHOUT_BRACKET "LICENSE1.md"


### PR DESCRIPTION
Fixed some recently introduced "regressions" that trigger Clang warnings while building on OS X (`checkout.c` one is a real bug too).
