### PR TITLE
openssl: Add all required includes for AF_INET6 and in6_addr.

### DIFF
--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -12,6 +12,9 @@
 #include <openssl/x509v3.h>
 
 #include <ctype.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 #include "global.h"
 #include "posix.h"


### PR DESCRIPTION
This fixes the build at least on FreeBSD, where those types were not
defined indirectly:

```
src/openssl_stream.c:100:18: error: variable has incomplete type 'struct in6_addr'
        struct in6_addr addr6;
                        ^
src/openssl_stream.c:100:9: note: forward declaration of 'struct in6_addr'
        struct in6_addr addr6;
               ^
src/openssl_stream.c:111:18: error: use of undeclared identifier 'AF_INET'
        if (p_inet_pton(AF_INET, host, &addr4)) {
                        ^
src/unix/posix.h:31:40: note: expanded from macro 'p_inet_pton'
                                       ^
src/openssl_stream.c:115:18: error: use of undeclared identifier 'AF_INET6'
                if(p_inet_pton(AF_INET6, host, &addr6)) {
                               ^
src/unix/posix.h:31:40: note: expanded from macro 'p_inet_pton'
                                       ^
```