### PR TITLE
Undef stat for Mingw

### DIFF
--- a/src/win32/mingw-compat.h
+++ b/src/win32/mingw-compat.h
@@ -9,6 +9,8 @@
 
 #if defined(__MINGW32__)
 
+#undef stat
+
 #if _WIN32_WINNT >= 0x0601
 #define stat __stat64
 #else


### PR DESCRIPTION
As part of #2471 (https://github.com/jacquesg/libgit2/commit/2f795d8fc50d81641d95723d9ddd92795886bed3#diff-3)  I introduces a minor regression in terms of compiler warnings. `stat` should be `undef`ed  before (possibly) redefining it.
