### PR TITLE
Android build doesn't need deps/regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,6 @@ OPTION( PROFILE				"Generate profiling information"		OFF )
 OPTION( ENABLE_TRACE		"Enables tracing support"				OFF )
 OPTION( LIBGIT2_FILENAME	"Name of the produced binary"			OFF )
 
-OPTION( ANDROID				"Build for android NDK"	 				OFF )
-
 OPTION( USE_ICONV			"Link with and use iconv library" 		OFF )
 OPTION( USE_SSH				"Link with libssh to enable SSH support" ON )
 OPTION( USE_GSSAPI			"Link with libgssapi for SPNEGO auth"   OFF )
@@ -249,7 +247,7 @@ IF (ENABLE_TRACE STREQUAL "ON")
 ENDIF()
 
 # Include POSIX regex when it is required
-IF(WIN32 OR AMIGA OR ANDROID OR CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
+IF(WIN32 OR AMIGA OR CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
 	INCLUDE_DIRECTORIES(deps/regex)
 	SET(SRC_REGEX deps/regex/regex.c)
 ENDIF()

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ with full path to the toolchain):
 	SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 	SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-Add `-DCMAKE_TOOLCHAIN_FILE={pathToToolchainFile} -DANDROID=1` to cmake command
+Add `-DCMAKE_TOOLCHAIN_FILE={pathToToolchainFile}` to cmake command
 when configuring.
 
 Language Bindings


### PR DESCRIPTION
The reason why Android build needed deps/regex is Android NDK 4 doesn't include those regex symbols in the libc.so. See https://groups.google.com/forum/#!topic/android-ndk/BepvBlDw4_w.

It is a bug in Android NDK 4 rather than Android 2.2 (froyo).
 
I cannot find an Android 2.2 (froyo) device or emulator. But the libc.so in Android NDK 10 for Android 2.2 (froyo) does contain the regex functions. (Froyo's Android API level is 8). This means the native library should be able to use these functions on Android 2.2 devices. Removing deps/regex from Android build can only break those projects that still use Android NDK 4. Should we worry about that?

  android-ndk-r10c/platforms/android-8/arch-arm/usr/lib$ arm-linux-androideabi-objdump -t libc.so | grep reg
  00008044 g F .text 00000014 __atexit_register_cleanup
  0000b230 g F .text 00000014 regcomp
  0000b244 g F .text 00000014 regerror
  0000b258 g F .text 00000014 regexec
  0000b26c g F .text 00000014 regfree
  0000b6b8 g F .text 00000014 setregid

The reason why I want to make this change is that some other native libraries (like sqlite) may also use regex functions and statically linked together with libgit2. In such a case, sqlite allocates a regex_t defined by Android NDK, which is a 16-byte struct, smaller than the regex_t defined in deps/regex (from GNU). But when it calls regcomp(), it will be the one in deps/regex, and will write out of the range, and cause a memory corruption.
