### PR TITLE
win32: clear connection data on close

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -1260,6 +1260,7 @@ static int winhttp_close(git_smart_subtransport *subtransport)
 	int ret = 0;
 
 	gitno_connection_data_free_ptrs(&t->connection_data);
+	memset(&t->connection_data, 0x0, sizeof(gitno_connection_data));
 
 	if (t->cred) {
 		t->cred->free(t->cred);


### PR DESCRIPTION
This is the winhttp version of #2719 .
