### PR TITLE
index: make the entries have more accurate sizes

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -24,9 +24,9 @@ GIT_BEGIN_DECL
 
 /** Time structure used in a git index entry */
 typedef struct {
-	git_time_t seconds;
+	int32_t seconds;
 	/* nsec should not be stored as time_t compatible */
-	unsigned int nanoseconds;
+	uint32_t nanoseconds;
 } git_index_time;
 
 /**
@@ -44,22 +44,27 @@ typedef struct {
  * accessed via the later `GIT_IDXENTRY_...` bitmasks below.  Some of
  * these flags are read from and written to disk, but some are set aside
  * for in-memory only reference.
+ *
+ * Note that the time and size fields are truncated to 32 bits. This
+ * is enough to detect changes, which is enough for the index to
+ * function as a cache, but it should not be taken as an authoritative
+ * source for that data.
  */
 typedef struct git_index_entry {
 	git_index_time ctime;
 	git_index_time mtime;
 
-	unsigned int dev;
-	unsigned int ino;
-	unsigned int mode;
-	unsigned int uid;
-	unsigned int gid;
-	git_off_t file_size;
+	uint32_t dev;
+	uint32_t ino;
+	uint32_t mode;
+	uint32_t uid;
+	uint32_t gid;
+	uint32_t file_size;
 
 	git_oid id;
 
-	unsigned short flags;
-	unsigned short flags_extended;
+	uint16_t flags;
+	uint16_t flags_extended;
 
 	const char *path;
 } git_index_entry;


### PR DESCRIPTION
While we are confident about the size of an int in architectures we're
likely to care about, the index format is defined by the exact size of
the fields. Use the definitions which show the exact width of the entry
fields.

As part of that, bring back 32-bit time and size fields, which currently
are 64 bits wide and can bring a false sense of security in how much
data they really store. Document that these fields are not to be taken
as authoritative.

---

Funnily enough, this doesn't throw any warnings during compilation, which means that we're already using these sizes internally.