### PR TITLE
Added filelist iterators to improve merge/diff performance.

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -124,6 +124,14 @@ typedef enum {
 	/** Use case insensitive filename comparisons */
 	GIT_DIFF_IGNORE_CASE = (1u << 10),
 
+	/** Use the FIELLIST versions of the index and workdir iterators when
+	 *  possible.  This is more broad than the DISABLE_PATHSPEC_MATCH flag.
+	 *  The caller must provide an array of paths (no patterns).
+	 *  The iterators will only values from that array that are also
+	 *  present in the underlying index or workdir.
+	 */
+	GIT_DIFF_ENABLE_FILELIST_MATCH = (1u << 11),
+
 	/** If the pathspec is set in the diff options, this flags means to
 	 *  apply it as an exact match instead of as an fnmatch pattern.
 	 */

--- a/src/diff.c
+++ b/src/diff.c
@@ -97,12 +97,16 @@ static int diff_delta__from_one(
 		DIFF_FLAG_ISNT_SET(diff, GIT_DIFF_INCLUDE_UNREADABLE))
 		return 0;
 
-	if (!git_pathspec__match(
-			&diff->pathspec, entry->path,
-			DIFF_FLAG_IS_SET(diff, GIT_DIFF_DISABLE_PATHSPEC_MATCH),
-			DIFF_FLAG_IS_SET(diff, GIT_DIFF_IGNORE_CASE),
-			&matched_pathspec, NULL))
-		return 0;
+	if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_ENABLE_FILELIST_MATCH)) {
+		matched_pathspec = entry->path;
+	} else {
+		if (!git_pathspec__match(
+				&diff->pathspec, entry->path,
+				DIFF_FLAG_IS_SET(diff, GIT_DIFF_DISABLE_PATHSPEC_MATCH),
+				DIFF_FLAG_IS_SET(diff, GIT_DIFF_IGNORE_CASE),
+				&matched_pathspec, NULL))
+			return 0;
+	}
 
 	delta = diff_delta__alloc(diff, status, entry->path);
 	GITERR_CHECK_ALLOC(delta);
@@ -312,11 +316,13 @@ static const char *diff_mnemonic_prefix(
 	const char *pfx = "";
 
 	switch (type) {
-	case GIT_ITERATOR_TYPE_EMPTY:   pfx = "c"; break;
-	case GIT_ITERATOR_TYPE_TREE:    pfx = "c"; break;
-	case GIT_ITERATOR_TYPE_INDEX:   pfx = "i"; break;
-	case GIT_ITERATOR_TYPE_WORKDIR: pfx = "w"; break;
-	case GIT_ITERATOR_TYPE_FS:      pfx = left_side ? "1" : "2"; break;
+	case GIT_ITERATOR_TYPE_EMPTY:           pfx = "c"; break;
+	case GIT_ITERATOR_TYPE_TREE:            pfx = "c"; break;
+	case GIT_ITERATOR_TYPE_INDEX:           pfx = "i"; break;
+	case GIT_ITERATOR_TYPE_INDEXFILELIST:   pfx = "i"; break;
+	case GIT_ITERATOR_TYPE_WORKDIR:         pfx = "w"; break;
+	case GIT_ITERATOR_TYPE_WORKDIRFILELIST: pfx = "w"; break;
+	case GIT_ITERATOR_TYPE_FS:              pfx = left_side ? "1" : "2"; break;
 	default: break;
 	}
 
@@ -401,9 +407,13 @@ static int diff_list_apply_options(
 		memcpy(&diff->opts, opts, sizeof(diff->opts));
 		DIFF_FLAG_SET(diff, GIT_DIFF_IGNORE_CASE, icase);
 
-		/* initialize pathspec from options */
-		if (git_pathspec__vinit(&diff->pathspec, &opts->pathspec, pool) < 0)
-			return -1;
+		if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_ENABLE_FILELIST_MATCH)) {
+			/* we do not use diff->pathspec, since the iterators have the filelist. */
+		} else {
+			/* initialize pathspec from options */
+			if (git_pathspec__vinit(&diff->pathspec, &opts->pathspec, pool) < 0)
+				return -1;
+		}
 	}
 
 	/* flag INCLUDE_TYPECHANGE_TREES implies INCLUDE_TYPECHANGE */
@@ -453,10 +463,10 @@ static int diff_list_apply_options(
 
 	/* Unset UPDATE_INDEX unless diffing workdir and index */
 	if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_UPDATE_INDEX) &&
-		(!(diff->old_src == GIT_ITERATOR_TYPE_WORKDIR ||
-		   diff->new_src == GIT_ITERATOR_TYPE_WORKDIR) ||
-		 !(diff->old_src == GIT_ITERATOR_TYPE_INDEX ||
-		   diff->new_src == GIT_ITERATOR_TYPE_INDEX)))
+		(!(GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->old_src) ||
+		   GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->new_src)) ||
+		 !(GIT_ITERATOR_TYPE_IS_INDEX_OR_FILELIST(diff->old_src) ||
+		   GIT_ITERATOR_TYPE_IS_INDEX_OR_FILELIST(diff->new_src))))
 		diff->opts.flags &= ~GIT_DIFF_UPDATE_INDEX;
 
 	/* if ignore_submodules not explicitly set, check diff config */
@@ -508,7 +518,9 @@ static void diff_list_free(git_diff *diff)
 {
 	git_vector_free_deep(&diff->deltas);
 
-	git_pathspec__vfree(&diff->pathspec);
+	if (!DIFF_FLAG_IS_SET(diff, GIT_DIFF_ENABLE_FILELIST_MATCH))
+		git_pathspec__vfree(&diff->pathspec);
+
 	git_pool_clear(&diff->pool);
 
 	git__memzero(diff, sizeof(*diff));
@@ -706,17 +718,21 @@ static int maybe_modified(
 	const git_index_entry *nitem = info->nitem;
 	unsigned int omode = oitem->mode;
 	unsigned int nmode = nitem->mode;
-	bool new_is_workdir = (info->new_iter->type == GIT_ITERATOR_TYPE_WORKDIR);
+	bool new_is_workdir = GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(info->new_iter->type);
 	bool modified_uncertain = false;
 	const char *matched_pathspec;
 	int error = 0;
 
-	if (!git_pathspec__match(
-			&diff->pathspec, oitem->path,
-			DIFF_FLAG_IS_SET(diff, GIT_DIFF_DISABLE_PATHSPEC_MATCH),
-			DIFF_FLAG_IS_SET(diff, GIT_DIFF_IGNORE_CASE),
-			&matched_pathspec, NULL))
-		return 0;
+	if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_ENABLE_FILELIST_MATCH)) {
+		matched_pathspec = oitem->path;
+	} else {
+		if (!git_pathspec__match(
+				&diff->pathspec, oitem->path,
+				DIFF_FLAG_IS_SET(diff, GIT_DIFF_DISABLE_PATHSPEC_MATCH),
+				DIFF_FLAG_IS_SET(diff, GIT_DIFF_IGNORE_CASE),
+				&matched_pathspec, NULL))
+			return 0;
+	}
 
 	memset(&noid, 0, sizeof(noid));
 
@@ -944,7 +960,7 @@ static int handle_unmatched_new_item(
 		/* item contained in ignored directory, so skip over it */
 		return git_iterator_advance(&info->nitem, info->new_iter);
 
-	else if (info->new_iter->type != GIT_ITERATOR_TYPE_WORKDIR)
+	else if (!GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(info->new_iter->type))
 		delta_type = GIT_DELTA_ADDED;
 
 	else if (nitem->mode == GIT_FILEMODE_COMMIT) {
@@ -1208,11 +1224,19 @@ int git_diff_index_to_workdir(
 	if (!index && (error = diff_load_index(&index, repo)) < 0)
 		return error;
 
-	DIFF_FROM_ITERATORS(
-		git_iterator_for_index(&a, index, 0, pfx, pfx),
-		git_iterator_for_workdir(
-			&b, repo, index, NULL, GIT_ITERATOR_DONT_AUTOEXPAND, pfx, pfx)
-	);
+	if ((opts) && (opts->pathspec.count > 0) && (opts->flags & GIT_DIFF_ENABLE_FILELIST_MATCH)) {
+		/* We use opts->pathspec to seed the filelists inside the iterators, rather than diff->pathspec. */
+		DIFF_FROM_ITERATORS(
+			git_iterator_for_indexfilelist(&a, index, &opts->pathspec, 0, pfx, pfx),
+			git_iterator_for_workdirfilelist(&b, repo, NULL, &opts->pathspec, 0, pfx, pfx)
+		);
+	} else {
+		DIFF_FROM_ITERATORS(
+			git_iterator_for_index(&a, index, 0, pfx, pfx),
+			git_iterator_for_workdir(
+				&b, repo, index, NULL, GIT_ITERATOR_DONT_AUTOEXPAND, pfx, pfx)
+		);
+	}
 
 	if (!error && DIFF_FLAG_IS_SET(*diff, GIT_DIFF_UPDATE_INDEX))
 		error = git_index_write(index);

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -380,7 +380,7 @@ int git_diff_file_content__load(git_diff_file_content *fc)
 	if ((fc->file->flags & GIT_DIFF_FLAG_BINARY) != 0)
 		return 0;
 
-	if (fc->src == GIT_ITERATOR_TYPE_WORKDIR)
+	if (GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(fc->src))
 		error = diff_file_content_load_workdir(fc);
 	else
 		error = diff_file_content_load_blob(fc);

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -402,7 +402,7 @@ static int apply_splits_and_deletes(
 			if (insert_delete_side_of_split(diff, &onto, delta) < 0)
 				goto on_error;
 
-			if (diff->new_src == GIT_ITERATOR_TYPE_WORKDIR)
+			if (GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->new_src))
 				delta->status = GIT_DELTA_UNTRACKED;
 			else
 				delta->status = GIT_DELTA_ADDED;
@@ -473,7 +473,7 @@ static int similarity_init(
 	info->blob = NULL;
 	git_buf_init(&info->data, 0);
 
-	if (info->file->size > 0 || info->src == GIT_ITERATOR_TYPE_WORKDIR)
+	if (info->file->size > 0 || GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(info->src))
 		return 0;
 
 	return git_diff_file__resolve_zero_size(
@@ -488,7 +488,7 @@ static int similarity_sig(
 	int error = 0;
 	git_diff_file *file = info->file;
 
-	if (info->src == GIT_ITERATOR_TYPE_WORKDIR) {
+	if (GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(info->src)) {
 		if ((error = git_buf_joinpath(
 			&info->data, git_repository_workdir(info->repo), file->path)) < 0)
 			return error;
@@ -574,13 +574,13 @@ static int similarity_measure(
 	/* if exact match is requested, force calculation of missing OIDs now */
 	if (exact_match) {
 		if (git_oid_iszero(&a_file->id) &&
-			diff->old_src == GIT_ITERATOR_TYPE_WORKDIR &&
+			GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->old_src) &&
 			!git_diff__oid_for_file(&a_file->id,
 				diff, a_file->path, a_file->mode, a_file->size))
 			a_file->flags |= GIT_DIFF_FLAG_VALID_ID;
 
 		if (git_oid_iszero(&b_file->id) &&
-			diff->new_src == GIT_ITERATOR_TYPE_WORKDIR &&
+			GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->new_src) &&
 			!git_diff__oid_for_file(&b_file->id,
 				diff, b_file->path, b_file->mode, b_file->size))
 			b_file->flags |= GIT_DIFF_FLAG_VALID_ID;
@@ -1022,7 +1022,7 @@ find_best_matches:
 
 				delta_make_rename(tgt, src, best_match->similarity);
 
-				src->status = (diff->new_src == GIT_ITERATOR_TYPE_WORKDIR) ?
+				src->status = (GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->new_src)) ?
 					GIT_DELTA_UNTRACKED : GIT_DELTA_ADDED;
 				src->nfiles = 1;
 				memset(&src->old_file, 0, sizeof(src->old_file));

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -24,12 +24,12 @@ typedef enum {
 	GIT_ITERATOR_TYPE_WORKDIRFILELIST = 6,
 } git_iterator_type_t;
 
-#define GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(t)						\
-	(((t) == GIT_ITERATOR_TYPE_WORKDIR) ||								\
+#define GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(t) \
+	(((t) == GIT_ITERATOR_TYPE_WORKDIR) ||          \
 	 ((t) == GIT_ITERATOR_TYPE_WORKDIRFILELIST))
 
-#define GIT_ITERATOR_TYPE_IS_INDEX_OR_FILELIST(t)						\
-	(((t) == GIT_ITERATOR_TYPE_INDEX) ||								\
+#define GIT_ITERATOR_TYPE_IS_INDEX_OR_FILELIST(t) \
+	(((t) == GIT_ITERATOR_TYPE_INDEX) ||          \
 	 ((t) == GIT_ITERATOR_TYPE_INDEXFILELIST))
 
 typedef enum {

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -20,7 +20,17 @@ typedef enum {
 	GIT_ITERATOR_TYPE_INDEX = 2,
 	GIT_ITERATOR_TYPE_WORKDIR = 3,
 	GIT_ITERATOR_TYPE_FS = 4,
+	GIT_ITERATOR_TYPE_INDEXFILELIST = 5,
+	GIT_ITERATOR_TYPE_WORKDIRFILELIST = 6,
 } git_iterator_type_t;
+
+#define GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(t)						\
+	(((t) == GIT_ITERATOR_TYPE_WORKDIR) ||								\
+	 ((t) == GIT_ITERATOR_TYPE_WORKDIRFILELIST))
+
+#define GIT_ITERATOR_TYPE_IS_INDEX_OR_FILELIST(t)						\
+	(((t) == GIT_ITERATOR_TYPE_INDEX) ||								\
+	 ((t) == GIT_ITERATOR_TYPE_INDEXFILELIST))
 
 typedef enum {
 	/** ignore case for entry sort order */
@@ -113,6 +123,25 @@ GIT_INLINE(int) git_iterator_for_workdir(
 extern int git_iterator_for_filesystem(
 	git_iterator **out,
 	const char *root,
+	git_iterator_flag_t flags,
+	const char *start,
+	const char *end);
+
+/* Iterates over the given filelist and enumerate the entries that are in the index. */
+int git_iterator_for_indexfilelist(
+	git_iterator **iter,
+	git_index *index,
+	const git_strarray *paths,
+	git_iterator_flag_t flags,
+	const char *start,
+	const char *end);
+
+/* Iterates over the given filelist and enumerate the entries that are in the workdir. */
+int git_iterator_for_workdirfilelist(
+	git_iterator **iter,
+	git_repository *repo,
+	const char *repo_workdir,
+	const git_strarray *paths,
 	git_iterator_flag_t flags,
 	const char *start,
 	const char *end);

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -141,6 +141,8 @@ int git_iterator_for_workdirfilelist(
 	git_iterator **iter,
 	git_repository *repo,
 	const char *repo_workdir,
+	git_index *index,
+	git_tree *tree,
 	const git_strarray *paths,
 	git_iterator_flag_t flags,
 	const char *start,

--- a/src/merge.c
+++ b/src/merge.c
@@ -2358,11 +2358,12 @@ static int merge_check_index(size_t *conflicts, git_repository *repo, git_index 
 			goto done;
 	}
 
+	opts.flags |= GIT_DIFF_ENABLE_FILELIST_MATCH;
 	opts.pathspec.count = staged_paths.length;
 	opts.pathspec.strings = (char **)staged_paths.contents;
 
-	if ((error = git_iterator_for_index(&iter_repo, index_repo, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&iter_new, index_new, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
+	if ((error = git_iterator_for_indexfilelist(&iter_repo, index_repo, &opts.pathspec, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
+		(error = git_iterator_for_indexfilelist(&iter_new, index_new, &opts.pathspec, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
 		(error = git_diff__from_iterators(&index_diff_list, repo, iter_repo, iter_new, &opts)) < 0)
 		goto done;
 
@@ -2406,6 +2407,7 @@ static int merge_check_workdir(size_t *conflicts, git_repository *repo, git_inde
 	 * will be applied by the merge (including conflicts).  Ensure that there
 	 * are no changes in the workdir to these paths.
 	 */
+	opts.flags |= GIT_DIFF_ENABLE_FILELIST_MATCH;
 	opts.pathspec.count = merged_paths->length;
 	opts.pathspec.strings = (char **)merged_paths->contents;
 
@@ -2428,7 +2430,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff_delta *delta;
 	git_vector paths = GIT_VECTOR_INIT;
-	size_t i, index_conflicts = 0, wd_conflicts = 0, conflicts;
+	size_t i, index_conflicts = 0, wd_conflicts = 0, conflicts = 0;
 	const git_index_entry *e;
 	int error = 0;
 

--- a/src/status.c
+++ b/src/status.c
@@ -82,14 +82,14 @@ static unsigned int workdir_delta2status(
 			 * discern between RENAMED vs RENAMED+MODIFED
 			 */
 			if (git_oid_iszero(&idx2wd->old_file.id) &&
-				diff->old_src == GIT_ITERATOR_TYPE_WORKDIR &&
+				GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->old_src) &&
 				!git_diff__oid_for_file(
 					&idx2wd->old_file.id, diff, idx2wd->old_file.path,
 					idx2wd->old_file.mode, idx2wd->old_file.size))
 			idx2wd->old_file.flags |= GIT_DIFF_FLAG_VALID_ID;
 
 			if (git_oid_iszero(&idx2wd->new_file.id) &&
-				diff->new_src == GIT_ITERATOR_TYPE_WORKDIR &&
+				GIT_ITERATOR_TYPE_IS_WORKDIR_OR_FILELIST(diff->new_src) &&
 				!git_diff__oid_for_file(
 					&idx2wd->new_file.id, diff, idx2wd->new_file.path,
 					idx2wd->new_file.mode, idx2wd->new_file.size))

--- a/tests/diff/submodules.c
+++ b/tests/diff/submodules.c
@@ -116,7 +116,7 @@ void test_diff_submodules__dirty_submodule(void)
 	git_diff_free(diff);
 }
 
-void test_diff_submodules__dirty_submodule_2(void)
+static void do__test_diff_submodules__dirty_submodule_2(bool enable_filelist_match)
 {
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff = NULL, *diff2 = NULL;
@@ -135,6 +135,8 @@ void test_diff_submodules__dirty_submodule_2(void)
 		GIT_DIFF_SHOW_UNTRACKED_CONTENT |
 		GIT_DIFF_RECURSE_UNTRACKED_DIRS |
 		GIT_DIFF_DISABLE_PATHSPEC_MATCH;
+	if (enable_filelist_match)
+		opts.flags |= GIT_DIFF_ENABLE_FILELIST_MATCH;
 	opts.old_prefix = "a"; opts.new_prefix = "b";
 	opts.pathspec.count = 1;
 	opts.pathspec.strings = &smpath;
@@ -166,6 +168,16 @@ void test_diff_submodules__dirty_submodule_2(void)
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
 	check_diff_patches(diff, expected_dirty);
 	git_diff_free(diff);
+}
+
+void test_diff_submodules__dirty_submodule_2_regular(void)
+{
+	do__test_diff_submodules__dirty_submodule_2(false);
+}
+
+void test_diff_submodules__dirty_submodule_2_filelist(void)
+{
+	do__test_diff_submodules__dirty_submodule_2(true);
 }
 
 void test_diff_submodules__submod2_index_to_wd(void)
@@ -225,7 +237,7 @@ void test_diff_submodules__submod2_head_to_index(void)
 	git_tree_free(head);
 }
 
-void test_diff_submodules__invalid_cache(void)
+static void do__test_diff_submodules__invalid_cache(bool enable_filelist_match)
 {
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff = NULL;
@@ -254,6 +266,8 @@ void test_diff_submodules__invalid_cache(void)
 	g_repo = setup_fixture_submod2();
 
 	opts.flags = GIT_DIFF_INCLUDE_UNTRACKED;
+	if (enable_filelist_match)
+		opts.flags |= GIT_DIFF_ENABLE_FILELIST_MATCH;
 	opts.old_prefix = "a"; opts.new_prefix = "b";
 	opts.pathspec.count = 1;
 	opts.pathspec.strings = &smpath;
@@ -355,6 +369,16 @@ void test_diff_submodules__invalid_cache(void)
 
 	git_index_free(smindex);
 	git_repository_free(smrepo);
+}
+
+void test_diff_submodules__invalid_cache_regular(void)
+{
+	do__test_diff_submodules__invalid_cache(false);
+}
+
+void test_diff_submodules__invalid_cache_filelist(void)
+{
+	do__test_diff_submodules__invalid_cache(true);
 }
 
 void test_diff_submodules__diff_ignore_options(void)

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -993,3 +993,196 @@ void test_repo_iterator__skips_fifos_and_such(void)
 	git_iterator_free(i);
 #endif
 }
+
+void test_repo_iterator__indexfilelist(void)
+{
+	git_iterator *i;
+	git_index *index;
+	git_vector filelist;
+	git_strarray paths;
+	int default_icase;
+	int expect;
+
+	cl_git_pass(git_vector_init(&filelist, 100, &git__strcmp_cb));
+	cl_git_pass(git_vector_insert(&filelist, "a"));
+	cl_git_pass(git_vector_insert(&filelist, "B"));
+	cl_git_pass(git_vector_insert(&filelist, "c"));
+	cl_git_pass(git_vector_insert(&filelist, "D"));
+	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k/1"));
+	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+	cl_git_pass(git_vector_insert(&filelist, "L/1"));
+	paths.count = filelist.length;
+	paths.strings = (char **)filelist.contents;
+
+	g_repo = cl_git_sandbox_init("icase");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	/* In this test we DO NOT force a case setting on the index. */
+	default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
+
+	/* All indexfilelist iterator tests are "autoexpand with no tree entries" */
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, NULL, NULL));
+	expect_iterator_items(i, 8, NULL, 8, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "c", NULL));
+	/* (c D e k/1 k/a L ==> 6) vs (c e k/1 k/a ==> 4) */
+	expect = ((default_icase) ? 6 : 4);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, NULL, "e"));
+	/* (a B c D e ==> 5) vs (B D L/1 a c e ==> 6) */
+	expect = ((default_icase) ? 5 : 6);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
+	git_iterator_free(i);
+
+	git_index_free(index);
+	git_vector_free(&filelist);
+}
+
+void test_repo_iterator__indexfilelist_icase(void)
+{
+	git_iterator *i;
+	git_index *index;
+	int caps;
+	git_vector filelist;
+	git_strarray paths;
+
+	cl_git_pass(git_vector_init(&filelist, 100, &git__strcmp_cb));
+	cl_git_pass(git_vector_insert(&filelist, "a"));
+	cl_git_pass(git_vector_insert(&filelist, "B"));
+	cl_git_pass(git_vector_insert(&filelist, "c"));
+	cl_git_pass(git_vector_insert(&filelist, "D"));
+	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k/1"));
+	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+	cl_git_pass(git_vector_insert(&filelist, "L/1"));
+	paths.count = filelist.length;
+	paths.strings = (char **)filelist.contents;
+
+	g_repo = cl_git_sandbox_init("icase");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	caps = git_index_caps(index);
+
+	/* force case sensitivity */
+	cl_git_pass(git_index_set_caps(index, caps & ~GIT_INDEXCAP_IGNORE_CASE));
+
+	/* All indexfilelist iterator tests are "autoexpand with no tree entries" */
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "c", "k/D"));
+	expect_iterator_items(i, 3, NULL, 3, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "k", "k/Z"));
+	expect_iterator_items(i, 1, NULL, 1, NULL);
+	git_iterator_free(i);
+
+	/* force case insensitivity */
+	cl_git_pass(git_index_set_caps(index, caps | GIT_INDEXCAP_IGNORE_CASE));
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "c", "k/D"));
+	expect_iterator_items(i, 5, NULL, 5, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "k", "k/Z"));
+	expect_iterator_items(i, 2, NULL, 2, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_index_set_caps(index, caps));
+	git_index_free(index);
+	git_vector_free(&filelist);
+}
+
+void test_repo_iterator__workdirfilelist(void)
+{
+	git_iterator *i;
+	git_vector filelist;
+	git_strarray paths;
+	bool default_icase;
+	int expect;
+
+	cl_git_pass(git_vector_init(&filelist, 100, &git__strcmp_cb));
+	cl_git_pass(git_vector_insert(&filelist, "a"));
+	cl_git_pass(git_vector_insert(&filelist, "B"));
+	cl_git_pass(git_vector_insert(&filelist, "c"));
+	cl_git_pass(git_vector_insert(&filelist, "D"));
+	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k/1"));
+	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+	cl_git_pass(git_vector_insert(&filelist, "L/1"));
+	paths.count = filelist.length;
+	paths.strings = (char **)filelist.contents;
+
+	g_repo = cl_git_sandbox_init("icase");
+
+	/* All indexfilelist iterator tests are "autoexpand with no tree entries" */
+	/* In this test we DO NOT force a case on the iteratords and verify default behavior. */
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, 0, NULL, NULL));
+	expect_iterator_items(i, 8, NULL, 8, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, 0, "c", NULL));
+	default_icase = git_iterator_ignore_case(i);
+	/* (c D e k/1 k/a L ==> 6) vs (c e k/1 k/a ==> 4) */
+	expect = ((default_icase) ? 6 : 4);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, 0, NULL, "e"));
+	default_icase = git_iterator_ignore_case(i);
+	/* (a B c D e ==> 5) vs (B D L/1 a c e ==> 6) */
+	expect = ((default_icase) ? 5 : 6);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
+	git_iterator_free(i);
+
+	git_vector_free(&filelist);
+}
+
+void test_repo_iterator__workdirfilelist_icase(void)
+{
+	git_iterator *i;
+	git_iterator_flag_t flag;
+	git_vector filelist;
+	git_strarray paths;
+
+	cl_git_pass(git_vector_init(&filelist, 100, &git__strcmp_cb));
+	cl_git_pass(git_vector_insert(&filelist, "a"));
+	cl_git_pass(git_vector_insert(&filelist, "B"));
+	cl_git_pass(git_vector_insert(&filelist, "c"));
+	cl_git_pass(git_vector_insert(&filelist, "D"));
+	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k/1"));
+	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+	cl_git_pass(git_vector_insert(&filelist, "L/1"));
+	paths.count = filelist.length;
+	paths.strings = (char **)filelist.contents;
+
+	g_repo = cl_git_sandbox_init("icase");
+
+	flag = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "c", "k/D"));
+	expect_iterator_items(i, 3, NULL, 3, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "k", "k/Z"));
+	expect_iterator_items(i, 1, NULL, 1, NULL);
+	git_iterator_free(i);
+
+	flag = GIT_ITERATOR_IGNORE_CASE;
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "c", "k/D"));
+	expect_iterator_items(i, 5, NULL, 5, NULL);
+	git_iterator_free(i);
+
+	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "k", "k/Z"));
+	expect_iterator_items(i, 2, NULL, 2, NULL);
+	git_iterator_free(i);
+
+	git_vector_free(&filelist);
+}

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -1024,27 +1024,6 @@ void test_repo_iterator__indexfilelist(void)
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
 
-#if 0 /* We do not currently allow "start" and "end" args for filelist iterators. */
-	{
-		int default_icase;
-		int expect;
-
-		default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
-
-		cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "c", NULL));
-		/* (c D e k/1 k/a L ==> 6) vs (c e k/1 k/a ==> 4) */
-		expect = ((default_icase) ? 6 : 4);
-		expect_iterator_items(i, expect, NULL, expect, NULL);
-		git_iterator_free(i);
-
-		cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, NULL, "e"));
-		/* (a B c D e ==> 5) vs (B D L/1 a c e ==> 6) */
-		expect = ((default_icase) ? 5 : 6);
-		expect_iterator_items(i, expect, NULL, expect, NULL);
-		git_iterator_free(i);
-	}
-#endif
-
 	git_index_free(index);
 	git_vector_free(&filelist);
 }
@@ -1083,32 +1062,12 @@ void test_repo_iterator__indexfilelist_icase(void)
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
 
-#if 0 /* We do not currently allow "start" and "end" args for filelist iterators. */
-	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "c", "k/D"));
-	expect_iterator_items(i, 3, NULL, 3, NULL);
-	git_iterator_free(i);
-
-	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "k", "k/Z"));
-	expect_iterator_items(i, 1, NULL, 1, NULL);
-	git_iterator_free(i);
-#endif
-
 	/* force case insensitivity */
 	cl_git_pass(git_index_set_caps(index, caps | GIT_INDEXCAP_IGNORE_CASE));
 
 	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, NULL, NULL));
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
-
-#if 0 /* We do not currently allow "start" and "end" args for filelist iterators. */
-	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "c", "k/D"));
-	expect_iterator_items(i, 5, NULL, 5, NULL);
-	git_iterator_free(i);
-
-	cl_git_pass(git_iterator_for_indexfilelist(&i, index, &paths, 0, "k", "k/Z"));
-	expect_iterator_items(i, 2, NULL, 2, NULL);
-	git_iterator_free(i);
-#endif
 
 	cl_git_pass(git_index_set_caps(index, caps));
 	git_index_free(index);
@@ -1142,27 +1101,6 @@ void test_repo_iterator__workdirfilelist(void)
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
 
-#if 0 /* We do not currently allow "start" and "end" args for filelist iterators. */
-	{
-		bool default_icase;
-		int expect;
-
-		cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, 0, "c", NULL));
-		default_icase = git_iterator_ignore_case(i);
-		/* (c D e k/1 k/a L ==> 6) vs (c e k/1 k/a ==> 4) */
-		expect = ((default_icase) ? 6 : 4);
-		expect_iterator_items(i, expect, NULL, expect, NULL);
-		git_iterator_free(i);
-
-		cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, 0, NULL, "e"));
-		default_icase = git_iterator_ignore_case(i);
-		/* (a B c D e ==> 5) vs (B D L/1 a c e ==> 6) */
-		expect = ((default_icase) ? 5 : 6);
-		expect_iterator_items(i, expect, NULL, expect, NULL);
-		git_iterator_free(i);
-	}
-#endif
-
 	git_vector_free(&filelist);
 }
 
@@ -1193,31 +1131,11 @@ void test_repo_iterator__workdirfilelist_icase(void)
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
 
-#if 0 /* We do not currently allow "start" and "end" args for filelist iterators. */
-	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "c", "k/D"));
-	expect_iterator_items(i, 3, NULL, 3, NULL);
-	git_iterator_free(i);
-
-	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "k", "k/Z"));
-	expect_iterator_items(i, 1, NULL, 1, NULL);
-	git_iterator_free(i);
-#endif
-
 	flag = GIT_ITERATOR_IGNORE_CASE;
 
 	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, NULL, NULL, &paths, 0, NULL, NULL));
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
-
-#if 0 /* We do not currently allow "start" and "end" args for filelist iterators. */
-	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "c", "k/D"));
-	expect_iterator_items(i, 5, NULL, 5, NULL);
-	git_iterator_free(i);
-
-	cl_git_pass(git_iterator_for_workdirfilelist(&i, g_repo, NULL, &paths, flag, "k", "k/Z"));
-	expect_iterator_items(i, 2, NULL, 2, NULL);
-	git_iterator_free(i);
-#endif
 
 	git_vector_free(&filelist);
 }


### PR DESCRIPTION
Here is code implementing the filelist iterators that were discussed in:
https://github.com/libgit2/libgit2/issues/2835

This commit contains the "index-filelist" and "workdir-filelist" iterators and unit tests for each.

It also contains changes to "merge" and "diff" to use them when appropriate.

I'll submit a follow-up PR with some large-merge test cases.
