### PR TITLE
submodule: add test initialising and cloning a repo

### DIFF
--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -1,6 +1,8 @@
 #include "clar_libgit2.h"
 
 #include "git2/clone.h"
+#include "git2/sys/commit.h"
+#include "../submodule/submodule_helpers.h"
 #include "remote.h"
 #include "fileops.h"
 #include "repository.h"
@@ -346,4 +348,57 @@ void test_clone_nonetwork__clone_from_empty_sets_upstream(void)
 	git_config_free(config);
 	git_repository_free(repo);
 	cl_fixture_cleanup("./repowithunborn");
+}
+
+static int just_return_origin(git_remote **out, git_repository *repo, const char *name, const char *url, void *payload)
+{
+	GIT_UNUSED(url); GIT_UNUSED(payload);
+
+	return git_remote_lookup(out, repo, name);
+}
+
+static int just_return_repo(git_repository **out, const char *path, int bare, void *payload)
+{
+	git_submodule *sm = payload;
+
+	GIT_UNUSED(path); GIT_UNUSED(bare);
+
+	return git_submodule_open(out, sm);
+}
+
+void test_clone_nonetwork__clone_submodule(void)
+{
+	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+	git_index *index;
+	git_oid tree_id, commit_id;
+	git_submodule *sm;
+	git_signature *sig;
+	git_repository *sm_repo;
+
+	cl_git_pass(git_repository_init(&g_repo, "willaddsubmodule", false));
+
+
+	/* Create the submodule structure, clone into it and finalize */
+	cl_git_pass(git_submodule_add_setup(&sm, g_repo, cl_fixture("testrepo.git"), "testrepo", true));
+
+	clone_opts.repository_cb = just_return_repo;
+	clone_opts.repository_cb_payload = sm;
+	clone_opts.remote_cb = just_return_origin;
+	clone_opts.remote_cb_payload = sm;
+	cl_git_pass(git_clone(&sm_repo, cl_fixture("testrepo.git"), "testrepo", &clone_opts));
+	cl_git_pass(git_submodule_add_finalize(sm));
+	git_repository_free(sm_repo);
+	git_submodule_free(sm);
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_write_tree(&tree_id, index));
+	git_index_free(index);
+
+	cl_git_pass(git_signature_now(&sig, "Submoduler", "submoduler@local"));
+	cl_git_pass(git_commit_create_from_ids(&commit_id, g_repo, "HEAD", sig, sig, NULL, "A submodule\n",
+					       &tree_id, 0, NULL));
+
+	git_signature_free(sig);
+
+	assert_submodule_exists(g_repo, "testrepo");
 }


### PR DESCRIPTION
We have a few tests checking each step, but we do not yet have a test
which tests the documented workflow for creating a submodule, namely
`setup_add` followed by cloning into it, followed by `add_finalize`.

Add such a test to protect against regressions in this workflow.