### PR TITLE
Remove the signature from ref-modifying functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ v0.22 + 1
   file handling during checkout, you may now use `GIT_CHECKOUT_SAFE |
   GIT_CHECKOUT_RECREATE_MISSING`.
 
+* The `git_clone_options` and `git_submodule_update_options`
+  structures no longer have a `signature` field.
+
+* The following functions have removed the signature and/or log message
+  parameters in favour of git-emulating ones.
+
+    * `git_branch_create()`, `git_branch_move()`
+    * `git_rebase_init()`, `git_rebase_abort()`
+    * `git_reference_symbolic_create_matching()`,
+      `git_reference_symbolic_create()`, `git_reference_create()`,
+      `git_reference_create_matching()`,
+      `git_reference_symbolic_set_target()`,
+      `git_reference_set_target()`, `git_reference_rename()`
+    * `git_remote_update_tips()`, `git_remote_fetch()`, `git_remote_push()`
+    * `git_repository_set_head()`,
+      `git_repository_set_head_detached()`,
+      `git_repository_detach_head()`
+    * `git_reset()`
+
 v0.22
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,19 @@ v0.22 + 1
 * Checkout can now handle an initial checkout of a repository, making
   `GIT_CHECKOUT_SAFE_CREATE` unnecessary for users of clone.
 
+* The signature parameter in the ref-modifying functions has been
+  removed. Use `git_repository_set_ident()` and
+  `git_repository_ident()` to override the signature to be used.
+
 ### API additions
 
 * Parsing and retrieving a configuration value as a path is exposed
   via `git_config_parse_path()` and `git_config_get_path()`
   respectively.
+
+* `git_repository_set_ident()` and `git_repository_ident()` serve to
+  set and query which identity will be used when writing to the
+  reflog.
 
 ### API removals
 

--- a/examples/network/fetch.c
+++ b/examples/network/fetch.c
@@ -156,7 +156,7 @@ int fetch(git_repository *repo, int argc, char **argv)
 	// right commits. This may be needed even if there was no packfile
 	// to download, which can happen e.g. when the branches have been
 	// changed but all the needed objects are available locally.
-	if (git_remote_update_tips(remote, NULL, NULL) < 0)
+	if (git_remote_update_tips(remote, NULL) < 0)
 		return -1;
 
 	git_remote_free(remote);

--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -43,10 +43,6 @@ GIT_BEGIN_DECL
  *
  * @param force Overwrite existing branch.
  *
- * @param log_message The one line long message to be appended to the reflog.
- * If NULL, the default is "Branch: created"; if you want something more
- * useful, provide a message.
- *
  * @return 0, GIT_EINVALIDSPEC or an error code.
  * A proper reference is written in the refs/heads namespace
  * pointing to the provided target commit.
@@ -56,8 +52,7 @@ GIT_EXTERN(int) git_branch_create(
 	git_repository *repo,
 	const char *branch_name,
 	const git_commit *target,
-	int force,
-	const char *log_message);
+	int force);
 
 /**
  * Delete an existing branch reference.
@@ -120,16 +115,13 @@ GIT_EXTERN(void) git_branch_iterator_free(git_branch_iterator *iter);
  *
  * @param force Overwrite existing branch.
  *
- * @param log_message The one line long message to be appended to the reflog
- *
  * @return 0 on success, GIT_EINVALIDSPEC or an error code.
  */
 GIT_EXTERN(int) git_branch_move(
 	git_reference **out,
 	git_reference *branch,
 	const char *new_branch_name,
-	int force,
-	const char *log_message);
+	int force);
 
 /**
  * Lookup a branch by its name in a repository.

--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -43,8 +43,6 @@ GIT_BEGIN_DECL
  *
  * @param force Overwrite existing branch.
  *
- * @param signature The identity that will used to populate the reflog entry
- *
  * @param log_message The one line long message to be appended to the reflog.
  * If NULL, the default is "Branch: created"; if you want something more
  * useful, provide a message.
@@ -59,7 +57,6 @@ GIT_EXTERN(int) git_branch_create(
 	const char *branch_name,
 	const git_commit *target,
 	int force,
-	const git_signature *signature,
 	const char *log_message);
 
 /**
@@ -123,8 +120,6 @@ GIT_EXTERN(void) git_branch_iterator_free(git_branch_iterator *iter);
  *
  * @param force Overwrite existing branch.
  *
- * @param signature The identity that will used to populate the reflog entry
- *
  * @param log_message The one line long message to be appended to the reflog
  *
  * @return 0 on success, GIT_EINVALIDSPEC or an error code.
@@ -134,7 +129,6 @@ GIT_EXTERN(int) git_branch_move(
 	git_reference *branch,
 	const char *new_branch_name,
 	int force,
-	const git_signature *signature,
 	const char *log_message);
 
 /**

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -137,12 +137,6 @@ typedef struct git_clone_options {
 	const char* checkout_branch;
 
 	/**
-	 * The identity used when updating the reflog. NULL means to
-	 * use the default signature using the config.
-	 */
-	git_signature *signature;
-
-	/**
 	 * A callback used to create the new repository into which to
 	 * clone. If NULL, the 'bare' field will be used to determine
 	 * whether to create a bare repository.

--- a/include/git2/rebase.h
+++ b/include/git2/rebase.h
@@ -139,7 +139,6 @@ GIT_EXTERN(int) git_rebase_init_options(
  *                 reachable commits
  * @param onto The branch to rebase onto, or NULL to rebase onto the given
  *             upstream
- * @param signature The signature of the rebaser (optional)
  * @param opts Options to specify how rebase is performed
  * @return Zero on success; -1 on failure.
  */
@@ -149,7 +148,6 @@ GIT_EXTERN(int) git_rebase_init(
 	const git_annotated_commit *branch,
 	const git_annotated_commit *upstream,
 	const git_annotated_commit *onto,
-	const git_signature *signature,
 	const git_rebase_options *opts);
 
 /**
@@ -241,13 +239,10 @@ GIT_EXTERN(int) git_rebase_commit(
  * and working directory to their state before rebase began.
  *
  * @param rebase The rebase that is in-progress
- * @param signature The identity that is aborting the rebase
  * @return Zero on success; GIT_ENOTFOUND if a rebase is not in progress,
  *         -1 on other errors.
  */
-GIT_EXTERN(int) git_rebase_abort(
-	git_rebase *rebase,
-	const git_signature *signature);
+GIT_EXTERN(int) git_rebase_abort(git_rebase *rebase);
 
 /**
  * Finishes a rebase that is currently in progress once all patches have

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -89,9 +89,9 @@ GIT_EXTERN(int) git_reference_dwim(git_reference **out, git_repository *repo, co
  * This function will return an error if a reference already exists with the
  * given name unless `force` is true, in which case it will be overwritten.
  *
- * The signature and message for the reflog will be ignored if the
- * reference does not belong in the standard set (HEAD, branches and
- * remote-tracking branches) and it does not have a reflog.
+ * The message for the reflog will be ignored if the reference does
+ * not belong in the standard set (HEAD, branches and remote-tracking
+ * branches) and it does not have a reflog.
  *
  * It will return GIT_EMODIFIED if the reference's value at the time
  * of updating does not match the one passed through `current_value`
@@ -103,11 +103,10 @@ GIT_EXTERN(int) git_reference_dwim(git_reference **out, git_repository *repo, co
  * @param target The target of the reference
  * @param force Overwrite existing references
  * @param current_value The expected value of the reference when updating
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC, GIT_EMODIFIED or an error code
  */
-GIT_EXTERN(int) git_reference_symbolic_create_matching(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const char *current_value, const git_signature *signature, const char *log_message);
+GIT_EXTERN(int) git_reference_symbolic_create_matching(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const char *current_value, const char *log_message);
 
 /**
  * Create a new symbolic reference.
@@ -131,20 +130,19 @@ GIT_EXTERN(int) git_reference_symbolic_create_matching(git_reference **out, git_
  * This function will return an error if a reference already exists with the
  * given name unless `force` is true, in which case it will be overwritten.
  *
- * The signature and message for the reflog will be ignored if the
- * reference does not belong in the standard set (HEAD, branches and
- * remote-tracking branches) and it does not have a reflog.
+ * The message for the reflog will be ignored if the reference does
+ * not belong in the standard set (HEAD, branches and remote-tracking
+ * branches) and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference will live
  * @param name The name of the reference
  * @param target The target of the reference
  * @param force Overwrite existing references
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const git_signature *signature, const char *log_message);
+GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const char *log_message);
 
 /**
  * Create a new direct reference.
@@ -169,20 +167,19 @@ GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repositor
  * This function will return an error if a reference already exists with the
  * given name unless `force` is true, in which case it will be overwritten.
  *
- * The signature and message for the reflog will be ignored if the
- * reference does not belong in the standard set (HEAD, branches and
- * remote-tracking branches) and and it does not have a reflog.
+ * The message for the reflog will be ignored if the reference does
+ * not belong in the standard set (HEAD, branches and remote-tracking
+ * branches) and and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference will live
  * @param name The name of the reference
  * @param id The object id pointed to by the reference.
  * @param force Overwrite existing references
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force, const git_signature *signature, const char *log_message);
+GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force, const char *log_message);
 
 /**
  * Conditionally create new direct reference
@@ -207,9 +204,9 @@ GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, 
  * This function will return an error if a reference already exists with the
  * given name unless `force` is true, in which case it will be overwritten.
  *
- * The signature and message for the reflog will be ignored if the
- * reference does not belong in the standard set (HEAD, branches and
- * remote-tracking branches) and and it does not have a reflog.
+ * The message for the reflog will be ignored if the reference does
+ * not belong in the standard set (HEAD, branches and remote-tracking
+ * branches) and and it does not have a reflog.
  *
  * It will return GIT_EMODIFIED if the reference's value at the time
  * of updating does not match the one passed through `current_id`
@@ -221,12 +218,11 @@ GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, 
  * @param id The object id pointed to by the reference.
  * @param force Overwrite existing references
  * @param current_id The expected value of the reference at the time of update
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EMODIFIED if the value of the reference
  * has changed, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code
  */
-GIT_EXTERN(int) git_reference_create_matching(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force, const git_oid *current_id, const git_signature *signature, const char *log_message);
+GIT_EXTERN(int) git_reference_create_matching(git_reference **out, git_repository *repo, const char *name, const git_oid *id, int force, const git_oid *current_id, const char *log_message);
 
 /**
  * Get the OID pointed to by a direct reference.
@@ -320,14 +316,13 @@ GIT_EXTERN(git_repository *) git_reference_owner(const git_reference *ref);
  * The target name will be checked for validity.
  * See `git_reference_symbolic_create()` for rules about valid names.
  *
- * The signature and message for the reflog will be ignored if the
- * reference does not belong in the standard set (HEAD, branches and
- * remote-tracking branches) and and it does not have a reflog.
+ * The message for the reflog will be ignored if the reference does
+ * not belong in the standard set (HEAD, branches and remote-tracking
+ * branches) and and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param ref The reference
  * @param target The new target for the reference
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EINVALIDSPEC or an error code
  */
@@ -335,7 +330,6 @@ GIT_EXTERN(int) git_reference_symbolic_set_target(
 	git_reference **out,
 	git_reference *ref,
 	const char *target,
-	const git_signature *signature,
 	const char *log_message);
 
 /**
@@ -348,7 +342,6 @@ GIT_EXTERN(int) git_reference_symbolic_set_target(
  * @param out Pointer to the newly created reference
  * @param ref The reference
  * @param id The new target OID for the reference
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EMODIFIED if the value of the reference
  * has changed since it was read, or an error code
@@ -357,7 +350,6 @@ GIT_EXTERN(int) git_reference_set_target(
 	git_reference **out,
 	git_reference *ref,
 	const git_oid *id,
-	const git_signature *signature,
 	const char *log_message);
 
 /**
@@ -379,7 +371,6 @@ GIT_EXTERN(int) git_reference_set_target(
  * @param ref The reference to rename
  * @param new_name The new name for the reference
  * @param force Overwrite an existing reference
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code
  *
@@ -389,7 +380,6 @@ GIT_EXTERN(int) git_reference_rename(
 	git_reference *ref,
 	const char *new_name,
 	int force,
-	const git_signature *signature,
 	const char *log_message);
 
 /**

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -376,7 +376,6 @@ GIT_EXTERN(void) git_remote_free(git_remote *remote);
  * Update the tips to the new state
  *
  * @param remote the remote to update
- * @param signature The identity to use when updating reflogs
  * @param reflog_message The message to insert into the reflogs. If NULL, the
  *                       default is "fetch <name>", where <name> is the name of
  *                       the remote (or its url, for in-memory remotes).
@@ -384,7 +383,6 @@ GIT_EXTERN(void) git_remote_free(git_remote *remote);
  */
 GIT_EXTERN(int) git_remote_update_tips(
 		git_remote *remote,
-		const git_signature *signature,
 		const char *reflog_message);
 
 /**
@@ -404,7 +402,6 @@ GIT_EXTERN(int) git_remote_prune(git_remote *remote);
  * @param remote the remote to fetch from
  * @param refspecs the refspecs to use for this fetch. Pass NULL or an
  *                 empty array to use the base refspecs.
- * @param signature The identity to use when updating reflogs
  * @param reflog_message The message to insert into the reflogs. If NULL, the
  *								 default is "fetch"
  * @return 0 or an error code
@@ -412,7 +409,6 @@ GIT_EXTERN(int) git_remote_prune(git_remote *remote);
 GIT_EXTERN(int) git_remote_fetch(
 		git_remote *remote,
 		const git_strarray *refspecs,
-		const git_signature *signature,
 		const char *reflog_message);
 
 /**
@@ -424,13 +420,12 @@ GIT_EXTERN(int) git_remote_fetch(
  * @param refspecs the refspecs to use for pushing. If none are
  * passed, the configured refspecs will be used
  * @param opts the options
- * @param signature signature to use for the reflog of updated references
  * @param reflog_message message to use for the reflog of upated references
  */
 GIT_EXTERN(int) git_remote_push(git_remote *remote,
 				const git_strarray *refspecs,
 				const git_push_options *opts,
-				const git_signature *signature, const char *reflog_message);
+				const char *reflog_message);
 
 /**
  * Get a list of the configured remotes for a repo

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -376,9 +376,10 @@ GIT_EXTERN(void) git_remote_free(git_remote *remote);
  * Update the tips to the new state
  *
  * @param remote the remote to update
- * @param reflog_message The message to insert into the reflogs. If NULL, the
- *                       default is "fetch <name>", where <name> is the name of
- *                       the remote (or its url, for in-memory remotes).
+ * @param reflog_message The message to insert into the reflogs. If
+ * NULL and fetching, the default is "fetch <name>", where <name> is
+ * the name of the remote (or its url, for in-memory remotes). This
+ * parameter is ignored when pushing.
  * @return 0 or an error code
  */
 GIT_EXTERN(int) git_remote_update_tips(
@@ -420,12 +421,10 @@ GIT_EXTERN(int) git_remote_fetch(
  * @param refspecs the refspecs to use for pushing. If none are
  * passed, the configured refspecs will be used
  * @param opts the options
- * @param reflog_message message to use for the reflog of upated references
  */
 GIT_EXTERN(int) git_remote_push(git_remote *remote,
 				const git_strarray *refspecs,
-				const git_push_options *opts,
-				const char *reflog_message);
+				const git_push_options *opts);
 
 /**
  * Get a list of the configured remotes for a repo

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -603,14 +603,12 @@ GIT_EXTERN(int) git_repository_hashfile(
  *
  * @param repo Repository pointer
  * @param refname Canonical name of the reference the HEAD should point at
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, or an error code
  */
 GIT_EXTERN(int) git_repository_set_head(
 	git_repository* repo,
 	const char* refname,
-	const git_signature *signature,
 	const char *log_message);
 
 /**
@@ -627,14 +625,12 @@ GIT_EXTERN(int) git_repository_set_head(
  *
  * @param repo Repository pointer
  * @param commitish Object id of the Commit the HEAD should point to
- * @param signature The identity that will used to populate the reflog entry
  * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, or an error code
  */
 GIT_EXTERN(int) git_repository_set_head_detached(
 	git_repository* repo,
 	const git_oid* commitish,
-	const git_signature *signature,
 	const char *log_message);
 
 /**
@@ -651,14 +647,12 @@ GIT_EXTERN(int) git_repository_set_head_detached(
  * Otherwise, the HEAD will be detached and point to the peeled Commit.
  *
  * @param repo Repository pointer
- * @param signature The identity that will used to populate the reflog entry
  * @param reflog_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EUNBORNBRANCH when HEAD points to a non existing
  * branch or an error code
  */
 GIT_EXTERN(int) git_repository_detach_head(
 	git_repository* repo,
-	const git_signature *signature,
 	const char *reflog_message);
 
 /**
@@ -719,6 +713,31 @@ GIT_EXTERN(const char *) git_repository_get_namespace(git_repository *repo);
  * @return 1 if shallow, zero if not
  */
 GIT_EXTERN(int) git_repository_is_shallow(git_repository *repo);
+
+/**
+ * Retrieve the configured identity to use for reflogs
+ *
+ * The memory is owned by the repository and must not be freed by the
+ * user.
+ *
+ * @param name where to store the pointer to the name
+ * @param email where to store the pointer to the email
+ * @param repo the repository
+ */
+GIT_EXTERN(int) git_repository_ident(const char **name, const char **email, const git_repository *repo);
+
+/**
+ * Set the identity to be used for writing reflogs
+ *
+ * If both are set, this name and email will be used to write to the
+ * reflog. Pass NULL to unset. When unset, the identity will be taken
+ * from the repository's configuration.
+ *
+ * @param repo the repository to configure
+ * @param name the name to use for the reflog entries
+ * @param name the email to use for the reflog entries
+ */
+GIT_EXTERN(int) git_repository_set_ident(git_repository *repo, const char *name, const char *email);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -603,13 +603,11 @@ GIT_EXTERN(int) git_repository_hashfile(
  *
  * @param repo Repository pointer
  * @param refname Canonical name of the reference the HEAD should point at
- * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, or an error code
  */
 GIT_EXTERN(int) git_repository_set_head(
 	git_repository* repo,
-	const char* refname,
-	const char *log_message);
+	const char* refname);
 
 /**
  * Make the repository HEAD directly point to the Commit.
@@ -625,13 +623,11 @@ GIT_EXTERN(int) git_repository_set_head(
  *
  * @param repo Repository pointer
  * @param commitish Object id of the Commit the HEAD should point to
- * @param log_message The one line long message to be appended to the reflog
  * @return 0 on success, or an error code
  */
 GIT_EXTERN(int) git_repository_set_head_detached(
 	git_repository* repo,
-	const git_oid* commitish,
-	const char *log_message);
+	const git_oid* commitish);
 
 /**
  * Detach the HEAD.
@@ -647,13 +643,11 @@ GIT_EXTERN(int) git_repository_set_head_detached(
  * Otherwise, the HEAD will be detached and point to the peeled Commit.
  *
  * @param repo Repository pointer
- * @param reflog_message The one line long message to be appended to the reflog
  * @return 0 on success, GIT_EUNBORNBRANCH when HEAD points to a non existing
  * branch or an error code
  */
 GIT_EXTERN(int) git_repository_detach_head(
-	git_repository* repo,
-	const char *reflog_message);
+	git_repository* repo);
 
 /**
  * Repository state

--- a/include/git2/reset.h
+++ b/include/git2/reset.h
@@ -56,20 +56,13 @@ typedef enum {
  * The checkout_strategy field will be overridden (based on reset_type).
  * This parameter can be used to propagate notify and progress callbacks.
  *
- *
- * @param log_message The one line long message to be appended to the reflog.
- * The reflog is only updated if the affected direct reference is actually
- * changing. If NULL, the default is "reset: moving"; if you want something more
- * useful, provide a message.
- *
  * @return 0 on success or an error code
  */
 GIT_EXTERN(int) git_reset(
 	git_repository *repo,
 	git_object *target,
 	git_reset_t reset_type,
-	git_checkout_options *checkout_opts,
-	const char *log_message);
+	git_checkout_options *checkout_opts);
 
 /**
  * Updates some entries in the index from the target commit tree.

--- a/include/git2/reset.h
+++ b/include/git2/reset.h
@@ -56,7 +56,6 @@ typedef enum {
  * The checkout_strategy field will be overridden (based on reset_type).
  * This parameter can be used to propagate notify and progress callbacks.
  *
- * @param signature The identity that will used to populate the reflog entry
  *
  * @param log_message The one line long message to be appended to the reflog.
  * The reflog is only updated if the affected direct reference is actually
@@ -70,7 +69,6 @@ GIT_EXTERN(int) git_reset(
 	git_object *target,
 	git_reset_t reset_type,
 	git_checkout_options *checkout_opts,
-	const git_signature *signature,
 	const char *log_message);
 
 /**

--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -141,12 +141,6 @@ typedef struct git_submodule_update_options {
 	 * in the working directory for the newly cloned repository.
 	 */
 	unsigned int clone_checkout_strategy;
-
-	/**
-	 * The identity used when updating the reflog. NULL means to
-	 * use the default signature using the config.
-	 */
-	git_signature *signature;
 } git_submodule_update_options;
 
 #define GIT_SUBMODULE_UPDATE_OPTIONS_VERSION 1

--- a/src/branch.c
+++ b/src/branch.c
@@ -54,13 +54,12 @@ int git_branch_create(
 	git_repository *repository,
 	const char *branch_name,
 	const git_commit *commit,
-	int force,
-	const char *log_message)
+	int force)
 {
 	int is_head = 0;
 	git_reference *branch = NULL;
 	git_buf canonical_branch_name = GIT_BUF_INIT,
-			  log_message_buf = GIT_BUF_INIT;
+			  log_message = GIT_BUF_INIT;
 	int error = -1;
 
 	assert(branch_name && commit && ref_out);
@@ -87,19 +86,19 @@ int git_branch_create(
 	if (git_buf_joinpath(&canonical_branch_name, GIT_REFS_HEADS_DIR, branch_name) < 0)
 		goto cleanup;
 
-	if (git_buf_sets(&log_message_buf, log_message ? log_message : "Branch: created") < 0)
+	if (git_buf_printf(&log_message, "Branch: created from %s", git_oid_tostr_s(git_commit_id(commit))) < 0)
 		goto cleanup;
 
 	error = git_reference_create(&branch, repository,
 		git_buf_cstr(&canonical_branch_name), git_commit_id(commit), force,
-		git_buf_cstr(&log_message_buf));
+		git_buf_cstr(&log_message));
 
 	if (!error)
 		*ref_out = branch;
 
 cleanup:
 	git_buf_free(&canonical_branch_name);
-	git_buf_free(&log_message_buf);
+	git_buf_free(&log_message);
 	return error;
 }
 
@@ -221,13 +220,12 @@ int git_branch_move(
 	git_reference **out,
 	git_reference *branch,
 	const char *new_branch_name,
-	int force,
-	const char *log_message)
+	int force)
 {
 	git_buf new_reference_name = GIT_BUF_INIT,
 	        old_config_section = GIT_BUF_INIT,
 	        new_config_section = GIT_BUF_INIT,
-	        log_message_buf = GIT_BUF_INIT;
+	        log_message = GIT_BUF_INIT;
 	int error;
 
 	assert(branch && new_branch_name);
@@ -238,20 +236,15 @@ int git_branch_move(
 	if ((error = git_buf_joinpath(&new_reference_name, GIT_REFS_HEADS_DIR, new_branch_name)) < 0)
 		goto done;
 
-	if (log_message) {
-		if ((error = git_buf_sets(&log_message_buf, log_message)) < 0)
+	if ((error = git_buf_printf(&log_message, "Branch: renamed %s to %s",
+				    git_reference_name(branch), git_buf_cstr(&new_reference_name))) < 0)
 			goto done;
-	} else {
-		if ((error = git_buf_printf(&log_message_buf, "Branch: renamed %s to %s",
-						git_reference_name(branch), git_buf_cstr(&new_reference_name))) < 0)
-			goto done;
-	}
 
 	/* first update ref then config so failure won't trash config */
 
 	error = git_reference_rename(
 		out, branch, git_buf_cstr(&new_reference_name), force,
-		git_buf_cstr(&log_message_buf));
+		git_buf_cstr(&log_message));
 	if (error < 0)
 		goto done;
 
@@ -268,7 +261,7 @@ done:
 	git_buf_free(&new_reference_name);
 	git_buf_free(&old_config_section);
 	git_buf_free(&new_config_section);
-	git_buf_free(&log_message_buf);
+	git_buf_free(&log_message);
 
 	return error;
 }

--- a/src/branch.c
+++ b/src/branch.c
@@ -55,7 +55,6 @@ int git_branch_create(
 	const char *branch_name,
 	const git_commit *commit,
 	int force,
-	const git_signature *signature,
 	const char *log_message)
 {
 	int is_head = 0;
@@ -92,7 +91,7 @@ int git_branch_create(
 		goto cleanup;
 
 	error = git_reference_create(&branch, repository,
-		git_buf_cstr(&canonical_branch_name), git_commit_id(commit), force, signature,
+		git_buf_cstr(&canonical_branch_name), git_commit_id(commit), force,
 		git_buf_cstr(&log_message_buf));
 
 	if (!error)
@@ -223,7 +222,6 @@ int git_branch_move(
 	git_reference *branch,
 	const char *new_branch_name,
 	int force,
-	const git_signature *signature,
 	const char *log_message)
 {
 	git_buf new_reference_name = GIT_BUF_INIT,
@@ -253,7 +251,7 @@ int git_branch_move(
 
 	error = git_reference_rename(
 		out, branch, git_buf_cstr(&new_reference_name), force,
-		signature, git_buf_cstr(&log_message_buf));
+		git_buf_cstr(&log_message_buf));
 	if (error < 0)
 		goto done;
 

--- a/src/clone.c
+++ b/src/clone.c
@@ -35,6 +35,7 @@ static int create_branch(
 {
 	git_commit *head_obj = NULL;
 	git_reference *branch_ref = NULL;
+	git_buf refname = GIT_BUF_INIT;
 	int error;
 
 	/* Find the target commit */
@@ -42,8 +43,11 @@ static int create_branch(
 		return error;
 
 	/* Create the new branch */
-	error = git_branch_create(&branch_ref, repo, name, head_obj, 0, log_message);
+	if ((error = git_buf_printf(&refname, GIT_REFS_HEADS_DIR "%s", name)) < 0)
+		return error;
 
+	error = git_reference_create(&branch_ref, repo, git_buf_cstr(&refname), target, 0, log_message);
+	git_buf_free(&refname);
 	git_commit_free(head_obj);
 
 	if (!error)

--- a/src/clone.c
+++ b/src/clone.c
@@ -24,14 +24,13 @@
 #include "repository.h"
 #include "odb.h"
 
-static int clone_local_into(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, int link, const git_signature *signature);
+static int clone_local_into(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, int link);
 
 static int create_branch(
 	git_reference **branch,
 	git_repository *repo,
 	const git_oid *target,
 	const char *name,
-	const git_signature *signature,
 	const char *log_message)
 {
 	git_commit *head_obj = NULL;
@@ -43,7 +42,7 @@ static int create_branch(
 		return error;
 
 	/* Create the new branch */
-	error = git_branch_create(&branch_ref, repo, name, head_obj, 0, signature, log_message);
+	error = git_branch_create(&branch_ref, repo, name, head_obj, 0, log_message);
 
 	git_commit_free(head_obj);
 
@@ -93,12 +92,11 @@ static int create_tracking_branch(
 	git_repository *repo,
 	const git_oid *target,
 	const char *branch_name,
-	const git_signature *signature,
 	const char *log_message)
 {
 	int error;
 
-	if ((error = create_branch(branch, repo, target, branch_name, signature, log_message)) < 0)
+	if ((error = create_branch(branch, repo, target, branch_name, log_message)) < 0)
 		return error;
 
 	return setup_tracking_config(
@@ -112,7 +110,6 @@ static int update_head_to_new_branch(
 	git_repository *repo,
 	const git_oid *target,
 	const char *name,
-	const git_signature *signature,
 	const char *reflog_message)
 {
 	git_reference *tracking_branch = NULL;
@@ -122,12 +119,12 @@ static int update_head_to_new_branch(
 		name += strlen(GIT_REFS_HEADS_DIR);
 
 	error = create_tracking_branch(&tracking_branch, repo, target, name,
-			signature, reflog_message);
+			reflog_message);
 
 	if (!error)
 		error = git_repository_set_head(
 			repo, git_reference_name(tracking_branch),
-			signature, reflog_message);
+			reflog_message);
 
 	git_reference_free(tracking_branch);
 
@@ -141,7 +138,6 @@ static int update_head_to_new_branch(
 static int update_head_to_remote(
 		git_repository *repo,
 		git_remote *remote,
-		const git_signature *signature,
 		const char *reflog_message)
 {
 	int error = 0;
@@ -169,7 +165,7 @@ static int update_head_to_remote(
 	error = git_remote_default_branch(&branch, remote);
 	if (error == GIT_ENOTFOUND) {
 		error = git_repository_set_head_detached(
-			repo, remote_head_id, signature, reflog_message);
+			repo, remote_head_id, reflog_message);
 		goto cleanup;
 	}
 
@@ -192,7 +188,7 @@ static int update_head_to_remote(
 		repo,
 		remote_head_id,
 		git_buf_cstr(&branch),
-		signature, reflog_message);
+		reflog_message);
 
 cleanup:
 	git_buf_free(&remote_master_name);
@@ -205,7 +201,6 @@ static int update_head_to_branch(
 		git_repository *repo,
 		const char *remote_name,
 		const char *branch,
-		const git_signature *signature,
 		const char *reflog_message)
 {
 	int retcode;
@@ -222,7 +217,7 @@ static int update_head_to_branch(
 		goto cleanup;
 
 	retcode = update_head_to_new_branch(repo, git_reference_target(remote_ref), branch,
-			signature, reflog_message);
+			reflog_message);
 
 cleanup:
 	git_reference_free(remote_ref);
@@ -313,16 +308,16 @@ static bool should_checkout(
 	return !git_repository_head_unborn(repo);
 }
 
-static int checkout_branch(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, const git_signature *signature, const char *reflog_message)
+static int checkout_branch(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, const char *reflog_message)
 {
 	int error;
 
 	if (branch)
 		error = update_head_to_branch(repo, git_remote_name(remote), branch,
-				signature, reflog_message);
+				reflog_message);
 	/* Point HEAD to the same ref as the remote's head */
 	else
-		error = update_head_to_remote(repo, remote, signature, reflog_message);
+		error = update_head_to_remote(repo, remote, reflog_message);
 
 	if (!error && should_checkout(repo, git_repository_is_bare(repo), co_opts))
 		error = git_checkout_head(repo, co_opts);
@@ -330,7 +325,7 @@ static int checkout_branch(git_repository *repo, git_remote *remote, const git_c
 	return error;
 }
 
-static int clone_into(git_repository *repo, git_remote *_remote, const git_checkout_options *co_opts, const char *branch, const git_signature *signature)
+static int clone_into(git_repository *repo, git_remote *_remote, const git_checkout_options *co_opts, const char *branch)
 {
 	int error;
 	git_buf reflog_message = GIT_BUF_INIT;
@@ -358,10 +353,10 @@ static int clone_into(git_repository *repo, git_remote *_remote, const git_check
 	git_remote_set_update_fetchhead(remote, 0);
 	git_buf_printf(&reflog_message, "clone: from %s", git_remote_url(remote));
 
-	if ((error = git_remote_fetch(remote, NULL, signature, git_buf_cstr(&reflog_message))) != 0)
+	if ((error = git_remote_fetch(remote, NULL, git_buf_cstr(&reflog_message))) != 0)
 		goto cleanup;
 
-	error = checkout_branch(repo, remote, co_opts, branch, signature, git_buf_cstr(&reflog_message));
+	error = checkout_branch(repo, remote, co_opts, branch, git_buf_cstr(&reflog_message));
 
 cleanup:
 	git_remote_free(remote);
@@ -442,11 +437,11 @@ int git_clone(
 		if (clone_local == 1)
 			error = clone_local_into(
 				repo, origin, &options.checkout_opts,
-				options.checkout_branch, link, options.signature);
+				options.checkout_branch, link);
 		else if (clone_local == 0)
 			error = clone_into(
 				repo, origin, &options.checkout_opts,
-				options.checkout_branch, options.signature);
+				options.checkout_branch);
 		else
 			error = -1;
 
@@ -508,7 +503,7 @@ static bool can_link(const char *src, const char *dst, int link)
 #endif
 }
 
-static int clone_local_into(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, int link, const git_signature *signature)
+static int clone_local_into(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, int link)
 {
 	int error, flags;
 	git_repository *src;
@@ -553,10 +548,10 @@ static int clone_local_into(git_repository *repo, git_remote *remote, const git_
 
 	git_buf_printf(&reflog_message, "clone: from %s", git_remote_url(remote));
 
-	if ((error = git_remote_fetch(remote, NULL, signature, git_buf_cstr(&reflog_message))) != 0)
+	if ((error = git_remote_fetch(remote, NULL, git_buf_cstr(&reflog_message))) != 0)
 		goto cleanup;
 
-	error = checkout_branch(repo, remote, co_opts, branch, signature, git_buf_cstr(&reflog_message));
+	error = checkout_branch(repo, remote, co_opts, branch, git_buf_cstr(&reflog_message));
 
 cleanup:
 	git_buf_free(&reflog_message);

--- a/src/clone.c
+++ b/src/clone.c
@@ -127,8 +127,7 @@ static int update_head_to_new_branch(
 
 	if (!error)
 		error = git_repository_set_head(
-			repo, git_reference_name(tracking_branch),
-			reflog_message);
+			repo, git_reference_name(tracking_branch));
 
 	git_reference_free(tracking_branch);
 
@@ -169,7 +168,7 @@ static int update_head_to_remote(
 	error = git_remote_default_branch(&branch, remote);
 	if (error == GIT_ENOTFOUND) {
 		error = git_repository_set_head_detached(
-			repo, remote_head_id, reflog_message);
+			repo, remote_head_id);
 		goto cleanup;
 	}
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -104,7 +104,7 @@ int git_commit_create_from_callback(
 
 	if (update_ref != NULL) {
 		error = git_reference__update_for_commit(
-			repo, ref, update_ref, id, committer, "commit");
+			repo, ref, update_ref, id, "commit");
 		git_reference_free(ref);
 		return error;
 	}
@@ -295,7 +295,7 @@ int git_commit_amend(
 
 	if (!error && update_ref) {
 		error = git_reference__update_for_commit(
-			repo, ref, NULL, id, committer, "commit");
+			repo, ref, NULL, id, "commit");
 		git_reference_free(ref);
 	}
 

--- a/src/push.c
+++ b/src/push.c
@@ -169,7 +169,6 @@ int git_push_add_refspec(git_push *push, const char *refspec)
 
 int git_push_update_tips(
 		git_push *push,
-		const git_signature *signature,
 		const char *reflog_message)
 {
 	git_buf remote_ref_name = GIT_BUF_INIT;
@@ -213,7 +212,7 @@ int git_push_update_tips(
 				}
 			} else {
 				error = git_reference_create(NULL, push->remote->repo,
-							git_buf_cstr(&remote_ref_name), &push_spec->loid, 1, signature,
+							git_buf_cstr(&remote_ref_name), &push_spec->loid, 1,
 							reflog_message ? reflog_message : "update by push");
 			}
 		}

--- a/src/push.c
+++ b/src/push.c
@@ -167,9 +167,7 @@ int git_push_add_refspec(git_push *push, const char *refspec)
 	return 0;
 }
 
-int git_push_update_tips(
-		git_push *push,
-		const char *reflog_message)
+int git_push_update_tips(git_push *push)
 {
 	git_buf remote_ref_name = GIT_BUF_INIT;
 	size_t i, j;
@@ -213,7 +211,7 @@ int git_push_update_tips(
 			} else {
 				error = git_reference_create(NULL, push->remote->repo,
 							git_buf_cstr(&remote_ref_name), &push_spec->loid, 1,
-							reflog_message ? reflog_message : "update by push");
+							"update by push");
 			}
 		}
 

--- a/src/push.h
+++ b/src/push.h
@@ -116,7 +116,6 @@ int git_push_add_refspec(git_push *push, const char *refspec);
  */
 int git_push_update_tips(
 		git_push *push,
-		const git_signature *signature,
 		const char *reflog_message);
 
 /**

--- a/src/push.h
+++ b/src/push.h
@@ -109,14 +109,10 @@ int git_push_add_refspec(git_push *push, const char *refspec);
  *
  * @param push The push object
  * @param signature The identity to use when updating reflogs
- * @param reflog_message The message to insert into the reflogs. If NULL, the
- *                       default is "update by push".
  *
  * @return 0 or an error code
  */
-int git_push_update_tips(
-		git_push *push,
-		const char *reflog_message);
+int git_push_update_tips(git_push *push);
 
 /**
  * Perform the push

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -971,7 +971,7 @@ int git_rebase_abort(git_rebase *rebase)
 	if ((error = git_commit_lookup(
 			&orig_head_commit, rebase->repo, &rebase->orig_head_id)) < 0 ||
 		(error = git_reset(rebase->repo, (git_object *)orig_head_commit,
-			GIT_RESET_HARD, NULL, NULL)) < 0)
+			GIT_RESET_HARD, NULL)) < 0)
 		goto done;
 
 	error = rebase_cleanup(rebase);

--- a/src/refs.c
+++ b/src/refs.c
@@ -416,12 +416,22 @@ static int reference__create(
 	return 0;
 }
 
+int configured_ident(git_signature **out, const git_repository *repo)
+{
+	if (repo->ident_name && repo->ident_email)
+		return git_signature_now(out, repo->ident_name, repo->ident_email);
+
+	/* if not configured let us fall-through to the next method  */
+	return -1;
+}
+
 int git_reference__log_signature(git_signature **out, git_repository *repo)
 {
 	int error;
 	git_signature *who;
 
-	if(((error = git_signature_default(&who, repo)) < 0) &&
+	if(((error = configured_ident(&who, repo)) < 0) &&
+	   ((error = git_signature_default(&who, repo)) < 0) &&
 	   ((error = git_signature_now(&who, "unknown", "unknown")) < 0))
 		return error;
 
@@ -436,7 +446,6 @@ int git_reference_create_matching(
 	const git_oid *id,
 	int force,
 	const git_oid *old_id,
-	const git_signature *signature,
 	const char *log_message)
 
 {
@@ -445,15 +454,11 @@ int git_reference_create_matching(
 	
 	assert(id);
 
-	if (!signature) {
-		if ((error = git_reference__log_signature(&who, repo)) < 0)
-			return error;
-		else
-			signature = who;
-	}
+	if ((error = git_reference__log_signature(&who, repo)) < 0)
+		return error;
 
 	error = reference__create(
-		ref_out, repo, name, id, NULL, force, signature, log_message, old_id, NULL);
+		ref_out, repo, name, id, NULL, force, who, log_message, old_id, NULL);
 
 	git_signature_free(who);
 	return error;
@@ -465,10 +470,9 @@ int git_reference_create(
 	const char *name,
 	const git_oid *id,
 	int force,
-	const git_signature *signature,
 	const char *log_message)
 {
-        return git_reference_create_matching(ref_out, repo, name, id, force, NULL, signature, log_message);
+        return git_reference_create_matching(ref_out, repo, name, id, force, NULL, log_message);
 }
 
 int git_reference_symbolic_create_matching(
@@ -478,7 +482,6 @@ int git_reference_symbolic_create_matching(
 	const char *target,
 	int force,
 	const char *old_target,
-	const git_signature *signature,
 	const char *log_message)
 {
 	int error;
@@ -486,15 +489,11 @@ int git_reference_symbolic_create_matching(
 
 	assert(target);
 
-	if (!signature) {
-		if ((error = git_reference__log_signature(&who, repo)) < 0)
-			return error;
-		else
-			signature = who;
-	}
+	if ((error = git_reference__log_signature(&who, repo)) < 0)
+		return error;
 
 	error = reference__create(
-		ref_out, repo, name, NULL, target, force, signature, log_message, NULL, old_target);
+		ref_out, repo, name, NULL, target, force, who, log_message, NULL, old_target);
 
 	git_signature_free(who);
 	return error;
@@ -506,10 +505,9 @@ int git_reference_symbolic_create(
 	const char *name,
 	const char *target,
 	int force,
-	const git_signature *signature,
 	const char *log_message)
 {
-	return git_reference_symbolic_create_matching(ref_out, repo, name, target, force, NULL, signature, log_message);
+	return git_reference_symbolic_create_matching(ref_out, repo, name, target, force, NULL, log_message);
 }
 
 static int ensure_is_an_updatable_direct_reference(git_reference *ref)
@@ -525,7 +523,6 @@ int git_reference_set_target(
 	git_reference **out,
 	git_reference *ref,
 	const git_oid *id,
-	const git_signature *signature,
 	const char *log_message)
 {
 	int error;
@@ -538,7 +535,7 @@ int git_reference_set_target(
 	if ((error = ensure_is_an_updatable_direct_reference(ref)) < 0)
 		return error;
 
-	return git_reference_create_matching(out, repo, ref->name, id, 1, &ref->target.oid, signature, log_message);
+	return git_reference_create_matching(out, repo, ref->name, id, 1, &ref->target.oid, log_message);
 }
 
 static int ensure_is_an_updatable_symbolic_reference(git_reference *ref)
@@ -554,7 +551,6 @@ int git_reference_symbolic_set_target(
 	git_reference **out,
 	git_reference *ref,
 	const char *target,
-	const git_signature *signature,
 	const char *log_message)
 {
 	int error;
@@ -565,7 +561,7 @@ int git_reference_symbolic_set_target(
 		return error;
 
 	return git_reference_symbolic_create_matching(
-		out, ref->db->repo, ref->name, target, 1, ref->target.symbolic, signature, log_message);
+		out, ref->db->repo, ref->name, target, 1, ref->target.symbolic, log_message);
 }
 
 static int reference__rename(git_reference **out, git_reference *ref, const char *new_name, int force,
@@ -593,7 +589,7 @@ static int reference__rename(git_reference **out, git_reference *ref, const char
 
 	/* Update HEAD it was pointing to the reference being renamed */
 	if (should_head_be_updated &&
-		(error = git_repository_set_head(ref->db->repo, normalized, signature, message)) < 0) {
+		(error = git_repository_set_head(ref->db->repo, normalized, message)) < 0) {
 		giterr_set(GITERR_REFERENCE, "Failed to update HEAD after renaming reference");
 		return error;
 	}
@@ -607,23 +603,16 @@ int git_reference_rename(
 	git_reference *ref,
 	const char *new_name,
 	int force,
-	const git_signature *signature,
 	const char *log_message)
 {
-	git_signature *who = (git_signature*)signature;
+	git_signature *who;
 	int error;
 
-	/* Should we return an error if there is no default? */
-	if (!who &&
-	    ((error = git_signature_default(&who, ref->db->repo)) < 0) &&
-	    ((error = git_signature_now(&who, "unknown", "unknown")) < 0)) {
+	if ((error = git_reference__log_signature(&who, ref->db->repo)) < 0)
 		return error;
-	}
 
 	error = reference__rename(out, ref, new_name, force, who, log_message);
-
-	if (!signature)
-		git_signature_free(who);
+	git_signature_free(who);
 
 	return error;
 }
@@ -1038,13 +1027,11 @@ int git_reference_cmp(
 	return git_oid__cmp(&ref1->target.oid, &ref2->target.oid);
 }
 
-static int reference__update_terminal(
-	git_repository *repo,
-	const char *ref_name,
-	const git_oid *oid,
-	int nesting,
-	const git_signature *signature,
-	const char *log_message)
+/**
+ * Get the end of a chain of references. If the final one is not
+ * found, we return the reference just before that.
+ */
+static int get_terminal(git_reference **out, git_repository *repo, const char *ref_name, int nesting)
 {
 	git_reference *ref;
 	int error = 0;
@@ -1054,27 +1041,23 @@ static int reference__update_terminal(
 		return GIT_ENOTFOUND;
 	}
 
-	error = git_reference_lookup(&ref, repo, ref_name);
-
-	/* If we haven't found the reference at all, create a new reference. */
-	if (error == GIT_ENOTFOUND) {
-		giterr_clear();
-		return git_reference_create(NULL, repo, ref_name, oid, 0, signature, log_message);
+	/* set to NULL to let the caller know that they're at the end of the chain */
+	if ((error = git_reference_lookup(&ref, repo, ref_name)) < 0) {
+		*out = NULL;
+		return error;
 	}
 
-	if (error < 0)
-		return error;
-
-	/* If the ref is a symbolic reference, follow its target. */
-	if (git_reference_type(ref) == GIT_REF_SYMBOLIC) {
-		error = reference__update_terminal(repo, git_reference_symbolic_target(ref), oid,
-			nesting+1, signature, log_message);
-		git_reference_free(ref);
+	if (git_reference_type(ref) == GIT_REF_OID) {
+		*out = ref;
+		error = 0;
 	} else {
-		/* If we're not moving the target, don't recreate the ref */
-		if (0 != git_oid_cmp(git_reference_target(ref), oid))
-			error = git_reference_create(NULL, repo, ref_name, oid, 1, signature, log_message);
-		git_reference_free(ref);
+		error = get_terminal(out, repo, git_reference_symbolic_target(ref), nesting + 1);
+		if (error == GIT_ENOTFOUND) {
+			if (!*out) /* set by the error case in lookup above */
+				*out = ref;
+		} else {
+			git_reference_free(ref);
+		}
 	}
 
 	return error;
@@ -1089,10 +1072,38 @@ int git_reference__update_terminal(
 	git_repository *repo,
 	const char *ref_name,
 	const git_oid *oid,
-	const git_signature *signature,
+	const git_signature *sig,
 	const char *log_message)
 {
-	return reference__update_terminal(repo, ref_name, oid, 0, signature, log_message);
+	git_reference *ref = NULL;
+	git_signature *who = NULL;
+	const git_signature *to_use;
+	int error = 0;
+
+	if (!sig && (error = git_reference__log_signature(&who, repo)) < 0)
+		return error;
+
+	to_use = sig ? sig : who;
+	error = get_terminal(&ref, repo, ref_name, 0);
+
+	/* found a dangling symref */
+	if (error == GIT_ENOTFOUND && ref) {
+		assert(git_reference_type(ref) == GIT_REF_SYMBOLIC);
+		giterr_clear();
+		error = reference__create(&ref, repo, ref->target.symbolic, oid, NULL, 0, to_use,
+					  log_message, NULL, NULL);
+	} else if (error == GIT_ENOTFOUND) {
+		giterr_clear();
+		error = reference__create(&ref, repo, ref_name, oid, NULL, 0, to_use,
+					  log_message, NULL, NULL);
+	}  else if (error == 0) {
+		assert(git_reference_type(ref) == GIT_REF_OID);
+		error = reference__create(&ref, repo, ref->name, oid, NULL, 1, to_use,
+					  log_message, &ref->target.oid, NULL);
+	}
+
+	git_signature_free(who);
+	return error;
 }
 
 int git_reference__update_for_commit(
@@ -1100,12 +1111,12 @@ int git_reference__update_for_commit(
 	git_reference *ref,
 	const char *ref_name,
 	const git_oid *id,
-	const git_signature *committer,
 	const char *operation)
 {
 	git_reference *ref_new = NULL;
 	git_commit *commit = NULL;
 	git_buf reflog_msg = GIT_BUF_INIT;
+	const git_signature *who;
 	int error;
 
 	if ((error = git_commit_lookup(&commit, repo, id)) < 0 ||
@@ -1115,12 +1126,18 @@ int git_reference__update_for_commit(
 			git_commit_summary(commit))) < 0)
 		goto done;
 
-	if (ref)
-		error = git_reference_set_target(
-			&ref_new, ref, id, committer, git_buf_cstr(&reflog_msg));
+	who = git_commit_committer(commit);
+
+	if (ref) {
+		if ((error = ensure_is_an_updatable_direct_reference(ref)) < 0)
+			return error;
+
+		error = reference__create(&ref_new, repo, ref->name, id, NULL, 1, who,
+					  git_buf_cstr(&reflog_msg), &ref->target.oid, NULL);
+	}
 	else
 		error = git_reference__update_terminal(
-			repo, ref_name, id, committer, git_buf_cstr(&reflog_msg));
+			repo, ref_name, id, who, git_buf_cstr(&reflog_msg));
 
 done:
 	git_reference_free(ref_new);

--- a/src/refs.c
+++ b/src/refs.c
@@ -589,7 +589,7 @@ static int reference__rename(git_reference **out, git_reference *ref, const char
 
 	/* Update HEAD it was pointing to the reference being renamed */
 	if (should_head_be_updated &&
-		(error = git_repository_set_head(ref->db->repo, normalized, message)) < 0) {
+		(error = git_repository_set_head(ref->db->repo, normalized)) < 0) {
 		giterr_set(GITERR_REFERENCE, "Failed to update HEAD after renaming reference");
 		return error;
 	}
@@ -1284,10 +1284,8 @@ int git_reference_is_valid_name(const char *refname)
 	return git_reference__is_valid_name(refname, GIT_REF_FORMAT_ALLOW_ONELEVEL);
 }
 
-const char *git_reference_shorthand(const git_reference *ref)
+const char *git_reference__shorthand(const char *name)
 {
-	const char *name = ref->name;
-
 	if (!git__prefixcmp(name, GIT_REFS_HEADS_DIR))
 		return name + strlen(GIT_REFS_HEADS_DIR);
 	else if (!git__prefixcmp(name, GIT_REFS_TAGS_DIR))
@@ -1299,4 +1297,9 @@ const char *git_reference_shorthand(const git_reference *ref)
 
 	/* No shorthands are avaiable, so just return the name */
 	return name;
+}
+
+const char *git_reference_shorthand(const git_reference *ref)
+{
+	return git_reference__shorthand(ref->name);
 }

--- a/src/refs.h
+++ b/src/refs.h
@@ -69,7 +69,7 @@ struct git_reference {
 git_reference *git_reference__set_name(git_reference *ref, const char *name);
 
 int git_reference__normalize_name(git_buf *buf, const char *name, unsigned int flags);
-int git_reference__update_terminal(git_repository *repo, const char *ref_name, const git_oid *oid, const git_signature *signature, const char *log_message);
+int git_reference__update_terminal(git_repository *repo, const char *ref_name, const git_oid *oid, const git_signature *sig, const char *log_message);
 int git_reference__is_valid_name(const char *refname, unsigned int flags);
 int git_reference__is_branch(const char *ref_name);
 int git_reference__is_remote(const char *ref_name);
@@ -106,7 +106,6 @@ int git_reference__update_for_commit(
 	git_reference *ref,
 	const char *ref_name,
 	const git_oid *id,
-	const git_signature *committer,
 	const char *operation);
 
 #endif

--- a/src/refs.h
+++ b/src/refs.h
@@ -74,6 +74,7 @@ int git_reference__is_valid_name(const char *refname, unsigned int flags);
 int git_reference__is_branch(const char *ref_name);
 int git_reference__is_remote(const char *ref_name);
 int git_reference__is_tag(const char *ref_name);
+const char *git_reference__shorthand(const char *name);
 
 /**
  * Lookup a reference by name and try to resolve to an OID.

--- a/src/remote.c
+++ b/src/remote.c
@@ -924,7 +924,6 @@ on_error:
 int git_remote_fetch(
 		git_remote *remote,
 		const git_strarray *refspecs,
-		const git_signature *signature,
 		const char *reflog_message)
 {
 	int error;
@@ -952,7 +951,7 @@ int git_remote_fetch(
 	}
 
 	/* Create "remote/foo" branches for all remote branches */
-	error = git_remote_update_tips(remote, signature, git_buf_cstr(&reflog_msg_buf));
+	error = git_remote_update_tips(remote, git_buf_cstr(&reflog_msg_buf));
 	git_buf_free(&reflog_msg_buf);
 	if (error < 0)
 		return error;
@@ -1257,7 +1256,6 @@ static int update_tips_for_spec(
 		git_remote *remote,
 		git_refspec *spec,
 		git_vector *refs,
-		const git_signature *signature,
 		const char *log_message)
 {
 	int error = 0, autotag;
@@ -1332,7 +1330,7 @@ static int update_tips_for_spec(
 
 		/* In autotag mode, don't overwrite any locally-existing tags */
 		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, !autotag, 
-				signature, log_message);
+				log_message);
 		if (error < 0 && error != GIT_EEXISTS)
 			goto on_error;
 
@@ -1418,7 +1416,7 @@ static int next_head(const git_remote *remote, git_vector *refs,
 	return GIT_ITEROVER;
 }
 
-static int opportunistic_updates(const git_remote *remote, git_vector *refs, const git_signature *sig, const char *msg)
+static int opportunistic_updates(const git_remote *remote, git_vector *refs, const char *msg)
 {
 	size_t i, j, k;
 	git_refspec *spec;
@@ -1441,7 +1439,7 @@ static int opportunistic_updates(const git_remote *remote, git_vector *refs, con
 		if ((error = git_refspec_transform(&refname, spec, head->name)) < 0)
 			return error;
 
-		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, true, sig, msg);
+		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, true, msg);
 		git_buf_free(&refname);
 		git_reference_free(ref);
 
@@ -1454,7 +1452,6 @@ static int opportunistic_updates(const git_remote *remote, git_vector *refs, con
 
 int git_remote_update_tips(
 		git_remote *remote,
-		const git_signature *signature,
 		const char *reflog_message)
 {
 	git_refspec *spec, tagspec;
@@ -1464,7 +1461,7 @@ int git_remote_update_tips(
 
 	/* push has its own logic hidden away in the push object */
 	if (remote->push) {
-		return git_push_update_tips(remote->push, signature, reflog_message);
+		return git_push_update_tips(remote->push, reflog_message);
 	}
 
 	if (git_refspec__parse(&tagspec, GIT_REFSPEC_TAGS, true) < 0)
@@ -1475,7 +1472,7 @@ int git_remote_update_tips(
 		goto out;
 
 	if (remote->download_tags == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {
-		if ((error = update_tips_for_spec(remote, &tagspec, &refs, signature, reflog_message)) < 0)
+		if ((error = update_tips_for_spec(remote, &tagspec, &refs, reflog_message)) < 0)
 			goto out;
 	}
 
@@ -1483,13 +1480,13 @@ int git_remote_update_tips(
 		if (spec->push)
 			continue;
 
-		if ((error = update_tips_for_spec(remote, spec, &refs, signature, reflog_message)) < 0)
+		if ((error = update_tips_for_spec(remote, spec, &refs, reflog_message)) < 0)
 			goto out;
 	}
 
 	/* only try to do opportunisitic updates if the refpec lists differ */
 	if (remote->passed_refspecs)
-		error = opportunistic_updates(remote, &refs, signature, reflog_message);
+		error = opportunistic_updates(remote, &refs, reflog_message);
 
 out:
 	git_vector_free(&refs);
@@ -1755,7 +1752,7 @@ static int rename_one_remote_reference(
 		goto cleanup;
 
 	if ((error = git_reference_rename(&ref, reference_in, git_buf_cstr(&new_name), 1,
-					  NULL, git_buf_cstr(&log_message))) < 0)
+					  git_buf_cstr(&log_message))) < 0)
 		goto cleanup;
 
 	if (git_reference_type(ref) != GIT_REF_SYMBOLIC)
@@ -1775,7 +1772,7 @@ static int rename_one_remote_reference(
 		goto cleanup;
 
 	error = git_reference_symbolic_set_target(&dummy, ref, git_buf_cstr(&new_name),
-						  NULL, git_buf_cstr(&log_message));
+						  git_buf_cstr(&log_message));
 
 	git_reference_free(dummy);
 
@@ -2374,7 +2371,7 @@ cleanup:
 }
 
 int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_push_options *opts,
-		    const git_signature *signature, const char *reflog_message)
+		    const char *reflog_message)
 {
 	int error;
 
@@ -2386,7 +2383,7 @@ int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_
 	if ((error = git_remote_upload(remote, refspecs, opts)) < 0)
 		return error;
 
-	error = git_remote_update_tips(remote, signature, reflog_message);
+	error = git_remote_update_tips(remote, reflog_message);
 
 	git_remote_disconnect(remote);
 	return error;

--- a/src/remote.c
+++ b/src/remote.c
@@ -1461,7 +1461,7 @@ int git_remote_update_tips(
 
 	/* push has its own logic hidden away in the push object */
 	if (remote->push) {
-		return git_push_update_tips(remote->push, reflog_message);
+		return git_push_update_tips(remote->push);
 	}
 
 	if (git_refspec__parse(&tagspec, GIT_REFSPEC_TAGS, true) < 0)
@@ -2370,8 +2370,7 @@ cleanup:
 	return error;
 }
 
-int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_push_options *opts,
-		    const char *reflog_message)
+int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_push_options *opts)
 {
 	int error;
 
@@ -2383,7 +2382,7 @@ int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_
 	if ((error = git_remote_upload(remote, refspecs, opts)) < 0)
 		return error;
 
-	error = git_remote_update_tips(remote, reflog_message);
+	error = git_remote_update_tips(remote, NULL);
 
 	git_remote_disconnect(remote);
 	return error;

--- a/src/repository.h
+++ b/src/repository.h
@@ -128,6 +128,9 @@ struct git_repository {
 	char *namespace;
 	char *name_8dot3;
 
+	char *ident_name;
+	char *ident_email;
+
 	unsigned is_bare:1,
 		has_8dot3:1,
 		has_8dot3_default:1;

--- a/src/reset.c
+++ b/src/reset.c
@@ -100,15 +100,14 @@ int git_reset(
 	git_repository *repo,
 	git_object *target,
 	git_reset_t reset_type,
-	git_checkout_options *checkout_opts,
-	const char *log_message)
+	git_checkout_options *checkout_opts)
 {
 	git_object *commit = NULL;
 	git_index *index = NULL;
 	git_tree *tree = NULL;
 	int error = 0;
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
-	git_buf log_message_buf = GIT_BUF_INIT;
+	git_buf log_message = GIT_BUF_INIT;
 
 	assert(repo && target);
 
@@ -140,10 +139,8 @@ int git_reset(
 		goto cleanup;
 	}
 
-	if (log_message)
-		git_buf_sets(&log_message_buf, log_message);
-	else
-		git_buf_sets(&log_message_buf, "reset: moving");
+	if ((error = git_buf_printf(&log_message, "reset: moving to %s", git_oid_tostr_s(git_object_id(commit)))) < 0)
+		return error;
 
 	/* move HEAD to the new target */
 	if ((error = git_reference__update_terminal(repo, GIT_HEAD_FILE,
@@ -175,7 +172,7 @@ cleanup:
 	git_object_free(commit);
 	git_index_free(index);
 	git_tree_free(tree);
-	git_buf_free(&log_message_buf);
+	git_buf_free(&log_message);
 
 	return error;
 }

--- a/src/reset.c
+++ b/src/reset.c
@@ -101,7 +101,6 @@ int git_reset(
 	git_object *target,
 	git_reset_t reset_type,
 	git_checkout_options *checkout_opts,
-	const git_signature *signature,
 	const char *log_message)
 {
 	git_object *commit = NULL;
@@ -148,7 +147,7 @@ int git_reset(
 
 	/* move HEAD to the new target */
 	if ((error = git_reference__update_terminal(repo, GIT_HEAD_FILE,
-		git_object_id(commit), signature, git_buf_cstr(&log_message_buf))) < 0)
+		git_object_id(commit), NULL, git_buf_cstr(&log_message))) < 0)
 		goto cleanup;
 
 	if (reset_type == GIT_RESET_HARD) {

--- a/src/stash.c
+++ b/src/stash.c
@@ -411,7 +411,6 @@ cleanup:
 static int update_reflog(
 	git_oid *w_commit_oid,
 	git_repository *repo,
-	const git_signature *stasher,
 	const char *message)
 {
 	git_reference *stash;
@@ -420,7 +419,7 @@ static int update_reflog(
 	if ((error = git_reference_ensure_log(repo, GIT_REFS_STASH_FILE)) < 0)
 		return error;
 
-	error = git_reference_create(&stash, repo, GIT_REFS_STASH_FILE, w_commit_oid, 1, stasher, message);
+	error = git_reference_create(&stash, repo, GIT_REFS_STASH_FILE, w_commit_oid, 1, message);
 
 	git_reference_free(stash);
 
@@ -534,7 +533,7 @@ int git_stash_save(
 
 	git_buf_rtrim(&msg);
 
-	if ((error = update_reflog(out, repo, stasher, git_buf_cstr(&msg))) < 0)
+	if ((error = update_reflog(out, repo, git_buf_cstr(&msg))) < 0)
 		goto cleanup;
 
 	if ((error = reset_index_and_workdir(

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -927,7 +927,6 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 
 	/* Copy over the remote callbacks */
 	clone_options.remote_callbacks = update_options.remote_callbacks;
-	clone_options.signature = update_options.signature;
 
 	/* Get the status of the submodule to determine if it is already initialized  */
 	if ((error = git_submodule_status(&submodule_status, sm)) < 0)
@@ -985,7 +984,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 		update_options.checkout_opts.checkout_strategy = update_options.clone_checkout_strategy;
 
 		if ((error = git_clone(&sub_repo, submodule_url, sm->path, &clone_options)) < 0 ||
-			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm), update_options.signature, NULL)) < 0 ||
+			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm), NULL)) < 0 ||
 			(error = git_checkout_head(sub_repo, &update_options.checkout_opts)) != 0)
 			goto done;
 	} else {
@@ -997,7 +996,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 		if ((error = git_submodule_open(&sub_repo, sm)) < 0 ||
 			(error = git_object_lookup(&target_commit, sub_repo, git_submodule_index_id(sm), GIT_OBJ_COMMIT)) < 0 ||
 			(error = git_checkout_tree(sub_repo, target_commit, &update_options.checkout_opts)) != 0 ||
-			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm), update_options.signature, NULL)) < 0)
+			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm), NULL)) < 0)
 			goto done;
 
 		/* Invalidate the wd flags as the workdir has been updated. */

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -984,7 +984,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 		update_options.checkout_opts.checkout_strategy = update_options.clone_checkout_strategy;
 
 		if ((error = git_clone(&sub_repo, submodule_url, sm->path, &clone_options)) < 0 ||
-			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm), NULL)) < 0 ||
+			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm))) < 0 ||
 			(error = git_checkout_head(sub_repo, &update_options.checkout_opts)) != 0)
 			goto done;
 	} else {
@@ -996,7 +996,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 		if ((error = git_submodule_open(&sub_repo, sm)) < 0 ||
 			(error = git_object_lookup(&target_commit, sub_repo, git_submodule_index_id(sm), GIT_OBJ_COMMIT)) < 0 ||
 			(error = git_checkout_tree(sub_repo, target_commit, &update_options.checkout_opts)) != 0 ||
-			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm), NULL)) < 0)
+			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm))) < 0)
 			goto done;
 
 		/* Invalidate the wd flags as the workdir has been updated. */

--- a/src/tag.c
+++ b/src/tag.c
@@ -273,7 +273,7 @@ static int git_tag_create__internal(
 	} else
 		git_oid_cpy(oid, git_object_id(target));
 
-	error = git_reference_create(&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL, NULL);
+	error = git_reference_create(&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL);
 
 cleanup:
 	git_reference_free(new_ref);
@@ -380,7 +380,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 	}
 
 	error = git_reference_create(
-		&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL, NULL);
+		&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL);
 
 	git_reference_free(new_ref);
 	git_buf_free(&ref_name);

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -348,7 +348,7 @@ static int local_push_update_remote_ref(
 	if (lref[0] != '\0') {
 		/* Create or update a ref */
 		error = git_reference_create(NULL, remote_repo, rref, loid,
-					     !git_oid_iszero(roid), NULL, NULL);
+					     !git_oid_iszero(roid), NULL);
 	} else {
 		/* Delete a ref */
 		if ((error = git_reference_lookup(&remote_ref, remote_repo, rref)) < 0) {

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -113,7 +113,7 @@ void test_checkout_crlf__detect_crlf_autocrlf_true_utf8(void)
 
 	cl_repo_set_bool(g_repo, "core.autocrlf", true);
 
-	git_repository_set_head(g_repo, "refs/heads/utf8", NULL);
+	git_repository_set_head(g_repo, "refs/heads/utf8");
 	git_checkout_head(g_repo, &opts);
 
 	if (GIT_EOL_NATIVE == GIT_EOL_LF)

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -113,7 +113,7 @@ void test_checkout_crlf__detect_crlf_autocrlf_true_utf8(void)
 
 	cl_repo_set_bool(g_repo, "core.autocrlf", true);
 
-	git_repository_set_head(g_repo, "refs/heads/utf8", NULL, NULL);
+	git_repository_set_head(g_repo, "refs/heads/utf8", NULL);
 	git_checkout_head(g_repo, &opts);
 
 	if (GIT_EOL_NATIVE == GIT_EOL_LF)

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -63,7 +63,7 @@ void test_checkout_tree__can_checkout_and_remove_directory(void)
 	cl_git_pass(git_revparse_single(&g_object, g_repo, "subtrees"));
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees"));
 
 	cl_assert_equal_i(true, git_path_isdir("./testrepo/ab/"));
 	cl_assert_equal_i(true, git_path_isfile("./testrepo/ab/de/2.txt"));
@@ -78,7 +78,7 @@ void test_checkout_tree__can_checkout_and_remove_directory(void)
 	cl_git_pass(git_revparse_single(&g_object, g_repo, "master"));
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master"));
 
 	/* This directory should no longer exist */
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/ab/"));
@@ -163,7 +163,7 @@ void test_checkout_tree__can_switch_branches(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir"));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));
@@ -183,7 +183,7 @@ void test_checkout_tree__can_switch_branches(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees"));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));
@@ -253,7 +253,7 @@ static int checkout_tree_with_blob_ignored_in_workdir(int strategy, bool isdir)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir"));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));
@@ -313,7 +313,7 @@ void test_checkout_tree__can_overwrite_ignored_by_default(void)
 {
 	cl_git_pass(checkout_tree_with_blob_ignored_in_workdir(GIT_CHECKOUT_SAFE, false));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees"));
 
 	cl_assert(git_path_isfile("testrepo/ab/4.txt"));
 
@@ -334,7 +334,7 @@ void test_checkout_tree__can_overwrite_ignored_folder_by_default(void)
 {
 	cl_git_pass(checkout_tree_with_blob_ignored_in_workdir(GIT_CHECKOUT_SAFE, true));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees"));
 
 	cl_assert(git_path_isfile("testrepo/ab/4.txt"));
 
@@ -367,7 +367,7 @@ void test_checkout_tree__can_update_only(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir"));
 
 	assert_on_branch(g_repo, "dir");
 
@@ -396,7 +396,7 @@ void test_checkout_tree__can_checkout_with_pattern(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 	cl_git_pass(
-		git_repository_set_head_detached(g_repo, git_object_id(g_object), NULL));
+		git_repository_set_head_detached(g_repo, git_object_id(g_object)));
 
 	git_object_free(g_object);
 	g_object = NULL;
@@ -435,7 +435,7 @@ void test_checkout_tree__can_disable_pattern_match(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 	cl_git_pass(
-		git_repository_set_head_detached(g_repo, git_object_id(g_object), NULL));
+		git_repository_set_head_detached(g_repo, git_object_id(g_object)));
 
 	git_object_free(g_object);
 	g_object = NULL;
@@ -677,7 +677,7 @@ void test_checkout_tree__can_checkout_with_last_workdir_item_missing(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &commit_id));
 
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)commit, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master"));
 
 	cl_git_pass(p_mkdir("./testrepo/this-is-dir", 0777));
 	cl_git_mkfile("./testrepo/this-is-dir/contained_file", "content\n");
@@ -1049,7 +1049,7 @@ void test_checkout_tree__case_changing_rename(void)
 	cl_git_pass(git_commit_lookup(&dir_commit, g_repo, &dir_commit_id));
 
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)dir_commit, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir"));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	case_sensitive = !git_path_isfile("testrepo/readme");
@@ -1086,7 +1086,7 @@ void test_checkout_tree__case_changing_rename(void)
 	cl_git_pass(git_commit_lookup(&master_commit, g_repo, &master_id));
 
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)master_commit, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master"));
 	
 	assert_on_branch(g_repo, "master");
 
@@ -1285,7 +1285,7 @@ void test_checkout_tree__safe_proceeds_if_no_index(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees"));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -63,7 +63,7 @@ void test_checkout_tree__can_checkout_and_remove_directory(void)
 	cl_git_pass(git_revparse_single(&g_object, g_repo, "subtrees"));
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
 
 	cl_assert_equal_i(true, git_path_isdir("./testrepo/ab/"));
 	cl_assert_equal_i(true, git_path_isfile("./testrepo/ab/de/2.txt"));
@@ -78,7 +78,7 @@ void test_checkout_tree__can_checkout_and_remove_directory(void)
 	cl_git_pass(git_revparse_single(&g_object, g_repo, "master"));
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL));
 
 	/* This directory should no longer exist */
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/ab/"));
@@ -163,7 +163,7 @@ void test_checkout_tree__can_switch_branches(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));
@@ -183,7 +183,7 @@ void test_checkout_tree__can_switch_branches(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));
@@ -253,7 +253,7 @@ static int checkout_tree_with_blob_ignored_in_workdir(int strategy, bool isdir)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	cl_assert(git_path_isfile("testrepo/branch_file.txt"));
@@ -313,7 +313,7 @@ void test_checkout_tree__can_overwrite_ignored_by_default(void)
 {
 	cl_git_pass(checkout_tree_with_blob_ignored_in_workdir(GIT_CHECKOUT_SAFE, false));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
 
 	cl_assert(git_path_isfile("testrepo/ab/4.txt"));
 
@@ -334,7 +334,7 @@ void test_checkout_tree__can_overwrite_ignored_folder_by_default(void)
 {
 	cl_git_pass(checkout_tree_with_blob_ignored_in_workdir(GIT_CHECKOUT_SAFE, true));
 
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/subtrees", NULL));
 
 	cl_assert(git_path_isfile("testrepo/ab/4.txt"));
 
@@ -367,7 +367,7 @@ void test_checkout_tree__can_update_only(void)
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJ_ANY));
 
 	cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
 
 	assert_on_branch(g_repo, "dir");
 
@@ -396,7 +396,7 @@ void test_checkout_tree__can_checkout_with_pattern(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 	cl_git_pass(
-		git_repository_set_head_detached(g_repo, git_object_id(g_object), NULL, NULL));
+		git_repository_set_head_detached(g_repo, git_object_id(g_object), NULL));
 
 	git_object_free(g_object);
 	g_object = NULL;
@@ -435,7 +435,7 @@ void test_checkout_tree__can_disable_pattern_match(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
 	cl_git_pass(
-		git_repository_set_head_detached(g_repo, git_object_id(g_object), NULL, NULL));
+		git_repository_set_head_detached(g_repo, git_object_id(g_object), NULL));
 
 	git_object_free(g_object);
 	g_object = NULL;
@@ -481,11 +481,11 @@ void assert_conflict(
 	/* Create a branch pointing at the parent */
 	cl_git_pass(git_revparse_single(&g_object, g_repo, parent_sha));
 	cl_git_pass(git_branch_create(&branch, g_repo,
-		"potential_conflict", (git_commit *)g_object, 0, NULL, NULL));
+		"potential_conflict", (git_commit *)g_object, 0,  NULL));
 
 	/* Make HEAD point to this branch */
 	cl_git_pass(git_reference_symbolic_create(
-		&head, g_repo, "HEAD", git_reference_name(branch), 1, NULL, NULL));
+		&head, g_repo, "HEAD", git_reference_name(branch), 1, NULL));
 	git_reference_free(head);
 	git_reference_free(branch);
 
@@ -572,7 +572,7 @@ void test_checkout_tree__donot_update_deleted_file_by_default(void)
 
 	cl_git_pass(git_oid_fromstr(&old_id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
 	cl_git_pass(git_commit_lookup(&old_commit, g_repo, &old_id));
-	cl_git_pass(git_reset(g_repo, (git_object *)old_commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(g_repo, (git_object *)old_commit, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(p_unlink("testrepo/branch_file.txt"));
 	cl_git_pass(git_index_remove_bypath(index ,"branch_file.txt"));
@@ -677,7 +677,7 @@ void test_checkout_tree__can_checkout_with_last_workdir_item_missing(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &commit_id));
 
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)commit, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL));
 
 	cl_git_pass(p_mkdir("./testrepo/this-is-dir", 0777));
 	cl_git_mkfile("./testrepo/this-is-dir/contained_file", "content\n");
@@ -1049,7 +1049,7 @@ void test_checkout_tree__case_changing_rename(void)
 	cl_git_pass(git_commit_lookup(&dir_commit, g_repo, &dir_commit_id));
 
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)dir_commit, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/dir", NULL));
 
 	cl_assert(git_path_isfile("testrepo/README"));
 	case_sensitive = !git_path_isfile("testrepo/readme");
@@ -1086,7 +1086,7 @@ void test_checkout_tree__case_changing_rename(void)
 	cl_git_pass(git_commit_lookup(&master_commit, g_repo, &master_id));
 
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)master_commit, &opts));
-	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/master", NULL));
 	
 	assert_on_branch(g_repo, "master");
 
@@ -1201,7 +1201,7 @@ void test_checkout_tree__can_not_update_index(void)
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "HEAD"));
 	cl_git_pass(git_object_lookup(&head, g_repo, &oid, GIT_OBJ_ANY));
 
-	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts, NULL, NULL));
+	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts, NULL));
 
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/ab/"));
 
@@ -1238,7 +1238,7 @@ void test_checkout_tree__can_update_but_not_write_index(void)
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "HEAD"));
 	cl_git_pass(git_object_lookup(&head, g_repo, &oid, GIT_OBJ_ANY));
 
-	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts, NULL, NULL));
+	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts, NULL));
 
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/ab/"));
 

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -481,7 +481,7 @@ void assert_conflict(
 	/* Create a branch pointing at the parent */
 	cl_git_pass(git_revparse_single(&g_object, g_repo, parent_sha));
 	cl_git_pass(git_branch_create(&branch, g_repo,
-		"potential_conflict", (git_commit *)g_object, 0,  NULL));
+		"potential_conflict", (git_commit *)g_object, 0));
 
 	/* Make HEAD point to this branch */
 	cl_git_pass(git_reference_symbolic_create(
@@ -1201,7 +1201,7 @@ void test_checkout_tree__can_not_update_index(void)
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "HEAD"));
 	cl_git_pass(git_object_lookup(&head, g_repo, &oid, GIT_OBJ_ANY));
 
-	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts, NULL));
+	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts));
 
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/ab/"));
 
@@ -1238,7 +1238,7 @@ void test_checkout_tree__can_update_but_not_write_index(void)
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "HEAD"));
 	cl_git_pass(git_object_lookup(&head, g_repo, &oid, GIT_OBJ_ANY));
 
-	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts, NULL));
+	cl_git_pass(git_reset(g_repo, head, GIT_RESET_HARD, &g_opts));
 
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/ab/"));
 

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -572,7 +572,7 @@ void test_checkout_tree__donot_update_deleted_file_by_default(void)
 
 	cl_git_pass(git_oid_fromstr(&old_id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
 	cl_git_pass(git_commit_lookup(&old_commit, g_repo, &old_id));
-	cl_git_pass(git_reset(g_repo, (git_object *)old_commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(g_repo, (git_object *)old_commit, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(p_unlink("testrepo/branch_file.txt"));
 	cl_git_pass(git_index_remove_bypath(index ,"branch_file.txt"));

--- a/tests/checkout/typechange.c
+++ b/tests/checkout/typechange.c
@@ -122,7 +122,7 @@ void test_checkout_typechange__checkout_typechanges_safe(void)
 		cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
 
 		cl_git_pass(
-			git_repository_set_head_detached(g_repo, git_object_id(obj), NULL, NULL));
+			git_repository_set_head_detached(g_repo, git_object_id(obj), NULL));
 
 		assert_workdir_matches_tree(g_repo, git_object_id(obj), NULL, true);
 
@@ -231,7 +231,7 @@ void test_checkout_typechange__checkout_with_conflicts(void)
 		cl_assert(!git_path_exists("typechanges/untracked"));
 
 		cl_git_pass(
-			git_repository_set_head_detached(g_repo, git_object_id(obj), NULL, NULL));
+			git_repository_set_head_detached(g_repo, git_object_id(obj), NULL));
 
 		assert_workdir_matches_tree(g_repo, git_object_id(obj), NULL, true);
 

--- a/tests/checkout/typechange.c
+++ b/tests/checkout/typechange.c
@@ -122,7 +122,7 @@ void test_checkout_typechange__checkout_typechanges_safe(void)
 		cl_git_pass(git_checkout_tree(g_repo, obj, &opts));
 
 		cl_git_pass(
-			git_repository_set_head_detached(g_repo, git_object_id(obj), NULL));
+			git_repository_set_head_detached(g_repo, git_object_id(obj)));
 
 		assert_workdir_matches_tree(g_repo, git_object_id(obj), NULL, true);
 
@@ -231,7 +231,7 @@ void test_checkout_typechange__checkout_with_conflicts(void)
 		cl_assert(!git_path_exists("typechanges/untracked"));
 
 		cl_git_pass(
-			git_repository_set_head_detached(g_repo, git_object_id(obj), NULL));
+			git_repository_set_head_detached(g_repo, git_object_id(obj)));
 
 		assert_workdir_matches_tree(g_repo, git_object_id(obj), NULL, true);
 

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -66,7 +66,7 @@ void test_cherrypick_workdir__automerge(void)
 		git_tree *cherrypicked_tree = NULL;
 
 		cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-		cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+		cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 		git_oid_fromstr(&cherry_oid, cherrypick_oids[i]);
 		cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -118,7 +118,7 @@ void test_cherrypick_workdir__empty_result(void)
 	cl_assert(git_path_exists(TEST_REPO_PATH "/file4.txt"));
 
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, cherrypick_oid);
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -155,7 +155,7 @@ void test_cherrypick_workdir__conflicts(void)
 	git_oid_fromstr(&head_oid, "bafbf6912c09505ac60575cd43d3f2aba3bd84d8");
 
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "e9b63f3655b2ad80c0ff587389b5a9589a3a7110");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -263,7 +263,7 @@ void test_cherrypick_workdir__conflict_use_ours(void)
 	git_oid_fromstr(&head_oid, "bafbf6912c09505ac60575cd43d3f2aba3bd84d8");
 
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "e9b63f3655b2ad80c0ff587389b5a9589a3a7110");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -275,7 +275,7 @@ void test_cherrypick_workdir__conflict_use_ours(void)
 	/* resolve conflicts in the index by taking "ours" */
 	opts.merge_opts.file_favor = GIT_MERGE_FILE_FAVOR_OURS;
 
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 	cl_git_pass(git_cherrypick(repo, commit, &opts));
 
 	cl_assert(merge_test_index(repo_index, merge_filesystem_entries, 3));
@@ -305,7 +305,7 @@ void test_cherrypick_workdir__rename(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "2a26c7e88b285613b302ba76712bc998863f3cbc");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -340,7 +340,7 @@ void test_cherrypick_workdir__both_renamed(void)
 
 	git_oid_fromstr(&head_oid, "44cd2ed2052c9c68f9a439d208e9614dc2a55c70");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "2a26c7e88b285613b302ba76712bc998863f3cbc");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -391,7 +391,7 @@ void test_cherrypick_workdir__merge_fails_without_mainline_specified(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "abe4603bc7cd5b8167a267e0e2418fd2348f8cff");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -423,7 +423,7 @@ void test_cherrypick_workdir__merge_first_parent(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "abe4603bc7cd5b8167a267e0e2418fd2348f8cff");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -455,7 +455,7 @@ void test_cherrypick_workdir__merge_second_parent(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&cherry_oid, "abe4603bc7cd5b8167a267e0e2418fd2348f8cff");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -66,7 +66,7 @@ void test_cherrypick_workdir__automerge(void)
 		git_tree *cherrypicked_tree = NULL;
 
 		cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-		cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+		cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 		git_oid_fromstr(&cherry_oid, cherrypick_oids[i]);
 		cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -118,7 +118,7 @@ void test_cherrypick_workdir__empty_result(void)
 	cl_assert(git_path_exists(TEST_REPO_PATH "/file4.txt"));
 
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, cherrypick_oid);
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -155,7 +155,7 @@ void test_cherrypick_workdir__conflicts(void)
 	git_oid_fromstr(&head_oid, "bafbf6912c09505ac60575cd43d3f2aba3bd84d8");
 
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "e9b63f3655b2ad80c0ff587389b5a9589a3a7110");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -263,7 +263,7 @@ void test_cherrypick_workdir__conflict_use_ours(void)
 	git_oid_fromstr(&head_oid, "bafbf6912c09505ac60575cd43d3f2aba3bd84d8");
 
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "e9b63f3655b2ad80c0ff587389b5a9589a3a7110");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -275,7 +275,7 @@ void test_cherrypick_workdir__conflict_use_ours(void)
 	/* resolve conflicts in the index by taking "ours" */
 	opts.merge_opts.file_favor = GIT_MERGE_FILE_FAVOR_OURS;
 
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 	cl_git_pass(git_cherrypick(repo, commit, &opts));
 
 	cl_assert(merge_test_index(repo_index, merge_filesystem_entries, 3));
@@ -305,7 +305,7 @@ void test_cherrypick_workdir__rename(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "2a26c7e88b285613b302ba76712bc998863f3cbc");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -340,7 +340,7 @@ void test_cherrypick_workdir__both_renamed(void)
 
 	git_oid_fromstr(&head_oid, "44cd2ed2052c9c68f9a439d208e9614dc2a55c70");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "2a26c7e88b285613b302ba76712bc998863f3cbc");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -391,7 +391,7 @@ void test_cherrypick_workdir__merge_fails_without_mainline_specified(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "abe4603bc7cd5b8167a267e0e2418fd2348f8cff");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -423,7 +423,7 @@ void test_cherrypick_workdir__merge_first_parent(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "abe4603bc7cd5b8167a267e0e2418fd2348f8cff");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));
@@ -455,7 +455,7 @@ void test_cherrypick_workdir__merge_second_parent(void)
 
 	git_oid_fromstr(&head_oid, "cfc4f0999a8367568e049af4f72e452d40828a15");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&cherry_oid, "abe4603bc7cd5b8167a267e0e2418fd2348f8cff");
 	cl_git_pass(git_commit_lookup(&commit, repo, &cherry_oid));

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -230,7 +230,7 @@ void test_clone_nonetwork__can_detached_head(void)
 	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 
 	cl_git_pass(git_revparse_single(&obj, g_repo, "master~1"));
-	cl_git_pass(git_repository_set_head_detached(g_repo, git_object_id(obj), NULL));
+	cl_git_pass(git_repository_set_head_detached(g_repo, git_object_id(obj)));
 
 	cl_git_pass(git_clone(&cloned, "./foo", "./foo1", &g_options));
 

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -120,7 +120,7 @@ void test_commit_write__root(void)
 	cl_assert(head_old != NULL);
 	git_reference_free(head);
 
-	cl_git_pass(git_reference_symbolic_create(&head, g_repo, "HEAD", branch_name, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, g_repo, "HEAD", branch_name, 1, NULL));
 
 	cl_git_pass(git_commit_create_v(
 		&commit_id, /* out id */

--- a/tests/describe/t6120.c
+++ b/tests/describe/t6120.c
@@ -113,7 +113,7 @@ static void commit_and_tag(
 	if (tag_name == NULL)
 		return;
 
-	cl_git_pass(git_reference_create(&ref, repo, tag_name, &commit_id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, repo, tag_name, &commit_id, 0, NULL));
 	git_reference_free(ref);
 }
 

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -961,7 +961,7 @@ void test_diff_rename__rejected_match_can_match_others(void)
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_git_pass(git_reference_symbolic_set_target(
-		&selfsimilar, head, "refs/heads/renames_similar", NULL, NULL));
+		&selfsimilar, head, "refs/heads/renames_similar", NULL));
 	cl_git_pass(git_checkout_head(g_repo, &opts));
 	cl_git_pass(git_repository_index(&index, g_repo));
 
@@ -1046,7 +1046,7 @@ void test_diff_rename__rejected_match_can_match_others_two(void)
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_git_pass(git_reference_symbolic_set_target(
-		&selfsimilar, head, "refs/heads/renames_similar_two", NULL, NULL));
+		&selfsimilar, head, "refs/heads/renames_similar_two", NULL));
 	cl_git_pass(git_checkout_head(g_repo, &opts));
 	cl_git_pass(git_repository_index(&index, g_repo));
 
@@ -1104,7 +1104,7 @@ void test_diff_rename__rejected_match_can_match_others_three(void)
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
 	cl_git_pass(git_reference_symbolic_set_target(
-		&selfsimilar, head, "refs/heads/renames_similar_two", NULL, NULL));
+		&selfsimilar, head, "refs/heads/renames_similar_two", NULL));
 	cl_git_pass(git_checkout_head(g_repo, &opts));
 	cl_git_pass(git_repository_index(&index, g_repo));
 

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -335,7 +335,7 @@ void test_fetchhead_nonetwork__unborn_with_upstream(void)
 	cl_git_pass(git_remote_set_url(remote, cl_fixture("testrepo.git")));
 	cl_git_pass(git_remote_save(remote));
 
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 	git_remote_free(remote);
 
 	cl_git_pass(git_repository_fetchhead_foreach(repo, assert_master_for_merge, NULL));

--- a/tests/index/names.c
+++ b/tests/index/names.c
@@ -89,7 +89,7 @@ void test_index_names__cleaned_on_reset_hard(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_names__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 	cl_assert(git_index_name_entrycount(repo_index) == 0);
 
 	git_object_free(target);
@@ -102,7 +102,7 @@ void test_index_names__cleaned_on_reset_mixed(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_names__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
 	cl_assert(git_index_name_entrycount(repo_index) == 0);
 
 	git_object_free(target);

--- a/tests/index/names.c
+++ b/tests/index/names.c
@@ -89,7 +89,7 @@ void test_index_names__cleaned_on_reset_hard(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_names__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 	cl_assert(git_index_name_entrycount(repo_index) == 0);
 
 	git_object_free(target);
@@ -102,7 +102,7 @@ void test_index_names__cleaned_on_reset_mixed(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_names__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
 	cl_assert(git_index_name_entrycount(repo_index) == 0);
 
 	git_object_free(target);

--- a/tests/index/reuc.c
+++ b/tests/index/reuc.c
@@ -298,7 +298,7 @@ void test_index_reuc__cleaned_on_reset_hard(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_reuc__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 	cl_assert(reuc_entry_exists() == false);
 
 	git_object_free(target);
@@ -311,7 +311,7 @@ void test_index_reuc__cleaned_on_reset_mixed(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_reuc__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
 	cl_assert(reuc_entry_exists() == false);
 
 	git_object_free(target);
@@ -323,10 +323,10 @@ void test_index_reuc__retained_on_reset_soft(void)
 
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
-	git_reset(repo, target, GIT_RESET_HARD, NULL, NULL);
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 
 	test_index_reuc__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	cl_assert(reuc_entry_exists() == true);
 
 	git_object_free(target);

--- a/tests/index/reuc.c
+++ b/tests/index/reuc.c
@@ -298,7 +298,7 @@ void test_index_reuc__cleaned_on_reset_hard(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_reuc__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 	cl_assert(reuc_entry_exists() == false);
 
 	git_object_free(target);
@@ -311,7 +311,7 @@ void test_index_reuc__cleaned_on_reset_mixed(void)
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
 	test_index_reuc__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
 	cl_assert(reuc_entry_exists() == false);
 
 	git_object_free(target);
@@ -323,10 +323,10 @@ void test_index_reuc__retained_on_reset_soft(void)
 
 	cl_git_pass(git_revparse_single(&target, repo, "3a34580"));
 
-	git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL);
+	git_reset(repo, target, GIT_RESET_HARD, NULL, NULL);
 
 	test_index_reuc__add();
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 	cl_assert(reuc_entry_exists() == true);
 
 	git_object_free(target);

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -90,7 +90,7 @@ int merge_branches(git_repository *repo,
 
 	head_checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
 
-	cl_git_pass(git_reference_symbolic_create(&head_ref, repo, "HEAD", ours_branch, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head_ref, repo, "HEAD", ours_branch, 1, NULL));
 	cl_git_pass(git_checkout_head(repo, &head_checkout_opts));
 
 	cl_git_pass(git_reference_lookup(&theirs_ref, repo, theirs_branch));

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -182,7 +182,7 @@ static void stage_content(char *content[])
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
 
 	for (i = 0, filename = content[i], text = content[++i];
 		filename && text;
@@ -209,7 +209,7 @@ static int merge_dirty_files(char *dirty_files[])
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
 
 	write_files(dirty_files);
 
@@ -229,7 +229,7 @@ static int merge_differently_filtered_files(char *files[])
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
 
 	write_files(files);
 	hack_index(files);
@@ -266,7 +266,7 @@ void test_merge_workdir_dirty__unstaged_deletes_maintained(void)
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(p_unlink("merge-resolve/unchanged.txt"));
 

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -182,7 +182,7 @@ static void stage_content(char *content[])
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL));
 
 	for (i = 0, filename = content[i], text = content[++i];
 		filename && text;
@@ -209,7 +209,7 @@ static int merge_dirty_files(char *dirty_files[])
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL));
 
 	write_files(dirty_files);
 
@@ -229,7 +229,7 @@ static int merge_differently_filtered_files(char *files[])
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL));
 
 	write_files(files);
 	hack_index(files);
@@ -266,7 +266,7 @@ void test_merge_workdir_dirty__unstaged_deletes_maintained(void)
 
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel(&head_object, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, head_object, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(p_unlink("merge-resolve/unchanged.txt"));
 

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -524,7 +524,7 @@ void test_merge_workdir_simple__directory_file(void)
 	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, GIT_REFS_HEADS_DIR OURS_DIRECTORY_FILE, 1, NULL));
 	cl_git_pass(git_reference_name_to_id(&head_commit_id, repo, GIT_HEAD_FILE));
 	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_commit_id));
-	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_oid_fromstr(&their_oids[0], THEIRS_DIRECTORY_FILE));
 	cl_git_pass(git_annotated_commit_lookup(&their_heads[0], repo, &their_oids[0]));
@@ -616,7 +616,7 @@ void test_merge_workdir_simple__binary(void)
 	cl_git_pass(git_oid_fromstr(&their_oid, "ad01aebfdf2ac13145efafe3f9fcf798882f1730"));
 
 	cl_git_pass(git_commit_lookup(&our_commit, repo, &our_oid));
-	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_annotated_commit_lookup(&their_head, repo, &their_oid));
 

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -521,10 +521,10 @@ void test_merge_workdir_simple__directory_file(void)
 		{ 0100644, "f5504f36e6f4eb797a56fc5bac6c6c7f32969bf2", 3, "file-5/new" },
 	};
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, GIT_REFS_HEADS_DIR OURS_DIRECTORY_FILE, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, GIT_REFS_HEADS_DIR OURS_DIRECTORY_FILE, 1, NULL));
 	cl_git_pass(git_reference_name_to_id(&head_commit_id, repo, GIT_HEAD_FILE));
 	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_commit_id));
-	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_oid_fromstr(&their_oids[0], THEIRS_DIRECTORY_FILE));
 	cl_git_pass(git_annotated_commit_lookup(&their_heads[0], repo, &their_oids[0]));
@@ -616,7 +616,7 @@ void test_merge_workdir_simple__binary(void)
 	cl_git_pass(git_oid_fromstr(&their_oid, "ad01aebfdf2ac13145efafe3f9fcf798882f1730"));
 
 	cl_git_pass(git_commit_lookup(&our_commit, repo, &our_oid));
-	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_annotated_commit_lookup(&their_head, repo, &their_oid));
 

--- a/tests/merge/workdir/submodules.c
+++ b/tests/merge/workdir/submodules.c
@@ -44,7 +44,7 @@ void test_merge_workdir_submodules__automerge(void)
 
 	cl_git_pass(git_reference_lookup(&our_ref, repo, "refs/heads/" SUBMODULE_MAIN_BRANCH));
 	cl_git_pass(git_commit_lookup(&our_commit, repo, git_reference_target(our_ref)));
-	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_reference_lookup(&their_ref, repo, "refs/heads/" SUBMODULE_OTHER_BRANCH));
 	cl_git_pass(git_annotated_commit_from_ref(&their_head, repo, their_ref));
@@ -77,7 +77,7 @@ void test_merge_workdir_submodules__take_changed(void)
 
 	cl_git_pass(git_reference_lookup(&our_ref, repo, "refs/heads/" SUBMODULE_MAIN_BRANCH));
 	cl_git_pass(git_commit_lookup(&our_commit, repo, git_reference_target(our_ref)));
-	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_reference_lookup(&their_ref, repo, "refs/heads/" SUBMODULE_OTHER2_BRANCH));
 	cl_git_pass(git_annotated_commit_from_ref(&their_head, repo, their_ref));

--- a/tests/merge/workdir/submodules.c
+++ b/tests/merge/workdir/submodules.c
@@ -44,7 +44,7 @@ void test_merge_workdir_submodules__automerge(void)
 
 	cl_git_pass(git_reference_lookup(&our_ref, repo, "refs/heads/" SUBMODULE_MAIN_BRANCH));
 	cl_git_pass(git_commit_lookup(&our_commit, repo, git_reference_target(our_ref)));
-	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_reference_lookup(&their_ref, repo, "refs/heads/" SUBMODULE_OTHER_BRANCH));
 	cl_git_pass(git_annotated_commit_from_ref(&their_head, repo, their_ref));
@@ -77,7 +77,7 @@ void test_merge_workdir_submodules__take_changed(void)
 
 	cl_git_pass(git_reference_lookup(&our_ref, repo, "refs/heads/" SUBMODULE_MAIN_BRANCH));
 	cl_git_pass(git_commit_lookup(&our_commit, repo, git_reference_target(our_ref)));
-	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)our_commit, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_reference_lookup(&their_ref, repo, "refs/heads/" SUBMODULE_OTHER2_BRANCH));
 	cl_git_pass(git_annotated_commit_from_ref(&their_head, repo, their_ref));

--- a/tests/merge/workdir/trivial.c
+++ b/tests/merge/workdir/trivial.c
@@ -38,7 +38,7 @@ static int merge_trivial(const char *ours, const char *theirs)
 	checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
 
 	git_buf_printf(&branch_buf, "%s%s", GIT_REFS_HEADS_DIR, ours);
-	cl_git_pass(git_reference_symbolic_create(&our_ref, repo, "HEAD", branch_buf.ptr, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&our_ref, repo, "HEAD", branch_buf.ptr, 1, NULL));
 
 	cl_git_pass(git_checkout_head(repo, &checkout_opts));
 

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -46,7 +46,7 @@ void test_network_fetchlocal__complete(void)
 	git_remote_set_callbacks(origin, &callbacks);
 	cl_git_pass(git_remote_connect(origin, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(origin, NULL));
-	cl_git_pass(git_remote_update_tips(origin, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(origin, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(19, (int)refnames.count);
@@ -76,7 +76,7 @@ void test_network_fetchlocal__prune(void)
 
 	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(19, (int)refnames.count);
@@ -93,7 +93,7 @@ void test_network_fetchlocal__prune(void)
 	cl_git_pass(git_remote_connect(origin, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(origin, NULL));
 	cl_git_pass(git_remote_prune(origin));
-	cl_git_pass(git_remote_update_tips(origin, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(origin, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(18, (int)refnames.count);
@@ -109,7 +109,7 @@ void test_network_fetchlocal__prune(void)
 	cl_git_pass(git_remote_connect(origin, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(origin, NULL));
 	cl_git_pass(git_remote_prune(origin));
-	cl_git_pass(git_remote_update_tips(origin, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(origin, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(17, (int)refnames.count);
@@ -158,7 +158,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	cl_git_pass(git_reference_lookup(&ref, remote_repo, "refs/heads/master"));
 	git_oid_cpy(&target, git_reference_target(ref));
 	git_reference_free(ref);
-	cl_git_pass(git_reference_create(&ref, remote_repo, "refs/pull/42/head", &target, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, remote_repo, "refs/pull/42/head", &target, 1, NULL));
 	git_reference_free(ref);
 
 	cl_set_cleanup(&cleanup_local_repo, "foo");
@@ -174,7 +174,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	git_remote_free(origin);
 	cl_git_pass(git_remote_lookup(&origin, repo, GIT_REMOTE_ORIGIN));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	assert_ref_exists(repo, "refs/remotes/origin/master");
 	assert_ref_exists(repo, "refs/remotes/origin/pr/42");
@@ -190,7 +190,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	cl_git_pass(git_remote_lookup(&origin, repo, GIT_REMOTE_ORIGIN));
 	callbacks.update_tips = update_tips_fail_on_call;
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	assert_ref_exists(repo, "refs/remotes/origin/master");
 	assert_ref_exists(repo, "refs/remotes/origin/pr/42");
@@ -206,7 +206,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	cl_git_pass(git_remote_lookup(&origin, repo, GIT_REMOTE_ORIGIN));
 	callbacks.update_tips = update_tips_fail_on_call;
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	git_config_free(config);
 	git_strarray_free(&refnames);
@@ -234,7 +234,7 @@ void test_network_fetchlocal__fetchprune(void)
 
 	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(19, (int)refnames.count);
@@ -248,7 +248,7 @@ void test_network_fetchlocal__fetchprune(void)
 
 	cl_git_pass(git_remote_lookup(&origin, repo, GIT_REMOTE_ORIGIN));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 	cl_git_pass(git_remote_prune(origin));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
@@ -266,7 +266,7 @@ void test_network_fetchlocal__fetchprune(void)
 	cl_git_pass(git_remote_lookup(&origin, repo, GIT_REMOTE_ORIGIN));
 	cl_assert_equal_i(1, git_remote_prune_refs(origin));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(17, (int)refnames.count);
@@ -299,12 +299,12 @@ void test_network_fetchlocal__prune_tag(void)
 
 	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 	git_remote_free(origin);
 
 	cl_git_pass(git_revparse_single(&obj, repo, "origin/master"));
 
-	cl_git_pass(git_reference_create(&ref, repo, "refs/remotes/origin/fake-remote", git_object_id(obj), 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, repo, "refs/remotes/origin/fake-remote", git_object_id(obj), 1, NULL));
 	git_reference_free(ref);
 
 	/* create signature */
@@ -322,7 +322,7 @@ void test_network_fetchlocal__prune_tag(void)
 	cl_git_pass(git_remote_lookup(&origin, repo, GIT_REMOTE_ORIGIN));
 	cl_assert_equal_i(1, git_remote_prune_refs(origin));
 	git_remote_set_callbacks(origin, &callbacks);
-	cl_git_pass(git_remote_fetch(origin, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(origin, NULL, NULL));
 
 	assert_ref_exists(repo, "refs/tags/some-tag");
 	cl_git_fail_with(GIT_ENOTFOUND, git_reference_lookup(&ref, repo, "refs/remotes/origin/fake-remote"));
@@ -360,7 +360,7 @@ void test_network_fetchlocal__partial(void)
 	git_remote_set_callbacks(origin, &callbacks);
 	cl_git_pass(git_remote_connect(origin, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(origin, NULL));
-	cl_git_pass(git_remote_update_tips(origin, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(origin, NULL));
 
 	git_strarray_free(&refnames);
 
@@ -427,7 +427,7 @@ void test_network_fetchlocal__multi_remotes(void)
 	git_remote_set_callbacks(test, &callbacks);
 	cl_git_pass(git_remote_connect(test, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(test, NULL));
-	cl_git_pass(git_remote_update_tips(test, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(test, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(32, (int)refnames.count);
@@ -438,7 +438,7 @@ void test_network_fetchlocal__multi_remotes(void)
 	git_remote_set_callbacks(test2, &callbacks);
 	cl_git_pass(git_remote_connect(test2, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(test2, NULL));
-	cl_git_pass(git_remote_update_tips(test2, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(test2, NULL));
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(44, (int)refnames.count);
@@ -475,7 +475,7 @@ void test_network_fetchlocal__call_progress(void)
 	callbacks.payload = &callcount;
 	cl_git_pass(git_remote_set_callbacks(remote, &callbacks));
 
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 	cl_assert(callcount != 0);
 
 	git_remote_free(remote);

--- a/tests/network/remote/defaultbranch.c
+++ b/tests/network/remote/defaultbranch.c
@@ -39,13 +39,13 @@ void test_network_remote_defaultbranch__master(void)
 
 void test_network_remote_defaultbranch__master_does_not_win(void)
 {
-	cl_git_pass(git_repository_set_head(g_repo_a, "refs/heads/not-good", NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo_a, "refs/heads/not-good", NULL));
 	assert_default_branch("refs/heads/not-good");
 }
 
 void test_network_remote_defaultbranch__master_on_detached(void)
 {
-	cl_git_pass(git_repository_detach_head(g_repo_a, NULL, NULL));
+	cl_git_pass(git_repository_detach_head(g_repo_a, NULL));
 	assert_default_branch("refs/heads/master");
 }
 
@@ -74,10 +74,10 @@ void test_network_remote_defaultbranch__detached_sharing_nonbranch_id(void)
 	git_repository *cloned_repo;
 
 	cl_git_pass(git_reference_name_to_id(&id, g_repo_a, "HEAD"));
-	cl_git_pass(git_repository_detach_head(g_repo_a, NULL, NULL));
+	cl_git_pass(git_repository_detach_head(g_repo_a, NULL));
 	cl_git_pass(git_reference_remove(g_repo_a, "refs/heads/master"));
 	cl_git_pass(git_reference_remove(g_repo_a, "refs/heads/not-good"));
-	cl_git_pass(git_reference_create(&ref, g_repo_a, "refs/foo/bar", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo_a, "refs/foo/bar", &id, 1, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_remote_connect(g_remote, GIT_DIRECTION_FETCH));
@@ -97,7 +97,7 @@ void test_network_remote_defaultbranch__unborn_HEAD_with_branches(void)
 	git_reference *ref;
 	git_repository *cloned_repo;
 
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo_a, "HEAD", "refs/heads/i-dont-exist", 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo_a, "HEAD", "refs/heads/i-dont-exist", 1, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_clone(&cloned_repo, git_repository_path(g_repo_a), "./semi-empty", NULL));

--- a/tests/network/remote/defaultbranch.c
+++ b/tests/network/remote/defaultbranch.c
@@ -39,13 +39,13 @@ void test_network_remote_defaultbranch__master(void)
 
 void test_network_remote_defaultbranch__master_does_not_win(void)
 {
-	cl_git_pass(git_repository_set_head(g_repo_a, "refs/heads/not-good", NULL));
+	cl_git_pass(git_repository_set_head(g_repo_a, "refs/heads/not-good"));
 	assert_default_branch("refs/heads/not-good");
 }
 
 void test_network_remote_defaultbranch__master_on_detached(void)
 {
-	cl_git_pass(git_repository_detach_head(g_repo_a, NULL));
+	cl_git_pass(git_repository_detach_head(g_repo_a));
 	assert_default_branch("refs/heads/master");
 }
 
@@ -74,7 +74,7 @@ void test_network_remote_defaultbranch__detached_sharing_nonbranch_id(void)
 	git_repository *cloned_repo;
 
 	cl_git_pass(git_reference_name_to_id(&id, g_repo_a, "HEAD"));
-	cl_git_pass(git_repository_detach_head(g_repo_a, NULL));
+	cl_git_pass(git_repository_detach_head(g_repo_a));
 	cl_git_pass(git_reference_remove(g_repo_a, "refs/heads/master"));
 	cl_git_pass(git_reference_remove(g_repo_a, "refs/heads/not-good"));
 	cl_git_pass(git_reference_create(&ref, g_repo_a, "refs/foo/bar", &id, 1, NULL));

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -18,6 +18,7 @@ static git_strarray push_array = {
 void test_network_remote_local__initialize(void)
 {
 	cl_git_pass(git_repository_init(&repo, "remotelocal/", 0));
+	cl_git_pass(git_repository_set_ident(repo, "Foo Bar", "foo@example.com"));
 	cl_assert(repo != NULL);
 }
 
@@ -138,7 +139,7 @@ void test_network_remote_local__shorthand_fetch_refspec0(void)
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 
 	cl_git_pass(git_remote_download(remote, &array));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 
 	cl_git_pass(git_reference_lookup(&ref, repo, "refs/remotes/sloppy/master"));
 	git_reference_free(ref);
@@ -164,7 +165,7 @@ void test_network_remote_local__shorthand_fetch_refspec1(void)
 	git_remote_clear_refspecs(remote);
 
 	cl_git_pass(git_remote_download(remote, &array));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 
 	cl_git_fail(git_reference_lookup(&ref, repo, "refs/remotes/master"));
 
@@ -177,7 +178,7 @@ void test_network_remote_local__tagopt(void)
 
 	cl_git_pass(git_remote_create(&remote, repo, "tagopt", cl_git_path_url(cl_fixture("testrepo.git"))));
 	git_remote_set_autotag(remote, GIT_REMOTE_DOWNLOAD_TAGS_ALL);
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 
 	cl_git_pass(git_reference_lookup(&ref, repo, "refs/remotes/tagopt/master"));
 	git_reference_free(ref);
@@ -185,7 +186,7 @@ void test_network_remote_local__tagopt(void)
 	git_reference_free(ref);
 
 	git_remote_set_autotag(remote, GIT_REMOTE_DOWNLOAD_TAGS_AUTO);
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 	cl_git_pass(git_reference_lookup(&ref, repo, "refs/remotes/tagopt/master"));
 	git_reference_free(ref);
 }
@@ -206,7 +207,7 @@ void test_network_remote_local__push_to_bare_remote(void)
 	/* Get some commits */
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 	cl_git_pass(git_remote_download(remote, &array));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 	git_remote_disconnect(remote);
 
 	/* Set up an empty bare repo to push into */
@@ -244,7 +245,7 @@ void test_network_remote_local__push_to_bare_remote_with_file_url(void)
 	/* Get some commits */
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 	cl_git_pass(git_remote_download(remote, &array));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 	git_remote_disconnect(remote);
 
 	/* Set up an empty bare repo to push into */
@@ -285,7 +286,7 @@ void test_network_remote_local__push_to_non_bare_remote(void)
 	/* Get some commits */
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 	cl_git_pass(git_remote_download(remote, &array));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 	git_remote_disconnect(remote);
 
 	/* Set up an empty non-bare repo to push into */
@@ -319,14 +320,11 @@ void test_network_remote_local__fetch(void)
 
 	git_reflog *log;
 	const git_reflog_entry *entry;
-	git_signature *sig;
 	git_reference *ref;
-
-	cl_git_pass(git_signature_now(&sig, "Foo Bar", "foo@example.com"));
 
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 
-	cl_git_pass(git_remote_fetch(remote, &array, sig, "UPDAAAAAATE!!"));
+	cl_git_pass(git_remote_fetch(remote, &array, "UPDAAAAAATE!!"));
 
 	cl_git_pass(git_reference_lookup(&ref, repo, "refs/remotes/sloppy/master"));
 	git_reference_free(ref);
@@ -338,7 +336,6 @@ void test_network_remote_local__fetch(void)
 	cl_assert_equal_s("UPDAAAAAATE!!", git_reflog_entry_message(entry));
 
 	git_reflog_free(log);
-	git_signature_free(sig);
 }
 
 void test_network_remote_local__reflog(void)
@@ -353,14 +350,11 @@ void test_network_remote_local__reflog(void)
 
 	git_reflog *log;
 	const git_reflog_entry *entry;
-	git_signature *sig;
-
-	cl_git_pass(git_signature_now(&sig, "Foo Bar", "foo@example.com"));
 
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 
 	cl_git_pass(git_remote_download(remote, &array));
-	cl_git_pass(git_remote_update_tips(remote, sig, "UPDAAAAAATE!!"));
+	cl_git_pass(git_remote_update_tips(remote, "UPDAAAAAATE!!"));
 
 	cl_git_pass(git_reflog_read(&log, repo, "refs/remotes/sloppy/master"));
 	cl_assert_equal_i(1, git_reflog_entrycount(log));
@@ -369,7 +363,6 @@ void test_network_remote_local__reflog(void)
 	cl_assert_equal_s("UPDAAAAAATE!!", git_reflog_entry_message(entry));
 
 	git_reflog_free(log);
-	git_signature_free(sig);
 }
 
 void test_network_remote_local__fetch_default_reflog_message(void)
@@ -384,14 +377,11 @@ void test_network_remote_local__fetch_default_reflog_message(void)
 
 	git_reflog *log;
 	const git_reflog_entry *entry;
-	git_signature *sig;
 	char expected_reflog_msg[1024];
-
-	cl_git_pass(git_signature_now(&sig, "Foo Bar", "foo@example.com"));
 
 	connect_to_local_repository(cl_fixture("testrepo.git"));
 
-	cl_git_pass(git_remote_fetch(remote, &array, sig, NULL));
+	cl_git_pass(git_remote_fetch(remote, &array, NULL));
 
 	cl_git_pass(git_reflog_read(&log, repo, "refs/remotes/sloppy/master"));
 	cl_assert_equal_i(1, git_reflog_entrycount(log));
@@ -402,7 +392,6 @@ void test_network_remote_local__fetch_default_reflog_message(void)
 	cl_assert_equal_s(expected_reflog_msg, git_reflog_entry_message(entry));
 
 	git_reflog_free(log);
-	git_signature_free(sig);
 }
 
 void test_network_remote_local__opportunistic_update(void)
@@ -419,7 +408,7 @@ void test_network_remote_local__opportunistic_update(void)
 	/* this remote has a passive refspec of "refs/heads/<star>:refs/remotes/origin/<star>" */
 	cl_git_pass(git_remote_create(&remote, repo, "origin", cl_git_fixture_url("testrepo.git")));
 	/* and we pass the active refspec "master" */
-	cl_git_pass(git_remote_fetch(remote, &array, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, &array, NULL));
 
 	/* and we expect that to update our copy of origin's master */
 	cl_git_pass(git_reference_lookup(&ref, repo, "refs/remotes/origin/master"));
@@ -445,7 +434,7 @@ void test_network_remote_local__update_tips_for_new_remote(void) {
 	cl_git_pass(git_remote_upload(new_remote, &push_array, NULL));
 
 	/* Update tips and make sure remote branch has been created */
-	cl_git_pass(git_remote_update_tips(new_remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(new_remote, NULL));
 	cl_git_pass(git_branch_lookup(&branch, src_repo, "bare/master", GIT_BRANCH_REMOTE));
 
 	git_reference_free(branch);
@@ -475,12 +464,12 @@ void test_network_remote_local__push_delete(void)
 	cl_git_pass(git_remote_create(&remote, src_repo, "origin", "./target.git"));
 
 	/* Push the master branch and verify it's there */
-	cl_git_pass(git_remote_push(remote, &specs, NULL, NULL, NULL));
+	cl_git_pass(git_remote_push(remote, &specs, NULL, NULL));
 	cl_git_pass(git_reference_lookup(&ref, dst_repo, "refs/heads/master"));
 	git_reference_free(ref);
 
 	specs.strings = spec_delete;
-	cl_git_pass(git_remote_push(remote, &specs, NULL, NULL, NULL));
+	cl_git_pass(git_remote_push(remote, &specs, NULL, NULL));
 	cl_git_fail(git_reference_lookup(&ref, dst_repo, "refs/heads/master"));
 
 	git_remote_free(remote);

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -464,12 +464,12 @@ void test_network_remote_local__push_delete(void)
 	cl_git_pass(git_remote_create(&remote, src_repo, "origin", "./target.git"));
 
 	/* Push the master branch and verify it's there */
-	cl_git_pass(git_remote_push(remote, &specs, NULL, NULL));
+	cl_git_pass(git_remote_push(remote, &specs, NULL));
 	cl_git_pass(git_reference_lookup(&ref, dst_repo, "refs/heads/master"));
 	git_reference_free(ref);
 
 	specs.strings = spec_delete;
-	cl_git_pass(git_remote_push(remote, &specs, NULL, NULL));
+	cl_git_pass(git_remote_push(remote, &specs, NULL));
 	cl_git_fail(git_reference_lookup(&ref, dst_repo, "refs/heads/master"));
 
 	git_remote_free(remote);

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -272,7 +272,7 @@ void test_network_remote_remotes__nonmatch_upstream_refspec(void)
 	cl_git_pass(git_config_set_string(config, "branch.master.remote", "taggy"));
 	cl_git_pass(git_config_set_string(config, "branch.master.merge", "refs/heads/foo"));
 
-	cl_git_pass(git_remote_fetch(remote, &specs, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, &specs, NULL));
 
 	git_remote_free(remote);
 }
@@ -545,7 +545,7 @@ void test_network_remote_remotes__fetch_from_anonymous(void)
 
 	cl_git_pass(git_remote_create_anonymous(&remote, _repo, cl_fixture("testrepo.git"),
 						"refs/heads/*:refs/other/*"));
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 	git_remote_free(remote);
 }
 

--- a/tests/network/remote/rename.c
+++ b/tests/network/remote/rename.c
@@ -181,7 +181,7 @@ void test_network_remote_rename__overwrite_ref_in_target(void)
 	git_strarray problems = {0};
 
 	cl_git_pass(git_oid_fromstr(&id, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750"));
-	cl_git_pass(git_reference_create(&ref, _repo, "refs/remotes/renamed/master", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, _repo, "refs/remotes/renamed/master", &id, 1, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "renamed"));
@@ -219,7 +219,7 @@ void test_network_remote_rename__symref_head(void)
 	char idstr[GIT_OID_HEXSZ + 1] = {0};
 	git_vector refs;
 
-	cl_git_pass(git_reference_symbolic_create(&ref, _repo, "refs/remotes/test/HEAD", "refs/remotes/test/master", 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, _repo, "refs/remotes/test/HEAD", "refs/remotes/test/master", 0, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "renamed"));

--- a/tests/online/fetch.c
+++ b/tests/online/fetch.c
@@ -48,7 +48,7 @@ static void do_fetch(const char *url, git_remote_autotag_option_t flag, int n)
 	git_remote_set_autotag(remote, flag);
 	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(remote, NULL));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 	git_remote_disconnect(remote);
 	cl_assert_equal_i(counter, n);
 	cl_assert(bytes_received > 0);
@@ -132,7 +132,7 @@ void test_online_fetch__doesnt_retrieve_a_pack_when_the_repository_is_up_to_date
 
 	cl_assert_equal_i(false, invoked);
 
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 	git_remote_disconnect(remote);
 
 	git_remote_free(remote);
@@ -208,8 +208,8 @@ void test_online_fetch__twice(void)
 	git_remote *remote;
 
 	cl_git_pass(git_remote_create(&remote, _repo, "test", "http://github.com/libgit2/TestGitRepository.git"));
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
-	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 
 	git_remote_free(remote);
 }

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -53,7 +53,7 @@ static void fetchhead_test_fetch(const char *fetchspec, const char *expected_fet
 
 	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(remote, active_refs));
-	cl_git_pass(git_remote_update_tips(remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(remote, NULL));
 	git_remote_disconnect(remote);
 	git_remote_free(remote);
 

--- a/tests/online/push.c
+++ b/tests/online/push.c
@@ -322,6 +322,7 @@ void test_online_push__initialize(void)
 
 	_repo = cl_git_sandbox_init("push_src");
 
+	cl_git_pass(git_repository_set_ident(_repo, "Random J. Hacker", "foo@example.com"));
 	cl_fixture_sandbox("testrepo.git");
 	cl_rename("push_src/submodule/.gitted", "push_src/submodule/.git");
 
@@ -395,7 +396,7 @@ void test_online_push__initialize(void)
 	/* Now that we've deleted everything, fetch from the remote */
 	cl_git_pass(git_remote_connect(_remote, GIT_DIRECTION_FETCH));
 	cl_git_pass(git_remote_download(_remote, NULL));
-	cl_git_pass(git_remote_update_tips(_remote, NULL, NULL));
+	cl_git_pass(git_remote_update_tips(_remote, NULL));
 	git_remote_disconnect(_remote);
 }
 
@@ -458,15 +459,12 @@ static void do_push(
 	size_t i;
 	int error;
 	git_strarray specs = {0};
-	git_signature *pusher;
 	git_remote_callbacks callbacks;
 	record_callbacks_data *data;
 
 	if (_remote) {
 		/* Auto-detect the number of threads to use */
 		opts.pb_parallelism = 0;
-
-		cl_git_pass(git_signature_now(&pusher, "Foo Bar", "foo@example.com"));
 
 		memcpy(&callbacks, git_remote_get_callbacks(_remote), sizeof(callbacks));
 		data = callbacks.payload;
@@ -489,7 +487,7 @@ static void do_push(
 		if (check_progress_cb && expected_ret == GIT_EUSER)
 			data->transfer_progress_calls = GIT_EUSER;
 
-		error = git_remote_push(_remote, &specs, &opts, pusher, "test push");
+		error = git_remote_push(_remote, &specs, &opts, "test push");
 		git__free(specs.strings);
 
 		if (expected_ret < 0) {
@@ -511,7 +509,6 @@ static void do_push(
 		if (check_update_tips_cb)
 			verify_update_tips_callback(_remote, expected_refs, expected_refs_len);
 
-		git_signature_free(pusher);
 	}
 
 }

--- a/tests/online/push.c
+++ b/tests/online/push.c
@@ -487,7 +487,7 @@ static void do_push(
 		if (check_progress_cb && expected_ret == GIT_EUSER)
 			data->transfer_progress_calls = GIT_EUSER;
 
-		error = git_remote_push(_remote, &specs, &opts, "test push");
+		error = git_remote_push(_remote, &specs, &opts);
 		git__free(specs.strings);
 
 		if (expected_ret < 0) {
@@ -608,7 +608,7 @@ void test_online_push__multi(void)
 	cl_git_pass(git_reflog_read(&log, _repo, "refs/remotes/test/b1"));
 	entry = git_reflog_entry_byindex(log, 0);
 	if (entry) {
-		cl_assert_equal_s("test push", git_reflog_entry_message(entry));
+		cl_assert_equal_s("update by push", git_reflog_entry_message(entry));
 		cl_assert_equal_s("foo@example.com", git_reflog_entry_committer(entry)->email);
 	}
 

--- a/tests/perf/helper__perf__do_merge.c
+++ b/tests/perf/helper__perf__do_merge.c
@@ -43,8 +43,7 @@ void perf__do_merge(const char *fixture,
 	cl_git_pass(git_checkout_tree(g_repo, (git_object*)commit_a, &checkout_opts));
 	perf__timer__stop(&t_checkout);
 
-	cl_git_pass(git_repository_set_head(g_repo,
-										git_reference_name(ref_branch_a), NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(ref_branch_a)));
 
 	git_oid_fromstr(&oid_b, id_b);
 	cl_git_pass(git_commit_lookup(&commit_b, g_repo, &oid_b));

--- a/tests/perf/helper__perf__do_merge.c
+++ b/tests/perf/helper__perf__do_merge.c
@@ -28,7 +28,6 @@ void perf__do_merge(const char *fixture,
 
 	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	clone_opts.checkout_opts = checkout_opts;
-	cl_git_pass(git_signature_now(&clone_opts.signature, "Me", "foo@example.com"));
 
 	perf__timer__start(&t_clone);
 	cl_git_pass(git_clone(&g_repo, fixture, test_name, &clone_opts));
@@ -38,21 +37,20 @@ void perf__do_merge(const char *fixture,
 	cl_git_pass(git_commit_lookup(&commit_a, g_repo, &oid_a));
 	cl_git_pass(git_branch_create(&ref_branch_a, g_repo,
 								  "A", commit_a,
-								  0, NULL, NULL));
+								  0, NULL));
 
 	perf__timer__start(&t_checkout);
 	cl_git_pass(git_checkout_tree(g_repo, (git_object*)commit_a, &checkout_opts));
 	perf__timer__stop(&t_checkout);
 
 	cl_git_pass(git_repository_set_head(g_repo,
-										git_reference_name(ref_branch_a),
-										NULL, NULL));
+										git_reference_name(ref_branch_a), NULL));
 
 	git_oid_fromstr(&oid_b, id_b);
 	cl_git_pass(git_commit_lookup(&commit_b, g_repo, &oid_b));
 	cl_git_pass(git_branch_create(&ref_branch_b, g_repo,
 								  "B", commit_b,
-								  0, NULL, NULL));
+								  0, NULL));
 
 	cl_git_pass(git_annotated_commit_lookup(&annotated_commits[0], g_repo, &oid_b));
 

--- a/tests/perf/helper__perf__do_merge.c
+++ b/tests/perf/helper__perf__do_merge.c
@@ -37,7 +37,7 @@ void perf__do_merge(const char *fixture,
 	cl_git_pass(git_commit_lookup(&commit_a, g_repo, &oid_a));
 	cl_git_pass(git_branch_create(&ref_branch_a, g_repo,
 								  "A", commit_a,
-								  0, NULL));
+								  0));
 
 	perf__timer__start(&t_checkout);
 	cl_git_pass(git_checkout_tree(g_repo, (git_object*)commit_a, &checkout_opts));
@@ -50,7 +50,7 @@ void perf__do_merge(const char *fixture,
 	cl_git_pass(git_commit_lookup(&commit_b, g_repo, &oid_b));
 	cl_git_pass(git_branch_create(&ref_branch_b, g_repo,
 								  "B", commit_b,
-								  0, NULL));
+								  0));
 
 	cl_git_pass(git_annotated_commit_lookup(&annotated_commits[0], g_repo, &oid_b));
 

--- a/tests/rebase/abort.c
+++ b/tests/rebase/abort.c
@@ -23,14 +23,12 @@ static void test_abort(git_annotated_commit *branch, git_annotated_commit *onto)
 {
 	git_rebase *rebase;
 	git_reference *head_ref, *branch_ref = NULL;
-	git_signature *signature;
 	git_status_list *statuslist;
 	git_reflog *reflog;
 	const git_reflog_entry *reflog_entry;
 
 	cl_git_pass(git_rebase_open(&rebase, repo));
-	cl_git_pass(git_signature_new(&signature, "Rebaser", "rebaser@example.com", 1404157834, -400));
-	cl_git_pass(git_rebase_abort(rebase, signature));
+	cl_git_pass(git_rebase_abort(rebase));
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
@@ -60,7 +58,6 @@ static void test_abort(git_annotated_commit *branch, git_annotated_commit *onto)
 	git_reflog_free(reflog);
 	git_reference_free(head_ref);
 	git_reference_free(branch_ref);
-	git_signature_free(signature);
 	git_rebase_free(rebase);
 }
 
@@ -68,7 +65,6 @@ void test_rebase_abort__merge(void)
 {
 	git_rebase *rebase;
 	git_reference *branch_ref, *onto_ref;
-	git_signature *signature;
 	git_annotated_commit *branch_head, *onto_head;
 
 	cl_git_pass(git_reference_lookup(&branch_ref, repo, "refs/heads/beef"));
@@ -77,14 +73,10 @@ void test_rebase_abort__merge(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&onto_head, repo, onto_ref));
 
-	cl_git_pass(git_signature_new(&signature, "Rebaser", "rebaser@example.com", 1404157834, -400));
-
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
 	test_abort(branch_head, onto_head);
-
-	git_signature_free(signature);
 
 	git_annotated_commit_free(branch_head);
 	git_annotated_commit_free(onto_head);
@@ -110,7 +102,7 @@ void test_rebase_abort__detached_head(void)
 
 	cl_git_pass(git_signature_new(&signature, "Rebaser", "rebaser@example.com", 1404157834, -400));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
 	test_abort(branch_head, onto_head);
@@ -139,7 +131,7 @@ void test_rebase_abort__old_style_head_file(void)
 
 	cl_git_pass(git_signature_new(&signature, "Rebaser", "rebaser@example.com", 1404157834, -400));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
 	p_rename("rebase-merge/.git/rebase-merge/orig-head",

--- a/tests/rebase/iterator.c
+++ b/tests/rebase/iterator.c
@@ -64,7 +64,7 @@ void test_rebase_iterator__iterates(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 	test_operations(rebase, 0);
 	git_rebase_free(rebase);
 

--- a/tests/rebase/merge.c
+++ b/tests/rebase/merge.c
@@ -53,7 +53,7 @@ void test_rebase_merge__next(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 
@@ -120,7 +120,7 @@ void test_rebase_merge__next_with_conflicts(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 
@@ -165,7 +165,7 @@ void test_rebase_merge__next_stops_with_iterover(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
@@ -221,7 +221,7 @@ void test_rebase_merge__commit(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
@@ -279,7 +279,7 @@ void test_rebase_merge__commit_updates_rewritten(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
@@ -319,7 +319,7 @@ void test_rebase_merge__commit_drops_already_applied(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 	cl_git_fail(error = git_rebase_commit(&commit_id, rebase, NULL, signature,
@@ -362,7 +362,7 @@ void test_rebase_merge__finish(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
@@ -433,7 +433,7 @@ static void test_copy_note(
 		git_commit_id(branch_commit),
 		"This is a commit note.", 0));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, opts));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, opts));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase, &checkout_opts));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,

--- a/tests/rebase/setup.c
+++ b/tests/rebase/setup.c
@@ -308,7 +308,7 @@ void test_rebase_setup__merge_null_branch_uses_HEAD(void)
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/beef", NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/beef"));
 	cl_git_pass(git_checkout_head(repo, &checkout_opts));
 
 	cl_git_pass(git_reference_lookup(&upstream_ref, repo, "refs/heads/master"));

--- a/tests/rebase/setup.c
+++ b/tests/rebase/setup.c
@@ -39,12 +39,12 @@ void test_rebase_setup__blocked_when_in_progress(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 	git_rebase_free(rebase);
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
-	cl_git_fail(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_fail(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	git_annotated_commit_free(branch_head);
 	git_annotated_commit_free(upstream_head);
@@ -70,7 +70,7 @@ void test_rebase_setup__merge(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
@@ -118,7 +118,7 @@ void test_rebase_setup__merge_root(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&onto_head, repo, onto_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
 
 	git_oid_fromstr(&head_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00");
 	cl_git_pass(git_repository_head(&head, repo));
@@ -168,7 +168,7 @@ void test_rebase_setup__merge_onto_and_upstream(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch2_head, repo, branch2_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&onto_head, repo, onto_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch1_head, branch2_head, onto_head, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch1_head, branch2_head, onto_head, NULL));
 
 	git_oid_fromstr(&head_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00");
 	cl_git_pass(git_repository_head(&head, repo));
@@ -215,7 +215,7 @@ void test_rebase_setup__branch_with_merges(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
@@ -263,7 +263,7 @@ void test_rebase_setup__orphan_branch(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
@@ -308,13 +308,13 @@ void test_rebase_setup__merge_null_branch_uses_HEAD(void)
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/beef", NULL, NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/beef", NULL));
 	cl_git_pass(git_checkout_head(repo, &checkout_opts));
 
 	cl_git_pass(git_reference_lookup(&upstream_ref, repo, "refs/heads/master"));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
-	cl_git_pass(git_rebase_init(&rebase, repo, NULL, upstream_head, NULL, signature, NULL));
+	cl_git_pass(git_rebase_init(&rebase, repo, NULL, upstream_head, NULL, NULL));
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
@@ -358,7 +358,7 @@ static int rebase_is_blocked(void)
 	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 												    
-	error = git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, signature, NULL);
+	error = git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL);
 
 	git_annotated_commit_free(branch_head);
 	git_annotated_commit_free(upstream_head);

--- a/tests/refs/branches/create.c
+++ b/tests/refs/branches/create.c
@@ -45,7 +45,7 @@ void test_refs_branches_create__can_create_a_local_branch(void)
 {
 	retrieve_known_commit(&target, repo);
 
-	cl_git_pass(git_branch_create(&branch, repo, NEW_BRANCH_NAME, target, 0, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, NEW_BRANCH_NAME, target, 0, NULL));
 	cl_git_pass(git_oid_cmp(git_reference_target(branch), git_commit_id(target)));
 }
 
@@ -53,14 +53,14 @@ void test_refs_branches_create__can_not_create_a_branch_if_its_name_collide_with
 {
 	retrieve_known_commit(&target, repo);
 
-	cl_assert_equal_i(GIT_EEXISTS, git_branch_create(&branch, repo, "br2", target, 0, NULL, NULL));
+	cl_assert_equal_i(GIT_EEXISTS, git_branch_create(&branch, repo, "br2", target, 0, NULL));
 }
 
 void test_refs_branches_create__can_force_create_over_an_existing_branch(void)
 {
 	retrieve_known_commit(&target, repo);
 
-	cl_git_pass(git_branch_create(&branch, repo, "br2", target, 1, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "br2", target, 1, NULL));
 	cl_git_pass(git_oid_cmp(git_reference_target(branch), git_commit_id(target)));
 	cl_assert_equal_s("refs/heads/br2", git_reference_name(branch));
 }
@@ -76,7 +76,7 @@ void test_refs_branches_create__cannot_force_create_over_current_branch(void)
 	cl_assert_equal_i(true, git_branch_is_head(branch2));
 	oid = git_reference_target(branch2);
 
-	cl_git_fail_with(-1, git_branch_create(&branch, repo, "master", target, 1, NULL, NULL));
+	cl_git_fail_with(-1, git_branch_create(&branch, repo, "master", target, 1, NULL));
 	branch = NULL;
 	cl_git_pass(git_branch_lookup(&branch, repo, "master", GIT_BRANCH_LOCAL));
 	cl_assert_equal_s("refs/heads/master", git_reference_name(branch));
@@ -89,7 +89,7 @@ void test_refs_branches_create__creating_a_branch_with_an_invalid_name_returns_E
 	retrieve_known_commit(&target, repo);
 
 	cl_assert_equal_i(GIT_EINVALIDSPEC,
-		git_branch_create(&branch, repo, "inv@{id", target, 0, NULL, NULL));
+		git_branch_create(&branch, repo, "inv@{id", target, 0, NULL));
 }
 
 void test_refs_branches_create__creation_creates_new_reflog(void)
@@ -101,13 +101,12 @@ void test_refs_branches_create__creation_creates_new_reflog(void)
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
 	retrieve_known_commit(&target, repo);
-	cl_git_pass(git_branch_create(&branch, repo, NEW_BRANCH_NAME, target, false, sig, "create!"));
+	cl_git_pass(git_branch_create(&branch, repo, NEW_BRANCH_NAME, target, false, "create!"));
 	cl_git_pass(git_reflog_read(&log, repo, "refs/heads/" NEW_BRANCH_NAME));
 
 	cl_assert_equal_i(1, git_reflog_entrycount(log));
 	entry = git_reflog_entry_byindex(log, 0);
 	cl_assert_equal_s("create!", git_reflog_entry_message(entry));
-	cl_assert_equal_s("foo@example.com", git_reflog_entry_committer(entry)->email);
 
 	git_reflog_free(log);
 	git_signature_free(sig);
@@ -128,7 +127,7 @@ void test_refs_branches_create__default_reflog_message(void)
 	cl_git_pass(git_signature_default(&sig, repo));
 
 	retrieve_known_commit(&target, repo);
-	cl_git_pass(git_branch_create(&branch, repo, NEW_BRANCH_NAME, target, false, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, NEW_BRANCH_NAME, target, false, NULL));
 	cl_git_pass(git_reflog_read(&log, repo, "refs/heads/" NEW_BRANCH_NAME));
 
 	entry = git_reflog_entry_byindex(log, 0);
@@ -181,7 +180,7 @@ void test_refs_branches_create__can_create_branch_with_unicode(void)
 	for (i = 0; i < ARRAY_SIZE(names); ++i) {
 		const char *name;
 		cl_git_pass(git_branch_create(
-			&branch, repo, names[i], target, 0, NULL, NULL));
+			&branch, repo, names[i], target, 0, NULL));
 		cl_git_pass(git_oid_cmp(
 			git_reference_target(branch), git_commit_id(target)));
 
@@ -239,7 +238,7 @@ void test_refs_branches_create__name_vs_namespace(void)
 	retrieve_known_commit(&target, repo);
 
 	for (p=item; p->first; p++) {
-		cl_git_pass(git_branch_create(&branch, repo, p->first, target, 0, NULL, NULL));
+		cl_git_pass(git_branch_create(&branch, repo, p->first, target, 0, NULL));
 		cl_git_pass(git_oid_cmp(git_reference_target(branch), git_commit_id(target)));
 		cl_git_pass(git_branch_name(&name, branch));
 		cl_assert_equal_s(name, p->first);
@@ -248,7 +247,7 @@ void test_refs_branches_create__name_vs_namespace(void)
 		git_reference_free(branch);
 		branch = NULL;
 
-		cl_git_pass(git_branch_create(&branch, repo, p->second, target, 0, NULL, NULL));
+		cl_git_pass(git_branch_create(&branch, repo, p->second, target, 0, NULL));
 		git_reference_free(branch);
 		branch = NULL;
 	}
@@ -277,7 +276,7 @@ void test_refs_branches_create__name_vs_namespace_fail(void)
 	retrieve_known_commit(&target, repo);
 
 	for (p=item; p->first; p++) {
-		cl_git_pass(git_branch_create(&branch, repo, p->first, target, 0, NULL, NULL));
+		cl_git_pass(git_branch_create(&branch, repo, p->first, target, 0, NULL));
 		cl_git_pass(git_oid_cmp(git_reference_target(branch), git_commit_id(target)));
 		cl_git_pass(git_branch_name(&name, branch));
 		cl_assert_equal_s(name, p->first);
@@ -286,7 +285,7 @@ void test_refs_branches_create__name_vs_namespace_fail(void)
 		git_reference_free(branch);
 		branch = NULL;
 
-		cl_git_pass(git_branch_create(&branch, repo, p->first_alternate, target, 0, NULL, NULL));
+		cl_git_pass(git_branch_create(&branch, repo, p->first_alternate, target, 0, NULL));
 		cl_git_pass(git_oid_cmp(git_reference_target(branch), git_commit_id(target)));
 		cl_git_pass(git_branch_name(&name, branch));
 		cl_assert_equal_s(name, p->first_alternate);
@@ -295,7 +294,7 @@ void test_refs_branches_create__name_vs_namespace_fail(void)
 		git_reference_free(branch);
 		branch = NULL;
 
-		cl_git_fail(git_branch_create(&branch, repo, p->second, target, 0, NULL, NULL));
+		cl_git_fail(git_branch_create(&branch, repo, p->second, target, 0, NULL));
 		git_reference_free(branch);
 		branch = NULL;
 	}

--- a/tests/refs/branches/delete.c
+++ b/tests/refs/branches/delete.c
@@ -13,7 +13,7 @@ void test_refs_branches_delete__initialize(void)
 	repo = cl_git_sandbox_init("testrepo.git");
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL));
 }
 
 void test_refs_branches_delete__cleanup(void)
@@ -75,7 +75,7 @@ void test_refs_branches_delete__can_delete_a_branch_pointed_at_by_detached_HEAD(
 	git_reference_free(head);
 
 	/* Detach HEAD and make it target the commit that "master" points to */
-	git_repository_detach_head(repo, NULL, NULL);
+	git_repository_detach_head(repo, NULL);
 
 	cl_git_pass(git_branch_lookup(&branch, repo, "master", GIT_BRANCH_LOCAL));
 	cl_git_pass(git_branch_delete(branch));

--- a/tests/refs/branches/delete.c
+++ b/tests/refs/branches/delete.c
@@ -75,7 +75,7 @@ void test_refs_branches_delete__can_delete_a_branch_pointed_at_by_detached_HEAD(
 	git_reference_free(head);
 
 	/* Detach HEAD and make it target the commit that "master" points to */
-	git_repository_detach_head(repo, NULL);
+	git_repository_detach_head(repo);
 
 	cl_git_pass(git_branch_lookup(&branch, repo, "master", GIT_BRANCH_LOCAL));
 	cl_git_pass(git_branch_delete(branch));

--- a/tests/refs/branches/ishead.c
+++ b/tests/refs/branches/ishead.c
@@ -82,9 +82,9 @@ void test_refs_branches_ishead__only_direct_references_are_considered(void)
 {
 	git_reference *linked, *super, *head;
 
-	cl_git_pass(git_reference_symbolic_create(&linked, repo, "refs/heads/linked", "refs/heads/master", 0, NULL, NULL));
-	cl_git_pass(git_reference_symbolic_create(&super, repo, "refs/heads/super", "refs/heads/linked", 0, NULL, NULL));
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/heads/super", 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&linked, repo, "refs/heads/linked", "refs/heads/master", 0, NULL));
+	cl_git_pass(git_reference_symbolic_create(&super, repo, "refs/heads/super", "refs/heads/linked", 0, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/heads/super", 1, NULL));
 
 	cl_assert_equal_i(false, git_branch_is_head(linked));
 	cl_assert_equal_i(false, git_branch_is_head(super));

--- a/tests/refs/branches/iterator.c
+++ b/tests/refs/branches/iterator.c
@@ -12,7 +12,7 @@ void test_refs_branches_iterator__initialize(void)
 	cl_git_pass(git_repository_open(&repo, "testrepo.git"));
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL));
 }
 
 void test_refs_branches_iterator__cleanup(void)
@@ -113,7 +113,7 @@ void test_refs_branches_iterator__retrieve_remote_symbolic_HEAD_when_present(voi
 	};
 
 	git_reference_free(fake_remote);
-	cl_git_pass(git_reference_symbolic_create(&fake_remote, repo, "refs/remotes/nulltoken/HEAD", "refs/remotes/nulltoken/master", 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&fake_remote, repo, "refs/remotes/nulltoken/HEAD", "refs/remotes/nulltoken/master", 0, NULL));
 
 	assert_retrieval(GIT_BRANCH_REMOTE, 3);
 

--- a/tests/refs/branches/move.c
+++ b/tests/refs/branches/move.c
@@ -22,7 +22,7 @@ void test_refs_branches_move__can_move_a_local_branch(void)
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
-	cl_git_pass(git_branch_move(&new_ref, original_ref, NEW_BRANCH_NAME, 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, NEW_BRANCH_NAME, 0, NULL));
 	cl_assert_equal_s(GIT_REFS_HEADS_DIR NEW_BRANCH_NAME, git_reference_name(new_ref));
 
 	git_reference_free(original_ref);
@@ -36,11 +36,11 @@ void test_refs_branches_move__can_move_a_local_branch_to_a_different_namespace(v
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
 	/* Downward */
-	cl_git_pass(git_branch_move(&new_ref, original_ref, "somewhere/" NEW_BRANCH_NAME, 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, "somewhere/" NEW_BRANCH_NAME, 0, NULL));
 	git_reference_free(original_ref);
 
 	/* Upward */
-	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0, NULL));
 	git_reference_free(new_ref);
 
 	git_reference_free(newer_ref);
@@ -53,11 +53,11 @@ void test_refs_branches_move__can_move_a_local_branch_to_a_partially_colliding_n
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
 	/* Downward */
-	cl_git_pass(git_branch_move(&new_ref, original_ref, "br2/" NEW_BRANCH_NAME, 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, "br2/" NEW_BRANCH_NAME, 0, NULL));
 	git_reference_free(original_ref);
 
 	/* Upward */
-	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0, NULL));
 	git_reference_free(new_ref);
 
 	git_reference_free(newer_ref);
@@ -81,7 +81,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
 	cl_assert_equal_i(GIT_EEXISTS,
-		git_branch_move(&new_ref, original_ref, "master", 0, NULL, NULL));
+		git_branch_move(&new_ref, original_ref, "master", 0, NULL));
 
 	cl_assert(giterr_last()->message != NULL);
 	cl_git_pass(git_config_get_entry(&ce, config, "branch.master.remote"));
@@ -91,7 +91,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 
 
 	cl_assert_equal_i(GIT_EEXISTS,
-		git_branch_move(&new_ref, original_ref, "cannot-fetch", 0, NULL, NULL));
+		git_branch_move(&new_ref, original_ref, "cannot-fetch", 0, NULL));
 
 	cl_assert(giterr_last()->message != NULL);
 	cl_git_pass(git_config_get_entry(&ce, config, "branch.master.remote"));
@@ -103,7 +103,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/track-local"));
 
 	cl_assert_equal_i(GIT_EEXISTS,
-		git_branch_move(&new_ref, original_ref, "master", 0, NULL, NULL));
+		git_branch_move(&new_ref, original_ref, "master", 0, NULL));
 
 	cl_assert(giterr_last()->message != NULL);
 	cl_git_pass(git_config_get_entry(&ce, config, "branch.master.remote"));
@@ -122,7 +122,7 @@ void test_refs_branches_move__moving_a_branch_with_an_invalid_name_returns_EINVA
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
-	cl_assert_equal_i(GIT_EINVALIDSPEC, git_branch_move(&new_ref, original_ref, "Inv@{id", 0, NULL, NULL));
+	cl_assert_equal_i(GIT_EINVALIDSPEC, git_branch_move(&new_ref, original_ref, "Inv@{id", 0, NULL));
 
 	git_reference_free(original_ref);
 }
@@ -132,7 +132,7 @@ void test_refs_branches_move__can_not_move_a_non_branch(void)
 	git_reference *tag, *new_ref;
 
 	cl_git_pass(git_reference_lookup(&tag, repo, "refs/tags/e90810b"));
-	cl_git_fail(git_branch_move(&new_ref, tag, NEW_BRANCH_NAME, 0, NULL, NULL));
+	cl_git_fail(git_branch_move(&new_ref, tag, NEW_BRANCH_NAME, 0, NULL));
 
 	git_reference_free(tag);
 }
@@ -143,7 +143,7 @@ void test_refs_branches_move__can_force_move_over_an_existing_branch(void)
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
-	cl_git_pass(git_branch_move(&new_ref, original_ref, "master", 1, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, "master", 1, NULL));
 
 	git_reference_free(original_ref);
 	git_reference_free(new_ref);
@@ -161,7 +161,7 @@ void test_refs_branches_move__moving_a_branch_moves_related_configuration_data(v
 	assert_config_entry_existence(repo, "branch.moved.remote", false);
 	assert_config_entry_existence(repo, "branch.moved.merge", false);
 
-	cl_git_pass(git_branch_move(&new_branch, branch, "moved", 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_branch, branch, "moved", 0, NULL));
 	git_reference_free(branch);
 
 	assert_config_entry_existence(repo, "branch.track-local.remote", false);
@@ -178,7 +178,7 @@ void test_refs_branches_move__moving_the_branch_pointed_at_by_HEAD_updates_HEAD(
 	git_reference *new_branch;
 
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
-	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, NULL));
 	git_reference_free(branch);
 	git_reference_free(new_branch);
 
@@ -198,12 +198,11 @@ void test_refs_branches_move__updates_the_reflog(void)
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
-	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, sig, "message"));
+	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, "message"));
 
 	cl_git_pass(git_reflog_read(&log, repo, git_reference_name(new_branch)));
 	entry = git_reflog_entry_byindex(log, 0);
 	cl_assert_equal_s("message", git_reflog_entry_message(entry));
-	cl_assert_equal_s("foo@example.com", git_reflog_entry_committer(entry)->email);
 
 	git_reference_free(branch);
 	git_reference_free(new_branch);
@@ -228,7 +227,7 @@ void test_refs_branches_move__default_reflog_message(void)
 	cl_git_pass(git_signature_default(&sig, repo));
 
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
-	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, NULL));
 
 	cl_git_pass(git_reflog_read(&log, repo, git_reference_name(new_branch)));
 	entry = git_reflog_entry_byindex(log, 0);
@@ -248,7 +247,7 @@ void test_refs_branches_move__can_move_with_unicode(void)
 	const char *new_branch_name = "\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D";
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
-	cl_git_pass(git_branch_move(&new_ref, original_ref, new_branch_name, 0, NULL, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, new_branch_name, 0, NULL));
 
 	if (cl_repo_get_bool(repo, "core.precomposeunicode"))
 		cl_assert_equal_s(GIT_REFS_HEADS_DIR "\xC3\x85\x73\x74\x72\xC3\xB6\x6D", git_reference_name(new_ref));

--- a/tests/refs/branches/move.c
+++ b/tests/refs/branches/move.c
@@ -22,7 +22,7 @@ void test_refs_branches_move__can_move_a_local_branch(void)
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
-	cl_git_pass(git_branch_move(&new_ref, original_ref, NEW_BRANCH_NAME, 0, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, NEW_BRANCH_NAME, 0));
 	cl_assert_equal_s(GIT_REFS_HEADS_DIR NEW_BRANCH_NAME, git_reference_name(new_ref));
 
 	git_reference_free(original_ref);
@@ -36,11 +36,11 @@ void test_refs_branches_move__can_move_a_local_branch_to_a_different_namespace(v
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
 	/* Downward */
-	cl_git_pass(git_branch_move(&new_ref, original_ref, "somewhere/" NEW_BRANCH_NAME, 0, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, "somewhere/" NEW_BRANCH_NAME, 0));
 	git_reference_free(original_ref);
 
 	/* Upward */
-	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0, NULL));
+	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0));
 	git_reference_free(new_ref);
 
 	git_reference_free(newer_ref);
@@ -53,11 +53,11 @@ void test_refs_branches_move__can_move_a_local_branch_to_a_partially_colliding_n
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
 	/* Downward */
-	cl_git_pass(git_branch_move(&new_ref, original_ref, "br2/" NEW_BRANCH_NAME, 0, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, "br2/" NEW_BRANCH_NAME, 0));
 	git_reference_free(original_ref);
 
 	/* Upward */
-	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0, NULL));
+	cl_git_pass(git_branch_move(&newer_ref, new_ref, "br2", 0));
 	git_reference_free(new_ref);
 
 	git_reference_free(newer_ref);
@@ -81,7 +81,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
 	cl_assert_equal_i(GIT_EEXISTS,
-		git_branch_move(&new_ref, original_ref, "master", 0, NULL));
+		git_branch_move(&new_ref, original_ref, "master", 0));
 
 	cl_assert(giterr_last()->message != NULL);
 	cl_git_pass(git_config_get_entry(&ce, config, "branch.master.remote"));
@@ -91,7 +91,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 
 
 	cl_assert_equal_i(GIT_EEXISTS,
-		git_branch_move(&new_ref, original_ref, "cannot-fetch", 0, NULL));
+		git_branch_move(&new_ref, original_ref, "cannot-fetch", 0));
 
 	cl_assert(giterr_last()->message != NULL);
 	cl_git_pass(git_config_get_entry(&ce, config, "branch.master.remote"));
@@ -103,7 +103,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/track-local"));
 
 	cl_assert_equal_i(GIT_EEXISTS,
-		git_branch_move(&new_ref, original_ref, "master", 0, NULL));
+		git_branch_move(&new_ref, original_ref, "master", 0));
 
 	cl_assert(giterr_last()->message != NULL);
 	cl_git_pass(git_config_get_entry(&ce, config, "branch.master.remote"));
@@ -122,7 +122,7 @@ void test_refs_branches_move__moving_a_branch_with_an_invalid_name_returns_EINVA
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
-	cl_assert_equal_i(GIT_EINVALIDSPEC, git_branch_move(&new_ref, original_ref, "Inv@{id", 0, NULL));
+	cl_assert_equal_i(GIT_EINVALIDSPEC, git_branch_move(&new_ref, original_ref, "Inv@{id", 0));
 
 	git_reference_free(original_ref);
 }
@@ -132,7 +132,7 @@ void test_refs_branches_move__can_not_move_a_non_branch(void)
 	git_reference *tag, *new_ref;
 
 	cl_git_pass(git_reference_lookup(&tag, repo, "refs/tags/e90810b"));
-	cl_git_fail(git_branch_move(&new_ref, tag, NEW_BRANCH_NAME, 0, NULL));
+	cl_git_fail(git_branch_move(&new_ref, tag, NEW_BRANCH_NAME, 0));
 
 	git_reference_free(tag);
 }
@@ -143,7 +143,7 @@ void test_refs_branches_move__can_force_move_over_an_existing_branch(void)
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
 
-	cl_git_pass(git_branch_move(&new_ref, original_ref, "master", 1, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, "master", 1));
 
 	git_reference_free(original_ref);
 	git_reference_free(new_ref);
@@ -161,7 +161,7 @@ void test_refs_branches_move__moving_a_branch_moves_related_configuration_data(v
 	assert_config_entry_existence(repo, "branch.moved.remote", false);
 	assert_config_entry_existence(repo, "branch.moved.merge", false);
 
-	cl_git_pass(git_branch_move(&new_branch, branch, "moved", 0, NULL));
+	cl_git_pass(git_branch_move(&new_branch, branch, "moved", 0));
 	git_reference_free(branch);
 
 	assert_config_entry_existence(repo, "branch.track-local.remote", false);
@@ -178,36 +178,13 @@ void test_refs_branches_move__moving_the_branch_pointed_at_by_HEAD_updates_HEAD(
 	git_reference *new_branch;
 
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
-	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, NULL));
+	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0));
 	git_reference_free(branch);
 	git_reference_free(new_branch);
 
 	cl_git_pass(git_repository_head(&branch, repo));
 	cl_assert_equal_s("refs/heads/master2", git_reference_name(branch));
 	git_reference_free(branch);
-}
-
-void test_refs_branches_move__updates_the_reflog(void)
-{
-	git_reference *branch;
-	git_reference *new_branch;
-	git_reflog *log;
-	const git_reflog_entry *entry;
-	git_signature *sig;
-
-	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
-
-	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
-	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, "message"));
-
-	cl_git_pass(git_reflog_read(&log, repo, git_reference_name(new_branch)));
-	entry = git_reflog_entry_byindex(log, 0);
-	cl_assert_equal_s("message", git_reflog_entry_message(entry));
-
-	git_reference_free(branch);
-	git_reference_free(new_branch);
-	git_reflog_free(log);
-	git_signature_free(sig);
 }
 
 void test_refs_branches_move__default_reflog_message(void)
@@ -227,7 +204,7 @@ void test_refs_branches_move__default_reflog_message(void)
 	cl_git_pass(git_signature_default(&sig, repo));
 
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
-	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0, NULL));
+	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0));
 
 	cl_git_pass(git_reflog_read(&log, repo, git_reference_name(new_branch)));
 	entry = git_reflog_entry_byindex(log, 0);
@@ -247,7 +224,7 @@ void test_refs_branches_move__can_move_with_unicode(void)
 	const char *new_branch_name = "\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D";
 
 	cl_git_pass(git_reference_lookup(&original_ref, repo, "refs/heads/br2"));
-	cl_git_pass(git_branch_move(&new_ref, original_ref, new_branch_name, 0, NULL));
+	cl_git_pass(git_branch_move(&new_ref, original_ref, new_branch_name, 0));
 
 	if (cl_repo_get_bool(repo, "core.precomposeunicode"))
 		cl_assert_equal_s(GIT_REFS_HEADS_DIR "\xC3\x85\x73\x74\x72\xC3\xB6\x6D", git_reference_name(new_ref));

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -91,7 +91,7 @@ static void assert_merge_and_or_remote_key_missing(git_repository *repository, c
 	git_reference *branch;
 
 	cl_assert_equal_i(GIT_OBJ_COMMIT, git_object_type((git_object*)target));
-	cl_git_pass(git_branch_create(&branch, repository, entry_name, (git_commit*)target, 0, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repository, entry_name, (git_commit*)target, 0, NULL));
 
 	cl_assert_equal_i(GIT_ENOTFOUND, git_branch_upstream(&upstream, branch));
 

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -91,7 +91,7 @@ static void assert_merge_and_or_remote_key_missing(git_repository *repository, c
 	git_reference *branch;
 
 	cl_assert_equal_i(GIT_OBJ_COMMIT, git_object_type((git_object*)target));
-	cl_git_pass(git_branch_create(&branch, repository, entry_name, (git_commit*)target, 0, NULL));
+	cl_git_pass(git_branch_create(&branch, repository, entry_name, (git_commit*)target, 0));
 
 	cl_assert_equal_i(GIT_ENOTFOUND, git_branch_upstream(&upstream, branch));
 

--- a/tests/refs/crashes.c
+++ b/tests/refs/crashes.c
@@ -7,7 +7,7 @@ void test_refs_crashes__double_free(void)
 	const char *REFNAME = "refs/heads/xxx";
 
 	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
-	cl_git_pass(git_reference_symbolic_create(&ref, repo, REFNAME, "refs/heads/master", 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, REFNAME, "refs/heads/master", 0, NULL));
 	cl_git_pass(git_reference_lookup(&ref2, repo, REFNAME));
 	cl_git_pass(git_reference_delete(ref));
 	git_reference_free(ref);

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -32,7 +32,7 @@ void test_refs_create__symbolic(void)
 	git_oid_fromstr(&id, current_master_tip);
 
 	/* Create and write the new symbolic reference */
-	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0, NULL));
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
@@ -73,7 +73,7 @@ void test_refs_create__deep_symbolic(void)
 
 	git_oid_fromstr(&id, current_master_tip);
 
-	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, current_head_target, 0, NULL));
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
 	cl_git_pass(git_reference_resolve(&resolved_ref, looked_up_ref));
 	cl_assert_equal_oid(&id, git_reference_target(resolved_ref));
@@ -95,7 +95,7 @@ void test_refs_create__oid(void)
 	git_oid_fromstr(&id, current_master_tip);
 
 	/* Create and write the new object id reference */
-	cl_git_pass(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL));
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head));
@@ -130,7 +130,7 @@ void test_refs_create__oid_unknown(void)
 	git_oid_fromstr(&id, "deadbeef3f795b2b4353bcce3a527ad0a4f7f644");
 
 	/* Create and write the new object id reference */
-	cl_git_fail(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL, NULL));
+	cl_git_fail(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL));
 
 	/* Ensure the reference can't be looked-up... */
 	cl_git_fail(git_reference_lookup(&looked_up_ref, g_repo, new_head));
@@ -144,10 +144,10 @@ void test_refs_create__propagate_eexists(void)
 
 	/* Make sure it works for oid and for symbolic both */
 	git_oid_fromstr(&oid, current_master_tip);
-	error = git_reference_create(&ref, g_repo, current_head_target, &oid, false, NULL, NULL);
+	error = git_reference_create(&ref, g_repo, current_head_target, &oid, false, NULL);
 	cl_assert(error == GIT_EEXISTS);
 
-	error = git_reference_symbolic_create(&ref, g_repo, "HEAD", current_head_target, false, NULL, NULL);
+	error = git_reference_symbolic_create(&ref, g_repo, "HEAD", current_head_target, false, NULL);
 	cl_assert(error == GIT_EEXISTS);
 }
 
@@ -159,10 +159,10 @@ static void test_invalid_name(const char *name)
 	git_oid_fromstr(&id, current_master_tip);
 
 	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_create(
-		&new_reference, g_repo, name, &id, 0, NULL, NULL));
+		&new_reference, g_repo, name, &id, 0, NULL));
 
 	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(
-		&new_reference, g_repo, name, current_head_target, 0, NULL, NULL));
+		&new_reference, g_repo, name, current_head_target, 0, NULL));
 }
 
 void test_refs_create__creating_a_reference_with_an_invalid_name_returns_EINVALIDSPEC(void)
@@ -188,7 +188,7 @@ static void test_win32_name(const char *name)
 
 	git_oid_fromstr(&id, current_master_tip);
 
-	ret = git_reference_create(&new_reference, g_repo, name, &id, 0, NULL, NULL);
+	ret = git_reference_create(&new_reference, g_repo, name, &id, 0, NULL);
 
 #ifdef GIT_WIN32
 	cl_assert_equal_i(GIT_EINVALIDSPEC, ret);

--- a/tests/refs/createwithlog.c
+++ b/tests/refs/createwithlog.c
@@ -23,7 +23,6 @@ void test_refs_createwithlog__creating_a_direct_reference_adds_a_reflog_entry(vo
 {
 	git_reference *reference;
 	git_oid id;
-	git_signature *signature;
 	git_reflog *reflog;
 	const git_reflog_entry *entry;
 
@@ -32,10 +31,8 @@ void test_refs_createwithlog__creating_a_direct_reference_adds_a_reflog_entry(vo
 
 	git_oid_fromstr(&id, current_master_tip);
 
-	cl_git_pass(git_signature_now(&signature, "foo", "foo@bar"));
-
 	cl_git_pass(
-		git_reference_create(&reference, g_repo, name, &id, 0, signature, message));
+		git_reference_create(&reference, g_repo, name, &id, 0, message));
 
 	cl_git_pass(git_reflog_read(&reflog, g_repo, name));
 	cl_assert_equal_sz(1, git_reflog_entrycount(reflog));
@@ -47,5 +44,4 @@ void test_refs_createwithlog__creating_a_direct_reference_adds_a_reflog_entry(vo
 
 	git_reflog_free(reflog);
 	git_reference_free(reference);
-	git_signature_free(signature);
 }

--- a/tests/refs/delete.c
+++ b/tests/refs/delete.c
@@ -66,7 +66,7 @@ void test_refs_delete__packed_only(void)
 	git_oid_fromstr(&id, current_master_tip);
 
 	/* Create and write the new object id reference */
-	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &id, 0, NULL));
 	git_reference_free(ref);
 
 	/* Lookup the reference */

--- a/tests/refs/foreachglob.c
+++ b/tests/refs/foreachglob.c
@@ -12,7 +12,7 @@ void test_refs_foreachglob__initialize(void)
 	cl_git_pass(git_repository_open(&repo, "testrepo.git"));
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&fake_remote, repo, "refs/remotes/nulltoken/master", &id, 0, NULL));
 }
 
 void test_refs_foreachglob__cleanup(void)

--- a/tests/refs/overwrite.c
+++ b/tests/refs/overwrite.c
@@ -27,8 +27,8 @@ void test_refs_overwrite__symbolic(void)
 	git_reference *ref, *branch_ref;
 
 	/* The target needds to exist and we need to check the name has changed */
-	cl_git_pass(git_reference_symbolic_create(&branch_ref, g_repo, ref_branch_name, ref_master_name, 0, NULL, NULL));
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_branch_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&branch_ref, g_repo, ref_branch_name, ref_master_name, 0, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_branch_name, 0, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place*/
@@ -38,8 +38,8 @@ void test_refs_overwrite__symbolic(void)
 	git_reference_free(ref);
 
 	/* Ensure we can't create it unless we force it to */
-	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1, NULL, NULL));
+	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place */
@@ -63,7 +63,7 @@ void test_refs_overwrite__object_id(void)
 	git_reference_free(ref);
 
 	/* Create it */
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_test_name));
@@ -72,8 +72,8 @@ void test_refs_overwrite__object_id(void)
 	git_reference_free(ref);
 
 	/* Ensure we can't overwrite unless we force it */
-	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1, NULL, NULL));
+	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it has been overwritten */
@@ -94,10 +94,10 @@ void test_refs_overwrite__object_id_with_symbolic(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL));
 	git_reference_free(ref);
-	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1, NULL, NULL));
+	cl_git_fail(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 1, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place */
@@ -120,11 +120,11 @@ void test_refs_overwrite__symbolic_with_object_id(void)
 	git_reference_free(ref);
 
 	/* Create the symbolic ref */
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL));
 	git_reference_free(ref);
 	/* It shouldn't overwrite unless we tell it to */
-	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL, NULL));
-	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1, NULL, NULL));
+	cl_git_fail(git_reference_create(&ref, g_repo, ref_name, &id, 0, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, ref_name, &id, 1, NULL));
 	git_reference_free(ref);
 
 	/* Ensure it points to the right place */

--- a/tests/refs/pack.c
+++ b/tests/refs/pack.c
@@ -93,11 +93,11 @@ void test_refs_pack__symbolic(void)
 	for (i = 0; i < 100; ++i) {
 		p_snprintf(name, sizeof(name), "refs/heads/symbolic-%03d", i);
 		cl_git_pass(git_reference_symbolic_create(
-			&ref, g_repo, name, "refs/heads/master", 0, NULL, NULL));
+			&ref, g_repo, name, "refs/heads/master", 0, NULL));
 		git_reference_free(ref);
 
 		p_snprintf(name, sizeof(name), "refs/heads/direct-%03d", i);
-		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL, NULL));
+		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL));
 		git_reference_free(ref);
 	}
 

--- a/tests/refs/races.c
+++ b/tests/refs/races.c
@@ -30,11 +30,11 @@ void test_refs_races__create_matching(void)
 	git_oid_fromstr(&id, commit_id);
 	git_oid_fromstr(&other_id, other_commit_id);
 
-	cl_git_fail_with(GIT_EMODIFIED, git_reference_create_matching(&ref, g_repo, refname, &other_id, 1, &other_id, NULL, NULL));
+	cl_git_fail_with(GIT_EMODIFIED, git_reference_create_matching(&ref, g_repo, refname, &other_id, 1, &other_id, NULL));
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, refname));
-	cl_git_pass(git_reference_create_matching(&ref2, g_repo, refname, &other_id, 1, &id, NULL, NULL));
-	cl_git_fail_with(GIT_EMODIFIED, git_reference_set_target(&ref3, ref, &other_id, NULL, NULL));
+	cl_git_pass(git_reference_create_matching(&ref2, g_repo, refname, &other_id, 1, &id, NULL));
+	cl_git_fail_with(GIT_EMODIFIED, git_reference_set_target(&ref3, ref, &other_id, NULL));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
@@ -49,11 +49,11 @@ void test_refs_races__symbolic_create_matching(void)
 	git_oid_fromstr(&id, commit_id);
 	git_oid_fromstr(&other_id, other_commit_id);
 
-	cl_git_fail_with(GIT_EMODIFIED, git_reference_symbolic_create_matching(&ref, g_repo, "HEAD", other_refname, 1, other_refname, NULL, NULL));
+	cl_git_fail_with(GIT_EMODIFIED, git_reference_symbolic_create_matching(&ref, g_repo, "HEAD", other_refname, 1, other_refname, NULL));
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, "HEAD"));
-	cl_git_pass(git_reference_symbolic_create_matching(&ref2, g_repo, "HEAD", other_refname, 1, NULL, NULL, refname));
-	cl_git_fail_with(GIT_EMODIFIED, git_reference_symbolic_set_target(&ref3, ref, other_refname, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create_matching(&ref2, g_repo, "HEAD", other_refname, 1, NULL, refname));
+	cl_git_fail_with(GIT_EMODIFIED, git_reference_symbolic_set_target(&ref3, ref, other_refname, NULL));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
@@ -75,18 +75,18 @@ void test_refs_races__delete(void)
 
 	/* We cannot delete a symbolic value that doesn't match */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, "HEAD"));
-	cl_git_pass(git_reference_symbolic_create_matching(&ref2, g_repo, "HEAD", other_refname, 1, NULL, NULL, refname));
+	cl_git_pass(git_reference_symbolic_create_matching(&ref2, g_repo, "HEAD", other_refname, 1, NULL, refname));
 	cl_git_fail_with(GIT_EMODIFIED, git_reference_delete(ref));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
 
-	cl_git_pass(git_reference_create(&ref, g_repo, refname, &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, refname, &id, 1, NULL));
 	git_reference_free(ref);
 
 	/* We cannot delete an oid value that doesn't match */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, refname));
-	cl_git_pass(git_reference_create_matching(&ref2, g_repo, refname, &other_id, 1, &id, NULL, NULL));
+	cl_git_pass(git_reference_create_matching(&ref2, g_repo, refname, &other_id, 1, &id, NULL));
 	cl_git_fail_with(GIT_EMODIFIED, git_reference_delete(ref));
 
 	git_reference_free(ref);
@@ -103,19 +103,19 @@ void test_refs_races__switch_oid_to_symbolic(void)
 
 	/* Removing a direct ref when it's currently symbolic should fail */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, refname));
-	cl_git_pass(git_reference_symbolic_create(&ref2, g_repo, refname, other_refname, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref2, g_repo, refname, other_refname, 1, NULL));
 	cl_git_fail_with(GIT_EMODIFIED, git_reference_delete(ref));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
 
-	cl_git_pass(git_reference_create(&ref, g_repo, refname, &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, refname, &id, 1, NULL));
 	git_reference_free(ref);
 
 	/* Updating a direct ref when it's currently symbolic should fail */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, refname));
-	cl_git_pass(git_reference_symbolic_create(&ref2, g_repo, refname, other_refname, 1, NULL, NULL));
-	cl_git_fail_with(GIT_EMODIFIED, git_reference_set_target(&ref3, ref, &other_id, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref2, g_repo, refname, other_refname, 1, NULL));
+	cl_git_fail_with(GIT_EMODIFIED, git_reference_set_target(&ref3, ref, &other_id, NULL));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
@@ -132,19 +132,19 @@ void test_refs_races__switch_symbolic_to_oid(void)
 
 	/* Removing a symbolic ref when it's currently direct should fail */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, "HEAD"));
-	cl_git_pass(git_reference_create(&ref2, g_repo, "HEAD", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref2, g_repo, "HEAD", &id, 1, NULL));
 	cl_git_fail_with(GIT_EMODIFIED, git_reference_delete(ref));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
 
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, "HEAD", refname, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, "HEAD", refname, 1, NULL));
 	git_reference_free(ref);
 
 	/* Updating a symbolic ref when it's currently direct should fail */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, "HEAD"));
-	cl_git_pass(git_reference_create(&ref2, g_repo, "HEAD", &id, 1, NULL, NULL));
-	cl_git_fail_with(GIT_EMODIFIED, git_reference_symbolic_set_target(&ref3, ref, other_refname, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref2, g_repo, "HEAD", &id, 1, NULL));
+	cl_git_fail_with(GIT_EMODIFIED, git_reference_symbolic_set_target(&ref3, ref, other_refname, NULL));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);

--- a/tests/refs/reflog/reflog.c
+++ b/tests/refs/reflog/reflog.c
@@ -82,7 +82,7 @@ void test_refs_reflog_reflog__append_then_read(void)
 
 	/* Create a new branch pointing at the HEAD */
 	git_oid_fromstr(&oid, current_master_tip);
-	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &oid, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, new_ref, &oid, 0, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_signature_now(&committer, "foo", "foo@bar"));
@@ -114,7 +114,7 @@ void test_refs_reflog_reflog__renaming_the_reference_moves_the_reflog(void)
 	cl_assert_equal_i(false, git_path_isfile(git_buf_cstr(&moved_log_path)));
 
 	cl_git_pass(git_reference_lookup(&master, g_repo, "refs/heads/master"));
-	cl_git_pass(git_reference_rename(&new_master, master, "refs/moved", 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&new_master, master, "refs/moved", 0, NULL));
 	git_reference_free(master);
 
 	cl_assert_equal_i(false, git_path_isfile(git_buf_cstr(&master_log_path)));
@@ -165,7 +165,7 @@ void test_refs_reflog_reflog__cannot_write_a_moved_reflog(void)
 
 	cl_git_pass(git_reflog_write(reflog));
 
-	cl_git_pass(git_reference_rename(&new_master, master, "refs/moved", 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&new_master, master, "refs/moved", 0, NULL));
 	git_reference_free(master);
 
 	cl_git_fail(git_reflog_write(reflog));
@@ -189,11 +189,11 @@ void test_refs_reflog_reflog__write_only_std_locations(void)
 
 	git_oid_fromstr(&id, current_master_tip);
 
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/foo", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/foo", &id, 1, NULL));
 	git_reference_free(ref);
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1, NULL));
 	git_reference_free(ref);
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/notes/foo", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/notes/foo", &id, 1, NULL));
 	git_reference_free(ref);
 
 	assert_has_reflog(true, "refs/heads/foo");
@@ -210,7 +210,7 @@ void test_refs_reflog_reflog__write_when_explicitly_active(void)
 	git_oid_fromstr(&id, current_master_tip);
 	git_reference_ensure_log(g_repo, "refs/tags/foo");
 
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/tags/foo", &id, 1, NULL));
 	git_reference_free(ref);
 	assert_has_reflog(true, "refs/tags/foo");
 }
@@ -228,7 +228,7 @@ void test_refs_reflog_reflog__append_to_HEAD_when_changing_current_branch(void)
 
 	/* Move it back */
 	git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/master", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/master", &id, 1, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_reflog_read(&log, g_repo, "HEAD"));
@@ -250,7 +250,7 @@ void test_refs_reflog_reflog__do_not_append_when_no_update(void)
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, "refs/heads/master"));
 	cl_git_pass(git_reference_create(&ref2, g_repo, "refs/heads/master",
-					 git_reference_target(ref), 1, NULL, NULL));
+					 git_reference_target(ref), 1, NULL));
 
 	git_reference_free(ref);
 	git_reference_free(ref2);
@@ -280,7 +280,7 @@ static void assert_no_reflog_update(void)
 
 	/* Move it back */
 	git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
-	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/master", &id, 1, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/master", &id, 1, NULL));
 	git_reference_free(ref);
 
 	cl_git_pass(git_reflog_read(&log, g_repo, "HEAD"));

--- a/tests/refs/rename.c
+++ b/tests/refs/rename.c
@@ -22,6 +22,7 @@ static git_repository *g_repo;
 void test_refs_rename__initialize(void)
 {
 	g_repo = cl_git_sandbox_init("testrepo");
+	cl_git_pass(git_repository_set_ident(g_repo, "me", "foo@example.com"));
 }
 
 void test_refs_rename__cleanup(void)
@@ -49,7 +50,7 @@ void test_refs_rename__loose(void)
 	cl_assert(reference_is_packed(looked_up_ref) == 0);
 
 	/* Now that the reference is renamed... */
-	cl_git_pass(git_reference_rename(&new_ref, looked_up_ref, new_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&new_ref, looked_up_ref, new_name, 0, NULL));
 	cl_assert_equal_s(new_ref->name, new_name);
 	git_reference_free(looked_up_ref);
 
@@ -91,7 +92,7 @@ void test_refs_rename__packed(void)
 	cl_assert(reference_is_packed(looked_up_ref) != 0);
 
 	/* Now that the reference is renamed... */
-	cl_git_pass(git_reference_rename(&new_ref, looked_up_ref, brand_new_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&new_ref, looked_up_ref, brand_new_name, 0, NULL));
 	cl_assert_equal_s(new_ref->name, brand_new_name);
 	git_reference_free(looked_up_ref);
 
@@ -140,7 +141,7 @@ void test_refs_rename__packed_doesnt_pack_others(void)
 	cl_assert(reference_is_packed(looked_up_ref) != 0);
 
 	/* Now that the reference is renamed... */
-	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, brand_new_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, brand_new_name, 0, NULL));
 	git_reference_free(looked_up_ref);
 
 	/* Lookup the other reference */
@@ -166,7 +167,7 @@ void test_refs_rename__name_collision(void)
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, packed_head_name));
 
 	/* Can not be renamed to the name of another existing reference. */
-	cl_git_fail(git_reference_rename(&renamed_ref, looked_up_ref, packed_test_head_name, 0, NULL, NULL));
+	cl_git_fail(git_reference_rename(&renamed_ref, looked_up_ref, packed_test_head_name, 0, NULL));
 	git_reference_free(looked_up_ref);
 
 	/* Failure to rename it hasn't corrupted its state */
@@ -187,12 +188,12 @@ void test_refs_rename__invalid_name(void)
 	/* Can not be renamed with an invalid name. */
 	cl_assert_equal_i(
 		GIT_EINVALIDSPEC,
-		git_reference_rename(&renamed_ref, looked_up_ref, "Hello! I'm a very invalid name.", 0, NULL, NULL));
+		git_reference_rename(&renamed_ref, looked_up_ref, "Hello! I'm a very invalid name.", 0, NULL));
 
 	/* Can not be renamed outside of the refs hierarchy
 	 * unless it's ALL_CAPS_AND_UNDERSCORES.
 	 */
-	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_rename(&renamed_ref, looked_up_ref, "i-will-sudo-you", 0, NULL, NULL));
+	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_rename(&renamed_ref, looked_up_ref, "i-will-sudo-you", 0, NULL));
 
 	/* Failure to rename it hasn't corrupted its state */
 	git_reference_free(looked_up_ref);
@@ -213,7 +214,7 @@ void test_refs_rename__force_loose_packed(void)
 	git_oid_cpy(&oid, git_reference_target(looked_up_ref));
 
 	/* Can be force-renamed to the name of another existing reference. */
-	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, packed_test_head_name, 1, NULL, NULL));
+	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, packed_test_head_name, 1, NULL));
 	git_reference_free(looked_up_ref);
 	git_reference_free(renamed_ref);
 
@@ -238,7 +239,7 @@ void test_refs_rename__force_loose(void)
 	git_oid_cpy(&oid, git_reference_target(looked_up_ref));
 
 	/* Can be force-renamed to the name of another existing reference. */
-	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, "refs/heads/test", 1, NULL, NULL));
+	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, "refs/heads/test", 1, NULL));
 	git_reference_free(looked_up_ref);
 	git_reference_free(renamed_ref);
 
@@ -268,15 +269,15 @@ void test_refs_rename__overwrite(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	/* Create loose references */
-	cl_git_pass(git_reference_create(&ref_one, g_repo, ref_one_name, &id, 0, NULL, NULL));
-	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref_one, g_repo, ref_one_name, &id, 0, NULL));
+	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0, NULL));
 
 	/* Pack everything */
 	cl_git_pass(git_repository_refdb(&refdb, g_repo));
 	cl_git_pass(git_refdb_compress(refdb));
 
 	/* Attempt to create illegal reference */
-	cl_git_fail(git_reference_create(&ref_one_new, g_repo, ref_one_name_new, &id, 0, NULL, NULL));
+	cl_git_fail(git_reference_create(&ref_one_new, g_repo, ref_one_name_new, &id, 0, NULL));
 
 	/* Illegal reference couldn't be created so this is supposed to fail */
 	cl_git_fail(git_reference_lookup(&ref_one_new, g_repo, ref_one_name_new));
@@ -301,13 +302,13 @@ void test_refs_rename__prefix(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	/* Create loose references */
-	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name, &id, 0, NULL));
 
 	/* An existing reference... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, ref_two_name));
 
 	/* Can be rename to a new name starting with the old name. */
-	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, ref_two_name_new, 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, ref_two_name_new, 0, NULL));
 	git_reference_free(looked_up_ref);
 	git_reference_free(renamed_ref);
 
@@ -334,14 +335,14 @@ void test_refs_rename__move_up(void)
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	/* Create loose references */
-	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name_new, &id, 0, NULL, NULL));
+	cl_git_pass(git_reference_create(&ref_two, g_repo, ref_two_name_new, &id, 0, NULL));
 	git_reference_free(ref_two);
 
 	/* An existing reference... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, ref_two_name_new));
 
 	/* Can be renamed upward the reference tree. */
-	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, ref_two_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&renamed_ref, looked_up_ref, ref_two_name, 0, NULL));
 	git_reference_free(looked_up_ref);
 	git_reference_free(renamed_ref);
 
@@ -361,7 +362,7 @@ void test_refs_rename__propagate_eexists(void)
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, packed_head_name));
 
-	cl_assert_equal_i(GIT_EEXISTS, git_reference_rename(&new_ref, ref, packed_test_head_name, 0, NULL, NULL));
+	cl_assert_equal_i(GIT_EEXISTS, git_reference_rename(&new_ref, ref, packed_test_head_name, 0, NULL));
 
 	git_reference_free(ref);
 }
@@ -371,13 +372,10 @@ void test_refs_rename__writes_to_reflog(void)
 	git_reference *ref, *new_ref;
 	git_reflog *log;
 	const git_reflog_entry *entry;
-	git_signature *sig;
-
-	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
 	cl_git_pass(git_reference_rename(&new_ref, ref, ref_one_name_new, false,
-				sig, "message"));
+				"message"));
 	cl_git_pass(git_reflog_read(&log, g_repo, git_reference_name(new_ref)));
 	entry = git_reflog_entry_byindex(log, 0);
 	cl_assert_equal_s("message", git_reflog_entry_message(entry));
@@ -386,5 +384,4 @@ void test_refs_rename__writes_to_reflog(void)
 	git_reflog_free(log);
 	git_reference_free(ref);
 	git_reference_free(new_ref);
-	git_signature_free(sig);
 }

--- a/tests/refs/revparse.c
+++ b/tests/refs/revparse.c
@@ -634,7 +634,7 @@ void test_refs_revparse__try_to_retrieve_branch_before_described_tag(void)
 	test_object_inrepo("blah-7-gc47800c", "c47800c7266a2be04c571c04d5a6614691ea99bd", repo);
 
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~3"));
-	cl_git_pass(git_branch_create(&branch, repo, "blah-7-gc47800c", (git_commit *)target, 0, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "blah-7-gc47800c", (git_commit *)target, 0));
 
 	git_oid_tostr(sha, GIT_OID_HEXSZ + 1, git_object_id(target));
 
@@ -672,7 +672,7 @@ void test_refs_revparse__try_to_retrieve_sha_before_branch(void)
 	test_object_inrepo("a65fedf39aefe402d3bb6e24df4d4f5fe4547750", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", repo);
 
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~3"));
-	cl_git_pass(git_branch_create(&branch, repo, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", (git_commit *)target, 0, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", (git_commit *)target, 0));
 
 	git_oid_tostr(sha, GIT_OID_HEXSZ + 1, git_object_id(target));
 
@@ -708,7 +708,7 @@ void test_refs_revparse__try_to_retrieve_branch_before_abbrev_sha(void)
 	test_object_inrepo("c47800", "c47800c7266a2be04c571c04d5a6614691ea99bd", repo);
 
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~3"));
-	cl_git_pass(git_branch_create(&branch, repo, "c47800", (git_commit *)target, 0, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "c47800", (git_commit *)target, 0));
 
 	git_oid_tostr(sha, GIT_OID_HEXSZ + 1, git_object_id(target));
 

--- a/tests/refs/revparse.c
+++ b/tests/refs/revparse.c
@@ -325,7 +325,7 @@ static void create_fake_stash_reference_and_reflog(git_repository *repo)
 	cl_assert_equal_i(false, git_path_isfile(git_buf_cstr(&log_path)));
 
 	cl_git_pass(git_reference_lookup(&master, repo, "refs/heads/master"));
-	cl_git_pass(git_reference_rename(&new_master, master, "refs/fakestash", 0, NULL, NULL));
+	cl_git_pass(git_reference_rename(&new_master, master, "refs/fakestash", 0, NULL));
 	git_reference_free(master);
 
 	cl_assert_equal_i(true, git_path_isfile(git_buf_cstr(&log_path)));
@@ -597,7 +597,7 @@ void test_refs_revparse__issue_994(void)
 		"refs/remotes/origin/bim_with_3d@11296",
 		git_reference_target(head),
 		0,
-		NULL, NULL));
+		NULL));
 
 	cl_git_pass(git_revparse_single(&target, repo, "origin/bim_with_3d@11296"));
 	git_object_free(target);
@@ -634,7 +634,7 @@ void test_refs_revparse__try_to_retrieve_branch_before_described_tag(void)
 	test_object_inrepo("blah-7-gc47800c", "c47800c7266a2be04c571c04d5a6614691ea99bd", repo);
 
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~3"));
-	cl_git_pass(git_branch_create(&branch, repo, "blah-7-gc47800c", (git_commit *)target, 0, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "blah-7-gc47800c", (git_commit *)target, 0, NULL));
 
 	git_oid_tostr(sha, GIT_OID_HEXSZ + 1, git_object_id(target));
 
@@ -672,7 +672,7 @@ void test_refs_revparse__try_to_retrieve_sha_before_branch(void)
 	test_object_inrepo("a65fedf39aefe402d3bb6e24df4d4f5fe4547750", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", repo);
 
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~3"));
-	cl_git_pass(git_branch_create(&branch, repo, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", (git_commit *)target, 0, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", (git_commit *)target, 0, NULL));
 
 	git_oid_tostr(sha, GIT_OID_HEXSZ + 1, git_object_id(target));
 
@@ -708,7 +708,7 @@ void test_refs_revparse__try_to_retrieve_branch_before_abbrev_sha(void)
 	test_object_inrepo("c47800", "c47800c7266a2be04c571c04d5a6614691ea99bd", repo);
 
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~3"));
-	cl_git_pass(git_branch_create(&branch, repo, "c47800", (git_commit *)target, 0, NULL, NULL));
+	cl_git_pass(git_branch_create(&branch, repo, "c47800", (git_commit *)target, 0, NULL));
 
 	git_oid_tostr(sha, GIT_OID_HEXSZ + 1, git_object_id(target));
 

--- a/tests/refs/settargetwithlog.c
+++ b/tests/refs/settargetwithlog.c
@@ -25,7 +25,6 @@ void test_refs_settargetwithlog__updating_a_direct_reference_adds_a_reflog_entry
 {
 	git_reference *reference, *reference_out;
 	git_oid current_id, target_id;
-	git_signature *signature;
 	git_reflog *reflog;
 	const git_reflog_entry *entry;
 
@@ -36,10 +35,8 @@ void test_refs_settargetwithlog__updating_a_direct_reference_adds_a_reflog_entry
 
 	cl_git_pass(git_reference_lookup(&reference, g_repo, br2_name));
 
-	cl_git_pass(git_signature_now(&signature, "foo", "foo@bar"));
-
 	cl_git_pass(git_reference_set_target(
-		&reference_out, reference, &target_id, signature, message));
+		&reference_out, reference, &target_id, message));
 
 	cl_git_pass(git_reflog_read(&reflog, g_repo, br2_name));
 
@@ -51,5 +48,4 @@ void test_refs_settargetwithlog__updating_a_direct_reference_adds_a_reflog_entry
 	git_reflog_free(reflog);
 	git_reference_free(reference_out);
 	git_reference_free(reference);
-	git_signature_free(signature);
 }

--- a/tests/refs/setter.c
+++ b/tests/refs/setter.c
@@ -34,7 +34,7 @@ void test_refs_setter__update_direct(void)
 	cl_git_pass(git_reference_lookup(&test_ref, g_repo, ref_test_name));
 	cl_assert(git_reference_type(test_ref) == GIT_REF_OID);
 
-	cl_git_pass(git_reference_set_target(&new_ref, test_ref, &id, NULL, NULL));
+	cl_git_pass(git_reference_set_target(&new_ref, test_ref, &id, NULL));
 
 	git_reference_free(test_ref);
 	git_reference_free(new_ref);
@@ -53,7 +53,7 @@ void test_refs_setter__update_symbolic(void)
 	cl_assert(git_reference_type(head) == GIT_REF_SYMBOLIC);
 	cl_assert(strcmp(git_reference_symbolic_target(head), ref_master_name) == 0);
 
-	cl_git_pass(git_reference_symbolic_set_target(&new_head, head, ref_test_name, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_set_target(&new_head, head, ref_test_name, NULL));
 	git_reference_free(new_head);
 	git_reference_free(head);
 
@@ -73,7 +73,7 @@ void test_refs_setter__cant_update_direct_with_symbolic(void)
 	cl_assert(git_reference_type(ref) == GIT_REF_OID);
 	git_oid_cpy(&id, git_reference_target(ref));
 
-	cl_git_fail(git_reference_symbolic_set_target(&new, ref, ref_name, NULL, NULL));
+	cl_git_fail(git_reference_symbolic_set_target(&new, ref, ref_name, NULL));
 
 	git_reference_free(ref);
 }
@@ -90,10 +90,10 @@ void test_refs_setter__cant_update_symbolic_with_direct(void)
 	git_reference_free(ref);
 
 	/* Create the symbolic ref */
-	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, g_repo, ref_name, ref_master_name, 0, NULL));
 
 	/* Can't set an OID on a direct ref */
-	cl_git_fail(git_reference_set_target(&new, ref, &id, NULL, NULL));
+	cl_git_fail(git_reference_set_target(&new, ref, &id, NULL));
 
 	git_reference_free(ref);
 }

--- a/tests/refs/unicode.c
+++ b/tests/refs/unicode.c
@@ -24,7 +24,7 @@ void test_refs_unicode__create_and_lookup(void)
 	/* Create the reference */
 	cl_git_pass(git_reference_lookup(&ref0, repo, master));
 	cl_git_pass(git_reference_create(
-		&ref1, repo, REFNAME, git_reference_target(ref0), 0, NULL, NULL));
+		&ref1, repo, REFNAME, git_reference_target(ref0), 0, NULL));
 	cl_assert_equal_s(REFNAME, git_reference_name(ref1));
 	git_reference_free(ref0);
 

--- a/tests/refs/update.c
+++ b/tests/refs/update.c
@@ -22,5 +22,5 @@ void test_refs_update__updating_the_target_of_a_symref_with_an_invalid_name_retu
 	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
 	git_reference_free(head);
 
-	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(&head, g_repo, GIT_HEAD_FILE, "refs/heads/inv@{id", 1, NULL, NULL));
+	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(&head, g_repo, GIT_HEAD_FILE, "refs/heads/inv@{id", 1, NULL));
 }

--- a/tests/repo/head.c
+++ b/tests/repo/head.c
@@ -3,11 +3,13 @@
 #include "repo_helpers.h"
 #include "posix.h"
 
+static const char *g_email = "foo@example.com";
 static git_repository *repo;
 
 void test_repo_head__initialize(void)
 {
 	repo = cl_git_sandbox_init("testrepo.git");
+	cl_git_pass(git_repository_set_ident(repo, "Foo Bar", g_email));
 }
 
 void test_repo_head__cleanup(void)
@@ -33,24 +35,20 @@ static void check_last_reflog_entry(const char *email, const char *message)
 void test_repo_head__head_detached(void)
 {
 	git_reference *ref;
-	git_signature *sig;
-
-	cl_git_pass(git_signature_now(&sig, "Foo Bar", "foo@example.com"));
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
-	cl_git_pass(git_repository_detach_head(repo, sig, "CABLE DETACHED"));
-	check_last_reflog_entry(sig->email, "CABLE DETACHED");
+	cl_git_pass(git_repository_detach_head(repo, "CABLE DETACHED"));
+	check_last_reflog_entry(g_email, "CABLE DETACHED");
 	cl_assert_equal_i(true, git_repository_head_detached(repo));
 
 	/* take the repo back to it's original state */
 	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master",
-				true, sig, "REATTACH"));
+				true, "REATTACH"));
 	git_reference_free(ref);
 
-	check_last_reflog_entry(sig->email, "REATTACH");
+	check_last_reflog_entry(g_email, "REATTACH");
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
-	git_signature_free(sig);
 }
 
 void test_repo_head__unborn_head(void)
@@ -65,7 +63,7 @@ void test_repo_head__unborn_head(void)
 
 
 	/* take the repo back to it's original state */
-	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master", 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, "HEAD", "refs/heads/master", 1, NULL));
 	cl_assert(git_repository_head_unborn(repo) == 0);
 
 	git_reference_free(ref);
@@ -75,7 +73,7 @@ void test_repo_head__set_head_Attaches_HEAD_to_un_unborn_branch_when_the_branch_
 {
 	git_reference *head;
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/doesnt/exist/yet", NULL, NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/doesnt/exist/yet", NULL));
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
@@ -84,19 +82,19 @@ void test_repo_head__set_head_Attaches_HEAD_to_un_unborn_branch_when_the_branch_
 
 void test_repo_head__set_head_Returns_ENOTFOUND_when_the_reference_doesnt_exist(void)
 {
-	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head(repo, "refs/tags/doesnt/exist/yet", NULL, NULL));
+	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head(repo, "refs/tags/doesnt/exist/yet", NULL));
 }
 
 void test_repo_head__set_head_Fails_when_the_reference_points_to_a_non_commitish(void)
 {
-	cl_git_fail(git_repository_set_head(repo, "refs/tags/point_to_blob", NULL, NULL));
+	cl_git_fail(git_repository_set_head(repo, "refs/tags/point_to_blob", NULL));
 }
 
 void test_repo_head__set_head_Attaches_HEAD_when_the_reference_points_to_a_branch(void)
 {
 	git_reference *head;
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/br2", NULL, NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/br2", NULL));
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
@@ -123,7 +121,7 @@ static void assert_head_is_correctly_detached(void)
 
 void test_repo_head__set_head_Detaches_HEAD_when_the_reference_doesnt_point_to_a_branch(void)
 {
-	cl_git_pass(git_repository_set_head(repo, "refs/tags/test", NULL, NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/tags/test", NULL));
 
 	cl_assert_equal_i(true, git_repository_head_detached(repo));
 
@@ -136,7 +134,7 @@ void test_repo_head__set_head_detached_Return_ENOTFOUND_when_the_object_doesnt_e
 
 	cl_git_pass(git_oid_fromstr(&oid, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
 
-	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head_detached(repo, &oid, NULL, NULL));
+	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head_detached(repo, &oid, NULL));
 }
 
 void test_repo_head__set_head_detached_Fails_when_the_object_isnt_a_commitish(void)
@@ -145,7 +143,7 @@ void test_repo_head__set_head_detached_Fails_when_the_object_isnt_a_commitish(vo
 
 	cl_git_pass(git_revparse_single(&blob, repo, "point_to_blob"));
 
-	cl_git_fail(git_repository_set_head_detached(repo, git_object_id(blob), NULL, NULL));
+	cl_git_fail(git_repository_set_head_detached(repo, git_object_id(blob), NULL));
 
 	git_object_free(blob);
 }
@@ -157,7 +155,7 @@ void test_repo_head__set_head_detached_Detaches_HEAD_and_make_it_point_to_the_pe
 	cl_git_pass(git_revparse_single(&tag, repo, "tags/test"));
 	cl_assert_equal_i(GIT_OBJ_TAG, git_object_type(tag));
 
-	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag), NULL, NULL));
+	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag), NULL));
 
 	assert_head_is_correctly_detached();
 
@@ -168,7 +166,7 @@ void test_repo_head__detach_head_Detaches_HEAD_and_make_it_point_to_the_peeled_c
 {
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
-	cl_git_pass(git_repository_detach_head(repo, NULL, NULL));
+	cl_git_pass(git_repository_detach_head(repo, NULL));
 
 	assert_head_is_correctly_detached();
 }
@@ -177,9 +175,9 @@ void test_repo_head__detach_head_Fails_if_HEAD_and_point_to_a_non_commitish(void
 {
 	git_reference *head;
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/tags/point_to_blob", 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/tags/point_to_blob", 1, NULL));
 
-	cl_git_fail(git_repository_detach_head(repo, NULL, NULL));
+	cl_git_fail(git_repository_detach_head(repo, NULL));
 
 	git_reference_free(head);
 }
@@ -188,7 +186,7 @@ void test_repo_head__detaching_an_unborn_branch_returns_GIT_EUNBORNBRANCH(void)
 {
 	make_head_unborn(repo, NON_EXISTING_HEAD);
 
-	cl_assert_equal_i(GIT_EUNBORNBRANCH, git_repository_detach_head(repo, NULL, NULL));
+	cl_assert_equal_i(GIT_EUNBORNBRANCH, git_repository_detach_head(repo, NULL));
 }
 
 void test_repo_head__retrieving_an_unborn_branch_returns_GIT_EUNBORNBRANCH(void)
@@ -256,11 +254,11 @@ void test_repo_head__setting_head_updates_reflog(void)
 
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", sig, "message1"));
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/unborn", sig, "message2"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", "message1"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/unborn", "message2"));
 	cl_git_pass(git_revparse_single(&tag, repo, "tags/test"));
-	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag), sig, "message3"));
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", sig, "message4"));
+	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag),"message3"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", "message4"));
 
 	test_reflog(repo, 2, NULL, "refs/heads/haacked", "foo@example.com", "message1");
 	test_reflog(repo, 1, NULL, "tags/test^{commit}", "foo@example.com", "message3");
@@ -301,12 +299,12 @@ void test_repo_head__detaching_writes_reflog(void)
 
 	msg = "message1";
 	git_oid_fromstr(&id, "e90810b8df3e80c413d903f631643c716887138d");
-	cl_git_pass(git_repository_set_head_detached(repo, &id, sig, msg));
+	cl_git_pass(git_repository_set_head_detached(repo, &id, msg));
 	assert_head_reflog(repo, 0, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 			   "e90810b8df3e80c413d903f631643c716887138d", msg);
 
 	msg = "message2";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", sig, msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
 	assert_head_reflog(repo, 0, "e90810b8df3e80c413d903f631643c716887138d",
 			   "258f0e2a959a364e40ed6603d5d44fbb24765b10", msg);
 
@@ -324,18 +322,18 @@ void test_repo_head__orphan_branch_does_not_count(void)
 	/* Have something known */
 	msg = "message1";
 	git_oid_fromstr(&id, "e90810b8df3e80c413d903f631643c716887138d");
-	cl_git_pass(git_repository_set_head_detached(repo, &id, sig, msg));
+	cl_git_pass(git_repository_set_head_detached(repo, &id, msg));
 	assert_head_reflog(repo, 0, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 			   "e90810b8df3e80c413d903f631643c716887138d", msg);
 
 	/* Switching to an orphan branch does not write tot he reflog */
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan", sig, "ignored message"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan", "ignored message"));
 	assert_head_reflog(repo, 0, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 			   "e90810b8df3e80c413d903f631643c716887138d", msg);
 
 	/* And coming back, we set the source to zero */
 	msg = "message2";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", sig, msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
 	assert_head_reflog(repo, 0, "0000000000000000000000000000000000000000",
 			   "258f0e2a959a364e40ed6603d5d44fbb24765b10", msg);
 
@@ -356,8 +354,8 @@ void test_repo_head__set_to_current_target(void)
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
 	msg = "message 1";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", sig, msg));
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", sig, msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
 
 	cl_git_pass(git_reflog_read(&log, repo, GIT_HEAD_FILE));
 	nentries_after = git_reflog_entrycount(log);
@@ -390,7 +388,7 @@ void test_repo_head__branch_birth(void)
 	git_reference_free(ref);
 
 	msg = "message 1";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan", sig, msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan", msg));
 
 	cl_git_pass(git_reflog_read(&log, repo, GIT_HEAD_FILE));
 	nentries_after = git_reflog_entrycount(log);
@@ -449,7 +447,7 @@ void test_repo_head__symref_chain(void)
 	nentries_master = entrycount(repo, "refs/heads/master");
 
 	msg = "message 1";
-	cl_git_pass(git_reference_symbolic_create(&ref, repo, "refs/heads/master", "refs/heads/foo", 1, sig, msg));
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, "refs/heads/master", "refs/heads/foo", 1, msg));
 	git_reference_free(ref);
 
 	cl_assert_equal_i(0, entrycount(repo, "refs/heads/foo"));

--- a/tests/repo/head.c
+++ b/tests/repo/head.c
@@ -38,8 +38,8 @@ void test_repo_head__head_detached(void)
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
-	cl_git_pass(git_repository_detach_head(repo, "CABLE DETACHED"));
-	check_last_reflog_entry(g_email, "CABLE DETACHED");
+	cl_git_pass(git_repository_detach_head(repo));
+	check_last_reflog_entry(g_email, "checkout: moving from master to a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	cl_assert_equal_i(true, git_repository_head_detached(repo));
 
 	/* take the repo back to it's original state */
@@ -73,7 +73,7 @@ void test_repo_head__set_head_Attaches_HEAD_to_un_unborn_branch_when_the_branch_
 {
 	git_reference *head;
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/doesnt/exist/yet", NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/doesnt/exist/yet"));
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
@@ -82,19 +82,19 @@ void test_repo_head__set_head_Attaches_HEAD_to_un_unborn_branch_when_the_branch_
 
 void test_repo_head__set_head_Returns_ENOTFOUND_when_the_reference_doesnt_exist(void)
 {
-	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head(repo, "refs/tags/doesnt/exist/yet", NULL));
+	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head(repo, "refs/tags/doesnt/exist/yet"));
 }
 
 void test_repo_head__set_head_Fails_when_the_reference_points_to_a_non_commitish(void)
 {
-	cl_git_fail(git_repository_set_head(repo, "refs/tags/point_to_blob", NULL));
+	cl_git_fail(git_repository_set_head(repo, "refs/tags/point_to_blob"));
 }
 
 void test_repo_head__set_head_Attaches_HEAD_when_the_reference_points_to_a_branch(void)
 {
 	git_reference *head;
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/br2", NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/br2"));
 
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
@@ -121,7 +121,7 @@ static void assert_head_is_correctly_detached(void)
 
 void test_repo_head__set_head_Detaches_HEAD_when_the_reference_doesnt_point_to_a_branch(void)
 {
-	cl_git_pass(git_repository_set_head(repo, "refs/tags/test", NULL));
+	cl_git_pass(git_repository_set_head(repo, "refs/tags/test"));
 
 	cl_assert_equal_i(true, git_repository_head_detached(repo));
 
@@ -134,7 +134,7 @@ void test_repo_head__set_head_detached_Return_ENOTFOUND_when_the_object_doesnt_e
 
 	cl_git_pass(git_oid_fromstr(&oid, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
 
-	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head_detached(repo, &oid, NULL));
+	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_set_head_detached(repo, &oid));
 }
 
 void test_repo_head__set_head_detached_Fails_when_the_object_isnt_a_commitish(void)
@@ -143,7 +143,7 @@ void test_repo_head__set_head_detached_Fails_when_the_object_isnt_a_commitish(vo
 
 	cl_git_pass(git_revparse_single(&blob, repo, "point_to_blob"));
 
-	cl_git_fail(git_repository_set_head_detached(repo, git_object_id(blob), NULL));
+	cl_git_fail(git_repository_set_head_detached(repo, git_object_id(blob)));
 
 	git_object_free(blob);
 }
@@ -155,7 +155,7 @@ void test_repo_head__set_head_detached_Detaches_HEAD_and_make_it_point_to_the_pe
 	cl_git_pass(git_revparse_single(&tag, repo, "tags/test"));
 	cl_assert_equal_i(GIT_OBJ_TAG, git_object_type(tag));
 
-	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag), NULL));
+	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag)));
 
 	assert_head_is_correctly_detached();
 
@@ -166,7 +166,7 @@ void test_repo_head__detach_head_Detaches_HEAD_and_make_it_point_to_the_peeled_c
 {
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
-	cl_git_pass(git_repository_detach_head(repo, NULL));
+	cl_git_pass(git_repository_detach_head(repo));
 
 	assert_head_is_correctly_detached();
 }
@@ -177,7 +177,7 @@ void test_repo_head__detach_head_Fails_if_HEAD_and_point_to_a_non_commitish(void
 
 	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, "refs/tags/point_to_blob", 1, NULL));
 
-	cl_git_fail(git_repository_detach_head(repo, NULL));
+	cl_git_fail(git_repository_detach_head(repo));
 
 	git_reference_free(head);
 }
@@ -186,7 +186,7 @@ void test_repo_head__detaching_an_unborn_branch_returns_GIT_EUNBORNBRANCH(void)
 {
 	make_head_unborn(repo, NON_EXISTING_HEAD);
 
-	cl_assert_equal_i(GIT_EUNBORNBRANCH, git_repository_detach_head(repo, NULL));
+	cl_assert_equal_i(GIT_EUNBORNBRANCH, git_repository_detach_head(repo));
 }
 
 void test_repo_head__retrieving_an_unborn_branch_returns_GIT_EUNBORNBRANCH(void)
@@ -254,15 +254,15 @@ void test_repo_head__setting_head_updates_reflog(void)
 
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", "message1"));
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/unborn", "message2"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/unborn"));
 	cl_git_pass(git_revparse_single(&tag, repo, "tags/test"));
-	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag),"message3"));
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", "message4"));
+	cl_git_pass(git_repository_set_head_detached(repo, git_object_id(tag)));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked"));
 
-	test_reflog(repo, 2, NULL, "refs/heads/haacked", "foo@example.com", "message1");
-	test_reflog(repo, 1, NULL, "tags/test^{commit}", "foo@example.com", "message3");
-	test_reflog(repo, 0, "tags/test^{commit}", "refs/heads/haacked", "foo@example.com", "message4");
+	test_reflog(repo, 2, NULL, "refs/heads/haacked", "foo@example.com", "checkout: moving from master to haacked");
+	test_reflog(repo, 1, NULL, "tags/test^{commit}", "foo@example.com", "checkout: moving from unborn to e90810b8df3e80c413d903f631643c716887138d");
+	test_reflog(repo, 0, "tags/test^{commit}", "refs/heads/haacked", "foo@example.com", "checkout: moving from e90810b8df3e80c413d903f631643c716887138d to haacked");
 
 	git_object_free(tag);
 	git_signature_free(sig);
@@ -297,14 +297,14 @@ void test_repo_head__detaching_writes_reflog(void)
 
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
-	msg = "message1";
+	msg = "checkout: moving from master to e90810b8df3e80c413d903f631643c716887138d";
 	git_oid_fromstr(&id, "e90810b8df3e80c413d903f631643c716887138d");
-	cl_git_pass(git_repository_set_head_detached(repo, &id, msg));
+	cl_git_pass(git_repository_set_head_detached(repo, &id));
 	assert_head_reflog(repo, 0, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 			   "e90810b8df3e80c413d903f631643c716887138d", msg);
 
-	msg = "message2";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
+	msg = "checkout: moving from e90810b8df3e80c413d903f631643c716887138d to haacked";
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked"));
 	assert_head_reflog(repo, 0, "e90810b8df3e80c413d903f631643c716887138d",
 			   "258f0e2a959a364e40ed6603d5d44fbb24765b10", msg);
 
@@ -313,37 +313,30 @@ void test_repo_head__detaching_writes_reflog(void)
 
 void test_repo_head__orphan_branch_does_not_count(void)
 {
-	git_signature *sig;
 	git_oid id;
 	const char *msg;
 
-	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
-
 	/* Have something known */
-	msg = "message1";
+	msg = "checkout: moving from master to e90810b8df3e80c413d903f631643c716887138d";
 	git_oid_fromstr(&id, "e90810b8df3e80c413d903f631643c716887138d");
-	cl_git_pass(git_repository_set_head_detached(repo, &id, msg));
+	cl_git_pass(git_repository_set_head_detached(repo, &id));
 	assert_head_reflog(repo, 0, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 			   "e90810b8df3e80c413d903f631643c716887138d", msg);
 
 	/* Switching to an orphan branch does not write tot he reflog */
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan", "ignored message"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan"));
 	assert_head_reflog(repo, 0, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 			   "e90810b8df3e80c413d903f631643c716887138d", msg);
 
 	/* And coming back, we set the source to zero */
-	msg = "message2";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
+	msg = "checkout: moving from orphan to haacked";
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked"));
 	assert_head_reflog(repo, 0, "0000000000000000000000000000000000000000",
 			   "258f0e2a959a364e40ed6603d5d44fbb24765b10", msg);
-
-	git_signature_free(sig);
 }
 
 void test_repo_head__set_to_current_target(void)
 {
-	git_signature *sig;
-	const char *msg;
 	git_reflog *log;
 	size_t nentries, nentries_after;
 
@@ -351,20 +344,14 @@ void test_repo_head__set_to_current_target(void)
 	nentries = git_reflog_entrycount(log);
 	git_reflog_free(log);
 
-	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
-
-	msg = "message 1";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked", msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked"));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/haacked"));
 
 	cl_git_pass(git_reflog_read(&log, repo, GIT_HEAD_FILE));
 	nentries_after = git_reflog_entrycount(log);
 	git_reflog_free(log);
 
 	cl_assert_equal_i(nentries + 1, nentries_after);
-
-	git_signature_free(sig);
-
 }
 
 void test_repo_head__branch_birth(void)
@@ -387,8 +374,7 @@ void test_repo_head__branch_birth(void)
 	cl_git_pass(git_reference_peel((git_object **) &tree, ref, GIT_OBJ_TREE));
 	git_reference_free(ref);
 
-	msg = "message 1";
-	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan", msg));
+	cl_git_pass(git_repository_set_head(repo, "refs/heads/orphan"));
 
 	cl_git_pass(git_reflog_read(&log, repo, GIT_HEAD_FILE));
 	nentries_after = git_reflog_entrycount(log);

--- a/tests/repo/headtree.c
+++ b/tests/repo/headtree.c
@@ -20,7 +20,7 @@ void test_repo_headtree__cleanup(void)
 
 void test_repo_headtree__can_retrieve_the_root_tree_from_a_detached_head(void)
 {
-	cl_git_pass(git_repository_detach_head(repo, NULL, NULL));
+	cl_git_pass(git_repository_detach_head(repo, NULL));
 
 	cl_git_pass(git_repository_head_tree(&tree, repo));
 

--- a/tests/repo/headtree.c
+++ b/tests/repo/headtree.c
@@ -20,7 +20,7 @@ void test_repo_headtree__cleanup(void)
 
 void test_repo_headtree__can_retrieve_the_root_tree_from_a_detached_head(void)
 {
-	cl_git_pass(git_repository_detach_head(repo, NULL));
+	cl_git_pass(git_repository_detach_head(repo));
 
 	cl_git_pass(git_repository_head_tree(&tree, repo));
 

--- a/tests/repo/repo_helpers.c
+++ b/tests/repo/repo_helpers.c
@@ -7,7 +7,7 @@ void make_head_unborn(git_repository* repo, const char *target)
 {
 	git_reference *head;
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, target, 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, GIT_HEAD_FILE, target, 1, NULL));
 	git_reference_free(head);
 }
 

--- a/tests/repo/state.c
+++ b/tests/repo/state.c
@@ -37,7 +37,7 @@ void test_repo_state__none_with_HEAD_attached(void)
 
 void test_repo_state__none_with_HEAD_detached(void)
 {
-	cl_git_pass(git_repository_detach_head(_repo, NULL, NULL));
+	cl_git_pass(git_repository_detach_head(_repo, NULL));
 	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 

--- a/tests/repo/state.c
+++ b/tests/repo/state.c
@@ -37,7 +37,7 @@ void test_repo_state__none_with_HEAD_attached(void)
 
 void test_repo_state__none_with_HEAD_detached(void)
 {
-	cl_git_pass(git_repository_detach_head(_repo, NULL));
+	cl_git_pass(git_repository_detach_head(_repo));
 	assert_repo_state(GIT_REPOSITORY_STATE_NONE);
 }
 

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -71,7 +71,7 @@ void test_reset_hard__resetting_reverts_modified_files(void)
 
 	cl_git_pass(git_revparse_single(&target, repo, "26a125e"));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 
 	for (i = 0; i < 4; ++i) {
 		cl_git_pass(git_buf_joinpath(&path, wd, files[i]));
@@ -96,7 +96,7 @@ void test_reset_hard__cannot_reset_in_a_bare_repository(void)
 
 	cl_git_pass(git_revparse_single(&target, bare, KNOWN_COMMIT_IN_BARE_REPO));
 
-	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_HARD, NULL, NULL));
 
 	git_repository_free(bare);
 }
@@ -152,7 +152,7 @@ void test_reset_hard__resetting_reverts_unmerged(void)
 		cl_git_pass(git_index_write(index));
 
 		cl_git_pass(git_revparse_single(&target, repo, "26a125e"));
-		cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+		cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 
 		cl_assert(git_path_exists("status/conflicting_file") == 0);
 
@@ -183,7 +183,7 @@ void test_reset_hard__cleans_up_merge(void)
 	cl_git_mkfile(git_buf_cstr(&orig_head_path), "0017bd4ab1ec30440b17bae1680cff124ab5f1f6");
 
 	cl_git_pass(git_revparse_single(&target, repo, "0017bd4"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 
 	cl_assert(!git_path_exists(git_buf_cstr(&merge_head_path)));
 	cl_assert(!git_path_exists(git_buf_cstr(&merge_msg_path)));
@@ -208,7 +208,7 @@ void test_reset_hard__reflog_is_correct(void)
 
 	/* Branch not moving, no reflog entry */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 	reflog_check(repo, "HEAD", 3, "emeric.fermas@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 3, "emeric.fermas@gmail.com", exp_msg);
 
@@ -217,7 +217,7 @@ void test_reset_hard__reflog_is_correct(void)
 	/* Moved branch, expect default message */
 	exp_msg = "reset: moving";
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
 	reflog_check(repo, "HEAD", 4, NULL, exp_msg);
 	reflog_check(repo, "refs/heads/master", 4, NULL, exp_msg);
 
@@ -226,7 +226,7 @@ void test_reset_hard__reflog_is_correct(void)
 	/* Moved branch, expect custom message */
 	exp_msg = "message1";
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL, "message1"));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, "message1"));
 	reflog_check(repo, "HEAD", 5, NULL, exp_msg);
 	reflog_check(repo, "refs/heads/master", 5, NULL, exp_msg);
 }

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -71,7 +71,7 @@ void test_reset_hard__resetting_reverts_modified_files(void)
 
 	cl_git_pass(git_revparse_single(&target, repo, "26a125e"));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 
 	for (i = 0; i < 4; ++i) {
 		cl_git_pass(git_buf_joinpath(&path, wd, files[i]));
@@ -96,7 +96,7 @@ void test_reset_hard__cannot_reset_in_a_bare_repository(void)
 
 	cl_git_pass(git_revparse_single(&target, bare, KNOWN_COMMIT_IN_BARE_REPO));
 
-	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_HARD, NULL, NULL));
+	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_HARD, NULL));
 
 	git_repository_free(bare);
 }
@@ -152,7 +152,7 @@ void test_reset_hard__resetting_reverts_unmerged(void)
 		cl_git_pass(git_index_write(index));
 
 		cl_git_pass(git_revparse_single(&target, repo, "26a125e"));
-		cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
+		cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 
 		cl_assert(git_path_exists("status/conflicting_file") == 0);
 
@@ -183,7 +183,7 @@ void test_reset_hard__cleans_up_merge(void)
 	cl_git_mkfile(git_buf_cstr(&orig_head_path), "0017bd4ab1ec30440b17bae1680cff124ab5f1f6");
 
 	cl_git_pass(git_revparse_single(&target, repo, "0017bd4"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 
 	cl_assert(!git_path_exists(git_buf_cstr(&merge_head_path)));
 	cl_assert(!git_path_exists(git_buf_cstr(&merge_msg_path)));
@@ -200,6 +200,7 @@ void test_reset_hard__cleans_up_merge(void)
 
 void test_reset_hard__reflog_is_correct(void)
 {
+	git_buf buf = GIT_BUF_INIT;
 	const char *exp_msg = "commit: Add a file which name should appear before the "
 		"\"subdir/\" folder while being dealt with by the treewalker";
 
@@ -208,25 +209,16 @@ void test_reset_hard__reflog_is_correct(void)
 
 	/* Branch not moving, no reflog entry */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
 	reflog_check(repo, "HEAD", 3, "emeric.fermas@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 3, "emeric.fermas@gmail.com", exp_msg);
 
 	git_object_free(target);
 
 	/* Moved branch, expect default message */
-	exp_msg = "reset: moving";
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, NULL));
-	reflog_check(repo, "HEAD", 4, NULL, exp_msg);
-	reflog_check(repo, "refs/heads/master", 4, NULL, exp_msg);
-
-	git_object_free(target);
-
-	/* Moved branch, expect custom message */
-	exp_msg = "message1";
-	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL, "message1"));
-	reflog_check(repo, "HEAD", 5, NULL, exp_msg);
-	reflog_check(repo, "refs/heads/master", 5, NULL, exp_msg);
+	cl_git_pass(git_buf_printf(&buf, "reset: moving to %s", git_oid_tostr_s(git_object_id(target))));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
+	reflog_check(repo, "HEAD", 4, NULL, git_buf_cstr(&buf));
+	reflog_check(repo, "refs/heads/master", 4, NULL, git_buf_cstr(&buf));
 }

--- a/tests/reset/mixed.c
+++ b/tests/reset/mixed.c
@@ -29,7 +29,7 @@ void test_reset_mixed__cannot_reset_in_a_bare_repository(void)
 
 	cl_git_pass(git_revparse_single(&target, bare, KNOWN_COMMIT_IN_BARE_REPO));
 
-	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_MIXED, NULL, NULL));
+	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_MIXED, NULL));
 
 	git_repository_free(bare);
 }
@@ -42,7 +42,7 @@ void test_reset_mixed__resetting_refreshes_the_index_to_the_commit_tree(void)
 	cl_assert(status == GIT_STATUS_CURRENT);
 	cl_git_pass(git_revparse_single(&target, repo, "605812a"));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
 
 	cl_git_pass(git_status_file(&status, repo, "macro_bad"));
 	cl_assert(status == GIT_STATUS_WT_NEW);
@@ -50,6 +50,7 @@ void test_reset_mixed__resetting_refreshes_the_index_to_the_commit_tree(void)
 
 void test_reset_mixed__reflog_is_correct(void)
 {
+	git_buf buf = GIT_BUF_INIT;
 	const char *exp_msg = "commit: Updating test data so we can test inter-hunk-context";
 
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
@@ -57,7 +58,7 @@ void test_reset_mixed__reflog_is_correct(void)
 
 	/* Branch not moving, no reflog entry */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 9, "yoram.harmelin@gmail.com", exp_msg);
 
@@ -65,19 +66,10 @@ void test_reset_mixed__reflog_is_correct(void)
 	target = NULL;
 
 	/* Moved branch, expect default message */
-	exp_msg = "reset: moving";
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
-	reflog_check(repo, "HEAD", 10, NULL, exp_msg);
-	reflog_check(repo, "refs/heads/master", 10, NULL, exp_msg);
-
-	git_object_free(target);
-	target = NULL;
-
-	/* Moved branch, expect custom message */
-	exp_msg = "message1";
-	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, "message1"));
-	reflog_check(repo, "HEAD", 11, NULL, exp_msg);
-	reflog_check(repo, "refs/heads/master", 11, NULL, exp_msg);
+	git_buf_clear(&buf);
+	cl_git_pass(git_buf_printf(&buf, "reset: moving to %s", git_oid_tostr_s(git_object_id(target))));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
+	reflog_check(repo, "HEAD", 10, NULL, git_buf_cstr(&buf));
+	reflog_check(repo, "refs/heads/master", 10, NULL, git_buf_cstr(&buf));
 }

--- a/tests/reset/mixed.c
+++ b/tests/reset/mixed.c
@@ -29,7 +29,7 @@ void test_reset_mixed__cannot_reset_in_a_bare_repository(void)
 
 	cl_git_pass(git_revparse_single(&target, bare, KNOWN_COMMIT_IN_BARE_REPO));
 
-	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_MIXED, NULL, NULL, NULL));
+	cl_assert_equal_i(GIT_EBAREREPO, git_reset(bare, target, GIT_RESET_MIXED, NULL, NULL));
 
 	git_repository_free(bare);
 }
@@ -42,7 +42,7 @@ void test_reset_mixed__resetting_refreshes_the_index_to_the_commit_tree(void)
 	cl_assert(status == GIT_STATUS_CURRENT);
 	cl_git_pass(git_revparse_single(&target, repo, "605812a"));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
 
 	cl_git_pass(git_status_file(&status, repo, "macro_bad"));
 	cl_assert(status == GIT_STATUS_WT_NEW);
@@ -57,7 +57,7 @@ void test_reset_mixed__reflog_is_correct(void)
 
 	/* Branch not moving, no reflog entry */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 9, "yoram.harmelin@gmail.com", exp_msg);
 
@@ -67,7 +67,7 @@ void test_reset_mixed__reflog_is_correct(void)
 	/* Moved branch, expect default message */
 	exp_msg = "reset: moving";
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL));
 	reflog_check(repo, "HEAD", 10, NULL, exp_msg);
 	reflog_check(repo, "refs/heads/master", 10, NULL, exp_msg);
 
@@ -77,7 +77,7 @@ void test_reset_mixed__reflog_is_correct(void)
 	/* Moved branch, expect custom message */
 	exp_msg = "message1";
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, NULL, "message1"));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL, "message1"));
 	reflog_check(repo, "HEAD", 11, NULL, exp_msg);
 	reflog_check(repo, "refs/heads/master", 11, NULL, exp_msg);
 }

--- a/tests/reset/reset_helpers.c
+++ b/tests/reset/reset_helpers.c
@@ -7,12 +7,12 @@ void reflog_check(git_repository *repo, const char *refname,
 	git_reflog *log;
 	const git_reflog_entry *entry;
 
+	exp_email = exp_email;
+
 	cl_git_pass(git_reflog_read(&log, repo, refname));
 	cl_assert_equal_i(exp_count, git_reflog_entrycount(log));
 	entry = git_reflog_entry_byindex(log, 0);
 
-	if (exp_email)
-		cl_assert_equal_s(exp_email, git_reflog_entry_committer(entry)->email);
 	if (exp_msg)
 		cl_assert_equal_s(exp_msg, git_reflog_entry_message(entry));
 

--- a/tests/reset/soft.c
+++ b/tests/reset/soft.c
@@ -30,7 +30,7 @@ static void assert_reset_soft(bool should_be_detached)
 
 	cl_assert(git_repository_head_detached(repo) == should_be_detached);
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 
 	cl_assert(git_repository_head_detached(repo) == should_be_detached);
 
@@ -45,7 +45,7 @@ void test_reset_soft__can_reset_the_non_detached_Head_to_the_specified_commit(vo
 
 void test_reset_soft__can_reset_the_detached_Head_to_the_specified_commit(void)
 {
-	git_repository_detach_head(repo, NULL, NULL);
+	git_repository_detach_head(repo, NULL);
 
 	assert_reset_soft(true);
 }
@@ -61,7 +61,7 @@ void test_reset_soft__resetting_to_the_commit_pointed_at_by_the_Head_does_not_ch
 
 	cl_git_pass(git_revparse_single(&target, repo, raw_head_oid));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 
 	cl_git_pass(git_reference_name_to_id(&oid, repo, "HEAD"));
 	cl_git_pass(git_oid_streq(&oid, raw_head_oid));
@@ -74,7 +74,7 @@ void test_reset_soft__resetting_to_a_tag_sets_the_Head_to_the_peeled_commit(void
 	/* b25fa35 is a tag, pointing to another tag which points to commit e90810b */
 	cl_git_pass(git_revparse_single(&target, repo, "b25fa35"));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 
 	cl_assert(git_repository_head_detached(repo) == false);
 	cl_git_pass(git_reference_name_to_id(&oid, repo, "HEAD"));
@@ -86,12 +86,12 @@ void test_reset_soft__cannot_reset_to_a_tag_not_pointing_at_a_commit(void)
 	/* 53fc32d is the tree of commit e90810b */
 	cl_git_pass(git_revparse_single(&target, repo, "53fc32d"));
 
-	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 	git_object_free(target);
 
 	/* 521d87c is an annotated tag pointing to a blob */
 	cl_git_pass(git_revparse_single(&target, repo, "521d87c"));
-	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 }
 
 void test_reset_soft__resetting_against_an_unborn_head_repo_makes_the_head_no_longer_unborn(void)
@@ -104,7 +104,7 @@ void test_reset_soft__resetting_against_an_unborn_head_repo_makes_the_head_no_lo
 
 	cl_assert_equal_i(true, git_repository_head_unborn(repo));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 
 	cl_assert_equal_i(false, git_repository_head_unborn(repo));
 
@@ -118,13 +118,13 @@ void test_reset_soft__fails_when_merging(void)
 {
 	git_buf merge_head_path = GIT_BUF_INIT;
 
-	cl_git_pass(git_repository_detach_head(repo, NULL, NULL));
+	cl_git_pass(git_repository_detach_head(repo, NULL));
 	cl_git_pass(git_buf_joinpath(&merge_head_path, git_repository_path(repo), "MERGE_HEAD"));
 	cl_git_mkfile(git_buf_cstr(&merge_head_path), "beefbeefbeefbeefbeefbeefbeefbeefbeefbeef\n");
 
 	cl_git_pass(git_revparse_single(&target, repo, KNOWN_COMMIT_IN_BARE_REPO));
 
-	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 	cl_git_pass(p_unlink(git_buf_cstr(&merge_head_path)));
 
 	git_buf_free(&merge_head_path);
@@ -152,7 +152,7 @@ void test_reset_soft__fails_when_index_contains_conflicts_independently_of_MERGE
 	cl_git_pass(git_reference_peel(&target, head, GIT_OBJ_COMMIT));
 	git_reference_free(head);
 
-	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 }
 
 void test_reset_soft_reflog_is_correct(void)
@@ -164,19 +164,19 @@ void test_reset_soft_reflog_is_correct(void)
 
 	/* Branch not moving, no reflog entry */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 9, "yoram.harmelin@gmail.com", exp_msg);
 
 	/* Moved branch, expect default message */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 10, NULL, "reset: moving");
 
 	/* Moved branch, expect custom message */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL, "message1"));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, "message1"));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 11, NULL, "message1");
 }

--- a/tests/reset/soft.c
+++ b/tests/reset/soft.c
@@ -30,7 +30,7 @@ static void assert_reset_soft(bool should_be_detached)
 
 	cl_assert(git_repository_head_detached(repo) == should_be_detached);
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 
 	cl_assert(git_repository_head_detached(repo) == should_be_detached);
 
@@ -61,7 +61,7 @@ void test_reset_soft__resetting_to_the_commit_pointed_at_by_the_Head_does_not_ch
 
 	cl_git_pass(git_revparse_single(&target, repo, raw_head_oid));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 
 	cl_git_pass(git_reference_name_to_id(&oid, repo, "HEAD"));
 	cl_git_pass(git_oid_streq(&oid, raw_head_oid));
@@ -74,7 +74,7 @@ void test_reset_soft__resetting_to_a_tag_sets_the_Head_to_the_peeled_commit(void
 	/* b25fa35 is a tag, pointing to another tag which points to commit e90810b */
 	cl_git_pass(git_revparse_single(&target, repo, "b25fa35"));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 
 	cl_assert(git_repository_head_detached(repo) == false);
 	cl_git_pass(git_reference_name_to_id(&oid, repo, "HEAD"));
@@ -86,12 +86,12 @@ void test_reset_soft__cannot_reset_to_a_tag_not_pointing_at_a_commit(void)
 	/* 53fc32d is the tree of commit e90810b */
 	cl_git_pass(git_revparse_single(&target, repo, "53fc32d"));
 
-	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	git_object_free(target);
 
 	/* 521d87c is an annotated tag pointing to a blob */
 	cl_git_pass(git_revparse_single(&target, repo, "521d87c"));
-	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_fail(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 }
 
 void test_reset_soft__resetting_against_an_unborn_head_repo_makes_the_head_no_longer_unborn(void)
@@ -104,7 +104,7 @@ void test_reset_soft__resetting_against_an_unborn_head_repo_makes_the_head_no_lo
 
 	cl_assert_equal_i(true, git_repository_head_unborn(repo));
 
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 
 	cl_assert_equal_i(false, git_repository_head_unborn(repo));
 
@@ -124,7 +124,7 @@ void test_reset_soft__fails_when_merging(void)
 
 	cl_git_pass(git_revparse_single(&target, repo, KNOWN_COMMIT_IN_BARE_REPO));
 
-	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	cl_git_pass(p_unlink(git_buf_cstr(&merge_head_path)));
 
 	git_buf_free(&merge_head_path);
@@ -152,7 +152,7 @@ void test_reset_soft__fails_when_index_contains_conflicts_independently_of_MERGE
 	cl_git_pass(git_reference_peel(&target, head, GIT_OBJ_COMMIT));
 	git_reference_free(head);
 
-	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL));
 }
 
 void test_reset_soft_reflog_is_correct(void)
@@ -164,19 +164,19 @@ void test_reset_soft_reflog_is_correct(void)
 
 	/* Branch not moving, no reflog entry */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 9, "yoram.harmelin@gmail.com", exp_msg);
 
 	/* Moved branch, expect default message */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, NULL));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 10, NULL, "reset: moving");
 
 	/* Moved branch, expect custom message */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
-	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL, "message1"));
+	cl_git_pass(git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
 	reflog_check(repo, "refs/heads/master", 11, NULL, "message1");
 }

--- a/tests/reset/soft.c
+++ b/tests/reset/soft.c
@@ -45,7 +45,7 @@ void test_reset_soft__can_reset_the_non_detached_Head_to_the_specified_commit(vo
 
 void test_reset_soft__can_reset_the_detached_Head_to_the_specified_commit(void)
 {
-	git_repository_detach_head(repo, NULL);
+	git_repository_detach_head(repo);
 
 	assert_reset_soft(true);
 }
@@ -118,7 +118,7 @@ void test_reset_soft__fails_when_merging(void)
 {
 	git_buf merge_head_path = GIT_BUF_INIT;
 
-	cl_git_pass(git_repository_detach_head(repo, NULL));
+	cl_git_pass(git_repository_detach_head(repo));
 	cl_git_pass(git_buf_joinpath(&merge_head_path, git_repository_path(repo), "MERGE_HEAD"));
 	cl_git_mkfile(git_buf_cstr(&merge_head_path), "beefbeefbeefbeefbeefbeefbeefbeefbeefbeef\n");
 

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -48,7 +48,7 @@ void test_revert_workdir__automerge(void)
 
 	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -81,7 +81,7 @@ void test_revert_workdir__conflicts(void)
 
 	cl_git_pass(git_repository_head(&head_ref, repo));
 	cl_git_pass(git_reference_peel((git_object **)&head, head_ref, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
 	cl_git_pass(git_revert(repo, commit, NULL));
@@ -144,7 +144,7 @@ void test_revert_workdir__orphan(void)
 
 	git_oid_fromstr(&head_oid, "39467716290f6df775a91cdb9a4eb39295018145");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&revert_oid, "ebb03002cee5d66c7732dd06241119fe72ab96a5");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -179,7 +179,7 @@ void test_revert_workdir__again(void)
 
 	cl_git_pass(git_repository_head(&head_ref, repo));
 	cl_git_pass(git_reference_peel((git_object **)&orig_head, head_ref, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_revert(repo, orig_head, NULL));
 
@@ -227,7 +227,7 @@ void test_revert_workdir__again_after_automerge(void)
 
 	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -275,7 +275,7 @@ void test_revert_workdir__again_after_edit(void)
 
 	cl_git_pass(git_oid_fromstr(&orig_head_oid, "399fb3aba3d9d13f7d40a9254ce4402067ef3149"));
 	cl_git_pass(git_commit_lookup(&orig_head, repo, &orig_head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_oid_fromstr(&revert_oid, "2d440f2b3147d3dc7ad1085813478d6d869d5a4d"));
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -324,7 +324,7 @@ void test_revert_workdir__again_after_edit_two(void)
 
 	cl_git_pass(git_oid_fromstr(&head_commit_oid, "75ec9929465623f17ff3ad68c0438ea56faba815"));
 	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_commit_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_oid_fromstr(&revert_commit_oid, "97e52d5e81f541080cd6b92829fb85bc4d81d90b"));
 	cl_git_pass(git_commit_lookup(&revert_commit, repo, &revert_commit_oid));
@@ -377,7 +377,7 @@ void test_revert_workdir__conflict_use_ours(void)
 
 	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -413,7 +413,7 @@ void test_revert_workdir__rename_1_of_2(void)
 
 	git_oid_fromstr(&head_oid, "cef56612d71a6af8d8015691e4865f7fece905b5");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&revert_oid, "55568c8de5322ff9a95d72747a239cdb64a19965");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -447,7 +447,7 @@ void test_revert_workdir__rename(void)
 
 	git_oid_fromstr(&head_oid, "55568c8de5322ff9a95d72747a239cdb64a19965");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	git_oid_fromstr(&revert_oid, "0aa8c7e40d342fff78d60b29a4ba8e993ed79c51");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -476,7 +476,7 @@ void test_revert_workdir__head(void)
 	/* HEAD is 2d440f2b3147d3dc7ad1085813478d6d869d5a4d */
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel((git_object **)&commit, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, (git_object *)commit, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)commit, GIT_RESET_HARD, NULL));
 	cl_git_pass(git_revert(repo, commit, NULL));
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));
@@ -513,7 +513,7 @@ void test_revert_workdir__merge_fails_without_mainline_specified(void)
 
 	git_oid_fromstr(&head_oid, "5acdc74af27172ec491d213ee36cea7eb9ef2579");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	cl_must_fail(git_revert(repo, head, NULL));
 	cl_assert(!git_path_exists(TEST_REPO_PATH "/.git/MERGE_MSG"));
@@ -540,7 +540,7 @@ void test_revert_workdir__merge_first_parent(void)
 
 	git_oid_fromstr(&head_oid, "5acdc74af27172ec491d213ee36cea7eb9ef2579");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_revert(repo, head, &opts));
 
@@ -565,7 +565,7 @@ void test_revert_workdir__merge_second_parent(void)
 
 	git_oid_fromstr(&head_oid, "5acdc74af27172ec491d213ee36cea7eb9ef2579");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL));
 
 	cl_git_pass(git_revert(repo, head, &opts));
 

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -48,7 +48,7 @@ void test_revert_workdir__automerge(void)
 
 	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -81,7 +81,7 @@ void test_revert_workdir__conflicts(void)
 
 	cl_git_pass(git_repository_head(&head_ref, repo));
 	cl_git_pass(git_reference_peel((git_object **)&head, head_ref, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
 	cl_git_pass(git_revert(repo, commit, NULL));
@@ -144,7 +144,7 @@ void test_revert_workdir__orphan(void)
 
 	git_oid_fromstr(&head_oid, "39467716290f6df775a91cdb9a4eb39295018145");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&revert_oid, "ebb03002cee5d66c7732dd06241119fe72ab96a5");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -179,7 +179,7 @@ void test_revert_workdir__again(void)
 
 	cl_git_pass(git_repository_head(&head_ref, repo));
 	cl_git_pass(git_reference_peel((git_object **)&orig_head, head_ref, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_revert(repo, orig_head, NULL));
 
@@ -227,7 +227,7 @@ void test_revert_workdir__again_after_automerge(void)
 
 	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -275,7 +275,7 @@ void test_revert_workdir__again_after_edit(void)
 
 	cl_git_pass(git_oid_fromstr(&orig_head_oid, "399fb3aba3d9d13f7d40a9254ce4402067ef3149"));
 	cl_git_pass(git_commit_lookup(&orig_head, repo, &orig_head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)orig_head, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_oid_fromstr(&revert_oid, "2d440f2b3147d3dc7ad1085813478d6d869d5a4d"));
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -324,7 +324,7 @@ void test_revert_workdir__again_after_edit_two(void)
 
 	cl_git_pass(git_oid_fromstr(&head_commit_oid, "75ec9929465623f17ff3ad68c0438ea56faba815"));
 	cl_git_pass(git_commit_lookup(&head_commit, repo, &head_commit_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head_commit, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_oid_fromstr(&revert_commit_oid, "97e52d5e81f541080cd6b92829fb85bc4d81d90b"));
 	cl_git_pass(git_commit_lookup(&revert_commit, repo, &revert_commit_oid));
@@ -377,7 +377,7 @@ void test_revert_workdir__conflict_use_ours(void)
 
 	git_oid_fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&revert_oid, "d1d403d22cbe24592d725f442835cf46fe60c8ac");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -413,7 +413,7 @@ void test_revert_workdir__rename_1_of_2(void)
 
 	git_oid_fromstr(&head_oid, "cef56612d71a6af8d8015691e4865f7fece905b5");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&revert_oid, "55568c8de5322ff9a95d72747a239cdb64a19965");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -447,7 +447,7 @@ void test_revert_workdir__rename(void)
 
 	git_oid_fromstr(&head_oid, "55568c8de5322ff9a95d72747a239cdb64a19965");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	git_oid_fromstr(&revert_oid, "0aa8c7e40d342fff78d60b29a4ba8e993ed79c51");
 	cl_git_pass(git_commit_lookup(&commit, repo, &revert_oid));
@@ -476,7 +476,7 @@ void test_revert_workdir__head(void)
 	/* HEAD is 2d440f2b3147d3dc7ad1085813478d6d869d5a4d */
 	cl_git_pass(git_repository_head(&head, repo));
 	cl_git_pass(git_reference_peel((git_object **)&commit, head, GIT_OBJ_COMMIT));
-	cl_git_pass(git_reset(repo, (git_object *)commit, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)commit, GIT_RESET_HARD, NULL, NULL));
 	cl_git_pass(git_revert(repo, commit, NULL));
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));
@@ -513,7 +513,7 @@ void test_revert_workdir__merge_fails_without_mainline_specified(void)
 
 	git_oid_fromstr(&head_oid, "5acdc74af27172ec491d213ee36cea7eb9ef2579");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	cl_must_fail(git_revert(repo, head, NULL));
 	cl_assert(!git_path_exists(TEST_REPO_PATH "/.git/MERGE_MSG"));
@@ -540,7 +540,7 @@ void test_revert_workdir__merge_first_parent(void)
 
 	git_oid_fromstr(&head_oid, "5acdc74af27172ec491d213ee36cea7eb9ef2579");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_revert(repo, head, &opts));
 
@@ -565,7 +565,7 @@ void test_revert_workdir__merge_second_parent(void)
 
 	git_oid_fromstr(&head_oid, "5acdc74af27172ec491d213ee36cea7eb9ef2579");
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));
-	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL, NULL));
+	cl_git_pass(git_reset(repo, (git_object *)head, GIT_RESET_HARD, NULL, NULL));
 
 	cl_git_pass(git_revert(repo, head, &opts));
 

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -195,7 +195,7 @@ void test_stash_save__cannot_stash_against_an_unborn_branch(void)
 {
 	git_reference *head;
 
-	cl_git_pass(git_reference_symbolic_create(&head, repo, "HEAD", "refs/heads/unborn", 1, NULL, NULL));
+	cl_git_pass(git_reference_symbolic_create(&head, repo, "HEAD", "refs/heads/unborn", 1, NULL));
 
 	cl_assert_equal_i(GIT_EUNBORNBRANCH,
 		git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
@@ -217,7 +217,7 @@ void test_stash_save__cannot_stash_against_a_bare_repository(void)
 
 void test_stash_save__can_stash_against_a_detached_head(void)
 {
-	git_repository_detach_head(repo, NULL, NULL);
+	git_repository_detach_head(repo, NULL);
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
 

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -217,7 +217,7 @@ void test_stash_save__cannot_stash_against_a_bare_repository(void)
 
 void test_stash_save__can_stash_against_a_detached_head(void)
 {
-	git_repository_detach_head(repo, NULL);
+	git_repository_detach_head(repo);
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
 

--- a/tests/status/submodules.c
+++ b/tests/status/submodules.c
@@ -143,7 +143,7 @@ void test_status_submodules__moved_head(void)
 	/* move submodule HEAD to c47800c7266a2be04c571c04d5a6614691ea99bd */
 	cl_git_pass(
 		git_oid_fromstr(&oid, "c47800c7266a2be04c571c04d5a6614691ea99bd"));
-	cl_git_pass(git_repository_set_head_detached(smrepo, &oid, NULL, NULL));
+	cl_git_pass(git_repository_set_head_detached(smrepo, &oid, NULL));
 
 	/* first do a normal status, which should now include the submodule */
 
@@ -503,7 +503,7 @@ void test_status_submodules__entry_but_dir_tracked(void)
 		cl_git_pass(git_signature_now(&sig, "Sloppy Submoduler", "sloppy@example.com"));
 		cl_git_pass(git_tree_lookup(&tree, repo, &tree_id));
 		cl_git_pass(git_commit_create(&commit_id, repo, NULL, sig, sig, NULL, "message", tree, 0, NULL));
-		cl_git_pass(git_reference_create(&ref, repo, "refs/heads/master", &commit_id, 1, sig, "commit: foo"));
+		cl_git_pass(git_reference_create(&ref, repo, "refs/heads/master", &commit_id, 1, "commit: foo"));
 		git_reference_free(ref);
 		git_signature_free(sig);
 	}

--- a/tests/status/submodules.c
+++ b/tests/status/submodules.c
@@ -143,7 +143,7 @@ void test_status_submodules__moved_head(void)
 	/* move submodule HEAD to c47800c7266a2be04c571c04d5a6614691ea99bd */
 	cl_git_pass(
 		git_oid_fromstr(&oid, "c47800c7266a2be04c571c04d5a6614691ea99bd"));
-	cl_git_pass(git_repository_set_head_detached(smrepo, &oid, NULL));
+	cl_git_pass(git_repository_set_head_detached(smrepo, &oid));
 
 	/* first do a normal status, which should now include the submodule */
 

--- a/tests/submodule/init.c
+++ b/tests/submodule/init.c
@@ -89,7 +89,7 @@ void test_submodule_init__relative_url_detached_head(void)
 	cl_git_pass(git_repository_head(&head_ref, g_repo));
 	cl_git_pass(git_reference_peel(&head_commit, head_ref, GIT_OBJ_COMMIT));
 
-	cl_git_pass(git_repository_set_head_detached(g_repo, git_commit_id((git_commit *)head_commit), NULL, NULL));
+	cl_git_pass(git_repository_set_head_detached(g_repo, git_commit_id((git_commit *)head_commit), NULL));
 
 	cl_assert(git_path_dirname_r(&absolute_url, git_repository_workdir(g_repo)) > 0);
 	cl_git_pass(git_buf_joinpath(&absolute_url, absolute_url.ptr, "testrepo.git"));

--- a/tests/submodule/init.c
+++ b/tests/submodule/init.c
@@ -89,7 +89,7 @@ void test_submodule_init__relative_url_detached_head(void)
 	cl_git_pass(git_repository_head(&head_ref, g_repo));
 	cl_git_pass(git_reference_peel(&head_commit, head_ref, GIT_OBJ_COMMIT));
 
-	cl_git_pass(git_repository_set_head_detached(g_repo, git_commit_id((git_commit *)head_commit), NULL));
+	cl_git_pass(git_repository_set_head_detached(g_repo, git_commit_id((git_commit *)head_commit)));
 
 	cl_assert(git_path_dirname_r(&absolute_url, git_repository_workdir(g_repo)) > 0);
 	cl_git_pass(git_buf_joinpath(&absolute_url, absolute_url.ptr, "testrepo.git"));

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -112,7 +112,7 @@ void test_submodule_lookup__lookup_even_with_unborn_head(void)
 
 	/* put us on an unborn branch */
 	cl_git_pass(git_reference_symbolic_create(
-		&head, g_repo, "HEAD", "refs/heads/garbage", 1, NULL, NULL));
+		&head, g_repo, "HEAD", "refs/heads/garbage", 1, NULL));
 	git_reference_free(head);
 
 	test_submodule_lookup__simple_lookup(); /* baseline should still pass */
@@ -259,10 +259,7 @@ void test_submodule_lookup__just_added(void)
 	assert_submodule_exists(g_repo, "sm_just_added_head");
 
 	{
-		git_signature *sig;
-		cl_git_pass(git_signature_now(&sig, "resetter", "resetter@email.com"));
-		cl_git_pass(git_reference_create(NULL, g_repo, "refs/heads/master", git_reference_target(original_head), 1, sig, "move head back"));
-		git_signature_free(sig);
+		cl_git_pass(git_reference_create(NULL, g_repo, "refs/heads/master", git_reference_target(original_head), 1, "move head back"));
 		git_reference_free(original_head);
 	}
 

--- a/tests/submodule/update.c
+++ b/tests/submodule/update.c
@@ -196,7 +196,7 @@ void test_submodule_update__update_already_checked_out_submodule(void)
 	cl_git_pass(git_reference_lookup(&branch_reference, g_repo, "refs/heads/alternate_1"));
 	cl_git_pass(git_reference_peel(&branch_commit, branch_reference, GIT_OBJ_COMMIT));
 	cl_git_pass(git_checkout_tree(g_repo, branch_commit, &checkout_options));
-	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL));
 
 	/*
 	 * Verify state after checkout of parent repository. The submodule ID in the
@@ -270,7 +270,7 @@ void test_submodule_update__update_blocks_on_dirty_wd(void)
 	cl_git_pass(git_reference_lookup(&branch_reference, g_repo, "refs/heads/alternate_1"));
 	cl_git_pass(git_reference_peel(&branch_commit, branch_reference, GIT_OBJ_COMMIT));
 	cl_git_pass(git_checkout_tree(g_repo, branch_commit, &checkout_options));
-	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL));
 
 	/*
 	 * Verify state after checkout of parent repository. The submodule ID in the
@@ -343,7 +343,7 @@ void test_submodule_update__can_force_update(void)
 	cl_git_pass(git_reference_lookup(&branch_reference, g_repo, "refs/heads/alternate_1"));
 	cl_git_pass(git_reference_peel(&branch_commit, branch_reference, GIT_OBJ_COMMIT));
 	cl_git_pass(git_checkout_tree(g_repo, branch_commit, &checkout_options));
-	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL, NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL));
 
 	/*
 	 * Verify state after checkout of parent repository. The submodule ID in the

--- a/tests/submodule/update.c
+++ b/tests/submodule/update.c
@@ -196,7 +196,7 @@ void test_submodule_update__update_already_checked_out_submodule(void)
 	cl_git_pass(git_reference_lookup(&branch_reference, g_repo, "refs/heads/alternate_1"));
 	cl_git_pass(git_reference_peel(&branch_commit, branch_reference, GIT_OBJ_COMMIT));
 	cl_git_pass(git_checkout_tree(g_repo, branch_commit, &checkout_options));
-	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference)));
 
 	/*
 	 * Verify state after checkout of parent repository. The submodule ID in the
@@ -270,7 +270,7 @@ void test_submodule_update__update_blocks_on_dirty_wd(void)
 	cl_git_pass(git_reference_lookup(&branch_reference, g_repo, "refs/heads/alternate_1"));
 	cl_git_pass(git_reference_peel(&branch_commit, branch_reference, GIT_OBJ_COMMIT));
 	cl_git_pass(git_checkout_tree(g_repo, branch_commit, &checkout_options));
-	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference)));
 
 	/*
 	 * Verify state after checkout of parent repository. The submodule ID in the
@@ -343,7 +343,7 @@ void test_submodule_update__can_force_update(void)
 	cl_git_pass(git_reference_lookup(&branch_reference, g_repo, "refs/heads/alternate_1"));
 	cl_git_pass(git_reference_peel(&branch_commit, branch_reference, GIT_OBJ_COMMIT));
 	cl_git_pass(git_checkout_tree(g_repo, branch_commit, &checkout_options));
-	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference), NULL));
+	cl_git_pass(git_repository_set_head(g_repo, git_reference_name(branch_reference)));
 
 	/*
 	 * Verify state after checkout of parent repository. The submodule ID in the

--- a/tests/threads/refdb.c
+++ b/tests/threads/refdb.c
@@ -59,7 +59,7 @@ void test_threads_refdb__iterator(void)
 
 	for (r = 0; r < 200; ++r) {
 		p_snprintf(name, sizeof(name), "refs/heads/direct-%03d", r);
-		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL, NULL));
+		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL));
 		git_reference_free(ref);
 	}
 
@@ -103,7 +103,7 @@ static void *create_refs(void *arg)
 
 	for (i = 0; i < 10; ++i) {
 		p_snprintf(name, sizeof(name), "refs/heads/thread-%03d-%02d", *id, i);
-		cl_git_pass(git_reference_create(&ref[i], g_repo, name, &head, 0, NULL, NULL));
+		cl_git_pass(git_reference_create(&ref[i], g_repo, name, &head, 0, NULL));
 
 		if (i == 5) {
 			git_refdb *refdb;
@@ -168,7 +168,7 @@ void test_threads_refdb__edit_while_iterate(void)
 
 	for (r = 0; r < 50; ++r) {
 		p_snprintf(name, sizeof(name), "refs/heads/starter-%03d", r);
-		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL, NULL));
+		cl_git_pass(git_reference_create(&ref, g_repo, name, &head, 0, NULL));
 		git_reference_free(ref);
 	}
 


### PR DESCRIPTION
The signature for the reflog is not something which changes
dynamically. Almost all uses will be NULL, since we want for the
repository's default identity to be used, making it noise.

In order to allow for changing the identity, we instead provide
git_repository_set_ident() and git_repository_ident() which allow a user
to override the choice of signature.

---

This is pretty huge, so it might make sense to put this together with other commits which remove the log message argument and put the one which git would create (e.g. for reset, branch renames or fetch)