### PR TITLE
Implementation of url.*.insteadOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ support for HTTPS connections insead of OpenSSL.
   `git_off_t` instead of `size_t` for the size of the blob, which
   allows putting large files into the odb on 32-bit systems.
 
+* The remote's push and pull URLs now honor the url.$URL.insteadOf
+  configuration. This allows modifying URL prefixes to a custom
+  value via gitconfig.
+
 ### API additions
 
 * The `git_merge_options` gained a `file_flags` member.

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -120,6 +120,9 @@ GIT_EXTERN(const char *) git_remote_name(const git_remote *remote);
 /**
  * Get the remote's url
  *
+ * If url.*.insteadOf has been configured for this URL, it will
+ * return the modified URL.
+ *
  * @param remote the remote
  * @return a pointer to the url
  */
@@ -127,6 +130,9 @@ GIT_EXTERN(const char *) git_remote_url(const git_remote *remote);
 
 /**
  * Get the remote's url for pushing
+ *
+ * If url.*.pushInsteadOf has been configured for this URL, it
+ * will return the modified URL.
  *
  * @param remote the remote
  * @return a pointer to the url or NULL if no special url for pushing is set

--- a/tests/remote/insteadof.c
+++ b/tests/remote/insteadof.c
@@ -1,0 +1,60 @@
+#include "clar_libgit2.h"
+#include "remote.h"
+#include "repository.h"
+
+#define REPO_PATH "testrepo2/.gitted"
+#define REMOTE_ORIGIN "origin"
+#define REMOTE_INSTEADOF "insteadof-test"
+
+static git_repository *g_repo;
+static git_remote *g_remote;
+
+void test_remote_insteadof__initialize(void)
+{
+	g_repo = NULL;
+	g_remote = NULL;
+}
+
+void test_remote_insteadof__cleanup(void)
+{
+	git_repository_free(g_repo);
+	git_remote_free(g_remote);
+}
+
+void test_remote_insteadof__url_insteadof_not_applicable(void)
+{
+	cl_git_pass(git_repository_open(&g_repo, cl_fixture(REPO_PATH)));
+	cl_git_pass(git_remote_lookup(&g_remote, g_repo, REMOTE_ORIGIN));
+
+	cl_assert_equal_s(
+		git_remote_url(g_remote),
+		"https://github.com/libgit2/false.git");
+}
+
+void test_remote_insteadof__url_insteadof_applicable(void)
+{
+	cl_git_pass(git_repository_open(&g_repo, cl_fixture(REPO_PATH)));
+	cl_git_pass(git_remote_lookup(&g_remote, g_repo, REMOTE_INSTEADOF));
+
+	cl_assert_equal_s(
+	    git_remote_url(g_remote),
+	    "http://github.com/libgit2/libgit2");
+}
+
+void test_remote_insteadof__pushurl_insteadof_not_applicable(void)
+{
+	cl_git_pass(git_repository_open(&g_repo, cl_fixture(REPO_PATH)));
+	cl_git_pass(git_remote_lookup(&g_remote, g_repo, REMOTE_ORIGIN));
+
+	cl_assert_equal_p(git_remote_pushurl(g_remote), NULL);
+}
+
+void test_remote_insteadof__pushurl_insteadof_applicable(void)
+{
+	cl_git_pass(git_repository_open(&g_repo, cl_fixture(REPO_PATH)));
+	cl_git_pass(git_remote_lookup(&g_remote, g_repo, REMOTE_INSTEADOF));
+
+	cl_assert_equal_s(
+	    git_remote_pushurl(g_remote),
+	    "git@github.com:libgit2/libgit2");
+}

--- a/tests/remote/insteadof.c
+++ b/tests/remote/insteadof.c
@@ -58,3 +58,15 @@ void test_remote_insteadof__pushurl_insteadof_applicable(void)
 	    git_remote_pushurl(g_remote),
 	    "git@github.com:libgit2/libgit2");
 }
+
+void test_remote_insteadof__anonymous_remote(void)
+{
+	cl_git_pass(git_repository_open(&g_repo, cl_fixture(REPO_PATH)));
+	cl_git_pass(git_remote_create_anonymous(&g_remote, g_repo,
+	    "http://example.com/libgit2/libgit2"));
+
+	cl_assert_equal_s(
+	    git_remote_url(g_remote),
+	    "http://github.com/libgit2/libgit2");
+	cl_assert_equal_p(git_remote_pushurl(g_remote), NULL);
+}

--- a/tests/resources/testrepo2/.gitted/config
+++ b/tests/resources/testrepo2/.gitted/config
@@ -8,7 +8,19 @@
 [remote "origin"]
 	url = https://github.com/libgit2/false.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "insteadof-test"]
+	url = http://example.com/libgit2/libgit2
+	pushurl = http://github.com/libgit2/libgit2
+	fetch = +refs/heads/*:refs/remotes/test/*
 [branch "master"]
 	remote = origin
 	merge = refs/heads/master
 	rebase = true
+[url "longer-non-prefix-match"]
+	insteadOf = ttp://example.com/li
+[url "shorter-prefix"]
+	insteadOf = http://example.co
+[url "http://github.com"]
+	insteadOf = http://example.com
+[url "git@github.com:"]
+	pushInsteadOf = http://github.com/


### PR DESCRIPTION
This PR implements intepretation of the url.*.insteadOf and url.*.pushInsteadOf configurations. They are intended to replace URL prefixes with user-chosen prefixes, e.g. url.git@foo.insteadOf = https://bar would result in the URL https://bar:repos/baz being rewritten to git@foo:repos/baz. This can be useful when a user wants to use different access methods for a certain repository or similar use cases.

I've implemented this by adding two new fields url_insteadof and pushurl_insteadof to the `git_remote` struct which can be accessed through newly added functions. It might have been nicer to fold this into existing methods, but like this backwards compatibility is intact as nothing will change for existing users.

In addition, there was a new option `apply_insteadof` added to `struct git_checkout_options`. If this field is set (by default it is not) it will lead to rewritten URLs being used instead of the specified ones. If a URL is not being rewritten while this field is set we just fall back to the unmodified URL. The settings `apply_insteadof` would've been more fitting in `struct git_clone_options`, as far as I am concerned, but without further refactorings it was not possible to use it as some code paths used `git_remote_url` where only a `struct git_checkout_options` was available.

As far as I can see I've adjusted every place where `git_remote_url(..)` is being used. As that's only been inside of the clone/checkout code paths only their behavior is modified by the mentioned `apply_insteadof` varibale. I've been a bit surprised, though, to not find a single use of `git_remote_pushurl`, so there are no adjustments regarding that.

Please feel free to criticize the proposed interface. I'm happy to change that if there are other proposals that suite the usecase better. 