### PR TITLE
Split the concerns of the commit creation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ v0.27 + 1
 
 ### API additions
 
+* `git_commit_create_on()` takes on the role which
+  `git_commit_create()` had when provided a reference name to
+  update. `git_commit_create_on_head()` always updates the current
+  branch.
+
+* `git_commit_create_fromstate()` is a variant of the commit creation
+  function which behaves closer to `git-commit` by taking the parents
+  and tree from the current branch and the index.
+
 ### API removals
+
+* `git_commit_create()` has been renamed to `git_commit_create_on()`.
 
 ### Breaking API changes
 

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -285,12 +285,12 @@ static int create_merge_commit(git_repository *repo, git_index *index, merge_opt
 	check_lg2(git_tree_lookup(&tree, repo, &tree_oid), "failed to lookup tree", NULL);
 
 	/* Commit time ! */
-	err = git_commit_create(&commit_oid,
-	                        repo, git_reference_name(head_ref),
-	                        sign, sign,
-	                        NULL, msg,
-	                        tree,
-	                        opts->annotated_count + 1, (const git_commit **)parents);
+	err = git_commit_create_on(&commit_oid,
+	                           repo, git_reference_name(head_ref),
+	                           sign, sign,
+	                           NULL, msg,
+	                           tree,
+	                           opts->annotated_count + 1, (const git_commit **)parents);
 	check_lg2(err, "failed to create commit", NULL);
 
 	/* We're done merging, cleanup the repository state */

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -443,6 +443,27 @@ GIT_EXTERN(int) git_commit_create_buffer(
 	size_t parent_count,
 	const git_commit *parents[]);
 
+/*
+ * Create a new commit from the current state and update the current branch
+ *
+ * Creates a new commit, similarly to the other functions. This
+ * variant takes the current state of the repository instead of
+ * arguments.
+ *
+ * The current branch will be updated. The tree will be created from
+ * the repository's index. The parents will be taken from HEAD and
+ * MERGE_HEAD, if applicable.
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_fromstate(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message);
+
 /**
  * Create a commit object from the given buffer and signature
  *

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -353,20 +353,20 @@ GIT_EXTERN(int) git_commit_create_on(
 	const git_commit *parents[]);
 
 /**
- * Create a commit and update the current branch
+ * Create a commit from the current state and update the current branch
  *
- * @see git_commit_create
+ * Like `git_commit_create_fromstate`; additionally the current branch will be
+ * updated.
+ *
+ * @see git_commit_create_fromstate
  */
-GIT_EXTERN(int) git_commit_create_on_head(
+GIT_EXTERN(int) git_commit_create_fromstate_on_head(
 	git_oid *id,
 	git_repository *repo,
 	const git_signature *author,
 	const git_signature *committer,
 	const char *message_encoding,
-	const char *message,
-	const git_tree *tree,
-	size_t parent_count,
-	const git_commit *parents[]);
+	const char *message);
 
 /**
  * Create new commit in the repository using a variable argument list.
@@ -478,9 +478,8 @@ GIT_EXTERN(int) git_commit_create_buffer(
  * variant takes the current state of the repository instead of
  * arguments.
  *
- * The current branch will be updated. The tree will be created from
- * the repository's index. The parents will be taken from HEAD and
- * MERGE_HEAD, if applicable.
+ * The tree will be created from the repository's index. The parents will be
+ * taken from HEAD and MERGE_HEAD, if applicable.
  *
  * @see git_commit_create
  */

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -294,14 +294,6 @@ GIT_EXTERN(int) git_commit_extract_signature(git_buf *signature, git_buf *signed
  *
  * @param repo Repository where to store the commit
  *
- * @param update_ref If not NULL, name of the reference that
- *	will be updated to point to this commit. If the reference
- *	is not direct, it will be resolved to a direct reference.
- *	Use "HEAD" to update the HEAD of the current branch and
- *	make it point to this commit. If the reference doesn't
- *	exist yet, it will be created. If it does exist, the first
- *	parent must be the tip of this branch.
- *
  * @param author Signature with author and author time of commit
  *
  * @param committer Signature with committer and * commit time of commit
@@ -331,7 +323,43 @@ GIT_EXTERN(int) git_commit_extract_signature(git_buf *signature, git_buf *signed
 GIT_EXTERN(int) git_commit_create(
 	git_oid *id,
 	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[]);
+
+/**
+ * Create a commit and update a reference
+ *
+ * @param update_ref reference to update with the new commit. The
+ * current tip of the reference must be the first commit in the parent
+ * list.
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_on(
+	git_oid *id,
+	git_repository *repo,
 	const char *update_ref,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[]);
+
+/**
+ * Create a commit and update the current branch
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_on_head(
+	git_oid *id,
+	git_repository *repo,
 	const git_signature *author,
 	const git_signature *committer,
 	const char *message_encoding,

--- a/src/commit.c
+++ b/src/commit.c
@@ -11,6 +11,7 @@
 #include "git2/object.h"
 #include "git2/repository.h"
 #include "git2/signature.h"
+#include "git2/index.h"
 #include "git2/sys/commit.h"
 
 #include "odb.h"
@@ -380,6 +381,90 @@ int git_commit_amend(
 	}
 
 	return error;
+}
+
+static int insert_commit(git_vector *v, git_repository *repo, const git_oid *id)
+{
+	int error;
+	git_commit *commit;
+
+	if ((error = git_commit_lookup(&commit, repo, id)) < 0)
+		return error;
+
+	if ((error = git_vector_insert(v, commit)) < 0) {
+		git_commit_free(commit);
+		return error;
+	}
+
+	return 0;
+}
+
+struct mergehead_data {
+	git_repository *repo;
+	git_vector *commits;
+};
+
+int gather_commit_ids(const git_oid *id, void *payload)
+{
+	struct mergehead_data *data = (struct mergehead_data *) payload;
+
+	return insert_commit(data->commits, data->repo, id);
+}
+
+int git_commit_create_fromstate(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message)
+{
+	int error;
+	size_t i;
+	git_tree *tree = NULL;
+	git_index *index = NULL;
+	git_oid current_id, tree_id;
+	git_commit *commit;
+	git_vector commits = GIT_VECTOR_INIT;
+	git_repository_state_t state;
+
+	state = git_repository_state(repo);
+
+	if ((error = git_reference_name_to_id(&current_id, repo, GIT_HEAD_FILE)) < 0)
+		return error;
+
+	if ((error = insert_commit(&commits, repo, &current_id)) < 0)
+		goto cleanup;
+
+	if (state == GIT_REPOSITORY_STATE_MERGE) {
+		struct mergehead_data mergehead_data = { repo, &commits };
+
+		if ((error = git_repository_mergehead_foreach(repo, gather_commit_ids, &mergehead_data)) < 0)
+			goto cleanup;
+	}
+
+	if ((error = git_repository_index(&index, repo)) < 0)
+		goto cleanup;
+
+	error = git_index_write_tree(&tree_id, index);
+	git_index_free(index);
+	if (error < 0)
+		goto cleanup;
+
+	if ((error = git_tree_lookup(&tree, repo, &tree_id)) < 0)
+		goto cleanup;
+
+	error = git_commit_create(id, repo, GIT_HEAD_FILE,
+				  author, committer, message_encoding, message,
+				  tree, commits.length, (const git_commit **) commits.contents);
+
+cleanup:
+	git_tree_free(tree);
+	git_vector_foreach(&commits, i, commit) {
+		git_commit_free(commit);
+	}
+	git_vector_free(&commits);
+	return 0;
 }
 
 int git_commit__parse(void *_commit, git_odb_object *odb_obj)

--- a/src/commit.c
+++ b/src/commit.c
@@ -291,7 +291,7 @@ static const git_oid *commit_parent_from_array(size_t curr, void *payload)
 	return git_commit_id(commit);
 }
 
-int git_commit_create(
+int git_commit_create_on(
 	git_oid *id,
 	git_repository *repo,
 	const char *update_ref,
@@ -311,6 +311,38 @@ int git_commit_create(
 		id, repo, update_ref, author, committer,
 		message_encoding, message, git_tree_id(tree),
 		commit_parent_from_array, &data, false);
+}
+
+int git_commit_create_on_head(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[])
+{
+	return git_commit_create_on(id, repo, GIT_HEAD_FILE,
+				    author, committer, message_encoding, message,
+				    tree, parent_count, parents);
+}
+
+int git_commit_create(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[])
+{
+	return git_commit_create_on(id, repo, NULL,
+				    author, committer, message_encoding, message,
+				    tree, parent_count, parents);
 }
 
 static const git_oid *commit_parent_for_amend(size_t curr, void *payload)
@@ -454,9 +486,9 @@ int git_commit_create_fromstate(
 	if ((error = git_tree_lookup(&tree, repo, &tree_id)) < 0)
 		goto cleanup;
 
-	error = git_commit_create(id, repo, GIT_HEAD_FILE,
-				  author, committer, message_encoding, message,
-				  tree, commits.length, (const git_commit **) commits.contents);
+	error = git_commit_create_on(id, repo, GIT_HEAD_FILE,
+				     author, committer, message_encoding, message,
+				     tree, commits.length, (const git_commit **) commits.contents);
 
 cleanup:
 	git_tree_free(tree);

--- a/src/commit.c
+++ b/src/commit.c
@@ -313,22 +313,6 @@ int git_commit_create_on(
 		commit_parent_from_array, &data, false);
 }
 
-int git_commit_create_on_head(
-	git_oid *id,
-	git_repository *repo,
-	const git_signature *author,
-	const git_signature *committer,
-	const char *message_encoding,
-	const char *message,
-	const git_tree *tree,
-	size_t parent_count,
-	const git_commit *parents[])
-{
-	return git_commit_create_on(id, repo, GIT_HEAD_FILE,
-				    author, committer, message_encoding, message,
-				    tree, parent_count, parents);
-}
-
 int git_commit_create(
 	git_oid *id,
 	git_repository *repo,
@@ -443,9 +427,10 @@ int gather_commit_ids(const git_oid *id, void *payload)
 	return insert_commit(data->commits, data->repo, id);
 }
 
-int git_commit_create_fromstate(
+static int commit_fromstate(
 	git_oid *id,
 	git_repository *repo,
+	const char *update_ref,
 	const git_signature *author,
 	const git_signature *committer,
 	const char *message_encoding,
@@ -486,7 +471,7 @@ int git_commit_create_fromstate(
 	if ((error = git_tree_lookup(&tree, repo, &tree_id)) < 0)
 		goto cleanup;
 
-	error = git_commit_create_on(id, repo, GIT_HEAD_FILE,
+	error = git_commit_create_on(id, repo, update_ref,
 				     author, committer, message_encoding, message,
 				     tree, commits.length, (const git_commit **) commits.contents);
 
@@ -497,6 +482,28 @@ cleanup:
 	}
 	git_vector_free(&commits);
 	return 0;
+}
+
+int git_commit_create_fromstate(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message)
+{
+	return commit_fromstate(id, repo, NULL, author, committer, message_encoding, message);
+}
+
+int git_commit_create_fromstate_on_head(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message)
+{
+	return commit_fromstate(id, repo, GIT_HEAD_FILE, author, committer, message_encoding, message);
 }
 
 int git_commit__parse(void *_commit, git_odb_object *odb_obj)

--- a/src/notes.c
+++ b/src/notes.c
@@ -300,9 +300,9 @@ static int note_write(
 		git_oid_cpy(notes_blob_out, &oid);
 
 
-	error = git_commit_create(&oid, repo, notes_ref, author, committer,
-				  NULL, GIT_NOTES_DEFAULT_MSG_ADD,
-				  tree, *parents == NULL ? 0 : 1, (const git_commit **) parents);
+	error = git_commit_create_on(&oid, repo, notes_ref, author, committer,
+				     NULL, GIT_NOTES_DEFAULT_MSG_ADD,
+				     tree, *parents == NULL ? 0 : 1, (const git_commit **) parents);
 
 	if (notes_commit_out)
 		git_oid_cpy(notes_commit_out, &oid);
@@ -385,7 +385,7 @@ static int note_remove(
 		remove_note_in_tree_eexists_cb, remove_note_in_tree_enotfound_cb)) < 0)
 		goto cleanup;
 
-	error = git_commit_create(&oid, repo, notes_ref, author, committer,
+	error = git_commit_create_on(&oid, repo, notes_ref, author, committer,
 	  NULL, GIT_NOTES_DEFAULT_MSG_RM,
 	  tree_after_removal,
 	  *parents == NULL ? 0 : 1,

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -978,7 +978,7 @@ static int rebase_commit__create(
 		message = git_commit_message(current_commit);
 	}
 
-	if ((error = git_commit_create(&commit_id, rebase->repo, NULL, author,
+	if ((error = git_commit_create(&commit_id, rebase->repo, author,
 		committer, message_encoding, message, tree, 1,
 		(const git_commit **)&parent_commit)) < 0 ||
 		(error = git_commit_lookup(&commit, rebase->repo, &commit_id)) < 0)

--- a/src/stash.c
+++ b/src/stash.c
@@ -135,7 +135,6 @@ static int commit_index(
 	if ((error = git_commit_create(
 		&i_commit_oid,
 		git_index_owner(index),
-		NULL,
 		stasher,
 		stasher,
 		NULL,
@@ -277,7 +276,6 @@ static int commit_untracked(
 	if ((error = git_commit_create(
 		&u_commit_oid,
 		git_index_owner(index),
-		NULL,
 		stasher,
 		stasher,
 		NULL,
@@ -380,7 +378,6 @@ static int commit_worktree(
 	error = git_commit_create(
 		w_commit_oid,
 		git_index_owner(index),
-		NULL,
 		stasher,
 		stasher,
 		NULL,

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -1231,7 +1231,7 @@ void test_checkout_tree__case_changing_rename(void)
 
 	cl_git_pass(git_signature_new(&signature, "Renamer", "rename@contoso.com", time(NULL), 0));
 
-	cl_git_pass(git_commit_create(&commit_id, g_repo, "refs/heads/dir", signature, signature, NULL, "case-changing rename", tree, 1, (const git_commit **)&dir_commit));
+	cl_git_pass(git_commit_create_on(&commit_id, g_repo, "refs/heads/dir", signature, signature, NULL, "case-changing rename", tree, 1, (const git_commit **)&dir_commit));
 
 	cl_assert(git_path_isfile("testrepo/readme"));
 	if (case_sensitive)

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -77,7 +77,7 @@ void test_cherrypick_workdir__automerge(void)
 
 		cl_git_pass(git_index_write_tree(&cherrypicked_tree_oid, repo_index));
 		cl_git_pass(git_tree_lookup(&cherrypicked_tree, repo, &cherrypicked_tree_oid));
-		cl_git_pass(git_commit_create(&cherrypicked_oid, repo, "HEAD", signature, signature, NULL,
+		cl_git_pass(git_commit_create_on(&cherrypicked_oid, repo, "HEAD", signature, signature, NULL,
 			"Cherry picked!", cherrypicked_tree, 1, (const git_commit **)&head));
 
 		cl_assert(merge_test_index(repo_index, merge_index_entries + i * 3, 3));

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -35,12 +35,12 @@ void test_commit_commit__create_unexisting_update_ref(void)
 	cl_git_pass(git_signature_now(&s, "alice", "alice@example.com"));
 
 	cl_git_fail(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
-	cl_git_pass(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
-				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+	cl_git_pass(git_commit_create_on(&oid, _repo, "refs/heads/foo/bar", s, s,
+					 NULL, "some msg", tree, 1, (const git_commit **) &commit));
 
 	/* fail because the parent isn't the tip of the branch anymore */
-	cl_git_fail(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
-				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+	cl_git_fail(git_commit_create_on(&oid, _repo, "refs/heads/foo/bar", s, s,
+					 NULL, "some msg", tree, 1, (const git_commit **) &commit));
 
 	cl_git_pass(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
 	cl_assert_equal_oid(&oid, git_reference_target(ref));
@@ -68,7 +68,7 @@ void test_commit_commit__create_initial_commit(void)
 	cl_git_pass(git_signature_now(&s, "alice", "alice@example.com"));
 
 	cl_git_fail(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
-	cl_git_pass(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
+	cl_git_pass(git_commit_create_on(&oid, _repo, "refs/heads/foo/bar", s, s,
 				      NULL, "initial commit", tree, 0, NULL));
 
 	cl_git_pass(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
@@ -99,7 +99,7 @@ void test_commit_commit__create_initial_commit_parent_not_current(void)
 
 	cl_git_pass(git_reference_name_to_id(&original_oid, _repo, "HEAD"));
 
-	cl_git_fail(git_commit_create(&oid, _repo, "HEAD", s, s,
+	cl_git_fail(git_commit_create_on(&oid, _repo, "HEAD", s, s,
 				      NULL, "initial commit", tree, 0, NULL));
 
 	cl_git_pass(git_reference_name_to_id(&oid, _repo, "HEAD"));

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -423,7 +423,7 @@ void test_diff_rename__test_small_files(void)
 	cl_git_pass(git_index_write_tree(&oid, index));
 	cl_git_pass(git_tree_lookup(&commit_tree, g_repo, &oid));
 	cl_git_pass(git_signature_new(&signature, "Rename", "rename@example.com", 1404157834, 0));
-	cl_git_pass(git_commit_create(&oid, g_repo, "HEAD", signature, signature, NULL, "Test commit", commit_tree, 1, (const git_commit**)&head_commit));
+	cl_git_pass(git_commit_create_on(&oid, g_repo, "HEAD", signature, signature, NULL, "Test commit", commit_tree, 1, (const git_commit**)&head_commit));
 
 	cl_git_mkfile("renames/copy.txt", "Hello World!\n");
 	cl_git_rmfile("renames/small.txt");

--- a/tests/odb/freshen.c
+++ b/tests/odb/freshen.c
@@ -123,7 +123,7 @@ void test_odb_freshen__tree_during_commit(void)
 	cl_git_pass(git_signature_new(&signature,
 		"Refresher", "refresher@example.com", 1488547083, 0));
 
-	cl_git_pass(git_commit_create(&commit_id, repo, NULL,
+	cl_git_pass(git_commit_create(&commit_id, repo,
 		signature, signature, NULL, "New commit pointing to old tree",
 		tree, 1, (const git_commit **)&parent));
 

--- a/tests/refs/reflog/messages.c
+++ b/tests/refs/reflog/messages.c
@@ -164,7 +164,7 @@ void test_refs_reflog_messages__branch_birth(void)
 	cl_assert_equal_i(nentries, nentries_after);
 
 	msg = "message 2";
-	cl_git_pass(git_commit_create(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
+	cl_git_pass(git_commit_create_on(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
 
 	cl_assert_equal_i(1, reflog_entrycount(g_repo, "refs/heads/orphan"));
 
@@ -203,7 +203,7 @@ void test_refs_reflog_messages__commit_on_symbolic_ref_updates_head_reflog(void)
 	cl_assert_equal_i(nentries_master, reflog_entrycount(g_repo, "refs/heads/master"));
 
 	msg = "message 2";
-	cl_git_pass(git_commit_create(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
+	cl_git_pass(git_commit_create_on(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
 
 	cl_assert_equal_i(1, reflog_entrycount(g_repo, "refs/heads/foo"));
 	cl_assert_equal_i(nentries_head + 1, reflog_entrycount(g_repo, GIT_HEAD_FILE));
@@ -239,7 +239,7 @@ void test_refs_reflog_messages__show_merge_for_merge_commits(void)
 
 	cl_git_pass(git_commit_tree(&tree, b1_commit));
 
-	cl_git_pass(git_commit_create(&merge_commit_oid,
+	cl_git_pass(git_commit_create_on(&merge_commit_oid,
 		g_repo, "HEAD", s, s, NULL,
 		"Merge commit", tree,
 		2, (const struct git_commit **) parent_commits));

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -265,7 +265,7 @@ void test_reset_hard__switch_file_to_dir(void)
 	cl_git_pass(git_index_clear(idx));
 
 	cl_git_pass(git_tree_lookup(&tree, repo, &src_tree_id));
-	cl_git_pass(git_commit_create(&src_id, repo, NULL, sig, sig, NULL, "foo", tree, 0, NULL));
+	cl_git_pass(git_commit_create(&src_id, repo, sig, sig, NULL, "foo", tree, 0, NULL));
 	git_tree_free(tree);
 
 	/* Create the new tree */
@@ -276,7 +276,7 @@ void test_reset_hard__switch_file_to_dir(void)
 
 	cl_git_pass(git_index_write_tree_to(&tgt_tree_id, idx, repo));
 	cl_git_pass(git_tree_lookup(&tree, repo, &tgt_tree_id));
-	cl_git_pass(git_commit_create(&tgt_id, repo, NULL, sig, sig, NULL, "foo", tree, 0, NULL));
+	cl_git_pass(git_commit_create(&tgt_id, repo, sig, sig, NULL, "foo", tree, 0, NULL));
 	git_tree_free(tree);
 	git_index_free(idx);
 	git_signature_free(sig);

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -189,7 +189,7 @@ void test_revert_workdir__again(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
+	cl_git_pass(git_commit_create_on(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
 
 	cl_git_pass(git_revert(repo, orig_head, NULL));
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));
@@ -239,7 +239,7 @@ void test_revert_workdir__again_after_automerge(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&head));
+	cl_git_pass(git_commit_create_on(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&head));
 
 	cl_git_pass(git_revert(repo, commit, NULL));
 	cl_assert(merge_test_index(repo_index, second_revert_entries, 6));
@@ -288,7 +288,7 @@ void test_revert_workdir__again_after_edit(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
+	cl_git_pass(git_commit_create_on(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
 
 	cl_git_pass(git_revert(repo, commit, NULL));
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -490,7 +490,7 @@ void test_revwalk_basic__big_timestamp(void)
 	cl_git_pass(git_signature_new(&sig, "Joe", "joe@example.com", 2399662595, 0));
 	cl_git_pass(git_commit_tree(&tree, tip));
 
-	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1,
+	cl_git_pass(git_commit_create_on(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1,
 		(const git_commit **)&tip));
 
 	cl_git_pass(git_revwalk_push_head(_walk));

--- a/tests/status/submodules.c
+++ b/tests/status/submodules.c
@@ -502,7 +502,7 @@ void test_status_submodules__entry_but_dir_tracked(void)
 		cl_git_pass(git_index_write_tree(&tree_id, index));
 		cl_git_pass(git_signature_now(&sig, "Sloppy Submoduler", "sloppy@example.com"));
 		cl_git_pass(git_tree_lookup(&tree, repo, &tree_id));
-		cl_git_pass(git_commit_create(&commit_id, repo, NULL, sig, sig, NULL, "message", tree, 0, NULL));
+		cl_git_pass(git_commit_create(&commit_id, repo, sig, sig, NULL, "message", tree, 0, NULL));
 		cl_git_pass(git_reference_create(&ref, repo, "refs/heads/master", &commit_id, 1, "commit: foo"));
 		git_reference_free(ref);
 		git_signature_free(sig);


### PR DESCRIPTION
As discussed on #2681 this PR splits up the commit creation functions into creating the commit and those which update a reference as well.

`_fromstate()` brings us closer to `git-commit` with its defaults for the parents and tree.

I don't love `git_commit_create_on_head()` since you can get the same by passing `"HEAD"` to `git_commit_create_on()` and we already have enough confusion about what we mean by `head` in function names.

The names are whatever I came up with, better names may come up.
