### PR TITLE
Fix leaking of the TLS objects on POSIX platforms

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -302,15 +302,16 @@ int git_libgit2_shutdown(void)
 	pthread_once_t new_once = PTHREAD_ONCE_INIT;
 	int ret;
 
+	if ((ptr = pthread_getspecific(_tls_key)) != NULL) {
+		pthread_setspecific(_tls_key, NULL);
+		git__free(ptr);
+	}
+
 	if ((ret = git_atomic_dec(&git__n_inits)) > 0)
 		return ret;
 
 	/* Shut down any subsystems that have global state */
 	git__shutdown();
-
-	ptr = pthread_getspecific(_tls_key);
-	pthread_setspecific(_tls_key, NULL);
-	git__free(ptr);
 
 	pthread_key_delete(_tls_key);
 	git_mutex_free(&git__mwindow_mutex);


### PR DESCRIPTION
Previously we only free the global state for the thread
on which the actual shutdown is performed. Global state
objects belonging to other threads actually got leaked.
This patch fixes the issue by freeing the thread specific
global object at the beginning of git_libgit2_shutdown
regardless the number of the init. This way we require
that each thread call git_libgit2_shutdown for proper
cleanup, which is reasonable.