### PR TITLE
Fix describe without refs and OID fallbacks

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -11,4 +11,5 @@ remote
 status
 tag
 for-each-ref
+describe
 *.dSYM

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,6 +5,7 @@ CFLAGS = -g -I../include -I../src -Wall -Wextra -Wmissing-prototypes -Wno-missin
 LFLAGS = -L../build -lgit2 -lz
 APPS = general showindex diff rev-list cat-file status log rev-parse init blame tag remote
 APPS += for-each-ref
+APPS += describe
 
 all: $(APPS)
 

--- a/src/describe.c
+++ b/src/describe.c
@@ -693,7 +693,7 @@ int git_describe_commit(
 			get_name, &data)) < 0)
 				goto cleanup;
 
-	if (git_oidmap_size(data.names) == 0) {
+	if (git_oidmap_size(data.names) == 0 && !opts->show_commit_oid_as_fallback) {
 		giterr_set(GITERR_DESCRIBE, "Cannot describe - "
 			"No reference found, cannot describe anything.");
 		error = -1;

--- a/tests/describe/describe.c
+++ b/tests/describe/describe.c
@@ -28,7 +28,7 @@ static int delete_cb(git_reference *ref, void *payload)
 	return 0;
 }
 
-void test_describe_describe__cannot_describe_against_a_repo_with_no_ref(void)
+void test_describe_describe__describe_a_repo_with_no_refs(void)
 {
 	git_repository *repo;
 	git_describe_options opts = GIT_DESCRIBE_OPTIONS_INIT;
@@ -41,7 +41,12 @@ void test_describe_describe__cannot_describe_against_a_repo_with_no_ref(void)
 
 	cl_git_pass(git_reference_foreach(repo, delete_cb, NULL));
 
+	/* Impossible to describe without falling back to OIDs */
 	cl_git_fail(git_describe_commit(&result, object, &opts));
+
+	/* Try again with OID fallbacks */
+	opts.show_commit_oid_as_fallback = 1;
+	cl_git_pass(git_describe_commit(&result, object, &opts));
 
 	git_describe_result_free(result);
 	git_object_free(object);


### PR DESCRIPTION
Currently it is not possible to describe a revision with OID fallbacks enabled and a repository that has got no refs. This PR fixes the issue and provides a test that detects the error.
In addition to the fix I also included a second commit that enables building the describe example by default and adds the resulting executable to .gitignore. Feel free to drop that patch if it is not desired.