### PR TITLE
win32 resource: allow custom comments field in DLL

### DIFF
--- a/src/win32/git2.rc
+++ b/src/win32/git2.rc
@@ -2,7 +2,11 @@
 #include "../../include/git2/version.h"
 
 #ifndef LIBGIT2_FILENAME
-#	define LIBGIT2_FILENAME "git2"
+# define LIBGIT2_FILENAME "git2"
+#endif
+
+#ifndef LIBGIT2_COMMENTS
+# define LIBGIT2_COMMENTS "For more information visit http://libgit2.github.com/"
 #endif
 
 VS_VERSION_INFO		VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE
@@ -30,7 +34,7 @@ BEGIN
       VALUE "OriginalFilename",	LIBGIT2_FILENAME ".dll\0"
       VALUE "ProductName",	"libgit2\0"
       VALUE "ProductVersion",	LIBGIT2_VERSION "\0"
-      VALUE "Comments",		"For more information visit http://libgit2.github.com/\0"
+      VALUE "Comments",		LIBGIT2_COMMENTS "\0"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
The "Comments" field of a DLL resource is not immediately visible (in Windows Explorer, for example) but it is queryable.  Consumers may wish to put something custom here about their DLL build - for example, the version of LibGit2 that it was built from.