### PR TITLE
treebuilder: rename _create() to _new()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,9 +142,13 @@ v0.21 + 1
   initializations of the library, so consumers may schedule work on the
   first initialization.
 
-* git_treebuilder_create now takes a repository so that it can query
-  repository configuration.  Subsequently, git_treebuilder_write no
-  longer takes a repository.
+* git_treebuilder_new (was git_treebuilder_create) now takes a
+  repository so that it can query repository configuration.
+  Subsequently, git_treebuilder_write no longer takes a repository.
+
+* git_treebuilder_create was renamed to git_treebuilder_new to better
+  reflect it being a constructor rather than something which writes to
+  disk.
 
 * git_checkout now handles case-changing renames correctly on
   case-insensitive filesystems; for example renaming "readme" to "README".

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -251,7 +251,7 @@ GIT_EXTERN(int) git_tree_entry_to_object(
  * @param source Source tree to initialize the builder (optional)
  * @return 0 on success; error code otherwise
  */
-GIT_EXTERN(int) git_treebuilder_create(
+GIT_EXTERN(int) git_treebuilder_new(
 	git_treebuilder **out, git_repository *repo, const git_tree *source);
 
 /**

--- a/src/notes.c
+++ b/src/notes.c
@@ -107,7 +107,7 @@ static int tree_write(
 	const git_tree_entry *entry;
 	git_oid tree_oid;
 
-	if ((error = git_treebuilder_create(&tb, repo, source_tree)) < 0)
+	if ((error = git_treebuilder_new(&tb, repo, source_tree)) < 0)
 		goto cleanup;
 
 	if (object_oid) {

--- a/src/tree.c
+++ b/src/tree.c
@@ -490,7 +490,7 @@ static int write_tree(
 		return (int)find_next_dir(dirname, index, start);
 	}
 
-	if ((error = git_treebuilder_create(&bld, repo, NULL)) < 0 || bld == NULL)
+	if ((error = git_treebuilder_new(&bld, repo, NULL)) < 0 || bld == NULL)
 		return -1;
 
 	/*
@@ -624,7 +624,7 @@ int git_tree__write_index(
 	return ret;
 }
 
-int git_treebuilder_create(
+int git_treebuilder_new(
 	git_treebuilder **builder_p,
 	git_repository *repo,
 	const git_tree *source)

--- a/tests/object/tree/attributes.c
+++ b/tests/object/tree/attributes.c
@@ -23,7 +23,7 @@ void test_object_tree_attributes__ensure_correctness_of_attributes_on_insertion(
 
 	cl_git_pass(git_oid_fromstr(&oid, blob_oid));
 
-	cl_git_pass(git_treebuilder_create(&builder, repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, repo, NULL));
 
 	cl_git_fail(git_treebuilder_insert(NULL, builder, "one.txt", &oid, (git_filemode_t)0777777));
 	cl_git_fail(git_treebuilder_insert(NULL, builder, "one.txt", &oid, (git_filemode_t)0100666));
@@ -58,7 +58,7 @@ void test_object_tree_attributes__treebuilder_reject_invalid_filemode(void)
 	const git_tree_entry *entry;
 
 	cl_git_pass(git_oid_fromstr(&bid, blob_oid));
-	cl_git_pass(git_treebuilder_create(&builder, repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, repo, NULL));
 
 	cl_git_fail(git_treebuilder_insert(
 		&entry,
@@ -80,7 +80,7 @@ void test_object_tree_attributes__normalize_attributes_when_creating_a_tree_from
 	cl_git_pass(git_oid_fromstr(&tid, tree_oid));
 	cl_git_pass(git_tree_lookup(&tree, repo, &tid));
 
-	cl_git_pass(git_treebuilder_create(&builder, repo, tree));
+	cl_git_pass(git_treebuilder_new(&builder, repo, tree));
 	
 	entry = git_treebuilder_get(builder, "old_mode.txt");
 	cl_assert_equal_i(

--- a/tests/object/tree/duplicateentries.c
+++ b/tests/object/tree/duplicateentries.c
@@ -57,7 +57,7 @@ static void tree_creator(git_oid *out, void (*fn)(git_treebuilder *))
 {
 	git_treebuilder *builder;
 
-	cl_git_pass(git_treebuilder_create(&builder, _repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, _repo, NULL));
 
 	fn(builder);
 

--- a/tests/object/tree/write.c
+++ b/tests/object/tree/write.c
@@ -35,7 +35,7 @@ void test_object_tree_write__from_memory(void)
 	 * on REPOSITORY_FOLDER.
 	 */
 	cl_git_pass(git_tree_lookup(&tree, g_repo, &id));
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, tree));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, tree));
 
 	cl_git_fail(git_treebuilder_insert(NULL, builder, "",
 		&bid, GIT_FILEMODE_BLOB));
@@ -75,7 +75,7 @@ void test_object_tree_write__subtree(void)
 	git_oid_fromstr(&bid, blob_oid);
 
 	/* create subtree */
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 	cl_git_pass(git_treebuilder_insert(
 		NULL, builder, "new.txt", &bid, GIT_FILEMODE_BLOB)); /* -V536 */
 	cl_git_pass(git_treebuilder_write(&subtree_id, builder));
@@ -83,7 +83,7 @@ void test_object_tree_write__subtree(void)
 
 	/* create parent tree */
 	cl_git_pass(git_tree_lookup(&tree, g_repo, &id));
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, tree));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, tree));
 	cl_git_pass(git_treebuilder_insert(
 		NULL, builder, "new", &subtree_id, GIT_FILEMODE_TREE)); /* -V536 */
 	cl_git_pass(git_treebuilder_write(&id_hiearar, builder));
@@ -135,7 +135,7 @@ void test_object_tree_write__sorted_subtrees(void)
 
 	memset(&blank_oid, 0x0, sizeof(blank_oid));
 
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 
 	for (i = 0; i < ARRAY_SIZE(entries); ++i) {
 		cl_git_pass(git_treebuilder_insert(NULL,
@@ -192,7 +192,7 @@ void test_object_tree_write__removing_and_re_adding_in_treebuilder(void)
 
 	memset(&blank_oid, 0x0, sizeof(blank_oid));
 
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 
 	cl_assert_equal_i(0, (int)git_treebuilder_entrycount(builder));
 
@@ -283,7 +283,7 @@ void test_object_tree_write__filtering(void)
 
 	memset(&blank_oid, 0x0, sizeof(blank_oid));
 
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 
 	for (i = 0; _entries[i].filename; ++i)
 		cl_git_pass(git_treebuilder_insert(NULL,
@@ -346,7 +346,7 @@ void test_object_tree_write__cruel_paths(void)
 	git_oid_fromstr(&bid, blob_oid);
 
 	/* create tree */
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 	for (scan = the_paths; *scan; ++scan) {
 		cl_git_pass(git_treebuilder_insert(
 			NULL, builder, *scan, &bid, GIT_FILEMODE_BLOB));
@@ -374,7 +374,7 @@ void test_object_tree_write__cruel_paths(void)
 	git_tree_free(tree);
 
 	/* let's try longer paths */
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 	for (scan = the_paths; *scan; ++scan) {
 		cl_git_pass(git_treebuilder_insert(
 			NULL, builder, *scan, &id, GIT_FILEMODE_TREE));
@@ -409,7 +409,7 @@ void test_object_tree_write__protect_filesystems(void)
 	/* Ensure that (by default) we can write objects with funny names on
 	 * platforms that are not affected.
 	 */
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 
 #ifndef GIT_WIN32
 	cl_git_pass(git_treebuilder_insert(NULL, builder, ".git.", &bid, GIT_FILEMODE_BLOB));
@@ -430,7 +430,7 @@ void test_object_tree_write__protect_filesystems(void)
 	cl_repo_set_bool(g_repo, "core.protectHFS", true);
 	cl_repo_set_bool(g_repo, "core.protectNTFS", true);
 
-	cl_git_pass(git_treebuilder_create(&builder, g_repo, NULL));
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
 
 	cl_git_fail(git_treebuilder_insert(NULL, builder, ".git.", &bid, GIT_FILEMODE_BLOB));
 	cl_git_fail(git_treebuilder_insert(NULL, builder, "git~1", &bid, GIT_FILEMODE_BLOB));

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -427,7 +427,7 @@ static void build_test_tree(
 	git_buf name = GIT_BUF_INIT;
 	va_list arglist;
 
-	cl_git_pass(git_treebuilder_create(&builder, repo, NULL)); /* start builder */
+	cl_git_pass(git_treebuilder_new(&builder, repo, NULL)); /* start builder */
 
 	va_start(arglist, fmt);
 	while (*scan) {


### PR DESCRIPTION
This function is a constructor, so let's name it like one and leave
_create() for the reference functions, which do create/write the
reference.

---

I'm slotting this for v0.22 as we've already done so much renaming it's probably better to put it in rather than deal it out piecemeal.
