### PR TITLE
Better test support for non-system volumes on Windows

### DIFF
--- a/tests/checkout/icase.c
+++ b/tests/checkout/icase.c
@@ -100,7 +100,11 @@ static void assert_name_is(const char *expected)
 	char *actual;
 	size_t actual_len, expected_len, start;
 
+	if (!cl_sandbox_supports_8dot3())
+		clar__skip();
+
 	cl_assert(actual = get_filename(expected));
+	cl_assert(actual = test_realpath(expected));
 
 	expected_len = strlen(expected);
 	actual_len = strlen(actual);

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -558,5 +558,36 @@ bool cl_sandbox_supports_8dot3(void)
 
 	return supported;
 }
+
+bool cl_sandbox_supports_reparse_points(void)
+{
+	unsigned int flags = 0;
+	char path[8];
+	char drive = 'A' + _getdrive() - 1;
+
+	sprintf(path, "%c:\\", drive);
+
+	GetVolumeInformation(path, NULL, 0, NULL, NULL, &flags, NULL, 0);
+
+	return flags & FILE_SUPPORTS_REPARSE_POINTS;
+}
 #endif
 
+bool cl_sandbox_supports_links(void)
+{
+#ifdef GIT_WIN32
+	unsigned int path_flags = 0;
+	unsigned int cl_flags = 0;
+	char path[8];
+	char drive = 'A' + _getdrive() - 1;
+
+	sprintf(path, "%c:\\", drive);
+
+	GetVolumeInformation(_cl_sandbox, NULL, 0, NULL, NULL, &cl_flags, NULL, 0);
+	GetVolumeInformation(path, NULL, 0, NULL, NULL, &path_flags, NULL, 0);
+
+	return cl_flags & path_flags & FILE_SUPPORTS_HARD_LINKS;
+#else
+	return true;
+#endif
+}

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -163,6 +163,9 @@ void cl_sandbox_set_search_path_defaults(void);
 
 #ifdef GIT_WIN32
 bool cl_sandbox_supports_8dot3(void);
+bool cl_sandbox_supports_reparse_points(void);
 #endif
+
+bool cl_sandbox_supports_links(void);
 
 #endif

--- a/tests/core/link.c
+++ b/tests/core/link.c
@@ -223,7 +223,7 @@ void test_core_link__stat_symlink(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	cl_git_rewritefile("stat_target", "This is the target of a symbolic link.\n");
@@ -242,7 +242,7 @@ void test_core_link__stat_symlink_directory(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	p_mkdir("stat_dirtarget", 0777);
@@ -259,7 +259,7 @@ void test_core_link__stat_symlink_chain(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	cl_git_rewritefile("stat_final_target", "Final target of some symbolic links...\n");
@@ -276,7 +276,7 @@ void test_core_link__stat_dangling_symlink(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	do_symlink("stat_nonexistent", "stat_dangling", 0);
@@ -289,7 +289,7 @@ void test_core_link__stat_dangling_symlink_directory(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	do_symlink("stat_nonexistent", "stat_dangling_dir", 1);
@@ -303,7 +303,7 @@ void test_core_link__lstat_symlink(void)
 	git_buf target_path = GIT_BUF_INIT;
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	/* Windows always writes the canonical path as the link target, so
@@ -330,7 +330,7 @@ void test_core_link__lstat_symlink_directory(void)
 	git_buf target_path = GIT_BUF_INIT;
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "lstat_dirtarget");
@@ -352,7 +352,7 @@ void test_core_link__lstat_dangling_symlink(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	do_symlink("lstat_nonexistent", "lstat_dangling", 0);
@@ -368,7 +368,7 @@ void test_core_link__lstat_dangling_symlink_directory(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	do_symlink("lstat_nonexistent", "lstat_dangling_dir", 1);
@@ -385,6 +385,9 @@ void test_core_link__stat_junction(void)
 #ifdef GIT_WIN32
 	git_buf target_path = GIT_BUF_INIT;
 	struct stat st;
+
+	if (!cl_sandbox_supports_links())
+		clar__skip();
 
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "stat_junctarget");
 
@@ -407,6 +410,9 @@ void test_core_link__stat_dangling_junction(void)
 	git_buf target_path = GIT_BUF_INIT;
 	struct stat st;
 
+	if (!cl_sandbox_supports_links())
+		clar__skip();
+
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "stat_nonexistent_junctarget");
 
 	p_mkdir("stat_nonexistent_junctarget", 0777);
@@ -426,6 +432,9 @@ void test_core_link__lstat_junction(void)
 #ifdef GIT_WIN32
 	git_buf target_path = GIT_BUF_INIT;
 	struct stat st;
+
+	if (!cl_sandbox_supports_links())
+		clar__skip();
 
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "lstat_junctarget");
 
@@ -448,6 +457,9 @@ void test_core_link__lstat_dangling_junction(void)
 	git_buf target_path = GIT_BUF_INIT;
 	struct stat st;
 
+	if (!cl_sandbox_supports_links())
+		clar__skip();
+
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "lstat_nonexistent_junctarget");
 
 	p_mkdir("lstat_nonexistent_junctarget", 0777);
@@ -469,7 +481,7 @@ void test_core_link__stat_hardlink(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	cl_git_rewritefile("stat_hardlink1", "This file has many names!\n");
@@ -488,7 +500,7 @@ void test_core_link__lstat_hardlink(void)
 {
 	struct stat st;
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	cl_git_rewritefile("lstat_hardlink1", "This file has many names!\n");
@@ -508,6 +520,9 @@ void test_core_link__stat_reparse_point(void)
 #ifdef GIT_WIN32
 	struct stat st;
 
+	if (!cl_sandbox_supports_reparse_points())
+		clar__skip();
+
 	/* Generic reparse points should be treated as regular files, only
 	 * symlinks and junctions should be treated as links.
 	 */
@@ -525,6 +540,9 @@ void test_core_link__lstat_reparse_point(void)
 {
 #ifdef GIT_WIN32
 	struct stat st;
+
+	if (!cl_sandbox_supports_reparse_points())
+		clar__skip();
 
 	cl_git_rewritefile("lstat_reparse", "This is a reparse point!\n");
 	do_custom_reparse("lstat_reparse");
@@ -558,7 +576,7 @@ void test_core_link__readlink_symlink(void)
 	int len;
 	char buf[2048];
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "readlink_target");
@@ -582,7 +600,7 @@ void test_core_link__readlink_dangling(void)
 	int len;
 	char buf[2048];
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "readlink_nonexistent");
@@ -606,7 +624,7 @@ void test_core_link__readlink_multiple(void)
 	int len;
 	char buf[2048];
 
-	if (!should_run())
+	if (!should_run() || !cl_sandbox_supports_links())
 		clar__skip();
 
 	git_buf_join(&target_path, '/', clar_sandbox_path(), "readlink_final");

--- a/tests/path/win32.c
+++ b/tests/path/win32.c
@@ -97,9 +97,16 @@ void test_path_win32__dot_and_dotdot(void)
 void test_path_win32__absolute_from_no_drive_letter(void)
 {
 #ifdef GIT_WIN32
+	char cwd_backup[MAX_PATH];
+
+	cl_must_pass(p_getcwd(cwd_backup, MAX_PATH));
+	cl_must_pass(p_chdir("C:/"));
+
 	test_utf8_to_utf16("\\Foo", L"\\\\?\\C:\\Foo");
 	test_utf8_to_utf16("\\Foo\\Bar", L"\\\\?\\C:\\Foo\\Bar");
 	test_utf8_to_utf16("/Foo/Bar", L"\\\\?\\C:\\Foo\\Bar");
+
+	cl_must_pass(p_chdir(cwd_backup));
 #endif
 }
 

--- a/tests/repo/reservedname.c
+++ b/tests/repo/reservedname.c
@@ -13,6 +13,9 @@ void test_repo_reservedname__includes_shortname_on_win32(void)
 	git_buf *reserved;
 	size_t reserved_len;
 
+	if (!cl_sandbox_supports_8dot3())
+		clar__skip();
+
 	repo = cl_git_sandbox_init("nasty");
 	cl_assert(git_repository__reserved_names(&reserved, &reserved_len, repo, false));
 
@@ -31,6 +34,9 @@ void test_repo_reservedname__includes_shortname_when_requested(void)
 	git_repository *repo;
 	git_buf *reserved;
 	size_t reserved_len;
+
+	if (!cl_sandbox_supports_8dot3())
+		clar__skip();
 
 	repo = cl_git_sandbox_init("nasty");
 	cl_assert(git_repository__reserved_names(&reserved, &reserved_len, repo, true));


### PR DESCRIPTION
Many non-system volumes do not support 8.3 short names, disabling testing on volumes that do not support the feature.

Many non-systems volumes do not support links (aka reparse points and/or junctions), disabling testing on volumes that do not support the feature.
