### PR TITLE
Make sure to pack referenced objects for non-branches

### DIFF
--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -128,6 +128,18 @@ GIT_EXTERN(int) git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid
 GIT_EXTERN(int) git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk);
 
 /**
+ * Recursively insert an object and its referenced objects
+ *
+ * Insert the object as well as any object it references.
+ *
+ * @param pb the packbuilder
+ * @param id the id of the root object to insert
+ * @param name optional name for the object
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_packbuilder_insert_recur(git_packbuilder *pb, const git_oid *id, const char *name);
+
+/**
  * Write the contents of the packfile to an in-memory buffer
  *
  * The contents of the buffer will become a valid packfile, even though there

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -544,7 +544,8 @@ static int local_download_pack(
 					error = 0;
 			}
 		} else {
-			error = git_packbuilder_insert(pack, &rhead->oid, rhead->name);
+			/* Tag or some other wanted object. Add it on its own */
+			error = git_packbuilder_insert_recur(pack, &rhead->oid, rhead->name);
 		}
 		git_object_free(obj);
 		if (error < 0)

--- a/src/tree.c
+++ b/src/tree.c
@@ -858,7 +858,7 @@ int git_tree_entry_bypath(
 
 	if (entry == NULL) {
 		giterr_set(GITERR_TREE,
-			"The path '%s' does not exist in the given tree", path);
+			   "the path '%.*s' does not exist in the given tree", filename_len, path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -868,7 +868,7 @@ int git_tree_entry_bypath(
 		 * then this entry *must* be a tree */
 		if (!git_tree_entry__is_tree(entry)) {
 			giterr_set(GITERR_TREE,
-				"The path '%s' does not exist in the given tree", path);
+				   "the path '%.*s' exists but is not a tree", filename_len, path);
 			return GIT_ENOTFOUND;
 		}
 


### PR DESCRIPTION
When we have e.g. a tag, we also need to recursively insert referenced objects, not just the top one as we do currently. This introduces a function to recursively insert objects without having to care about the particular type and then uses it in the local transport.

While getting the test wrong, I also saw that we have some misleading error messages in the tree entry lookup, so one of the commits changes the error message a bit as well.