### PR TITLE
Fix some build warnings

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1457,7 +1457,7 @@ static int blob_content_to_file(
 	writer.fd = fd;
 	writer.open = 1;
 
-	error = git_filter_list_stream_blob(fl, blob, (git_writestream *)&writer);
+	error = git_filter_list_stream_blob(fl, blob, &writer.base);
 
 	assert(writer.open == 0);
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -671,7 +671,7 @@ int git_filter_list_apply_to_data(
 	buf_stream_init(&writer, tgt);
 
 	if ((error = git_filter_list_stream_data(filters, src,
-		(git_writestream *)&writer)) < 0)
+		&writer.parent)) < 0)
 			return error;
 
 	assert(writer.complete);
@@ -690,7 +690,7 @@ int git_filter_list_apply_to_file(
 	buf_stream_init(&writer, out);
 
 	if ((error = git_filter_list_stream_file(
-		filters, repo, path, (git_writestream *)&writer)) < 0)
+		filters, repo, path, &writer.parent)) < 0)
 			return error;
 
 	assert(writer.complete);
@@ -721,7 +721,7 @@ int git_filter_list_apply_to_blob(
 	buf_stream_init(&writer, out);
 
 	if ((error = git_filter_list_stream_blob(
-		filters, blob, (git_writestream *)&writer)) < 0)
+		filters, blob, &writer.parent)) < 0)
 			return error;
 
 	assert(writer.complete);

--- a/src/remote.c
+++ b/src/remote.c
@@ -171,11 +171,11 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 		if ((error = git_repository_config_snapshot(&config, repo)) < 0)
 			goto on_error;
 
-		if (lookup_remote_prune_config(remote, config, name) < 0)
+		if ((error = lookup_remote_prune_config(remote, config, name)) < 0)
 			goto on_error;
 
 		/* Move the data over to where the matching functions can find them */
-		if (dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs) < 0)
+		if ((error = dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs)) < 0)
 			goto on_error;
 	}
 
@@ -457,7 +457,7 @@ int git_remote_lookup(git_remote **out, git_repository *repo, const char *name)
 		goto cleanup;
 
 	/* Move the data over to where the matching functions can find them */
-	if (dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs) < 0)
+	if ((error = dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs)) < 0)
 		goto cleanup;
 
 	*out = remote;
@@ -2330,7 +2330,7 @@ int git_remote_upload(git_remote *remote, const git_strarray *refspecs, const gi
 		goto cleanup;
 
 	free_refspecs(&remote->active_refspecs);
-	if (dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs) < 0)
+	if ((error = dwim_refspecs(&remote->active_refspecs, &remote->refspecs, &remote->refs)) < 0)
 		goto cleanup;
 
 	if (remote->push) {


### PR DESCRIPTION
In checkout.c and filter.c we were casting a sub struct
to a parent struct which breaks the strict aliasing rules
in C. However we can use .parent or .base to access the
parent struct to avoid the build warnings.

In remote.c the local variable error was not initialized
or updated in some cases. For unintialized error a build
warning will be generated. So always keep error variable
up-to-date.