### PR TITLE
Add missing else directive

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -131,6 +131,7 @@ int git_openssl_set_locking(void)
 	giterr_set(GITERR_THREAD, "libgit2 as not built with threads");
 	return -1;
 # endif
+#else
 	giterr_set(GITERR_SSL, "libgit2 was not built with OpenSSL support");
 	return -1;
 #endif


### PR DESCRIPTION
Add missing else directive to fix compiler warning: control reaches end of non-void function
