### PR TITLE
odb: `git_odb_object` contents are never NULL

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -762,12 +762,12 @@ static int hardcoded_objects(git_rawobj *raw, const git_oid *id)
 	if (!git_oid_cmp(id, &empty_blob)) {
 		raw->type = GIT_OBJ_BLOB;
 		raw->len = 0;
-		raw->data = NULL;
+		raw->data = git__calloc(1, sizeof(uint8_t));
 		return 0;
 	} else if (!git_oid_cmp(id, &empty_tree)) {
 		raw->type = GIT_OBJ_TREE;
 		raw->len = 0;
-		raw->data = NULL;
+		raw->data = git__calloc(1, sizeof(uint8_t));
 		return 0;
 	} else {
 		return GIT_ENOTFOUND;

--- a/tests/odb/emptyobjects.c
+++ b/tests/odb/emptyobjects.c
@@ -21,6 +21,8 @@ void test_odb_emptyobjects__read(void)
 	cl_git_pass(git_oid_fromstr(&id, "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"));
 	cl_git_pass(git_blob_lookup(&blob, g_repo, &id));
 	cl_assert_equal_i(GIT_OBJ_BLOB, git_object_type((git_object *) blob));
+	cl_assert(git_blob_rawcontent(blob));
+	cl_assert_equal_s("", git_blob_rawcontent(blob));
 	cl_assert_equal_i(0, git_blob_rawsize(blob));
 	git_blob_free(blob);
 }
@@ -36,4 +38,20 @@ void test_odb_emptyobjects__read_tree(void)
 	cl_assert_equal_i(0, git_tree_entrycount(tree));
 	cl_assert_equal_p(NULL, git_tree_entry_byname(tree, "foo"));
 	git_tree_free(tree);
+}
+
+void test_odb_emptyobjects__read_tree_odb(void)
+{
+	git_oid id;
+	git_odb *odb;
+	git_odb_object *tree_odb;
+
+	cl_git_pass(git_oid_fromstr(&id, "4b825dc642cb6eb9a060e54bf8d69288fbee4904"));
+	cl_git_pass(git_repository_odb(&odb, g_repo));
+	cl_git_pass(git_odb_read(&tree_odb, odb, &id));
+	cl_assert(git_odb_object_data(tree_odb));
+	cl_assert_equal_s("", git_odb_object_data(tree_odb));
+	cl_assert_equal_i(0, git_odb_object_size(tree_odb));
+	git_odb_object_free(tree_odb);
+	git_odb_free(odb);
 }


### PR DESCRIPTION
@carlosmn's commit at https://github.com/libgit2/libgit2/commit/e1ac0101480c29631ad56409d77f2dd7b65bfd09 breaks the contract that the contents of a blob are never `NULL` even if the blob is empty.

This breaks (amongst other things) the attributes and filter code as soon as empty blobs are involved. Don't do that!
