### PR TITLE
Fix test failures when NTFS  8.3 is disabled

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -808,7 +808,7 @@ const char *git_repository__8dot3_name(git_repository *repo)
 
 			/* We anticipate the 8.3 name is "GIT~1", so use a static for
 			 * easy testing in the common case */
-			if (strcasecmp(repo->name_8dot3, git_repository__8dot3_default) == 0)
+			if (repo->name_8dot3 && strcasecmp(repo->name_8dot3, git_repository__8dot3_default) == 0)
 				repo->has_8dot3_default = 1;
 		}
 #endif


### PR DESCRIPTION
Windows user can disable NTFS 8.3 option.
But libgit2 may crash.