### PR TITLE
PERF: In MERGE, lazily compute is_binary

### DIFF
--- a/src/merge.h
+++ b/src/merge.h
@@ -107,7 +107,6 @@ typedef struct {
 	git_index_entry their_entry;
 	git_delta_t their_status;
 
-	int binary:1;
 } git_merge_diff;
 
 int git_merge__bases_many(


### PR DESCRIPTION
The MERGE code is calling merge_diff_detect_binary() for every modified file -- even if it was only modified by one branch.  This requires fetching all 2 or 3 versions of the file and scanning them.   Only the code in merge_conflict_resolve_automerge() actually cares if the files are in fact binary.

This change moves the "is binary" check into the automerge code.

I also removed the "git_merge_diff.binary" field, since it is is only needed by automerge and to prevent accidents.
