### PR TITLE
transport: Lock usage of custom_transports

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -149,10 +149,6 @@ typedef int (*git_transport_cb)(git_transport **out, git_remote *owner, void *pa
  * Add a custom transport definition, to be used in addition to the built-in
  * set of transports that come with libgit2.
  *
- * The caller is responsible for synchronizing calls to git_transport_register
- * and git_transport_unregister with other calls to the library that
- * instantiate transports.
- *
  * @param prefix The scheme (ending in "://") to match, i.e. "git://"
  * @param cb The callback used to create an instance of the transport
  * @param param A fixed parameter to pass to cb at creation time
@@ -167,6 +163,9 @@ GIT_EXTERN(int) git_transport_register(
  *
  * Unregister a custom transport definition which was previously registered
  * with git_transport_register.
+ *
+ * Note that there may still be active instances of the transport being
+ * unregistered even after this function returns.
  *
  * @param prefix From the previous call to git_transport_register
  * @return 0 or an error code

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_transport_h__
+#define INCLUDE_transport_h__
+
+extern int git_transport_global_init(void);
+
+#endif


### PR DESCRIPTION
It was previously stated in the documentation that callers of
`git_transport_register` are responsible for synchronizing with other calls as
well as "other calls to the library that instantiate transports". When writing a
binding library for libgit2, however, this is quite difficult as the list of
APIs that need to be synchronized are:

* git_transport_register
* git_transport_unregister
* git_remote_connect
* git_push_finish
* git_remote_fetch
* git_remote_upload
* git_remote_push
* git_clone
* ... (I may have missed some)

This list is also growing over time, so it's quite difficult to ensure that a
library is properly synchronized in a general fashion.

This commit adds a global `git_mutex` which protects access to the global
`custom_transports` list as well as mentioning in the documentation that
transports created by the callback may linger even after the transport is
unregistered.