### PR TITLE
Fix error when saving last submodule section.

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -628,8 +628,10 @@ int git_submodule_save(git_submodule *submodule)
 		(error = git_config_file_set_string(mods, key.ptr, submodule->url)) < 0)
 		goto cleanup;
 
-	if ((error = submodule_config_key_trunc_puts(&key, "branch")) < 0 ||
-		(error = git_config_file_set_string(mods, key.ptr, submodule->branch)) < 0)
+	if (!(error = submodule_config_key_trunc_puts(&key, "branch")) &&
+		submodule->branch != NULL)
+		error = git_config_file_set_string(mods, key.ptr, submodule->branch);
+	if (error < 0)
 		goto cleanup;
 
 	if (!(error = submodule_config_key_trunc_puts(&key, "update")) &&

--- a/tests/submodule/modify.c
+++ b/tests/submodule/modify.c
@@ -236,3 +236,11 @@ void test_submodule_modify__edit_and_save(void)
 	git_repository_free(r2);
 	git__free(old_url);
 }
+
+void test_submodule_modify__save_last(void)
+{
+	git_submodule *sm;
+
+	cl_git_pass(git_submodule_lookup(&sm, g_repo, "sm_gitmodules_only"));
+	cl_git_pass(git_submodule_save(sm));
+}


### PR DESCRIPTION
Currently we unconditionally try to write a submodule's branch configuration,
even when no branch is set. This can cause an error in libgit2 when we try to
save a submodule's configuration when this submodule is the last section in the
corresponding file. Fix this error by first checking if the submodule has a
branch.
