### PR TITLE
Update message for error during push

### DIFF
--- a/src/push.c
+++ b/src/push.c
@@ -360,7 +360,8 @@ static int revwalk(git_vector *commits, git_push *push)
 				continue;
 
 			if (!git_odb_exists(push->repo->_odb, &spec->roid)) {
-				giterr_set(GITERR_REFERENCE, "Cannot push missing reference");
+				giterr_set(GITERR_REFERENCE, 
+					"Cannot push because a reference that you are trying to update on the remote contains commits that are not present locally.");
 				error = GIT_ENONFASTFORWARD;
 				goto on_error;
 			}


### PR DESCRIPTION
When attempting to update a reference on a remote during push, and the
reference on the remote refers to a commit that does not exist locally,
then we should report a more clear error message.

Git makes a distinction between `non-fast-forward`:

```
! [rejected]        master  -> master (non-fast-forward)
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

and `fetch first`:

```
 ! [rejected]        master -> master (fetch first)
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

If consumers wanted to make a distinction between `non-fast-forward` and `fetch first`, I am not sure there is currently an easy way to do this... they would have to query the remote references. Maybe this could be done in the bindings without another network call, but consumers of the bindings probably would have a bit more work to do. Also, if you are pushing multiple refs, there is not an easy way to know which ref fails this test. I am not sure how useful it is to expose this subtlety to consumers of libgit2, but we could return a different error code for the `fast forward` case.

For now, this PR is to just update the message to something that is more understandable by a user (although, it is still a bit wordy...)

/cc @jeffhostetler
