### PR TITLE
Added git__timer() variant for AmigaOS.

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -434,6 +434,17 @@ GIT_INLINE(double) git__timer(void)
    return (double)time * scaling_factor / 1.0E9;
 }
 
+#elif defined(AMIGA)
+
+#include <proto/timer.h>
+
+GIT_INLINE(double) git__timer(void)
+{
+	struct TimeVal tv;
+	ITimer->GetUpTime(&tv);
+	return (double)tv.Seconds + (double)tv.Microseconds / 1.0E6;
+}
+
 #else
 
 #include <sys/time.h>


### PR DESCRIPTION
This currently simply uses gettimeofday(), and thus is very
similar to the standard case, except that clock_gettime() is not
tried (this function is not available on AmigaOS). In the
future, it would be much better to use GetUpTime() from
timer.device though.
