### PR TITLE
config_write -- handle duplicate section headers when deleting entries

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1460,9 +1460,12 @@ static int config_write(diskfile_backend *cfg, const char *key, const regex_t *p
 			 * don't loose that information, but we only need to
 			 * update post_start if we're going to use it in this
 			 * iteration.
+			 * If the section doesn't match and we are trying to delete an entry
+			 * (value == NULL), we must continue searching; there may be another
+			 * matching section later.
 			 */
 			if (!section_matches) {
-				if (!last_section_matched) {
+				if (!last_section_matched || value == NULL) {
 					reader_consume_line(reader);
 					continue;
 				}

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -6,7 +6,6 @@ void test_config_write__initialize(void)
 	cl_fixture_sandbox("config/config9");
 	cl_fixture_sandbox("config/config15");
 	cl_fixture_sandbox("config/config17");
-	cl_fixture_sandbox("config/config21");
 }
 
 void test_config_write__cleanup(void)
@@ -14,7 +13,6 @@ void test_config_write__cleanup(void)
 	cl_fixture_cleanup("config9");
 	cl_fixture_cleanup("config15");
 	cl_fixture_cleanup("config17");
-	cl_fixture_cleanup("config21");
 }
 
 void test_config_write__replace_value(void)
@@ -114,12 +112,21 @@ void test_config_write__delete_value_at_specific_level(void)
  */
 void test_config_write__delete_value_with_duplicate_header(void)
 {
-	const char *file_name  = "config21";
+	const char *file_name  = "config-duplicate-header";
 	const char *entry_name = "remote.origin.url";
 	git_config *cfg;
 	git_config_entry *entry;
 
-	/* Make sure the expected entry exists */
+	/* This config can occur after removing and re-adding the origin remote */
+	const char *file_content =
+		"[remote \"origin\"]\n"		\
+		"[branch \"master\"]\n"		\
+		"	remote = \"origin\"\n"	\
+		"[remote \"origin\"]\n"		\
+		"	url = \"foo\"\n";
+
+	/* Write the test config and make sure the expected entry exists */
+	cl_git_mkfile(file_name, file_content);
 	cl_git_pass(git_config_open_ondisk(&cfg, file_name));
 	cl_git_pass(git_config_get_entry(&entry, cfg, entry_name));
 

--- a/tests/resources/config/config21
+++ b/tests/resources/config/config21
@@ -1,6 +1,0 @@
-# This configuration can occur after removing and re-adding the origin remote
-[remote "origin"]
-[branch "master"]
-  remote = "origin"
-[remote "origin"]
-  url = "foo"

--- a/tests/resources/config/config21
+++ b/tests/resources/config/config21
@@ -1,0 +1,6 @@
+# This configuration can occur after removing and re-adding the origin remote
+[remote "origin"]
+[branch "master"]
+  remote = "origin"
+[remote "origin"]
+  url = "foo"


### PR DESCRIPTION
When `config_write` is called with `value = NULL`, ensure that we searche the whole config file before giving up.

This is necessary to handle the possibility of duplicate headers.
For example, given:
```
[remote "origin"]
[branch "master"]
    remote = "origin"
[remote "origin"]
    url = "foo"
```
Trying to delete remote.origin.url would silently fail to remove the actual entry as it would exit after passing through the first matching section.

Fixes #3043, where this bug could cause `remote_rename` to duplicate a remote (it created a new remote while silently failing to delete the old one).