### PR TITLE
Fix checking of return value for regcomp.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -478,7 +478,7 @@ int git_config_iterator_glob_new(git_config_iterator **out, const git_config *cf
 	iter = git__calloc(1, sizeof(all_iter));
 	GITERR_CHECK_ALLOC(iter);
 
-	if ((result = regcomp(&iter->regex, regexp, REG_EXTENDED)) < 0) {
+	if ((result = regcomp(&iter->regex, regexp, REG_EXTENDED)) != 0) {
 		giterr_set_regex(&iter->regex, result);
 		regfree(&iter->regex);
 		git__free(iter);
@@ -513,7 +513,7 @@ int git_config_backend_foreach_match(
 	int error = 0;
 
 	if (regexp != NULL) {
-		if ((error = regcomp(&regex, regexp, REG_EXTENDED)) < 0) {
+		if ((error = regcomp(&regex, regexp, REG_EXTENDED)) != 0) {
 			giterr_set_regex(&regex, error);
 			regfree(&regex);
 			return -1;
@@ -1004,7 +1004,7 @@ int git_config_multivar_iterator_new(git_config_iterator **out, const git_config
 
 	if (regexp != NULL) {
 		error = regcomp(&iter->regex, regexp, REG_EXTENDED);
-		if (error < 0) {
+		if (error != 0) {
 			giterr_set_regex(&iter->regex, error);
 			error = -1;
 			regfree(&iter->regex);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -576,7 +576,7 @@ static int config_set_multivar(
 	}
 
 	result = regcomp(&preg, regexp, REG_EXTENDED);
-	if (result < 0) {
+	if (result != 0) {
 		giterr_set_regex(&preg, result);
 		result = -1;
 		goto out;
@@ -662,7 +662,7 @@ static int config_delete_multivar(git_config_backend *cfg, const char *name, con
 	refcounted_strmap_free(map);
 
 	result = regcomp(&preg, regexp, REG_EXTENDED);
-	if (result < 0) {
+	if (result != 0) {
 		giterr_set_regex(&preg, result);
 		result = -1;
 		goto out;

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -116,7 +116,7 @@ static int diff_driver_add_patterns(
 		if (error < 0)
 			break;
 
-		if ((error = regcomp(&pat->re, buf.ptr, regex_flags)) < 0) {
+		if ((error = regcomp(&pat->re, buf.ptr, regex_flags)) != 0) {
 			/* if regex fails to compile, warn? fail? */
 			error = giterr_set_regex(&pat->re, error);
 			regfree(&pat->re);

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -350,6 +350,18 @@ static void check_glob_iter(git_config *cfg, const char *regexp, int expected)
 	git_config_iterator_free(iter);
 }
 
+void test_config_read__iterator_invalid_glob(void)
+{
+	git_config *cfg;
+	git_config_iterator *iter;
+
+	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config9")));
+
+	cl_git_fail(git_config_iterator_glob_new(&iter, cfg, "*"));
+
+	git_config_free(cfg);
+}
+
 void test_config_read__iterator_glob(void)
 {
 	git_config *cfg;


### PR DESCRIPTION
The regcomp function returns a non-zero value if compilation of
a regular expression fails. In most places we only check for
negative values, but positive values indicate an error, as well.
Fix this tree-wide, fixing a segmentation fault when calling
git_config_iterator_glob_new with an invalid regexp.