### PR TITLE
Initialize refs vector in git_remote_update_tips().

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -1458,7 +1458,7 @@ int git_remote_update_tips(
 		const char *reflog_message)
 {
 	git_refspec *spec, tagspec;
-	git_vector refs;
+	git_vector refs = GIT_VECTOR_INIT;
 	int error;
 	size_t i;
 


### PR DESCRIPTION
Otherwise, bailing out early when ls_to_vector() fails accesses
uninitialized memory.

This is also a possible candidate for v0.22.