### PR TITLE
Configure a 30 seconds timeout for recv() and send() on new sockets

### DIFF
--- a/src/socket_stream.c
+++ b/src/socket_stream.c
@@ -126,6 +126,17 @@ int socket_connect(git_stream *stream)
 		return -1;
 	}
 
+	/* Configure a 30 seconds timeout for recv() and send() on the socket */
+	struct timeval tv;
+	tv.tv_sec = 30;
+	tv.tv_usec = 0;
+	if (setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+		net_set_error("error setting socket receive timeout");
+	}
+	if (setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+		net_set_error("error setting socket send timeout");
+	}
+
 	st->s = s;
 	p_freeaddrinfo(info);
 	return 0;


### PR DESCRIPTION
This prevents libgit2 transport to hang forever when communicating with
non-responding hosts.