### PR TITLE
RFC: add mingw to appveyor matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,11 @@ IF (BUILD_CLAR)
 	ENDIF ()
 
 	ENABLE_TESTING()
-	ADD_TEST(libgit2_clar libgit2_clar -ionline)
+	IF (WINHTTP OR OPENSSL_FOUND)
+		ADD_TEST(libgit2_clar libgit2_clar -ionline)
+	ELSE ()
+		ADD_TEST(libgit2_clar libgit2_clar -v)
+	ENDIF ()
 ENDIF ()
 
 IF (TAGS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,10 @@ environment:
     ARCH: 32
 build_script:
 - ps: |
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+      https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+      Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+      throw "There are newer queued builds for this pull request, failing early." }
     mkdir build
     cd build
     if ($env:GENERATOR -ne "MSYS Makefiles") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,17 @@ environment:
     ARCH: 32
   - GENERATOR: "Visual Studio 11 Win64"
     ARCH: 64
+  - GENERATOR: "MSYS Makefiles"
+    ARCH: 32
 build_script:
 - ps: |
     mkdir build
     cd build
-    cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$env:GENERATOR"
-    cmake --build . --config RelWithDebInfo
+    if ($env:GENERATOR -ne "MSYS Makefiles") {
+      cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$env:GENERATOR"
+      cmake --build . --config RelWithDebInfo
+    } else {
+      C:\MinGW\msys\1.0\bin\sh --login /c/projects/libgit2/script/appveyor-mingw.sh
+    }
 test_script:
 - ps: ctest -V .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,10 @@ environment:
     ARCH: i686 # this is for 32-bit MinGW-w64
   - GENERATOR: "MSYS Makefiles"
     ARCH: 64
+matrix:
+  allow_failures:
+    - GENERATOR: "MSYS Makefiles"
+      ARCH: 32
 cache:
 - i686-4.9.2-release-win32-sjlj-rt_v3-rev1.7z
 - x86_64-4.9.2-release-win32-seh-rt_v3-rev1.7z

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,13 @@ environment:
     ARCH: 64
   - GENERATOR: "MSYS Makefiles"
     ARCH: 32
+  - GENERATOR: "MSYS Makefiles"
+    ARCH: i686 # this is for 32-bit MinGW-w64
+  - GENERATOR: "MSYS Makefiles"
+    ARCH: 64
+cache:
+- i686-4.9.2-release-win32-sjlj-rt_v3-rev1.7z
+- x86_64-4.9.2-release-win32-seh-rt_v3-rev1.7z
 build_script:
 - ps: |
     if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
@@ -24,8 +31,8 @@ build_script:
     if ($env:GENERATOR -ne "MSYS Makefiles") {
       cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$env:GENERATOR"
       cmake --build . --config RelWithDebInfo
-    } else {
-      C:\MinGW\msys\1.0\bin\sh --login /c/projects/libgit2/script/appveyor-mingw.sh
     }
+- cmd: |
+    if "%GENERATOR%"=="MSYS Makefiles" (C:\MinGW\msys\1.0\bin\sh --login /c/projects/libgit2/script/appveyor-mingw.sh)
 test_script:
 - ps: ctest -V .

--- a/script/appveyor-mingw.sh
+++ b/script/appveyor-mingw.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+cd `dirname "$0"`/../build
+echo 'C:\MinGW\ /MinGW' > /etc/fstab
+cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$GENERATOR"
+cmake --build . --config RelWithDebInfo

--- a/script/appveyor-mingw.sh
+++ b/script/appveyor-mingw.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 set -e
-cd `dirname "$0"`/../build
-echo 'C:\MinGW\ /MinGW' > /etc/fstab
+cd `dirname "$0"`/..
+if [ "$ARCH" = "32" ]; then
+  echo 'C:\MinGW\ /MinGW' > /etc/fstab
+elif [ "$ARCH" = "i686" ]; then
+  f=i686-4.9.2-release-win32-sjlj-rt_v3-rev1.7z
+  if ! [ -e $f ]; then
+    curl -LsSO http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-win32/sjlj/$f
+  fi
+  7z x $f > /dev/null
+  mv mingw32 /MinGW
+else
+  f=x86_64-4.9.2-release-win32-seh-rt_v3-rev1.7z
+  if ! [ -e $f ]; then
+    curl -LsSO http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-win32/seh/$f
+  fi
+  7z x $f > /dev/null
+  mv mingw64 /MinGW
+fi
+cd build
 cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$GENERATOR"
 cmake --build . --config RelWithDebInfo

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Fail fast for superseded builds to PR's
+if ! [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    if ! [ \"$TRAVIS_BUILD_NUMBER\" = $(curl -H "Accept: application/vnd.travis-ci.2+json" \
+        https://api.travis-ci.org/repos/libgit2/libgit2/builds?event_type=pull_request | \
+        jq ".builds | map(select(.pull_request_number == $TRAVIS_PULL_REQUEST))[0].number") ]; then
+        echo "There are newer queued builds for this pull request, failing early."
+        exit 1
+    fi
+fi
+
 if [ -n "$COVERITY" ];
 then
 	./script/coverity.sh;

--- a/script/install-deps-linux.sh
+++ b/script/install-deps-linux.sh
@@ -3,4 +3,4 @@
 set -x
 
 sudo apt-get -qq update &&
-sudo apt-get -qq install cmake libssh2-1-dev openssh-client openssh-server
+sudo apt-get -qq install cmake libssh2-1-dev openssh-client openssh-server jq

--- a/script/install-deps-osx.sh
+++ b/script/install-deps-osx.sh
@@ -2,4 +2,4 @@
 
 set -x
 
-brew install libssh2 cmake
+brew install libssh2 cmake jq

--- a/src/win32/mingw-compat.h
+++ b/src/win32/mingw-compat.h
@@ -17,6 +17,13 @@
 #define stat _stati64
 #endif
 
+#if _WIN32_WINNT < 0x0600 && !defined(__MINGW64_VERSION_MAJOR)
+#undef MemoryBarrier
+void __mingworg_MemoryBarrier(void);
+#define MemoryBarrier __mingworg_MemoryBarrier
+#define VOLUME_NAME_DOS 0x0
+#endif
+
 #endif
 
 #endif /* INCLUDE_mingw_compat__ */

--- a/src/win32/msvc-compat.h
+++ b/src/win32/msvc-compat.h
@@ -15,6 +15,9 @@
 typedef unsigned short mode_t;
 typedef SSIZE_T ssize_t;
 
+#define strcasecmp(s1, s2) _stricmp(s1, s2)
+#define strncasecmp(s1, s2, c) _strnicmp(s1, s2, c)
+
 #endif
 
 #define GIT_STDLIB_CALL __cdecl

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -32,8 +32,6 @@ extern int p_recv(GIT_SOCKET socket, void *buffer, size_t length, int flags);
 extern int p_send(GIT_SOCKET socket, const void *buffer, size_t length, int flags);
 extern int p_inet_pton(int af, const char* src, void* dst);
 
-#define strcasecmp(s1, s2) _stricmp(s1, s2)
-#define strncasecmp(s1, s2, c) _strnicmp(s1, s2, c)
 extern int p_vsnprintf(char *buffer, size_t count, const char *format, va_list argptr);
 extern int p_snprintf(char *buffer, size_t count, const char *format, ...) GIT_FORMAT_PRINTF(3, 4);
 extern int p_mkstemp(char *tmp_path);

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -55,7 +55,7 @@ int p_ftruncate(int fd, git_off_t size)
 		return -1;
 	}
 
-#if !defined(__MINGW32__)
+#if !defined(__MINGW32__) || defined(MINGW_HAS_SECURE_API)
 	return ((_chsize_s(fd, size) == 0) ? 0 : -1);
 #else
 	/* TODO MINGW32 Find a replacement for _chsize() that handles big files. */


### PR DESCRIPTION
As discussed here https://github.com/libgit2/libgit2/pull/2414#issuecomment-76848152

This is just a start, ~~and is only using the 32-bit mingw.org that is already installed on the AppVeyor VM's. I can keep working on this and add 32 and 64 bit MinGW-w64 distributions. Just need to pick which distribution to download.~~

It looks like there might be a build issue with mingw.org at the moment. On my fork I got
```
[ 16%] Building C object CMakeFiles/git2.dir/src/trace.c.obj
In file included from c:/projects/libgit2/src/common.h:66:0,
                 from c:/projects/libgit2/src/buffer.h:10,
                 from c:/projects/libgit2/src/trace.c:8:
c:/projects/libgit2/src/trace.c: In function 'git_trace_set':
 
c:/projects/libgit2/src/thread-utils.h:279:43: error: expected expression before ')' token
 # define GIT_MEMORY_BARRIER MemoryBarrier()
                                           ^
c:/projects/libgit2/src/trace.c:27:2: note: in expansion of macro 'GIT_MEMORY_BARRIER'
  GIT_MEMORY_BARRIER;
  ^
 
make[2]: 
*** [CMakeFiles/git2.dir/src/trace.c.obj] Error 1
 
make[1]: 
*** [CMakeFiles/git2.dir/all] Error 2
```
Which is interesting, since the cross-compile on Travis appears to be working.