### PR TITLE
Add `const` qualifier

### DIFF
--- a/include/git2/describe.h
+++ b/include/git2/describe.h
@@ -94,7 +94,7 @@ typedef struct {
 	 * If the workdir is dirty and this is set, this string will
 	 * be appended to the description string.
 	 */
-	char *dirty_suffix;
+	const char *dirty_suffix;
 } git_describe_format_options;
 
 #define GIT_DESCRIBE_FORMAT_OPTIONS_VERSION 1


### PR DESCRIPTION
This fixes a warning in `examples/describe.c` without breaking the main build.

OTOH, I'm not sure if this is an API-compatible change.