### PR TITLE
More coverity fixes

### DIFF
--- a/src/diff_patch.c
+++ b/src/diff_patch.c
@@ -823,7 +823,8 @@ int git_patch__invoke_callbacks(
 	for (i = 0; !error && i < git_array_size(patch->hunks); ++i) {
 		diff_patch_hunk *h = git_array_get(patch->hunks, i);
 
-		error = hunk_cb(patch->delta, &h->hunk, payload);
+		if (hunk_cb)
+			error = hunk_cb(patch->delta, &h->hunk, payload);
 
 		if (!line_cb)
 			continue;

--- a/src/index.c
+++ b/src/index.c
@@ -292,6 +292,9 @@ static void index_entry_reuc_free(git_index_reuc_entry *reuc)
 
 static void index_entry_free(git_index_entry *entry)
 {
+	if (!entry)
+		return;
+
 	memset(&entry->id, 0, sizeof(entry->id));
 	git__free(entry);
 }

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -315,6 +315,9 @@ static git_pathspec_match_list *pathspec_match_alloc(
 		m = NULL;
 	}
 
+	if (!m)
+		return NULL;
+
 	/* need to keep reference to pathspec and increment refcount because
 	 * failures array stores pointers to the pattern strings of the
 	 * pathspec that had no matches


### PR DESCRIPTION
This fixes a few scenarios where we may be dereferencing ```NULL``` pointers.