### PR TITLE
README.md: Add Swift bindings "Gift"

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Here are the bindings to libgit2 that are currently available:
     * Rugged <https://github.com/libgit2/rugged>
 * Rust
     * git2-rs <https://github.com/alexcrichton/git2-rs>
+* Swift
+    * Gift <https://github.com/modocache/Gift>
 * Vala
     * libgit2.vapi <https://github.com/apmasell/vapis/blob/master/libgit2.vapi>
 


### PR DESCRIPTION
First of all, thanks a ton for this project. It's been a real pleasure building a wrapper around such a thoughtfully implemented API.

I was wondering if my project, a set of [Swift bindings to libgit2 called Gift](https://github.com/modocache/Gift), could be added to the list in the README?

Gift currently has several maintainers that are committed to its maintenance and feature development. We've also encountered a few issues in libgit2 we wish to fix and pull request back upstream. In addition to mentioning Gift in the README, how would the libgit2 maintainers feel about including Gift in [the libgit2 GitHub organization](https://github.com/libgit2)?

Just a thought. Thanks again! :+1: 