### PR TITLE
odb: reverse the default backend priorities

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -21,9 +21,12 @@
 
 #define GIT_ALTERNATES_FILE "info/alternates"
 
-/* TODO: is this correct? */
-#define GIT_LOOSE_PRIORITY 2
-#define GIT_PACKED_PRIORITY 1
+/*
+ * We work under the assumption that most objects for long-running
+ * operations will be packed
+ */
+#define GIT_LOOSE_PRIORITY 1
+#define GIT_PACKED_PRIORITY 2
 
 #define GIT_ALTERNATES_MAX_DEPTH 5
 


### PR DESCRIPTION
We currently first look in the loose object dir and then in the packs
for objects. When performing operations on recent history this has a
higher likelihood of hitting, but when we deal with operations which
look further back into the past, we start spending a large amount of
time getting ENOTENT from `access`.

Reversing the priorities means that long-running operations can get to
their objects faster, as we can look at the index data we have in memory
(or rather mapped) to figure out whether we have an object, which is
faster than going out to the filesystem.

The packed backend already implements an optimistic read algorithm by
first looking at the packs we know about and only going out to disk to
referesh if the object is not found which means that in the case where
we do have the object (which will be in the majority for anything that
traverses the graph) we can avoid going to to disk entirely to determine
whether an object exists.

Operations which look at recent history may take a slight impact, but
these would be operations which look a lot less at object and thus take
less time regardless.

---

The time where we might hit an actual perf regression would be where we keep looking over and over at hundreds or thousands of objects which are all loose, but considering that git will auto-gc when this kind of thing happens, I don't know that you can have such a use-case without being very wasteful of the data you read.