### PR TITLE
fetch: clear the connection data on close

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -1009,6 +1009,7 @@ static int http_close(git_smart_subtransport *subtransport)
 	git_vector_clear(&t->auth_contexts);
 
 	gitno_connection_data_free_ptrs(&t->connection_data);
+	memset(&t->connection_data, 0x0, sizeof(gitno_connection_data));
 
 	return 0;
 }

--- a/tests/online/fetch.c
+++ b/tests/online/fetch.c
@@ -202,3 +202,14 @@ void test_online_fetch__remote_symrefs(void)
 
 	git_remote_free(remote);
 }
+
+void test_online_fetch__twice(void)
+{
+	git_remote *remote;
+
+	cl_git_pass(git_remote_create(&remote, _repo, "test", "http://github.com/libgit2/TestGitRepository.git"));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+
+	git_remote_free(remote);
+}


### PR DESCRIPTION
When we fetch twice with the same remote object, we did not properly
clear the connection flags, so we would leak state from the last
connection.

This can cause the second fetch with the same remote object to fail if
using a HTTP URL where the server redirects to HTTPS, as the second
fetch would see `use_ssl` set and think the initial connection wanted to
downgrade the connection.

This should fix  #2712 
