### PR TITLE
Remove extra semicolon outside of a function

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -7,7 +7,7 @@
 #include "git2/oid.h"
 #include <ctype.h>
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 const char *git_attr__true  = "[internal]__TRUE__";
 const char *git_attr__false = "[internal]__FALSE__";

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -5,7 +5,7 @@
 #include "sysdir.h"
 #include "ignore.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 GIT_INLINE(int) attr_cache_lock(git_attr_cache *cache)
 {

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -32,7 +32,7 @@
 #include "pool.h"
 #include "strmap.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 /* See docs/checkout-internals.md for more information */
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -400,7 +400,7 @@ GIT_COMMIT_GETTER(const char *, raw_header, commit->raw_header)
 GIT_COMMIT_GETTER(git_time_t, time, commit->committer->when.time)
 GIT_COMMIT_GETTER(int, time_offset, commit->committer->when.offset)
 GIT_COMMIT_GETTER(unsigned int, parentcount, (unsigned int)git_array_size(commit->parent_ids))
-GIT_COMMIT_GETTER(const git_oid *, tree_id, &commit->tree_id);
+GIT_COMMIT_GETTER(const git_oid *, tree_id, &commit->tree_id)
 
 const char *git_commit_message(const git_commit *commit)
 {

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 #include <regex.h>
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 typedef struct cvar_t {
 	struct cvar_t *next;

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -17,7 +17,7 @@
 #include "config.h"
 #include "repository.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 typedef enum {
 	DIFF_DRIVER_AUTO = 0,

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -13,7 +13,7 @@
 #include "win32/findfile.h"
 #endif
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 int git_futils_mkpath2file(const char *file_path, const mode_t mode)
 {

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -14,7 +14,7 @@
 #include "strmap.h"
 #include "pack.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 #define DEFAULT_WINDOW_SIZE \
 	(sizeof(void*) >= 8 \

--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -18,7 +18,7 @@
 #include "git2/types.h"
 #include "git2/pack.h"
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 struct memobject {
 	git_oid oid;

--- a/src/offmap.h
+++ b/src/offmap.h
@@ -17,11 +17,11 @@
 #define kfree git__free
 #include "khash.h"
 
-__KHASH_TYPE(off, git_off_t, void *);
+__KHASH_TYPE(off, git_off_t, void *)
 typedef khash_t(off) git_offmap;
 
 #define GIT__USE_OFFMAP \
-	__KHASH_IMPL(off, static kh_inline, git_off_t, void *, 1, kh_int64_hash_func, kh_int64_hash_equal);
+	__KHASH_IMPL(off, static kh_inline, git_off_t, void *, 1, kh_int64_hash_func, kh_int64_hash_equal)
 
 #define git_offmap_alloc()  kh_init(off)
 #define git_offmap_free(h)  kh_destroy(off, h), h = NULL

--- a/src/oidmap.h
+++ b/src/oidmap.h
@@ -17,7 +17,7 @@
 #define kfree git__free
 #include "khash.h"
 
-__KHASH_TYPE(oid, const git_oid *, void *);
+__KHASH_TYPE(oid, const git_oid *, void *)
 typedef khash_t(oid) git_oidmap;
 
 GIT_INLINE(khint_t) git_oidmap_hash(const git_oid *oid)

--- a/src/pack.h
+++ b/src/pack.h
@@ -72,8 +72,8 @@ typedef git_array_t(struct pack_chain_elem) git_dependency_chain;
 
 #include "offmap.h"
 
-GIT__USE_OFFMAP;
-GIT__USE_OIDMAP;
+GIT__USE_OFFMAP
+GIT__USE_OIDMAP
 
 #define GIT_PACK_CACHE_MEMORY_LIMIT 16 * 1024 * 1024
 #define GIT_PACK_CACHE_SIZE_LIMIT 1024 * 1024 /* don't bother caching anything over 1MB */

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -26,7 +26,7 @@
 #include <git2/sys/refs.h>
 #include <git2/sys/reflog.h>
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 #define DEFAULT_NESTING_LEVEL	5
 #define MAX_NESTING_LEVEL		10

--- a/src/refs.c
+++ b/src/refs.c
@@ -24,7 +24,7 @@
 #include <git2/signature.h>
 #include <git2/commit.h>
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 #define DEFAULT_NESTING_LEVEL	5
 #define MAX_NESTING_LEVEL		10

--- a/src/revwalk.h
+++ b/src/revwalk.h
@@ -14,7 +14,7 @@
 #include "pool.h"
 #include "vector.h"
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 struct git_revwalk {
 	git_repository *repo;

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -1,6 +1,6 @@
 #include "sortedcache.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 int git_sortedcache_new(
 	git_sortedcache **out,

--- a/src/strmap.h
+++ b/src/strmap.h
@@ -16,7 +16,7 @@
 #define kfree git__free
 #include "khash.h"
 
-__KHASH_TYPE(str, const char *, void *);
+__KHASH_TYPE(str, const char *, void *)
 typedef khash_t(str) git_strmap;
 typedef khiter_t git_strmap_iter;
 

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -85,7 +85,7 @@ static kh_inline int str_equal_no_trailing_slash(const char *a, const char *b)
 
 __KHASH_IMPL(
 	str, static kh_inline, const char *, void *, 1,
-	str_hash_no_trailing_slash, str_equal_no_trailing_slash);
+	str_hash_no_trailing_slash, str_equal_no_trailing_slash)
 
 static int submodule_cache_init(git_repository *repo, int refresh);
 static void submodule_cache_free(git_submodule_cache *cache);

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -17,7 +17,7 @@
 #include "git2/sys/refs.h"
 #include "git2/sys/refdb_backend.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 typedef struct {
 	const char *name;

--- a/src/tree.c
+++ b/src/tree.c
@@ -17,7 +17,7 @@
 #define DEFAULT_TREE_SIZE 16
 #define MAX_FILEMODE_BYTES 6
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 static bool valid_filemode(const int filemode)
 {

--- a/tests/core/oidmap.c
+++ b/tests/core/oidmap.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "oidmap.h"
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 typedef struct {
 	git_oid oid;

--- a/tests/core/strmap.c
+++ b/tests/core/strmap.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "strmap.h"
 
-GIT__USE_STRMAP;
+GIT__USE_STRMAP
 
 git_strmap *g_table;
 


### PR DESCRIPTION
This pull request is related to the R bindings [git2r](https://github.com/ropensci/git2r) and the pedantic compiler warnings in https://github.com/ropensci/git2r/issues/101

This changes removes `;` outside of a function, which generates the following warning with gcc and pedantic:
`ISO C does not allow extra ‘;’ outside of a function`
