### PR TITLE
README: Point to libgit2 account's AppVeyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ libgit2 - the Git linkable library
 ==================================
 
 [![Travis Build Status](https://secure.travis-ci.org/libgit2/libgit2.svg?branch=master)](http://travis-ci.org/libgit2/libgit2)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/gnjsdi9r48cfoveg/branch/master?svg=true)](https://ci.appveyor.com/project/nulltoken/libgit2/branch/master)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/xvof5b4t5480a2q3/branch/master?svg=true)](https://ci.appveyor.com/project/libgit2/libgit2/branch/master)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/639/badge.svg)](https://scan.coverity.com/projects/639)
 
 `libgit2` is a portable, pure C implementation of the Git core methods


### PR DESCRIPTION
Microsoft is sponsoring a Pro account at AppVeyor for the libgit2
and LibGit2Sharp projects.  Point to that account's badge.