### PR TITLE
Add annotated versions of ref-modying functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ v0.22 + 1
 * The local transport now auto-scales the number of threads to use
   when creating the packfile instead of sticking to one.
 
+* Reference renaming now uses the right id for the old value.
+
+* The annotated version of branch creation, HEAD detaching and reset
+  allow for specifying the expression from the user to be put into the
+  reflog.
+
 ### API additions
 
 * Parsing and retrieving a configuration value as a path is exposed
@@ -33,7 +39,14 @@ v0.22 + 1
 * `git_config_get_string_buf()` provides a way to safely retrieve a
   string from a non-snapshot configuration.
 
-* Reference renaming now uses the right id for the old value.
+* `git_annotated_commit_from_revspec()` allows to get an annotated
+  commit from an extended sha synatx string.
+
+* `git_repository_set_head_detached_from_annotated()`,
+  `git_branch_create_from_annotated()` and
+  `git_reset_from_annotated()` allow for the caller to provide an
+  annotated commit through which they can control what expression is
+  put into the reflog as the source/target.
 
 * `git_index_add_frombuffer()` can now create a blob from memory
    buffer and add it to the index which is attached to a repository.

--- a/include/git2/annotated_commit.h
+++ b/include/git2/annotated_commit.h
@@ -78,6 +78,23 @@ GIT_EXTERN(int) git_annotated_commit_lookup(
 	const git_oid *id);
 
 /**
+ * Creates a `git_annotated_comit` from a revision string.
+ *
+ * See `man gitrevisions`, or
+ * http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for
+ * information on the syntax accepted.
+ *
+ * @param out pointer to store the git_annotated_commit result in
+ * @param repo repository that contains the given commit
+ * @param revspec the extended sha syntax string to use to lookup the commit
+ * @return 0 on success or error code
+ */
+GIT_EXTERN(int) git_annotated_commit_from_revspec(
+	git_annotated_commit **out,
+	git_repository *repo,
+	const char *revspec);
+
+/**
  * Gets the commit ID that the given `git_annotated_commit` refers to.
  *
  * @param commit the given annotated commit

--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -55,6 +55,24 @@ GIT_EXTERN(int) git_branch_create(
 	int force);
 
 /**
+ * Create a new branch pointing at a target commit
+ *
+ * This behaves like `git_branch_create()` but takes an annotated
+ * commit, which lets you specify which extended sha syntax string was
+ * specified by a user, allowing for more exact reflog messages.
+ *
+ * See the documentation for `git_branch_create()`.
+ *
+ * @see git_branch_create
+ */
+GIT_EXTERN(int) git_branch_create_from_annotated(
+	git_reference **ref_out,
+	git_repository *repository,
+	const char *branch_name,
+	const git_annotated_commit *commit,
+	int force);
+
+/**
  * Delete an existing branch reference.
  *
  * If the branch is successfully deleted, the passed reference

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -630,6 +630,22 @@ GIT_EXTERN(int) git_repository_set_head_detached(
 	const git_oid* commitish);
 
 /**
+ * Make the repository HEAD directly point to the Commit.
+ *
+ * This behaves like `git_repository_set_head_detached()` but takes an
+ * annotated commit, which lets you specify which extended sha syntax
+ * string was specified by a user, allowing for more exact reflog
+ * messages.
+ *
+ * See the documentation for `git_repository_set_head_detached()`.
+ *
+ * @see git_repository_set_head_detached
+ */
+GIT_EXTERN(int) git_repository_set_head_detached_from_annotated(
+	git_repository *repo,
+	const git_annotated_commit *commitish);
+
+/**
  * Detach the HEAD.
  *
  * If the HEAD is already detached and points to a Commit, 0 is returned.

--- a/include/git2/reset.h
+++ b/include/git2/reset.h
@@ -65,6 +65,24 @@ GIT_EXTERN(int) git_reset(
 	git_checkout_options *checkout_opts);
 
 /**
+ * Sets the current head to the specified commit oid and optionally
+ * resets the index and working tree to match.
+ *
+ * This behaves like `git_reset()` but takes an annotated commit,
+ * which lets you specify which extended sha syntax string was
+ * specified by a user, allowing for more exact reflog messages.
+ *
+ * See the documentation for `git_reset()`.
+ *
+ * @see git_reset
+ */
+GIT_EXTERN(int) git_reset_from_annotated(
+	git_repository *repo,
+	git_annotated_commit *commit,
+	git_reset_t reset_type,
+	git_checkout_options *checkout_opts);
+
+/**
  * Updates some entries in the index from the target commit tree.
  *
  * The scope of the updated entries is determined by the paths

--- a/src/reset.c
+++ b/src/reset.c
@@ -10,6 +10,7 @@
 #include "tag.h"
 #include "merge.h"
 #include "diff.h"
+#include "annotated_commit.h"
 #include "git2/reset.h"
 #include "git2/checkout.h"
 #include "git2/merge.h"
@@ -96,9 +97,10 @@ cleanup:
 	return error;
 }
 
-int git_reset(
+static int reset(
 	git_repository *repo,
 	git_object *target,
+	const char *to,
 	git_reset_t reset_type,
 	git_checkout_options *checkout_opts)
 {
@@ -139,7 +141,7 @@ int git_reset(
 		goto cleanup;
 	}
 
-	if ((error = git_buf_printf(&log_message, "reset: moving to %s", git_oid_tostr_s(git_object_id(commit)))) < 0)
+	if ((error = git_buf_printf(&log_message, "reset: moving to %s", to)) < 0)
 		return error;
 
 	/* move HEAD to the new target */
@@ -175,4 +177,22 @@ cleanup:
 	git_buf_free(&log_message);
 
 	return error;
+}
+
+int git_reset(
+	git_repository *repo,
+	git_object *target,
+	git_reset_t reset_type,
+	git_checkout_options *checkout_opts)
+{
+	return reset(repo, target, git_oid_tostr_s(git_object_id(target)), reset_type, checkout_opts);
+}
+
+int git_reset_from_annotated(
+	git_repository *repo,
+	git_annotated_commit *commit,
+	git_reset_t reset_type,
+	git_checkout_options *checkout_opts)
+{
+	return reset(repo, (git_object *) commit->commit, commit->ref_name, reset_type, checkout_opts);
 }

--- a/tests/repo/head.c
+++ b/tests/repo/head.c
@@ -2,6 +2,7 @@
 #include "refs.h"
 #include "repo_helpers.h"
 #include "posix.h"
+#include "git2/annotated_commit.h"
 
 static const char *g_email = "foo@example.com";
 static git_repository *repo;
@@ -251,6 +252,7 @@ void test_repo_head__setting_head_updates_reflog(void)
 {
 	git_object *tag;
 	git_signature *sig;
+	git_annotated_commit *annotated;
 
 	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
@@ -264,6 +266,12 @@ void test_repo_head__setting_head_updates_reflog(void)
 	test_reflog(repo, 1, NULL, "tags/test^{commit}", "foo@example.com", "checkout: moving from unborn to e90810b8df3e80c413d903f631643c716887138d");
 	test_reflog(repo, 0, "tags/test^{commit}", "refs/heads/haacked", "foo@example.com", "checkout: moving from e90810b8df3e80c413d903f631643c716887138d to haacked");
 
+	cl_git_pass(git_annotated_commit_from_revspec(&annotated, repo, "haacked~0"));
+	cl_git_pass(git_repository_set_head_detached_from_annotated(repo, annotated));
+
+	test_reflog(repo, 0, NULL, "refs/heads/haacked", "foo@example.com", "checkout: moving from haacked to haacked~0");
+
+	git_annotated_commit_free(annotated);
 	git_object_free(tag);
 	git_signature_free(sig);
 }

--- a/tests/reset/mixed.c
+++ b/tests/reset/mixed.c
@@ -51,6 +51,7 @@ void test_reset_mixed__resetting_refreshes_the_index_to_the_commit_tree(void)
 void test_reset_mixed__reflog_is_correct(void)
 {
 	git_buf buf = GIT_BUF_INIT;
+	git_annotated_commit *annotated;
 	const char *exp_msg = "commit: Updating test data so we can test inter-hunk-context";
 
 	reflog_check(repo, "HEAD", 9, "yoram.harmelin@gmail.com", exp_msg);
@@ -65,13 +66,20 @@ void test_reset_mixed__reflog_is_correct(void)
 	git_object_free(target);
 	target = NULL;
 
-	/* Moved branch, expect default message */
+	/* Moved branch, expect id in message */
 	cl_git_pass(git_revparse_single(&target, repo, "HEAD~^{commit}"));
 	git_buf_clear(&buf);
 	cl_git_pass(git_buf_printf(&buf, "reset: moving to %s", git_oid_tostr_s(git_object_id(target))));
 	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
 	reflog_check(repo, "HEAD", 10, NULL, git_buf_cstr(&buf));
 	reflog_check(repo, "refs/heads/master", 10, NULL, git_buf_cstr(&buf));
-
 	git_buf_free(&buf);
+
+	/* Moved branch, expect revspec in message */
+	exp_msg = "reset: moving to HEAD~^{commit}";
+	cl_git_pass(git_annotated_commit_from_revspec(&annotated, repo, "HEAD~^{commit}"));
+	cl_git_pass(git_reset_from_annotated(repo, annotated, GIT_RESET_MIXED, NULL));
+	reflog_check(repo, "HEAD", 11, NULL, exp_msg);
+	reflog_check(repo, "refs/heads/master", 11, NULL, exp_msg);
+	git_annotated_commit_free(annotated);
 }


### PR DESCRIPTION
This adds a way to get an annotated commit from an extended sha string in order to know what the user typed so we can put that in the reflog.

This provides for branch creation, detaching HEAD and reset.

This fixes #2949 