### PR TITLE
Ensure frameworks are mentioned in libgit2.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,10 +156,12 @@ INCLUDE_DIRECTORIES(src include)
 
 IF (SECURITY_FOUND)
   MESSAGE("-- Found Security ${SECURITY_DIRS}")
+  SET(LIBGIT2_PC_LIBS "${LIBGIT2_PC_LIBS} -framework Security")
 ENDIF()
 
 IF (COREFOUNDATION_FOUND)
   MESSAGE("-- Found CoreFoundation ${COREFOUNDATION_DIRS}")
+  SET(LIBGIT2_PC_LIBS "${LIBGIT2_PC_LIBS} -framework CoreFoundation")
 ENDIF()
 
 


### PR DESCRIPTION
When building on Mac OS X, the `CoreFoundation` and `Security` frameworks where missing from `Libs.private` in the generated `libgit2.pc` file.

This should fix building Rugged on OS X.