### PR TITLE
cmake: include FindPkgConfig for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Mo
 
 INCLUDE(CheckLibraryExists)
 INCLUDE(AddCFlagIfSupported)
+INCLUDE(FindPkgConfig)
 
 # Build options
 #


### PR DESCRIPTION
Apparently FindPkgConfig is not included by default on VS builds,
only Unix and Unix-like (mingw) builds.
