### PR TITLE
Fix cloning of over 2 Gb repositories on Windows

### DIFF
--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -35,6 +35,8 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	DWORD page_size = get_page_size();
 	DWORD fmap_prot = 0;
 	DWORD view_prot = 0;
+	DWORD max_size_low = 0;
+	DWORD max_size_hi = 0;
 	DWORD off_low = 0;
 	DWORD off_hi = 0;
 	git_off_t page_start;
@@ -71,7 +73,9 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 		return -1;
 	}
 
-	out->fmh = CreateFileMapping(fh, NULL, fmap_prot, 0, 0, NULL);
+	max_size_low = (DWORD)(page_start + len);
+	max_size_hi = (DWORD)((page_start + len) >> 32);
+	out->fmh = CreateFileMapping(fh, NULL, fmap_prot, max_size_hi, max_size_low, NULL);
 	if (!out->fmh || out->fmh == INVALID_HANDLE_VALUE) {
 		giterr_set(GITERR_OS, "Failed to mmap. Invalid handle value");
 		out->fmh = NULL;

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -55,7 +55,7 @@ int p_ftruncate(int fd, git_off_t size)
 		return -1;
 	}
 
-#if !defined(__MINGW32__)
+#if !defined(__MINGW32__) || defined(MINGW_HAS_SECURE_API)
 	return ((_chsize_s(fd, size) == 0) ? 0 : -1);
 #else
 	/* TODO MINGW32 Find a replacement for _chsize() that handles big files. */


### PR DESCRIPTION
Libgit2 failed to clone a repository with over 2 Gb of objects on Windows. This seems to have been caused by libgit2 failing to increase the size of the pack file into which it was downloading objects from the repository and inability to use MapViewOfFile to map beyond 2 Gb.

The former is resolved by using _chsize_s instead of _chsize. The latter I fixed by explicitly specifying the maximum size in the call to CreateFileMapping when creating the file mapping object.