### PR TITLE
Handle hide-then-push in the revwalk

### DIFF
--- a/include/git2/revwalk.h
+++ b/include/git2/revwalk.h
@@ -90,15 +90,17 @@ GIT_EXTERN(int) git_revwalk_new(git_revwalk **out, git_repository *repo);
 GIT_EXTERN(void) git_revwalk_reset(git_revwalk *walker);
 
 /**
- * Mark a commit to start traversal from.
+ * Add a new root for the traversal
  *
- * The given OID must belong to a committish on the walked
+ * The pushed commit will be marked as one of the roots from which to
+ * start the walk. This commit may not be walked if it or a child is
+ * hidden.
+ *
+ * At least one commit must be pushed onto the walker before a walk
+ * can be started.
+ *
+ * The given id must belong to a committish on the walked
  * repository.
- *
- * The given commit will be used as one of the roots
- * when starting the revision walk. At least one commit
- * must be pushed onto the walker before a walk can
- * be started.
  *
  * @param walk the walker being used for the traversal.
  * @param id the oid of the commit to start from.
@@ -135,7 +137,7 @@ GIT_EXTERN(int) git_revwalk_push_head(git_revwalk *walk);
 /**
  * Mark a commit (and its ancestors) uninteresting for the output.
  *
- * The given OID must belong to a committish on the walked
+ * The given id must belong to a committish on the walked
  * repository.
  *
  * The resolved commit and all its parents will be hidden from the

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -144,6 +144,10 @@ static int push_commit(git_revwalk *walk, const git_oid *oid, int uninteresting,
 	if (commit == NULL)
 		return -1; /* error already reported by failed lookup */
 
+	/* A previous hide already told us we don't want this commit  */
+	if (commit->uninteresting)
+		return 0;
+
 	if (uninteresting)
 		walk->did_hide = 1;
 	else

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -314,6 +314,23 @@ void test_revwalk_basic__disallow_non_commit(void)
 	cl_git_fail(git_revwalk_push(_walk, &oid));
 }
 
+void test_revwalk_basic__hide_then_push(void)
+{
+	git_oid oid;
+	int i = 0;
+
+	revwalk_basic_setup_walk(NULL);
+	cl_git_pass(git_oid_fromstr(&oid, "5b5b025afb0b4c913b4c338a42934a3863bf3644"));
+
+	cl_git_pass(git_revwalk_hide(_walk, &oid));
+	cl_git_pass(git_revwalk_push(_walk, &oid));
+
+	while (git_revwalk_next(&oid, _walk) == 0)
+		i++;
+
+	cl_assert_equal_i(i, 0);
+}
+
 void test_revwalk_basic__push_range(void)
 {
 	revwalk_basic_setup_walk(NULL);


### PR DESCRIPTION
 When a commit is first set as unintersting and then pushed, we must take care that we do not put it into the commit list as that makes us return at least that commit (but maybe more) as we've inserted it into the list because we have the assumption that we want anything in the commit list.

This fixes the aside made in #3034 though it shouldn't be the cause of the slowness.