### PR TITLE
Examples cleanup

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,17 @@ ELSE()
 	TARGET_LINK_LIBRARIES(cgit2 git2 pthread)
 ENDIF()
 
+# Use -Wno-declaration-after-statement -Wunused-but-set-variable on global.c
+FOREACH(warn declaration-after-statement unused-but-set-variable)
+	SET(no_warn "-Wno-${warn}")
+	STRING(TOUPPER ${warn} _UPCASE)
+	SET(_var "IS_WNO_${_UPCASE}_SUPPORTED")
+	CHECK_C_COMPILER_FLAG(${no_warn} ${_var})
+	IF(${_var})
+		SET_PROPERTY(SOURCE general.c APPEND_STRING PROPERTY COMPILE_FLAGS " ${no_warn}")
+	ENDIF()
+ENDFOREACH()
+
 FILE(GLOB SRC_EXAMPLE_APPS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c)
 FOREACH(src_app ${SRC_EXAMPLE_APPS})
 	STRING(REPLACE ".c" "" app_name ${src_app})

--- a/examples/blame.c
+++ b/examples/blame.c
@@ -37,7 +37,8 @@ static void parse_opts(struct opts *o, int argc, char *argv[]);
 
 int main(int argc, char *argv[])
 {
-	int i, line, break_on_null_hunk;
+	unsigned int i;
+	int line, break_on_null_hunk;
 	size_t rawsize;
 	char spec[1024] = {0};
 	struct opts o = {0};

--- a/examples/common.c
+++ b/examples/common.c
@@ -127,6 +127,25 @@ static const char *match_numeric_arg(struct args_info *args, const char *opt)
 	return found;
 }
 
+int match_uint32_arg(
+	uint32_t *out, struct args_info *args, const char *opt)
+{
+	const char *found = match_numeric_arg(args, opt);
+	uint32_t val;
+	char *endptr = NULL;
+
+	if (!found)
+		return 0;
+
+	val = (uint32_t)strtoul(found, &endptr, 0);
+	if (!endptr || *endptr != '\0')
+		fatal("expected number after argument", opt);
+
+	if (out)
+		*out = val;
+	return 1;
+}
+
 int match_uint16_arg(
 	uint16_t *out, struct args_info *args, const char *opt)
 {

--- a/examples/common.h
+++ b/examples/common.h
@@ -73,6 +73,15 @@ extern int match_uint16_arg(
 	uint16_t *out, struct args_info *args, const char *opt);
 
 /**
+ * Check current `args` entry against `opt` string parsing as uint32.  If
+ * `opt` matches exactly, take the next arg as a uint32_t value; if `opt`
+ * is a prefix (equal sign optional), take the remainder of the arg as a
+ * uint32_t value; otherwise return 0.
+ */
+extern int match_uint32_arg(
+	uint32_t *out, struct args_info *args, const char *opt);
+
+/**
  * Check current `args` entry against `opt` string parsing as int.  If
  * `opt` matches exactly, take the next arg as an int value; if it matches
  * as a prefix (equal sign optional), take the remainder of the arg as a

--- a/examples/diff.c
+++ b/examples/diff.c
@@ -293,11 +293,11 @@ static void parse_opts(struct opts *o, int argc, char *argv[])
 		else if (is_prefixed(a, "-B") || is_prefixed(a, "--break-rewrites"))
 			/* TODO: parse thresholds */
 			o->findopts.flags |= GIT_DIFF_FIND_REWRITES;
-		else if (!match_uint16_arg(
+		else if (!match_uint32_arg(
 				&o->diffopts.context_lines, &args, "-U") &&
-			!match_uint16_arg(
+			!match_uint32_arg(
 				&o->diffopts.context_lines, &args, "--unified") &&
-			!match_uint16_arg(
+			!match_uint32_arg(
 				&o->diffopts.interhunk_lines, &args, "--inter-hunk-context") &&
 			!match_uint16_arg(
 				&o->diffopts.id_abbrev, &args, "--abbrev") &&

--- a/examples/log.c
+++ b/examples/log.c
@@ -340,14 +340,14 @@ static void print_time(const git_time *intime, const char *prefix)
 static void print_commit(git_commit *commit)
 {
 	char buf[GIT_OID_HEXSZ + 1];
-	int i, count;
+	unsigned int i, count;
 	const git_signature *sig;
 	const char *scan, *eol;
 
 	git_oid_tostr(buf, sizeof(buf), git_commit_id(commit));
 	printf("commit %s\n", buf);
 
-	if ((count = (int)git_commit_parentcount(commit)) > 1) {
+	if ((count = git_commit_parentcount(commit)) > 1) {
 		printf("Merge:");
 		for (i = 0; i < count; ++i) {
 			git_oid_tostr(buf, 8, git_commit_parent_id(commit, i));


### PR DESCRIPTION
Reduce the number of warnings in `examples/`

A commit that touches the code outside `examples/` will be pushed as a separate pull request.