### PR TITLE
Fix for misleading "missing delta bases" error.

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -671,8 +671,10 @@ static int inject_object(git_indexer *idx, git_oid *id)
 	seek_back_trailer(idx);
 	entry_start = idx->pack->mwf.size;
 
-	if (git_odb_read(&obj, idx->odb, id) < 0)
+	if (git_odb_read(&obj, idx->odb, id) < 0) {
+		giterr_set(GITERR_INDEXER, "missing delta bases");
 		return -1;
+	}
 
 	data = git_odb_object_data(obj);
 	len = git_odb_object_size(obj);
@@ -827,7 +829,6 @@ static int resolve_deltas(git_indexer *idx, git_transfer_progress *stats)
 			break;
 
 		if (!progressed && (fix_thin_pack(idx, stats) < 0)) {
-			giterr_set(GITERR_INDEXER, "missing delta bases");
 			return -1;
 		}
 	}

--- a/src/pack.c
+++ b/src/pack.c
@@ -408,11 +408,14 @@ static int packfile_unpack_header1(
 	size = c & 15;
 	shift = 4;
 	while (c & 0x80) {
-		if (len <= used)
+		if (len <= used) {
+			giterr_set(GITERR_ODB, "buffer too small");
 			return GIT_EBUFS;
+		}
 
 		if (bitsizeof(long) <= shift) {
 			*usedp = 0;
+			giterr_set(GITERR_ODB, "packfile corrupted");
 			return -1;
 		}
 


### PR DESCRIPTION
This addresses issue libgit2/issues/2721

Created a new pull request. The previous one got mixed with the fix for memory leak issue inadvertently.
Incorporated CR comments from @vmg on previous PR
