### PR TITLE
Remove stale reflog namespace directory before branch creation

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1771,6 +1771,15 @@ static int reflog_append(refdb_fs_backend *backend, const git_reference *ref, co
 		goto cleanup;
 	}
 
+	/* If the new branch matches part of the namespace of a previously deleted branch,
+	 * there maybe an obsolete/unused directory (or directory hierarchy) in the way.
+	 */
+	if (git_path_isdir(git_buf_cstr(&path)) &&
+		(git_futils_rmdir_r(git_buf_cstr(&path), NULL, GIT_RMDIR_SKIP_NONEMPTY) < 0)) {
+		error = -1;
+		goto cleanup;
+	}
+
 	error = git_futils_writebuffer(&buf, git_buf_cstr(&path), O_WRONLY|O_CREAT|O_APPEND, GIT_REFLOG_FILE_MODE);
 
 cleanup:


### PR DESCRIPTION
When a namespace branch such as "level_one/level_two" is deleted, the "level_two" branch files are deleted, but the containing directories are not.  A later attempt to create a "level_one" branch fails because of a collision on the stale ".git/logs/refs/heads/level_one" directory.

This fix removes an empty reflog directory before trying to create the new reflog file.
(Existing code already handles cleaning up the stale ".git/refs/heads/level_one" directory.)

This issue was originally reported by @jamill against LibGit2Sharp in 
https://github.com/libgit2/libgit2sharp/pull/859
