### PR TITLE
git_futils_mkdir_ext: tolerate EEXIST from p_mkdir

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -422,7 +422,7 @@ int git_futils_mkdir_ext(
 			if (p_lstat(make_path.ptr, &st) < 0) {
 				if (errno != ENOENT || mkdir_attempted == 1) {
 					giterr_set(GITERR_OS, "Failed to make directory '%s'", make_path.ptr);
-					error = GIT_EEXISTS;
+					error = -1;
 					goto done;
 				}
 
@@ -432,7 +432,7 @@ int git_futils_mkdir_ext(
 					break;
 				} else if (errno != EEXIST) {
 					giterr_set(GITERR_OS, "Failed to make directory '%s'", make_path.ptr);
-					error = GIT_EEXISTS;
+					error = -1;
 					goto done;
 				} else {
 					/* re-stat the path and check again */

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -339,7 +339,7 @@ int git_futils_mkdir_ext(
 	struct git_futils_mkdir_options *opts)
 {
 	int error = -1;
-	int mkdir_attempted = 0;
+	int mkdir_attempted;
 	git_buf make_path = GIT_BUF_INIT;
 	ssize_t root = 0, min_root_len, root_len;
 	char lastch = '/', *tail;
@@ -416,6 +416,7 @@ int git_futils_mkdir_ext(
 			continue;
 
 		/* See what's going on with this path component */
+		mkdir_attempted = 0;
 		do {
 			opts->perfdata.stat_calls++;
 			if (p_lstat(make_path.ptr, &st) < 0) {

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -417,7 +417,7 @@ int git_futils_mkdir_ext(
 
 		/* See what's going on with this path component */
 		mkdir_attempted = 0;
-		do {
+		for (;;) {
 			opts->perfdata.stat_calls++;
 			if (p_lstat(make_path.ptr, &st) < 0) {
 				if (errno != ENOENT || mkdir_attempted == 1) {
@@ -452,7 +452,7 @@ int git_futils_mkdir_ext(
 
 				break;
 			}
-		} while (1);
+		}
 
 		/* chmod if requested and necessary */
 		if (((flags & GIT_MKDIR_CHMOD_PATH) != 0 ||

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -420,7 +420,8 @@ int git_futils_mkdir_ext(
 		if (p_lstat(make_path.ptr, &st) < 0) {
 			opts->perfdata.mkdir_calls++;
 
-			if (errno != ENOENT || p_mkdir(make_path.ptr, mode) < 0) {
+			if (errno != ENOENT ||
+				(p_mkdir(make_path.ptr, mode) < 0 && errno != EEXIST)) {
 				giterr_set(GITERR_OS, "Failed to make directory '%s'", make_path.ptr);
 				error = GIT_EEXISTS;
 				goto done;


### PR DESCRIPTION
In function `git_futils_mkdir_ext` there is a non-atomic stat-then-mkdir sequence which opens a race whereby two processes may proceed past their stat checks, and both proceed to try to mkdir.  One of the processes will fail with errno `EEXIST`.

With this change, `EEXIST` is tolerated from the mkdir call such that the overall directory initialization can continue on rather than fail.

My proposed fix to resolve https://github.com/libgit2/libgit2/issues/2987.