### PR TITLE
Initialize config variable

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -139,7 +139,7 @@ static int canonicalize_url(git_buf *out, const char *in)
 static int create_internal(git_remote **out, git_repository *repo, const char *name, const char *url, const char *fetch)
 {
 	git_remote *remote;
-	git_config *config;
+	git_config *config = NULL;
 	git_buf canonical_url = GIT_BUF_INIT, fetchbuf = GIT_BUF_INIT;
 	int error = -1;
 


### PR DESCRIPTION
```git_repository_config_snapshot``` may return an error resulting in us passing an uninitialized value to ```git_config_free```.