### PR TITLE
Adjusting stream buffer size to 64KB

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -875,7 +875,7 @@ void stream_list_free(git_vector *streams)
 	git_vector_free(streams);
 }
 
-#define STREAM_BUFSIZE 10240
+#define STREAM_BUFSIZE 65536
 
 int git_filter_list_stream_file(
 	git_filter_list *filters,


### PR DESCRIPTION
64K is optimal buffer size per https://technet.microsoft.com/en-us/library/cc938632.aspx. This change should benefit any x86 based system, not just Windows.