### PR TITLE
pathspec: do not try to dereference NULL

### DIFF
--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -296,6 +296,9 @@ int git_pathspec_matches_path(
 
 static void pathspec_match_free(git_pathspec_match_list *m)
 {
+	if (!m)
+		return;
+
 	git_pathspec_free(m->pathspec);
 	m->pathspec = NULL;
 


### PR DESCRIPTION
pathspec_match_free() should not dereference a NULL passed to it.

I found this issue when I tried to run example log program with
nonexistent branch:

./example/log help

Such call leads to segmentation fault.