### PR TITLE
Include git2/common.h in sys/openssl.h.

### DIFF
--- a/include/git2/sys/openssl.h
+++ b/include/git2/sys/openssl.h
@@ -7,7 +7,7 @@
 #ifndef INCLUDE_git_openssl_h__
 #define INCLUDE_git_openssl_h__
 
-#include "common.h"
+#include "git2/common.h"
 
 GIT_BEGIN_DECL
 


### PR DESCRIPTION
I know that's a last resort for threading, but I still feel like this should work :smile:

The path to `common.h` didn't change when `threads.h` was renamed to `sys/openssl.h`. Now, if you include `sys/openssl.h` anywhere you'll get an error because the path to `common.h` is invalid.