### PR TITLE
Handle 8dot3 filenames being disabled on Win32

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -808,7 +808,8 @@ const char *git_repository__8dot3_name(git_repository *repo)
 
 			/* We anticipate the 8.3 name is "GIT~1", so use a static for
 			 * easy testing in the common case */
-			if (repo->name_8dot3 && strcasecmp(repo->name_8dot3, git_repository__8dot3_default) == 0)
+			if (repo->name_8dot3 &&
+				strcasecmp(repo->name_8dot3, git_repository__8dot3_default) == 0)
 				repo->has_8dot3_default = 1;
 		}
 #endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -808,7 +808,7 @@ const char *git_repository__8dot3_name(git_repository *repo)
 
 			/* We anticipate the 8.3 name is "GIT~1", so use a static for
 			 * easy testing in the common case */
-			if (strcasecmp(repo->name_8dot3, git_repository__8dot3_default) == 0)
+			if (repo->name_8dot3 && strcasecmp(repo->name_8dot3, git_repository__8dot3_default) == 0)
 				repo->has_8dot3_default = 1;
 		}
 #endif

--- a/tests/checkout/nasty.c
+++ b/tests/checkout/nasty.c
@@ -217,11 +217,8 @@ void test_checkout_nasty__git_tilde1(void)
 void test_checkout_nasty__git_custom_shortname(void)
 {
 #ifdef GIT_WIN32
-	char *shortname = git_win32_path_8dot3_name("C:\\Program Files");
-	if (shortname == NULL)
+	if (!cl_sandbox_supports_8dot3())
 		clar__skip();
-
-	git__free(shortname);
 
 	cl_must_pass(p_rename("nasty/.git", "nasty/_temp"));
 	cl_git_write2file("nasty/git~1", "", 0, O_RDWR|O_CREAT, 0666);

--- a/tests/checkout/nasty.c
+++ b/tests/checkout/nasty.c
@@ -10,25 +10,6 @@ static const char *repo_name = "nasty";
 static git_repository *repo;
 static git_checkout_options checkout_opts;
 
-#ifdef GIT_WIN32
-static bool is_8dot3_disabled(void)
-{
-#define IS_8DOT3_BUF_SIZE (MAX_PATH + 20)
-	char src[IS_8DOT3_BUF_SIZE];
-	wchar_t dest[IS_8DOT3_BUF_SIZE], shortPath[IS_8DOT3_BUF_SIZE];
-	FILE *fp;
-	strcpy_s(src, IS_8DOT3_BUF_SIZE, clar_sandbox_path());
-	strcat_s(src, IS_8DOT3_BUF_SIZE, "/longer_than_8dot3");
-	git__utf8_to_16(dest, IS_8DOT3_BUF_SIZE, src);
-	fp = _wfopen(dest, L"w");
-	cl_assert(fp);
-	fclose(fp);
-	cl_assert(GetShortPathNameW(dest, shortPath, IS_8DOT3_BUF_SIZE) > 0);
-	DeleteFileW(dest);
-	return !wcscmp(dest, shortPath);
-}
-#endif
-
 void test_checkout_nasty__initialize(void)
 {
 	repo = cl_git_sandbox_init(repo_name);
@@ -236,13 +217,16 @@ void test_checkout_nasty__git_tilde1(void)
 void test_checkout_nasty__git_custom_shortname(void)
 {
 #ifdef GIT_WIN32
+	char *shortname = git_win32_path_8dot3_name("C:\\Program Files");
+	if (shortname == NULL)
+		clar__skip();
+
+	git__free(shortname);
+
 	cl_must_pass(p_rename("nasty/.git", "nasty/_temp"));
 	cl_git_write2file("nasty/git~1", "", 0, O_RDWR|O_CREAT, 0666);
 	cl_must_pass(p_rename("nasty/_temp", "nasty/.git"));
-	if (is_8dot3_disabled())
-		test_checkout_passes("refs/heads/git_tilde2", ".git/foobar");
-	else
-		test_checkout_fails("refs/heads/git_tilde2", ".git/foobar");
+	test_checkout_fails("refs/heads/git_tilde2", ".git/foobar");
 #endif
 }
 

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -538,3 +538,25 @@ void cl_sandbox_set_search_path_defaults(void)
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, sandbox_path);
 }
 
+#ifdef GIT_WIN32
+bool cl_sandbox_supports_8dot3(void)
+{
+	git_buf longpath = GIT_BUF_INIT;
+	char *shortname;
+	bool supported;
+
+	cl_git_pass(
+		git_buf_joinpath(&longpath, clar_sandbox_path(), "longer_than_8dot3"));
+
+	cl_git_write2file(longpath.ptr, "", 0, O_RDWR|O_CREAT, 0666);
+	shortname = git_win32_path_8dot3_name(longpath.ptr);
+
+	supported = (shortname != NULL);
+
+	git__free(shortname);
+	git_buf_free(&longpath);
+
+	return supported;
+}
+#endif
+

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -161,4 +161,8 @@ void cl_fake_home_cleanup(void *);
 
 void cl_sandbox_set_search_path_defaults(void);
 
+#ifdef GIT_WIN32
+bool cl_sandbox_supports_8dot3(void);
+#endif
+
 #endif

--- a/tests/path/win32.c
+++ b/tests/path/win32.c
@@ -4,18 +4,6 @@
 
 #ifdef GIT_WIN32
 #include "win32/path_w32.h"
-
-static bool is_8dot3_disabled(void)
-{
-	wchar_t shortPath[MAX_PATH];
-	wchar_t *dest = L"longer_than_8dot3";
-	FILE *fp = _wfopen(dest, L"w");
-	cl_assert(fp);
-	fclose(fp);
-	cl_assert(GetShortPathNameW(dest, shortPath, MAX_PATH) > 0);
-	DeleteFileW(dest);
-	return !wcscmp(dest, shortPath);
-}
 #endif
 
 void test_utf8_to_utf16(const char *utf8_in, const wchar_t *utf16_expected)
@@ -205,11 +193,14 @@ void test_path_win32__8dot3_name(void)
 {
 #ifdef GIT_WIN32
 	char *shortname;
-	bool disable8dot3 = is_8dot3_disabled();
 
 	/* Some guaranteed short names */
 	shortname = git_win32_path_8dot3_name("C:\\Program Files");
-	cl_assert(!shortname || !strcmp(shortname, "PROGRA~1")); // null when 8.3 stripped, otherwise in 8.3 format
+
+	if (shortname == NULL)
+		clar__skip();
+
+	cl_assert_equal_s("PROGRA~1", shortname);
 	git__free(shortname);
 
 	cl_assert_equal_s("WINDOWS", (shortname = git_win32_path_8dot3_name("C:\\WINDOWS")));
@@ -217,12 +208,12 @@ void test_path_win32__8dot3_name(void)
 
 	/* Create some predictible short names */
 	cl_must_pass(p_mkdir(".foo", 0777));
-	cl_assert_equal_s(disable8dot3 ? ".foo" : "FOO~1", (shortname = git_win32_path_8dot3_name(".foo")));
+	cl_assert_equal_s("FOO~1", (shortname = git_win32_path_8dot3_name(".foo")));
 	git__free(shortname);
 
 	cl_git_write2file("bar~1", "foobar\n", 7, O_RDWR|O_CREAT, 0666);
 	cl_must_pass(p_mkdir(".bar", 0777));
-	cl_assert_equal_s(disable8dot3 ? ".bar" : "BAR~2", (shortname = git_win32_path_8dot3_name(".bar")));
+	cl_assert_equal_s("BAR~2", (shortname = git_win32_path_8dot3_name(".bar")));
 	git__free(shortname);
 #endif
 }

--- a/tests/path/win32.c
+++ b/tests/path/win32.c
@@ -194,13 +194,11 @@ void test_path_win32__8dot3_name(void)
 #ifdef GIT_WIN32
 	char *shortname;
 
-	/* Some guaranteed short names */
-	shortname = git_win32_path_8dot3_name("C:\\Program Files");
-
-	if (shortname == NULL)
+	if (!cl_sandbox_supports_8dot3())
 		clar__skip();
 
-	cl_assert_equal_s("PROGRA~1", shortname);
+	/* Some guaranteed short names */
+	cl_assert_equal_s("PROGRA~1", (shortname = git_win32_path_8dot3_name("C:\\Program Files")));
 	git__free(shortname);
 
 	cl_assert_equal_s("WINDOWS", (shortname = git_win32_path_8dot3_name("C:\\WINDOWS")));


### PR DESCRIPTION
Fixes #2863 