### PR TITLE
Added git_clone_into() API

### DIFF
--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -203,6 +203,25 @@ GIT_EXTERN(int) git_clone(
 	const char *local_path,
 	const git_clone_options *options);
 
+/**
+ * Clone a remote repository into an existing empty repository using
+ * a pre-existing remote.
+ *
+ * @param repo the repository to clone into
+ * @param remote the remote to use for cloning
+ * @param options the checkout options to use (NULL is equivalent to
+          passing GIT_CHECKOUT_OPTIONS_INIT i.e. no checkout is performed)
+ * @param branch name of the branch to checkout (NULL means use the
+ *        remote's default branch)
+ * @return 0 on success, any non-zero return value from a callback
+ *         function, or a negative value to indicate an error
+ */
+GIT_EXTERN(int) git_clone_into(
+	git_repository *repo,
+	git_remote *remote,
+	const git_checkout_options *options,
+	const char *branch);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -250,9 +250,10 @@ GIT_EXTERN(int) git_submodule_foreach(
  * from the working directory to the new repo.
  *
  * To fully emulate "git submodule add" call this function, then open the
- * submodule repo and perform the clone step as needed.  Lastly, call
- * `git_submodule_add_finalize()` to wrap up adding the new submodule and
- * .gitmodules to the index to be ready to commit.
+ * submodule repo, lookup the "origin" remote and perform the clone step
+ * using `git_clone_into()`.  Lastly, call `git_submodule_add_finalize()`
+ * to wrap up adding the new submodule and .gitmodules to the index to be
+ * ready to commit.
  *
  * You must call `git_submodule_free` on the submodule object when done.
  *

--- a/src/clone.c
+++ b/src/clone.c
@@ -467,6 +467,25 @@ int git_clone(
 	return error;
 }
 
+int git_clone_into(
+	git_repository *repo,
+	git_remote *remote,
+	const git_checkout_options *options,
+	const char *branch)
+{
+	git_checkout_options default_options = GIT_CHECKOUT_OPTIONS_INIT;
+	const git_checkout_options* opts;
+
+	assert(repo && remote);
+
+	if (options)
+		opts = options;
+	else
+		opts = &default_options;
+
+	return clone_into(repo, remote, opts, branch);
+}
+
 int git_clone_init_options(git_clone_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(


### PR DESCRIPTION
Exposing this internal API is really needed if you want to be able to add submodules using libgit2. Otherwise, a lot of unnecessary code duplicating libgit2's internals is needed.