### PR TITLE
Fixed initialization of libssh2 sessions and set a default 30s timeout

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -362,7 +362,7 @@ static int _git_ssh_authenticate_session(
 		default:
 			rc = LIBSSH2_ERROR_AUTHENTICATION_FAILED;
 		}
-	} while (LIBSSH2_ERROR_EAGAIN == rc || LIBSSH2_ERROR_TIMEOUT == rc);
+	} while (LIBSSH2_ERROR_TIMEOUT == rc);
 
         if (rc == LIBSSH2_ERROR_PASSWORD_EXPIRED || rc == LIBSSH2_ERROR_AUTHENTICATION_FAILED)
                 return GIT_EAUTH;
@@ -417,7 +417,6 @@ static int _git_ssh_session_create(
 	LIBSSH2_SESSION** session,
 	git_stream *io)
 {
-	int rc = 0;
 	LIBSSH2_SESSION* s;
 	git_socket_stream *socket = (git_socket_stream *) io;
 
@@ -429,17 +428,15 @@ static int _git_ssh_session_create(
 		return -1;
 	}
 
-	do {
-		rc = libssh2_session_startup(s, socket->s);
-	} while (LIBSSH2_ERROR_EAGAIN == rc || LIBSSH2_ERROR_TIMEOUT == rc);
+	/* Configure libssh2 to be blocking with a 30s timeout */
+	libssh2_session_set_blocking(s, 1);
+	libssh2_session_set_timeout(s, 30 * 1000);
 
-	if (rc != LIBSSH2_ERROR_NONE) {
+	if (libssh2_session_startup(s, socket->s) != LIBSSH2_ERROR_NONE) {
 		ssh_error(s, "Failed to start SSH session");
 		libssh2_session_free(s);
 		return -1;
 	}
-
-	libssh2_session_set_blocking(s, 1);
 
 	*session = s;
 


### PR DESCRIPTION
There are 2 issues with the current initialization code for libssh2 in _git_ssh_session_create():
1) It's not using libssh2_session_startup() properly.
2) It will hang forever if the remote side is not responding.

The default state of new libssh2 sessions appears to be blocking with no timeout set i.e. infinite.
In this mode, libssh2_session_startup() cannot return LIBSSH2_ERROR_EAGAIN and will not return
LIBSSH2_ERROR_TIMEOUT either since no timeout has been set.

The 2 issues can be addressed by simplifying the code to first configure the libssh2 session in blocking
mode and a 30 seconds timeout, and then call libssh2_session_startup() and check for any error.

The reason to still explicitely enable blocking mode is that even if it appears to be the default,
the libssh2 docs do not mention such a default, so maybe different libssh2 versions have different
defaults.

Since the libssh2 session is in blocking mode, LIBSSH2_ERROR_EAGAIN cannot be returned either
in _git_ssh_authenticate_session() so it has been removed.