### PR TITLE
Avoid retaining / releasing the index more than necessary when GIT_DIFF_...

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -620,10 +620,9 @@ int git_diff__oid_for_entry(
 	if (!error && update_match && git_oid_equal(out, update_match)) {
 		git_index *idx;
 
-		if (!(error = git_repository_index(&idx, diff->repo))) {
+		if (!(error = git_repository_index__weakptr(&idx, diff->repo))) {
 			memcpy(&entry.id, out, sizeof(entry.id));
 			error = git_index_add(idx, &entry);
-			git_index_free(idx);
 		}
  	}
 


### PR DESCRIPTION
...UPDATE_INDEX is enabled