### PR TITLE
note: use a git_buf to return the default namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ v0.22 + 1
   non-snapshot configuration, as there can be no guarantee that the
   returned pointer is valid.
 
+* `git_note_default_ref()` now uses a `git_buf` to return the string,
+  as the string is otherwise not guaranteed to stay allocated.
+
 v0.22
 ------
 

--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -183,12 +183,12 @@ GIT_EXTERN(void) git_note_free(git_note *note);
 /**
  * Get the default notes reference for a repository
  *
- * @param out Pointer to the default notes reference
+ * @param out buffer in which to store the name of the default notes reference
  * @param repo The Git repository
  *
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_note_default_ref(const char **out, git_repository *repo);
+GIT_EXTERN(int) git_note_default_ref(git_buf *out, git_repository *repo);
 
 /**
  * Loop over all the notes within a specified namespace

--- a/tests/notes/notes.c
+++ b/tests/notes/notes.c
@@ -1,5 +1,7 @@
 #include "clar_libgit2.h"
 
+#include "buffer.h"
+
 static git_repository *_repo;
 static git_signature *_sig;
 
@@ -150,7 +152,7 @@ void test_notes_notes__inserting_a_note_without_passing_a_namespace_uses_the_def
 {
 	git_oid note_oid, target_oid;
 	git_note *note, *default_namespace_note;
-	const char *default_ref;
+	git_buf default_ref = GIT_BUF_INIT;
 
 	cl_git_pass(git_oid_fromstr(&target_oid, "08b041783f40edfe12bb406c9c9a8a040177c125"));
 	cl_git_pass(git_note_default_ref(&default_ref, _repo));
@@ -158,11 +160,12 @@ void test_notes_notes__inserting_a_note_without_passing_a_namespace_uses_the_def
 	create_note(&note_oid, NULL, "08b041783f40edfe12bb406c9c9a8a040177c125", "hello world\n");
 
 	cl_git_pass(git_note_read(&note, _repo, NULL, &target_oid));
-	cl_git_pass(git_note_read(&default_namespace_note, _repo, default_ref, &target_oid));
+	cl_git_pass(git_note_read(&default_namespace_note, _repo, git_buf_cstr(&default_ref), &target_oid));
 
 	assert_note_equal(note, "hello world\n", &note_oid);
 	assert_note_equal(default_namespace_note, "hello world\n", &note_oid);
 
+	git_buf_free(&default_ref);
 	git_note_free(note);
 	git_note_free(default_namespace_note);
 }

--- a/tests/notes/notesref.c
+++ b/tests/notes/notesref.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 
 #include "notes.h"
+#include "buffer.h"
 
 static git_repository *_repo;
 static git_note *_note;
@@ -33,7 +34,7 @@ void test_notes_notesref__cleanup(void)
 void test_notes_notesref__config_corenotesref(void)
 {
 	git_oid oid, note_oid;
-	const char *default_ref;
+	git_buf default_ref = GIT_BUF_INIT;
 
 	cl_git_pass(git_signature_now(&_sig, "alice", "alice@example.com"));
 	cl_git_pass(git_oid_fromstr(&oid, "8496071c1b46c854b31185ea97743be6a8774479"));
@@ -55,10 +56,13 @@ void test_notes_notesref__config_corenotesref(void)
 	cl_assert_equal_oid(git_note_id(_note), &note_oid);
 
 	cl_git_pass(git_note_default_ref(&default_ref, _repo));
-	cl_assert_equal_s("refs/notes/mydefaultnotesref", default_ref);
+	cl_assert_equal_s("refs/notes/mydefaultnotesref", default_ref.ptr);
+	git_buf_clear(&default_ref);
 
 	cl_git_pass(git_config_delete_entry(_cfg, "core.notesRef"));
 
 	cl_git_pass(git_note_default_ref(&default_ref, _repo));
-	cl_assert_equal_s(GIT_NOTES_DEFAULT_REF, default_ref);
+	cl_assert_equal_s(GIT_NOTES_DEFAULT_REF, default_ref.ptr);
+
+	git_buf_free(&default_ref);
 }


### PR DESCRIPTION
The caller has otherwise no way to know how long the string will be
allocated or ability to free it.

This fixes #2944.

---

The code is still a bit awkward, as we return an allocated string which for most uses we do not use, but at least it's safe and freeable.