### PR TITLE
local: create pack with multiple threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ v0.22 + 1
   removed. Use `git_repository_set_ident()` and
   `git_repository_ident()` to override the signature to be used.
 
+* The local transport now auto-scales the number of threads to use
+  when creating the packfile instead of sticking to one.
+
 ### API additions
 
 * Parsing and retrieving a configuration value as a path is exposed

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -609,6 +609,9 @@ static int local_download_pack(
 		data.progress_payload = progress_payload;
 		data.writepack = writepack;
 
+		/* autodetect */
+		git_packbuilder_set_threads(pack, 0);
+
 		if ((error = git_packbuilder_foreach(pack, foreach_cb, &data)) != 0)
 			goto cleanup;
 	}


### PR DESCRIPTION
The default behaviour for the packbuilder is to perform the work in a
single thread, which is fine for the public API, but we currently have
no way for a user to determine the number of threads to use when
creating the packfile, which makes our clone behaviour over the
filesystem quite a bit slower than what git offers.

This is a very particular scenario, in which we avoid spawning git by
being ourselves the server-side, so it's probably ok to auto-set the
threading, as the upload-pack process would do if we were talking to
git.