### PR TITLE
Borrowing configuration entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ v0.22 + 1
   set and query which identity will be used when writing to the
   reflog.
 
+* `git_config_entry_free()` frees a config entry.
+
+* `git_config_get_string_buf()` provides a way to safely retrieve a
+  string from a non-snapshot configuration.
+
 ### API removals
 
 ### Breaking API changes
@@ -52,6 +57,13 @@ v0.22 + 1
       `git_repository_set_head_detached()`,
       `git_repository_detach_head()`
     * `git_reset()`
+
+* `git_config_get_entry()` now gives back a ref-counted
+  `git_config_entry`. You must free it when you no longer need it.
+
+* `git_config_get_string()` will return an error if used on a
+  non-snapshot configuration, as there can be no guarantee that the
+  returned pointer is valid.
 
 v0.22
 ------

--- a/include/git2/sys/config.h
+++ b/include/git2/sys/config.h
@@ -53,11 +53,13 @@ struct git_config_iterator {
  */
 struct git_config_backend {
 	unsigned int version;
+	/** True if this backend is for a snapshot */
+	int readonly;
 	struct git_config *cfg;
 
 	/* Open means open the file/database and parse if necessary */
 	int (*open)(struct git_config_backend *, git_config_level_t level);
-	int (*get)(struct git_config_backend *, const char *key, const git_config_entry **entry);
+	int (*get)(struct git_config_backend *, const char *key, git_config_entry **entry);
 	int (*set)(struct git_config_backend *, const char *key, const char *value);
 	int (*set_multivar)(git_config_backend *cfg, const char *name, const char *regexp, const char *value);
 	int (*del)(struct git_config_backend *, const char *key);

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -276,7 +276,7 @@ static int attr_cache__lookup_path(
 {
 	git_buf buf = GIT_BUF_INIT;
 	int error;
-	const git_config_entry *entry = NULL;
+	git_config_entry *entry = NULL;
 
 	*out = NULL;
 
@@ -296,6 +296,7 @@ static int attr_cache__lookup_path(
 	else if (!git_sysdir_find_xdg_file(&buf, fallback))
 		*out = git_buf_detach(&buf);
 
+	git_config_entry_free(entry);
 	git_buf_free(&buf);
 
 	return error;

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2390,25 +2390,27 @@ static int checkout_data_init(
 
 	if ((data->opts.checkout_strategy &
 		(GIT_CHECKOUT_CONFLICT_STYLE_MERGE | GIT_CHECKOUT_CONFLICT_STYLE_DIFF3)) == 0) {
-		const char *conflict_style;
+		git_config_entry *conflict_style = NULL;
 		git_config *cfg = NULL;
 
 		if ((error = git_repository_config__weakptr(&cfg, repo)) < 0 ||
-			(error = git_config_get_string(&conflict_style, cfg, "merge.conflictstyle")) < 0 ||
+			(error = git_config_get_entry(&conflict_style, cfg, "merge.conflictstyle")) < 0 ||
 			error == GIT_ENOTFOUND)
 			;
 		else if (error)
 			goto cleanup;
-		else if (strcmp(conflict_style, "merge") == 0)
+		else if (strcmp(conflict_style->value, "merge") == 0)
 			data->opts.checkout_strategy |= GIT_CHECKOUT_CONFLICT_STYLE_MERGE;
-		else if (strcmp(conflict_style, "diff3") == 0)
+		else if (strcmp(conflict_style->value, "diff3") == 0)
 			data->opts.checkout_strategy |= GIT_CHECKOUT_CONFLICT_STYLE_DIFF3;
 		else {
 			giterr_set(GITERR_CHECKOUT, "unknown style '%s' given for 'merge.conflictstyle'",
 				conflict_style);
 			error = -1;
+			git_config_entry_free(conflict_style);
 			goto cleanup;
 		}
+		git_config_entry_free(conflict_style);
 	}
 
 	if ((error = git_vector_init(&data->removes, 0, git__strcmp_cb)) < 0 ||

--- a/src/config.h
+++ b/src/config.h
@@ -48,7 +48,7 @@ extern int git_config__normalize_name(const char *in, char **out);
 
 /* internal only: does not normalize key and sets out to NULL if not found */
 extern int git_config__lookup_entry(
-	const git_config_entry **out,
+	git_config_entry **out,
 	const git_config *cfg,
 	const char *key,
 	bool no_errors);
@@ -67,7 +67,7 @@ extern int git_config__update_entry(
  * failures occur while trying to access the value.
  */
 
-extern const char *git_config__get_string_force(
+extern char *git_config__get_string_force(
 	const git_config *cfg, const char *key, const char *fallback_value);
 
 extern int git_config__get_bool_force(

--- a/src/config_cache.c
+++ b/src/config_cache.c
@@ -84,7 +84,7 @@ int git_config__cvar(int *out, git_config *config, git_cvar_cached cvar)
 {
 	int error = 0;
 	struct map_data *data = &_cvar_maps[(int)cvar];
-	const git_config_entry *entry;
+	git_config_entry *entry;
 
 	git_config__lookup_entry(&entry, config, data->cvar_name, false);
 
@@ -96,6 +96,7 @@ int git_config__cvar(int *out, git_config *config, git_cvar_cached cvar)
 	else
 		error = git_config_parse_bool(out, entry->value);
 
+	git_config_entry_free(entry);
 	return error;
 }
 

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -21,7 +21,7 @@ GIT_INLINE(void) git_config_file_free(git_config_backend *cfg)
 }
 
 GIT_INLINE(int) git_config_file_get_string(
-	const git_config_entry **out, git_config_backend *cfg, const char *name)
+	git_config_entry **out, git_config_backend *cfg, const char *name)
 {
 	return cfg->get(cfg, name, out);
 }

--- a/src/diff.c
+++ b/src/diff.c
@@ -461,12 +461,13 @@ static int diff_list_apply_options(
 
 	/* if ignore_submodules not explicitly set, check diff config */
 	if (diff->opts.ignore_submodules <= 0) {
-		const git_config_entry *entry;
+		 git_config_entry *entry;
 		git_config__lookup_entry(&entry, cfg, "diff.ignoresubmodules", true);
 
 		if (entry && git_submodule_parse_ignore(
 				&diff->opts.ignore_submodules, entry->value) < 0)
 			giterr_clear();
+		git_config_entry_free(entry);
 	}
 
 	/* if either prefix is not set, figure out appropriate value */

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -242,7 +242,7 @@ static int git_diff_driver_load(
 	khiter_t pos;
 	git_config *cfg = NULL;
 	git_buf name = GIT_BUF_INIT;
-	const git_config_entry *ce;
+	git_config_entry *ce = NULL;
 	bool found_driver = false;
 
 	if ((reg = git_repository_driver_registry(repo)) == NULL)
@@ -341,6 +341,7 @@ static int git_diff_driver_load(
 	*out = drv;
 
 done:
+	git_config_entry_free(ce);
 	git_buf_free(&name);
 	git_config_free(cfg);
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -52,7 +52,7 @@ static int add_refspec(git_remote *remote, const char *string, bool is_fetch)
 
 static int download_tags_value(git_remote *remote, git_config *cfg)
 {
-	const git_config_entry *ce;
+	git_config_entry *ce;
 	git_buf buf = GIT_BUF_INIT;
 	int error;
 
@@ -70,6 +70,7 @@ static int download_tags_value(git_remote *remote, git_config *cfg)
 			remote->download_tags = GIT_REMOTE_DOWNLOAD_TAGS_ALL;
 	}
 
+	git_config_entry_free(ce);
 	return error;
 }
 
@@ -548,7 +549,7 @@ int git_remote_save(const git_remote *remote)
 	git_config *cfg;
 	const char *tagopt = NULL;
 	git_buf buf = GIT_BUF_INIT;
-	const git_config_entry *existing;
+	git_config_entry *existing = NULL;
 
 	assert(remote);
 
@@ -618,6 +619,7 @@ int git_remote_save(const git_remote *remote)
 		cfg, git_buf_cstr(&buf), tagopt, true, false);
 
 cleanup:
+	git_config_entry_free(existing);
 	git_buf_free(&buf);
 	return error;
 }
@@ -753,7 +755,7 @@ int git_remote_ls(const git_remote_head ***out, size_t *size, git_remote *remote
 int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_url)
 {
 	git_config *cfg;
-	const git_config_entry *ce;
+	git_config_entry *ce = NULL;
 	const char *val = NULL;
 	int error;
 
@@ -805,6 +807,7 @@ found:
 		*proxy_url = git__strdup(val);
 		GITERR_CHECK_ALLOC(*proxy_url);
 	}
+	git_config_entry_free(ce);
 
 	return 0;
 }

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -291,7 +291,7 @@ void test_clone_nonetwork__clone_from_empty_sets_upstream(void)
 	cl_set_cleanup(&cleanup_repository, "./repowithunborn");
 	cl_git_pass(git_clone(&repo, "./test1", "./repowithunborn", NULL));
 
-	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_repository_config_snapshot(&config, repo));
 
 	cl_git_pass(git_config_get_string(&str, config, "branch.master.remote"));
 	cl_assert_equal_s("origin", str);

--- a/tests/config/config_helpers.c
+++ b/tests/config/config_helpers.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 #include "config_helpers.h"
 #include "repository.h"
+#include "buffer.h"
 
 void assert_config_entry_existence(
 	git_repository *repo,
@@ -8,12 +9,13 @@ void assert_config_entry_existence(
 	bool is_supposed_to_exist)
 {
 	git_config *config;
-	const char *out;
+	git_config_entry *entry = NULL;
 	int result;
 
 	cl_git_pass(git_repository_config__weakptr(&config, repo));
 	
-	result = git_config_get_string(&out, config, name);
+	result = git_config_get_entry(&entry, config, name);
+	git_config_entry_free(entry);
 
 	if (is_supposed_to_exist)
 		cl_git_pass(result);
@@ -27,13 +29,14 @@ void assert_config_entry_value(
 	const char *expected_value)
 {
 	git_config *config;
-	const char *out;
+	git_buf buf = GIT_BUF_INIT;
 
 	cl_git_pass(git_repository_config__weakptr(&config, repo));
 
-	cl_git_pass(git_config_get_string(&out, config, name));
+	cl_git_pass(git_config_get_string_buf(&buf, config, name));
 
-	cl_assert_equal_s(expected_value, out);
+	cl_assert_equal_s(expected_value, git_buf_cstr(&buf));
+	git_buf_free(&buf);
 }
 
 static int count_config_entries_cb(

--- a/tests/config/configlevel.c
+++ b/tests/config/configlevel.c
@@ -22,7 +22,7 @@ void test_config_configlevel__adding_the_same_level_twice_returns_EEXISTS(void)
 void test_config_configlevel__can_replace_a_config_file_at_an_existing_level(void)
 {
 	git_config *cfg;
-	const char *s;
+	git_buf buf = {0};
 
 	cl_git_pass(git_config_new(&cfg));
 	cl_git_pass(git_config_add_file_ondisk(cfg, cl_fixture("config/config18"),
@@ -30,9 +30,10 @@ void test_config_configlevel__can_replace_a_config_file_at_an_existing_level(voi
 	cl_git_pass(git_config_add_file_ondisk(cfg, cl_fixture("config/config19"),
 		GIT_CONFIG_LEVEL_LOCAL, 1));
 
-	cl_git_pass(git_config_get_string(&s, cfg, "core.stringglobal"));
-	cl_assert_equal_s("don't find me!", s);
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.stringglobal"));
+	cl_assert_equal_s("don't find me!", buf.ptr);
 
+	git_buf_free(&buf);
 	git_config_free(cfg);
 }
 
@@ -40,7 +41,7 @@ void test_config_configlevel__can_read_from_a_single_level_focused_file_after_pa
 {
 	git_config *cfg;
 	git_config *single_level_cfg;
-	const char *s;
+	git_buf buf = {0};
 
 	cl_git_pass(git_config_new(&cfg));
 	cl_git_pass(git_config_add_file_ondisk(cfg, cl_fixture("config/config18"),
@@ -52,9 +53,10 @@ void test_config_configlevel__can_read_from_a_single_level_focused_file_after_pa
 
 	git_config_free(cfg);
 
-	cl_git_pass(git_config_get_string(&s, single_level_cfg, "core.stringglobal"));
-	cl_assert_equal_s("don't find me!", s);
+	cl_git_pass(git_config_get_string_buf(&buf, single_level_cfg, "core.stringglobal"));
+	cl_assert_equal_s("don't find me!", buf.ptr);
 
+	git_buf_free(&buf);
 	git_config_free(single_level_cfg);
 }
 

--- a/tests/config/global.c
+++ b/tests/config/global.c
@@ -46,8 +46,9 @@ void test_config_global__open_global(void)
 void test_config_global__open_xdg(void)
 {
 	git_config *cfg, *xdg, *selected;
-	const char *val, *str = "teststring";
+	const char *str = "teststring";
 	const char *key = "this.variable";
+	git_buf buf = {0};
 
 	cl_git_mkfile("xdg/git/config", "# XDG config\n[core]\n  test = 1\n");
 
@@ -56,9 +57,10 @@ void test_config_global__open_xdg(void)
 	cl_git_pass(git_config_open_global(&selected, cfg));
 
 	cl_git_pass(git_config_set_string(xdg, key, str));
-	cl_git_pass(git_config_get_string(&val, selected, key));
-	cl_assert_equal_s(str, val);
+	cl_git_pass(git_config_get_string_buf(&buf, selected, key));
+	cl_assert_equal_s(str, buf.ptr);
 
+	git_buf_free(&buf);
 	git_config_free(selected);
 	git_config_free(xdg);
 	git_config_free(cfg);

--- a/tests/config/new.c
+++ b/tests/config/new.c
@@ -8,8 +8,8 @@
 
 void test_config_new__write_new_config(void)
 {
-	const char *out;
 	git_config *config;
+	git_buf buf = GIT_BUF_INIT;
 
 	cl_git_mkfile(TEST_CONFIG, "");
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
@@ -21,11 +21,13 @@ void test_config_new__write_new_config(void)
 
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
 
-	cl_git_pass(git_config_get_string(&out, config, "color.ui"));
-	cl_assert_equal_s(out, "auto");
-	cl_git_pass(git_config_get_string(&out, config, "core.editor"));
-	cl_assert_equal_s(out, "ed");
+	cl_git_pass(git_config_get_string_buf(&buf, config, "color.ui"));
+	cl_assert_equal_s("auto", git_buf_cstr(&buf));
+	git_buf_clear(&buf);
+	cl_git_pass(git_config_get_string_buf(&buf, config, "core.editor"));
+	cl_assert_equal_s("ed", git_buf_cstr(&buf));
 
+	git_buf_free(&buf);
 	git_config_free(config);
 
 	p_unlink(TEST_CONFIG);

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -2,6 +2,13 @@
 #include "buffer.h"
 #include "path.h"
 
+static git_buf buf = GIT_BUF_INIT;
+
+void test_config_read__cleanup(void)
+{
+	git_buf_free(&buf);
+}
+
 void test_config_read__simple_read(void)
 {
 	git_config *cfg;
@@ -25,14 +32,15 @@ void test_config_read__case_sensitive(void)
 {
 	git_config *cfg;
 	int i;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config1")));
 
-	cl_git_pass(git_config_get_string(&str, cfg, "this.that.other"));
-	cl_assert_equal_s(str, "true");
-	cl_git_pass(git_config_get_string(&str, cfg, "this.That.other"));
-	cl_assert_equal_s(str, "yes");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "this.that.other"));
+	cl_assert_equal_s("true", git_buf_cstr(&buf));
+	git_buf_clear(&buf);
+
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "this.That.other"));
+	cl_assert_equal_s("yes", git_buf_cstr(&buf));
 
 	cl_git_pass(git_config_get_bool(&i, cfg, "this.that.other"));
 	cl_assert(i == 1);
@@ -52,12 +60,11 @@ void test_config_read__case_sensitive(void)
 void test_config_read__multiline_value(void)
 {
 	git_config *cfg;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config2")));
 
-	cl_git_pass(git_config_get_string(&str, cfg, "this.That.and"));
-	cl_assert_equal_s(str, "one one one two two three three");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "this.That.and"));
+	cl_assert_equal_s("one one one two two three three", git_buf_cstr(&buf));
 
 	git_config_free(cfg);
 }
@@ -68,15 +75,14 @@ void test_config_read__multiline_value(void)
 void test_config_read__subsection_header(void)
 {
 	git_config *cfg;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config3")));
 
-	cl_git_pass(git_config_get_string(&str, cfg, "section.subsection.var"));
-	cl_assert_equal_s(str, "hello");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "section.subsection.var"));
+	cl_assert_equal_s("hello", git_buf_cstr(&buf));
 
 	/* The subsection is transformed to lower-case */
-	cl_must_fail(git_config_get_string(&str, cfg, "section.subSectIon.var"));
+	cl_must_fail(git_config_get_string_buf(&buf, cfg, "section.subSectIon.var"));
 
 	git_config_free(cfg);
 }
@@ -84,21 +90,21 @@ void test_config_read__subsection_header(void)
 void test_config_read__lone_variable(void)
 {
 	git_config *cfg;
-	const char *str;
 	int i;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config4")));
 
 	cl_git_fail(git_config_get_int32(&i, cfg, "some.section.variable"));
 
-	cl_git_pass(git_config_get_string(&str, cfg, "some.section.variable"));
-	cl_assert_equal_s(str, "");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "some.section.variable"));
+	cl_assert_equal_s("", git_buf_cstr(&buf));
+	git_buf_clear(&buf);
 
 	cl_git_pass(git_config_get_bool(&i, cfg, "some.section.variable"));
 	cl_assert(i == 1);
 
-	cl_git_pass(git_config_get_string(&str, cfg, "some.section.variableeq"));
-	cl_assert_equal_s(str, "");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "some.section.variableeq"));
+	cl_assert_equal_s("", git_buf_cstr(&buf));
 
 	cl_git_pass(git_config_get_bool(&i, cfg, "some.section.variableeq"));
 	cl_assert(i == 0);
@@ -184,14 +190,14 @@ void test_config_read__header_in_last_line(void)
 void test_config_read__prefixes(void)
 {
 	git_config *cfg;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config9")));
-	cl_git_pass(git_config_get_string(&str, cfg, "remote.ab.url"));
-	cl_assert_equal_s(str, "http://example.com/git/ab");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "remote.ab.url"));
+	cl_assert_equal_s("http://example.com/git/ab", git_buf_cstr(&buf));
+	git_buf_clear(&buf);
 
-	cl_git_pass(git_config_get_string(&str, cfg, "remote.abba.url"));
-	cl_assert_equal_s(str, "http://example.com/git/abba");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "remote.abba.url"));
+	cl_assert_equal_s("http://example.com/git/abba", git_buf_cstr(&buf));
 
 	git_config_free(cfg);
 }
@@ -199,11 +205,10 @@ void test_config_read__prefixes(void)
 void test_config_read__escaping_quotes(void)
 {
 	git_config *cfg;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config13")));
-	cl_git_pass(git_config_get_string(&str, cfg, "core.editor"));
-	cl_assert_equal_s("\"C:/Program Files/Nonsense/bah.exe\" \"--some option\"", str);
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.editor"));
+	cl_assert_equal_s("\"C:/Program Files/Nonsense/bah.exe\" \"--some option\"", git_buf_cstr(&buf));
 
 	git_config_free(cfg);
 }
@@ -363,15 +368,15 @@ void test_config_read__iterator_glob(void)
 void test_config_read__whitespace_not_required_around_assignment(void)
 {
 	git_config *cfg;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config14")));
 
-	cl_git_pass(git_config_get_string(&str, cfg, "a.b"));
-	cl_assert_equal_s(str, "c");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "a.b"));
+	cl_assert_equal_s("c", git_buf_cstr(&buf));
+	git_buf_clear(&buf);
 
-	cl_git_pass(git_config_get_string(&str, cfg, "d.e"));
-	cl_assert_equal_s(str, "f");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "d.e"));
+	cl_assert_equal_s("f", git_buf_cstr(&buf));
 
 	git_config_free(cfg);
 }
@@ -379,7 +384,7 @@ void test_config_read__whitespace_not_required_around_assignment(void)
 void test_config_read__read_git_config_entry(void)
 {
 	git_config *cfg;
-	const git_config_entry *entry;
+	git_config_entry *entry;
 
 	cl_git_pass(git_config_new(&cfg));
 	cl_git_pass(git_config_add_file_ondisk(cfg, cl_fixture("config/config9"),
@@ -390,6 +395,7 @@ void test_config_read__read_git_config_entry(void)
 	cl_assert_equal_s("42", entry->value);
 	cl_assert_equal_i(GIT_CONFIG_LEVEL_SYSTEM, entry->level);
 
+	git_config_entry_free(entry);
 	git_config_free(cfg);
 }
 
@@ -480,7 +486,6 @@ void test_config_read__simple_read_from_specific_level(void)
 	git_config *cfg, *cfg_specific;
 	int i;
 	int64_t l, expected = +9223372036854775803;
-	const char *s;
 
 	cl_git_pass(git_config_new(&cfg));
 	cl_git_pass(git_config_add_file_ondisk(cfg, cl_fixture("config/config18"),
@@ -496,8 +501,8 @@ void test_config_read__simple_read_from_specific_level(void)
 	cl_assert(l == expected);
 	cl_git_pass(git_config_get_bool(&i, cfg_specific, "core.boolglobal"));
 	cl_assert_equal_b(true, i);
-	cl_git_pass(git_config_get_string(&s, cfg_specific, "core.stringglobal"));
-	cl_assert_equal_s("I'm a global config value!", s);
+	cl_git_pass(git_config_get_string_buf(&buf, cfg_specific, "core.stringglobal"));
+	cl_assert_equal_s("I'm a global config value!", git_buf_cstr(&buf));
 
 	git_config_free(cfg_specific);
 	git_config_free(cfg);
@@ -558,14 +563,13 @@ void test_config_read__corrupt_header3(void)
 void test_config_read__override_variable(void)
 {
 	git_config *cfg;
-	const char *str;
 
 	cl_set_cleanup(&clean_test_config, NULL);
 	cl_git_mkfile("./testconfig", "[some] var = one\nvar = two");
 	cl_git_pass(git_config_open_ondisk(&cfg, "./testconfig"));
 
-	cl_git_pass(git_config_get_string(&str, cfg, "some.var"));
-	cl_assert_equal_s(str, "two");
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "some.var"));
+	cl_assert_equal_s("two", git_buf_cstr(&buf));
 
 	git_config_free(cfg);
 }

--- a/tests/config/rename.c
+++ b/tests/config/rename.c
@@ -21,11 +21,12 @@ void test_config_rename__cleanup(void)
 
 void test_config_rename__can_rename(void)
 {
-	const git_config_entry *ce;
+	git_config_entry *ce;
 
 	cl_git_pass(git_config_get_entry(
 		&ce, g_config, "branch.track-local.remote"));
 	cl_assert_equal_s(".", ce->value);
+	git_config_entry_free(ce);
 
 	cl_git_fail(git_config_get_entry(
 		&ce, g_config, "branch.local-track.remote"));
@@ -36,6 +37,7 @@ void test_config_rename__can_rename(void)
 	cl_git_pass(git_config_get_entry(
 		&ce, g_config, "branch.local-track.remote"));
 	cl_assert_equal_s(".", ce->value);
+	git_config_entry_free(ce);
 
 	cl_git_fail(git_config_get_entry(
 		&ce, g_config, "branch.track-local.remote"));
@@ -43,7 +45,7 @@ void test_config_rename__can_rename(void)
 
 void test_config_rename__prevent_overwrite(void)
 {
-	const git_config_entry *ce;
+	git_config_entry *ce;
 
 	cl_git_pass(git_config_set_string(
 		g_config, "branch.local-track.remote", "yellow"));
@@ -51,6 +53,7 @@ void test_config_rename__prevent_overwrite(void)
 	cl_git_pass(git_config_get_entry(
 		&ce, g_config, "branch.local-track.remote"));
 	cl_assert_equal_s("yellow", ce->value);
+	git_config_entry_free(ce);
 
 	cl_git_pass(git_config_rename_section(
 		g_repo, "branch.track-local", "branch.local-track"));
@@ -58,6 +61,7 @@ void test_config_rename__prevent_overwrite(void)
 	cl_git_pass(git_config_get_entry(
 		&ce, g_config, "branch.local-track.remote"));
 	cl_assert_equal_s(".", ce->value);
+	git_config_entry_free(ce);
 
 	/* so, we don't currently prevent overwrite... */
 	/* {

--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -6,6 +6,8 @@
 
 #define TEST_CONFIG "git-test-config"
 
+static git_buf buf = GIT_BUF_INIT;
+
 void test_config_stress__initialize(void)
 {
 	git_filebuf file = GIT_FILEBUF_INIT;
@@ -20,50 +22,43 @@ void test_config_stress__initialize(void)
 
 void test_config_stress__cleanup(void)
 {
+	git_buf_free(&buf);
 	p_unlink(TEST_CONFIG);
 }
 
 void test_config_stress__dont_break_on_invalid_input(void)
 {
-	const char *editor, *color;
 	git_config *config;
 
 	cl_assert(git_path_exists(TEST_CONFIG));
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
 
-	cl_git_pass(git_config_get_string(&color, config, "color.ui"));
-	cl_git_pass(git_config_get_string(&editor, config, "core.editor"));
+	cl_git_pass(git_config_get_string_buf(&buf, config, "color.ui"));
+	cl_git_pass(git_config_get_string_buf(&buf, config, "core.editor"));
 
 	git_config_free(config);
+}
+
+void assert_config_value(git_config *config, const char *key, const char *value)
+{
+	git_buf_clear(&buf);
+	cl_git_pass(git_config_get_string_buf(&buf, config, key));
+	cl_assert_equal_s(value, git_buf_cstr(&buf));
 }
 
 void test_config_stress__comments(void)
 {
 	git_config *config;
-	const char *str;
 
 	cl_git_pass(git_config_open_ondisk(&config, cl_fixture("config/config12")));
 
-	cl_git_pass(git_config_get_string(&str, config, "some.section.test2"));
-	cl_assert_equal_s("hello", str);
-
-	cl_git_pass(git_config_get_string(&str, config, "some.section.test3"));
-	cl_assert_equal_s("welcome", str);
-
-	cl_git_pass(git_config_get_string(&str, config, "some.section.other"));
-	cl_assert_equal_s("hello! \" ; ; ; ", str);
-
-	cl_git_pass(git_config_get_string(&str, config, "some.section.other2"));
-	cl_assert_equal_s("cool! \" # # # ", str);
-
-	cl_git_pass(git_config_get_string(&str, config, "some.section.multi"));
-	cl_assert_equal_s("hi, this is a ; multiline comment # with ;\n special chars and other stuff !@#", str);
-
-	cl_git_pass(git_config_get_string(&str, config, "some.section.multi2"));
-	cl_assert_equal_s("good, this is a ; multiline comment # with ;\n special chars and other stuff !@#", str);
-
-	cl_git_pass(git_config_get_string(&str, config, "some.section.back"));
-	cl_assert_equal_s("this is \ba phrase", str);
+	assert_config_value(config, "some.section.test2", "hello");
+	assert_config_value(config, "some.section.test3", "welcome");
+	assert_config_value(config, "some.section.other", "hello! \" ; ; ; ");
+	assert_config_value(config, "some.section.other2", "cool! \" # # # ");
+	assert_config_value(config, "some.section.multi", "hi, this is a ; multiline comment # with ;\n special chars and other stuff !@#");
+	assert_config_value(config, "some.section.multi2", "good, this is a ; multiline comment # with ;\n special chars and other stuff !@#");
+	assert_config_value(config, "some.section.back", "this is \ba phrase");
 
 	git_config_free(config);
 }
@@ -71,7 +66,6 @@ void test_config_stress__comments(void)
 void test_config_stress__escape_subsection_names(void)
 {
 	git_config *config;
-	const char *str;
 
 	cl_assert(git_path_exists("git-test-config"));
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
@@ -81,15 +75,14 @@ void test_config_stress__escape_subsection_names(void)
 
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
 
-	cl_git_pass(git_config_get_string(&str, config, "some.sec\\tion.other"));
-	cl_assert_equal_s("foo", str);
+	assert_config_value(config, "some.sec\\tion.other", "foo");
+
 	git_config_free(config);
 }
 
 void test_config_stress__trailing_backslash(void)
 {
 	git_config *config;
-	const char *str;
 	const char *path =  "C:\\iam\\some\\windows\\path\\";
 
 	cl_assert(git_path_exists("git-test-config"));
@@ -98,20 +91,19 @@ void test_config_stress__trailing_backslash(void)
 	git_config_free(config);
 
 	cl_git_pass(git_config_open_ondisk(&config, TEST_CONFIG));
-	cl_git_pass(git_config_get_string(&str, config, "windows.path"));
-	cl_assert_equal_s(path, str);
+	assert_config_value(config, "windows.path", path);
+
 	git_config_free(config);
 }
 
 void test_config_stress__complex(void)
 {
 	git_config *config;
-	const char *str;
 	const char *path = "./config-immediate-multiline";
 
 	cl_git_mkfile(path, "[imm]\n multi = \"\\\nfoo\"");
 	cl_git_pass(git_config_open_ondisk(&config, path));
-	cl_git_pass(git_config_get_string(&str, config, "imm.multi"));
-	cl_assert_equal_s(str, "foo");
+	assert_config_value(config, "imm.multi", "foo");
+
 	git_config_free(config);
 }

--- a/tests/config/validkeyname.c
+++ b/tests/config/validkeyname.c
@@ -3,7 +3,6 @@
 #include "config.h"
 
 static git_config *cfg;
-static const char *value;
 
 void test_config_validkeyname__initialize(void)
 {
@@ -22,7 +21,9 @@ void test_config_validkeyname__cleanup(void)
 
 static void assert_invalid_config_key_name(const char *name)
 {
-	cl_git_fail_with(git_config_get_string(&value, cfg, name),
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_fail_with(git_config_get_string_buf(&buf, cfg, name),
 		GIT_EINVALIDSPEC);
 	cl_git_fail_with(git_config_set_string(cfg, name, "42"),
 		GIT_EINVALIDSPEC);

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "config/config_helpers.h"
 #include "buffer.h"
 #include "refspec.h"
 #include "remote.h"
@@ -385,26 +386,17 @@ void test_network_remote_remotes__cannot_add_a_remote_with_an_invalid_name(void)
 
 void test_network_remote_remotes__tagopt(void)
 {
-	const char *opt;
-	git_config *cfg;
-
-	cl_git_pass(git_repository_config(&cfg, _repo));
-
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_ALL);
 	cl_git_pass(git_remote_save(_remote));
-	cl_git_pass(git_config_get_string(&opt, cfg, "remote.test.tagopt"));
-	cl_assert_equal_s("--tags", opt);
+	assert_config_entry_value(_repo, "remote.test.tagopt", "--tags");
 
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_NONE);
 	cl_git_pass(git_remote_save(_remote));
-	cl_git_pass(git_config_get_string(&opt, cfg, "remote.test.tagopt"));
-	cl_assert_equal_s("--no-tags", opt);
+	assert_config_entry_value(_repo, "remote.test.tagopt", "--no-tags");
 
 	git_remote_set_autotag(_remote, GIT_REMOTE_DOWNLOAD_TAGS_AUTO);
 	cl_git_pass(git_remote_save(_remote));
-	cl_assert(git_config_get_string(&opt, cfg, "remote.test.tagopt") == GIT_ENOTFOUND);
-
-	git_config_free(cfg);
+	assert_config_entry_existence(_repo, "remote.test.tagopt", false);
 }
 
 void test_network_remote_remotes__can_load_with_an_empty_url(void)

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "config/config_helpers.h"
 #include "refs.h"
 
 static git_repository *repo;
@@ -123,8 +124,6 @@ void test_refs_branches_upstream__set_unset_upstream(void)
 {
 	git_reference *branch;
 	git_repository *repository;
-	const char *value;
-	git_config *config;
 
 	repository = cl_git_sandbox_init("testrepo.git");
 
@@ -132,11 +131,8 @@ void test_refs_branches_upstream__set_unset_upstream(void)
 	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/test"));
 	cl_git_pass(git_branch_set_upstream(branch, "test/master"));
 
-	cl_git_pass(git_repository_config(&config, repository));
-	cl_git_pass(git_config_get_string(&value, config, "branch.test.remote"));
-	cl_assert_equal_s(value, "test");
-	cl_git_pass(git_config_get_string(&value, config, "branch.test.merge"));
-	cl_assert_equal_s(value, "refs/heads/master");
+	assert_config_entry_value(repository, "branch.test.remote", "test");
+	assert_config_entry_value(repository, "branch.test.merge", "refs/heads/master");
 
 	git_reference_free(branch);
 
@@ -144,25 +140,22 @@ void test_refs_branches_upstream__set_unset_upstream(void)
 	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/test"));
 	cl_git_pass(git_branch_set_upstream(branch, "master"));
 
-	cl_git_pass(git_config_get_string(&value, config, "branch.test.remote"));
-	cl_assert_equal_s(value, ".");
-	cl_git_pass(git_config_get_string(&value, config, "branch.test.merge"));
-	cl_assert_equal_s(value, "refs/heads/master");
+	assert_config_entry_value(repository, "branch.test.remote", ".");
+	assert_config_entry_value(repository, "branch.test.merge", "refs/heads/master");
 
 	/* unset */
 	cl_git_pass(git_branch_set_upstream(branch, NULL));
-	cl_git_fail_with(git_config_get_string(&value, config, "branch.test.merge"), GIT_ENOTFOUND);
-	cl_git_fail_with(git_config_get_string(&value, config, "branch.test.remote"), GIT_ENOTFOUND);
+	assert_config_entry_existence(repository, "branch.test.remote", false);
+	assert_config_entry_existence(repository, "branch.test.merge", false);
 
 	git_reference_free(branch);
 
 	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/master"));
 	cl_git_pass(git_branch_set_upstream(branch, NULL));
-	cl_git_fail_with(git_config_get_string(&value, config, "branch.master.merge"), GIT_ENOTFOUND);
-	cl_git_fail_with(git_config_get_string(&value, config, "branch.master.remote"), GIT_ENOTFOUND);
+	assert_config_entry_existence(repository, "branch.test.remote", false);
+	assert_config_entry_existence(repository, "branch.test.merge", false);
 
 	git_reference_free(branch);
 
-	git_config_free(config);
 	cl_git_sandbox_cleanup();
 }

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -3,6 +3,7 @@
 #include "repository.h"
 #include "config.h"
 #include "path.h"
+#include "config/config_helpers.h"
 
 enum repo_mode {
 	STANDARD_REPOSITORY = 0,
@@ -370,8 +371,6 @@ void test_repo_init__extended_1(void)
 void test_repo_init__relative_gitdir(void)
 {
 	git_repository_init_options opts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
-	git_config *cfg;
-	const char *worktree_path;
 	git_buf dot_git_content = GIT_BUF_INIT;
 
 	opts.workdir_path = "../c_wd";
@@ -391,24 +390,19 @@ void test_repo_init__relative_gitdir(void)
 	/* Verify that the gitlink and worktree entries are relative */
 
 	/* Verify worktree */
-	cl_git_pass(git_repository_config(&cfg, _repo));
-	cl_git_pass(git_config_get_string(&worktree_path, cfg, "core.worktree"));
-	cl_assert_equal_s("../c_wd/", worktree_path);
+	assert_config_entry_value(_repo, "core.worktree", "../c_wd/");
 
 	/* Verify gitlink */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
 	cl_assert_equal_s("gitdir: ../my_repository/", dot_git_content.ptr);
 
 	git_buf_free(&dot_git_content);
-	git_config_free(cfg);
 	cleanup_repository("root");
 }
 
 void test_repo_init__relative_gitdir_2(void)
 {
 	git_repository_init_options opts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
-	git_config *cfg;
-	const char *worktree_path;
 	git_buf dot_git_content = GIT_BUF_INIT;
 	git_buf full_path = GIT_BUF_INIT;
 
@@ -433,16 +427,13 @@ void test_repo_init__relative_gitdir_2(void)
 	/* Verify that the gitlink and worktree entries are relative */
 
 	/* Verify worktree */
-	cl_git_pass(git_repository_config(&cfg, _repo));
-	cl_git_pass(git_config_get_string(&worktree_path, cfg, "core.worktree"));
-	cl_assert_equal_s("../c_wd/", worktree_path);
+	assert_config_entry_value(_repo, "core.worktree", "../c_wd/");
 
 	/* Verify gitlink */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
 	cl_assert_equal_s("gitdir: ../my_repository/", dot_git_content.ptr);
 
 	git_buf_free(&dot_git_content);
-	git_config_free(cfg);
 	cleanup_repository("root");
 }
 

--- a/tests/repo/setters.c
+++ b/tests/repo/setters.c
@@ -46,7 +46,7 @@ void test_repo_setters__setting_a_workdir_prettifies_its_path(void)
 void test_repo_setters__setting_a_workdir_creates_a_gitlink(void)
 {
 	git_config *cfg;
-	const char *val;
+	git_buf buf = GIT_BUF_INIT;
 	git_buf content = GIT_BUF_INIT;
 
 	cl_git_pass(git_repository_set_workdir(repo, "./new_workdir", true));
@@ -59,8 +59,10 @@ void test_repo_setters__setting_a_workdir_creates_a_gitlink(void)
 	git_buf_free(&content);
 
 	cl_git_pass(git_repository_config(&cfg, repo));
-	cl_git_pass(git_config_get_string(&val, cfg, "core.worktree"));
-	cl_assert(git__suffixcmp(val, "new_workdir/") == 0);
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.worktree"));
+	cl_assert(git__suffixcmp(git_buf_cstr(&buf), "new_workdir/") == 0);
+
+	git_buf_free(&buf);
 	git_config_free(cfg);
 }
 

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -2,6 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
+#include "config/config_helpers.h"
 #include "fileops.h"
 
 static git_repository *g_repo = NULL;
@@ -13,26 +14,19 @@ void test_submodule_add__cleanup(void)
 
 static void assert_submodule_url(const char* name, const char *url)
 {
-	git_config *cfg;
-	const char *s;
 	git_buf key = GIT_BUF_INIT;
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
 
 	cl_git_pass(git_buf_printf(&key, "submodule.%s.url", name));
-	cl_git_pass(git_config_get_string(&s, cfg, git_buf_cstr(&key)));
-	cl_assert_equal_s(s, url);
+	assert_config_entry_value(g_repo, git_buf_cstr(&key), url);
 
-	git_config_free(cfg);
 	git_buf_free(&key);
 }
 
 void test_submodule_add__url_absolute(void)
 {
 	git_submodule *sm;
-	git_config *cfg;
 	git_repository *repo;
-	const char *worktree_path;
 	git_buf dot_git_content = GIT_BUF_INIT;
 
 	g_repo = setup_fixture_submod2();
@@ -59,15 +53,12 @@ void test_submodule_add__url_absolute(void)
 	cl_git_pass(git_repository_open(&repo, "submod2/" "sm_libgit2"));
 
 	/* Verify worktree path is relative */
-	cl_git_pass(git_repository_config(&cfg, repo));
-	cl_git_pass(git_config_get_string(&worktree_path, cfg, "core.worktree"));
-	cl_assert_equal_s("../../../sm_libgit2/", worktree_path);
+	assert_config_entry_value(repo, "core.worktree", "../../../sm_libgit2/");
 
 	/* Verify gitdir path is relative */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "submod2/" "sm_libgit2" "/.git"));
 	cl_assert_equal_s("gitdir: ../.git/modules/sm_libgit2/", dot_git_content.ptr);
 
-	git_config_free(cfg);
 	git_repository_free(repo);
 	git_buf_free(&dot_git_content);
 

--- a/tests/submodule/init.c
+++ b/tests/submodule/init.c
@@ -34,9 +34,9 @@ void test_submodule_init__absolute_url(void)
 	/* init and verify that absolute path is written to .git/config */
 	cl_git_pass(git_submodule_init(sm, false));
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_snapshot(&cfg, g_repo));
 
-	git_config_get_string(&config_url, cfg, "submodule.testrepo.url");
+	cl_git_pass(git_config_get_string(&config_url, cfg, "submodule.testrepo.url"));
 	cl_assert_equal_s(absolute_url.ptr, config_url);
 
 	git_buf_free(&absolute_url);
@@ -64,9 +64,9 @@ void test_submodule_init__relative_url(void)
 	/* init and verify that absolute path is written to .git/config */
 	cl_git_pass(git_submodule_init(sm, false));
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_snapshot(&cfg, g_repo));
 
-	git_config_get_string(&config_url, cfg, "submodule.testrepo.url");
+	cl_git_pass(git_config_get_string(&config_url, cfg, "submodule.testrepo.url"));
 	cl_assert_equal_s(absolute_url.ptr, config_url);
 
 	git_buf_free(&absolute_url);
@@ -102,9 +102,9 @@ void test_submodule_init__relative_url_detached_head(void)
 	/* init and verify that absolute path is written to .git/config */
 	cl_git_pass(git_submodule_init(sm, false));
 
-	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_repository_config_snapshot(&cfg, g_repo));
 
-	git_config_get_string(&config_url, cfg, "submodule.testrepo.url");
+	cl_git_pass(git_config_get_string(&config_url, cfg, "submodule.testrepo.url"));
 	cl_assert_equal_s(absolute_url.ptr, config_url);
 
 	git_buf_free(&absolute_url);

--- a/tests/submodule/repository_init.c
+++ b/tests/submodule/repository_init.c
@@ -2,6 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
+#include "config/config_helpers.h"
 #include "fileops.h"
 
 static git_repository *g_repo = NULL;
@@ -10,8 +11,6 @@ void test_submodule_repository_init__basic(void)
 {
 	git_submodule *sm;
 	git_repository *repo;
-	git_config *cfg;
-	const char *worktree_path;
 	git_buf dot_git_content = GIT_BUF_INIT;
 
 	g_repo = setup_fixture_submod2();
@@ -21,9 +20,7 @@ void test_submodule_repository_init__basic(void)
 	cl_git_pass(git_submodule_repo_init(&repo, sm, 1));
 
 	/* Verify worktree */
-	cl_git_pass(git_repository_config(&cfg, repo));
-	cl_git_pass(git_config_get_string(&worktree_path, cfg, "core.worktree"));
-	cl_assert_equal_s("../../../sm_gitmodules_only/", worktree_path);
+	assert_config_entry_value(repo, "core.worktree", "../../../sm_gitmodules_only/");
 
 	/* Verify gitlink */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "submod2/" "sm_gitmodules_only" "/.git"));
@@ -35,7 +32,6 @@ void test_submodule_repository_init__basic(void)
 	cl_assert(git_path_isdir("submod2/.git/modules/" "sm_gitmodules_only"));
 	cl_assert(git_path_isfile("submod2/.git/modules/" "sm_gitmodules_only" "/HEAD"));
 
-	git_config_free(cfg);
 	git_submodule_free(sm);
 	git_repository_free(repo);
 	git_buf_free(&dot_git_content);


### PR DESCRIPTION
This code won't compile for now, as it would involve changes to every use of `_get_string()`.

We currently have "live" config objects and snapshots. The live ones are currently only useful for writing unless you're in a environment with absolutely no concurrency and you're careful. The snapshot is only useful for reading.

This makes reading a single entry a bit more hassle, as you need to take the snapshot and then free it just for the one entry. We have `git_repository_config_snapshot()` to save on temp vars, but you still need to remember to switch objects for writing. And id you use `git_repository_config()` and then perform a read, it may crash or the pointer it gives back may be already invalid.

So it'd be good to say how long an entry will be valid, and what better way than by refcounting everything. What I'm proposing here is that instead of an entry simply having the name, value and level, it should also have a way to say when we're done with it. The way I've implemented this is by using the refcount of the whole hashmap keeping the entries. Keeping one entry alive will keep everything else alive too, but you shouldn't be making use of them too long anyhow.

As part of this "making stuff safe", we cannot expect a `char *` to remain active for a live entry, so `_get_string()` uses a `git_buf` as a way to make a defensive copy which can be freed by the user. This is safe, which is good for live configs, but sucks for snapshots because now every use of `_get_string()` needs to keep track of yet another thing to free instead of relying on the snapshot, where we already know how long the string is going to live and creates a useless copy.

While it's not the end of the world, I'd like it if we could find a way to make this work by returning a `const char *` for the snapshot case but still use a `git_buf` for the live case. I've considered using two functions, and asserting that `_get_string(const char **out, ...)` can only be used for snapshot entries, but I'm not sure if the different APIs are worth the trouble.