### PR TITLE
Add a custom param to git_smart_subtransport_definition

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -289,7 +289,8 @@ struct git_smart_subtransport {
 /* A function which creates a new subtransport for the smart transport */
 typedef int (*git_smart_subtransport_cb)(
 	git_smart_subtransport **out,
-	git_transport* owner);
+	git_transport* owner,
+	void* param);
 
 /**
  * Definition for a "subtransport"
@@ -306,6 +307,10 @@ typedef struct git_smart_subtransport_definition {
 	 * http:// is stateless, but git:// is not.
 	 */
 	unsigned rpc;
+
+	/** Param of the callback
+	 */
+	void* param;
 } git_smart_subtransport_definition;
 
 /* Smart transport subtransports that come with libgit2 */
@@ -321,7 +326,8 @@ typedef struct git_smart_subtransport_definition {
  */
 GIT_EXTERN(int) git_smart_subtransport_http(
 	git_smart_subtransport **out,
-	git_transport* owner);
+	git_transport* owner,
+	void *param);
 
 /**
  * Create an instance of the git subtransport.
@@ -332,7 +338,8 @@ GIT_EXTERN(int) git_smart_subtransport_http(
  */
 GIT_EXTERN(int) git_smart_subtransport_git(
 	git_smart_subtransport **out,
-	git_transport* owner);
+	git_transport* owner,
+	void *param);
 
 /**
  * Create an instance of the ssh subtransport.
@@ -343,7 +350,8 @@ GIT_EXTERN(int) git_smart_subtransport_git(
  */
 GIT_EXTERN(int) git_smart_subtransport_ssh(
 	git_smart_subtransport **out,
-	git_transport* owner);
+	git_transport* owner,
+	void *param);
 
 /**
  * Sets a custom transport factory for the remote. The caller can use this

--- a/src/transport.c
+++ b/src/transport.c
@@ -18,10 +18,10 @@ typedef struct transport_definition {
 	void *param;
 } transport_definition;
 
-static git_smart_subtransport_definition http_subtransport_definition = { git_smart_subtransport_http, 1 };
-static git_smart_subtransport_definition git_subtransport_definition = { git_smart_subtransport_git, 0 };
+static git_smart_subtransport_definition http_subtransport_definition = { git_smart_subtransport_http, 1, NULL };
+static git_smart_subtransport_definition git_subtransport_definition = { git_smart_subtransport_git, 0, NULL };
 #ifdef GIT_SSH
-static git_smart_subtransport_definition ssh_subtransport_definition = { git_smart_subtransport_ssh, 0 };
+static git_smart_subtransport_definition ssh_subtransport_definition = { git_smart_subtransport_ssh, 0, NULL };
 #endif
 
 static transport_definition local_transport_definition = { "file://", git_transport_local, NULL };

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -340,9 +340,11 @@ static void _git_free(git_smart_subtransport *subtransport)
 	git__free(t);
 }
 
-int git_smart_subtransport_git(git_smart_subtransport **out, git_transport *owner)
+int git_smart_subtransport_git(git_smart_subtransport **out, git_transport *owner, void *param)
 {
 	git_subtransport *t;
+
+	GIT_UNUSED(param);
 
 	if (!out)
 		return -1;

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -1007,9 +1007,11 @@ static void http_free(git_smart_subtransport *subtransport)
 	git__free(t);
 }
 
-int git_smart_subtransport_http(git_smart_subtransport **out, git_transport *owner)
+int git_smart_subtransport_http(git_smart_subtransport **out, git_transport *owner, void *param)
 {
 	http_subtransport *t;
+
+	GIT_UNUSED(param);
 
 	if (!out)
 		return -1;

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -409,7 +409,7 @@ int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 		return -1;
 	}
 
-	if (definition->callback(&t->wrapped, &t->parent) < 0) {
+	if (definition->callback(&t->wrapped, &t->parent, definition->param) < 0) {
 		git__free(t);
 		return -1;
 	}

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -754,12 +754,14 @@ static int list_auth_methods(int *out, LIBSSH2_SESSION *session, const char *use
 #endif
 
 int git_smart_subtransport_ssh(
-	git_smart_subtransport **out, git_transport *owner)
+	git_smart_subtransport **out, git_transport *owner, void *param)
 {
 #ifdef GIT_SSH
 	ssh_subtransport *t;
 
 	assert(out);
+
+	GIT_UNUSED(param);
 
 	t = git__calloc(sizeof(ssh_subtransport), 1);
 	GITERR_CHECK_ALLOC(t);
@@ -773,6 +775,7 @@ int git_smart_subtransport_ssh(
 	return 0;
 #else
 	GIT_UNUSED(owner);
+	GIT_UNUSED(param);
 
 	assert(out);
 	*out = NULL;
@@ -793,6 +796,7 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 	git_smart_subtransport_definition ssh_definition = {
 		git_smart_subtransport_ssh,
 		0, /* no RPC */
+		NULL,
 	};
 
 	if (paths->count != 2) {

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -1322,9 +1322,11 @@ static void winhttp_free(git_smart_subtransport *subtransport)
 	git__free(t);
 }
 
-int git_smart_subtransport_http(git_smart_subtransport **out, git_transport *owner)
+int git_smart_subtransport_http(git_smart_subtransport **out, git_transport *owner, void *param)
 {
 	winhttp_subtransport *t;
+
+	GIT_UNUSED(param);
 
 	if (!out)
 		return -1;


### PR DESCRIPTION
A custom param will enable the implementer of a smart subtransport to store payload.