### PR TITLE
"In-memory" repos are bare by default

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -171,7 +171,13 @@ static git_repository *repository_alloc(void)
 
 int git_repository_new(git_repository **out)
 {
-	*out = repository_alloc();
+	git_repository *repo;
+
+	*out = repo = repository_alloc();
+	GITERR_CHECK_ALLOC(repo);
+
+	repo->is_bare = 1;
+
 	return 0;
 }
 

--- a/tests/repo/new.c
+++ b/tests/repo/new.c
@@ -1,0 +1,27 @@
+#include "clar_libgit2.h"
+#include "git2/sys/repository.h"
+
+void test_repo_new__has_nothing(void)
+{
+	git_repository *repo;
+
+	cl_git_pass(git_repository_new(&repo));
+	cl_assert_equal_b(true, git_repository_is_bare(repo));
+	cl_assert_equal_p(NULL, git_repository_path(repo));
+	cl_assert_equal_p(NULL, git_repository_workdir(repo));
+	git_repository_free(repo);
+}
+
+void test_repo_new__is_bare_until_workdir_set(void)
+{
+	git_repository *repo;
+
+	cl_git_pass(git_repository_new(&repo));
+	cl_assert_equal_b(true, git_repository_is_bare(repo));
+
+	cl_git_pass(git_repository_set_workdir(repo, clar_sandbox_path(), 0));
+	cl_assert_equal_b(false, git_repository_is_bare(repo));
+
+	git_repository_free(repo);
+}
+


### PR DESCRIPTION
A repository created using `git_repository_new` lacks a working directory and thus should report `true` when queried with `git_repository_is_bare`.

(This repository will no longer be bare when `set_workdir` is called, if it is called.)