### PR TITLE
global: include sys/openssl.h for GIT_EXPORT of fn

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -9,6 +9,7 @@
 #include "hash.h"
 #include "sysdir.h"
 #include "git2/global.h"
+#include "git2/sys/openssl.h"
 #include "thread-utils.h"
 
 


### PR DESCRIPTION
The openssl setup function needs to be GIT_EXPORT'ed, be sure
to include the `sys/openssl.h` header so that it is appropriately
decorated as an export function.
