### PR TITLE
Do not call regfree() on an empty regex that is not successfully created...

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -343,7 +343,6 @@ typedef struct {
 	git_config_iterator *current;
 	const git_config *cfg;
 	regex_t regex;
-	int has_regex;
 	size_t i;
 } all_iter;
 
@@ -480,7 +479,6 @@ int git_config_iterator_glob_new(git_config_iterator **out, const git_config *cf
 
 	if ((result = regcomp(&iter->regex, regexp, REG_EXTENDED)) != 0) {
 		giterr_set_regex(&iter->regex, result);
-		regfree(&iter->regex);
 		git__free(iter);
 		return -1;
 	}
@@ -983,7 +981,8 @@ void multivar_iter_free(git_config_iterator *_iter)
 	iter->iter->free(iter->iter);
 
 	git__free(iter->name);
-	regfree(&iter->regex);
+	if (iter->have_regex)
+		regfree(&iter->regex);
 	git__free(iter);
 }
 


### PR DESCRIPTION
... by regcomp

(also removed an unused member "has_regex" from all_iter)

See http://pubs.opengroup.org/onlinepubs/9699919799/functions/regfree.html

When regcomp() fails, the "regex" will be undefined. The sample code doesn't call regfree() on regcomp() failure. 