### PR TITLE
Fix git_submodule_sync writing URL to wrong key.

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1091,10 +1091,10 @@ int git_submodule_sync(git_submodule *sm)
 			/* return error from reading submodule config */;
 		else if ((error = lookup_head_remote_key(&remote_name, smrepo)) < 0) {
 			giterr_clear();
-			error = git_buf_sets(&key, "branch.origin.remote");
+			error = git_buf_sets(&key, "remote.origin.url");
 		} else {
 			error = git_buf_join3(
-				&key, '.', "branch", remote_name.ptr, "remote");
+				&key, '.', "remote", remote_name.ptr, "url");
 			git_buf_free(&remote_name);
 		}
 

--- a/tests/submodule/modify.c
+++ b/tests/submodule/modify.c
@@ -118,11 +118,11 @@ void test_submodule_modify__sync(void)
 
 	/* check that submodule config is updated */
 	assert_submodule_url_is_synced(
-		sm1, "submodule."SM1".url", "branch.origin.remote");
+		sm1, "submodule."SM1".url", "remote.origin.url");
 	assert_submodule_url_is_synced(
-		sm2, "submodule."SM2".url", "branch.origin.remote");
+		sm2, "submodule."SM2".url", "remote.origin.url");
 	assert_submodule_url_is_synced(
-		sm3, "submodule."SM3".url", "branch.origin.remote");
+		sm3, "submodule."SM3".url", "remote.origin.url");
 
 	git_submodule_free(sm1);
 	git_submodule_free(sm2);


### PR DESCRIPTION
Currently git_submodule_sync writes the submodule's URL to the
key 'branch.REMOTE_NAME.remote' while the reference
implementation of `git submodule sync` writes to
'remote.REMOTE_NAME.url', which is the intended behavior
according to git-submodule(1).