### PR TITLE
http: enforce the credential types

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -350,6 +350,11 @@ static int on_headers_complete(http_parser *parser)
 				} else {
 					assert(t->cred);
 
+					if (!(t->cred->credtype & allowed_auth_types)) {
+						giterr_set(GITERR_NET, "credentials callback returned an invalid cred type");
+						return t->parse_error = PARSE_ERROR_GENERIC;
+					}
+
 					/* Successfully acquired a credential. */
 					t->parse_error = PARSE_ERROR_REPLAY;
 					return 0;


### PR DESCRIPTION
The user may decide to return any type of credential, including ones we
did not say we support. Add a check to make sure the user returned an
object of the right type and error out if not.

---

This should handle #2940 @mattyclarkson can you give it a try?