### PR TITLE
Added git_repository_precompose_path()

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -749,6 +749,19 @@ GIT_EXTERN(int) git_repository_ident(const char **name, const char **email, cons
  */
 GIT_EXTERN(int) git_repository_set_ident(git_repository *repo, const char *name, const char *email);
 
+/**
+ * Revert the unicode decomposition of a path
+ *
+ * This function simply copies the path unmodified if libgit2 was built without
+ * iconv support or if "core.precomposeUnicode" is not set to true in the
+ * repository's configuration.
+ *
+ * @param repo the repository
+ * @param path the path to precompose
+ * @param out the buffer to write the precomposed path into
+ */
+GIT_EXTERN(int) git_repository_precompose_path(git_repository *repo, const char *path, git_buf *out);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/tests/repo/config.c
+++ b/tests/repo/config.c
@@ -209,3 +209,26 @@ void test_repo_config__read_with_no_configs_at_all(void)
 	cl_assert(!git_path_exists("empty_standard_repo/.git/config"));
 	cl_assert(!git_path_exists("alternate/3/.gitconfig"));
 }
+
+void test_repo_config__precompose_paths(void)
+{
+	char *composed = "ḱṷṓn", *decomposed = "ḱṷṓn";
+	git_repository *repo;
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
+
+	cl_repo_set_bool(repo, "core.precomposeunicode", false);
+	cl_git_pass(git_repository_precompose_path(repo, decomposed, &buf));
+	cl_assert(!strcmp(buf.ptr, decomposed));
+
+	cl_repo_set_bool(repo, "core.precomposeunicode", true);
+	cl_git_pass(git_repository_precompose_path(repo, decomposed, &buf));
+#ifdef GIT_USE_ICONV
+	cl_assert(!strcmp(buf.ptr, composed));
+#else
+	cl_assert(!strcmp(buf.ptr, decomposed));
+#endif
+
+	git_repository_free(repo);
+}


### PR DESCRIPTION
This exposes the internal APIs used by libgit2 to handle path precomposition on OS X.

I realized this was needed as I hit the same roadblock as described in #2268.