### PR TITLE
Don't ask for a stream's certificate unless it's encrypted

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -15,6 +15,11 @@ GIT_INLINE(int) git_stream_connect(git_stream *st)
 	return st->connect(st);
 }
 
+GIT_INLINE(int) git_stream_is_encrypted(git_stream *st)
+{
+	return st->encrypted;
+}
+
 GIT_INLINE(int) git_stream_certificate(git_cert **out, git_stream *st)
 {
 	if (!st->encrypted) {

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -558,7 +558,8 @@ static int http_connect(http_subtransport *t)
 	error = git_stream_connect(t->io);
 
 #ifdef GIT_SSL
-	if ((!error || error == GIT_ECERTIFICATE) && t->owner->certificate_check_cb != NULL) {
+	if ((!error || error == GIT_ECERTIFICATE) && t->owner->certificate_check_cb != NULL &&
+	    git_stream_is_encrypted(t->io)) {
 		git_cert *cert;
 		int is_valid;
 

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -565,3 +565,10 @@ void test_online_clone__certificate_valid(void)
 
 	cl_git_pass(git_clone(&g_repo, "https://github.com/libgit2/TestGitRepository", "./foo", &g_options));
 }
+
+void test_online_clone__start_with_http(void)
+{
+	g_options.remote_callbacks.certificate_check = succeed_certificate_check;
+
+	cl_git_pass(git_clone(&g_repo, "http://github.com/libgit2/TestGitRepository", "./foo", &g_options));
+}


### PR DESCRIPTION
When dealing with an unencrypted stream, do not attempt to perform certificate validation.

This fixes #2904 