### PR TITLE
Fixed internal push state not being cleared when calling git_remote_download()

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -885,6 +885,11 @@ int git_remote_download(git_remote *remote, const git_strarray *refspecs)
 	if (error < 0)
 		return error;
 
+	if (remote->push) {
+		git_push_free(remote->push);
+		remote->push = NULL;
+	}
+
 	if ((error = git_fetch_negotiate(remote)) < 0)
 		return error;
 


### PR DESCRIPTION
That's a recent regression due to the addition of the `git_remote_download()` API: if re-using the same remote to upload then download, the internal push state is still around and calling `git_remote_update_tips()` doesn't update the tags anymore.

BTW: I think there's another issue with `git_remote_download()`: the doc says it connects if needed, but I don't think it does looking at the implementation. `git_remote_upload()` does it for sure though. IMO neither API should auto-connect since they are low-level. For `git_remote_push()` and `git_remote_fetch()` however, it certainly makes sense.