### PR TITLE
Fixed unused warning in tests/rebase/merge.c

### DIFF
--- a/tests/rebase/merge.c
+++ b/tests/rebase/merge.c
@@ -517,6 +517,11 @@ void rebase_checkout_progress_cb(
 	void *payload)
 {
 	int *called = payload;
+
+	GIT_UNUSED(path);
+	GIT_UNUSED(completed_steps);
+	GIT_UNUSED(total_steps);
+
 	*called = 1;
 }
 


### PR DESCRIPTION
Should fix #3078 