### PR TITLE
Fix for Issue #3023 tests fail with no network

### DIFF
--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -513,24 +513,6 @@ void test_network_remote_remotes__query_refspecs(void)
 	git_remote_free(remote);
 }
 
-static int remote_single_branch(git_remote **out, git_repository *repo, const char *name, const char *url, void *payload)
-{
-	char *fetch_refspecs[] = {
-		"refs/heads/first-merge:refs/remotes/origin/first-merge",
-	};
-	git_strarray fetch_refspecs_strarray = {
-		fetch_refspecs,
-		1,
-	};
-
-	GIT_UNUSED(payload);
-
-	cl_git_pass(git_remote_create(out, repo, name, url));
-	cl_git_pass(git_remote_set_fetch_refspecs(*out, &fetch_refspecs_strarray));
-
-	return 0;
-}
-
 void test_network_remote_remotes__fetch_from_anonymous(void)
 {
 	git_remote *remote;
@@ -539,37 +521,4 @@ void test_network_remote_remotes__fetch_from_anonymous(void)
 						"refs/heads/*:refs/other/*"));
 	cl_git_pass(git_remote_fetch(remote, NULL, NULL));
 	git_remote_free(remote);
-}
-
-void test_network_remote_remotes__single_branch(void)
-{
-	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
-	git_repository *repo;
-	git_strarray refs;
-	size_t i, count = 0;
-
-	opts.remote_cb = remote_single_branch;
-	opts.checkout_branch = "first-merge";
-
-	cl_git_pass(git_clone(&repo, "git://github.com/libgit2/TestGitRepository", "./single-branch", &opts));
-	cl_git_pass(git_reference_list(&refs, repo));
-
-	for (i = 0; i < refs.count; i++) {
-		if (!git__prefixcmp(refs.strings[i], "refs/heads/"))
-			count++;
-	}
-	cl_assert_equal_i(1, count);
-
-	git_strarray_free(&refs);
-	git_repository_free(repo);
-}
-
-void test_network_remote_remotes__restricted_refspecs(void)
-{
-	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
-	git_repository *repo;
-
-	opts.remote_cb = remote_single_branch;
-
-	cl_git_fail_with(GIT_EINVALIDSPEC, git_clone(&repo, "git://github.com/libgit2/TestGitRepository", "./restrict-refspec", &opts));
 }

--- a/tests/online/remotes.c
+++ b/tests/online/remotes.c
@@ -1,0 +1,52 @@
+#include "clar_libgit2.h"
+
+static int remote_single_branch(git_remote **out, git_repository *repo, const char *name, const char *url, void *payload)
+{
+	char *fetch_refspecs[] = {
+		"refs/heads/first-merge:refs/remotes/origin/first-merge",
+	};
+	git_strarray fetch_refspecs_strarray = {
+		fetch_refspecs,
+		1,
+	};
+
+	GIT_UNUSED(payload);
+
+	cl_git_pass(git_remote_create(out, repo, name, url));
+	cl_git_pass(git_remote_set_fetch_refspecs(*out, &fetch_refspecs_strarray));
+
+	return 0;
+}
+
+void test_online_remotes__single_branch(void)
+{
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+	git_repository *repo;
+	git_strarray refs;
+	size_t i, count = 0;
+
+	opts.remote_cb = remote_single_branch;
+	opts.checkout_branch = "first-merge";
+
+	cl_git_pass(git_clone(&repo, "git://github.com/libgit2/TestGitRepository", "./single-branch", &opts));
+	cl_git_pass(git_reference_list(&refs, repo));
+
+	for (i = 0; i < refs.count; i++) {
+		if (!git__prefixcmp(refs.strings[i], "refs/heads/"))
+			count++;
+	}
+	cl_assert_equal_i(1, count);
+
+	git_strarray_free(&refs);
+	git_repository_free(repo);
+}
+
+void test_online_remotes__restricted_refspecs(void)
+{
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+	git_repository *repo;
+
+	opts.remote_cb = remote_single_branch;
+
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_clone(&repo, "git://github.com/libgit2/TestGitRepository", "./restrict-refspec", &opts));
+}


### PR DESCRIPTION
I wrangled moving the 2 tests that were failing over to the online subdirectory and renamed the test functions accordingly.  Thanks for marking things as "up for grabs" by the way, as it makes it much easier to help/participate.

Please let me know if you guys want anything changed here, but I think the change set seems pretty reasonable.

Commit Message:
Moved offending tests from network to online so they will get skipped
when there is a lack of network connectivity:
-test_online_remotes__single_branch
-test_online_remotes__restricted_refspecs