### PR TITLE
Don't call git_reflog_delete() unless the branch actually has a reflog

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -109,6 +109,7 @@ int git_branch_delete(git_reference *branch)
 	int is_head;
 	git_buf config_section = GIT_BUF_INIT;
 	int error = -1;
+	int has_log;
 
 	assert(branch);
 
@@ -138,7 +139,11 @@ int git_branch_delete(git_reference *branch)
 	if (git_reference_delete(branch) < 0)
 		goto on_error;
 
-	if (git_reflog_delete(git_reference_owner(branch), git_reference_name(branch)) < 0)
+	has_log = git_reference_has_log(git_reference_owner(branch), git_reference_name(branch));
+	if (has_log < 0)
+		goto on_error;
+
+	if (has_log && git_reflog_delete(git_reference_owner(branch), git_reference_name(branch)) < 0)
 		goto on_error;
 
 	error = 0;


### PR DESCRIPTION
This is an issue I found when implementing a custom refdb backend. git_reflog_delete() is only called from git_branch_delete() in libgit2 so that was the only call site to review.

This is a no-op with the built-in FS refdb backend since it doesn't return an error when attempting to delete a non-existing reflog. However, since deleting a non-existing reference fails, I would say deleting a non-existing reflog should also fail in the backend(s).