### PR TITLE
Fix crash in regfree() on Android when using system's regex API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,7 @@ OPTION( PROFILE				"Generate profiling information"		OFF )
 OPTION( ENABLE_TRACE		"Enables tracing support"				OFF )
 OPTION( LIBGIT2_FILENAME	"Name of the produced binary"			OFF )
 
-OPTION( ANDROID				"Build for android NDK"	 				OFF )
-
+OPTION( USE_OPENSSL                     "Link with and use openssl library"             ON )
 OPTION( USE_ICONV			"Link with and use iconv library" 		OFF )
 OPTION( USE_SSH				"Link with libssh to enable SSH support" ON )
 OPTION( USE_GSSAPI			"Link with libgssapi for SPNEGO auth"   OFF )
@@ -249,7 +248,7 @@ IF (ENABLE_TRACE STREQUAL "ON")
 ENDIF()
 
 # Include POSIX regex when it is required
-IF(WIN32 OR AMIGA OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
+IF(WIN32 OR AMIGA OR CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
 	INCLUDE_DIRECTORIES(deps/regex)
 	SET(SRC_REGEX deps/regex/regex.c)
 ENDIF()

--- a/src/config.c
+++ b/src/config.c
@@ -343,7 +343,6 @@ typedef struct {
 	git_config_iterator *current;
 	const git_config *cfg;
 	regex_t regex;
-	int has_regex;
 	size_t i;
 } all_iter;
 
@@ -983,7 +982,8 @@ void multivar_iter_free(git_config_iterator *_iter)
 	iter->iter->free(iter->iter);
 
 	git__free(iter->name);
-	regfree(&iter->regex);
+	if (iter->have_regex)
+		regfree(&iter->regex);
 	git__free(iter);
 }
 


### PR DESCRIPTION
config.c: should always check have_regex before calling regfree() and regexec

With this, Android build no longer requires deps/regex

Also see https://github.com/libgit2/libgit2/issues/3082
