### PR TITLE
clone example: don't divide by zero

### DIFF
--- a/examples/network/clone.c
+++ b/examples/network/clone.c
@@ -18,14 +18,20 @@ typedef struct progress_data {
 
 static void print_progress(const progress_data *pd)
 {
-	int network_percent = (100*pd->fetch_progress.received_objects) / pd->fetch_progress.total_objects;
-	int index_percent = (100*pd->fetch_progress.indexed_objects) / pd->fetch_progress.total_objects;
+	int network_percent = pd->fetch_progress.total_objects > 0 ?
+		(100*pd->fetch_progress.received_objects) / pd->fetch_progress.total_objects :
+		0;
+	int index_percent = pd->fetch_progress.total_objects > 0 ?
+		(100*pd->fetch_progress.indexed_objects) / pd->fetch_progress.total_objects :
+		0;
+
 	int checkout_percent = pd->total_steps > 0
 		? (100 * pd->completed_steps) / pd->total_steps
 		: 0;
 	int kbytes = pd->fetch_progress.received_bytes / 1024;
 
-	if (pd->fetch_progress.received_objects == pd->fetch_progress.total_objects) {
+	if (pd->fetch_progress.total_objects &&
+		pd->fetch_progress.received_objects == pd->fetch_progress.total_objects) {
 		printf("Resolving deltas %d/%d\r",
 		       pd->fetch_progress.indexed_deltas,
 		       pd->fetch_progress.total_deltas);


### PR DESCRIPTION
Local transports don't have data about the size, avoid dividing by
zero in the callback.

Fixes #2812