### PR TITLE
git_branch_delete() should ignore errors from non-existing reflogs

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -138,8 +138,13 @@ int git_branch_delete(git_reference *branch)
 	if (git_reference_delete(branch) < 0)
 		goto on_error;
 
-	if (git_reflog_delete(git_reference_owner(branch), git_reference_name(branch)) < 0)
+	if (git_reflog_delete(git_reference_owner(branch), git_reference_name(branch)) < 0) {
+		if (error == GIT_ENOTFOUND) {
+			giterr_clear();
+			error = 0;
+		}
 		goto on_error;
+	}
 
 	error = 0;
 


### PR DESCRIPTION
See #2842 for details