### PR TITLE
[WIP/RFC] push: report the update plan to the caller

### DIFF
--- a/include/git2/push.h
+++ b/include/git2/push.h
@@ -59,6 +59,36 @@ typedef int (*git_push_transfer_progress)(
 	size_t bytes,
 	void* payload);
 
+/**
+ * Represents an update which will be performed on the remote during push
+ */
+typedef struct {
+	/**
+	 * The source name of the reference
+	 */
+	char *src_refname;
+	/**
+	 * The name of the reference to update on the server
+	 */
+	char *dst_refname;
+	/**
+	 * The current target of the reference
+	 */
+	git_oid src;
+	/**
+	 * The new target for the reference
+	 */
+	git_oid dst;
+} git_push_update;
+
+/**
+ * @param updates an array containing the updates which will be sent
+ * as commands to the destination.
+ * @param len number of elements in `updates`
+ * @param payload Payload provided by the caller
+ */
+typedef int (*git_push_negotiation)(const git_push_update **updates, size_t len, void *payload);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -521,6 +521,12 @@ struct git_remote_callbacks {
 	int (*push_update_reference)(const char *refname, const char *status, void *data);
 
 	/**
+	 * Called once between the negotiation step and the upload. It
+	 * provides information about what updates will be performed.
+	 */
+	git_push_negotiation push_negotiation;
+
+	/**
 	 * This will be passed to each of the callbacks in this struct
 	 * as the last parameter.
 	 */

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -273,6 +273,7 @@ typedef int (*git_transfer_progress_cb)(const git_transfer_progress *stats, void
  */
 typedef int (*git_transport_message_cb)(const char *str, int len, void *payload);
 
+
 /**
  * Type of host certificate structure that is passed to the check callback
  */

--- a/src/push.h
+++ b/src/push.h
@@ -29,6 +29,7 @@ struct git_push {
 	git_packbuilder *pb;
 	git_remote *remote;
 	git_vector specs;
+	git_vector updates;
 	bool report_status;
 
 	/* report-status */
@@ -42,6 +43,8 @@ struct git_push {
 	void *pack_progress_cb_payload;
 	git_push_transfer_progress transfer_progress_cb;
 	void *transfer_progress_cb_payload;
+	git_push_negotiation negotiation_cb;
+	void *negotiation_cb_payload;
 };
 
 /**
@@ -85,6 +88,8 @@ int git_push_set_options(
  * the upload portion of a push. Be aware that this is called inline with
  * pack building operations, so performance may be affected.
  * @param transfer_progress_cb_payload Payload for the network progress callback.
+ * @param push_negotiation_cb Function to call before sending the commands to the remote.
+ * @param push_negotiation_cb_payload Payload for the negotiation callback
  * @return 0 or an error code
  */
 int git_push_set_callbacks(
@@ -92,7 +97,9 @@ int git_push_set_callbacks(
 	git_packbuilder_progress pack_progress_cb,
 	void *pack_progress_cb_payload,
 	git_push_transfer_progress transfer_progress_cb,
-	void *transfer_progress_cb_payload);
+	void *transfer_progress_cb_payload,
+	git_push_negotiation negotiation_cb,
+	void *negotiation_cb_payload);
 
 /**
  * Add a refspec to be pushed

--- a/src/remote.c
+++ b/src/remote.c
@@ -2363,7 +2363,8 @@ int git_remote_upload(git_remote *remote, const git_strarray *refspecs, const gi
 	cbs = &remote->callbacks;
 	if ((error = git_push_set_callbacks(push,
 					    cbs->pack_progress, cbs->payload,
-					    cbs->push_transfer_progress, cbs->payload)) < 0)
+					    cbs->push_transfer_progress, cbs->payload,
+					    cbs->push_negotiation, cbs->payload)) < 0)
 		goto cleanup;
 
 	if ((error = git_push_finish(push)) < 0)

--- a/tests/online/push_util.h
+++ b/tests/online/push_util.h
@@ -12,7 +12,7 @@ extern const git_oid OID_ZERO;
  * @param data pointer to a record_callbacks_data instance
  */
 #define RECORD_CALLBACKS_INIT(data) \
-	{ GIT_REMOTE_CALLBACKS_VERSION, NULL, NULL, cred_acquire_cb, NULL, NULL, record_update_tips_cb, NULL, NULL, NULL, data }
+	{ GIT_REMOTE_CALLBACKS_VERSION, NULL, NULL, cred_acquire_cb, NULL, NULL, record_update_tips_cb, NULL, NULL, NULL, NULL, data }
 
 typedef struct {
 	char *name;


### PR DESCRIPTION
It can be useful for the caller to know which update commands will be
sent to the server before the packfile is pushed up. git does this via
the pre-push hook.

We don't have hooks, but as it adds introspection into what is
happening, we can add a callback which performs the same function.

---

This isn't tested yet beyond not crashing the current tests but it should provide a good platform on which to decide how we want to approach our equivalent to the pre-push hook, which is at the heart of what #3004 is trying to get to.

I wanted to make it work for both upload and download and we might still do so, but we should probably focus on the push part first.