### PR TITLE
Fix crash in git_clone on extremely large repos

### DIFF
--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -41,7 +41,7 @@ extern int p_chdir(const char* path);
 extern int p_chmod(const char* path, mode_t mode);
 extern int p_rmdir(const char* path);
 extern int p_access(const char* path, mode_t mode);
-extern int p_ftruncate(int fd, long size);
+extern int p_ftruncate(int fd, git_off_t size);
 
 /* p_lstat is almost but not quite POSIX correct.  Specifically, the use of
  * ENOTDIR is wrong, in that it does not mean precisely that a non-directory

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -55,12 +55,10 @@ int p_ftruncate(int fd, git_off_t size)
 		return -1;
 	}
 
-#if defined(_MSC_VER) && _MSC_VER >= 1500
+#if !defined(__MINGW32__)
 	return ((_chsize_s(fd, size) == 0) ? 0 : -1);
 #else
-	/* TODO Find a replacement for _chsize() that handles big files.
-	 *      This comment is probably __MINGW32__ specific.
-	 */
+	/* TODO MINGW32 Find a replacement for _chsize() that handles big files. */
 	if (size > INT32_MAX) {
 		errno = EFBIG;
 		return -1;

--- a/tests/core/ftruncate.c
+++ b/tests/core/ftruncate.c
@@ -1,0 +1,48 @@
+/**
+ * Some tests for p_ftruncate() to ensure that
+ * properly handles large (2Gb+) files.
+ */
+
+#include "clar_libgit2.h"
+
+static const char *filename = "core_ftruncate.txt";
+static int fd = -1;
+
+void test_core_ftruncate__initialize(void)
+{
+	if (!cl_getenv("GITTEST_INVASIVE_FS_SIZE"))
+		cl_skip();
+
+	cl_must_pass((fd = p_open(filename, O_CREAT | O_RDWR, 0644)));
+}
+
+void test_core_ftruncate__cleanup(void)
+{
+	if (fd < 0)
+		return;
+
+	p_close(fd);
+	fd = 0;
+
+	p_unlink(filename);
+}
+
+static void _extend(git_off_t i64len)
+{
+	struct stat st;
+	int error;
+
+	cl_assert((error = p_ftruncate(fd, i64len)) == 0);
+	cl_assert((error = p_fstat(fd, &st)) == 0);
+	cl_assert(st.st_size == i64len);
+}
+
+void test_core_ftruncate__2gb(void)
+{
+	_extend(0x80000001);
+}
+
+void test_core_ftruncate__4gb(void)
+{
+	_extend(0x100000001);
+}


### PR DESCRIPTION
A crash was observed on Windows when cloning a very large repo. In this instance, the received packfile was nearly 6Gb.

The problem was in sloppy casting of the "size" field from src/indexer.c:append_to_pack() to src/win32/posix_w32.c:p_ftruncate() to _chsize_s().
Where the file position was being truncated and then sign-extended.

Also fixed the return value from _chsize_s() which differs from _chsize().

