### PR TITLE
Simple benchmark tools (based upon #2948).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,6 @@ IF (BUILD_BENCHMARK)
 		# Precompiled headers
 		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h /FIprecompiled.h")
 	ELSE ()
-		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS "-include malloc.h")
+		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS)
 	ENDIF ()
 ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ OPTION( BUILD_SHARED_LIBS	"Build Shared Library (OFF for Static)"	ON  )
 OPTION( THREADSAFE			"Build libgit2 as threadsafe"			ON )
 OPTION( BUILD_CLAR			"Build Tests using the Clar suite"		ON  )
 OPTION( BUILD_EXAMPLES		"Build library usage example apps"		OFF )
+OPTION( BUILD_BENCHMARK     "Builds benchmarking tools"             ON  )
 OPTION( TAGS				"Generate tags"							OFF )
 OPTION( PROFILE				"Generate profiling information"		OFF )
 OPTION( ENABLE_TRACE		"Enables tracing support"				OFF )
@@ -568,4 +569,27 @@ ENDIF ()
 
 IF (BUILD_EXAMPLES)
 	ADD_SUBDIRECTORY(examples)
+ENDIF ()
+
+IF (BUILD_BENCHMARK)
+	SET(BENCH_PATH "${CMAKE_CURRENT_SOURCE_DIR}/benchmark")
+	INCLUDE_DIRECTORIES(${BENCH_PATH})
+
+	FILE(GLOB_RECURSE SRC_BENCH ${BENCH_PATH}/*.c ${BENCH_PATH}/*.h)
+
+	ADD_EXECUTABLE(libgit2_bench ${SRC_BENCH} ${SRC_H} ${SRC_GIT2} ${SRC_OS} ${SRC_ZLIB} ${SRC_HTTP} ${SRC_REGEX} ${SRC_SSH} ${SRC_SHA1})
+
+	TARGET_LINK_LIBRARIES(libgit2_bench ${SSL_LIBRARIES})
+	TARGET_LINK_LIBRARIES(libgit2_bench ${SSH_LIBRARIES})
+	TARGET_LINK_LIBRARIES(libgit2_bench ${GSSAPI_LIBRARIES})
+	TARGET_LINK_LIBRARIES(libgit2_bench ${ICONV_LIBRARIES})
+	TARGET_OS_LIBRARIES(libgit2_bench)
+	MSVC_SPLIT_SOURCES(libgit2_bench)
+
+	IF (MSVC_IDE)
+		# Precompiled headers
+		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS "/Yuprecompiled.h /FIprecompiled.h")
+	ELSE ()
+		SET_TARGET_PROPERTIES(libgit2_bench PROPERTIES COMPILE_FLAGS "-include malloc.h")
+	ENDIF ()
 ENDIF ()

--- a/benchmark/bench_util.c
+++ b/benchmark/bench_util.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <fcntl.h>
+#include "common.h"
+#include "fileops.h"
+#include "buffer.h"
+
+static int tempdir_isvalid(const char *path)
+{
+	struct stat st;
+
+	if (p_stat(path, &st) != 0)
+		return 0;
+
+	if (!S_ISDIR(st.st_mode))
+		return 0;
+
+	return (access(path, W_OK) == 0);
+}
+
+int gitbench__create_tempdir(char **out)
+{
+	git_buf buf_env = GIT_BUF_INIT;
+	git_buf tempdir = GIT_BUF_INIT;
+	static const char *tempname = "libgit2_bench_XXXXXX";
+	int error = -1;
+
+	if ((git_buf_sets(&buf_env, getenv("BM_TEMP")) < 0) ||
+		(git_buf_len(&buf_env) == 0)) {
+		giterr_set(GITERR_OS, "Set BM_TEMP to tempdir");
+		error = -1;
+		goto done;
+	}
+
+#ifdef GIT_WIN32
+	git_path_mkposix(buf_env.ptr);
+#endif
+
+	if ((!tempdir_isvalid(buf_env.ptr)) ||
+		(git_buf_joinpath(&tempdir, buf_env.ptr, tempname) < 0)) {
+		giterr_set(GITERR_OS, "Set BM_TEMP to tempdir");
+		error = -1;
+		goto done;
+	}
+
+#ifdef GIT_WIN32
+	if (_mktemp_s(tempdir.ptr, tempdir.size+1) != 0 ||
+		p_mkdir(tempdir.ptr, 0700) != 0) {
+		giterr_set(GITERR_OS, "Set BM_TEMP to tempdir");
+		error = -1;
+		goto done;
+	}
+#else
+	if (mkdtemp(tempdir.ptr) == NULL) {
+		giterr_set(GITERR_OS, "Set BM_TEMP to tempdir");
+		error = -1;
+		goto done;
+	}
+#endif
+
+	*out = git_buf_detach(&tempdir);
+	error = 0;
+
+done:
+	git_buf_free(&buf_env);
+	git_buf_free(&tempdir);
+	return error;
+}

--- a/benchmark/bench_util.h
+++ b/benchmark/bench_util.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef BENCH_UTIL_H
+#define BENCH_UTIL_H
+
+/*****************************************************************/
+
+#if defined(_WIN32)
+#define BM_GIT_EXE "git.exe"
+#else
+#define BM_GIT_EXE "/usr/bin/git"
+#endif
+
+/*****************************************************************/
+
+
+#define GITBENCH_EARGUMENTS (INT_MIN+1)
+
+extern FILE *logfile;
+extern const char *progname;
+extern int verbosity;
+
+extern int gitbench__create_tempdir(char **out);
+
+#endif

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef BENCHMARK_H
+#define BENCHMARK_H
+
+#include "operation.h"
+#include "run.h"
+
+typedef struct gitbench_benchmark gitbench_benchmark;
+
+struct gitbench_benchmark {
+	gitbench_operation_spec *operations;
+	size_t operation_cnt;
+	int (*run_fn)(gitbench_benchmark *benchmark, gitbench_run *run);
+	void (*free_fn)(gitbench_benchmark *benchmark);
+};
+
+
+/** Specification for a benchmark command. */
+typedef struct {
+	/** Name of the benchmark option. */
+	const char *name;
+
+	/** The initialization function to execute. */
+	int (*init)(gitbench_benchmark **out, int argc, const char **argv);
+
+	/** The description of the benchmark. */
+	const char *description;
+} gitbench_benchmark_spec;
+
+/* Benchmark initializers */
+extern int gitbench_benchmark_checkout_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv);
+
+extern int gitbench_benchmark_checkoutn_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv);
+
+extern int gitbench_benchmark_clone_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv);
+
+extern int gitbench_benchmark_merge_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv);
+
+#endif

--- a/benchmark/bm_checkout.c
+++ b/benchmark/bm_checkout.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdio.h>
+#include "git2.h"
+#include "git2/sys/repository.h"
+#include "common.h"
+#include "bench_util.h"
+#include "buffer.h"
+#include "fileops.h"
+#include "opt.h"
+#include "run.h"
+#include "operation.h"
+#include "benchmark.h"
+
+typedef struct gitbench_benchmark_checkout {
+	gitbench_benchmark base;
+
+	char *repo_path;
+	char *ref_name;
+	unsigned int autocrlf:1;
+} gitbench_benchmark_checkout;
+
+enum checkout_operation_t {
+	CHECKOUT_OPERATION_SETUP = 0,
+	CHECKOUT_OPERATION_SETUP_FILTERS,
+	CHECKOUT_OPERATION_CHECKOUT,
+	CHECKOUT_OPERATION_CLEANUP
+};
+
+static gitbench_operation_spec checkout_operations[] = {
+	{ CHECKOUT_OPERATION_SETUP, "openrepo" },
+	{ CHECKOUT_OPERATION_SETUP_FILTERS, "config" },
+	{ CHECKOUT_OPERATION_CHECKOUT, "checkout" },
+	{ CHECKOUT_OPERATION_CLEANUP, "close" },
+};
+#define CHECKOUT_OPERATIONS_COUNT 4
+
+static const gitbench_opt_spec checkout_cmdline_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",       0,   NULL,      "display help",   GITBENCH_OPT_USAGE_HIDDEN },
+	{ GITBENCH_OPT_ARG,    "repository", 0,   NULL,      "the repository to checkout", GITBENCH_OPT_USAGE_REQUIRED },
+	{ GITBENCH_OPT_VALUE,  "reference",  'r', "refname", "the reference to checkout", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_SWITCH, "autocrlf",   0,   NULL,      "turn on core.autocrlf=true" },
+	{ 0 }
+};
+
+static int checkout_run(gitbench_benchmark *b, gitbench_run *run)
+{
+	git_repository *repo = NULL;
+	git_oid id;
+	git_object *obj = NULL;
+	git_config *config = NULL;
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	gitbench_benchmark_checkout *benchmark = (gitbench_benchmark_checkout *)b;
+	git_buf wd_path = GIT_BUF_INIT, config_path = GIT_BUF_INIT;
+	const char *ref_name = "HEAD";
+	int error;
+
+	/* setup repository */
+	gitbench_run_start_operation(run, CHECKOUT_OPERATION_SETUP);
+
+	if (benchmark->ref_name)
+		ref_name = benchmark->ref_name;
+
+	if ((error = git_repository_open(&repo, benchmark->repo_path)) < 0 ||
+		(error = git_reference_name_to_id(&id, repo, ref_name)) < 0 ||
+		(error = git_object_lookup(&obj, repo, &id, GIT_OBJ_ANY)) < 0 ||
+		(error = git_buf_joinpath(&wd_path, run->tempdir, "workdir")) < 0 ||
+		(error = git_futils_mkdir(wd_path.ptr, NULL, 0700, GIT_MKDIR_VERIFY_DIR)) < 0 ||
+		(error = git_repository_set_workdir(repo, wd_path.ptr, 0)) < 0 ||
+		(error = git_config_new(&config)) < 0) {
+		gitbench_run_finish_operation(run);
+		goto done;
+	}
+
+	git_repository_set_index(repo, NULL);
+	git_repository_set_config(repo, config);
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	gitbench_run_finish_operation(run);
+
+	if (benchmark->autocrlf) {
+		gitbench_run_start_operation(run, CHECKOUT_OPERATION_SETUP_FILTERS);
+
+		if ((error = git_buf_joinpath(&config_path, run->tempdir, ".config")) == 0 &&
+			(error = git_config_add_file_ondisk(config, config_path.ptr, GIT_CONFIG_LEVEL_LOCAL, 0)) == 0)
+			error = git_config_set_bool(config, "core.autocrlf", true);
+
+		gitbench_run_finish_operation(run);
+
+		if (error < 0)
+			goto done;
+	}
+
+	/* do the checkout */
+	gitbench_run_start_operation(run, CHECKOUT_OPERATION_CHECKOUT);
+	error = git_checkout_tree(repo, obj, &opts);
+	gitbench_run_finish_operation(run);
+
+done:
+	/* cleanup */
+	gitbench_run_start_operation(run, CHECKOUT_OPERATION_CLEANUP);
+	git_object_free(obj);
+	git_config_free(config);
+	git_repository_free(repo);
+	git_buf_free(&wd_path);
+	git_buf_free(&config_path);
+	gitbench_run_finish_operation(run);
+
+	return error;
+}
+
+static void checkout_free(gitbench_benchmark *b)
+{
+	gitbench_benchmark_checkout *benchmark = (gitbench_benchmark_checkout *)b;
+
+	if (!b)
+		return;
+
+	git__free(benchmark->repo_path);
+	git__free(benchmark->ref_name);
+	git__free(benchmark);
+}
+
+static int checkout_configure(
+	gitbench_benchmark_checkout *benchmark,
+	int argc,
+	const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+
+	gitbench_opt_parser_init(&parser, checkout_cmdline_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			fprintf(stderr, "%s: unknown argument: '%s'\n", progname, argv[parser.idx]);
+			gitbench_opt_usage_fprint(stderr, progname, checkout_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		}
+
+		if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_opt_usage_fprint(stderr, progname, checkout_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		} else if (strcmp(opt.spec->name, "repository") == 0) {
+			benchmark->repo_path = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->repo_path);
+		} else if (strcmp(opt.spec->name, "reference") == 0) {
+			benchmark->ref_name = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->ref_name);
+		} else if (strcmp(opt.spec->name, "autocrlf") == 0) {
+			benchmark->autocrlf = 1;
+		}
+	}
+
+	if (!benchmark->repo_path) {
+		gitbench_opt_usage_fprint(stderr, progname, checkout_cmdline_opts);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return 0;
+}
+
+int gitbench_benchmark_checkout_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv)
+{
+	gitbench_benchmark_checkout *benchmark;
+	int error;
+
+	if ((benchmark = git__calloc(1, sizeof(gitbench_benchmark_checkout))) == NULL)
+		return -1;
+
+	benchmark->base.operation_cnt = CHECKOUT_OPERATIONS_COUNT;
+	benchmark->base.operations = checkout_operations;
+	benchmark->base.run_fn = checkout_run;
+	benchmark->base.free_fn = checkout_free;
+
+	if ((error = checkout_configure(benchmark, argc, argv)) < 0) {
+		checkout_free((gitbench_benchmark *)benchmark);
+		return error;
+	}
+
+	*out = (gitbench_benchmark *)benchmark;
+	return 0;
+}

--- a/benchmark/bm_checkoutn.c
+++ b/benchmark/bm_checkoutn.c
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdio.h>
+#include "git2.h"
+#include "git2/sys/repository.h"
+#include "common.h"
+#include "bench_util.h"
+#include "buffer.h"
+#include "fileops.h"
+#include "opt.h"
+#include "run.h"
+#include "shell.h"
+#include "operation.h"
+#include "benchmark.h"
+
+typedef struct gitbench_benchmark_checkoutn {
+	gitbench_benchmark base;
+
+	char *repo_url;
+	git_vector vec_refs;
+
+	unsigned int autocrlf:1;
+
+	int status_count;
+
+} gitbench_benchmark_checkoutn;
+
+enum checkoutn_operation_t {
+	CHECKOUTN_OPERATION_EXE_CLONE = 0,
+	CHECKOUTN_OPERATION_EXE_INIT_CO, /* Initial checkout */
+	CHECKOUTN_OPERATION_LG2_INIT_CO, /* Initial checkout */
+	CHECKOUTN_OPERATION_EXE_DO_CO,   /* Subsequent checkouts */
+	CHECKOUTN_OPERATION_LG2_DO_CO,   /* Subsequent checkouts */
+	CHECKOUTN_OPERATION_EXE_STATUS,
+	CHECKOUTN_OPERATION_LG2_STATUS
+};
+
+static gitbench_operation_spec checkoutn_operations[] = {
+	{ CHECKOUTN_OPERATION_EXE_CLONE,    "ExeClone" },
+	{ CHECKOUTN_OPERATION_EXE_INIT_CO,  "ExeInitCO" },
+	{ CHECKOUTN_OPERATION_LG2_INIT_CO,  "Lg2InitCO" },
+	{ CHECKOUTN_OPERATION_EXE_DO_CO,    "ExeDoCO" },
+	{ CHECKOUTN_OPERATION_LG2_DO_CO,    "Lg2DoCO" },
+	{ CHECKOUTN_OPERATION_EXE_STATUS,   "ExeStatus" },
+	{ CHECKOUTN_OPERATION_LG2_STATUS,   "Lg2Status" },
+};
+#define CHECKOUTN_OPERATIONS_COUNT (sizeof(checkoutn_operations) / sizeof(checkoutn_operations[0]))
+
+static const gitbench_opt_spec checkoutn_cmdline_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",       0, NULL,      "display help",                GITBENCH_OPT_USAGE_HIDDEN },
+	{ GITBENCH_OPT_SWITCH, "autocrlf",   0, NULL,      "turn on core.autocrlf=true" },
+	{ GITBENCH_OPT_VALUE,  "status",   's', "count",   "times to run status aftwards", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_ARG,    "repository", 0, NULL,      "the repository",              GITBENCH_OPT_USAGE_REQUIRED },
+	{ GITBENCH_OPT_ARGS,   "refs",       0, NULL, "2 or more references to checkout", GITBENCH_OPT_USAGE_REQUIRED },
+	{ 0 }
+};
+
+
+/**
+ * Clone the requested repo to TMP.
+ * DO NOT let clone checkout the default HEAD.
+ */
+static int _init_exe_clone(
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int k;
+	int error;
+
+	gitbench_run_start_operation(run, CHECKOUTN_OPERATION_EXE_CLONE);
+
+	k = 0;
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "clone";
+	argv[k++] = "--quiet";
+	argv[k++] = "--no-checkout";
+	argv[k++] = benchmark->repo_url;
+	argv[k++] = wd;
+	argv[k++] = 0;
+
+	if ((error = gitbench_shell(argv, NULL, NULL)) < 0)
+		goto done;
+
+	k = 0;
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "config";
+	argv[k++] = "core.autocrlf";
+	argv[k++] = ((benchmark->autocrlf) ? "true" : "false");
+	argv[k++] = 0;
+
+	if ((error = gitbench_shell(argv, wd, NULL)) < 0)
+		goto done;
+
+done:
+	gitbench_run_finish_operation(run);
+	return error;
+}
+
+
+static int _do_core_setup(
+	git_buf *wd_path,
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run)
+{
+	int error;
+
+	if ((error = git_buf_joinpath(wd_path, run->tempdir, "wd")) < 0)
+		return error;
+	if ((error = git_futils_mkdir(wd_path->ptr, NULL, 0700, GIT_MKDIR_VERIFY_DIR)) < 0)
+		return error;
+
+	return error;
+}
+
+
+static int _do_lg2_status(
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	git_repository *repo = NULL;
+	git_status_list *status = NULL;
+	git_status_options status_opts = GIT_STATUS_OPTIONS_INIT;
+	int error;
+	int x;
+
+	status_opts.show = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
+	status_opts.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED |
+		GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX;
+
+	if ((error = git_repository_open(&repo, wd)) < 0)
+		goto done;
+
+	for (x = 0; x < benchmark->status_count; x++) {
+		gitbench_run_start_operation(run, CHECKOUTN_OPERATION_LG2_STATUS);
+		error = git_status_list_new(&status, repo, &status_opts);
+		gitbench_run_finish_operation(run);
+		if (error < 0)
+			goto done;
+	}
+
+done:
+	gitbench_run_finish_operation(run);
+	git_status_list_free(status);
+	git_repository_free(repo);
+	return error;
+}
+
+static int _do_exe_status(
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int k = 0;
+	int error;
+	int x;
+
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "status";
+	argv[k++] = "--porcelain";
+	argv[k++] = "--branch";
+	argv[k++] = 0;
+
+	for (x = 0; x < benchmark->status_count; x++) {
+		gitbench_run_start_operation(run, CHECKOUTN_OPERATION_EXE_STATUS);
+		error = gitbench_shell(argv, wd, NULL);
+		gitbench_run_finish_operation(run);
+		if (error < 0)
+			goto done;
+	}
+
+done:
+	gitbench_run_finish_operation(run);
+	return error;
+}
+
+static int _do_lg2_checkoutn(
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run,
+	const char *wd,
+	int j)
+{
+	git_repository *repo = NULL;
+	git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_object *obj = NULL;
+	int error;
+	enum checkoutn_operation_t op = ((j == 0)
+									 ? CHECKOUTN_OPERATION_LG2_INIT_CO
+									 : CHECKOUTN_OPERATION_LG2_DO_CO);
+	const char *sz_ref = (const char *)git_vector_get(&benchmark->vec_refs, j);
+
+	gitbench_run_start_operation(run, op);
+
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	if ((error = git_repository_open(&repo, wd)) < 0)
+		goto done;
+
+	if ((error = git_revparse_single(&obj, repo, sz_ref)) < 0)
+		goto done;
+
+	if ((error = git_checkout_tree(repo, obj, &checkout_opts)) < 0)
+		goto done;
+
+	if ((error = git_repository_set_head_detached(repo, git_object_id(obj))) < 0)
+		goto done;
+
+done:
+	gitbench_run_finish_operation(run);
+	git_object_free(obj);
+	git_repository_free(repo);
+	return error;
+}
+
+static int _do_exe_checkoutn(
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run,
+	const char *wd,
+	int j)
+{
+	const char * argv[10] = {0};
+	int result;
+	int k = 0;
+	enum checkoutn_operation_t op = ((j == 0)
+									 ? CHECKOUTN_OPERATION_EXE_INIT_CO
+									 : CHECKOUTN_OPERATION_EXE_DO_CO);
+
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "checkout";
+	argv[k++] = "--quiet";
+	argv[k++] = "--force";
+	argv[k++] = "--detach";
+	argv[k++] = (const char *)git_vector_get(&benchmark->vec_refs, j);
+	argv[k++] = 0;
+
+	gitbench_run_start_operation(run, op);
+
+	if ((result = gitbench_shell(argv, wd, NULL)) < 0)
+		goto done;
+
+done:
+	gitbench_run_finish_operation(run);
+	return result;
+}
+
+static int _do_checkoutn(
+	gitbench_benchmark_checkoutn *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	char *sz_i;
+	size_t i;
+	int error;
+
+	git_vector_foreach(&benchmark->vec_refs, i, sz_i) {
+		if (run->verbosity)
+			fprintf(logfile, ": Checkout %s\n", sz_i);
+
+		if (run->use_git_exe) {
+			if ((error = _do_exe_checkoutn(benchmark, run, wd, i)) < 0)
+				goto done;
+		} else {
+			if ((error = _do_lg2_checkoutn(benchmark, run, wd, i)) < 0)
+				goto done;
+		}
+
+		/* We can run both version of status regardless of who does the checkout. */
+		if ((error = _do_exe_status(benchmark, run, wd)) < 0)
+			goto done;
+		if ((error = _do_lg2_status(benchmark, run, wd)) < 0)
+			goto done;
+	}
+
+done:
+	return error;
+}
+
+
+static int checkoutn_run(gitbench_benchmark *b, gitbench_run *run)
+{
+	gitbench_benchmark_checkoutn *benchmark = (gitbench_benchmark_checkoutn *)b;
+	git_buf wd_path = GIT_BUF_INIT;
+	int error;
+
+	if ((error = _do_core_setup(&wd_path, benchmark, run)) < 0)
+		goto done;
+
+	// TODO Consider having lg2-based version of clone.
+	if ((error = _init_exe_clone(benchmark, run, wd_path.ptr)) < 0)
+		goto done;
+
+	if ((error = _do_checkoutn(benchmark, run, wd_path.ptr)) < 0)
+		goto done;
+
+done:
+	git_buf_free(&wd_path);
+	return error;
+}
+
+static void checkoutn_free(gitbench_benchmark *b)
+{
+	gitbench_benchmark_checkoutn *benchmark = (gitbench_benchmark_checkoutn *)b;
+	char *sz_i;
+	size_t i;
+
+	if (!b)
+		return;
+
+	git__free(benchmark->repo_url);
+	git_vector_foreach(&benchmark->vec_refs, i, sz_i)
+		git__free(sz_i);
+	git__free(benchmark);
+}
+
+static int checkoutn_configure(
+	gitbench_benchmark_checkoutn *benchmark,
+	int argc,
+	const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+
+	gitbench_opt_parser_init(&parser, checkoutn_cmdline_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			git_vector_insert(&benchmark->vec_refs, git__strdup(opt.value));
+		} else if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_opt_usage_fprint(stderr, progname, checkoutn_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		} else if (strcmp(opt.spec->name, "autocrlf") == 0) {
+			benchmark->autocrlf = 1;
+		} else if (strcmp(opt.spec->name, "repository") == 0) {
+			benchmark->repo_url = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->repo_url);
+		} else if (strcmp(opt.spec->name, "refs") == 0) {
+			git_vector_insert(&benchmark->vec_refs,
+							  git__strdup(opt.value));
+		} else if (strcmp(opt.spec->name, "status") == 0) {
+			char *end;
+			long c = strtol(opt.value, &end, 10);
+			if (c <= 0 || *end) {
+				fprintf(stderr, "%s: invalid status count '%s'\n", progname, opt.value);
+				gitbench_opt_usage_fprint(stderr, progname, checkoutn_cmdline_opts);
+				return GITBENCH_EARGUMENTS;
+			}
+			benchmark->status_count = c;
+		} else {
+			fprintf(stderr, "%s: unknown argument: '%s'\n", progname, argv[parser.idx]);
+			gitbench_opt_usage_fprint(stderr, progname, checkoutn_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		}
+	}
+
+	if (benchmark->status_count == 0)
+		benchmark->status_count = 1;
+
+	/* vec_refs[0] is the initial checkout performed during the setup.
+	 * vec_refs[1] is the first timed checkout.
+	 * vec_refs[2..n] are optional.
+	 */
+
+	if (!benchmark->repo_url ||
+		(git_vector_length(&benchmark->vec_refs) < 2)) {
+		gitbench_opt_usage_fprint(stderr, progname, checkoutn_cmdline_opts);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return 0;
+}
+
+int gitbench_benchmark_checkoutn_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv)
+{
+	gitbench_benchmark_checkoutn *benchmark;
+	int error;
+
+	if ((benchmark = git__calloc(1, sizeof(gitbench_benchmark_checkoutn))) == NULL)
+		return -1;
+
+	benchmark->base.operation_cnt = CHECKOUTN_OPERATIONS_COUNT;
+	benchmark->base.operations = checkoutn_operations;
+	benchmark->base.run_fn = checkoutn_run;
+	benchmark->base.free_fn = checkoutn_free;
+
+	git_vector_init(&benchmark->vec_refs, 0, NULL);
+
+	if ((error = checkoutn_configure(benchmark, argc, argv)) < 0) {
+		checkoutn_free((gitbench_benchmark *)benchmark);
+		return error;
+	}
+
+	*out = (gitbench_benchmark *)benchmark;
+	return 0;
+}

--- a/benchmark/bm_clone.c
+++ b/benchmark/bm_clone.c
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdio.h>
+#include "git2.h"
+#include "git2/sys/repository.h"
+#include "common.h"
+#include "bench_util.h"
+#include "buffer.h"
+#include "fileops.h"
+#include "opt.h"
+#include "run.h"
+#include "operation.h"
+#include "benchmark.h"
+#include "shell.h"
+
+
+typedef struct gitbench_benchmark_clone {
+	gitbench_benchmark base;
+
+	char *repo_path;
+	char *username;
+	char *password;
+
+	git_clone_local_t local;
+	bool bare;
+
+} gitbench_benchmark_clone;
+
+enum clone_operation_t {
+	CLONE_OPERATION_SETUP = 0,
+	CLONE_OPERATION_CLONE,
+	CLONE_OPERATION_CLEANUP
+};
+
+static gitbench_operation_spec clone_operations[] = {
+	{ CLONE_OPERATION_SETUP,   "setup" },
+	{ CLONE_OPERATION_CLONE, "clone" },
+	{ CLONE_OPERATION_CLEANUP, "close" },
+};
+#define CLONE_OPERATIONS_COUNT (sizeof(clone_operations) / sizeof(clone_operations[0]))
+
+static const gitbench_opt_spec clone_cmdline_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",           0, NULL,      "display help",   GITBENCH_OPT_USAGE_HIDDEN },
+	{ GITBENCH_OPT_ARG,    "repository",     0, NULL,      "the repository", GITBENCH_OPT_USAGE_REQUIRED },
+	{ GITBENCH_OPT_SWITCH, "local",          0, "local",        "local" },
+	{ GITBENCH_OPT_SWITCH, "no-local",       0, "no-local",     "no-local" },
+	{ GITBENCH_OPT_SWITCH, "no-hardlinks",   0, "no-hardlinks", "no-hardlinks" },
+	{ GITBENCH_OPT_VALUE,  "username",     'u', "username", "username", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_VALUE,  "password",     'p', "password", "password", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ 0 }
+};
+
+
+/**
+ * Supply credentials for the call to git_clone().
+ * We use the optional command line args or the
+ * environment variables.
+ *
+ * I don't like either of these methods, but I
+ * don't want to hook up a credential helper right
+ * now (and which may still prompt the user).
+ *
+ * This is only used by the libgit2 code; we don't
+ * control what git.exe will do -- so to have a
+ * fully automated test, you'll need to address
+ * that separately.
+ */
+static int cred_cb(
+	git_cred **cred,
+	const char *url,
+	const char *username_from_url,
+	unsigned int allowed_types,
+	void *payload)
+{
+	gitbench_benchmark_clone *benchmark = (gitbench_benchmark_clone *)payload;
+	const char *user;
+	const char *pass;
+
+	GIT_UNUSED(url);
+	GIT_UNUSED(allowed_types);
+
+	if (username_from_url)
+		user = username_from_url;
+	else if (benchmark->username)
+		user = benchmark->username;
+	else
+		user = getenv("BENCHMARK_USERNAME");
+
+	if (benchmark->password)
+		pass = benchmark->password;
+	else
+		pass = getenv("BENCHMARK_PASSWORD");
+
+	return git_cred_userpass_plaintext_new(cred, user, pass);
+}
+
+
+static int _do_clone(
+	gitbench_benchmark_clone *benchmark,
+	const char *wd)
+{
+	git_repository *repo = NULL;
+	git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+	git_remote_callbacks remote_callbacks = GIT_REMOTE_CALLBACKS_INIT;
+	int error;
+
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+	remote_callbacks.credentials = cred_cb;
+	remote_callbacks.payload = benchmark;
+
+	clone_opts.checkout_opts = checkout_opts;
+	clone_opts.remote_callbacks = remote_callbacks;
+	clone_opts.bare = benchmark->bare;
+	clone_opts.local = benchmark->local;
+	error = git_clone(&repo, benchmark->repo_path, wd, &clone_opts);
+
+	git_repository_free(repo);
+	return error;
+}
+
+static int _do_clone_using_git_exe(
+	gitbench_benchmark_clone *benchmark,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int k = 0;
+
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "clone";
+	argv[k++] = "--quiet";
+
+	if (benchmark->bare)
+		argv[k++] = "--bare";
+
+	if (benchmark->local == GIT_CLONE_LOCAL)
+		argv[k++] = "--local";
+	else if (benchmark->local == GIT_CLONE_NO_LOCAL)
+		argv[k++] = "--no-local";
+	else if (benchmark->local == GIT_CLONE_LOCAL_NO_LINKS)
+		argv[k++] = "--no-hardlinks";
+
+	argv[k++] = benchmark->repo_path;
+	argv[k++] = wd;
+	argv[k++] = 0;
+
+	return gitbench_shell(argv, NULL, NULL);
+}
+
+static int _time_clone(
+	gitbench_benchmark_clone *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	int error;
+
+	gitbench_run_start_operation(run, CLONE_OPERATION_CLONE);
+	if (run->use_git_exe)
+		error = _do_clone_using_git_exe(benchmark, wd);
+	else
+		error = _do_clone(benchmark, wd);
+	gitbench_run_finish_operation(run);
+
+	return error;
+}
+
+
+static int _do_setup(
+	git_buf *wd_path,
+	gitbench_benchmark_clone *benchmark,
+	gitbench_run *run)
+{
+	int error;
+
+	GIT_UNUSED(benchmark);
+
+	if ((error = git_buf_joinpath(wd_path, run->tempdir, "wd")) < 0)
+		return error;
+	if ((error = git_futils_mkdir(wd_path->ptr, NULL, 0700, GIT_MKDIR_VERIFY_DIR)) < 0)
+		return error;
+
+	return error;
+}
+
+static int _time_setup(
+	git_buf *wd_path,
+	gitbench_benchmark_clone *benchmark,
+	gitbench_run *run)
+{
+	int error;
+
+	gitbench_run_start_operation(run, CLONE_OPERATION_SETUP);
+	error = _do_setup(wd_path, benchmark, run);
+	gitbench_run_finish_operation(run);
+
+	return error;
+}
+
+
+static int clone_run(gitbench_benchmark *b, gitbench_run *run)
+{
+	gitbench_benchmark_clone *benchmark = (gitbench_benchmark_clone *)b;
+	git_buf wd_path = GIT_BUF_INIT;
+	int error;
+
+	if ((error = _time_setup(&wd_path, benchmark, run)) < 0)
+		goto done;
+	
+	error = _time_clone(benchmark, run, wd_path.ptr);
+
+done:
+	git_buf_free(&wd_path);
+	return error;
+}
+
+static void clone_free(gitbench_benchmark *b)
+{
+	gitbench_benchmark_clone *benchmark = (gitbench_benchmark_clone *)b;
+
+	if (!b)
+		return;
+
+	git__free(benchmark->repo_path);
+	git__free(benchmark->username);
+	git__free(benchmark->password);
+	git__free(benchmark);
+}
+
+static int clone_configure(
+	gitbench_benchmark_clone *benchmark,
+	int argc,
+	const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+
+	/* the 3 local-related args should be treated as
+	 * a radio group, but we just take the last value
+	 * we see.
+	 */
+	benchmark->local = GIT_CLONE_LOCAL_AUTO;
+
+	/* TODO decide if we want a "--bare" command line arg. */
+	benchmark->bare = true;
+
+	gitbench_opt_parser_init(&parser, clone_cmdline_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			fprintf(stderr, "%s: unknown argument: '%s'\n", progname, argv[parser.idx]);
+			gitbench_opt_usage_fprint(stderr, progname, clone_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		}
+
+		if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_opt_usage_fprint(stderr, progname, clone_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		} else if (strcmp(opt.spec->name, "repository") == 0) {
+			benchmark->repo_path = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->repo_path);
+		} else if (strcmp(opt.spec->name, "username") == 0) {
+			benchmark->username = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->username);
+		} else if (strcmp(opt.spec->name, "password") == 0) {
+			benchmark->password = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->password);
+
+		} else if (strcmp(opt.spec->name, "local") == 0) {
+			benchmark->local = GIT_CLONE_LOCAL;
+		} else if (strcmp(opt.spec->name, "no-local") == 0) {
+			benchmark->local = GIT_CLONE_NO_LOCAL;
+		} else if (strcmp(opt.spec->name, "no-hardlinks") == 0) {
+			benchmark->local = GIT_CLONE_LOCAL_NO_LINKS;
+		}
+	}
+
+	if (!benchmark->repo_path) {
+		gitbench_opt_usage_fprint(stderr, progname, clone_cmdline_opts);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return 0;
+}
+
+int gitbench_benchmark_clone_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv)
+{
+	gitbench_benchmark_clone *benchmark;
+	int error;
+
+	if ((benchmark = git__calloc(1, sizeof(gitbench_benchmark_clone))) == NULL)
+		return -1;
+
+	benchmark->base.operation_cnt = CLONE_OPERATIONS_COUNT;
+	benchmark->base.operations = clone_operations;
+	benchmark->base.run_fn = clone_run;
+	benchmark->base.free_fn = clone_free;
+
+	if ((error = clone_configure(benchmark, argc, argv)) < 0) {
+		clone_free((gitbench_benchmark *)benchmark);
+		return error;
+	}
+
+	*out = (gitbench_benchmark *)benchmark;
+	return 0;
+}

--- a/benchmark/bm_merge.c
+++ b/benchmark/bm_merge.c
@@ -1,0 +1,429 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdio.h>
+#include "git2.h"
+#include "git2/sys/repository.h"
+#include "common.h"
+#include "bench_util.h"
+#include "buffer.h"
+#include "fileops.h"
+#include "opt.h"
+#include "run.h"
+#include "shell.h"
+#include "operation.h"
+#include "benchmark.h"
+
+typedef struct gitbench_benchmark_merge {
+	gitbench_benchmark base;
+
+	char *repo_url;
+	char *ref_name_checkout;
+	char *ref_name_merge;
+
+	unsigned int autocrlf:1;
+
+	int status_count;
+
+} gitbench_benchmark_merge;
+
+enum merge_operation_t {
+	MERGE_OPERATION_EXE_CLONE = 0,
+	MERGE_OPERATION_EXE_CHECKOUT,
+	MERGE_OPERATION_EXE_MERGE,
+	MERGE_OPERATION_LG2_MERGE,
+	MERGE_OPERATION_EXE_STATUS,
+	MERGE_OPERATION_LG2_STATUS
+};
+
+/* descriptions must be 10 chars or less for column header alignment. */
+static gitbench_operation_spec merge_operations[] = {
+	{ MERGE_OPERATION_EXE_CLONE,    "ExeClone" },
+	{ MERGE_OPERATION_EXE_CHECKOUT, "ExeCO" },
+	{ MERGE_OPERATION_EXE_MERGE,    "ExeMerge" },
+	{ MERGE_OPERATION_LG2_MERGE,    "Lg2Merge" },
+	{ MERGE_OPERATION_EXE_STATUS,   "ExeStatus" },
+	{ MERGE_OPERATION_LG2_STATUS,   "Lg2Status" },
+};
+#define MERGE_OPERATIONS_COUNT (sizeof(merge_operations) / sizeof(merge_operations[0]))
+
+static const gitbench_opt_spec merge_cmdline_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",           0, NULL,      "display help",   GITBENCH_OPT_USAGE_HIDDEN },
+	{ GITBENCH_OPT_SWITCH, "autocrlf",       0, NULL,      "turn on core.autocrlf=true" },
+	{ GITBENCH_OPT_VALUE,  "ref_checkout", 'r', "refname", "the reference to checkout", GITBENCH_OPT_USAGE_REQUIRED | GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_VALUE,  "ref_merge",    'm', "refname", "the reference to merge in", GITBENCH_OPT_USAGE_REQUIRED | GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_VALUE,  "status",       's', "count",   "times to run status aftwards", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_ARG,    "repository",     0, NULL,      "the repository",            GITBENCH_OPT_USAGE_REQUIRED },
+	{ 0 }
+};
+
+
+/**
+ * Clone the requested repo to TMP.
+ * DO NOT let clone checkout the default HEAD.
+ * Fix merge.renameLimit.
+ */
+static int _init_exe_clone(
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int k;
+	int error;
+
+	gitbench_run_start_operation(run, MERGE_OPERATION_EXE_CLONE);
+
+	k = 0;
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "clone";
+	argv[k++] = "--quiet";
+	argv[k++] = "--no-checkout";
+	argv[k++] = "--local";
+	argv[k++] = benchmark->repo_url;
+	argv[k++] = wd;
+	argv[k++] = 0;
+
+	if ((error = gitbench_shell(argv, NULL, NULL)) < 0)
+		goto done;
+
+	k = 0;
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "config";
+	argv[k++] = "core.autocrlf";
+	argv[k++] = ((benchmark->autocrlf) ? "true" : "false");
+	argv[k++] = 0;
+
+	if ((error = gitbench_shell(argv, wd, NULL)) < 0)
+		return error;
+
+	k = 0;
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "config";
+	argv[k++] = "merge.renameLimit";
+	argv[k++] = "999999";
+	argv[k++] = 0;
+
+	if ((error = gitbench_shell(argv, wd, NULL)) < 0)
+		goto done;
+
+done:
+	gitbench_run_finish_operation(run);
+	return error;
+}
+
+/**
+ * Checkout the requested commit in detached head state.
+ */
+static int _init_exe_checkout(
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int k;
+	int error;
+
+	gitbench_run_start_operation(run, MERGE_OPERATION_EXE_CHECKOUT);
+
+	k = 0;
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "checkout";
+	argv[k++] = "--quiet";
+	argv[k++] = "-B";
+	argv[k++] = "bm";
+	argv[k++] = benchmark->ref_name_checkout;
+	argv[k++] = 0;
+
+	if ((error = gitbench_shell(argv, wd, NULL)) < 0)
+		goto done;
+
+done:
+	gitbench_run_finish_operation(run);
+	return error;
+}
+
+static int _do_core_setup(
+	git_buf *wd_path,
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run)
+{
+	int error;
+
+	if ((error = git_buf_joinpath(wd_path, run->tempdir, "wd")) < 0)
+		return error;
+	if ((error = git_futils_mkdir(wd_path->ptr, NULL, 0700, GIT_MKDIR_VERIFY_DIR)) < 0)
+		return error;
+
+	return error;
+}
+
+static int _do_lg2_merge(
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	git_repository *repo = NULL;
+	git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_merge_options merge_opts = GIT_MERGE_OPTIONS_INIT;
+	git_annotated_commit *ac[1] = { NULL };
+	git_object *obj = NULL;
+	int error;
+
+	gitbench_run_start_operation(run, MERGE_OPERATION_LG2_MERGE);
+
+	if ((error = git_repository_open(&repo, wd)) < 0)
+		goto done;
+	if ((error = git_revparse_single(&obj, repo, benchmark->ref_name_merge)) < 0)
+		goto done;
+	if ((error = git_annotated_commit_lookup(&ac[0], repo, git_object_id(obj))) < 0)
+		goto done;
+
+	error = git_merge(repo, (const git_annotated_commit **)ac, 1,
+					  &merge_opts, &checkout_opts);
+
+done:
+	gitbench_run_finish_operation(run);
+	git_annotated_commit_free(ac[0]);
+	git_object_free(obj);
+	git_repository_free(repo);
+	return error;
+}
+
+static int _do_exe_merge(
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int exit_status;
+	int result;
+	int k = 0;
+
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "merge";
+	argv[k++] = "--no-commit";
+	argv[k++] = "--quiet";
+	argv[k++] = benchmark->ref_name_merge;
+	argv[k++] = 0;
+
+	gitbench_run_start_operation(run, MERGE_OPERATION_EXE_MERGE);
+	result = gitbench_shell(argv, wd, &exit_status);
+	gitbench_run_finish_operation(run);
+
+	/* "git merge" exits with 1 when there are merge conflicts
+	 * OR when the target commit cannot be found.  (We get 128
+	 * or 129 for usage errors.)
+	 *
+	 * If we get a 1, assume a conflict.  This implies that
+	 * merge finished and we can continue with the timing.
+	 * So we ignore the sanitized result and key off the
+	 * actual exit status instead.
+	 */
+	if (exit_status == 1)
+		fprintf(logfile, "::::: git-merge.exe exited with 1; assuming conflicts\n");
+	if ((exit_status == 0) || (exit_status == 1))
+		return 0;
+	return result;
+}
+
+
+static int _do_lg2_status(
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	git_repository *repo = NULL;
+	git_status_list *status = NULL;
+	git_status_options status_opts = GIT_STATUS_OPTIONS_INIT;
+	int error;
+	int x;
+
+	status_opts.show = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
+	status_opts.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED |
+		GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX;
+
+	if ((error = git_repository_open(&repo, wd)) < 0)
+		goto done;
+
+	for (x = 0; x < benchmark->status_count; x++) {
+		gitbench_run_start_operation(run, MERGE_OPERATION_LG2_STATUS);
+		error = git_status_list_new(&status, repo, &status_opts);
+		gitbench_run_finish_operation(run);
+		if (error < 0)
+			goto done;
+	}
+
+done:
+	gitbench_run_finish_operation(run);
+	git_status_list_free(status);
+	git_repository_free(repo);
+	return error;
+}
+
+static int _do_exe_status(
+	gitbench_benchmark_merge *benchmark,
+	gitbench_run *run,
+	const char *wd)
+{
+	const char * argv[10] = {0};
+	int k = 0;
+	int error;
+	int x;
+
+	argv[k++] = BM_GIT_EXE;
+	argv[k++] = "status";
+	argv[k++] = "--porcelain";
+	argv[k++] = "--branch";
+	argv[k++] = 0;
+
+	for (x = 0; x < benchmark->status_count; x++) {
+		gitbench_run_start_operation(run, MERGE_OPERATION_EXE_STATUS);
+		error = gitbench_shell(argv, wd, NULL);
+		gitbench_run_finish_operation(run);
+		if (error < 0)
+			goto done;
+	}
+
+done:
+	gitbench_run_finish_operation(run);
+	return error;
+}
+
+
+static int merge_run(gitbench_benchmark *b, gitbench_run *run)
+{
+	gitbench_benchmark_merge *benchmark = (gitbench_benchmark_merge *)b;
+	git_buf wd_path = GIT_BUF_INIT;
+	int error;
+
+	if ((error = _do_core_setup(&wd_path, benchmark, run)) < 0)
+		goto done;
+
+	// TODO Consider having lg2-based version of clone and checkout.
+	if ((error = _init_exe_clone(benchmark, run, wd_path.ptr)) < 0)
+		goto done;
+	if ((error = _init_exe_checkout(benchmark, run, wd_path.ptr)) < 0)
+		goto done;
+
+	if (run->use_git_exe) {
+		if ((error = _do_exe_merge(benchmark, run, wd_path.ptr)) < 0)
+			goto done;
+	} else {
+		if ((error = _do_lg2_merge(benchmark, run, wd_path.ptr)) < 0)
+			goto done;
+	}
+
+	/* Always run both version of status since we can.
+	 * Note that there is probably a minor penalty for
+	 * being first here since that one may have to re-write
+	 * the index. I'm going to average a few runs to smooth
+	 * this out.
+	 */
+	if ((error = _do_exe_status(benchmark, run, wd_path.ptr)) < 0)
+		goto done;
+	if ((error = _do_lg2_status(benchmark, run, wd_path.ptr)) < 0)
+		goto done;
+
+done:
+	git_buf_free(&wd_path);
+	return error;
+}
+
+static void merge_free(gitbench_benchmark *b)
+{
+	gitbench_benchmark_merge *benchmark = (gitbench_benchmark_merge *)b;
+
+	if (!b)
+		return;
+
+	git__free(benchmark->repo_url);
+	git__free(benchmark->ref_name_checkout);
+	git__free(benchmark->ref_name_merge);
+	git__free(benchmark);
+}
+
+static int merge_configure(
+	gitbench_benchmark_merge *benchmark,
+	int argc,
+	const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+
+	gitbench_opt_parser_init(&parser, merge_cmdline_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			fprintf(stderr, "%s: unknown argument: '%s'\n", progname, argv[parser.idx]);
+			gitbench_opt_usage_fprint(stderr, progname, merge_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		}
+
+		if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_opt_usage_fprint(stderr, progname, merge_cmdline_opts);
+			return GITBENCH_EARGUMENTS;
+		} else if (strcmp(opt.spec->name, "autocrlf") == 0) {
+			benchmark->autocrlf = 1;
+		} else if (strcmp(opt.spec->name, "repository") == 0) {
+			benchmark->repo_url = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->repo_url);
+		} else if (strcmp(opt.spec->name, "ref_checkout") == 0) {
+			benchmark->ref_name_checkout = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->ref_name_checkout);
+		} else if (strcmp(opt.spec->name, "ref_merge") == 0) {
+			benchmark->ref_name_merge = git__strdup(opt.value);
+			GITERR_CHECK_ALLOC(benchmark->ref_name_merge);
+		} else if (strcmp(opt.spec->name, "status") == 0) {
+			char *end;
+			long c = strtol(opt.value, &end, 10);
+			if (c <= 0 || *end) {
+				fprintf(stderr, "%s: invalid status count '%s'\n", progname, opt.value);
+				gitbench_opt_usage_fprint(stderr, progname, merge_cmdline_opts);
+				return GITBENCH_EARGUMENTS;
+			}
+			benchmark->status_count = c;
+		}
+	}
+
+	if (benchmark->status_count == 0)
+		benchmark->status_count = 1;
+
+	if (!benchmark->repo_url ||
+		!benchmark->ref_name_checkout ||
+		!benchmark->ref_name_merge) {
+		gitbench_opt_usage_fprint(stderr, progname, merge_cmdline_opts);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return 0;
+}
+
+int gitbench_benchmark_merge_init(
+	gitbench_benchmark **out,
+	int argc,
+	const char **argv)
+{
+	gitbench_benchmark_merge *benchmark;
+	int error;
+
+	if ((benchmark = git__calloc(1, sizeof(gitbench_benchmark_merge))) == NULL)
+		return -1;
+
+	benchmark->base.operation_cnt = MERGE_OPERATIONS_COUNT;
+	benchmark->base.operations = merge_operations;
+	benchmark->base.run_fn = merge_run;
+	benchmark->base.free_fn = merge_free;
+
+	if ((error = merge_configure(benchmark, argc, argv)) < 0) {
+		merge_free((gitbench_benchmark *)benchmark);
+		return error;
+	}
+
+	*out = (gitbench_benchmark *)benchmark;
+	return 0;
+}

--- a/benchmark/main.c
+++ b/benchmark/main.c
@@ -1,0 +1,437 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "git2.h"
+#include "common.h"
+#include "fileops.h"
+#include "vector.h"
+#include "path.h"
+
+#include "bench_util.h"
+#include "opt.h"
+#include "benchmark.h"
+#include "run.h"
+
+FILE *logfile = NULL;
+const char *progname;
+int verbosity = 0;
+
+static bool compare_with_git_exe = false;
+static int gitbench_init(void);
+static void gitbench_shutdown(void);
+static const char *gitbench_basename(const char *in);
+static void print_usage(FILE *out);
+static int help_adapter(gitbench_benchmark **out, int argc, const char **argv);
+static const gitbench_benchmark_spec *benchmark_spec_lookup(const char *name);
+static int benchmark_init(gitbench_benchmark **out, const char *name, int argc, const char **argv);
+static int benchmark_run(git_vector *runs, gitbench_benchmark *benchmark, unsigned int count, bool use_git_exe);
+static void report_logfile_header(int argc, const char **argv);
+static void report_benchmark(
+	const char *label,
+	git_vector *runs,
+	gitbench_benchmark *benchmark);
+
+static void runs_free(git_vector *runs);
+static void benchmark_free(gitbench_benchmark *benchmark);
+
+const gitbench_benchmark_spec gitbench_benchmarks[] = {
+	{ "checkout",  gitbench_benchmark_checkout_init,  "time the checkout of a repository" },
+	{ "checkoutn", gitbench_benchmark_checkoutn_init, "time the checkout of a repository" }, /* new version */
+	{ "clone",    gitbench_benchmark_clone_init,    "time a clone" },
+	{ "merge",    gitbench_benchmark_merge_init,    "time a merge" },
+
+	{ "help",     help_adapter, NULL },
+	{ NULL }
+};
+
+static const gitbench_opt_spec gitbench_opts[] = {
+	{ GITBENCH_OPT_SWITCH, "help",        0,   NULL,  "display help", GITBENCH_OPT_USAGE_HIDDEN },
+	{ GITBENCH_OPT_VALUE,  "count",       'c', "num", "number of runs", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_VALUE,  "logfile",     'l', "logfile", "write to file rather than stdout", GITBENCH_OPT_USAGE_VALUE_REQUIRED },
+	{ GITBENCH_OPT_SWITCH, "verbose",     'v', NULL,  "increase the verbosity" },
+	{ GITBENCH_OPT_SWITCH, "git",         'g', "git", "compare performance with git.exe" },
+	{ GITBENCH_OPT_ARG,    "benchmark",   0,   NULL,  "the benchmark to run", GITBENCH_OPT_USAGE_REQUIRED },
+	{ GITBENCH_OPT_ARGS,   "args",        0,   NULL,  "arguments for the benchmark" },
+	{ 0 }
+};
+
+#define gitbench_try(x) if ((error = (x)) < 0) goto done;
+
+int main(int argc, const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+	const char *benchmark_name = NULL;
+	git_vector cmd_args = GIT_VECTOR_INIT;
+	gitbench_benchmark *benchmark = NULL;
+	unsigned int count = 1;
+	git_vector runs_lg2 = GIT_VECTOR_INIT;
+	git_vector runs_git = GIT_VECTOR_INIT;
+	int error = 0;
+
+	logfile = stdout;
+
+	progname = gitbench_basename(argv[0]);
+
+	gitbench_try(gitbench_init());
+
+	gitbench_try(git_vector_insert(&cmd_args, (char *)progname));
+
+	gitbench_opt_parser_init(&parser, gitbench_opts, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (!opt.spec) {
+			gitbench_try(git_vector_insert(&cmd_args, (char *)argv[parser.idx]));
+			continue;
+		}
+
+		if (strcmp(opt.spec->name, "help") == 0) {
+			gitbench_try(git_vector_insert(&cmd_args, (char *)argv[parser.idx]));
+		} else if (strcmp(opt.spec->name, "verbose") == 0) {
+			verbosity++;
+		} else if (strcmp(opt.spec->name, "git") == 0) {
+			compare_with_git_exe = true;
+		} else if (strcmp(opt.spec->name, "logfile") == 0) {
+			logfile = fopen(opt.value, "a");
+			if (logfile == NULL) {
+				fprintf(stderr, "%s: cannot open logfile '%s'\n", progname, opt.value);
+				print_usage(stderr);
+				error = 1;
+				goto done;
+			}
+			report_logfile_header(argc, argv);
+		} else if (strcmp(opt.spec->name, "count") == 0) {
+			char *end;
+			long c = strtol(opt.value, &end, 10);
+
+			if (c <= 0 || *end) {
+				fprintf(stderr, "%s: invalid count '%s'\n'", progname, opt.value);
+				print_usage(stderr);
+				error = 1;
+				goto done;
+			}
+
+			count = (unsigned int)c;
+		} else if (strcmp(opt.spec->name, "benchmark") == 0) {
+			benchmark_name = argv[parser.idx];
+		}
+	}
+
+	if ((error = benchmark_init(&benchmark, benchmark_name, cmd_args.length, (const char **)cmd_args.contents)) < 0) {
+		if (error == GITBENCH_EARGUMENTS)
+			error = 1;
+		goto done;
+	}
+
+	gitbench_try(benchmark_run(&runs_lg2, benchmark, count, false));
+	report_benchmark("LibGit2", &runs_lg2, benchmark);
+
+	if (compare_with_git_exe) {
+		gitbench_try(benchmark_run(&runs_git, benchmark, count, true));
+		report_benchmark("GitExe", &runs_git, benchmark);
+	}
+
+done:
+	if (error < 0) {
+		const git_error *err = giterr_last();
+		fprintf(stderr, "%s: %s\n", progname, err ? err->message : "unknown error");
+
+		if (logfile != stdout) {
+			fprintf(logfile, "\n\n________________________________________________________________\n");
+			fprintf(logfile, "%s: %s\n", progname, err ? err->message : "unknown error");
+		}
+	}
+
+	runs_free(&runs_lg2);
+	runs_free(&runs_git);
+	benchmark_free(benchmark);
+
+	gitbench_shutdown();
+
+	if (logfile)
+		fclose(logfile);
+	return error ? 1 : 0;
+}
+
+int gitbench_init(void)
+{
+	return git_libgit2_init();
+}
+
+void gitbench_shutdown(void)
+{
+	git_libgit2_shutdown();
+}
+
+const char *gitbench_basename(const char *in)
+{
+	const char *c, *last = in;
+	for (c = in; *c; c++)
+		if ((*c == '/' || *c == '\\') && *(c+1)) last = c+1;
+	return last;
+}
+
+int benchmark_init(gitbench_benchmark **out, const char *name, int argc, const char **argv)
+{
+	const gitbench_benchmark_spec *benchmark_spec = NULL;
+
+	if (!name) {
+		print_usage(stdout);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	if ((benchmark_spec = benchmark_spec_lookup(name)) == NULL) {
+		fprintf(stderr, "%s: unknown benchmark '%s'\n", progname, name);
+		print_usage(stderr);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	return benchmark_spec->init(out, argc, argv);
+}
+
+const gitbench_benchmark_spec *benchmark_spec_lookup(const char *name)
+{
+	const gitbench_benchmark_spec *spec;
+
+	for (spec = gitbench_benchmarks; spec->name; spec++) {
+		if (strcmp(spec->name, name) == 0)
+			return spec;
+	}
+
+	return NULL;
+}
+
+int benchmark_run(
+	git_vector *runs,
+	gitbench_benchmark *benchmark,
+	unsigned int count,
+	bool use_git_exe)
+{
+	size_t i;
+	int error = 0;
+
+	assert(runs && benchmark);
+
+	if (git_vector_init(runs, count, NULL) < 0)
+		return -1;
+
+	for (i = 0; i < count; i++) {
+		gitbench_run *run;
+
+		if (gitbench_run_init(
+			&run, i+1,
+			benchmark->operation_cnt,
+			benchmark->operations) < 0)
+			return -1;
+
+		run->verbosity = verbosity;
+		run->use_git_exe = use_git_exe;
+
+		if (git_vector_insert(runs, run) < 0)
+			return -1;
+	}
+
+	for (i = 0; i < count; i++) {
+		gitbench_run *run = git_vector_get(runs, i);
+
+		if ((error = gitbench_run_start(run)) < 0 ||
+			(error = benchmark->run_fn(benchmark, run)) < 0 ||
+			(error = gitbench_run_finish(run)) < 0)
+			break;
+	}
+
+	return error;
+}
+
+static void report_logfile_header(int argc, const char **argv)
+{
+	int k;
+
+	fprintf(logfile, "\n");
+	fprintf(logfile, "################################################################\n");
+	fprintf(logfile, "%s", progname);
+	for (k=1; k<argc; k++)
+		fprintf(logfile, " %s", argv[k]);
+	fprintf(logfile, "\n");
+	fprintf(logfile, "\n");
+}
+
+void report_benchmark(
+	const char *label,
+	git_vector *runs,
+	gitbench_benchmark *benchmark)
+{
+	double *tally = NULL;
+	int *ran_op = NULL;
+	gitbench_run *run;
+	int count_runs = (int)git_vector_length(runs);
+	size_t i, j;
+
+	tally = (double *)git__calloc(benchmark->operation_cnt + 1, sizeof(double));
+	ran_op = (int *)git__calloc(benchmark->operation_cnt, sizeof(int));
+
+	/* Column headers */
+
+	fprintf(logfile, "\n");
+	fprintf(logfile, "%-15s", label);
+	for (j = 0; j < benchmark->operation_cnt; j++)
+		fprintf(logfile, " %13s", benchmark->operations[j].description);
+	fprintf(logfile, " : %10s\n", "TOTAL");
+
+	/* Each run (--count x) */
+
+	git_vector_foreach(runs, i, run) {
+		bool multiple = false;
+		double run_total = run->overall_end - run->overall_start;
+
+		/* Data for each run */
+
+		fprintf(logfile, "%-15d", (int)(i+1));
+		for (j = 0; j < benchmark->operation_cnt; j++) {
+			if (run->operation_data.ptr[j].ran_count) {
+				/* We have data for this "column". */
+
+				double time_j = run->operation_data.ptr[j].op_sum;
+				fprintf(logfile, " %10.3f/", time_j);
+				if (run->operation_data.ptr[j].ran_count > 1)
+					fprintf(logfile, "%02d", run->operation_data.ptr[j].ran_count);
+				else
+					fprintf(logfile, "__");
+
+				tally[j] += time_j;
+				ran_op[j] += run->operation_data.ptr[j].ran_count;
+
+				if (run->operation_data.ptr[j].ran_count > 1)
+					multiple = true;
+
+			} else {
+				fprintf(logfile, " %13s", " ");
+			}
+		}
+		fprintf(logfile, " : %10.3f\n", run_total);
+
+		tally[benchmark->operation_cnt] += run_total;
+
+		/* If any column in this row had a repeat count, report sub line with average. */
+
+		if (multiple) {
+			fprintf(logfile, "%15s", "(sub-avg)");
+			for (j = 0; j < benchmark->operation_cnt; j++) {
+				if (run->operation_data.ptr[j].ran_count > 1) {
+
+					double time_j = run->operation_data.ptr[j].op_sum;
+					double avg_j = (time_j / run->operation_data.ptr[j].ran_count);
+					fprintf(logfile, " %10.3f   ", avg_j);
+				} else {
+					fprintf(logfile, " %13s", " ");
+				}
+			}
+			fprintf(logfile, "\n");
+		}
+
+		fprintf(logfile, "\n");
+	}
+
+	/* Total of all runs */
+
+	fprintf(logfile, "%-15s", "Total");
+	for (j = 0; j < benchmark->operation_cnt; j++) {
+		if (ran_op[j])
+			fprintf(logfile, " %10.3f/%02d", tally[j], ran_op[j]);
+		else
+			fprintf(logfile, " %13s", " ");
+	}
+	fprintf(logfile, " : %10.3f\n", tally[benchmark->operation_cnt]);
+	fprintf(logfile, "\n");
+
+	/* Average of the runs */
+
+	fprintf(logfile, "%-15s", "Average");
+	for (j = 0; j < benchmark->operation_cnt; j++) {
+		if (ran_op[j])
+			fprintf(logfile, " %10.3f   ", (tally[j] / ran_op[j]));
+		else
+			fprintf(logfile, " %13s", " ");
+	}
+	fprintf(logfile, " : %10.3f\n", (tally[benchmark->operation_cnt] / count_runs));
+	fprintf(logfile, "\n");
+
+	git__free(tally);
+}
+
+void runs_free(git_vector *runs)
+{
+	gitbench_run *run;
+	size_t i;
+
+	if (runs) {
+		git_vector_foreach(runs, i, run)
+			gitbench_run_free(run);
+
+		git_vector_free(runs);
+	}
+}
+
+void benchmark_free(gitbench_benchmark *benchmark)
+{
+	if (benchmark)
+		benchmark->free_fn(benchmark);
+}
+
+void print_usage(FILE *out)
+{
+	const gitbench_benchmark_spec *b;
+
+	gitbench_opt_usage_fprint(out, progname, gitbench_opts);
+	fprintf(out, "\n");
+
+	fprintf(out, "Available benchmarks are:\n");
+
+	for (b = gitbench_benchmarks; b->name; b++) {
+		if (b->description)
+			fprintf(out, "    %-10s %s\n", b->name, b->description);
+	}
+}
+
+int help_adapter(gitbench_benchmark **out, int argc, const char **argv)
+{
+	gitbench_opt_parser parser;
+	gitbench_opt opt;
+	const char *benchmark_name = NULL;
+	gitbench_benchmark *benchmark = NULL;
+	const char *help_args[] = { NULL, "--help" };
+
+	const gitbench_opt_spec gitbench_opts__help_adapter[] = {
+		{ GITBENCH_OPT_ARG,    "benchmark", 0,   NULL,  "the benchmark to run", GITBENCH_OPT_USAGE_REQUIRED },
+		{ 0 }
+	};
+
+	gitbench_opt_parser_init(&parser, gitbench_opts__help_adapter, argv + 1, argc - 1);
+
+	while (gitbench_opt_parser_next(&opt, &parser)) {
+		if (opt.spec && strcmp(opt.spec->name, "benchmark") == 0) {
+			benchmark_name = opt.value;
+			break;
+		}
+	}
+
+	if (!benchmark_name) {
+		print_usage(stdout);
+		return GITBENCH_EARGUMENTS;
+	}
+
+	help_args[0] = benchmark_name;
+
+	if (benchmark_init(&benchmark, benchmark_name, 2, help_args) == 0) {
+		fprintf(stderr, "%s: no help available for '%s'\n",
+				progname, benchmark_name);
+		benchmark->free_fn(benchmark);
+	}
+
+	*out = NULL;
+	return GITBENCH_EARGUMENTS;
+}

--- a/benchmark/operation.h
+++ b/benchmark/operation.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef OPERATION_H
+#define OPERATION_H
+
+typedef struct gitbench_operation_spec {
+	unsigned int code;
+	const char *description;
+} gitbench_operation_spec;
+
+#endif

--- a/benchmark/opt.c
+++ b/benchmark/opt.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c), Edward Thomson <ethomson@edwardthomson.com>
+ * All rights reserved.
+ *
+ * This file is part of adopt, distributed under the MIT license.
+ * For full terms and conditions, see the included LICENSE file.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "opt.h"
+
+#ifdef _WIN32
+# include <Windows.h>
+#else
+# include <fcntl.h>
+# include <sys/ioctl.h>
+#endif
+
+#ifdef _MSC_VER
+# define INLINE(type) static __inline type
+#else
+# define INLINE(type) static inline type
+#endif
+
+INLINE(const gitbench_opt_spec *) spec_byname(
+	gitbench_opt_parser *parser, const char *name, size_t namelen)
+{
+	const gitbench_opt_spec *spec;
+
+	for (spec = parser->specs; spec->type; ++spec) {
+		if (spec->type == GITBENCH_OPT_LITERAL && namelen == 0)
+			return spec;
+
+		if ((spec->type == GITBENCH_OPT_SWITCH || spec->type == GITBENCH_OPT_VALUE) &&
+			spec->name &&
+			strlen(spec->name) == namelen &&
+			strncmp(name, spec->name, namelen) == 0)
+			return spec;
+	}
+
+	return NULL;
+}
+
+INLINE(const gitbench_opt_spec *) spec_byalias(gitbench_opt_parser *parser, char alias)
+{
+	const gitbench_opt_spec *spec;
+
+	for (spec = parser->specs; spec->type; ++spec) {
+		if ((spec->type == GITBENCH_OPT_SWITCH || spec->type == GITBENCH_OPT_VALUE) &&
+			alias == spec->alias)
+			return spec;
+	}
+
+	return NULL;
+}
+
+INLINE(const gitbench_opt_spec *) spec_nextarg(gitbench_opt_parser *parser)
+{
+	const gitbench_opt_spec *spec;
+	size_t args = 0;
+
+	for (spec = parser->specs; spec->type; ++spec) {
+		if (spec->type == GITBENCH_OPT_ARG) {
+			if (args == parser->arg_idx) {
+				parser->arg_idx++;
+				return spec;
+			}
+
+			args++;
+		}
+	}
+
+	return NULL;
+}
+
+static void parse_long(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	const gitbench_opt_spec *spec;
+	const char *arg = parser->args[parser->idx++], *name = arg + 2, *eql;
+	size_t namelen;
+
+	namelen = (eql = strrchr(arg, '=')) ? (size_t)(eql - name) : strlen(name);
+
+	if ((spec = spec_byname(parser, name, namelen)) == NULL) {
+		opt->spec = NULL;
+		opt->value = arg;
+
+		return;
+	}
+
+	opt->spec = spec;
+
+	/* Future options parsed as literal */
+	if (spec->type == GITBENCH_OPT_LITERAL) {
+		parser->in_literal = 1;
+	}
+
+	/* Parse values as "--foo=bar" or "--foo bar" */
+	if (spec->type == GITBENCH_OPT_VALUE) {
+		if (eql)
+			opt->value = eql + 1;
+		else if ((parser->idx + 1) <= parser->args_len)
+			opt->value = parser->args[parser->idx++];
+	}
+}
+
+static void parse_short(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	const gitbench_opt_spec *spec;
+	const char *arg = parser->args[parser->idx++], alias = *(arg + 1);
+
+	if ((spec = spec_byalias(parser, alias)) == NULL) {
+		opt->spec = NULL;
+		opt->value = arg;
+
+		return;
+	}
+
+	opt->spec = spec;
+
+	/* Parse values as "-ifoo" or "-i foo" */
+	if (spec->type == GITBENCH_OPT_VALUE) {
+		if (strlen(arg) > 2)
+			opt->value = arg + 2;
+		else if ((parser->idx + 1) <= parser->args_len)
+			opt->value = parser->args[parser->idx++];
+	}
+}
+
+static void parse_arg(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	opt->spec = spec_nextarg(parser);
+	opt->value = parser->args[parser->idx++];
+}
+
+void gitbench_opt_parser_init(
+	gitbench_opt_parser *parser,
+	const gitbench_opt_spec specs[],
+	const char **args,
+	size_t args_len)
+{
+	assert(parser);
+
+	memset(parser, 0x0, sizeof(gitbench_opt_parser));
+
+	parser->specs = specs;
+	parser->args = args;
+	parser->args_len = args_len;
+}
+
+int gitbench_opt_parser_next(gitbench_opt *opt, gitbench_opt_parser *parser)
+{
+	assert(opt && parser);
+
+	memset(opt, 0x0, sizeof(gitbench_opt));
+
+	if (parser->idx >= parser->args_len)
+		return 0;
+
+	/* Handle arguments in long form, those beginning with "--" */
+	if (strncmp(parser->args[parser->idx], "--", 2) == 0 &&
+		!parser->in_literal)
+		parse_long(opt, parser);
+
+	/* Handle arguments in short form, those beginning with "-" */
+	else if (strncmp(parser->args[parser->idx], "-", 1) == 0 &&
+		!parser->in_literal)
+		parse_short(opt, parser);
+
+	/* Handle "free" arguments, those without a dash */
+	else
+		parse_arg(opt, parser);
+
+	return 1;
+}
+
+int gitbench_opt_usage_fprint(
+	FILE *file,
+	const char *command,
+	const gitbench_opt_spec specs[])
+{
+	const gitbench_opt_spec *spec;
+	int error;
+
+	if ((error = fprintf(file, "usage: %s", command)) < 0)
+		goto done;
+
+	for (spec = specs; spec->type; ++spec) {
+		int required = (spec->usage & GITBENCH_OPT_USAGE_REQUIRED);
+		int value_required = (spec->usage & GITBENCH_OPT_USAGE_VALUE_REQUIRED);
+
+		if (spec->usage & GITBENCH_OPT_USAGE_HIDDEN)
+			continue;
+
+		if ((error = fprintf(file, " ")) < 0)
+			goto done;
+
+		/* TODO if (OPT_VALUE && required && value_required)
+		 * TODO    display "-c <%s>" or "--%s=<%s>" (without
+		 * TODO    the brackets.
+		 */
+		if (spec->type == GITBENCH_OPT_VALUE && value_required && spec->alias)
+			error = fprintf(file, "[-%c <%s>]", spec->alias, spec->value);
+		else if (spec->type == GITBENCH_OPT_VALUE && value_required)
+			error = fprintf(file, "[--%s=<%s>]", spec->name, spec->value);
+		else if (spec->type == GITBENCH_OPT_VALUE)
+			error = fprintf(file, "[--%s[=<%s>]]", spec->name, spec->value);
+		else if (spec->type == GITBENCH_OPT_ARG && required)
+			error = fprintf(file, "<%s>", spec->name);
+		else if (spec->type == GITBENCH_OPT_ARG)
+			error = fprintf(file, "[<%s>]", spec->name);
+		else if (spec->type == GITBENCH_OPT_ARGS && required)
+			error = fprintf(file, "<%s...>", spec->name);
+		else if (spec->type == GITBENCH_OPT_ARGS)
+			error = fprintf(file, "[<%s...>]", spec->name);
+		else if (spec->type == GITBENCH_OPT_LITERAL)
+			error = fprintf(file, "--");
+		else if (spec->alias)
+			error = fprintf(file, "[-%c]", spec->alias);
+		else
+			error = fprintf(file, "[--%s]", spec->name);
+
+		if (error < 0)
+			goto done;
+	}
+
+	error = fprintf(file, "\n");
+
+done:
+	error = (error < 0) ? -1 : 0;
+	return error;
+}
+

--- a/benchmark/opt.h
+++ b/benchmark/opt.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c), Edward Thomson <ethomson@edwardthomson.com>
+ * All rights reserved.
+ *
+ * This file is part of adopt, distributed under the MIT license.
+ * For full terms and conditions, see the included LICENSE file.
+ */
+
+#ifndef OPT_H
+#define OPT_H
+
+#include <stdio.h>
+
+/**
+ * The type of argument to be parsed.
+ */
+typedef enum {
+	GITBENCH_OPT_NONE = 0,
+
+	/** An argument that is specified ("--help" or "--debug") */
+	GITBENCH_OPT_SWITCH,
+
+	/** An argument that has a value ("--name value" or "-n value") */
+	GITBENCH_OPT_VALUE,
+
+	/** The literal arguments follow specifier, bare "--" */
+	GITBENCH_OPT_LITERAL,
+
+	/** A single "free" argument ("path") */
+	GITBENCH_OPT_ARG,
+
+	/** Unmatched arguments, a collection of "free" arguments ("paths...") */
+	GITBENCH_OPT_ARGS,
+} gitbench_opt_type_t;
+
+/**
+ * Usage information for an argument, to be displayed to the end-user.
+ * This is only for display, the parser ignores this usage information.
+ */
+typedef enum {
+	/** This argument is required. */
+	GITBENCH_OPT_USAGE_REQUIRED = (1u << 0),
+
+	/** A value is required for this argument. */
+	GITBENCH_OPT_USAGE_VALUE_REQUIRED = (1u << 1),
+
+	/** This argument should not be displayed in usage. */
+	GITBENCH_OPT_USAGE_HIDDEN = (1u << 2),
+
+	/** This is a multiple choice argument, combined with the previous arg. */
+	GITBENCH_OPT_USAGE_CHOICE = (1u << 3),
+} gitbench_opt_usage_t;
+
+/** Specification for an available option. */
+typedef struct gitbench_opt_spec {
+	/** Type of option expected. */
+	gitbench_opt_type_t type;
+
+	/** Name of the long option. */
+	const char *name;
+
+	/** The alias is the short (one-character) option alias. */
+	const char alias;
+
+	/** The name of the value, provided when creating usage information. */
+	const char *value;
+
+	/**
+	 * Short description of the option, used when creating usage
+	 * information.
+	 */
+	const char *help;
+
+	/**
+	 * Optional `gitbench_opt_usage_t`, used when creating usage information.
+	 */
+	gitbench_opt_usage_t usage;
+} gitbench_opt_spec;
+
+/** An option provided on the command-line. */
+typedef struct gitbench_opt {
+	/**
+	 * The specification that was provided on the command-line, or
+	 * `NULL` if the argument did not match an `gitbench_opt_spec`.
+	 */
+	const gitbench_opt_spec *spec;
+
+	/**
+	 * The value provided to the argument, or `NULL` if the given
+	 * argument is a switch argument that does not take a value.
+	 * If the argument did not match and `gitbench_opt_spec`, this will
+	 * point to the unknown argument.
+	 */
+	const char *value;
+} gitbench_opt;
+
+/**
+ * The gitbench_opt_parser structure.  Callers should not modify these values
+ * directory.
+ */
+typedef struct gitbench_opt_parser {
+	const gitbench_opt_spec *specs;
+	const char **args;
+	size_t args_len;
+
+	size_t idx;
+	size_t arg_idx;
+	int in_literal : 1,
+		in_short : 1;
+} gitbench_opt_parser;
+
+/**
+ * Initializes a parser that parses the given arguments according to the
+ * given specifications.
+ *
+ * @param parser The `gitbench_opt_parser` that will be initialized
+ * @param specs A NULL-terminated array of `gitbench_opt_spec`s that can be parsed
+ * @param argv The arguments that will be parsed
+ * @param args_len The length of arguments to be parsed
+ */
+void gitbench_opt_parser_init(
+	gitbench_opt_parser *parser,
+	const gitbench_opt_spec specs[],
+	const char **argv,
+	size_t args_len);
+
+/**
+ * Parses the next command-line argument and places the information about
+ * the argument into the given `opt` data.
+ *
+ * @param opt The `gitbench_opt` information parsed from the argument
+ * @param parser An `gitbench_opt_parser` that has been initialized with
+ *        `gitbench_opt_parser_init`
+ * @return true if the caller should continue iterating, or 0 if there are
+ *         no arguments left to process.
+ */
+int gitbench_opt_parser_next(
+	gitbench_opt *opt,
+	gitbench_opt_parser *parser);
+
+/**
+ * Prints usage information to the given file handle.
+ *
+ * @param file The file to print information to
+ * @param command The name of the command to use when printing
+ * @param specs The specifications allowed by the command
+ * @return 0 on success, -1 on failure
+ */
+int gitbench_opt_usage_fprint(
+	FILE *file,
+	const char *command,
+	const gitbench_opt_spec specs[]);
+
+#endif /* OPT_H */

--- a/benchmark/run.c
+++ b/benchmark/run.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "fileops.h"
+#include "run.h"
+#include "bench_util.h"
+
+#define RUN_OPERATION_NONE UINT_MAX
+
+int gitbench_run_init(
+	gitbench_run **out,
+	size_t id,
+	size_t operation_cnt,
+	gitbench_operation_spec operations[])
+{
+	gitbench_run *run;
+	size_t i;
+
+	assert(out);
+	assert(operation_cnt != RUN_OPERATION_NONE);
+
+	*out = NULL;
+
+	if ((run = git__calloc(1, sizeof(gitbench_run))) == NULL)
+		return -1;
+
+	git_array_init_to_size(run->operation_data, operation_cnt);
+	GITERR_CHECK_ALLOC(run->operation_data.ptr);
+
+	run->id = id;
+	run->current_operation = RUN_OPERATION_NONE;
+
+	memset(run->operation_data.ptr, 0, sizeof(*run->operation_data.ptr));
+	run->operation_data.size = operation_cnt;
+
+	for (i = 0; i < operation_cnt; i++)
+		run->operation_data.ptr[i].spec = &operations[i];
+
+	*out = run;
+	return 0;
+}
+
+int gitbench_run_start(gitbench_run *run)
+{
+	assert(run);
+	assert(run->overall_start == 0);
+
+	if (gitbench__create_tempdir((char **)&run->tempdir) < 0)
+		return -1;
+
+	if (run->verbosity)
+		fprintf(logfile, ": Starting run %" PRIuZ "\n", run->id);
+
+	run->overall_start = git__timer();
+	return 0;
+}
+
+int gitbench_run_finish(gitbench_run *run)
+{
+	assert(run);
+	assert(run->overall_end == 0);
+
+	run->overall_end = git__timer();
+
+	if (run->verbosity)
+		fprintf(logfile, ": Finished run %" PRIuZ "\n", run->id);
+
+	git_futils_rmdir_r(run->tempdir, NULL, GIT_RMDIR_REMOVE_FILES);
+
+	return 0;
+}
+
+int gitbench_run_start_operation(gitbench_run *run, unsigned int opcode)
+{
+	gitbench_run_operationdata *opdata;
+
+	assert(run);
+	assert(opcode < run->operation_data.size);
+	assert(run->current_operation == RUN_OPERATION_NONE);
+
+	opdata = git_array_get(run->operation_data, opcode);
+
+	if (run->verbosity) {
+		const char *type = "operation";
+		fprintf(logfile, "::: Starting %s: %s\n", type, opdata->spec->description);
+	}
+
+	run->current_operation = opcode;
+
+	opdata->ran_count++;
+	opdata->op_start = git__timer();
+
+	return 0;
+}
+
+int gitbench_run_finish_operation(gitbench_run *run)
+{
+	gitbench_run_operationdata *opdata;
+
+	assert(run);
+
+	/* Allow multiple finishes for error handling. */
+	if (run->current_operation == RUN_OPERATION_NONE)
+		return 0;
+
+	opdata = git_array_get(run->operation_data, run->current_operation);
+	opdata->op_end = git__timer();
+	opdata->op_sum += (opdata->op_end - opdata->op_start);
+
+	run->current_operation = RUN_OPERATION_NONE;
+
+	if (run->verbosity) {
+		const char *type = "operation";
+		fprintf(logfile, "::: Finished %s: %s (total=%f seconds)\n",
+			type, opdata->spec->description, (opdata->op_end - opdata->op_start));
+	}
+
+	return 0;
+}
+
+void gitbench_run_free(gitbench_run *run)
+{
+	if (!run)
+		return;
+
+	git__free((char *)run->tempdir);
+	git__free(run);
+}

--- a/benchmark/run.h
+++ b/benchmark/run.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef RUN_H
+#define RUN_H
+
+#include "common.h"
+#include "vector.h"
+#include "array.h"
+#include "operation.h"
+
+typedef struct {
+	gitbench_operation_spec *spec;
+	int ran_count;
+	double op_start;
+	double op_end;
+	double op_sum;
+} gitbench_run_operationdata;
+
+/** Specification for a benchmark command. */
+typedef struct {
+	size_t id;
+	int verbosity;
+
+	/* use git.exe for this run */
+	unsigned int use_git_exe:1;
+
+	const char *tempdir;
+
+	/* start and end of the overall run */
+	double overall_start;
+	double overall_end;
+	git_array_t(gitbench_run_operationdata) operation_data;
+	unsigned int current_operation;
+} gitbench_run;
+
+/** Allocate a run. */
+extern int gitbench_run_init(
+	gitbench_run **run,
+	size_t id,
+	size_t operation_cnt,
+	gitbench_operation_spec operations[]);
+
+/** Start an overall run. */
+extern int gitbench_run_start(gitbench_run *run);
+
+/** Finish an overall run. */
+extern int gitbench_run_finish(gitbench_run *run);
+
+/** Start a single operation within a run. */
+extern int gitbench_run_start_operation(gitbench_run *run, unsigned int operation);
+
+/** Finish a single operation within a run. */
+extern int gitbench_run_finish_operation(gitbench_run *run);
+
+/** Free a run. */
+extern void gitbench_run_free(gitbench_run *run);
+
+#endif

--- a/benchmark/scripts/gitgit/__all.sh
+++ b/benchmark/scripts/gitgit/__all.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+## Script to run all of the benchmarks (which are ready for general use).
+## CD to this directory and run this script from here.
+##################################################################
+
+set -vx
+
+sh ./checkoutn.sh
+sh ./merge.sh

--- a/benchmark/scripts/gitgit/__setup.sh
+++ b/benchmark/scripts/gitgit/__setup.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+## Setup shell environment to run a series of benchmarks.
+## This script provides core variable settings and will be run
+## from other scripts in this directory.
+##
+## This script is for Unix-based systems *AND* Windows.
+##
+## Variables prefixed with BM_ are exported to the environment.
+## Individual benchmarks should use a different prefix for local
+## variables to avoid confusion (and cross-script contamination).
+##################################################################
+
+set -vx
+
+## The name of the benchmark EXE.
+##
+## On Linux and Mac, I'm assuming you built the tree in release mode.
+##
+if [ "`uname`" = "Linux" ]; then
+    export BM_EXE=../../../build/libgit2_bench
+elif [ "`uname`" = "Darwin" ]; then
+    export BM_EXE=../../../build/libgit2_bench
+else
+    export BM_EXE=../../../build/RelWithDebInfo/libgit2_bench.exe
+fi
+
+
+## Some repos have deep paths in them and our benchmarks inherit
+## and (at least on Windows) we need this to be as shallow as
+## possible.
+if [ "`uname`" = "Linux" ]; then
+    export BM_TEMP=/tmp
+elif [ "`uname`" = "Darwin" ]; then
+    export BM_TEMP=$TMPDIR
+else
+    export BM_TEMP=C:/t
+    ## Force Windows GetTempPath() and friends to use this too.
+    export TMP=$BM_TEMP
+    export TEMP=$BM_TEMP
+fi
+[ -d $BM_TEMP ] || mkdir $BM_TEMP
+
+
+## Code name for tests based upon the repo we are testing with.
+export BM_PWD=`pwd`
+export BM_CODE=`basename $BM_PWD`
+
+
+## Remote URL of the repo.
+## (Install a credential helper in advance if a clone will need creds.)
+export BM_RURL=https://github.com/git/git.git
+
+
+## Convert our current branch into a label for the logs.
+export BM_LABEL=`git branch | grep '*' | sed 's/\* //' | sed 's|/|__|g'`
+
+
+## Place to accumulate output and logs.
+export BM_LOGS_DIR=$BM_TEMP/logs/$BM_LABEL/$BM_CODE
+[ -d $BM_LOGS_DIR ] || mkdir -p $BM_LOGS_DIR
+
+
+## Some benchmarks will reference a local/bare repo.  (Others do their own
+## remote clone.)
+##
+## We will try to clone this exactly once and re-use the repo on subsequent
+## benchmark runs, so don't mess with it.
+export BM_LURL=$BM_TEMP/$BM_CODE
+export BM_FURL=file:///$BM_TEMP/$BM_CODE
+
+
+date
+[ -d $BM_LURL ] || git clone -q --bare $BM_RURL $BM_LURL
+date
+
+
+## Gather some info about the version of the benchmark
+## source tree (to allow the individual benchmarks to
+## prepend to their test run logfiles).
+##
+## We pipe "git log" thru cat to keep it from launching
+## a pager.
+##
+bm_get_info () {
+    echo
+    echo "################################################################"
+    echo "################################################################"
+    echo
+    date
+    echo
+    git log --oneline -9 | cat
+    echo
+    git status -b -s --porcelain
+    echo
+    echo "________________________________________________________________"
+    echo
+}
+
+## End of setup.

--- a/benchmark/scripts/gitgit/checkoutn.sh
+++ b/benchmark/scripts/gitgit/checkoutn.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+## Script to run some checkout benchmarks.
+## CD to this directory and run this script from here.
+##################################################################
+
+set -vx
+
+
+. ./__setup.sh || exit 1
+
+
+## A short name for this script. We use this to separate
+## the log files from other benchmarks.
+XX_BM=`basename $0 .sh`
+
+## All log/output for this run will be in the following directory.
+XX_LOG_DIR=$BM_LOGS_DIR/$XX_BM/`/bin/date +%Y%m%d.%H%M%S`
+[ -d $XX_LOG_DIR ] || mkdir -p $XX_LOG_DIR
+
+## Perf data goes here.  Subsequent runs are APPENDED to this file.
+XX_LOG=$XX_LOG_DIR/run.log
+
+## How many times to run the tests (passed into the benchmark).
+XX_COUNT=3
+
+## A list of commits to checkout and cycle thru.
+XX_COMMITS="355d4e1 8004647 355d4e1 8004647"
+
+## Also run benchmark using git.exe in the body of the test.
+XX_USEGIT=--git
+
+## Verbose setting within benchmark.
+##XX_VERBOSE=-v
+
+## How many times to call status after merge/checkout completes.
+XX_STATUS=5
+
+## Write details of the current libgit2 branch to the log before
+## we run the benchmark.
+bm_get_info >> $XX_LOG
+
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT checkoutn -s $XX_STATUS --autocrlf $BM_LURL $XX_COMMITS
+date
+
+
+##################################################################
+## Dump the stats to the console so they don't have to look for it.
+
+echo "################################################################"
+echo "################################################################"
+echo
+cat $XX_LOG

--- a/benchmark/scripts/gitgit/clone_file.sh
+++ b/benchmark/scripts/gitgit/clone_file.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+## Script to run some checkout benchmarks.
+## CD to this directory and run this script from here.
+##################################################################
+
+set -vx
+
+
+. ./__setup.sh || exit 1
+
+
+## A short name for this script. We use this to separate
+## the log files from other benchmarks.
+XX_BM=`basename $0 .sh`
+
+## All log/output for this run will be in the following directory.
+XX_LOG_DIR=$BM_LOGS_DIR/$XX_BM/`/bin/date +%Y%m%d.%H%M%S`
+[ -d $XX_LOG_DIR ] || mkdir -p $XX_LOG_DIR
+
+## Perf data goes here.  Subsequent runs are APPENDED to this file.
+XX_LOG=$XX_LOG_DIR/run.log
+
+## How many times to run the tests (passed into the benchmark).
+XX_COUNT=3
+
+## Also run benchmark using git.exe in the body of the test.
+XX_USEGIT=--git
+
+## Verbose setting within benchmark.
+##XX_VERBOSE=-v
+
+## Write details of the current libgit2 branch to the log before
+## we run the benchmark.
+bm_get_info >> $XX_LOG
+
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone $BM_FURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone --local $BM_FURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone --no-local $BM_FURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone --no-hardlinks $BM_FURL
+date
+

--- a/benchmark/scripts/gitgit/clone_local.sh
+++ b/benchmark/scripts/gitgit/clone_local.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+## Script to run some checkout benchmarks.
+## CD to this directory and run this script from here.
+##################################################################
+
+set -vx
+
+
+. ./__setup.sh || exit 1
+
+
+## A short name for this script. We use this to separate
+## the log files from other benchmarks.
+XX_BM=`basename $0 .sh`
+
+## All log/output for this run will be in the following directory.
+XX_LOG_DIR=$BM_LOGS_DIR/$XX_BM/`/bin/date +%Y%m%d.%H%M%S`
+[ -d $XX_LOG_DIR ] || mkdir -p $XX_LOG_DIR
+
+## Perf data goes here.  Subsequent runs are APPENDED to this file.
+XX_LOG=$XX_LOG_DIR/run.log
+
+## How many times to run the tests (passed into the benchmark).
+XX_COUNT=3
+
+## Also run benchmark using git.exe in the body of the test.
+XX_USEGIT=--git
+
+## Verbose setting within benchmark.
+##XX_VERBOSE=-v
+
+## Write details of the current libgit2 branch to the log before
+## we run the benchmark.
+bm_get_info >> $XX_LOG
+
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone $BM_LURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone --local $BM_LURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone --no-local $BM_LURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone --no-hardlinks $BM_LURL
+date
+

--- a/benchmark/scripts/gitgit/clone_remote.sh
+++ b/benchmark/scripts/gitgit/clone_remote.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+## Script to run some checkout benchmarks.
+## CD to this directory and run this script from here.
+##################################################################
+
+set -vx
+
+
+. ./__setup.sh || exit 1
+
+
+## A short name for this script. We use this to separate
+## the log files from other benchmarks.
+XX_BM=`basename $0 .sh`
+
+## All log/output for this run will be in the following directory.
+XX_LOG_DIR=$BM_LOGS_DIR/$XX_BM/`/bin/date +%Y%m%d.%H%M%S`
+[ -d $XX_LOG_DIR ] || mkdir -p $XX_LOG_DIR
+
+## Perf data goes here.  Subsequent runs are APPENDED to this file.
+XX_LOG=$XX_LOG_DIR/run.log
+
+## How many times to run the tests (passed into the benchmark).
+XX_COUNT=3
+
+## Also run benchmark using git.exe in the body of the test.
+XX_USEGIT=--git
+
+## Verbose setting within benchmark.
+##XX_VERBOSE=-v
+
+## Write details of the current libgit2 branch to the log before
+## we run the benchmark.
+bm_get_info >> $XX_LOG
+
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT clone $BM_RURL
+date
+

--- a/benchmark/scripts/gitgit/merge.sh
+++ b/benchmark/scripts/gitgit/merge.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+## Script to run some checkout benchmarks.
+## CD to this directory and run this script from here.
+##################################################################
+
+set -vx
+
+
+. ./__setup.sh || exit 1
+
+
+## A short name for this script. We use this to separate
+## the log files from other benchmarks.
+XX_BM=`basename $0 .sh`
+
+## All log/output for this run will be in the following directory.
+XX_LOG_DIR=$BM_LOGS_DIR/$XX_BM/`/bin/date +%Y%m%d.%H%M%S`
+[ -d $XX_LOG_DIR ] || mkdir -p $XX_LOG_DIR
+
+## Perf data goes here.  Subsequent runs are APPENDED to this file.
+XX_LOG=$XX_LOG_DIR/run.log
+
+## How many times to run the tests (passed into the benchmark).
+XX_COUNT=3
+
+## We bang on 2 commits. Checkout A and merge B.  Then
+## checkout B and merge A.
+XX_COMMIT_A=355d4e1
+XX_COMMIT_B=8004647
+
+## Also run benchmark using git.exe in the body of the test.
+XX_USEGIT=--git
+
+## Verbose setting within benchmark.
+##XX_VERBOSE=-v
+
+## How many times to call status after merge/checkout completes.
+XX_STATUS=5
+
+## Write details of the current libgit2 branch to the log before
+## we run the benchmark.
+bm_get_info >> $XX_LOG
+
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT merge --autocrlf -r $XX_COMMIT_A -m $XX_COMMIT_B -s $XX_STATUS $BM_LURL
+date
+time $BM_EXE $XX_VERBOSE -c $XX_COUNT --logfile $XX_LOG $XX_USEGIT merge --autocrlf -r $XX_COMMIT_B -m $XX_COMMIT_A -s $XX_STATUS $BM_LURL
+date
+
+
+##################################################################
+## Dump the stats to the console so they don't have to look for it.
+
+echo "################################################################"
+echo "################################################################"
+echo
+cat $XX_LOG

--- a/benchmark/shell.c
+++ b/benchmark/shell.c
@@ -1,0 +1,123 @@
+#include <stdio.h>
+#include "git2.h"
+#include "git2/sys/repository.h"
+#include "common.h"
+#include "bench_util.h"
+#include "buffer.h"
+#include "fileops.h"
+#include "opt.h"
+#include "run.h"
+#include "operation.h"
+#include "benchmark.h"
+#include "shell.h"
+
+#if defined(_WIN32)
+
+extern int gitbench_shell(
+	const char * const argv[],
+	const char *new_cwd,
+	int *p_raw_exit_status)
+{
+	STARTUPINFO si;
+	PROCESS_INFORMATION pi;
+	DWORD dw;
+	git_buf buf_cl = GIT_BUF_INIT;
+	int k;
+	bool ok = false;
+
+	memset(&si, 0, sizeof(si));
+	si.cb = sizeof(si);
+	memset(&pi, 0, sizeof(pi));
+
+	/* TODO decide if we need to re-quote the args. */
+	for (k = 0; argv[k]; k++) {
+		const char *pk = argv[k];
+		git_buf_puts(&buf_cl, pk);
+		git_buf_putc(&buf_cl, ' ');
+	}
+
+	if (verbosity)
+		fprintf(logfile, "::::: %s\n", buf_cl.ptr);
+
+	if (!CreateProcessA(NULL, buf_cl.ptr, NULL, NULL, TRUE,
+						0, NULL, new_cwd, &si, &pi)) {
+		fprintf(stderr, "Error[0x%08lx] CreateProcessA: %s\n",
+				GetLastError(), buf_cl.ptr);
+		goto done;
+	}
+
+	if (WaitForSingleObject(pi.hProcess, INFINITE) != WAIT_OBJECT_0) {
+		fprintf(stderr, "Error[0x%08lx] Wait failed\n",
+				GetLastError());
+		goto done;
+	}
+
+	if (!GetExitCodeProcess(pi.hProcess, &dw)) {
+		fprintf(stderr, "Error[0x%08lx] GetExitCodeProcess failed\n",
+				GetLastError());
+		goto done;
+	}
+
+	if (p_raw_exit_status)
+		*p_raw_exit_status = (int)dw;
+
+	ok = (dw == 0);
+
+done:
+	if (pi.hThread != INVALID_HANDLE_VALUE)
+		CloseHandle(pi.hThread);
+	if (pi.hProcess != INVALID_HANDLE_VALUE)
+		CloseHandle(pi.hProcess);
+	git_buf_free(&buf_cl);
+	return ((ok) ? 0 : -1);
+}
+
+#else
+
+/* Non-windows version adapted from tests/clar/fs.h:shell_out() */
+
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+extern int gitbench_shell(
+	const char * const argv[],
+	const char *new_cwd,
+	int *p_raw_exit_status)
+{
+	int status, piderr;
+	int raw_exit_status;
+	bool ok = false;
+	pid_t pid;
+
+	pid = fork();
+
+	if (pid < 0) {
+		fprintf(stderr,
+			"System error: `fork()` call failed (%d) - %s\n",
+			errno, strerror(errno));
+		goto done;
+	}
+
+	if (pid == 0) {
+		if (new_cwd && (p_chdir(new_cwd) != 0))
+			exit(-1);
+		exit(execv(argv[0], (char **)argv));
+	}
+
+	do {
+		piderr = waitpid(pid, &status, WUNTRACED);
+	} while (piderr < 0 && (errno == EAGAIN || errno == EINTR));
+
+	raw_exit_status = WEXITSTATUS(status);
+	if (p_raw_exit_status)
+		*p_raw_exit_status = raw_exit_status;
+
+	ok = (raw_exit_status == 0);
+
+done:
+	return ((ok) ? 0 : -1);
+}
+
+#endif /* !_WIN32 */

--- a/benchmark/shell.h
+++ b/benchmark/shell.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef SHELL_H
+#define SHELL_H
+
+extern int gitbench_shell(
+	const char * const argv[],
+	const char *new_cwd,
+	int *p_raw_exit_status);
+
+#endif


### PR DESCRIPTION
A simple benchmark framework based upon the
RFC described in PR #2948 by @ethomson.

Includes a standalone executable libgit2_bench.exe
that offers a series of benchmarks.  A set of sample
scripts is provided to exercise checkout and merge.
They also try to compare LibGit2 and Git.exe times
doing equivalent operations.

I've used this on Windows to compare performance between LibGit2 and Git.exe and to compare performance before and after performance improvements within LibGit2.

I have not yet run this version on Linux or Mac. (Though I have run earlier dev versions over there.)

This is not by any means finished, as we'll want to add other benchmarks as time goes on, but it is a nice start.
 