### PR TITLE
checkout: report correct invalid path

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1197,7 +1197,7 @@ static int checkout_verify_paths(
 
 	if (action & ~CHECKOUT_ACTION__REMOVE) {
 		if (!git_path_isvalid(repo, delta->new_file.path, flags)) {
-			giterr_set(GITERR_CHECKOUT, "Cannot checkout to invalid path '%s'", delta->old_file.path);
+			giterr_set(GITERR_CHECKOUT, "Cannot checkout to invalid path '%s'", delta->new_file.path);
 			return -1;
 		}
 	}


### PR DESCRIPTION
Oops.  (On file creation, you won't have a `new` path and this is a less than good experience.)