### PR TITLE
for-each-ref example: initialize libgit2 in main

### DIFF
--- a/examples/for-each-ref.c
+++ b/examples/for-each-ref.c
@@ -34,6 +34,7 @@ static int show_ref(git_reference *ref, void *data)
 int main(int argc, char **argv)
 {
         git_repository *repo;
+        git_libgit2_init();
 
         if (argc != 1 || argv[1] /* silence -Wunused-parameter */)
                 fatal("Sorry, no for-each-ref options supported yet", NULL);
@@ -42,5 +43,7 @@ int main(int argc, char **argv)
                   "Could not open repository", NULL);
         check_lg2(git_reference_foreach(repo, show_ref, repo),
                   "Could not iterate over references", NULL);
+
+        git_libgit2_shutdown();
         return 0;
 }


### PR DESCRIPTION
I don't get how it was working without git_libgit2_init() call. I run it
and libgit2 throws assertion somewhere in its internals. Now it works.