### PR TITLE
Fix compiler warning

### DIFF
--- a/src/bswap.h
+++ b/src/bswap.h
@@ -31,7 +31,7 @@ GIT_INLINE(uint16_t) default_swab16(uint16_t val)
 
 #if defined(__GNUC__) && defined(__i386__)
 
-#define bswap32(x) ({ \
+#define bswap32(x) __extension__ ({ \
 	uint32_t __res; \
 	if (__builtin_constant_p(x)) { \
 		__res = default_swab32(x); \
@@ -40,7 +40,7 @@ GIT_INLINE(uint16_t) default_swab16(uint16_t val)
 	} \
 	__res; })
 
-#define bswap16(x) ({ \
+#define bswap16(x) __extension__ ({ \
 	uint16_t __res; \
 	if (__builtin_constant_p(x)) { \
 		__res = default_swab16(x); \
@@ -51,7 +51,7 @@ GIT_INLINE(uint16_t) default_swab16(uint16_t val)
 
 #elif defined(__GNUC__) && defined(__x86_64__)
 
-#define bswap32(x) ({ \
+#define bswap32(x) __extension__ ({ \
 	uint32_t __res; \
 	if (__builtin_constant_p(x)) { \
 		__res = default_swab32(x); \
@@ -60,7 +60,7 @@ GIT_INLINE(uint16_t) default_swab16(uint16_t val)
 	} \
 	__res; })
 
-#define bswap16(x) ({ \
+#define bswap16(x) __extension__ ({ \
 	uint16_t __res; \
 	if (__builtin_constant_p(x)) { \
 		__res = default_swab16(x); \

--- a/src/hash/hash_generic.c
+++ b/src/hash/hash_generic.c
@@ -18,7 +18,7 @@
  * rotate with a loop.
  */
 
-#define SHA_ASM(op, x, n) ({ unsigned int __res; __asm__(op " %1,%0":"=r" (__res):"i" (n), "0" (x)); __res; })
+#define SHA_ASM(op, x, n) __extension__ ({ unsigned int __res; __asm__(op " %1,%0":"=r" (__res):"i" (n), "0" (x)); __res; })
 #define SHA_ROL(x,n)	SHA_ASM("rol", x, n)
 #define SHA_ROR(x,n)	SHA_ASM("ror", x, n)
 


### PR DESCRIPTION
Compiling with gcc and pedantic generates warning: `ISO C forbids braced-groups within expressions`. Adding the `__extension__` keyword before the parenthesis when `__GNUC__` is defined suppresses the
warning.