### PR TITLE
Fixed error when including git2/include/sys/stream.h

### DIFF
--- a/include/git2/sys/stream.h
+++ b/include/git2/sys/stream.h
@@ -37,4 +37,6 @@ typedef struct git_stream {
 	void (*free)(struct git_stream *);
 } git_stream;
 
+GIT_END_DECL
+
 #endif


### PR DESCRIPTION
`include/git2/sys/stream.h` doesn't have a trailing `GIT_END_DECL` which is causing a compile time error when including it in other files.