### PR TITLE
Add support to read ssh keys from memory.

### DIFF
--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -112,7 +112,7 @@ typedef enum {
 	 *
 	 * Only available for libssh2+OpenSSL for now.
 	 */
-	+GIT_CREDTYPE_SSH_MEMORY = (1u << 6),
+	GIT_CREDTYPE_SSH_MEMORY = (1u << 6),
 #endif
 } git_credtype_t;
 
@@ -307,7 +307,7 @@ GIT_EXTERN(int) git_cred_username_new(git_cred **cred, const char *username);
  * @param passphrase The passphrase of the credential.
  * @return 0 for success or an error code for failure
  */
-IT_EXTERN(int) git_cred_ssh_key_memory_new(
+GIT_EXTERN(int) git_cred_ssh_key_memory_new(
 	git_cred **out,
 	const char *username,
 	const char *publickey,

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -296,7 +296,6 @@ GIT_EXTERN(int) git_cred_default_new(git_cred **out);
  */
 GIT_EXTERN(int) git_cred_username_new(git_cred **cred, const char *username);
 
-#ifdef GIT_SSH_MEMORY_CREDENTIALS
 /**
  * Create a new ssh key credential object reading the keys from memory.
  *
@@ -313,7 +312,6 @@ GIT_EXTERN(int) git_cred_ssh_key_memory_new(
 	const char *publickey,
 	const char *privatekey,
 	const char *passphrase);
-#endif
 
 /**
  * Signature of a function which acquires a credential object.

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -105,6 +105,15 @@ typedef enum {
 	 * it will ask via this credential type.
 	 */
 	GIT_CREDTYPE_USERNAME = (1u << 5),
+
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
+	/**
+	 * Credentials read from memory.
+	 *
+	 * Only available for libssh2+OpenSSL for now.
+	 */
+	+GIT_CREDTYPE_SSH_MEMORY = (1u << 6),
+#endif
 } git_credtype_t;
 
 /* The base structure for all credential types */
@@ -286,6 +295,25 @@ GIT_EXTERN(int) git_cred_default_new(git_cred **out);
  * none is specified in the url.
  */
 GIT_EXTERN(int) git_cred_username_new(git_cred **cred, const char *username);
+
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
+/**
+ * Create a new ssh key credential object reading the keys from memory.
+ *
+ * @param out The newly created credential object.
+ * @param username username to use to authenticate.
+ * @param publickey The public key of the credential.
+ * @param privatekey The private key of the credential.
+ * @param passphrase The passphrase of the credential.
+ * @return 0 for success or an error code for failure
+ */
+IT_EXTERN(int) git_cred_ssh_key_memory_new(
+	git_cred **out,
+	const char *username,
+	const char *publickey,
+	const char *privatekey,
+	const char *passphrase);
+#endif
 
 /**
  * Signature of a function which acquires a credential object.

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -9,6 +9,14 @@
 #include "smart.h"
 #include "git2/cred_helpers.h"
 
+static int git_cred_ssh_key_type_new(
+	git_cred **cred,
+	const char *username,
+	const char *publickey,
+	const char *privatekey,
+	const char *passphrase,
+	git_credtype_t credtype);
+
 int git_cred_has_username(git_cred *cred)
 {
 	if (cred->credtype == GIT_CREDTYPE_DEFAULT)
@@ -31,6 +39,9 @@ const char *git_cred__username(git_cred *cred)
 		return c->username;
 	}
 	case GIT_CREDTYPE_SSH_KEY:
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
+	case GIT_CREDTYPE_SSH_MEMORY:
+#endif
 	{
 		git_cred_ssh_key *c = (git_cred_ssh_key *) cred;
 		return c->username;
@@ -175,6 +186,41 @@ int git_cred_ssh_key_new(
 	const char *privatekey,
 	const char *passphrase)
 {
+	return git_cred_ssh_key_type_new(
+		cred,
+		username,
+		publickey,
+		privatekey,
+		passphrase,
+		GIT_CREDTYPE_SSH_KEY);
+}
+
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
+int git_cred_ssh_key_memory_new(
+	git_cred **cred,
+	const char *username,
+	const char *publickey,
+	const char *privatekey,
+	const char *passphrase)
+{
+	return git_cred_ssh_key_type_new(
+		cred,
+		username,
+		publickey,
+		privatekey,
+		passphrase,
+		GIT_CREDTYPE_SSH_MEMORY);
+}
+#endif
+
+static int git_cred_ssh_key_type_new(
+	git_cred **cred,
+	const char *username,
+	const char *publickey,
+	const char *privatekey,
+	const char *passphrase,
+	git_credtype_t credtype)
+{
 	git_cred_ssh_key *c;
 
 	assert(username && cred && privatekey);
@@ -182,7 +228,7 @@ int git_cred_ssh_key_new(
 	c = git__calloc(1, sizeof(git_cred_ssh_key));
 	GITERR_CHECK_ALLOC(c);
 
-	c->parent.credtype = GIT_CREDTYPE_SSH_KEY;
+	c->parent.credtype = credtype;
 	c->parent.free = ssh_key_free;
 
 	c->username = git__strdup(username);

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -195,7 +195,6 @@ int git_cred_ssh_key_new(
 		GIT_CREDTYPE_SSH_KEY);
 }
 
-#ifdef GIT_SSH_MEMORY_CREDENTIALS
 int git_cred_ssh_key_memory_new(
 	git_cred **cred,
 	const char *username,
@@ -203,6 +202,7 @@ int git_cred_ssh_key_memory_new(
 	const char *privatekey,
 	const char *passphrase)
 {
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
 	return git_cred_ssh_key_type_new(
 		cred,
 		username,
@@ -210,8 +210,12 @@ int git_cred_ssh_key_memory_new(
 		privatekey,
 		passphrase,
 		GIT_CREDTYPE_SSH_MEMORY);
-}
+#else
+	giterr_set(GITERR_INVALID,
+		"This version of libgit2 was not built with ssh memory credentials.");
+	return -1;
 #endif
+}
 
 static int git_cred_ssh_key_type_new(
 	git_cred **cred,

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -359,6 +359,22 @@ static int _git_ssh_authenticate_session(
 				session, c->username, c->prompt_callback);
 			break;
 		}
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
+		case GIT_CREDTYPE_SSH_MEMORY: {
+			git_cred_ssh_key *c = (git_cred_ssh_key *)cred;
+
+			rc = libssh2_userauth_publickey_frommemory(
+				session,
+				c->username,
+				strlen(c->username),
+				c->publickey,
+				strlen(c->publickey),
+				c->privatekey,
+				strlen(c->privatekey),
+				c->passphrase);
+			break;
+		}
+#endif
 		default:
 			rc = LIBSSH2_ERROR_AUTHENTICATION_FAILED;
 		}
@@ -729,6 +745,9 @@ static int list_auth_methods(int *out, LIBSSH2_SESSION *session, const char *use
 		if (!git__prefixcmp(ptr, SSH_AUTH_PUBLICKEY)) {
 			*out |= GIT_CREDTYPE_SSH_KEY;
 			*out |= GIT_CREDTYPE_SSH_CUSTOM;
+#ifdef GIT_SSH_MEMORY_CREDENTIALS
+			*out |= GIT_CREDTYPE_SSH_MEMORY;
+#endif
 			ptr += strlen(SSH_AUTH_PUBLICKEY);
 			continue;
 		}


### PR DESCRIPTION
Libssh2 got the ability to read keys from memory recently.
Although it's only supported when combined with OpenSSL for now. :unamused:

https://github.com/libssh2/libssh2/commit/18cfec8336e88ab7df8a4427b803b9a177053674

This adds a new credentials type to be able to authenticate using keys in memory.
I've used a flag to enable all this, since you'll have to compile libssh2 from master to have access to it.

I'm not really sure how to add tests, but I pretty promise that it works. :grin: