### PR TITLE
Remove symlinks from the repository

### DIFF
--- a/tests/resources/template/hooks/link.sample
+++ b/tests/resources/template/hooks/link.sample
@@ -1,1 +1,0 @@
-update.sample


### PR DESCRIPTION
At present, we have one symbolic link checked into our repo - it's a test resource (`template/hooks/link.sample`) that ensures that we create template symlinks correctly.

It would be nice if we could not have symlinks in the repository, so that we could create a zip file that contains the full src and test resources.  So this adds a simple function to create a template sandbox dir and (on non-Windows) creates the symlink hook.

The test now looks at the new sandboxed template directory instead of the old fixture location.