### PR TITLE
Pass current remote to git_push_negotiation callback

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -379,10 +379,11 @@ typedef struct {
 /**
  * @param updates an array containing the updates which will be sent
  * as commands to the destination.
+ * @param the remote being pushed
  * @param len number of elements in `updates`
  * @param payload Payload provided by the caller
  */
-typedef int (*git_push_negotiation)(const git_push_update **updates, size_t len, void *payload);
+typedef int (*git_push_negotiation)(git_remote *remote, const git_push_update **updates, size_t len, void *payload);
 
 /**
  * The callback settings structure

--- a/src/push.c
+++ b/src/push.c
@@ -601,7 +601,7 @@ static int do_push(git_push *push, const git_remote_callbacks *callbacks)
 		goto on_error;
 
 	if (callbacks && callbacks->push_negotiation &&
-	    (error = callbacks->push_negotiation((const git_push_update **) push->updates.contents,
+	    (error = callbacks->push_negotiation(push->remote, (const git_push_update **) push->updates.contents,
 					  push->updates.length, callbacks->payload)) < 0)
 	    goto on_error;
 


### PR DESCRIPTION
This makes it quite easier to implement the Git 'pre-push' hook.