### PR TITLE
Ensure we can make a repo at the root of the filesystem

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ branches:
   only:
   - master
 environment:
+  GITTEST_INVASIVE_FILESYSTEM: 1
+
   matrix:
   - GENERATOR: "Visual Studio 11"
     ARCH: 32

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -448,12 +448,8 @@ int p_stat(const char* path, struct stat* buf)
 	git_win32_path path_w;
 	int len;
 
-	if ((len = git_win32_path_from_utf8(path_w, path)) < 0)
-		return -1;
-
-	git_win32__path_trim_end(path_w, len);
-
-	if (lstat_w(path_w, buf, false) < 0)
+	if ((len = git_win32_path_from_utf8(path_w, path)) < 0 ||
+		lstat_w(path_w, buf, false) < 0)
 		return -1;
 
 	/* The item is a symbolic link or mount point. No need to iterate

--- a/tests/core/stat.c
+++ b/tests/core/stat.c
@@ -95,3 +95,20 @@ void test_core_stat__0(void)
 	cl_assert_error(ENOTDIR);
 }
 
+void test_core_stat__root(void)
+{
+	const char *sandbox = clar_sandbox_path();
+	git_buf root = GIT_BUF_INIT;
+	int root_len;
+	struct stat st;
+
+	root_len = git_path_root(sandbox);
+	cl_assert(root_len >= 0);
+
+	git_buf_set(&root, sandbox, root_len+1);
+
+	cl_must_pass(p_stat(root.ptr, &st));
+	cl_assert(S_ISDIR(st.st_mode));
+
+	git_buf_free(&root);
+}

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -714,3 +714,29 @@ void test_repo_init__init_with_initial_commit(void)
 
 	git_index_free(index);
 }
+
+void test_repo_init__at_filesystem_root(void)
+{
+	git_repository *repo;
+	const char *sandbox = clar_sandbox_path();
+	git_buf root = GIT_BUF_INIT;
+	int root_len;
+
+	if (!cl_getenv("GITTEST_INVASIVE_FILESYSTEM"))
+		cl_skip();
+
+	root_len = git_path_root(sandbox);
+	cl_assert(root_len >= 0);
+
+	git_buf_put(&root, sandbox, root_len+1);
+	git_buf_joinpath(&root, root.ptr, "libgit2_test_dir");
+
+	cl_assert(!git_path_exists(root.ptr));
+
+	cl_git_pass(git_repository_init(&repo, root.ptr, 0));
+	cl_assert(git_path_isdir(root.ptr));
+	cl_git_pass(git_futils_rmdir_r(root.ptr, NULL, GIT_RMDIR_REMOVE_FILES));
+
+	git_buf_free(&root);
+	git_repository_free(repo);
+}


### PR DESCRIPTION
It seems that initializing a repository at the root of the filesystem (eg `c:\foo`) is failing.  This appears to be a regression, something I busted in some of the insidious refactoring I did recently.

Add a unit test that exercises this, but guard it in an environment variable `GITTEST_INVASIVE_FILESYSTEM`.  It is not expected that normal people would ever set this, because - you know - it creates a directory at the root of your disk.  And then `rm -r`s it!  But this seems like something that we could safely hook up in our CI builds.

So, enable these for AppVeyor, which (I think) basically runs as administrator.  Don't enable these for Travis, though we could later add a second pass of test execution that runs as root(!).