### PR TITLE
Fix public header on sys/refs.h

### DIFF
--- a/include/git2/sys/refs.h
+++ b/include/git2/sys/refs.h
@@ -12,6 +12,15 @@
 #include "git2/oid.h"
 
 /**
+ * @file git2/sys/refs.h
+ * @brief Low-level Git ref creation
+ * @defgroup git_backend Git custom backend APIs
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
  * Create a new direct reference from an OID.
  *
  * @param name the reference name
@@ -35,4 +44,6 @@ GIT_EXTERN(git_reference *) git_reference__alloc_symbolic(
 	const char *name,
 	const char *target);
 
+/** @} */
+GIT_END_DECL
 #endif


### PR DESCRIPTION
GIT_BEGIN/END_DECL were missing from sys/refs.h and preventing
compilation with g++ as the symbol were mangled.
