### PR TITLE
travis: disable the cert callback on OSX

### DIFF
--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -43,6 +43,9 @@ export GITTEST_REMOTE_SSH_PUBKEY="$HOME/.ssh/id_rsa.pub"
 export GITTEST_REMOTE_SSH_PASSPHRASE=""
 
 if [ -e ./libgit2_clar ]; then
-    ./libgit2_clar -sonline::push -sonline::clone::cred_callback -sonline::clone::ssh_cert &&
+    ./libgit2_clar -sonline::push -sonline::clone::ssh_cert &&
     ./libgit2_clar -sonline::clone::ssh_with_paths
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+        ./libgit2_clar -sonline::clone::cred_callback
+    fi
 fi


### PR DESCRIPTION
The sshd on OSX has stopped responding to the setting which this test
assumes is there, so let's disable it until we can figure out what's
happening.
