### PR TITLE
C# userdiff patterns update

### DIFF
--- a/src/userdiff.h
+++ b/src/userdiff.h
@@ -167,21 +167,45 @@ PATTERNS("cpp",
 	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lLuU]*"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->\\*?|\\.\\*"),
 
+	/* Possible TODO: Contextual keywords
+	 * http://msdn.microsoft.com/en-us/library/the35c6y.aspx
+	 * http://msdn.microsoft.com/en-us/library/bb310804.aspx
+	 */
+#define CS_VISIBILITY "internal|private|protected|public"
+#define CS_MEMBER_MODIFIER "abstract|new|override|partial|sealed|static|unsafe|virtual|" CS_VISIBILITY
+#define CS_METHOD_MODIFIER "async|extern|" CS_MEMBER_MODIFIER
+#define CS_KEYWORD \
+	"if|else|switch|case|" \
+	"do|for|foreach|in|while|" \
+	"break|continue|default|goto|return|yield|" \
+	"throw|try|catch|finally|" \
+	"unsafe|fixed|lock|" \
+	"await|base|this|new|var|" \
+	"null|true|false|" \
+	"as|is|sizeof|typeof|checked|unchecked|stackalloc|" \
+	"explicit|implicit|operator|" \
+	"delegate|readonly|ref|out|using"
+
 PATTERNS("csharp",
-	 /* Keywords */
-	 "!^[ \t]*(do|while|for|if|else|instanceof|new|return|switch|case|throw|catch|using)\n"
 	 /* Methods and constructors */
-	 "^[ \t]*(((static|public|internal|private|protected|new|virtual|sealed|override|unsafe)[ \t]+)*[][<>@.~_[:alnum:]]+[ \t]+[<>@._[:alnum:]]+[ \t]*\\(.*\\))[ \t]*$\n"
-	 /* Properties */
-	 "^[ \t]*(((static|public|internal|private|protected|new|virtual|sealed|override|unsafe)[ \t]+)*[][<>@.~_[:alnum:]]+[ \t]+[@._[:alnum:]]+)[ \t]*$\n"
+	 "^[ \t]*(((" CS_METHOD_MODIFIER ")[ \t]+)*[][<>@.~_[:alnum:]]+[ \t]+[<>@._[:alnum:]]+[ \t]*\\(.*\\))[ \t]*$\n"
+	 /* Properties, events, delegates */
+	 "^[ \t]*(((" CS_MEMBER_MODIFIER ")[ \t]+)*((delegate|event)[ \t]+)*[][<>@.~_[:alnum:]]+[ \t]+[@._[:alnum:]]+)[ \t]*$\n"
 	 /* Type definitions */
-	 "^[ \t]*(((static|public|internal|private|protected|new|unsafe|sealed|abstract|partial)[ \t]+)*(class|enum|interface|struct)[ \t]+.*)$\n"
+	 "^[ \t]*(((" CS_MEMBER_MODIFIER ")[ \t]+)*(class|enum|interface|struct)[ \t]+.*)$\n"
+	 /* Keywords */
+	 "!^[ \t]*(" CS_KEYWORD ")\n"
 	 /* Namespace */
 	 "^[ \t]*(namespace[ \t]+.*)$",
 	 /* -- */
 	 "[a-zA-Z_][a-zA-Z0-9_]*"
 	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lL]?"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->"),
+
+#undef CS_KEYWORD
+#undef CS_METHOD_MODIFIER
+#undef CS_MEMBER_MODIFIER
+#undef CS_VISIBILITY
 
 PATTERNS("php",
 	 "^[ \t]*(((public|private|protected|static|final)[ \t]+)*((class|function)[ \t].*))$",

--- a/tests/resources/userdiff/after/file.csharp
+++ b/tests/resources/userdiff/after/file.csharp
@@ -1,0 +1,31 @@
+using System;
+
+namespace Namespace.Some
+{
+	/// <summary>
+	/// Fake comment here for some line context.
+	/// </summary>
+	internal class Class
+	{
+		private void TestUnchanged()
+		{
+		}
+
+		// Scrub comment.
+		int changed;
+
+		async void TestFunction()
+		{
+			// Padding.
+			int changed;
+		}
+
+		static readonly int SomeProperty
+		{
+			get
+			{
+				return 1;
+			}
+		}
+	}
+}

--- a/tests/resources/userdiff/before/file.csharp
+++ b/tests/resources/userdiff/before/file.csharp
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+
+namespace Namespace.Some
+{
+	/// <summary>
+	/// Fake comment here for some line context.
+	/// </summary>
+	public class Class
+	{
+		private void TestUnchanged()
+		{
+		}
+
+		// Scrub comment.
+		const int changed;
+
+		async void TestFunction()
+		{
+			// Padding.
+			int changeme;
+		}
+
+		static readonly int SomeProperty
+		{
+			get
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/tests/resources/userdiff/expected/driver/diff.csharp
+++ b/tests/resources/userdiff/expected/driver/diff.csharp
@@ -1,0 +1,2 @@
+diff --git a/files/file.csharp b/files/file.csharp
+TODO: FILL ME

--- a/tests/resources/userdiff/expected/nodriver/diff.csharp
+++ b/tests/resources/userdiff/expected/nodriver/diff.csharp
@@ -1,0 +1,2 @@
+diff --git a/files/file.csharp b/files/file.csharp
+TODO: FILL ME

--- a/tests/resources/userdiff/files/file.csharp
+++ b/tests/resources/userdiff/files/file.csharp
@@ -1,0 +1,31 @@
+using System;
+
+namespace Namespace.Some
+{
+	/// <summary>
+	/// Fake comment here for some line context.
+	/// </summary>
+	internal class Class
+	{
+		private void TestUnchanged()
+		{
+		}
+
+		// Scrub comment.
+		int changed;
+
+		async void TestFunction()
+		{
+			// Padding.
+			int changed;
+		}
+
+		static readonly int SomeProperty
+		{
+			get
+			{
+				return 1;
+			}
+		}
+	}
+}


### PR DESCRIPTION
New keywords: foreach, break, in, try, finally, as, is, typeof, var,
default, fixed, checked, unchecked, this, lock, readonly, unsafe,
ref, out, base, null, delegate, continue.

Moved keywords to happen before modifier parsing, as matching a keyword
will stop modifiers from being matched.

The reasoning behind adding unsafe to keywords is being also a
statement that can happen inline in code to mention blocks which are
unsafe. Also, delegates are not necessarily declared in class bodies,
but can also happen inline in other functions.

Added parsing of events and delegates, which are like properties, but
take an extra keyword.

Added extern, abstract to methods modifiers.

Added abstract to properties/events/delegates.

Also, removed instanceof.
