### PR TITLE
Stash apply

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Microsoft Corporation
 Olivier Ramonat
 Peter Drahoš
 Pierre Habouzit
+Pierre-Olivier Latour
 Przemyslaw Pawelczyk
 Ramsay Jones
 Robert G. Jakabosky

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ support for HTTPS connections insead of OpenSSL.
 * `git_index_add_frombuffer()` can now create a blob from memory
    buffer and add it to the index which is attached to a repository.
 
+* `git_stash_apply()` can now apply a stashed state from the stash list,
+  placing the data into the working directory and index.
+
+* `git_stash_pop()` will apply a stashed state (like `git_stash_apply()`)
+  but will remove the stashed state after a successful application.
+
 ### API removals
 
 ### Breaking API changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ v0.22 + 1
 * On Mac OS X, we now use SecureTransport to provide the cryptographic
 support for HTTPS connections insead of OpenSSL.
 
+* Checkout can now accept an index for the baseline computations via the
+  `baseline_index` member.
+
 ### API additions
 
 * The `git_merge_options` gained a `file_flags` member.

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -272,7 +272,15 @@ typedef struct git_checkout_options {
 	 */
 	git_strarray paths;
 
-	git_tree *baseline; /**< expected content of workdir, defaults to HEAD */
+	/** The expected content of the working directory; defaults to HEAD.
+	 *  If the working directory does not match this baseline information,
+	 *  that will produce a checkout conflict.
+	 */
+	git_tree *baseline;
+
+	/** Like `baseline` above, though expressed as an index.  This
+	 *  option overrides `baseline`.
+	 */
 	git_index *baseline_index; /**< expected content of workdir, expressed as an index. */
 
 	const char *target_directory; /**< alternative checkout path to workdir */

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -273,6 +273,7 @@ typedef struct git_checkout_options {
 	git_strarray paths;
 
 	git_tree *baseline; /**< expected content of workdir, defaults to HEAD */
+	git_index *baseline_index; /**< expected content of workdir, expressed as an index. */
 
 	const char *target_directory; /**< alternative checkout path to workdir */
 

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -97,10 +97,9 @@ typedef enum {
  * the workdir and index will be left untouched.
  *
  * @param repo The owning repository.
- *
  * @param index The position within the stash list. 0 points to the
- * most recent stashed state.
- *
+ *              most recent stashed state.
+ * @param checkout_options Options to control how files are checked out
  * @param flags Flags to control the applying process. (see GIT_APPLY_* above)
  *
  * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the given
@@ -109,6 +108,7 @@ typedef enum {
 GIT_EXTERN(int) git_stash_apply(
 	git_repository *repo,
 	size_t index,
+	const git_checkout_options *checkout_options,
 	unsigned int flags);
 
 /**
@@ -167,10 +167,9 @@ GIT_EXTERN(int) git_stash_drop(
  * if successful.
  *
  * @param repo The owning repository.
- *
  * @param index The position within the stash list. 0 points to the
- * most recent stashed state.
- *
+ *              most recent stashed state.
+ * @param checkout_options Options to control how files are checked out
  * @param flags Flags to control the applying process. (see GIT_APPLY_* above)
  *
  * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the given
@@ -179,6 +178,7 @@ GIT_EXTERN(int) git_stash_drop(
 GIT_EXTERN(int) git_stash_pop(
 	git_repository *repo,
 	size_t index,
+	const git_checkout_options *checkout_options,
 	unsigned int flags);
 
 /** @} */

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -82,19 +82,16 @@ typedef enum {
 /**
  * Apply a single stashed state from the stash list.
  *
- * If any untracked or ignored file saved in the stash already exist in the
- * workdir, the function will return GIT_EEXISTS and both the workdir and index
- * will be left untouched.
- *
- * If local changes in the workdir would be overwritten when applying
- * modifications saved in the stash, the function will return GIT_EMERGECONFLICT
- * and the index will be left untouched. The workdir files will be left
- * unmodified as well but restored untracked or ignored files that were saved
- * in the stash will be left around in the workdir.
+ * If local changes in the working directory conflict with changes in the
+ * stash then GIT_EMERGECONFLICT will be returned.  In this case, the index
+ * will always remain unmodified and all files in the working directory will
+ * remain unmodified.  However, if you are restoring untracked files or
+ * ignored files and there is a conflict when applying the modified files,
+ * then those files will remain in the working directory.
  *
  * If passing the GIT_APPLY_REINSTATE_INDEX flag and there would be conflicts
- * when reinstating the index, the function will return GIT_EUNMERGED and both
- * the workdir and index will be left untouched.
+ * when reinstating the index, the function will return GIT_EMERGECONFLICT
+ * and both the working directory and index will be left unmodified.
  *
  * @param repo The owning repository.
  * @param index The position within the stash list. 0 points to the
@@ -102,8 +99,9 @@ typedef enum {
  * @param checkout_options Options to control how files are checked out
  * @param flags Flags to control the applying process. (see GIT_APPLY_* above)
  *
- * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the given
- * index, or error code. (see details above)
+ * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the
+ *         given index, GIT_EMERGECONFLICT if changes exist in the working
+ *         directory, or an error code
  */
 GIT_EXTERN(int) git_stash_apply(
 	git_repository *repo,

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -80,6 +80,40 @@ typedef enum {
 	GIT_STASH_APPLY_REINSTATE_INDEX = (1 << 0),
 } git_stash_apply_flags;
 
+typedef enum {
+	GIT_STASH_APPLY_PROGRESS_NONE = 0,
+
+	/** Loading the stashed data from the object database. */
+	GIT_STASH_APPLY_PROGRESS_LOADING_STASH,
+
+	/** The stored index is being analyzed. */
+	GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX,
+
+	/** The modified files are being analyzed. */
+	GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED,
+
+	/** The untracked and ignored files are being analyzed. */
+	GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED,
+
+	/** The untracked files are being written to disk. */
+	GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED,
+
+	/** The modified files are being written to disk. */
+	GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED,
+
+	/** The stash was applied successfully. */
+	GIT_STASH_APPLY_PROGRESS_DONE,
+} git_stash_apply_progress_t;
+
+/**
+ * Stash application progress notification function.
+ * Return 0 to continue processing, or a negative value to
+ * abort the stash application.
+ */
+typedef int (*git_stash_apply_progress_cb)(
+	git_stash_apply_progress_t progress,
+	void *payload);
+
 /** Stash application options structure.
  *
  * Initialize with the `GIT_STASH_APPLY_OPTIONS_INIT` macro to set
@@ -95,6 +129,10 @@ typedef struct git_stash_apply_options {
 
 	/** Options to use when writing files to the working directory. */
 	git_checkout_options checkout_options;
+
+	/** Optional callback to notify the consumer of application progress. */
+	git_stash_apply_progress_cb progress_cb;
+	void *progress_payload;
 } git_stash_apply_options;
 
 #define GIT_STASH_APPLY_OPTIONS_VERSION 1

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -96,7 +96,9 @@ typedef enum {
  * @param repo The owning repository.
  * @param index The position within the stash list. 0 points to the
  *              most recent stashed state.
- * @param checkout_options Options to control how files are checked out
+ * @param checkout_options Options to control how files are checked out.
+ *                         A minimum strategy of `GIT_CHECKOUT_SAFE` is
+ *                         implied.
  * @param flags Flags to control the applying process. (see GIT_APPLY_* above)
  *
  * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the

--- a/src/index.h
+++ b/src/index.h
@@ -93,6 +93,8 @@ extern int git_index_snapshot_find(
 	size_t *at_pos, git_vector *snap, git_vector_cmp entry_srch,
 	const char *path, size_t path_len, int stage);
 
+/* Replace an index with a new index */
+int git_index_read_index(git_index *index, const git_index *new_index);
 
 typedef struct {
 	git_index *index;

--- a/src/merge.h
+++ b/src/merge.h
@@ -10,6 +10,7 @@
 #include "vector.h"
 #include "commit_list.h"
 #include "pool.h"
+#include "iterator.h"
 
 #include "git2/merge.h"
 #include "git2/types.h"
@@ -121,10 +122,11 @@ int git_merge__bases_many(
 
 git_merge_diff_list *git_merge_diff_list__alloc(git_repository *repo);
 
-int git_merge_diff_list__find_differences(git_merge_diff_list *merge_diff_list,
-	const git_tree *ancestor_tree,
-	const git_tree *ours_tree,
-	const git_tree *theirs_tree);
+int git_merge_diff_list__find_differences(
+	git_merge_diff_list *merge_diff_list,
+	git_iterator *ancestor_iterator,
+	git_iterator *ours_iter,
+	git_iterator *theirs_iter);
 
 int git_merge_diff_list__find_renames(git_repository *repo, git_merge_diff_list *merge_diff_list, const git_merge_options *opts);
 
@@ -137,6 +139,14 @@ int git_merge__setup(
 	const git_annotated_commit *our_head,
 	const git_annotated_commit *heads[],
 	size_t heads_len);
+
+int git_merge__iterators(
+	git_index **out,
+	git_repository *repo,
+	git_iterator *ancestor_iter,
+	git_iterator *our_iter,
+	git_iterator *their_iter,
+	const git_merge_options *given_opts);
 
 int git_merge__check_result(git_repository *repo, git_index *index_new);
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -681,10 +681,11 @@ static void normalize_checkout_options(
 		memcpy(checkout_opts, given_checkout_opts, sizeof(git_checkout_options));
 	} else {
 		git_checkout_options default_checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
-		default_checkout_opts.checkout_strategy =  GIT_CHECKOUT_SAFE;
-
 		memcpy(checkout_opts, &default_checkout_opts, sizeof(git_checkout_options));
 	}
+
+	if ((checkout_opts->checkout_strategy & (GIT_CHECKOUT_SAFE | GIT_CHECKOUT_FORCE)) == 0)
+		checkout_opts->checkout_strategy = GIT_CHECKOUT_SAFE;
 
 	if (!checkout_opts->our_label)
 		checkout_opts->our_label = "Updated upstream";

--- a/src/stash.c
+++ b/src/stash.c
@@ -106,7 +106,7 @@ static int build_tree_from_index(git_tree **out, git_index *index)
 	git_oid i_tree_oid;
 
 	if ((error = git_index_write_tree(&i_tree_oid, index)) < 0)
-		return -1;
+		return error;
 
 	return git_tree_lookup(out, git_index_owner(index), &i_tree_oid);
 }

--- a/src/stash.c
+++ b/src/stash.c
@@ -738,10 +738,8 @@ int git_stash_apply(
 				&unstashed_index, repo, index_parent_tree, repo_index, index_tree)) < 0)
 			goto cleanup;
 
-
-		/* TODO: GIT_EMERGECONFLICT  */
 		if (git_index_has_conflicts(unstashed_index)) {
-			error = GIT_EUNMERGED;
+			error = GIT_EMERGECONFLICT;
 			goto cleanup;
 		}
 	}

--- a/src/stash.c
+++ b/src/stash.c
@@ -564,7 +564,7 @@ static int retrieve_stash_commit(
 		goto cleanup;
 
 	max = git_reflog_entrycount(reflog);
-	if (index > max - 1) {
+	if (!max || index > max - 1) {
 		error = GIT_ENOTFOUND;
 		giterr_set(GITERR_STASH, "No stashed state at position %" PRIuZ, index);
 		goto cleanup;
@@ -949,7 +949,7 @@ int git_stash_drop(
 
 	max = git_reflog_entrycount(reflog);
 
-	if (index > max - 1) {
+	if (!max || index > max - 1) {
 		error = GIT_ENOTFOUND;
 		giterr_set(GITERR_STASH, "No stashed state at position %" PRIuZ, index);
 		goto cleanup;

--- a/src/stash.c
+++ b/src/stash.c
@@ -8,6 +8,7 @@
 #include "common.h"
 #include "repository.h"
 #include "commit.h"
+#include "message.h"
 #include "tree.h"
 #include "reflog.h"
 #include "git2/diff.h"
@@ -50,23 +51,14 @@ static int append_abbreviated_oid(git_buf *out, const git_oid *b_commit)
 
 static int append_commit_description(git_buf *out, git_commit* commit)
 {
-	const char *message;
-	size_t pos = 0, len;
+	const char *summary = git_commit_summary(commit);
+	GITERR_CHECK_ALLOC(summary);
 
 	if (append_abbreviated_oid(out, git_commit_id(commit)) < 0)
 		return -1;
 
-	message = git_commit_message(commit);
-	len = strlen(message);
-
-	/* TODO: Replace with proper commit short message
-	 * when git_commit_message_short() is implemented.
-	 */
-	while (pos < len && message[pos] != '\n')
-		pos++;
-
 	git_buf_putc(out, ' ');
-	git_buf_put(out, message, pos);
+	git_buf_puts(out, summary);
 	git_buf_putc(out, '\n');
 
 	return git_buf_oom(out) ? -1 : 0;

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -131,6 +131,11 @@ void test_core_structinit__compare(void)
 		git_revert_options, GIT_REVERT_OPTIONS_VERSION, \
 		GIT_REVERT_OPTIONS_INIT, git_revert_init_options);
 
+	/* stash apply */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_stash_apply_options, GIT_STASH_APPLY_OPTIONS_VERSION, \
+		GIT_STASH_APPLY_OPTIONS_INIT, git_stash_apply_init_options);
+
 	/* status */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_status_options, GIT_STATUS_OPTIONS_VERSION, \

--- a/tests/index/read_index.c
+++ b/tests/index/read_index.c
@@ -1,0 +1,73 @@
+#include "clar_libgit2.h"
+#include "posix.h"
+#include "index.h"
+
+static git_repository *_repo;
+static git_index *_index;
+
+void test_index_read_index__initialize(void)
+{
+	git_object *head;
+	git_reference *head_ref;
+
+	_repo = cl_git_sandbox_init("testrepo");
+	cl_git_pass(git_revparse_ext(&head, &head_ref, _repo, "HEAD"));
+	cl_git_pass(git_reset(_repo, head, GIT_RESET_HARD, NULL));
+	cl_git_pass(git_repository_index(&_index, _repo));
+
+	git_reference_free(head_ref);
+	git_object_free(head);
+}
+
+void test_index_read_index__cleanup(void)
+{
+	git_index_free(_index);
+	cl_git_sandbox_cleanup();
+}
+
+void test_index_read_index__maintains_stat_cache(void)
+{
+	git_index *new_index;
+	git_oid index_id;
+	git_index_entry new_entry;
+	const git_index_entry *e;
+	git_tree *tree;
+	size_t i;
+
+	cl_assert_equal_i(4, git_index_entrycount(_index));
+
+	/* write-tree */
+	cl_git_pass(git_index_write_tree(&index_id, _index));
+
+	/* read-tree, then read index */
+	git_tree_lookup(&tree, _repo, &index_id);
+	cl_git_pass(git_index_new(&new_index));
+	cl_git_pass(git_index_read_tree(new_index, tree));
+	git_tree_free(tree);
+
+	/* add a new entry that will not have stat data */
+	memset(&new_entry, 0, sizeof(git_index_entry));
+	new_entry.path = "Hello";
+	git_oid_fromstr(&new_entry.id, "0123456789012345678901234567890123456789");
+	new_entry.file_size = 1234;
+	new_entry.mode = 0100644;
+	cl_git_pass(git_index_add(new_index, &new_entry));
+	cl_assert_equal_i(5, git_index_entrycount(new_index));
+
+	cl_git_pass(git_index_read_index(_index, new_index));
+	git_index_free(new_index);
+
+	cl_assert_equal_i(5, git_index_entrycount(_index));
+
+	for (i = 0; i < git_index_entrycount(_index); i++) {
+		e = git_index_get_byindex(_index, i);
+
+		if (strcmp(e->path, "Hello") == 0) {
+			cl_assert_equal_i(0, e->ctime.seconds);
+			cl_assert_equal_i(0, e->mtime.seconds);
+		} else {
+			cl_assert(0 != e->ctime.seconds);
+			cl_assert(0 != e->mtime.seconds);
+		}
+	}
+}

--- a/tests/merge/trees/treediff.c
+++ b/tests/merge/trees/treediff.c
@@ -43,6 +43,7 @@ static void test_find_differences(
     git_merge_diff_list *merge_diff_list = git_merge_diff_list__alloc(repo);
     git_oid ancestor_oid, ours_oid, theirs_oid;
     git_tree *ancestor_tree, *ours_tree, *theirs_tree;
+	git_iterator *ancestor_iter, *ours_iter, *theirs_iter;
 
 	git_merge_options opts = GIT_MERGE_OPTIONS_INIT;
 	opts.tree_flags |= GIT_MERGE_TREE_FIND_RENAMES;
@@ -66,7 +67,14 @@ static void test_find_differences(
 	cl_git_pass(git_tree_lookup(&ours_tree, repo, &ours_oid));
 	cl_git_pass(git_tree_lookup(&theirs_tree, repo, &theirs_oid));
 
-	cl_git_pass(git_merge_diff_list__find_differences(merge_diff_list, ancestor_tree, ours_tree, theirs_tree));
+	cl_git_pass(git_iterator_for_tree(&ancestor_iter, ancestor_tree,
+			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+	cl_git_pass(git_iterator_for_tree(&ours_iter, ours_tree,
+			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+	cl_git_pass(git_iterator_for_tree(&theirs_iter, theirs_tree,
+			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+
+	cl_git_pass(git_merge_diff_list__find_differences(merge_diff_list, ancestor_iter, ours_iter, theirs_iter));
 	cl_git_pass(git_merge_diff_list__find_renames(repo, merge_diff_list, &opts));
 
 	/*
@@ -76,6 +84,10 @@ static void test_find_differences(
 	cl_assert(treediff_conflict_data_len == merge_diff_list->conflicts.length);
 
 	cl_assert(merge_test_merge_conflicts(&merge_diff_list->conflicts, treediff_conflict_data, treediff_conflict_data_len));
+
+	git_iterator_free(ancestor_iter);
+	git_iterator_free(ours_iter);
+	git_iterator_free(theirs_iter);
 
 	git_tree_free(ancestor_tree);
 	git_tree_free(ours_tree);

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -1,0 +1,215 @@
+#include "clar_libgit2.h"
+#include "fileops.h"
+#include "stash_helpers.h"
+
+static git_signature *signature;
+static git_repository *repo;
+static git_index *repo_index;
+
+void test_stash_apply__initialize(void)
+{
+	git_oid oid;
+
+	cl_git_pass(git_signature_new(&signature, "nulltoken", "emeric.fermas@gmail.com", 1323847743, 60)); /* Wed Dec 14 08:29:03 2011 +0100 */
+
+	cl_git_pass(git_repository_init(&repo, "stash", 0));
+	cl_git_pass(git_repository_index(&repo_index, repo));
+
+	cl_git_mkfile("stash/what", "hello\n");
+	cl_git_mkfile("stash/how", "small\n");
+	cl_git_mkfile("stash/who", "world\n");
+
+	cl_git_pass(git_index_add_bypath(repo_index, "what"));
+	cl_git_pass(git_index_add_bypath(repo_index, "how"));
+	cl_git_pass(git_index_add_bypath(repo_index, "who"));
+
+	cl_repo_commit_from_index(NULL, repo, signature, 0, "Initial commit");
+
+	cl_git_rewritefile("stash/what", "goodbye\n");
+	cl_git_rewritefile("stash/who", "funky world\n");
+	cl_git_mkfile("stash/when", "tomorrow\n");
+
+	cl_git_pass(git_index_add_bypath(repo_index, "who"));
+
+	/* Pre-stash state */
+	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+
+	cl_git_pass(git_stash_save(&oid, repo, signature, NULL, GIT_STASH_INCLUDE_UNTRACKED));
+
+	/* Post-stash state */
+	assert_status(repo, "what", GIT_STATUS_CURRENT);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_CURRENT);
+	assert_status(repo, "when", GIT_ENOTFOUND);
+}
+
+void test_stash_apply__cleanup(void)
+{
+	git_signature_free(signature);
+	signature = NULL;
+
+	git_index_free(repo_index);
+	repo_index = NULL;
+
+	git_repository_free(repo);
+	repo = NULL;
+
+	cl_git_pass(git_futils_rmdir_r("stash", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_fixture_cleanup("sorry-it-is-a-non-bare-only-party");
+}
+
+void test_stash_apply__with_default(void)
+{
+	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT));
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__with_reinstate_index(void)
+{
+	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX));
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_index_with_default(void)
+{
+	const git_index_entry *ancestor;
+	const git_index_entry *our;
+	const git_index_entry *their;
+
+	cl_git_rewritefile("stash/who", "nothing\n");
+	cl_git_pass(git_index_add_bypath(repo_index, "who"));
+	cl_git_pass(git_index_write(repo_index));
+
+	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT));
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 1);
+	assert_status(repo, "what", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	cl_git_pass(git_index_conflict_get(&ancestor, &our, &their, repo_index, "who")); /* unmerged */
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_index_with_reinstate_index(void)
+{
+	cl_git_rewritefile("stash/who", "nothing\n");
+	cl_git_pass(git_index_add_bypath(repo_index, "who"));
+	cl_git_pass(git_index_write(repo_index));
+
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EUNMERGED);
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_CURRENT);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "when", GIT_ENOTFOUND);
+}
+
+void test_stash_apply__conflict_untracked_with_default(void)
+{
+	cl_git_mkfile("stash/when", "nothing\n");
+
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT), GIT_EEXISTS);
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_CURRENT);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_CURRENT);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_untracked_with_reinstate_index(void)
+{
+	cl_git_mkfile("stash/when", "nothing\n");
+
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EEXISTS);
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_CURRENT);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_CURRENT);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_workdir_with_default(void)
+{
+	cl_git_rewritefile("stash/what", "ciao\n");
+
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT), GIT_EMERGECONFLICT);
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_CURRENT);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_workdir_with_reinstate_index(void)
+{
+	cl_git_rewritefile("stash/what", "ciao\n");
+
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
+	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_CURRENT);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_commit_with_default(void)
+{
+	const git_index_entry *ancestor;
+	const git_index_entry *our;
+	const git_index_entry *their;
+
+	cl_git_rewritefile("stash/what", "ciao\n");
+	cl_git_pass(git_index_add_bypath(repo_index, "what"));
+	cl_repo_commit_from_index(NULL, repo, signature, 0, "Other commit");
+
+	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT));
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 1);
+	cl_git_pass(git_index_conflict_get(&ancestor, &our, &their, repo_index, "what")); /* unmerged */
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__conflict_commit_with_reinstate_index(void)
+{
+	const git_index_entry *ancestor;
+	const git_index_entry *our;
+	const git_index_entry *their;
+
+	cl_git_rewritefile("stash/what", "ciao\n");
+	cl_git_pass(git_index_add_bypath(repo_index, "what"));
+	cl_repo_commit_from_index(NULL, repo, signature, 0, "Other commit");
+
+	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX));
+
+	cl_assert_equal_i(git_index_has_conflicts(repo_index), 1);
+	cl_git_pass(git_index_conflict_get(&ancestor, &our, &their, repo_index, "what")); /* unmerged */
+	assert_status(repo, "how", GIT_STATUS_CURRENT);
+	assert_status(repo, "who", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_apply__pop(void)
+{
+	cl_git_pass(git_stash_pop(repo, 0, GIT_APPLY_DEFAULT));
+
+	cl_git_fail_with(git_stash_pop(repo, 0, GIT_APPLY_DEFAULT), GIT_ENOTFOUND);
+}

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -121,7 +121,7 @@ void test_stash_apply__conflict_untracked_with_default(void)
 {
 	cl_git_mkfile("stash/when", "nothing\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT), GIT_EEXISTS);
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -134,7 +134,7 @@ void test_stash_apply__conflict_untracked_with_reinstate_index(void)
 {
 	cl_git_mkfile("stash/when", "nothing\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EEXISTS);
+	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -108,7 +108,7 @@ void test_stash_apply__conflict_index_with_reinstate_index(void)
 	cl_git_pass(git_index_add_bypath(repo_index, "who"));
 	cl_git_pass(git_index_write(repo_index));
 
-	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX), GIT_EUNMERGED);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -63,7 +63,7 @@ void test_stash_apply__cleanup(void)
 
 void test_stash_apply__with_default(void)
 {
-	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT));
+	cl_git_pass(git_stash_apply(repo, 0, NULL, GIT_APPLY_DEFAULT));
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
@@ -74,7 +74,7 @@ void test_stash_apply__with_default(void)
 
 void test_stash_apply__with_reinstate_index(void)
 {
-	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX));
+	cl_git_pass(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX));
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
@@ -93,7 +93,7 @@ void test_stash_apply__conflict_index_with_default(void)
 	cl_git_pass(git_index_add_bypath(repo_index, "who"));
 	cl_git_pass(git_index_write(repo_index));
 
-	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT));
+	cl_git_pass(git_stash_apply(repo, 0, NULL, GIT_APPLY_DEFAULT));
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 1);
 	assert_status(repo, "what", GIT_STATUS_INDEX_MODIFIED);
@@ -108,7 +108,7 @@ void test_stash_apply__conflict_index_with_reinstate_index(void)
 	cl_git_pass(git_index_add_bypath(repo_index, "who"));
 	cl_git_pass(git_index_write(repo_index));
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EUNMERGED);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX), GIT_EUNMERGED);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -121,7 +121,7 @@ void test_stash_apply__conflict_untracked_with_default(void)
 {
 	cl_git_mkfile("stash/when", "nothing\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_DEFAULT), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -134,7 +134,7 @@ void test_stash_apply__conflict_untracked_with_reinstate_index(void)
 {
 	cl_git_mkfile("stash/when", "nothing\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -147,7 +147,7 @@ void test_stash_apply__conflict_workdir_with_default(void)
 {
 	cl_git_rewritefile("stash/what", "ciao\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_DEFAULT), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
@@ -160,7 +160,7 @@ void test_stash_apply__conflict_workdir_with_reinstate_index(void)
 {
 	cl_git_rewritefile("stash/what", "ciao\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX), GIT_EMERGECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
@@ -179,7 +179,7 @@ void test_stash_apply__conflict_commit_with_default(void)
 	cl_git_pass(git_index_add_bypath(repo_index, "what"));
 	cl_repo_commit_from_index(NULL, repo, signature, 0, "Other commit");
 
-	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_DEFAULT));
+	cl_git_pass(git_stash_apply(repo, 0, NULL, GIT_APPLY_DEFAULT));
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 1);
 	cl_git_pass(git_index_conflict_get(&ancestor, &our, &their, repo_index, "what")); /* unmerged */
@@ -198,7 +198,7 @@ void test_stash_apply__conflict_commit_with_reinstate_index(void)
 	cl_git_pass(git_index_add_bypath(repo_index, "what"));
 	cl_repo_commit_from_index(NULL, repo, signature, 0, "Other commit");
 
-	cl_git_pass(git_stash_apply(repo, 0, GIT_APPLY_REINSTATE_INDEX));
+	cl_git_pass(git_stash_apply(repo, 0, NULL, GIT_APPLY_REINSTATE_INDEX));
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 1);
 	cl_git_pass(git_index_conflict_get(&ancestor, &our, &their, repo_index, "what")); /* unmerged */
@@ -209,7 +209,7 @@ void test_stash_apply__conflict_commit_with_reinstate_index(void)
 
 void test_stash_apply__pop(void)
 {
-	cl_git_pass(git_stash_pop(repo, 0, GIT_APPLY_DEFAULT));
+	cl_git_pass(git_stash_pop(repo, 0, NULL, GIT_APPLY_DEFAULT));
 
-	cl_git_fail_with(git_stash_pop(repo, 0, GIT_APPLY_DEFAULT), GIT_ENOTFOUND);
+	cl_git_fail_with(git_stash_pop(repo, 0, NULL, GIT_APPLY_DEFAULT), GIT_ENOTFOUND);
 }


### PR DESCRIPTION
A modification on #2705.  I made some notes in that PR, though actually acting on those notes was quite a bit more challenging than I had hoped.  This introduces two lower level ideas:

* `git_merge__iterators`, to allow one to merge a tree and an index and get an index out as a result.  (Interestingly `git_merge` had this broken out as a helper function at one point, and it was brought back in.  So now it's a helper function again.)  This allows us to merge the results of another merge, without having to write it out to a tree.

* `git_index_read_index`, which behaves like `git_index_read_tree` except that it reads an index into the index.  This maintains the stat cache of the existing items.

Sorry about the long delay in finishing this up.  Stash application is completely and totally ridiculous (put these files on disk and these in the index _unless_ this happens or this), as I'm sure @swisspol can attest to.  I think that with the two basic functions mentioned above that the `stash_apply` can be a bit simpler and not necessarily have to write objects for the intermediate steps.