### PR TITLE
Add API to precompile all diff drivers

### DIFF
--- a/include/git2/sys/diff.h
+++ b/include/git2/sys/diff.h
@@ -89,6 +89,18 @@ GIT_EXTERN(int) git_diff_get_perfdata(
 GIT_EXTERN(int) git_status_list_get_perfdata(
 	git_diff_perfdata *out, const git_status_list *status);
 
+/**
+ * Compile all builtin diff drivers.
+ *
+ * Normally builtin diff drivers are only compiled on-demand when they are
+ * used.  This function loops through the internal table and compiles and
+ * caches all of the builtin diff drivers.  This can be done for testing
+ * purposes or to control when the driver compilation costs are paid.
+ *
+ * @return 0 for success, <0 for error
+ */
+GIT_EXTERN(int) git_diff_driver_compile_builtins(git_repository *repo);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/tests/diff/drivers.c
+++ b/tests/diff/drivers.c
@@ -250,3 +250,12 @@ void test_diff_drivers__builtins(void)
 	git_buf_free(&expected);
 	git_vector_free(&files);
 }
+
+#include "git2/sys/diff.h"
+
+void test_diff_drivers__check_builtins(void)
+{
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+	cl_git_pass(git_diff_driver_compile_builtins(g_repo));
+}
+


### PR DESCRIPTION
While checking out the latest issues mentioned in #813, I wanted a way to compile all of the regular expressions in all of the builtin diff drivers. It seems like exposing the API through the `include/git2/sys/diff.h` might be reasonable for users who want to avoid the "on-demand" driver compilation behavior.

I'm not sure if this API matters, but I want to have Travis run on the new test and make sure it passes on all platforms.

---

Now that I think about it, this points out an existing bug in my code - I cached compiled diff drivers and didn't do any cache validation. As a result, if you invoke this function, it will compile and cache the internal version of all drivers and ignore any overrides in the `.git/config` or other external files. This bug also means that if you change to data in one of those external files after the original diff driver is compiled then we will never pick up the change.

The "fix" for this bug is either to make `diff_driver.c:git_diff_driver_load()` validate the cached driver definition (which might be acceptable if we rewrite the function to quickly realize that if there is no section named `diff.<driver>...` then we can always use the cached version - which will be the common case), or to always invalidate the diff driver cache at the start of every major API operation.

I lean towards the second fix so that a given driver definition will be used without revalidation throughout an API call, but the next high-level diff API will pick up any changes that have been made on disk. This suggests that the diff driver cache should be stored in the `git_diff` object instead of in the `git_repository` (and the cached versions of the builtin drivers should be stored globally beside the table of builtins for quick instantiation when we hit the fallback case - although that has threading issues).
