### PR TITLE
merge: lock index during the merge (not just checkout)

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -135,7 +135,10 @@ typedef enum {
 	/** Only update existing files, don't create new ones */
 	GIT_CHECKOUT_UPDATE_ONLY = (1u << 7),
 
-	/** Normally checkout updates index entries as it goes; this stops that */
+	/**
+	 * Normally checkout updates index entries as it goes; this stops that.
+	 * Implies `GIT_CHECKOUT_DONT_WRITE_INDEX`.
+	 */
 	GIT_CHECKOUT_DONT_UPDATE_INDEX = (1u << 8),
 
 	/** Don't refresh index/config/etc before doing checkout */
@@ -165,6 +168,9 @@ typedef enum {
 
 	/** Don't overwrite existing files or folders */
 	GIT_CHECKOUT_DONT_REMOVE_EXISTING = (1u << 22),
+
+	/** Normally checkout writes the index upon completion; this prevents that. */
+	GIT_CHECKOUT_DONT_WRITE_INDEX = (1u << 23),
 
 	/**
 	 * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2375,6 +2375,9 @@ cleanup:
 	return error;
 }
 
+#define CHECKOUT_INDEX_DONT_WRITE_MASK \
+	(GIT_CHECKOUT_DONT_UPDATE_INDEX | GIT_CHECKOUT_DONT_WRITE_INDEX)
+
 int git_checkout_iterator(
 	git_iterator *target,
 	git_index *index,
@@ -2481,7 +2484,7 @@ int git_checkout_iterator(
 
 cleanup:
 	if (!error && data.index != NULL &&
-		(data.strategy & GIT_CHECKOUT_DONT_UPDATE_INDEX) == 0)
+		(data.strategy & CHECKOUT_INDEX_DONT_WRITE_MASK) == 0)
 		error = git_index_write(data.index);
 
 	git_diff_free(data.diff);

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -10,6 +10,7 @@
 #include "filebuf.h"
 #include "merge.h"
 #include "vector.h"
+#include "index.h"
 
 #include "git2/types.h"
 #include "git2/merge.h"
@@ -171,7 +172,9 @@ int git_cherrypick(
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 	const char *commit_msg, *commit_summary;
 	git_buf their_label = GIT_BUF_INIT;
-	git_index *index_new = NULL;
+	git_index *index = NULL, *index_new = NULL;
+	git_indexwriter indexwriter = GIT_INDEXWRITER_INIT;
+	bool write_index = false;
 	int error = 0;
 
 	assert(repo && commit);
@@ -191,21 +194,38 @@ int git_cherrypick(
 
 	if ((error = write_merge_msg(repo, commit_msg)) < 0 ||
 		(error = git_buf_printf(&their_label, "%.7s... %s", commit_oidstr, commit_summary)) < 0 ||
-		(error = cherrypick_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0 ||
-		(error = write_cherrypick_head(repo, commit_oidstr)) < 0 ||
+		(error = cherrypick_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0)
+		goto on_error;
+
+	write_index = (opts.checkout_opts.checkout_strategy & GIT_CHECKOUT_DONT_WRITE_INDEX) == 0;
+
+	if (write_index) {
+		/* Never let checkout update the index, we'll update it ourselves. */
+		opts.checkout_opts.checkout_strategy |= GIT_CHECKOUT_DONT_WRITE_INDEX;
+
+		if ((error = git_repository_index(&index, repo)) < 0 ||
+			(error = git_indexwriter_init(&indexwriter, index)) < 0)
+			goto on_error;
+	}
+
+	if ((error = write_cherrypick_head(repo, commit_oidstr)) < 0 ||
 		(error = git_repository_head(&our_ref, repo)) < 0 ||
 		(error = git_reference_peel((git_object **)&our_commit, our_ref, GIT_OBJ_COMMIT)) < 0 ||
 		(error = git_cherrypick_commit(&index_new, repo, commit, our_commit, opts.mainline, &opts.merge_opts)) < 0 ||
 		(error = git_merge__check_result(repo, index_new)) < 0 ||
 		(error = git_merge__append_conflicts_to_merge_msg(repo, index_new)) < 0 ||
-		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0)
+		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0 ||
+		(write_index && (error = git_indexwriter_commit(&indexwriter)) < 0))
 		goto on_error;
+
 	goto done;
 
 on_error:
 	cherrypick_state_cleanup(repo);
 
 done:
+	git_indexwriter_cleanup(&indexwriter);
+	git_index_free(index);
 	git_index_free(index_new);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);

--- a/src/index.h
+++ b/src/index.h
@@ -94,4 +94,22 @@ extern int git_index_snapshot_find(
 	const char *path, size_t path_len, int stage);
 
 
+typedef struct {
+	git_index *index;
+	git_filebuf file;
+} git_indexwriter;
+
+#define GIT_INDEXWRITER_INIT { NULL, GIT_FILEBUF_INIT }
+
+/* Lock the index for eventual writing. */
+extern int git_indexwriter_init(git_indexwriter *writer, git_index *index);
+
+/* Write the index and unlock it. */
+extern int git_indexwriter_commit(git_indexwriter *writer);
+
+/* Cleanup an index writing session, unlocking the file (if it is still
+ * locked and freeing any data structures.
+ */
+extern void git_indexwriter_cleanup(git_indexwriter *writer);
+
 #endif

--- a/src/index.h
+++ b/src/index.h
@@ -97,12 +97,23 @@ extern int git_index_snapshot_find(
 typedef struct {
 	git_index *index;
 	git_filebuf file;
+	unsigned int should_write:1;
 } git_indexwriter;
 
 #define GIT_INDEXWRITER_INIT { NULL, GIT_FILEBUF_INIT }
 
 /* Lock the index for eventual writing. */
 extern int git_indexwriter_init(git_indexwriter *writer, git_index *index);
+
+/* Lock the index for eventual writing by a repository operation: a merge,
+ * revert, cherry-pick or a rebase.  Note that the given checkout strategy
+ * will be updated for the operation's use so that checkout will not write
+ * the index.
+ */
+extern int git_indexwriter_init_for_operation(
+	git_indexwriter *writer,
+	git_repository *repo,
+	unsigned int *checkout_strategy);
 
 /* Write the index and unlock it. */
 extern int git_indexwriter_commit(git_indexwriter *writer);

--- a/src/merge.c
+++ b/src/merge.c
@@ -2651,9 +2651,8 @@ int git_merge(
 	git_checkout_options checkout_opts;
 	git_annotated_commit *ancestor_head = NULL, *our_head = NULL;
 	git_tree *ancestor_tree = NULL, *our_tree = NULL, **their_trees = NULL;
-	git_index *index = NULL, *index_new = NULL;
+	git_index *index = NULL;
 	git_indexwriter indexwriter = GIT_INDEXWRITER_INIT;
-	bool write_index = false;
 	size_t i;
 	int error = 0;
 
@@ -2667,23 +2666,11 @@ int git_merge(
 	their_trees = git__calloc(their_heads_len, sizeof(git_tree *));
 	GITERR_CHECK_ALLOC(their_trees);
 
-	if ((error = merge_heads(&ancestor_head, &our_head, repo, their_heads, their_heads_len)) < 0)
+	if ((error = merge_heads(&ancestor_head, &our_head, repo, their_heads, their_heads_len)) < 0 ||
+		(error = merge_normalize_checkout_opts(repo, &checkout_opts, given_checkout_opts,
+			ancestor_head, our_head, their_heads_len, their_heads)) < 0 ||
+		(error = git_indexwriter_init_for_operation(&indexwriter, repo, &checkout_opts.checkout_strategy)) < 0)
 		goto on_error;
-
-	if ((error = merge_normalize_checkout_opts(repo, &checkout_opts, given_checkout_opts,
-		ancestor_head, our_head, their_heads_len, their_heads)) < 0)
-		goto on_error;
-
-	write_index = (checkout_opts.checkout_strategy & GIT_CHECKOUT_DONT_WRITE_INDEX) == 0;
-
-	if (write_index) {
-		/* Never let checkout update the index, we'll update it ourselves. */
-		checkout_opts.checkout_strategy |= GIT_CHECKOUT_DONT_WRITE_INDEX;
-
-		if ((error = git_repository_index(&index, repo)) < 0 ||
-			(error = git_indexwriter_init(&indexwriter, index)) < 0)
-			goto on_error;
-	}
 
 	/* Write the merge files to the repository. */
 	if ((error = git_merge__setup(repo, our_head, their_heads, their_heads_len)) < 0)
@@ -2703,11 +2690,11 @@ int git_merge(
 
 	/* TODO: recursive, octopus, etc... */
 
-	if ((error = git_merge_trees(&index_new, repo, ancestor_tree, our_tree, their_trees[0], merge_opts)) < 0 ||
-		(error = git_merge__check_result(repo, index_new)) < 0 ||
-		(error = git_merge__append_conflicts_to_merge_msg(repo, index_new)) < 0 ||
-		(error = git_checkout_index(repo, index_new, &checkout_opts)) < 0 ||
-		(write_index && (error = git_indexwriter_commit(&indexwriter)) < 0))
+	if ((error = git_merge_trees(&index, repo, ancestor_tree, our_tree, their_trees[0], merge_opts)) < 0 ||
+		(error = git_merge__check_result(repo, index)) < 0 ||
+		(error = git_merge__append_conflicts_to_merge_msg(repo, index)) < 0 ||
+		(error = git_checkout_index(repo, index, &checkout_opts)) < 0 ||
+		(error = git_indexwriter_commit(&indexwriter)) < 0)
 		goto on_error;
 
 	goto done;
@@ -2719,7 +2706,6 @@ done:
 	git_indexwriter_cleanup(&indexwriter);
 
 	git_index_free(index);
-	git_index_free(index_new);
 
 	git_tree_free(ancestor_tree);
 	git_tree_free(our_tree);

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -14,6 +14,7 @@
 #include "array.h"
 #include "config.h"
 #include "annotated_commit.h"
+#include "index.h"
 
 #include <git2/types.h>
 #include <git2/annotated_commit.h>
@@ -725,7 +726,9 @@ static int rebase_next_merge(
 	git_checkout_options checkout_opts = {0};
 	git_commit *current_commit = NULL, *parent_commit = NULL;
 	git_tree *current_tree = NULL, *head_tree = NULL, *parent_tree = NULL;
-	git_index *index = NULL;
+	git_index *index = NULL, *index_new = NULL;
+	git_indexwriter indexwriter = GIT_INDEXWRITER_INIT;
+	bool write_index = false;
 	git_rebase_operation *operation;
 	char current_idstr[GIT_OID_HEXSZ];
 	unsigned int parent_count;
@@ -755,6 +758,17 @@ static int rebase_next_merge(
 
 	git_oid_fmt(current_idstr, &operation->id);
 
+	write_index = (checkout_opts.checkout_strategy & GIT_CHECKOUT_DONT_WRITE_INDEX) == 0;
+
+	if (write_index) {
+		/* Never let checkout update the index, we'll update it ourselves. */
+		checkout_opts.checkout_strategy |= GIT_CHECKOUT_DONT_WRITE_INDEX;
+
+		if ((error = git_repository_index(&index, rebase->repo)) < 0 ||
+			(error = git_indexwriter_init(&indexwriter, index)) < 0)
+			goto done;
+	}
+
 	if ((error = rebase_setupfile(rebase, MSGNUM_FILE, -1, "%d\n", rebase->current+1)) < 0 ||
 		(error = rebase_setupfile(rebase, CURRENT_FILE, -1, "%.*s\n", GIT_OID_HEXSZ, current_idstr)) < 0)
 		goto done;
@@ -762,14 +776,17 @@ static int rebase_next_merge(
 	normalize_checkout_opts(rebase, current_commit, &checkout_opts, given_checkout_opts);
 
 	if ((error = git_merge_trees(&index, rebase->repo, parent_tree, head_tree, current_tree, NULL)) < 0 ||
-		(error = git_merge__check_result(rebase->repo, index)) < 0 ||
-		(error = git_checkout_index(rebase->repo, index, &checkout_opts)) < 0)
+		(error = git_merge__check_result(rebase->repo, index_new)) < 0 ||
+		(error = git_checkout_index(rebase->repo, index_new, &checkout_opts)) < 0 ||
+		(write_index && (error = git_indexwriter_commit(&indexwriter)) < 0))
 		goto done;
 
 	*out = operation;
 
 done:
+	git_indexwriter_cleanup(&indexwriter);
 	git_index_free(index);
+	git_index_free(index_new);
 	git_tree_free(current_tree);
 	git_tree_free(head_tree);
 	git_tree_free(parent_tree);

--- a/src/revert.c
+++ b/src/revert.c
@@ -9,6 +9,7 @@
 #include "repository.h"
 #include "filebuf.h"
 #include "merge.h"
+#include "index.h"
 
 #include "git2/types.h"
 #include "git2/merge.h"
@@ -174,7 +175,9 @@ int git_revert(
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 	const char *commit_msg;
 	git_buf their_label = GIT_BUF_INIT;
-	git_index *index_new = NULL;
+	git_index *index = NULL, *index_new = NULL;
+	git_indexwriter indexwriter = GIT_INDEXWRITER_INIT;
+	bool write_index = false;
 	int error;
 
 	assert(repo && commit);
@@ -193,15 +196,29 @@ int git_revert(
 	}
 
 	if ((error = git_buf_printf(&their_label, "parent of %.7s... %s", commit_oidstr, commit_msg)) < 0 ||
-		(error = revert_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0 ||
-		(error = write_revert_head(repo, commit_oidstr)) < 0 ||
+		(error = revert_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0)
+		goto on_error;
+
+	write_index = (opts.checkout_opts.checkout_strategy & GIT_CHECKOUT_DONT_WRITE_INDEX) == 0;
+
+	if (write_index) {
+		/* Never let checkout update the index, we'll update it ourselves. */
+		opts.checkout_opts.checkout_strategy |= GIT_CHECKOUT_DONT_WRITE_INDEX;
+
+		if ((error = git_repository_index(&index, repo)) < 0 ||
+			(error = git_indexwriter_init(&indexwriter, index)) < 0)
+			goto on_error;
+	}
+
+	if ((error = write_revert_head(repo, commit_oidstr)) < 0 ||
 		(error = write_merge_msg(repo, commit_oidstr, commit_msg)) < 0 ||
 		(error = git_repository_head(&our_ref, repo)) < 0 ||
 		(error = git_reference_peel((git_object **)&our_commit, our_ref, GIT_OBJ_COMMIT)) < 0 ||
 		(error = git_revert_commit(&index_new, repo, commit, our_commit, opts.mainline, &opts.merge_opts)) < 0 ||
 		(error = git_merge__check_result(repo, index_new)) < 0 ||
 		(error = git_merge__append_conflicts_to_merge_msg(repo, index_new)) < 0 ||
-		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0)
+		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0 ||
+		(write_index && (error = git_indexwriter_commit(&indexwriter)) < 0))
 		goto on_error;
 
 	goto done;
@@ -210,6 +227,8 @@ on_error:
 	revert_state_cleanup(repo);
 
 done:
+	git_indexwriter_cleanup(&indexwriter);
+	git_index_free(index);
 	git_index_free(index_new);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);

--- a/src/revert.c
+++ b/src/revert.c
@@ -175,9 +175,8 @@ int git_revert(
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 	const char *commit_msg;
 	git_buf their_label = GIT_BUF_INIT;
-	git_index *index = NULL, *index_new = NULL;
+	git_index *index = NULL;
 	git_indexwriter indexwriter = GIT_INDEXWRITER_INIT;
-	bool write_index = false;
 	int error;
 
 	assert(repo && commit);
@@ -196,29 +195,17 @@ int git_revert(
 	}
 
 	if ((error = git_buf_printf(&their_label, "parent of %.7s... %s", commit_oidstr, commit_msg)) < 0 ||
-		(error = revert_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0)
-		goto on_error;
-
-	write_index = (opts.checkout_opts.checkout_strategy & GIT_CHECKOUT_DONT_WRITE_INDEX) == 0;
-
-	if (write_index) {
-		/* Never let checkout update the index, we'll update it ourselves. */
-		opts.checkout_opts.checkout_strategy |= GIT_CHECKOUT_DONT_WRITE_INDEX;
-
-		if ((error = git_repository_index(&index, repo)) < 0 ||
-			(error = git_indexwriter_init(&indexwriter, index)) < 0)
-			goto on_error;
-	}
-
-	if ((error = write_revert_head(repo, commit_oidstr)) < 0 ||
+		(error = revert_normalize_opts(repo, &opts, given_opts, git_buf_cstr(&their_label))) < 0 ||
+		(error = git_indexwriter_init_for_operation(&indexwriter, repo, &opts.checkout_opts.checkout_strategy)) < 0 ||
+		(error = write_revert_head(repo, commit_oidstr)) < 0 ||
 		(error = write_merge_msg(repo, commit_oidstr, commit_msg)) < 0 ||
 		(error = git_repository_head(&our_ref, repo)) < 0 ||
 		(error = git_reference_peel((git_object **)&our_commit, our_ref, GIT_OBJ_COMMIT)) < 0 ||
-		(error = git_revert_commit(&index_new, repo, commit, our_commit, opts.mainline, &opts.merge_opts)) < 0 ||
-		(error = git_merge__check_result(repo, index_new)) < 0 ||
-		(error = git_merge__append_conflicts_to_merge_msg(repo, index_new)) < 0 ||
-		(error = git_checkout_index(repo, index_new, &opts.checkout_opts)) < 0 ||
-		(write_index && (error = git_indexwriter_commit(&indexwriter)) < 0))
+		(error = git_revert_commit(&index, repo, commit, our_commit, opts.mainline, &opts.merge_opts)) < 0 ||
+		(error = git_merge__check_result(repo, index)) < 0 ||
+		(error = git_merge__append_conflicts_to_merge_msg(repo, index)) < 0 ||
+		(error = git_checkout_index(repo, index, &opts.checkout_opts)) < 0 ||
+		(error = git_indexwriter_commit(&indexwriter)) < 0)
 		goto on_error;
 
 	goto done;
@@ -229,7 +216,6 @@ on_error:
 done:
 	git_indexwriter_cleanup(&indexwriter);
 	git_index_free(index);
-	git_index_free(index_new);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);
 	git_buf_free(&their_label);

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -677,3 +677,24 @@ void test_index_tests__reload_while_ignoring_case(void)
 
 	git_index_free(index);
 }
+
+void test_index_tests__can_lock_index(void)
+{
+	git_index *index;
+	git_indexwriter one = GIT_INDEXWRITER_INIT,
+		two = GIT_INDEXWRITER_INIT;
+
+	cl_git_pass(git_index_open(&index, TEST_INDEX_PATH));
+	cl_git_pass(git_indexwriter_init(&one, index));
+
+	cl_git_fail_with(GIT_ELOCKED, git_indexwriter_init(&two, index));
+	cl_git_fail_with(GIT_ELOCKED, git_index_write(index));
+
+	cl_git_pass(git_indexwriter_commit(&one));
+
+	cl_git_pass(git_index_write(index));
+
+	git_indexwriter_cleanup(&one);
+	git_indexwriter_cleanup(&two);
+	git_index_free(index);
+}

--- a/tests/merge/workdir/setup.c
+++ b/tests/merge/workdir/setup.c
@@ -1018,6 +1018,7 @@ void test_merge_workdir_setup__retained_after_success(void)
 	git_annotated_commit_free(their_heads[0]);
 }
 
+
 void test_merge_workdir_setup__removed_after_failure(void)
 {
 	git_oid our_oid;
@@ -1030,16 +1031,14 @@ void test_merge_workdir_setup__removed_after_failure(void)
 	cl_git_pass(git_reference_lookup(&octo1_ref, repo, GIT_REFS_HEADS_DIR OCTO1_BRANCH));
 	cl_git_pass(git_annotated_commit_from_ref(&their_heads[0], repo, octo1_ref));
 
-	cl_git_rewritefile("merge-resolve/new-in-octo1.txt",
-		"Conflicting file!\n\nMerge will fail!\n");
+	cl_git_write2file("merge-resolve/.git/index.lock", "foo\n", 4, O_RDWR|O_CREAT, 0666);
 
 	cl_git_fail(git_merge(
 		repo, (const git_annotated_commit **)&their_heads[0], 1, NULL, NULL));
 
-	cl_assert(!git_path_exists("merge-resolve/" GIT_MERGE_HEAD_FILE));
-	cl_assert(!git_path_exists("merge-resolve/" GIT_ORIG_HEAD_FILE));
-	cl_assert(!git_path_exists("merge-resolve/" GIT_MERGE_MODE_FILE));
-	cl_assert(!git_path_exists("merge-resolve/" GIT_MERGE_MSG_FILE));
+	cl_assert(!git_path_exists("merge-resolve/.git/" GIT_MERGE_HEAD_FILE));
+	cl_assert(!git_path_exists("merge-resolve/.git/" GIT_MERGE_MODE_FILE));
+	cl_assert(!git_path_exists("merge-resolve/.git/" GIT_MERGE_MSG_FILE));
 
 	git_reference_free(octo1_ref);
 


### PR DESCRIPTION
Always lock the index when we begin the merge, before we write
any of the metdata files.  This prevents a race where another
client may run a commit after we have written the `MERGE_HEAD` but
before we have updated the index, which will produce a merge
commit that is treesame to one parent.  The merge will finish and
update the index and the resultant commit would not be a merge at
all.