### PR TITLE
Fix leaking of the TLS objects on POSIX platforms

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -273,8 +273,9 @@ static void init_once(void)
 {
 	if ((init_error = git_mutex_init(&git__mwindow_mutex)) != 0)
 		return;
-	pthread_key_create(&_tls_key, &cb__free_status);
 
+	if (!_tls_key)
+		pthread_key_create(&_tls_key, &cb__free_status);
 
 	/* Initialize any other subsystems that have global state */
 	if ((init_error = git_hash_global_init()) >= 0)
@@ -308,11 +309,6 @@ int git_libgit2_shutdown(void)
 	/* Shut down any subsystems that have global state */
 	git__shutdown();
 
-	ptr = pthread_getspecific(_tls_key);
-	pthread_setspecific(_tls_key, NULL);
-	git__free(ptr);
-
-	pthread_key_delete(_tls_key);
 	git_mutex_free(&git__mwindow_mutex);
 	_once_init = new_once;
 


### PR DESCRIPTION
Previously we free the global state for the thread on
which the actual shutdown is performed and then delete
the TLS key. Global state objects belonging to other
threads actually got leaked if those threads haven't
exited when the actual shutdown happens. This is
because the TLS key got deleted and as a result the
destructor cb__free_status won't be called for those
threads. This patch fixes the issue by keeping the
TLS key as long as possible. Although with this patch
the TLS key will never get deleted, it's OK because only
one key is globally alive until the whole process exits.