### PR TITLE
Make sure sys/repository.h includes the required headers

### DIFF
--- a/include/git2/sys/repository.h
+++ b/include/git2/sys/repository.h
@@ -7,6 +7,9 @@
 #ifndef INCLUDE_sys_git_repository_h__
 #define INCLUDE_sys_git_repository_h__
 
+#include "git2/common.h"
+#include "git2/types.h"
+
 /**
  * @file git2/sys/repository.h
  * @brief Git repository custom implementation routines


### PR DESCRIPTION
It was missing "common.h" and "types.h" like other system headers.
This generated compilation errors if including it directly.