### PR TITLE
repository: parse init.templatedir as a path

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1265,7 +1265,8 @@ static int repo_init_structure(
 		if (opts->template_path)
 			tdir = opts->template_path;
 		else if ((error = git_config_open_default(&cfg)) >= 0) {
-			error = git_config_get_string(&tdir, cfg, "init.templatedir");
+			if (!git_config_get_path(&template_buf, cfg, "init.templatedir"))
+				tdir = template_buf.ptr;
 			giterr_clear();
 		}
 


### PR DESCRIPTION
This is a path so we must use the path getter so we get the tilde
expansion done.

---

@alexcrichton this should fix #2814 