### PR TITLE
Speed up AppVeyor builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ environment:
     ARCH: 64
 build_script:
 - ps: |
-    choco install cmake
-    choco install python2
     mkdir build
     cd build
     cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$env:GENERATOR"


### PR DESCRIPTION
AppVeyor build machines come with Python 2.7 and CMake 2.8 pre-installed and in the PATH.