### PR TITLE
Lower case the include directive of windows header

### DIFF
--- a/tests/checkout/icase.c
+++ b/tests/checkout/icase.c
@@ -4,7 +4,7 @@
 #include "path.h"
 
 #ifdef GIT_WIN32
-# include <Windows.h>
+# include <windows.h>
 #endif
 
 static git_repository *repo;


### PR DESCRIPTION
Since the Linux platform has a case sensitive file system, the header name should be lower case for cross 
compiling purposes. (On Linux, the mingw header is called ```windows.h```).