### PR TITLE
Load prune configuration when a remote is created.

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -21,6 +21,7 @@
 #include "push.h"
 
 static int dwim_refspecs(git_vector *out, git_vector *refspecs, git_vector *refs);
+static int lookup_remote_prune_config(git_remote *remote, git_config *config, const char *name);
 
 static int add_refspec_to(git_vector *vector, const char *string, bool is_fetch)
 {
@@ -138,6 +139,7 @@ static int canonicalize_url(git_buf *out, const char *in)
 static int create_internal(git_remote **out, git_repository *repo, const char *name, const char *url, const char *fetch)
 {
 	git_remote *remote;
+	git_config *config;
 	git_buf canonical_url = GIT_BUF_INIT, fetchbuf = GIT_BUF_INIT;
 	int error = -1;
 
@@ -165,6 +167,12 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 		if (add_refspec(remote, fetch, true) < 0)
 			goto on_error;
 
+		if ((error = git_repository_config_snapshot(&config, repo)) < 0)
+			goto on_error;
+
+		if (lookup_remote_prune_config(remote, config, name) < 0)
+			goto on_error;
+
 		/* Move the data over to where the matching functions can find them */
 		if (dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs) < 0)
 			goto on_error;
@@ -181,6 +189,7 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 
 on_error:
 	git_remote_free(remote);
+	git_config_free(config);
 	git_buf_free(&fetchbuf);
 	git_buf_free(&canonical_url);
 	return error;
@@ -444,21 +453,8 @@ int git_remote_lookup(git_remote **out, git_repository *repo, const char *name)
 	if (download_tags_value(remote, config) < 0)
 		goto cleanup;
 
-	git_buf_clear(&buf);
-	git_buf_printf(&buf, "remote.%s.prune", name);
-
-	if ((error = git_config_get_bool(&remote->prune_refs, config, git_buf_cstr(&buf))) < 0) {
-		if (error == GIT_ENOTFOUND) {
-			giterr_clear();
-
-			if ((error = git_config_get_bool(&remote->prune_refs, config, "fetch.prune")) < 0) {
-				if (error == GIT_ENOTFOUND) {
-					giterr_clear();
-					error = 0;
-				}
-			}
-		}
-	}
+	if ((error = lookup_remote_prune_config(remote, config, name)) < 0)
+		goto cleanup;
 
 	/* Move the data over to where the matching functions can find them */
 	if (dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs) < 0)
@@ -473,6 +469,30 @@ cleanup:
 	if (error < 0)
 		git_remote_free(remote);
 
+	return error;
+}
+
+static int lookup_remote_prune_config(git_remote *remote, git_config *config, const char *name)
+{
+	git_buf buf = GIT_BUF_INIT;
+	int error = 0;
+
+	git_buf_printf(&buf, "remote.%s.prune", name);
+
+	if ((error = git_config_get_bool(&remote->prune_refs, config, git_buf_cstr(&buf))) < 0) {
+		if (error == GIT_ENOTFOUND) {
+			giterr_clear();
+
+			if ((error = git_config_get_bool(&remote->prune_refs, config, "fetch.prune")) < 0) {
+				if (error == GIT_ENOTFOUND) {
+					giterr_clear();
+          error = 0;
+				}
+			}
+		}
+	}
+
+	git_buf_free(&buf);
 	return error;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -486,7 +486,7 @@ static int lookup_remote_prune_config(git_remote *remote, git_config *config, co
 			if ((error = git_config_get_bool(&remote->prune_refs, config, "fetch.prune")) < 0) {
 				if (error == GIT_ENOTFOUND) {
 					giterr_clear();
-          error = 0;
+					error = 0;
 				}
 			}
 		}

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -508,7 +508,7 @@ void test_network_fetchlocal__prune_load_fetch_prune_config(void)
 {
 	git_repository *repo;
 	git_remote *origin;
-  git_config *config;
+	git_config *config;
 	git_repository *remote_repo = cl_git_sandbox_init("testrepo.git");
 	const char *url = cl_git_path_url(git_repository_path(remote_repo));
 

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -486,7 +486,7 @@ void test_network_fetchlocal__prune_load_remote_prune_config(void)
 {
 	git_repository *repo;
 	git_remote *origin;
-  git_config *config;
+	git_config *config;
 	git_repository *remote_repo = cl_git_sandbox_init("testrepo.git");
 	const char *url = cl_git_path_url(git_repository_path(remote_repo));
 

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -481,3 +481,47 @@ void test_network_fetchlocal__call_progress(void)
 	git_remote_free(remote);
 	git_repository_free(repo);
 }
+
+void test_network_fetchlocal__prune_load_remote_prune_config(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+  git_config *config;
+	git_repository *remote_repo = cl_git_sandbox_init("testrepo.git");
+	const char *url = cl_git_path_url(git_repository_path(remote_repo));
+
+	cl_set_cleanup(&cleanup_local_repo, "foo");
+	cl_git_pass(git_repository_init(&repo, "foo", true));
+
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_bool(config, "remote.origin.prune", 1));
+
+	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
+	cl_assert_equal_i(1, git_remote_prune_refs(origin));
+
+	git_config_free(config);
+	git_remote_free(origin);
+	git_repository_free(repo);
+}
+
+void test_network_fetchlocal__prune_load_fetch_prune_config(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+  git_config *config;
+	git_repository *remote_repo = cl_git_sandbox_init("testrepo.git");
+	const char *url = cl_git_path_url(git_repository_path(remote_repo));
+
+	cl_set_cleanup(&cleanup_local_repo, "foo");
+	cl_git_pass(git_repository_init(&repo, "foo", true));
+
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_bool(config, "fetch.prune", 1));
+
+	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
+	cl_assert_equal_i(1, git_remote_prune_refs(origin));
+
+	git_config_free(config);
+	git_remote_free(origin);
+	git_repository_free(repo);
+}


### PR DESCRIPTION
`git_remote_create` doesn't load the prune configuration for the repository like `git_remote_lookup` does.
So `remote->prune_refs` is false after creating the remote, even when the configuration says that it should be true.

This PR changes this behaviour to load the prune configuration when a remote is created. I've added a couple of tests to verify that this works as expected.