### PR TITLE
refdb: use the same id for old and new when renaming a reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ v0.22 + 1
 * `git_config_get_string_buf()` provides a way to safely retrieve a
   string from a non-snapshot configuration.
 
+* Reference renaming now uses the right id for the old value.
+
 ### API removals
 
 ### Breaking API changes

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1324,7 +1324,7 @@ static int refdb_fs_backend__rename(
 	/* Try to rename the refog; it's ok if the old doesn't exist */
 	error = refdb_reflog_fs__rename(_backend, old_name, new_name);
 	if (((error == 0) || (error == GIT_ENOTFOUND)) &&
-	    ((error = reflog_append(backend, new, NULL, NULL, who, message)) < 0)) {
+	    ((error = reflog_append(backend, new, git_reference_target(new), NULL, who, message)) < 0)) {
 		git_reference_free(new);
 		git_filebuf_cleanup(&file);
 		return error;

--- a/tests/refs/branches/move.c
+++ b/tests/refs/branches/move.c
@@ -203,6 +203,7 @@ void test_refs_branches_move__default_reflog_message(void)
 	const git_reflog_entry *entry;
 	git_signature *sig;
 	git_config *cfg;
+	git_oid id;
 
 	cl_git_pass(git_repository_config(&cfg, repo));
 	cl_git_pass(git_config_set_string(cfg, "user.name", "Foo Bar"));
@@ -212,6 +213,7 @@ void test_refs_branches_move__default_reflog_message(void)
 	cl_git_pass(git_signature_default(&sig, repo));
 
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/master"));
+	git_oid_cpy(&id, git_reference_target(branch));
 	cl_git_pass(git_branch_move(&new_branch, branch, "master2", 0));
 
 	cl_git_pass(git_reflog_read(&log, repo, git_reference_name(new_branch)));
@@ -219,6 +221,8 @@ void test_refs_branches_move__default_reflog_message(void)
 	cl_assert_equal_s("branch: renamed refs/heads/master to refs/heads/master2",
 			git_reflog_entry_message(entry));
 	cl_assert_equal_s(sig->email, git_reflog_entry_committer(entry)->email);
+	cl_assert_equal_oid(&id, git_reflog_entry_id_old(entry));
+	cl_assert_equal_oid(&id, git_reflog_entry_id_new(entry));
 
 	git_reference_free(branch);
 	git_reference_free(new_branch);


### PR DESCRIPTION
When we rename a reference, we want the old and new ids to be the same
one (as we did not change it). The normal code path looks up the old id
from the current value of the brtanch, but by the time we look it up, it
does not exist anymore and thus we write a zero id.

Pass the old id explicitly instead.