### PR TITLE
Use the packbuilder in local push

### DIFF
--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -398,7 +398,10 @@ static int local_push(
 
 	/* We don't currently support pushing locally to non-bare repos. Proper
 	   non-bare repo push support would require checking configs to see if
-	   we should override the default 'don't let this happen' behavior */
+	   we should override the default 'don't let this happen' behavior.
+
+	   Note that this is only an issue when pushing to the current branch,
+	   but we forbid all pushes just in case */
 	if (!remote_repo->is_bare) {
 		error = GIT_EBAREREPO;
 		giterr_set(GITERR_INVALID, "Local push doesn't (yet) support pushing to non-bare repos.");

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -217,7 +217,7 @@ void test_network_remote_local__push_to_bare_remote(void)
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH, NULL));
 
 	/* Try to push */
-	cl_git_pass(git_remote_upload(remote, &push_array, NULL));
+	cl_git_pass(git_remote_upload(localremote, &push_array, NULL));
 
 	/* Clean up */
 	git_remote_free(localremote);
@@ -256,7 +256,7 @@ void test_network_remote_local__push_to_bare_remote_with_file_url(void)
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH, NULL));
 
 	/* Try to push */
-	cl_git_pass(git_remote_upload(remote, &push_array, NULL));
+	cl_git_pass(git_remote_upload(localremote, &push_array, NULL));
 
 	/* Clean up */
 	git_remote_free(localremote);


### PR DESCRIPTION
This is what #1902 was complaining about all that time ago.

What we currently do is likely one of the worst ways of pushing. By actually using the packbuilder we also get the progress which we lack.
