### PR TITLE
RFC: Introduce some "simple" benchmark tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,10 @@ INCLUDE(FindPkgConfig)
 #
 OPTION( SONAME				"Set the (SO)VERSION of the target"		ON  )
 OPTION( BUILD_SHARED_LIBS	"Build Shared Library (OFF for Static)"	ON  )
-OPTION( THREADSAFE			"Build libgit2 as threadsafe"			ON )
+OPTION( THREADSAFE			"Build libgit2 as threadsafe"			ON  )
 OPTION( BUILD_CLAR			"Build Tests using the Clar suite"		ON  )
 OPTION( BUILD_EXAMPLES		"Build library usage example apps"		OFF )
+OPTION( BUILD_BENCHMARK     "Builds benchmarking tools"             ON  )
 OPTION( TAGS				"Generate tags"							OFF )
 OPTION( PROFILE				"Generate profiling information"		OFF )
 OPTION( ENABLE_TRACE		"Enables tracing support"				OFF )
@@ -35,11 +36,11 @@ OPTION( LIBGIT2_FILENAME	"Name of the produced binary"			OFF )
 
 OPTION( ANDROID				"Build for android NDK"	 				OFF )
 
-OPTION( USE_OPENSSL                     "Link with and use openssl library"             ON )
+OPTION( USE_OPENSSL         "Link with and use openssl library"     ON  )
 OPTION( USE_ICONV			"Link with and use iconv library" 		OFF )
-OPTION( USE_SSH				"Link with libssh to enable SSH support" ON )
+OPTION( USE_SSH				"Link with libssh for SSH support"      ON  )
 OPTION( USE_GSSAPI			"Link with libgssapi for SPNEGO auth"   OFF )
-OPTION( VALGRIND			"Configure build for valgrind"			OFF )
+OPTION( VALGRIND			"Configure build for valgrind"          OFF )
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	SET( USE_ICONV ON )
@@ -517,4 +518,33 @@ ENDIF ()
 
 IF (BUILD_EXAMPLES)
 	ADD_SUBDIRECTORY(examples)
+ENDIF ()
+
+IF (BUILD_BENCHMARK)
+	SET(BENCH_PATH "${CMAKE_CURRENT_SOURCE_DIR}/benchmark")
+	INCLUDE_DIRECTORIES(${BENCH_PATH})
+
+#	ADD_DEFINITIONS(-Dgit__malloc=gitbench__malloc)
+#	ADD_DEFINITIONS(-Dgit__calloc=gitbench__calloc)
+#	ADD_DEFINITIONS(-Dgit__realloc=gitbench__realloc)
+#	ADD_DEFINITIONS(-Dgit__free=gitbench__free)
+#	ADD_DEFINITIONS(-Dgit__strdup=gitbench__strdup)
+
+	FILE(GLOB_RECURSE SRC_BENCH ${BENCH_PATH}/*.c ${BENCH_PATH}/*.h)
+
+	ADD_EXECUTABLE(libgit2_bench ${SRC_BENCH} ${SRC_H} ${SRC_GIT2} ${SRC_OS} ${SRC_ZLIB} ${SRC_HTTP} ${SRC_REGEX} ${SRC_SSH} ${SRC_SHA1})
+
+	TARGET_LINK_LIBRARIES(libgit2_bench ${SSL_LIBRARIES})
+	TARGET_LINK_LIBRARIES(libgit2_bench ${SSH_LIBRARIES})
+	TARGET_LINK_LIBRARIES(libgit2_bench ${GSSAPI_LIBRARIES})
+	TARGET_LINK_LIBRARIES(libgit2_bench ${ICONV_LIBRARIES})
+	TARGET_OS_LIBRARIES(libgit2_bench)
+	MSVC_SPLIT_SOURCES(libgit2_bench)
+
+	IF (MSVC_IDE)
+		# Precompiled headers
+		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h /FIalloc.h /FIprecompiled.h")
+	ELSE ()
+		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS "-include malloc.h")
+	ENDIF ()
 ENDIF ()

--- a/benchmark/alloc.c
+++ b/benchmark/alloc.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdint.h>
+#include "alloc.h"
+#include "allocmap.h"
+#include "bench_util.h"
+
+GIT__USE_ALLOCMAP
+
+static git_allocmap *alloc_map = NULL;
+static uint32_t alloc_run = 0;
+
+static bool alloc_profile = false;
+
+static struct gitbench_alloc_stat_t alloc_stats = {0};
+
+int gitbench_alloc_init(void)
+{
+	int error;
+
+	assert(alloc_map == NULL);
+
+	error = git_allocmap_alloc(&alloc_map);
+	alloc_profile = true;
+
+	return error;
+}
+
+void gitbench_alloc_start(void)
+{
+	assert(alloc_map);
+	alloc_run++;
+
+	alloc_stats.run_alloc_count = 0;
+	alloc_stats.run_dealloc_count = 0;
+	alloc_stats.run_alloc_current = 0;
+	alloc_stats.run_alloc_max = 0;
+}
+
+void gitbench_alloc_stop(void)
+{
+	assert(alloc_map);
+}
+
+struct gitbench_alloc_stat_t *gitbench_alloc_stats(void)
+{
+	return &alloc_stats;
+}
+
+void gitbench_alloc_shutdown(void)
+{
+	assert(alloc_map);
+	git_allocmap_free(alloc_map);
+	alloc_map = NULL;
+}
+
+
+GIT_INLINE(void) update_stats(size_t new_len, size_t old_len)
+{
+	if (new_len > 0) {
+		alloc_stats.total_alloc_count++;
+		alloc_stats.run_alloc_count++;
+	}
+
+	if (old_len > 0) {
+		alloc_stats.total_dealloc_count++;
+		alloc_stats.run_dealloc_count++;
+	}
+
+	if (new_len > old_len) {
+		size_t diff = new_len - old_len;
+
+		alloc_stats.total_alloc_max = max(alloc_stats.total_alloc_max, diff);
+		alloc_stats.run_alloc_max = max(alloc_stats.run_alloc_max, diff);
+		
+		alloc_stats.total_alloc_current += diff;
+		alloc_stats.run_alloc_current += diff;
+	} else {
+		size_t diff = old_len - new_len;
+
+		alloc_stats.total_alloc_current -= diff;
+		alloc_stats.run_alloc_current -= diff;
+	}
+}
+
+GIT_INLINE(void *) gitbench__malloc_standard(size_t len)
+{
+	void *p = malloc(len);
+	if (p == NULL)
+		giterr_set_oom();
+	return p;
+}
+
+GIT_INLINE(void *) gitbench__malloc_profile(size_t len)
+{
+	void *p = gitbench__malloc_standard(len);
+	int error;
+
+	if (p) {
+		git_allocmap_insert(alloc_map, p, len, error);
+		assert(error >= 0);
+
+		if (verbosity > 1)
+			printf("::::: Allocated %p (%" PRIuZ ")\n", p, len);
+
+		update_stats(len, 0);
+	}
+
+	return p;
+}
+
+void *gitbench__calloc(size_t nelem, size_t elsize)
+{
+	size_t len;
+	void *p;
+
+	/* TODO: mult w/ overflow */
+	len = nelem * elsize;
+
+	if ((p = gitbench__malloc(len)) == NULL)
+		return NULL;
+
+	memset(p, 0, len);
+	return p;
+}
+
+GIT_INLINE(void *) gitbench__realloc_standard(void *ptr, size_t len)
+{
+	void *p;
+
+	if ((p = realloc(ptr, len)) == NULL)
+		giterr_set_oom();
+
+	return p;
+}
+
+GIT_INLINE(void *) gitbench__realloc_profile(void *old_ptr, size_t new_len)
+{
+	khiter_t old_idx;
+	size_t old_len;
+	void *new_ptr;
+	int error;
+
+	if (!old_ptr)
+		return gitbench__malloc_profile(new_len);
+
+	if ((new_ptr = gitbench__realloc_standard(old_ptr, new_len)) == NULL)
+		return NULL;
+
+	old_idx = git_allocmap_lookup_index(alloc_map, old_ptr);
+	assert(git_allocmap_valid_index(alloc_map, old_idx));
+
+	if (old_ptr == new_ptr) {
+		old_len = git_allocmap_value_at(alloc_map, old_idx);
+		git_allocmap_set_value_at(alloc_map, old_idx, new_len);
+	} else {
+		old_len = git_allocmap_value_at(alloc_map, old_idx);
+		git_allocmap_delete_at(alloc_map, old_idx);
+
+		git_allocmap_insert(alloc_map, new_ptr, new_len, error);
+		assert(error >= 0);
+	}
+
+	update_stats(new_len, old_len);
+	return new_ptr;
+}
+
+GIT_INLINE(void) gitbench__free_standard(void *ptr)
+{
+	free(ptr);
+}
+
+GIT_INLINE(void) gitbench__free_profile(void *ptr)
+{
+	khiter_t idx;
+	size_t len;
+
+	if (!ptr)
+		return;
+
+	free(ptr);
+
+	idx = git_allocmap_lookup_index(alloc_map, ptr);
+	if (!git_allocmap_valid_index(alloc_map, idx))
+		return;
+
+	len = git_allocmap_value_at(alloc_map, idx);
+	git_allocmap_delete_at(alloc_map, idx);
+
+	if (verbosity > 1)
+		printf("::::: Dellocated %p (%" PRIuZ ")\n", ptr, len);
+
+	update_stats(0, len);
+}
+
+char *gitbench__strdup(const char *str)
+{
+	char *dup;
+	size_t len = strlen(str);
+
+	if ((dup = gitbench__malloc(len + 1)) == NULL)
+		return NULL;
+
+	memcpy(dup, str, len + 1);
+	return dup;
+}
+
+
+void *gitbench__malloc(size_t len)
+{
+	return alloc_profile ? gitbench__malloc_profile(len) :
+		gitbench__malloc_standard(len);
+}
+
+void *gitbench__realloc(void *ptr, size_t len)
+{
+	return alloc_profile ? gitbench__realloc_profile(ptr, len) :
+		gitbench__realloc_standard(ptr, len);
+}
+
+void gitbench__free(void *ptr)
+{
+	alloc_profile ? gitbench__free_profile(ptr) :
+		gitbench__free_standard(ptr);
+}

--- a/benchmark/alloc.h
+++ b/benchmark/alloc.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef ALLOC_H
+#define ALLOC_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#define git__malloc  gitbench__malloc
+#define git__calloc  gitbench__calloc
+#define git__realloc gitbench__realloc
+#define git__free    gitbench__free
+#define git__strdup  gitbench__strdup
+
+typedef struct gitbench_alloc_stat_t {
+	size_t total_alloc_count;
+	size_t total_dealloc_count;
+	size_t total_alloc_current;
+	size_t total_alloc_max;
+
+	size_t run_alloc_count;
+	size_t run_dealloc_count;
+	size_t run_alloc_current;
+	size_t run_alloc_max;
+} gitbench_alloc_stat_t;
+
+extern int gitbench_alloc_init(void);
+extern void gitbench_alloc_start(void);
+extern void gitbench_alloc_stop(void);
+extern gitbench_alloc_stat_t *gitbench_alloc_stats(void);
+extern void gitbench_alloc_shutdown(void);
+
+extern void *gitbench__malloc(size_t len);
+extern void *gitbench__calloc(size_t nelem, size_t elsize);
+extern void *gitbench__realloc(void *ptr, size_t size);
+extern void gitbench__free(void *ptr);
+extern char *gitbench__strdup(const char *str);
+
+#endif

--- a/benchmark/allocmap.h
+++ b/benchmark/allocmap.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef ALLOCMAP_H
+#define ALLOCMAP_H
+
+#include "common.h"
+#include "alloc.h"
+
+#define kmalloc  malloc
+#define kcalloc  calloc
+#define krealloc realloc
+#define kfree    free
+
+#include "khash.h"
+
+#if (SIZE_MAX == UINT_MAX)
+# define kh_alloc_hash_func(k) (khint32_t)((size_t)k)
+#elif (SIZE_MAX == ULONG_MAX)
+# define kh_alloc_hash_func(k) (khint32_t)(((size_t)key)>>33^((size_t)key)^((size_t)key)<<11)
+#else
+# error unknown architecture
+#endif
+
+#define kh_alloc_hash_equal(a, b) (((size_t)a) == ((size_t)b))
+
+__KHASH_TYPE(alloc, void *, size_t);
+typedef khash_t(alloc) git_allocmap;
+typedef khiter_t git_allocmap_iter;
+
+#define GIT__USE_ALLOCMAP \
+	__KHASH_IMPL(alloc, static kh_inline, void *, size_t, 1, kh_alloc_hash_func, kh_alloc_hash_equal)
+
+#define git_allocmap_alloc(hp) \
+	((*(hp) = kh_init(alloc)) == NULL) ? giterr_set_oom(), -1 : 0
+
+#define git_allocmap_free(h)  kh_destroy(alloc, h), h = NULL
+#define git_allocmap_clear(h) kh_clear(alloc, h)
+
+#define git_allocmap_num_entries(h) kh_size(h)
+
+#define git_allocmap_lookup_index(h, k)  kh_get(alloc, h, k)
+#define git_allocmap_valid_index(h, idx) (idx != kh_end(h))
+
+#define git_allocmap_exists(h, k) (kh_get(alloc, h, k) != kh_end(h))
+#define git_allocmap_has_data(h, idx) kh_exist(h, idx)
+
+#define git_allocmap_key(h, idx)             kh_key(h, idx)
+#define git_allocmap_value_at(h, idx)        kh_val(h, idx)
+#define git_allocmap_set_value_at(h, idx, v) kh_val(h, idx) = v
+#define git_allocmap_delete_at(h, idx)       kh_del(alloc, h, idx)
+
+#define git_allocmap_insert(h, key, val, rval) do { \
+	khiter_t __pos = kh_put(alloc, h, key, &rval); \
+	if (rval >= 0) { \
+		if (rval == 0) kh_key(h, __pos) = key; \
+		kh_val(h, __pos) = val; \
+	} } while (0)
+
+#define git_allocmap_insert2(h, key, val, oldv, rval) do { \
+	khiter_t __pos = kh_put(alloc, h, key, &rval); \
+	if (rval >= 0) { \
+		if (rval == 0) { \
+			oldv = kh_val(h, __pos); \
+			kh_key(h, __pos) = key; \
+		} else { oldv = NULL; } \
+		kh_val(h, __pos) = val; \
+	} } while (0)
+
+#define git_allocmap_delete(h, key) do { \
+	khiter_t __pos = git_allocmap_lookup_index(h, key); \
+	if (git_allocmap_valid_index(h, __pos)) \
+		git_allocmap_delete_at(h, __pos); } while (0)
+
+#define git_allocmap_foreach		kh_foreach
+#define git_allocmap_foreach_value	kh_foreach_value
+
+#define git_allocmap_begin		kh_begin
+#define git_allocmap_end		kh_end
+
+int git_allocmap_next(
+	void **data,
+	git_allocmap_iter* iter,
+	git_allocmap *map);
+
+#endif

--- a/benchmark/bench_util.c
+++ b/benchmark/bench_util.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <fcntl.h>
+#include "common.h"
+#include "fileops.h"
+#include "buffer.h"
+
+static int tempdir_isvalid(const char *path)
+{
+	struct stat st;
+
+	if (p_stat(path, &st) != 0)
+		return 0;
+
+	if (!S_ISDIR(st.st_mode))
+		return 0;
+
+	return (access(path, W_OK) == 0);
+}
+
+int gitbench__create_tempdir(char **out)
+{
+	git_buf tempdir = GIT_BUF_INIT;
+	static const char *tempname = "libgit2_bench_XXXXXX";
+	char *root;
+
+#ifdef GIT_WIN32
+	char winroot[MAX_PATH];
+	DWORD winroot_len;
+
+	if ((winroot_len = GetTempPath(MAX_PATH, winroot)) == 0 ||
+		winroot_len > MAX_PATH || !tempdir_isvalid(winroot)) {
+		giterr_set(GITERR_OS, "could not determine temporary path");
+		return -1;
+	}
+
+	root = winroot;
+
+	git_path_mkposix(root);
+#else
+	if ((root = getenv("TMPDIR")) == NULL || !tempdir_isvalid(root)) {
+		giterr_set(GITERR_OS, "could not determine temporary path");
+		return -1;
+	}
+#endif
+
+	if (git_buf_joinpath(&tempdir, root, tempname) < 0)
+		return -1;
+
+#ifdef GIT_WIN32
+	if (_mktemp_s(tempdir.ptr, tempdir.size+1) != 0 ||
+		p_mkdir(tempdir.ptr, 0700) != 0) {
+		giterr_set(GITERR_OS, "could not determine temporary path");
+		return -1;
+	}
+#else
+	if (mkdtemp(tempdir.ptr) == NULL)
+		return -1;
+#endif
+
+	*out = git_buf_detach(&tempdir);
+	return 0;
+}

--- a/benchmark/bench_util.h
+++ b/benchmark/bench_util.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef BENCH_UTIL_H
+#define BENCH_UTIL_H
+
+#define GITBENCH_EARGUMENTS (INT_MIN+1)
+
+extern const char *progname;
+extern int verbosity;
+
+extern int gitbench__create_tempdir(char **out);
+
+#endif

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef BENCHMARK_H
+#define BENCHMARK_H
+
+#include "operation.h"
+#include "run.h"
+
+typedef struct gitbench_benchmark gitbench_benchmark;
+
+struct gitbench_benchmark {
+	gitbench_operation_spec *operations;
+	size_t operation_cnt;
+	int (*run_fn)(gitbench_benchmark *benchmark, gitbench_run *run);
+	void (*free_fn)(gitbench_benchmark *benchmark);
+};
+
+
+/** Specification for a benchmark command. */
+typedef struct {
+	/** Name of the benchmark option. */
+	const char *name;
+
+	/** The initialization function to execute. */
+	int (*init)(gitbench_benchmark **out, int argc, const char **argv);
+
+	/** The description of the benchmark. */
+	const char *description;
+} gitbench_benchmark_spec;
+
+/* Benchmark initializers */
+extern int gitbench_benchmark_checkout_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv);
+
+#endif

--- a/benchmark/checkout.c
+++ b/benchmark/checkout.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdio.h>
+#include "git2.h"
+#include "git2/sys/repository.h"
+#include "common.h"
+#include "bench_util.h"
+#include "buffer.h"
+#include "fileops.h"
+#include "opt.h"
+#include "run.h"
+#include "operation.h"
+#include "benchmark.h"
+
+typedef struct gitbench_benchmark_checkout {
+	gitbench_benchmark base;
+
+	char *repo_path;
+	char *ref_name;
+	unsigned int autocrlf:1;
+} gitbench_benchmark_checkout;
+
+enum checkout_operation_t {
+	CHECKOUT_OPERATION_SETUP = 0,
+	CHECKOUT_OPERATION_SETUP_FILTERS,
+	CHECKOUT_OPERATION_CHECKOUT,
+	CHECKOUT_OPERATION_CLEANUP
+};
+
+static gitbench_operation_spec checkout_operations[] = {
+	{ CHECKOUT_OPERATION_SETUP, GITBENCH_OPERATION_SETUP, "open repository" },
+	{ CHECKOUT_OPERATION_SETUP_FILTERS, GITBENCH_OPERATION_SETUP, "configure cr/lf filters" },
+	{ CHECKOUT_OPERATION_CHECKOUT, GITBENCH_OPERATION_EXECUTE, "execute checkout" },
+	{ CHECKOUT_OPERATION_CLEANUP, GITBENCH_OPERATION_CLEANUP, "close repository" },
+};
+#define CHECKOUT_OPERATIONS_COUNT 4
+
+static const gitbench_opt_spec checkout_cmdline_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",       0,   NULL,      NULL },
+	{ GITBENCH_OPT_ARG,    "repository", 0,   NULL,      "the repository to checkout", GITBENCH_OPT_USAGE_REQUIRED },
+	{ GITBENCH_OPT_VALUE,  "reference",  'r', "refname", "the reference to checkout", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_SWITCH, "autocrlf",   0,   NULL,      "turn on core.autocrlf=true" },
+	{ 0 }
+};
+
+int checkout_run(gitbench_benchmark *b, gitbench_run *run)
+{
+	git_repository *repo = NULL;
+	git_oid id;
+	git_object *obj = NULL;
+	git_config *config = NULL;
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	gitbench_benchmark_checkout *benchmark = (gitbench_benchmark_checkout *)b;
+	git_buf wd_path = GIT_BUF_INIT, config_path = GIT_BUF_INIT;
+	const char *ref_name = "HEAD";
+	int error;
+
+	/* setup repository */
+	gitbench_run_start_operation(run, CHECKOUT_OPERATION_SETUP);
+
+	if (benchmark->ref_name)
+		ref_name = benchmark->ref_name;
+
+	if ((error = git_repository_open(&repo, benchmark->repo_path)) < 0 ||
+		(error = git_reference_name_to_id(&id, repo, ref_name)) < 0 ||
+		(error = git_object_lookup(&obj, repo, &id, GIT_OBJ_ANY)) < 0 ||
+		(error = git_buf_joinpath(&wd_path, run->tempdir, "workdir")) < 0 ||
+		(error = git_futils_mkdir(wd_path.ptr, NULL, 0700, GIT_MKDIR_VERIFY_DIR)) < 0 ||
+		(error = git_repository_set_workdir(repo, wd_path.ptr, 0)) < 0 ||
+		(error = git_config_new(&config)) < 0) {
+		gitbench_run_finish_operation(run);
+		goto done;
+	}
+
+	git_repository_set_index(repo, NULL);
+	git_repository_set_config(repo, config);
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	gitbench_run_finish_operation(run);
+
+	if (benchmark->autocrlf) {
+		gitbench_run_start_operation(run, CHECKOUT_OPERATION_SETUP_FILTERS);
+
+		if ((error = git_buf_joinpath(&config_path, run->tempdir, ".config")) == 0 &&
+			(error = git_config_add_file_ondisk(config, config_path.ptr, GIT_CONFIG_LEVEL_LOCAL, 0)) == 0)
+			error = git_config_set_bool(config, "core.autocrlf", true);
+
+		gitbench_run_finish_operation(run);
+
+		if (error < 0)
+			goto done;
+	}
+
+	/* do the checkout */
+	gitbench_run_start_operation(run, CHECKOUT_OPERATION_CHECKOUT);
+	error = git_checkout_tree(repo, obj, &opts);
+	gitbench_run_finish_operation(run);
+
+done:
+	/* cleanup */
+	gitbench_run_start_operation(run, CHECKOUT_OPERATION_CLEANUP);
+	git_object_free(obj);
+	git_config_free(config);
+	git_repository_free(repo);
+	git_buf_free(&wd_path);
+	git_buf_free(&config_path);
+	gitbench_run_finish_operation(run);
+
+	return error;
+}
+
+void checkout_free(gitbench_benchmark *b)
+{
+	gitbench_benchmark_checkout *benchmark = (gitbench_benchmark_checkout *)b;
+
+	if (!b)
+		return;
+
+	git__free(benchmark->repo_path);
+	git__free(benchmark->ref_name);
+	git__free(benchmark);
+}
+
+int checkout_configure(
+	gitbench_benchmark_checkout *benchmark,
+	int argc,
+	const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+
+	gitbench_opt_parser_init(&parser, checkout_cmdline_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			fprintf(stderr, "%s: unknown argument: '%s'\n", progname, argv[parser.idx]);
+			gitbench_opt_usage_fprint(stderr, progname, checkout_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		}
+
+		if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_opt_usage_fprint(stderr, progname, checkout_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		} else if (strcmp(opt.spec->name, "repository") == 0) {
+			benchmark->repo_path = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->repo_path);
+		} else if (strcmp(opt.spec->name, "reference") == 0) {
+			benchmark->ref_name = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->ref_name);
+		} else if (strcmp(opt.spec->name, "autocrlf") == 0) {
+			benchmark->autocrlf = 1;
+		}
+	}
+
+	if (!benchmark->repo_path) {
+		gitbench_opt_usage_fprint(stderr, progname, checkout_cmdline_opts);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return 0;
+}
+
+int gitbench_benchmark_checkout_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv)
+{
+	gitbench_benchmark_checkout *benchmark;
+	int error;
+
+	if ((benchmark = git__calloc(1, sizeof(gitbench_benchmark_checkout))) == NULL)
+		return -1;
+
+	benchmark->base.operation_cnt = CHECKOUT_OPERATIONS_COUNT;
+	benchmark->base.operations = checkout_operations;
+	benchmark->base.run_fn = checkout_run;
+	benchmark->base.free_fn = checkout_free;
+
+	if ((error = checkout_configure(benchmark, argc, argv)) < 0) {
+		checkout_free((gitbench_benchmark *)benchmark);
+		return error;
+	}
+
+	*out = (gitbench_benchmark *)benchmark;
+	return 0;
+}

--- a/benchmark/main.c
+++ b/benchmark/main.c
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "git2.h"
+#include "common.h"
+#include "fileops.h"
+#include "vector.h"
+#include "path.h"
+
+#include "bench_util.h"
+#include "opt.h"
+#include "benchmark.h"
+#include "run.h"
+#include "alloc.h"
+
+const char *progname;
+int verbosity = 0;
+
+static bool profile_alloc = false;
+
+static int gitbench_init(void);
+static void gitbench_shutdown(void);
+static void print_usage(FILE *out);
+static int help_adapter(gitbench_benchmark **out, int argc, const char **argv);
+static const gitbench_benchmark_spec *benchmark_spec_lookup(const char *name);
+static int benchmark_init(gitbench_benchmark **out, const char *name, int argc, const char **argv);
+static int benchmark_run(git_vector *runs, gitbench_benchmark *benchmark, size_t count);
+static void report_benchmark(git_vector *runs, gitbench_benchmark *benchmark);
+static void benchmark_free(git_vector *runs, gitbench_benchmark *benchmark);
+static void report_alloc(void);
+
+#ifdef GIT_WIN32
+static const char *basename(const char *in);
+#endif
+
+const gitbench_benchmark_spec gitbench_benchmarks[] = {
+	{ "checkout", gitbench_benchmark_checkout_init, "time the checkout of a repository" },
+	{ "help", help_adapter, NULL },
+	{ NULL }
+};
+
+static const gitbench_opt_spec gitbench_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",        0,   NULL,  "display help", GITBENCH_OPT_USAGE_HIDDEN },
+	{ GITBENCH_OPT_VALUE,  "count",       'c', "num", "number of runs", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_SWITCH, "verbose",     'v', NULL,  "increase the verbosity" },
+	{ GITBENCH_OPT_SWITCH, "allocations", 0,   NULL,  "profile allocations" },
+	{ GITBENCH_OPT_ARG,    "benchmark",   0,   NULL,  "the benchmark to run", GITBENCH_OPT_USAGE_REQUIRED },
+	{ GITBENCH_OPT_ARGS,   "args",        0,   NULL,  "arguments for the benchmark" },
+	{ 0 }
+};
+
+#define gitbench_try(x) if ((error = (x)) < 0) goto done;
+
+int main(int argc, const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+	const char *benchmark_name = NULL;
+	git_vector cmd_args = GIT_VECTOR_INIT;
+	gitbench_benchmark *benchmark = NULL;
+	unsigned int count = 1;
+	git_vector runs = GIT_VECTOR_INIT;
+	int error = 0;
+
+	progname = basename(argv[0]);
+
+	gitbench_try(gitbench_init());
+
+	gitbench_try(git_vector_insert(&cmd_args, (char *)progname));
+
+	gitbench_opt_parser_init(&parser, gitbench_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			gitbench_try(git_vector_insert(&cmd_args, (char *)argv[parser.idx]));
+			continue;
+		}
+
+		if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_try(git_vector_insert(&cmd_args, (char *)argv[parser.idx]));
+		} else if (strcmp(opt.spec->name, "verbose") == 0) {
+			verbosity++;
+		} else if (strcmp(opt.spec->name, "allocations") == 0) {
+			profile_alloc = true;
+		} else if (strcmp(opt.spec->name, "count") == 0) {
+			char *end;
+			long c = strtol(opt.value, &end, 10);
+
+			if (c <= 0 || *end) {
+				fprintf(stderr, "%s: invalid count '%s'\n'", progname, opt.value);
+				print_usage(stderr);
+				error = 1;
+				goto done;
+			}
+
+			count = (unsigned int)c;
+		} else if (strcmp(opt.spec->name, "benchmark") == 0) {
+			benchmark_name = argv[parser.idx];
+		}
+	}
+
+	if ((error = benchmark_init(&benchmark, benchmark_name, cmd_args.length, (const char **)cmd_args.contents)) < 0) {
+		if (error == GITBENCH_EARGUMENTS)
+			error = 1;
+		goto done;
+	}
+
+	gitbench_try(benchmark_run(&runs, benchmark, count));
+
+	report_benchmark(&runs, benchmark);
+
+	if (profile_alloc)
+		report_alloc();
+
+done:
+	if (error < 0) {
+		const git_error *err = giterr_last();
+		fprintf(stderr, "%s: %s\n", progname, err ? err->message : "unknown error");
+	}
+
+	benchmark_free(&runs, benchmark);
+
+	gitbench_shutdown();
+	return error ? 1 : 0;
+}
+
+int gitbench_init(void)
+{
+	gitbench_alloc_init();
+	return git_libgit2_init();
+}
+
+void gitbench_shutdown(void)
+{
+	git_libgit2_shutdown();
+	gitbench_alloc_shutdown();
+}
+
+#ifdef GIT_WIN32
+const char *basename(const char *in)
+{
+	const char *c, *last = in;
+	for (c = in; *c; c++)
+		if ((*c == '/' || *c == '\\') && *(c+1)) last = c+1;
+	return last;
+}
+#endif
+
+int benchmark_init(gitbench_benchmark **out, const char *name, int argc, const char **argv)
+{
+	const gitbench_benchmark_spec *benchmark_spec = NULL;
+
+	if (!name) {
+		print_usage(stdout);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	if ((benchmark_spec = benchmark_spec_lookup(name)) == NULL) {
+		fprintf(stderr, "%s: unknown benchmark '%s'\n", progname, name);
+		print_usage(stderr);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return benchmark_spec->init(out, argc, argv);
+}
+
+const gitbench_benchmark_spec *benchmark_spec_lookup(const char *name)
+{
+	const gitbench_benchmark_spec *spec;
+
+	for (spec = gitbench_benchmarks; spec->name; spec++) {
+		if (strcmp(spec->name, name) == 0)
+			return spec;
+	}
+
+	return NULL;
+}
+
+int benchmark_run(
+	git_vector *runs,
+	gitbench_benchmark *benchmark,
+	size_t count)
+{
+	size_t i;
+	int error = 0;
+
+	assert(runs && benchmark);
+
+	if (git_vector_init(runs, count, NULL) < 0)
+		return -1;
+
+	for (i = 0; i < count; i++) {
+		gitbench_run *run;
+
+		if (gitbench_run_init(
+			&run, i+1,
+			benchmark->operation_cnt,
+			benchmark->operations) < 0)
+			return -1;
+
+		run->verbosity = verbosity;
+		run->profile_alloc = profile_alloc;
+
+		if (git_vector_insert(runs, run) < 0)
+			return -1;
+	}
+
+	for (i = 0; i < count; i++) {
+		gitbench_run *run = git_vector_get(runs, i);
+
+		if ((error = gitbench_run_start(run)) < 0 ||
+			(error = benchmark->run_fn(benchmark, run)) < 0 ||
+			(error = gitbench_run_finish(run)) < 0)
+			break;
+	}
+
+	return error;
+}
+
+static void report_run(const char *desc, size_t num,
+	double execute, double setup, double cleanup, double total)
+{
+	if (desc)
+		printf("%s", desc);
+	else
+		printf("%" PRIuZ, num);
+
+	printf("\t%-#f", execute);
+
+	if (1)
+		printf("\t%-#f\t%-#f\t%-#f", setup, cleanup, total);
+
+	printf("\n");
+}
+
+void report_benchmark(git_vector *runs, gitbench_benchmark *benchmark)
+{
+	gitbench_run *run;
+	double total_setup = 0, total_execute = 0, total_cleanup = 0, total = 0,
+		average_setup, average_execute, average_cleanup, average;
+	size_t i, j;
+
+	printf("Run\tTime\tSetup\tCleanup\tTotal\n");
+
+	git_vector_foreach(runs, i, run) {
+		double run_setup = 0, run_execute = 0, run_cleanup = 0,
+			run_total = run->end - run->start;
+
+		for (j = 0; j < benchmark->operation_cnt; j++) {
+			double operation_time = run->operation_data.ptr[j].end -
+				run->operation_data.ptr[j].start;
+
+			if (benchmark->operations[j].type == GITBENCH_OPERATION_SETUP)
+				run_setup += operation_time;
+			else if (benchmark->operations[j].type == GITBENCH_OPERATION_CLEANUP)
+				run_cleanup += operation_time;
+			else
+				run_execute += operation_time;
+		}
+
+		report_run(NULL, i + 1,
+			run_execute, run_setup, run_cleanup, run_total);
+
+		total_setup += run_setup;
+		total_execute += run_execute;
+		total_cleanup += run_cleanup;
+
+		total += (run->end - run->start);
+	}
+
+	report_run("Total", 0, total_execute, total_setup, total_cleanup, total);
+
+	average_setup = total_setup / runs->length;
+	average_execute = total_execute / runs->length;
+	average_cleanup = total_cleanup / runs->length;
+	average = total / runs->length;
+
+	report_run("Average", 0, average_execute, average_setup, average_cleanup, average);
+}
+
+void benchmark_free(git_vector *runs, gitbench_benchmark *benchmark)
+{
+	gitbench_run *run;
+	size_t i;
+
+	if (runs) {
+		git_vector_foreach(runs, i, run)
+			gitbench_run_free(run);
+
+		git_vector_free(runs);
+	}
+
+	if (benchmark)
+		benchmark->free_fn(benchmark);
+}
+
+void report_alloc(void)
+{
+	gitbench_alloc_stat_t *stats = gitbench_alloc_stats();
+
+	printf("Alloc count: %" PRIuZ " / Dealloc count: %" PRIuZ " / Max size: %" PRIuZ "\n",
+		stats->total_alloc_count, stats->total_dealloc_count, stats->total_alloc_max);
+}
+
+void print_usage(FILE *out)
+{
+	const gitbench_benchmark_spec *b;
+
+	gitbench_opt_usage_fprint(out, progname, gitbench_opts);
+	fprintf(out, "\n");
+
+	fprintf(out, "Available benchmarks are:\n");
+
+	for (b = gitbench_benchmarks; b->name; b++) {
+		if (b->description)
+			fprintf(out, "    %-10s %s\n", b->name, b->description);
+	}
+}
+
+int help_adapter(gitbench_benchmark **out, int argc, const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+	const char *benchmark_name = NULL;
+	gitbench_benchmark *benchmark = NULL;
+	const char *help_args[] = { NULL, "--help" };
+
+	const gitbench_opt_spec gitbench_opts[] = {
+		{ GITBENCH_OPT_ARG,    "benchmark", 0,   NULL,  "the benchmark to run", GITBENCH_OPT_USAGE_REQUIRED },
+		{ 0 }
+	};
+
+	gitbench_opt_parser_init(&parser, gitbench_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (opt.spec && strcmp(opt.spec->name, "benchmark") == 0) {
+			benchmark_name = opt.value;
+			break;
+		}
+	}
+
+	if (!benchmark_name) {
+		print_usage(stdout);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	help_args[0] = benchmark_name;
+
+	if (benchmark_init(&benchmark, benchmark_name, 2, help_args) == 0) {
+		fprintf(stderr, "%s: no help available for '%s'\n",
+			progname, benchmark_name);
+		benchmark->free_fn(benchmark);
+	}
+
+	*out = NULL;
+	return GITBENCH_EARGUMENTS;
+}

--- a/benchmark/operation.h
+++ b/benchmark/operation.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef OPERATION_H
+#define OPERATION_H
+
+enum gitbench_operation_t {
+	GITBENCH_OPERATION_SETUP = 1,
+	GITBENCH_OPERATION_EXECUTE = 2,
+	GITBENCH_OPERATION_CLEANUP = 3
+};
+
+typedef struct gitbench_operation_spec {
+	unsigned int code;
+	unsigned int type;
+	const char *description;
+} gitbench_operation_spec;
+
+#endif

--- a/benchmark/opt.c
+++ b/benchmark/opt.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c), Edward Thomson <ethomson@edwardthomson.com>
+ * All rights reserved.
+ *
+ * This file is part of adopt, distributed under the MIT license.
+ * For full terms and conditions, see the included LICENSE file.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "opt.h"
+
+#ifdef _WIN32
+# include <Windows.h>
+#else
+# include <fcntl.h>
+# include <sys/ioctl.h>
+#endif
+
+#ifdef _MSC_VER
+# define INLINE(type) static __inline type
+#else
+# define INLINE(type) static inline type
+#endif
+
+INLINE(const gitbench_opt_spec *) spec_byname(
+	gitbench_opt_parser *parser, const char *name, size_t namelen)
+{
+	const gitbench_opt_spec *spec;
+
+	for (spec = parser->specs; spec->type; ++spec) {
+		if (spec->type == GITBENCH_OPT_LITERAL && namelen == 0)
+			return spec;
+
+		if ((spec->type == GITBENCH_OPT_SWITCH || spec->type == GITBENCH_OPT_VALUE) &&
+			spec->name &&
+			strlen(spec->name) == namelen &&
+			strncmp(name, spec->name, namelen) == 0)
+			return spec;
+	}
+
+	return NULL;
+}
+
+INLINE(const gitbench_opt_spec *) spec_byalias(gitbench_opt_parser *parser, char alias)
+{
+	const gitbench_opt_spec *spec;
+
+	for (spec = parser->specs; spec->type; ++spec) {
+		if ((spec->type == GITBENCH_OPT_SWITCH || spec->type == GITBENCH_OPT_VALUE) &&
+			alias == spec->alias)
+			return spec;
+	}
+
+	return NULL;
+}
+
+INLINE(const gitbench_opt_spec *) spec_nextarg(gitbench_opt_parser *parser)
+{
+	const gitbench_opt_spec *spec;
+	size_t args = 0;
+	
+	for (spec = parser->specs; spec->type; ++spec) {
+		if (spec->type == GITBENCH_OPT_ARG) {
+			if (args == parser->arg_idx) {
+				parser->arg_idx++;
+				return spec;
+			}
+			
+			args++;
+		}
+	}
+	
+	return NULL;
+}
+
+static void parse_long(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	const gitbench_opt_spec *spec;
+	const char *arg = parser->args[parser->idx++], *name = arg + 2, *eql;
+	size_t namelen;
+
+	namelen = (eql = strrchr(arg, '=')) ? (size_t)(eql - name) : strlen(name);
+
+	if ((spec = spec_byname(parser, name, namelen)) == NULL) {
+		opt->spec = NULL;
+		opt->value = arg;
+
+		return;
+	}
+
+	opt->spec = spec;
+
+	/* Future options parsed as literal */
+	if (spec->type == GITBENCH_OPT_LITERAL) {
+		parser->in_literal = 1;
+	}
+
+	/* Parse values as "--foo=bar" or "--foo bar" */
+	if (spec->type == GITBENCH_OPT_VALUE) {
+		if (eql)
+			opt->value = eql + 1;
+		else if ((parser->idx + 1) <= parser->args_len)
+			opt->value = parser->args[parser->idx++];
+	}
+}
+
+static void parse_short(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	const gitbench_opt_spec *spec;
+	const char *arg = parser->args[parser->idx++], alias = *(arg + 1);
+
+	if ((spec = spec_byalias(parser, alias)) == NULL) {
+		opt->spec = NULL;
+		opt->value = arg;
+
+		return;
+	}
+
+	opt->spec = spec;
+
+	/* Parse values as "-ifoo" or "-i foo" */
+	if (spec->type == GITBENCH_OPT_VALUE) {
+		if (strlen(arg) > 2)
+			opt->value = arg + 2;
+		else if ((parser->idx + 1) <= parser->args_len)
+			opt->value = parser->args[parser->idx++];
+	}
+}
+
+static void parse_arg(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	opt->spec = spec_nextarg(parser);
+	opt->value = parser->args[parser->idx++];
+}
+
+void gitbench_opt_parser_init(
+	gitbench_opt_parser *parser,
+	const gitbench_opt_spec specs[],
+	const char **args,
+	size_t args_len)
+{
+	assert(parser);
+
+	memset(parser, 0x0, sizeof(gitbench_opt_parser));
+
+	parser->specs = specs;
+	parser->args = args;
+	parser->args_len = args_len;
+}
+
+int gitbench_opt_parser_next(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	assert(opt && parser);
+
+	memset(opt, 0x0, sizeof(gitbench_opt));
+
+	if (parser->idx >= parser->args_len)
+		return 0;
+
+	/* Handle arguments in long form, those beginning with "--" */
+	if (strncmp(parser->args[parser->idx], "--", 2) == 0 &&
+		!parser->in_literal)
+		parse_long(opt, parser);
+
+	/* Handle arguments in short form, those beginning with "-" */
+	else if (strncmp(parser->args[parser->idx], "-", 1) == 0 &&
+		!parser->in_literal)
+		parse_short(opt, parser);
+
+	/* Handle "free" arguments, those without a dash */
+	else
+		parse_arg(opt, parser);
+
+	return 1;
+}
+
+int gitbench_opt_usage_fprint(
+	FILE *file,
+	const char *command,
+	const gitbench_opt_spec specs[])
+{
+	const gitbench_opt_spec *spec;
+	int error;
+
+	if ((error = fprintf(file, "usage: %s", command)) < 0)
+		goto done;
+
+	for (spec = specs; spec->type; ++spec) {
+		int required = (spec->usage & GITBENCH_OPT_USAGE_REQUIRED);
+		int value_required = (spec->usage & GITBENCH_OPT_USAGE_VALUE_REQUIRED);
+
+		if (spec->usage & GITBENCH_OPT_USAGE_HIDDEN)
+			continue;
+
+		if ((error = fprintf(file, " ")) < 0)
+			goto done;
+
+		if (spec->type == GITBENCH_OPT_VALUE && value_required && spec->alias)
+			error = fprintf(file, "[-%c <%s>]", spec->alias, spec->value);
+		else if (spec->type == GITBENCH_OPT_VALUE && value_required)
+			error = fprintf(file, "[--%s=<%s>]", spec->name, spec->value);
+		else if (spec->type == GITBENCH_OPT_VALUE)
+			error = fprintf(file, "[--%s[=<%s>]]", spec->name, spec->value);
+		else if (spec->type == GITBENCH_OPT_ARG && required)
+			error = fprintf(file, "<%s>", spec->name);
+		else if (spec->type == GITBENCH_OPT_ARG)
+			error = fprintf(file, "[<%s>]", spec->name);
+		else if (spec->type == GITBENCH_OPT_ARGS && required)
+			error = fprintf(file, "<%s...>", spec->name);
+		else if (spec->type == GITBENCH_OPT_ARGS)
+			error = fprintf(file, "[<%s...>]", spec->name);
+		else if (spec->type == GITBENCH_OPT_LITERAL)
+			error = fprintf(file, "--");
+		else if (spec->alias)
+			error = fprintf(file, "[-%c]", spec->alias);
+		else
+			error = fprintf(file, "[--%s]", spec->name);
+
+		if (error < 0)
+			goto done;
+	}
+
+	error = fprintf(file, "\n");
+
+done:
+	error = (error < 0) ? -1 : 0;
+	return error;
+}
+

--- a/benchmark/opt.h
+++ b/benchmark/opt.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c), Edward Thomson <ethomson@edwardthomson.com>
+ * All rights reserved.
+ *
+ * This file is part of adopt, distributed under the MIT license.
+ * For full terms and conditions, see the included LICENSE file.
+ */
+
+#ifndef OPT_H
+#define OPT_H
+
+#include <stdio.h>
+
+/**
+ * The type of argument to be parsed.
+ */
+typedef enum {
+	GITBENCH_OPT_NONE = 0,
+
+	/** An argument that is specified ("--help" or "--debug") */
+	GITBENCH_OPT_SWITCH,
+
+	/** An argument that has a value ("--name value" or "-n value") */
+	GITBENCH_OPT_VALUE,
+
+	/** The literal arguments follow specifier, bare "--" */
+	GITBENCH_OPT_LITERAL,
+
+	/** A single "free" argument ("path") */
+	GITBENCH_OPT_ARG,
+
+	/** Unmatched arguments, a collection of "free" arguments ("paths...") */
+	GITBENCH_OPT_ARGS,
+} gitbench_opt_type_t;
+
+/**
+ * Usage information for an argument, to be displayed to the end-user.
+ * This is only for display, the parser ignores this usage information.
+ */
+typedef enum {
+	/** This argument is required. */
+	GITBENCH_OPT_USAGE_REQUIRED = (1u << 0),
+
+	/** A value is required for this argument. */
+	GITBENCH_OPT_USAGE_VALUE_REQUIRED = (1u << 1),
+
+	/** This argument should not be displayed in usage. */
+	GITBENCH_OPT_USAGE_HIDDEN = (1u << 2),
+
+	/** This is a multiple choice argument, combined with the previous arg. */
+	GITBENCH_OPT_USAGE_CHOICE = (1u << 3),
+} gitbench_opt_usage_t;
+
+/** Specification for an available option. */
+typedef struct gitbench_opt_spec {
+	/** Type of option expected. */
+	gitbench_opt_type_t type;
+
+	/** Name of the long option. */
+	const char *name;
+
+	/** The alias is the short (one-character) option alias. */
+	const char alias;
+
+	/** The name of the value, provided when creating usage information. */
+	const char *value;
+
+	/**
+	 * Short description of the option, used when creating usage
+	 * information.
+	 */
+	const char *help;
+
+	/**
+	 * Optional `gitbench_opt_usage_t`, used when creating usage information.
+	 */
+	gitbench_opt_usage_t usage;
+} gitbench_opt_spec;
+
+/** An option provided on the command-line. */
+typedef struct gitbench_opt {
+	/**
+	 * The specification that was provided on the command-line, or 
+	 * `NULL` if the argument did not match an `gitbench_opt_spec`.
+	 */
+	const gitbench_opt_spec *spec;
+
+	/**
+	 * The value provided to the argument, or `NULL` if the given
+	 * argument is a switch argument that does not take a value.
+	 * If the argument did not match and `gitbench_opt_spec`, this will
+	 * point to the unknown argument.
+	 */
+	const char *value;
+} gitbench_opt;
+
+/**
+ * The gitbench_opt_parser structure.  Callers should not modify these values
+ * directory.
+ */
+typedef struct gitbench_opt_parser {
+	const gitbench_opt_spec *specs;
+	const char **args;
+	size_t args_len;
+
+	size_t idx;
+	size_t arg_idx;
+	int in_literal : 1,
+		in_short : 1;
+} gitbench_opt_parser;
+
+/**
+ * Initializes a parser that parses the given arguments according to the
+ * given specifications.
+ *
+ * @param parser The `gitbench_opt_parser` that will be initialized
+ * @param specs A NULL-terminated array of `gitbench_opt_spec`s that can be parsed
+ * @param argv The arguments that will be parsed
+ * @param args_len The length of arguments to be parsed
+ */
+void gitbench_opt_parser_init(
+	gitbench_opt_parser *parser,
+	const gitbench_opt_spec specs[],
+	const char **argv,
+	size_t args_len);
+
+/**
+ * Parses the next command-line argument and places the information about
+ * the argument into the given `opt` data.
+ * 
+ * @param opt The `gitbench_opt` information parsed from the argument
+ * @param parser An `gitbench_opt_parser` that has been initialized with
+ *        `gitbench_opt_parser_init`
+ * @return true if the caller should continue iterating, or 0 if there are
+ *         no arguments left to process.
+ */
+int gitbench_opt_parser_next(
+	gitbench_opt *opt,
+	gitbench_opt_parser *parser);
+
+/**
+ * Prints usage information to the given file handle.
+ *
+ * @param file The file to print information to
+ * @param command The name of the command to use when printing
+ * @param specs The specifications allowed by the command
+ * @return 0 on success, -1 on failure
+ */
+int gitbench_opt_usage_fprint(
+	FILE *file,
+	const char *command,
+	const gitbench_opt_spec specs[]);
+
+#endif /* OPT_H */

--- a/benchmark/run.c
+++ b/benchmark/run.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "fileops.h"
+#include "run.h"
+#include "bench_util.h"
+#include "alloc.h"
+
+#define RUN_OPERATION_NONE UINT_MAX
+
+int gitbench_run_init(
+	gitbench_run **out,
+	size_t id,
+	size_t operation_cnt,
+	gitbench_operation_spec operations[])
+{
+	gitbench_run *run;
+	size_t i;
+
+	assert(out);
+	assert(operation_cnt != RUN_OPERATION_NONE);
+
+	*out = NULL;
+
+	if ((run = git__calloc(1, sizeof(gitbench_run))) == NULL)
+		return -1;
+
+	git_array_init_to_size(run->operation_data, operation_cnt);
+	GITERR_CHECK_ALLOC(run->operation_data.ptr);
+
+	run->id = id;
+	run->current_operation = RUN_OPERATION_NONE;
+
+	memset(run->operation_data.ptr, 0, sizeof(run->operation_data.ptr));
+	run->operation_data.size = operation_cnt;
+
+	for (i = 0; i < operation_cnt; i++)
+		run->operation_data.ptr[i].spec = &operations[i];
+
+	*out = run;
+	return 0;
+}
+
+int gitbench_run_start(gitbench_run *run)
+{
+	assert(run);
+	assert(run->start == 0);
+
+	if (gitbench__create_tempdir((char **)&run->tempdir) < 0)
+		return -1;
+
+	if (run->verbosity)
+		printf(": Starting run %" PRIuZ "\n", run->id);
+
+	run->start = git__timer();
+	return 0;
+}
+
+int gitbench_run_finish(gitbench_run *run)
+{
+	assert(run);
+	assert(run->end == 0);
+
+	run->end = git__timer();
+
+	if (run->verbosity)
+		printf(": Finished run %" PRIuZ "\n", run->id);
+
+	git_futils_rmdir_r(run->tempdir, NULL, GIT_RMDIR_REMOVE_FILES);
+
+	return 0;
+}
+
+int gitbench_run_start_operation(gitbench_run *run, unsigned int opcode)
+{
+	gitbench_run_operationdata *opdata;
+
+	assert(run);
+	assert(opcode < run->operation_data.size);
+	assert(run->current_operation == RUN_OPERATION_NONE);
+
+	opdata = git_array_get(run->operation_data, opcode);
+
+	assert(!opdata->ran);
+
+	if (run->profile_alloc) {
+		gitbench_alloc_start();
+
+		if (run->verbosity)
+			printf("::: Replacing allocation functions...\n");
+	}
+
+	if (run->verbosity) {
+		const char *type = "operation";
+
+		if (opdata->spec->type == GITBENCH_OPERATION_SETUP)
+			type = "setup";
+		else if (opdata->spec->type == GITBENCH_OPERATION_CLEANUP)
+			type = "cleanup";
+
+		printf("::: Starting %s: %s\n", type, opdata->spec->description);
+	}
+
+	run->current_operation = opcode;
+
+	opdata->ran = 1;
+	opdata->start = git__timer();
+
+	return 0;
+}
+
+int gitbench_run_finish_operation(gitbench_run *run)
+{
+	gitbench_run_operationdata *opdata;
+
+	assert(run);
+	assert(run->current_operation != RUN_OPERATION_NONE);
+
+	opdata = git_array_get(run->operation_data, run->current_operation);
+	opdata->end = git__timer();
+
+	run->current_operation = RUN_OPERATION_NONE;
+
+	if (run->verbosity) {
+		const char *type = "operation";
+
+		if (opdata->spec->type == GITBENCH_OPERATION_SETUP)
+			type = "setup";
+		else if (opdata->spec->type == GITBENCH_OPERATION_CLEANUP)
+			type = "cleanup";
+
+		printf("::: Finished %s: %s (total=%f seconds)\n",
+			type, opdata->spec->description, (opdata->end - opdata->start));
+	}
+
+	if (run->profile_alloc) {
+		gitbench_alloc_stop();
+	}
+
+	return 0;
+}
+
+void gitbench_run_free(gitbench_run *run)
+{
+	if (!run)
+		return;
+
+	git__free((char *)run->tempdir);
+	git__free(run);
+}

--- a/benchmark/run.h
+++ b/benchmark/run.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef RUN_H
+#define RUN_H
+
+#include "common.h"
+#include "vector.h"
+#include "array.h"
+#include "operation.h"
+
+typedef struct {
+	gitbench_operation_spec *spec;
+	bool ran;
+	double start;
+	double end;
+} gitbench_run_operationdata;
+
+/** Specification for a benchmark command. */
+typedef struct {
+	size_t id;
+	int verbosity;
+	unsigned int profile_alloc:1;
+
+	const char *tempdir;
+
+	/* start and end of the overall run */
+	double start;
+	double end;
+	git_array_t(gitbench_run_operationdata) operation_data;
+	unsigned int current_operation;
+} gitbench_run;
+
+/** Allocate a run. */
+extern int gitbench_run_init(
+	gitbench_run **run,
+	size_t id,
+	size_t operation_cnt,
+	gitbench_operation_spec operations[]);
+
+/** Start an overall run. */
+extern int gitbench_run_start(gitbench_run *run);
+
+/** Finish an overall run. */
+extern int gitbench_run_finish(gitbench_run *run);
+
+/** Start a single operation within a run. */
+extern int gitbench_run_start_operation(gitbench_run *run, unsigned int operation);
+
+/** Finish a single operation within a run. */
+extern int gitbench_run_finish_operation(gitbench_run *run);
+
+/** Free a run. */
+extern void gitbench_run_free(gitbench_run *run);
+
+#endif


### PR DESCRIPTION
While @jeffhostetler and I have been working on some perf improvements in libgit2, I think that we've both been fooling around mostly with clar tests, since that's the easiest way to have a self-contained executor within the existing framework.  However my experience is that these end up being abandoned and re-written often (I have a patch file hanging around for a clar test of the included checkout test that I periodically reapply, sigh.)  Or we end up checking them in and they require exacting setup to keep working.

This is an attempt at a more purpose-built benchmark runner.  It allows for setup, execution and teardown steps, timing each, and computes the overall time of each step (and all execution time).  It will allow you to perform multiple runs and display the output in a tab-delimited format.

Because we use `git__malloc` and friends everywhere, if we build a monolithic executable with libgit2, we can also substitute our own allocator to instrument number and size of allocations within our execution.

This, like many of these sorts of PRs, might be crazy.