### PR TITLE
Allow to set ref-prune setting in remote

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -614,6 +614,16 @@ GIT_EXTERN(void) git_remote_set_autotag(
 GIT_EXTERN(int) git_remote_prune_refs(const git_remote *remote);
 
 /**
+* Set the ref-prune setting
+*
+* @param remote the remote to configure
+* @param value 0 to disable ref-prune
+*/
+GIT_EXTERN(void) git_remote_set_prune_refs(
+	git_remote *remote,
+	int value);
+
+/**
  * Give the remote a new name
  *
  * All remote-tracking branches and configuration settings

--- a/src/remote.c
+++ b/src/remote.c
@@ -1639,6 +1639,11 @@ int git_remote_prune_refs(const git_remote *remote)
 	return remote->prune_refs;
 }
 
+void git_remote_set_prune_refs(git_remote *remote, int value)
+{
+	remote->prune_refs = value;
+}
+
 static int rename_remote_config_section(
 	git_repository *repo,
 	const char *old_name,


### PR DESCRIPTION
This is for overriding the config setting, e.g. to explicitly disable pruning.