### PR TITLE
Fixed checkout to correctly handle executable bit changes

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -183,6 +183,12 @@ static bool checkout_is_workdir_modified(
 		return rval;
 	}
 
+	/* If the executable bit differ we need to checkout
+	 */
+	if ((baseitem->mode == GIT_FILEMODE_BLOB && wditem->mode == GIT_FILEMODE_BLOB_EXECUTABLE)
+		|| (baseitem->mode == GIT_FILEMODE_BLOB_EXECUTABLE && wditem->mode == GIT_FILEMODE_BLOB))
+		return true;
+
 	/* Look at the cache to decide if the workdir is modified.  If not,
 	 * we can simply compare the oid in the cache to the baseitem instead
 	 * of hashing the file.  If so, we allow the checkout to proceed if the


### PR DESCRIPTION
The current implementation of checkout wasn't taking into account
file mode changes between blob and executable blob when looking
at changes in the workdir. This means that if a file was executable
in the index but not in the workdir, even a force checkout would not
update the file in the workdir.