### PR TITLE
diff_tform: don't compare empty hashsig_heaps

### DIFF
--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -34,6 +34,7 @@ typedef struct {
 struct git_hashsig {
 	hashsig_heap mins;
 	hashsig_heap maxs;
+	size_t lines;
 	git_hashsig_option_t opt;
 };
 
@@ -185,8 +186,10 @@ static int hashsig_add_hashes(
 			++scan;
 
 			/* check run terminator */
-			if (ch == '\n' || ch == '\0')
+			if (ch == '\n' || ch == '\0') {
+				sig->lines++;
 				break;
+			}
 
 			++len;
 			HASHSIG_HASH_MIX(state, ch);
@@ -314,9 +317,6 @@ static int hashsig_heap_compare(const hashsig_heap *a, const hashsig_heap *b)
 
 	assert(a->cmp == b->cmp);
 
-	if (a->size + b->size == 0)
-		return 0;
-
 	/* hash heaps are sorted - just look for overlap vs total */
 
 	for (i = 0, j = 0; i < a->size && j < b->size; ) {
@@ -336,6 +336,18 @@ static int hashsig_heap_compare(const hashsig_heap *a, const hashsig_heap *b)
 
 int git_hashsig_compare(const git_hashsig *a, const git_hashsig *b)
 {
+	/* if we have no elements in either file then each file is either
+	 * empty or blank.  if we're ignoring whitespace then the files are
+	 * similar, otherwise they're dissimilar.
+	 */
+	if (a->mins.size == 0 && b->mins.size == 0) {
+		if ((!a->lines && !b->lines) ||
+			(a->opt & GIT_HASHSIG_IGNORE_WHITESPACE))
+			return HASHSIG_SCALE;
+		else
+			return 0;
+	}
+
 	/* if we have fewer than the maximum number of elements, then just use
 	 * one array since the two arrays will be the same
 	 */

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -314,6 +314,9 @@ static int hashsig_heap_compare(const hashsig_heap *a, const hashsig_heap *b)
 
 	assert(a->cmp == b->cmp);
 
+	if (a->size + b->size == 0)
+		return 0;
+
 	/* hash heaps are sorted - just look for overlap vs total */
 
 	for (i = 0, j = 0; i < a->size && j < b->size; ) {

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -1602,3 +1602,41 @@ void test_diff_rename__by_config_doesnt_mess_with_whitespace_settings(void)
 	git_tree_free(tree1);
 	git_tree_free(tree2);
 }
+
+/* test some variations on empty files */
+void test_diff_rename__empty_files(void)
+{
+	git_index *index;
+	git_diff *diff = NULL;
+	diff_expects exp;
+	git_diff_options diffopts = GIT_DIFF_OPTIONS_INIT;
+	git_diff_find_options findopts = GIT_DIFF_FIND_OPTIONS_INIT;
+
+	diffopts.flags = GIT_DIFF_INCLUDE_UNTRACKED;
+
+	findopts.flags = GIT_DIFF_FIND_FOR_UNTRACKED |
+		GIT_DIFF_FIND_AND_BREAK_REWRITES |
+		GIT_DIFF_FIND_RENAMES_FROM_REWRITES;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_rewritefile("renames/ikeepsix.txt", "");
+	cl_git_pass(git_index_add_bypath(index, "ikeepsix.txt"));
+
+	cl_git_rmfile("renames/ikeepsix.txt");
+	cl_git_rewritefile("renames/ikeepsix2.txt", "\n\n\n");
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, &diffopts));
+	cl_git_pass(git_diff_find_similar(diff, &findopts));
+
+	memset(&exp, 0, sizeof(exp));
+
+	cl_git_pass(git_diff_foreach(
+		diff, diff_file_cb, diff_hunk_cb, diff_line_cb, &exp));
+	cl_assert_equal_i(2, exp.files);
+	cl_assert_equal_i(1, exp.file_status[GIT_DELTA_DELETED]);
+	cl_assert_equal_i(1, exp.file_status[GIT_DELTA_UNTRACKED]);
+
+	git_diff_free(diff);
+	git_index_free(index);
+}


### PR DESCRIPTION
Don't try to compare two empty hashsig_heaps.