### PR TITLE
Unittest to validate config entry deletion bug.

### DIFF
--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -6,7 +6,6 @@ void test_config_write__initialize(void)
 	cl_fixture_sandbox("config/config9");
 	cl_fixture_sandbox("config/config15");
 	cl_fixture_sandbox("config/config17");
-	cl_fixture_sandbox("config/config21");
 }
 
 void test_config_write__cleanup(void)
@@ -14,7 +13,6 @@ void test_config_write__cleanup(void)
 	cl_fixture_cleanup("config9");
 	cl_fixture_cleanup("config15");
 	cl_fixture_cleanup("config17");
-	cl_fixture_cleanup("config21");
 }
 
 void test_config_write__replace_value(void)
@@ -114,12 +112,21 @@ void test_config_write__delete_value_at_specific_level(void)
  */
 void test_config_write__delete_value_with_duplicate_header(void)
 {
-	const char *file_name  = "config21";
+	const char *file_name  = "config-duplicate-header";
 	const char *entry_name = "remote.origin.url";
 	git_config *cfg;
 	git_config_entry *entry;
 
-	/* Make sure the expected entry exists */
+	/* This config can occur after removing and re-adding the origin remote */
+	const char *file_content =
+		"[remote \"origin\"]\n"		\
+		"[branch \"master\"]\n"		\
+		"	remote = \"origin\"\n"	\
+		"[remote \"origin\"]\n"		\
+		"	url = \"foo\"\n";
+
+	/* Write the test config and make sure the expected entry exists */
+	cl_git_mkfile(file_name, file_content);
 	cl_git_pass(git_config_open_ondisk(&cfg, file_name));
 	cl_git_pass(git_config_get_entry(&entry, cfg, entry_name));
 

--- a/tests/resources/config/config21
+++ b/tests/resources/config/config21
@@ -1,6 +1,0 @@
-# This configuration can occur after removing and re-adding the origin remote
-[remote "origin"]
-[branch "master"]
-  remote = "origin"
-[remote "origin"]
-  url = "foo"

--- a/tests/resources/config/config21
+++ b/tests/resources/config/config21
@@ -1,0 +1,6 @@
+# This configuration can occur after removing and re-adding the origin remote
+[remote "origin"]
+[branch "master"]
+  remote = "origin"
+[remote "origin"]
+  url = "foo"


### PR DESCRIPTION
Add a unittest to validate bug #3043, where a duplicate empty config header
could cause deletion of a config entry to fail silently. The bug is currently
unresolved and this test will fail.