### PR TITLE
refspec: report errors when parsing an invalid refspec

### DIFF
--- a/src/refspec.c
+++ b/src/refspec.c
@@ -133,6 +133,9 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 	return 0;
 
  invalid:
+        giterr_set(
+                GITERR_INVALID,
+                "'%s' is not a valid refspec.", input);
 	return -1;
 }
 


### PR DESCRIPTION
Adding an invalid refspec would return a nonspecific error code and
would not include an error message or class, making it hard to debug errors with
malformed refspecs. This commit fixes this by returning the appropriate
error code and setting a specific error message.

This can reproduced via rugged with the following:

```ruby
#!/usr/bin/env ruby
require 'rugged'
require 'tmpdir'
repo = Rugged::Repository.init_at(Dir.mktmpdir)
repo.config.tap do |c|
  c['remote.origin.url'] = 'git@github.com:libgit2/libgit2'
  c['remote.origin.fetch'] = '/an/invalid:/refspec'
end
repo.fetch('origin')
```

```
/home/adrien/development/repro/.bundle/ruby/1.9.1/gems/rugged-0.21.4/lib/rugged/repository.rb:200:in `[]': Unknown Error (Rugged::OSError)
    from /home/adrien/development/repro/.bundle/ruby/1.9.1/gems/rugged-0.21.4/lib/rugged/repository.rb:200:in `fetch'
    from ./reproduction.rb:11:in `<main>'
```