### PR TITLE
Fix Mac 32 bit build problem described in libgit2/libgit2#2917

### DIFF
--- a/src/integer.h
+++ b/src/integer.h
@@ -58,7 +58,7 @@ GIT_INLINE(bool) git__add_uint64_overflow(uint64_t *out, uint64_t one, uint64_t 
 #if (SIZE_MAX == UINT_MAX) && __has_builtin(__builtin_uadd_overflow)
 # define git__add_sizet_overflow(out, one, two) \
 	__builtin_uadd_overflow(one, two, out)
-# define git__multiply_sizet_overflow(out, one, two)
+# define git__multiply_sizet_overflow(out, one, two) \
 	__builtin_umul_overflow(one, two, out)
 #elif (SIZE_MAX == ULONG_MAX) && __has_builtin(__builtin_uaddl_overflow)
 # define git__add_sizet_overflow(out, one, two) \


### PR DESCRIPTION
Fix compile problem reported in #2917 on Mac when 32 bit.
