### PR TITLE
Case changing rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,6 @@ v0.21 + 1
 * git_treebuilder_create now takes a repository so that it can query
   repository configuration.  Subsequently, git_treebuilder_write no
   longer takes a repository.
+
+* git_checkout now handles case-changing renames correctly on
+  case-insensitive filesystems; for example renaming "readme" to "README".

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2474,7 +2474,7 @@ int git_checkout_tree(
 	if ((error = git_repository_index(&index, repo)) < 0)
 		return error;
 
-	if (!(error = git_iterator_for_tree(&tree_i, tree, 0, NULL, NULL)))
+	if (!(error = git_iterator_for_tree(&tree_i, tree, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)))
 		error = git_checkout_iterator(tree_i, index, opts);
 
 	git_iterator_free(tree_i);

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -645,14 +645,7 @@ void test_checkout_tree__can_cancel_checkout_from_notify(void)
 	cl_git_fail_with(git_checkout_tree(g_repo, obj, &opts), -5555);
 
 	cl_assert(!git_path_exists("testrepo/new.txt"));
-
-	/* on case-insensitive FS = a/b.txt, branch_file.txt, new.txt */
-	/* on case-sensitive FS   = README, then above */
-
-	if (git_path_exists("testrepo/.git/CoNfIg")) /* case insensitive */
-		cl_assert_equal_i(3, ca.count);
-	else
-		cl_assert_equal_i(4, ca.count);
+	cl_assert_equal_i(4, ca.count);
 
 	/* and again with a different stopping point and return code */
 	ca.filename = "README";
@@ -662,11 +655,7 @@ void test_checkout_tree__can_cancel_checkout_from_notify(void)
 	cl_git_fail_with(git_checkout_tree(g_repo, obj, &opts), 123);
 
 	cl_assert(!git_path_exists("testrepo/new.txt"));
-
-	if (git_path_exists("testrepo/.git/CoNfIg")) /* case insensitive */
-		cl_assert_equal_i(4, ca.count);
-	else
-		cl_assert_equal_i(1, ca.count);
+	cl_assert_equal_i(1, ca.count);
 
 	git_object_free(obj);
 }


### PR DESCRIPTION
On a case insensitive filesystem, we always checkout using a case insensitive iterator, so we end up with a delta that contains (for example) old file: `readme` and new file: `README`.  This is treated as a modification of the same file.  Instead, we should treat this as a remove of the old name and an add of the new name.  If we do not update the index and working directory with the new name, we think that we are (rightly) different from the `HEAD` tree.

For example, I'm on the `master` branch, which contains a file `Foo.txt`:  I `git_checkout_tree` a different branch, which renamed this file to `FOO.txt`.  Neither the index or working directory are updated:

```
C:\Temp\TestRepo>dir
 Volume in drive C is ethomson-t430s
 Volume Serial Number is 8E09-4C48

 Directory of C:\Temp\TestRepo

05/09/2014  07:39 PM    <DIR>          .
05/09/2014  07:39 PM    <DIR>          ..
05/09/2014  07:38 PM                 6 Foo.txt
               1 File(s)              6 bytes
               2 Dir(s)  159,162,114,048 bytes free

C:\Temp\TestRepo>git ls-files --stage
100644 b4a3ed0e1a5cf987598e8bf4ebe3f64baa8a20c9 0       Foo.txt

C:\Temp\TestRepo>git status
On branch branch
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        renamed:    FOO.txt -> Foo.txt
```

Further, update the existing test which expects items to be sorted by the filesystem case sensitivity to handle the new case sensitivity.
