### PR TITLE
Update documentation for API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ support for HTTPS connections insead of OpenSSL.
 
 ### Breaking API changes
 
+* `git_smart_subtransport_cb` now has a `param` parameter.
+
 * The `git_merge_options` structure member `flags` has been renamed
   to `tree_flags`.
 

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -169,7 +169,7 @@ typedef struct {
 	/** The file to favor in region conflicts. */
 	git_merge_file_favor_t favor;
 
-	/** Merge file flags. */
+	/** see `git_merge_file_flags_t` above */
 	unsigned int flags;
 } git_merge_file_options;
 
@@ -246,6 +246,7 @@ typedef struct {
 	/** Flags for handling conflicting content. */
 	git_merge_file_favor_t file_favor;
 
+	/** see `git_merge_file_flags_t` above */
 	unsigned int file_flags;
 } git_merge_options;
 


### PR DESCRIPTION
As part of updating the version of libgit used by LibGit2Sharp, I came across a couple of breaking changes where some more documentation would have been helpful.

The CHANGELOG.md changes are for modifications in 142e5379