### PR TITLE
Performance improvement to eliminate some tolower calls

### DIFF
--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1292,13 +1292,17 @@ GIT_INLINE(bool) workdir_path_is_dotgit(const git_buf *path)
 	if (path->ptr[len - 1] == '/')
 		len--;
 
-	if (tolower(path->ptr[len - 1]) != 't' ||
-		tolower(path->ptr[len - 2]) != 'i' ||
-		tolower(path->ptr[len - 3]) != 'g' ||
-		tolower(path->ptr[len - 4]) != '.')
+	if ((len > 4) && (path->ptr[len - 5] != '/'))
 		return false;
-
-	return (len == 4 || path->ptr[len - 5] == '/');
+	if (path->ptr[len - 4] != '.')
+		return false;
+	if ((path->ptr[len - 3] != 'g') && (path->ptr[len - 3] != 'G'))
+		return false;
+	if ((path->ptr[len - 2] != 'i') && (path->ptr[len - 2] != 'I'))
+		return false;
+	if ((path->ptr[len - 1] != 't') && (path->ptr[len - 1] != 'T'))
+		return false;
+	return true;
 }
 
 /**


### PR DESCRIPTION
Eliminate some calls to tolower() duing iteration and path validation during checkout.

tolower() is very expensive on Windows.  I changed 2 sections where a path is being compared against a constant string using tolower().