### PR TITLE
index: reuc and name entrycounts should be size_t

### DIFF
--- a/include/git2/sys/index.h
+++ b/include/git2/sys/index.h
@@ -42,7 +42,7 @@ typedef struct git_index_reuc_entry {
  * @param index an existing index object
  * @return integer of count of current filename conflict entries
  */
-GIT_EXTERN(unsigned int) git_index_name_entrycount(git_index *index);
+GIT_EXTERN(size_t) git_index_name_entrycount(git_index *index);
 
 /**
  * Get a filename conflict entry from the index.
@@ -90,7 +90,7 @@ GIT_EXTERN(void) git_index_name_clear(git_index *index);
  * @param index an existing index object
  * @return integer of count of current resolve undo entries
  */
-GIT_EXTERN(unsigned int) git_index_reuc_entrycount(git_index *index);
+GIT_EXTERN(size_t) git_index_reuc_entrycount(git_index *index);
 
 /**
  * Finds the resolve undo entry that points to the given path in the Git

--- a/src/index.c
+++ b/src/index.c
@@ -1497,10 +1497,10 @@ void git_index_conflict_iterator_free(git_index_conflict_iterator *iterator)
 	git__free(iterator);
 }
 
-unsigned int git_index_name_entrycount(git_index *index)
+size_t git_index_name_entrycount(git_index *index)
 {
 	assert(index);
-	return (unsigned int)index->names.length;
+	return index->names.length;
 }
 
 const git_index_name_entry *git_index_name_get_byindex(
@@ -1557,10 +1557,10 @@ void git_index_name_clear(git_index *index)
 	git_vector_clear(&index->names);
 }
 
-unsigned int git_index_reuc_entrycount(git_index *index)
+size_t git_index_reuc_entrycount(git_index *index)
 {
 	assert(index);
-	return (unsigned int)index->reuc.length;
+	return index->reuc.length;
 }
 
 static int index_reuc_insert(


### PR DESCRIPTION
For the REUC and NAME entries, we use size_t internally, and we take
size_t for the get_byindex() functions, but the entrycount() functions
strangely cast to an unsigned int instead.
