### PR TITLE
clar: update to 08f434d

### DIFF
--- a/tests/clar.c
+++ b/tests/clar.c
@@ -346,7 +346,7 @@ clar_parse_args(int argc, char **argv)
 						_clar.report_suite_names = 1;
 
 					switch (action) {
-					case 's': clar_run_suite(&_clar_suites[j], argument); break;
+					case 's': _clar_suites[j].enabled = 1; clar_run_suite(&_clar_suites[j], argument); break;
 					case 'i': _clar_suites[j].enabled = 1; break;
 					case 'x': _clar_suites[j].enabled = 0; break;
 					}


### PR DESCRIPTION
Update clar to 08f434d.  This could save us a little bit of time in test execution on the CI builds as it makes the `-s` flag imply the `-i` flag for tests that are disabled by default.  Our test workflow at present is to run the default tests, then run the online tests afterward (using `-s...`).  This patch should mean that we don't re-run all the tests we've already run *and* the online tests, it will *only* run the online tests.