### PR TITLE
Attempt to fix Windows TLS memory leak.

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -270,13 +270,21 @@ git_global_st *git__global_state(void)
 	return ptr;
 }
 
+void git__free_thread_global_state(void)
+{
+	void *ptr = TlsGetValue(_tls_index);
+	if (!ptr)
+		return;
+
+	git__global_state_cleanup(ptr);
+	git__free(ptr);
+	TlsSetValue(_tls_index, NULL);
+}
+
 BOOL WINAPI DllMain(HINSTANCE dll, DWORD reason, LPVOID reserved)
 {
-	if (reason == DLL_THREAD_DETACH) {
-		void *ptr = TlsGetValue(_tls_index);
-		git__global_state_cleanup(ptr);
-		git__free(ptr);
-	}
+	if (reason == DLL_THREAD_DETACH)
+		git__free_thread_global_state();
 
 	return TRUE;
 }

--- a/src/global.c
+++ b/src/global.c
@@ -226,7 +226,7 @@ static void synchronized_threads_shutdown(void)
 	/* Shut down any subsystems that have global state */
 	git__shutdown();
 
-	git__free_thread_global_state();
+	git__free_tls_data();
 
 	TlsFree(_tls_index);
 	git_mutex_free(&git__mwindow_mutex);
@@ -267,7 +267,12 @@ git_global_st *git__global_state(void)
 	return ptr;
 }
 
-void git__free_thread_global_state(void)
+/**
+ * Free the TLS data associated with this thread.
+ * This should only be used by the thread as it
+ * is exiting.
+ */
+void git__free_tls_data(void)
 {
 	void *ptr = TlsGetValue(_tls_index);
 	if (!ptr)

--- a/src/global.c
+++ b/src/global.c
@@ -223,13 +223,10 @@ int git_libgit2_init(void)
 
 static void synchronized_threads_shutdown(void)
 {
-	void *ptr;
-
 	/* Shut down any subsystems that have global state */
 	git__shutdown();
 
-	ptr = TlsGetValue(_tls_index);
-	git__global_state_cleanup(ptr);
+	git__free_thread_global_state();
 
 	TlsFree(_tls_index);
 	git_mutex_free(&git__mwindow_mutex);

--- a/src/global.c
+++ b/src/global.c
@@ -278,14 +278,6 @@ void git__free_thread_global_state(void)
 	TlsSetValue(_tls_index, NULL);
 }
 
-BOOL WINAPI DllMain(HINSTANCE dll, DWORD reason, LPVOID reserved)
-{
-	if (reason == DLL_THREAD_DETACH)
-		git__free_thread_global_state();
-
-	return TRUE;
-}
-
 #elif defined(GIT_THREADS) && defined(_POSIX_THREADS)
 
 static pthread_key_t _tls_key;

--- a/src/global.h
+++ b/src/global.h
@@ -32,6 +32,6 @@ typedef void (*git_global_shutdown_fn)(void);
 
 extern void git__on_shutdown(git_global_shutdown_fn callback);
 
-extern void git__free_thread_global_state(void);
+extern void git__free_tls_data(void);
 
 #endif

--- a/src/global.h
+++ b/src/global.h
@@ -32,4 +32,6 @@ typedef void (*git_global_shutdown_fn)(void);
 
 extern void git__on_shutdown(git_global_shutdown_fn callback);
 
+extern void git__free_thread_global_state(void);
+
 #endif

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -20,7 +20,7 @@ static DWORD WINAPI git_win32__threadproc(LPVOID lpParameter)
 
 	thread->result = thread->proc(thread->param);
 
-	git__free_thread_global_state();
+	git__free_tls_data();
 
 	return CLEAN_THREAD_EXIT;
 }

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -20,6 +20,8 @@ static DWORD WINAPI git_win32__threadproc(LPVOID lpParameter)
 
 	thread->result = thread->proc(thread->param);
 
+	git__free_thread_global_state();
+
 	return CLEAN_THREAD_EXIT;
 }
 


### PR DESCRIPTION
Here is an attempt to fix the TLS leak on Windows reported by CRTDBG. 

```
D:\lg2\src\global.c(264) : {644153} normal block at 0x0433E948, 56 bytes long.
 Data: <                > 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```

The thread TLS data contains space for storing the thread's error info.  It looks like this is only used by the thread itself during its lifetime.  Control thread waiting for the thread to finish just look at the final exit code (in the various thread_join) calls.  So it looks safe to have the thread dispose of the data as it is exiting.

I have only tested this using the CLAR suite on Windows.

