### PR TITLE
Add set of git_trace calls to iterators and ENABLE_TRACE_ITERATOR option...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ OPTION( BUILD_EXAMPLES		"Build library usage example apps"		OFF )
 OPTION( TAGS				"Generate tags"							OFF )
 OPTION( PROFILE				"Generate profiling information"		OFF )
 OPTION( ENABLE_TRACE		"Enables tracing support"				OFF )
+OPTION( ENABLE_TRACE_ITERATOR	"Enables iterator tracing"			OFF )
 OPTION( LIBGIT2_FILENAME	"Name of the produced binary"			OFF )
 
 OPTION( ANDROID				"Build for android NDK"	 				OFF )
@@ -187,6 +188,10 @@ ENDIF()
 # Enable tracing
 IF (ENABLE_TRACE STREQUAL "ON")
 	ADD_DEFINITIONS(-DGIT_TRACE)
+ENDIF()
+IF (ENABLE_TRACE_ITERATOR STREQUAL "ON")
+	ADD_DEFINITIONS(-DGIT_TRACE)
+	ADD_DEFINITIONS(-DGIT_TRACE_ITERATOR)
 ENDIF()
 
 # Include POSIX regex when it is required

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -155,6 +155,13 @@ int git_iterator_for_nothing(
 	empty_iterator *i = git__calloc(1, sizeof(empty_iterator));
 	GITERR_CHECK_ALLOC(i);
 
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_for_nothing: [iter %p] [flags 0x%08lx] '%s' '%s'",
+			  i, flags,
+			  ((start) ? start : "(nil)"),
+			  ((end) ? end : "(nil)"));
+#endif
+
 #define empty_iterator__current empty_iterator__noop
 #define empty_iterator__advance empty_iterator__noop
 #define empty_iterator__advance_into empty_iterator__noop
@@ -620,6 +627,13 @@ int git_iterator_for_tree(
 	ti = git__calloc(1, sizeof(tree_iterator));
 	GITERR_CHECK_ALLOC(ti);
 
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_for_tree: [iter %p] [flags 0x%08lx] '%s' '%s'",
+			  ti, flags,
+			  ((start) ? start : "(nil)"),
+			  ((end) ? end : "(nil)"));
+#endif
+
 	ITERATOR_BASE_INIT(ti, tree, TREE, git_tree_owner(tree));
 
 	if ((error = iterator__update_ignore_case((git_iterator *)ti, flags)) < 0)
@@ -861,6 +875,13 @@ int git_iterator_for_index(
 	int error = 0;
 	index_iterator *ii = git__calloc(1, sizeof(index_iterator));
 	GITERR_CHECK_ALLOC(ii);
+
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_for_index: [iter %p] [flags 0x%08lx] '%s' '%s'",
+			  ii, flags,
+			  ((start) ? start : "(nil)"),
+			  ((end) ? end : "(nil)"));
+#endif
 
 	if ((error = git_index_snapshot_new(&ii->entries, index)) < 0) {
 		git__free(ii);
@@ -1255,6 +1276,13 @@ int git_iterator_for_filesystem(
 	fs_iterator *fi = git__calloc(1, sizeof(fs_iterator));
 	GITERR_CHECK_ALLOC(fi);
 
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_for_filesystem: [iter %p] [flags 0x%08lx] '%s' '%s'",
+			  fi, flags,
+			  ((start) ? start : "(nil)"),
+			  ((end) ? end : "(nil)"));
+#endif
+
 	ITERATOR_BASE_INIT(fi, fs, FS, NULL);
 
 	if ((flags & GIT_ITERATOR_IGNORE_CASE) != 0)
@@ -1445,6 +1473,14 @@ int git_iterator_for_workdir_ext(
 	/* initialize as an fs iterator then do overrides */
 	wi = git__calloc(1, sizeof(workdir_iterator));
 	GITERR_CHECK_ALLOC(wi);
+
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_for_workdir_ext: [iter %p] [flags 0x%08lx] '%s' '%s'",
+			  wi, flags,
+			  ((start) ? start : "(nil)"),
+			  ((end) ? end : "(nil)"));
+#endif
+
 	ITERATOR_BASE_INIT((&wi->fi), fs, FS, repo);
 
 	wi->fi.base.type = GIT_ITERATOR_TYPE_WORKDIR;
@@ -1500,6 +1536,11 @@ void git_iterator_free(git_iterator *iter)
 int git_iterator_set_ignore_case(git_iterator *iter, bool ignore_case)
 {
 	bool desire_ignore_case  = (ignore_case != 0);
+
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_set_ignore_case: [iter %p] [was %d][new %d]",
+			  iter, iterator__ignore_case(iter), desire_ignore_case);
+#endif
 
 	if (iterator__ignore_case(iter) == desire_ignore_case)
 		return 0;

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1523,6 +1523,10 @@ void git_iterator_free(git_iterator *iter)
 	if (iter == NULL)
 		return;
 
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_free: [iter %p]", iter);
+#endif
+
 	iter->cb->free(iter);
 
 	git__free(iter->start);

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -11,6 +11,9 @@
 #include "git2/index.h"
 #include "vector.h"
 #include "buffer.h"
+#if defined(GIT_TRACE_ITERATOR)
+#include "trace.h"
+#endif
 
 typedef struct git_iterator git_iterator;
 
@@ -133,7 +136,13 @@ extern void git_iterator_free(git_iterator *iter);
 GIT_INLINE(int) git_iterator_current(
 	const git_index_entry **entry, git_iterator *iter)
 {
-	return iter->cb->current(entry, iter);
+	int r = iter->cb->current(entry, iter);
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_current: [iter %p] yields [%d, %p, %s]",
+			  iter, r, *entry,
+			  (((*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
+#endif
+	return r;
 }
 
 /**
@@ -146,7 +155,14 @@ GIT_INLINE(int) git_iterator_current(
 GIT_INLINE(int) git_iterator_advance(
 	const git_index_entry **entry, git_iterator *iter)
 {
-	return iter->cb->advance(entry, iter);
+	int r = iter->cb->advance(entry, iter);
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_advance: [iter %p] yields [%d, %p, %s]",
+			  iter, r,
+			  ((entry) ? *entry : NULL),
+			  (((entry) && (*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
+#endif
+	return r;
 }
 
 /**
@@ -167,7 +183,13 @@ GIT_INLINE(int) git_iterator_advance(
 GIT_INLINE(int) git_iterator_advance_into(
 	const git_index_entry **entry, git_iterator *iter)
 {
-	return iter->cb->advance_into(entry, iter);
+	int r = iter->cb->advance_into(entry, iter);
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_advance_into: [iter %p] yields [%d, %p, %s]",
+			  iter, r, *entry,
+			  (((*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
+#endif
+	return r;
 }
 
 /**
@@ -206,7 +228,14 @@ GIT_INLINE(int) git_iterator_seek(
 GIT_INLINE(int) git_iterator_reset(
 	git_iterator *iter, const char *start, const char *end)
 {
-	return iter->cb->reset(iter, start, end);
+	int r = iter->cb->reset(iter, start, end);
+#if defined(GIT_TRACE_ITERATOR)
+	git_trace(GIT_TRACE_TRACE, "git_iterator_reset: [iter %p] yields [%d] '%s' '%s'",
+			  iter, r,
+			  ((start) ? start : "(nil)"),
+			  ((end) ? end : "(nil)"));
+#endif
+	return r;
 }
 
 /**

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -138,8 +138,10 @@ GIT_INLINE(int) git_iterator_current(
 {
 	int r = iter->cb->current(entry, iter);
 #if defined(GIT_TRACE_ITERATOR)
-	git_trace(GIT_TRACE_TRACE, "git_iterator_current: [iter %p] yields [%d, %p, %s]",
-			  iter, r, *entry,
+	git_trace(GIT_TRACE_TRACE, "git_iterator_current: [iter %p] yields [%d, %p, 0%o, %s]",
+			  iter, r,
+			  ((entry) ? *entry : NULL),
+			  (((entry) && (*entry)) ? ((*entry)->mode) : 0),
 			  (((*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
 #endif
 	return r;
@@ -157,9 +159,10 @@ GIT_INLINE(int) git_iterator_advance(
 {
 	int r = iter->cb->advance(entry, iter);
 #if defined(GIT_TRACE_ITERATOR)
-	git_trace(GIT_TRACE_TRACE, "git_iterator_advance: [iter %p] yields [%d, %p, %s]",
+	git_trace(GIT_TRACE_TRACE, "git_iterator_advance: [iter %p] yields [%d, %p, 0%o, %s]",
 			  iter, r,
 			  ((entry) ? *entry : NULL),
+			  (((entry) && (*entry)) ? ((*entry)->mode) : 0),
 			  (((entry) && (*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
 #endif
 	return r;
@@ -185,9 +188,11 @@ GIT_INLINE(int) git_iterator_advance_into(
 {
 	int r = iter->cb->advance_into(entry, iter);
 #if defined(GIT_TRACE_ITERATOR)
-	git_trace(GIT_TRACE_TRACE, "git_iterator_advance_into: [iter %p] yields [%d, %p, %s]",
-			  iter, r, *entry,
-			  (((*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
+	git_trace(GIT_TRACE_TRACE, "git_iterator_advance_into: [iter %p] yields [%d, %p, 0%o, %s]",
+			  iter, r,
+			  ((entry) ? *entry : NULL),
+			  (((entry) && (*entry)) ? ((*entry)->mode) : 0),
+			  (((entry) && (*entry) && ((*entry)->path)) ? ((*entry)->path) : "(null)"));
 #endif
 	return r;
 }


### PR DESCRIPTION
This code adds iterator tracing for use in debugging iterators and/or learning about how they work.

Code is ifdef'd GIT_TRACE_ITERATOR and only enabled if ENABLE_TRACE_ITERATOR is turned on in cmake.


