### PR TITLE
buffer: Expose git_buf_put() to bindings

### DIFF
--- a/include/git2/buffer.h
+++ b/include/git2/buffer.h
@@ -121,6 +121,16 @@ GIT_EXTERN(int) git_buf_is_binary(const git_buf *buf);
 */
 GIT_EXTERN(int) git_buf_contains_nul(const git_buf *buf);
 
+/**
+* Append to an existing buffer a copy of some raw data.
+*
+* @param buffer The buffer to append to
+* @param data The data to copy into the buffer
+* @param len The length of the data to copy into the buffer
+* @return 0 on success, -1 on allocation failure
+*/
+GIT_EXTERN(int) git_buf_put(git_buf *buf, const char *data, size_t len);
+
 GIT_END_DECL
 
 /** @} */

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -89,7 +89,6 @@ GIT_INLINE(bool) git_buf_oom(const git_buf *buf)
 int git_buf_sets(git_buf *buf, const char *string);
 int git_buf_putc(git_buf *buf, char c);
 int git_buf_putcn(git_buf *buf, char c, size_t len);
-int git_buf_put(git_buf *buf, const char *data, size_t len);
 int git_buf_puts(git_buf *buf, const char *string);
 int git_buf_printf(git_buf *buf, const char *format, ...) GIT_FORMAT_PRINTF(2, 3);
 int git_buf_vprintf(git_buf *buf, const char *format, va_list ap);


### PR DESCRIPTION
This should allow to more easily deal with filters from a binding standpoint.

In libgit2/libgit2sharp#854 and libgit2/libgit2sharp#946, filters invoke `git_buf_set()` to provide libgit2 with the result of the filtering.

Instead of calling `git_buf_set()` once, the idea would be to invoke `git_buf_put()` each time the binding callback outputs a chunk. 

This should provide the bindings with a stream-like approach when doing filters (working at the chunk level) until libgit2 provides a real stream oriented API for filters.

Another side effect will  be to smoothen the overall memory pressure.