### PR TITLE
Allow passing a NULL index to git_repository_set_index()

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -776,7 +776,7 @@ int git_repository_index(git_index **out, git_repository *repo)
 
 void git_repository_set_index(git_repository *repo, git_index *index)
 {
-	assert(repo && index);
+	assert(repo);
 	set_index(repo, index);
 }
 


### PR DESCRIPTION
This is supported by the underlying set_index() implementation
and setting the repository index to NULL is recommended by the
git_repository_set_bare() documentation.