### PR TITLE
[maint/v0.21] Fix build of tests with mingw

### DIFF
--- a/src/path.h
+++ b/src/path.h
@@ -8,6 +8,7 @@
 #define INCLUDE_path_h__
 
 #include "common.h"
+#include "posix.h"
 #include "buffer.h"
 #include "vector.h"
 


### PR DESCRIPTION
very, very partial backport of 2f795d8fc50d81641d95723d9ddd92795886bed3 to maint/v0.21 branch

without this include (or equivalent in some other location), O_RDWR and O_CREAT are undeclared when building tests/path/win32.c with mingw

ref #2766 for discussion
