### PR TITLE
Fix build on mingw

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -33,6 +33,7 @@
 # include <direct.h>
 # include <winsock2.h>
 # include <windows.h>
+# include <ws2tcpip.h>
 # include "win32/msvc-compat.h"
 # include "win32/mingw-compat.h"
 # include "win32/error.h"

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -7,10 +7,6 @@
 
 #ifdef GIT_SSL
 
-#include <openssl/ssl.h>
-#include <openssl/err.h>
-#include <openssl/x509v3.h>
-
 #include <ctype.h>
 
 #include "global.h"
@@ -19,6 +15,10 @@
 #include "socket_stream.h"
 #include "netops.h"
 #include "git2/transport.h"
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/x509v3.h>
 
 static int ssl_set_error(SSL *ssl, int error)
 {


### PR DESCRIPTION
Fixes issue #2850.

Might break build on Windows, I don't know! I don't have a Windows machine where to test that.

Also I put this to the maint/v0.22 branch because master branch doesn't build on mingw because of commit 3cda6be76b which includes various headers unconditionally on every platform. One or more of those headers aren't available on mingw.