### PR TITLE
Added strategy argument to git_diff_merge()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,3 +247,6 @@ v0.22
   functions. This is not something which we can know to do. A
   last-resort convenience function is provided in sys/openssl.h,
   `git_openssl_set_locking()` which can be used to set the locking.
+
+* `git_diff_merge()` now takes an explicit strategy argument on how to perform
+  the merge.

--- a/src/diff.c
+++ b/src/diff.c
@@ -1263,7 +1263,7 @@ int git_diff_tree_to_workdir_with_index(
 
 	if (!(error = git_diff_tree_to_index(&d1, repo, old_tree, index, opts)) &&
 		!(error = git_diff_index_to_workdir(&d2, repo, index, opts)))
-		error = git_diff_merge(d1, d2);
+		error = git_diff_merge(d1, d2, GIT_DIFF_MERGE_CGIT);
 
 	git_diff_free(d2);
 

--- a/tests/diff/submodules.c
+++ b/tests/diff/submodules.c
@@ -154,7 +154,7 @@ void test_diff_submodules__dirty_submodule_2(void)
 
 		cl_git_pass(git_repository_head_tree(&head, g_repo));
 		cl_git_pass(git_diff_tree_to_index(&diff2, g_repo, head, NULL, &opts));
-		cl_git_pass(git_diff_merge(diff, diff2));
+		cl_git_pass(git_diff_merge(diff, diff2, GIT_DIFF_MERGE_CGIT));
 		git_diff_free(diff2);
 		git_tree_free(head);
 

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -188,7 +188,7 @@ void test_diff_workdir__to_tree(void)
 	 */
 	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, a, NULL, &opts));
 	cl_git_pass(git_diff_index_to_workdir(&diff2, g_repo, NULL, &opts));
-	cl_git_pass(git_diff_merge(diff, diff2));
+	cl_git_pass(git_diff_merge(diff, diff2, GIT_DIFF_MERGE_CGIT));
 	git_diff_free(diff2);
 
 	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
@@ -225,7 +225,7 @@ void test_diff_workdir__to_tree(void)
 	 */
 	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, b, NULL, &opts));
 	cl_git_pass(git_diff_index_to_workdir(&diff2, g_repo, NULL, &opts));
-	cl_git_pass(git_diff_merge(diff, diff2));
+	cl_git_pass(git_diff_merge(diff, diff2, GIT_DIFF_MERGE_CGIT));
 	git_diff_free(diff2);
 
 	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
@@ -261,7 +261,7 @@ void test_diff_workdir__to_tree(void)
 
 	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, b, NULL, &opts));
 	cl_git_pass(git_diff_index_to_workdir(&diff2, g_repo, NULL, &opts));
-	cl_git_pass(git_diff_merge(diff, diff2));
+	cl_git_pass(git_diff_merge(diff, diff2, GIT_DIFF_MERGE_CGIT));
 	git_diff_free(diff2);
 
 	memset(&exp, 0, sizeof(exp));
@@ -572,7 +572,7 @@ void test_diff_workdir__head_index_and_workdir_all_differ(void)
 		cl_assert_equal_i(0, exp.line_dels);
 	}
 
-	cl_git_pass(git_diff_merge(diff_i2t, diff_w2i));
+	cl_git_pass(git_diff_merge(diff_i2t, diff_w2i, GIT_DIFF_MERGE_CGIT));
 
 	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
 		memset(&exp, 0, sizeof(exp));
@@ -1099,7 +1099,7 @@ void test_diff_workdir__to_tree_issue_1397(void)
 
 	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, a, NULL, &opts));
 	cl_git_pass(git_diff_index_to_workdir(&diff2, g_repo, NULL, &opts));
-	cl_git_pass(git_diff_merge(diff, diff2));
+	cl_git_pass(git_diff_merge(diff, diff2, GIT_DIFF_MERGE_CGIT));
 	git_diff_free(diff2);
 
 	memset(&exp, 0, sizeof(exp));


### PR DESCRIPTION
git_diff_merge() now lets the caller choose between a naive merge strategy, which merges the delta records without any special cases, or a C git one, which emulates 'git diff {sha}' and its special cases.