### PR TITLE
Remove strlen() calls from loop condition

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -277,7 +277,7 @@ GIT_INLINE(int) git__fromhex(char h)
 GIT_INLINE(int) git__ishex(const char *str)
 {
 	unsigned i;
-	for (i=0; i<strlen(str); i++)
+	for (i=0; str[i] != '\0'; i++)
 		if (git__fromhex(str[i]) < 0)
 			return 0;
 	return 1;


### PR DESCRIPTION
Avoid str length recalculation every iteration