### PR TITLE
Centralizing all IO buffer size values

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -74,7 +74,7 @@ static int write_file_stream(
 	git_oid *id, git_odb *odb, const char *path, git_off_t file_size)
 {
 	int fd, error;
-	char buffer[4096];
+	char buffer[FILEIO_BUFSIZE];
 	git_odb_stream *stream = NULL;
 	ssize_t read_len = -1, written = 0;
 

--- a/src/common.h
+++ b/src/common.h
@@ -68,6 +68,11 @@
 
 #include <regex.h>
 
+#define DEFAULT_BUFSIZE 65536
+#define FILEIO_BUFSIZE DEFAULT_BUFSIZE
+#define FILTERIO_BUFSIZE DEFAULT_BUFSIZE
+#define NETIO_BUFSIZE DEFAULT_BUFSIZE
+
 /**
  * Check a pointer allocation result, returning -1 if it failed.
  */

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -68,7 +68,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 
 	if ((flags & GIT_FILEBUF_APPEND) && git_path_exists(file->path_original) == true) {
 		git_file source;
-		char buffer[2048];
+		char buffer[FILEIO_BUFSIZE];
 		ssize_t read_bytes;
 
 		source = p_open(file->path_original, O_RDONLY);

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -689,7 +689,7 @@ int git_futils_fake_symlink(const char *old, const char *new)
 static int cp_by_fd(int ifd, int ofd, bool close_fd_when_done)
 {
 	int error = 0;
-	char buffer[4096];
+	char buffer[FILEIO_BUFSIZE];
 	ssize_t len = 0;
 
 	while (!error && (len = p_read(ifd, buffer, sizeof(buffer))) > 0)

--- a/src/filter.c
+++ b/src/filter.c
@@ -875,15 +875,13 @@ void stream_list_free(git_vector *streams)
 	git_vector_free(streams);
 }
 
-#define STREAM_BUFSIZE 65536
-
 int git_filter_list_stream_file(
 	git_filter_list *filters,
 	git_repository *repo,
 	const char *path,
 	git_writestream *target)
 {
-	char buf[STREAM_BUFSIZE];
+	char buf[FILTERIO_BUFSIZE];
 	git_buf abspath = GIT_BUF_INIT;
 	const char *base = repo ? git_repository_workdir(repo) : NULL;
 	git_vector filter_streams = GIT_VECTOR_INIT;
@@ -901,7 +899,7 @@ int git_filter_list_stream_file(
 		goto done;
 	}
 
-	while ((readlen = p_read(fd, buf, STREAM_BUFSIZE)) > 0) {
+	while ((readlen = p_read(fd, buf, sizeof(buf))) > 0) {
 		if ((error = stream_start->write(stream_start, buf, readlen)) < 0)
 			goto done;
 	}

--- a/src/odb.c
+++ b/src/odb.c
@@ -142,7 +142,7 @@ void git_odb_object_free(git_odb_object *object)
 int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 {
 	int hdr_len;
-	char hdr[64], buffer[2048];
+	char hdr[64], buffer[FILEIO_BUFSIZE];
 	git_hash_ctx ctx;
 	ssize_t read_len = 0;
 	int error = 0;

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -70,7 +70,7 @@ typedef struct {
 	gitno_buffer parse_buffer;
 	git_buf parse_header_name;
 	git_buf parse_header_value;
-	char parse_buffer_data[2048];
+	char parse_buffer_data[NETIO_BUFSIZE];
 	char *content_type;
 	char *location;
 	git_vector www_authenticate;


### PR DESCRIPTION
Moving all IO buffer size values into common.h for easy modification for those who actually need to restrict the size of stack allocated buffers.

Defaulting the value of buffer sizes to 64KiB.