### PR TITLE
Include conflicts when diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ support for HTTPS connections insead of OpenSSL.
   the error message, which allows you to get the "repository not
   found" messages.
 
+* `git_index_conflict_add()` will remove staged entries that exist for
+  conflicted paths.
 
 ### API additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ support for HTTPS connections insead of OpenSSL.
 * `git_index_conflict_add()` will remove staged entries that exist for
   conflicted paths.
 
+* The flags for a `git_diff_file` will now have the `GIT_DIFF_FLAG_EXISTS`
+  bit set when a file exists on that side of the diff.  This is useful
+  for understanding whether a side of the diff exists in the presence of
+  a conflict.
+
 ### API additions
 
 * The `git_merge_options` gained a `file_flags` member.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,14 @@ support for HTTPS connections insead of OpenSSL.
   configuration of the server, and tools can use this to show messages
   about failing to communicate with the server.
 
+* `git_diff_index_to_workdir()` and `git_diff_tree_to_index()` will now
+  produce deltas of type `GIT_DELTA_CONFLICTED` to indicate that the index
+  side of the delta is a conflict.
+
+* The `git_status` family of functions will now produce status of type
+  `GIT_STATUS_CONFLICTED` to indicate that a conflict exists for that file
+  in the index.
+
 ### API removals
 
 * `git_remote_save()` and `git_remote_clear_refspecs()` has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ support for HTTPS connections insead of OpenSSL.
   `GIT_STATUS_CONFLICTED` to indicate that a conflict exists for that file
   in the index.
 
+* `git_index_entry_is_conflict()` is a utility function to determine if
+  a given index entry has a non-zero stage entry, indicating that it is
+  one side of a conflict.
+
 ### API removals
 
 * `git_remote_save()` and `git_remote_clear_refspecs()` has been

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -239,16 +239,17 @@ typedef enum {
  * DELETED pairs).
  */
 typedef enum {
-	GIT_DELTA_UNMODIFIED = 0, /**< no changes */
-	GIT_DELTA_ADDED = 1,	  /**< entry does not exist in old version */
-	GIT_DELTA_DELETED = 2,	  /**< entry does not exist in new version */
-	GIT_DELTA_MODIFIED = 3,   /**< entry content changed between old and new */
-	GIT_DELTA_RENAMED = 4,    /**< entry was renamed between old and new */
-	GIT_DELTA_COPIED = 5,     /**< entry was copied from another old entry */
-	GIT_DELTA_IGNORED = 6,    /**< entry is ignored item in workdir */
-	GIT_DELTA_UNTRACKED = 7,  /**< entry is untracked item in workdir */
-	GIT_DELTA_TYPECHANGE = 8, /**< type of entry changed between old and new */
-	GIT_DELTA_UNREADABLE = 9, /**< entry is unreadable */
+	GIT_DELTA_UNMODIFIED = 0,  /**< no changes */
+	GIT_DELTA_ADDED = 1,	   /**< entry does not exist in old version */
+	GIT_DELTA_DELETED = 2,	   /**< entry does not exist in new version */
+	GIT_DELTA_MODIFIED = 3,    /**< entry content changed between old and new */
+	GIT_DELTA_RENAMED = 4,     /**< entry was renamed between old and new */
+	GIT_DELTA_COPIED = 5,      /**< entry was copied from another old entry */
+	GIT_DELTA_IGNORED = 6,     /**< entry is ignored item in workdir */
+	GIT_DELTA_UNTRACKED = 7,   /**< entry is untracked item in workdir */
+	GIT_DELTA_TYPECHANGE = 8,  /**< type of entry changed between old and new */
+	GIT_DELTA_UNREADABLE = 9,  /**< entry is unreadable */
+	GIT_DELTA_CONFLICTED = 10, /**< entry in the index is conflicted */
 } git_delta_t;
 
 /**

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -226,6 +226,7 @@ typedef enum {
 	GIT_DIFF_FLAG_BINARY     = (1u << 0), /**< file(s) treated as binary data */
 	GIT_DIFF_FLAG_NOT_BINARY = (1u << 1), /**< file(s) treated as text data */
 	GIT_DIFF_FLAG_VALID_ID   = (1u << 2), /**< `id` value is known correct */
+	GIT_DIFF_FLAG_EXISTS     = (1u << 3), /**< file exists at this side of the delta */
 } git_diff_flag_t;
 
 /**

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -631,7 +631,8 @@ GIT_EXTERN(int) git_index_find(size_t *at_pos, git_index *index, const char *pat
 /**@{*/
 
 /**
- * Add or update index entries to represent a conflict
+ * Add or update index entries to represent a conflict.  Any staged
+ * entries that exist at the given paths will be removed.
  *
  * The entries are the entries from the tree included in the merge.  Any
  * entry may be null to indicate that that file was not present in the

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -430,6 +430,15 @@ GIT_EXTERN(int) git_index_add(git_index *index, const git_index_entry *source_en
  */
 GIT_EXTERN(int) git_index_entry_stage(const git_index_entry *entry);
 
+/**
+ * Return whether the given index entry is a conflict (has a high stage
+ * entry).  This is simply shorthand for `git_index_entry_stage > 0`.
+ *
+ * @param entry The entry
+ * @return 1 if the entry is a conflict entry, 0 otherwise
+ */
+GIT_EXTERN(int) git_index_entry_is_conflict(const git_index_entry *entry);
+
 /**@}*/
 
 /** @name Workdir Index Entry Functions

--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -46,6 +46,7 @@ typedef enum {
 	GIT_STATUS_WT_UNREADABLE    = (1u << 12),
 
 	GIT_STATUS_IGNORED          = (1u << 14),
+	GIT_STATUS_CONFLICTED       = (1u << 15),
 } git_status_t;
 
 /**

--- a/src/diff.c
+++ b/src/diff.c
@@ -766,43 +766,45 @@ static int maybe_modified(
 
 	/* if one side is a conflict, mark the whole delta as conflicted */
 	if (git_index_entry_is_conflict(oitem) ||
-		git_index_entry_is_conflict(nitem))
+			git_index_entry_is_conflict(nitem)) {
 		status = GIT_DELTA_CONFLICTED;
 
 	/* support "assume unchanged" (poorly, b/c we still stat everything) */
-	else if ((oitem->flags & GIT_IDXENTRY_VALID) != 0)
+	} else if ((oitem->flags & GIT_IDXENTRY_VALID) != 0) {
 		status = GIT_DELTA_UNMODIFIED;
 
 	/* support "skip worktree" index bit */
-	else if ((oitem->flags_extended & GIT_IDXENTRY_SKIP_WORKTREE) != 0)
+	} else if ((oitem->flags_extended & GIT_IDXENTRY_SKIP_WORKTREE) != 0) {
 		status = GIT_DELTA_UNMODIFIED;
 
 	/* if basic type of file changed, then split into delete and add */
-	else if (GIT_MODE_TYPE(omode) != GIT_MODE_TYPE(nmode)) {
-		if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_INCLUDE_TYPECHANGE))
+	} else if (GIT_MODE_TYPE(omode) != GIT_MODE_TYPE(nmode)) {
+		if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_INCLUDE_TYPECHANGE)) {
 			status = GIT_DELTA_TYPECHANGE;
+		}
+
 		else if (nmode == GIT_FILEMODE_UNREADABLE) {
 			if (!(error = diff_delta__from_one(diff, GIT_DELTA_DELETED, oitem, NULL)))
 				error = diff_delta__from_one(diff, GIT_DELTA_UNREADABLE, NULL, nitem);
 			return error;
 		}
+
 		else {
 			if (!(error = diff_delta__from_one(diff, GIT_DELTA_DELETED, oitem, NULL)))
 				error = diff_delta__from_one(diff, GIT_DELTA_ADDED, NULL, nitem);
 			return error;
 		}
-	}
 
 	/* if oids and modes match (and are valid), then file is unmodified */
-	else if (git_oid_equal(&oitem->id, &nitem->id) &&
+	} else if (git_oid_equal(&oitem->id, &nitem->id) &&
 			 omode == nmode &&
-			 !git_oid_iszero(&oitem->id))
+			 !git_oid_iszero(&oitem->id)) {
 		status = GIT_DELTA_UNMODIFIED;
 
 	/* if we have an unknown OID and a workdir iterator, then check some
 	 * circumstances that can accelerate things or need special handling
 	 */
-	else if (git_oid_iszero(&nitem->id) && new_is_workdir) {
+	} else if (git_oid_iszero(&nitem->id) && new_is_workdir) {
 		bool use_ctime = ((diff->diffcaps & GIT_DIFFCAPS_TRUST_CTIME) != 0);
 		bool use_nanos = ((diff->diffcaps & GIT_DIFFCAPS_TRUST_NANOSECS) != 0);
 
@@ -833,12 +835,12 @@ static int maybe_modified(
 			status = GIT_DELTA_MODIFIED;
 			modified_uncertain = true;
 		}
-	}
 
 	/* if mode is GITLINK and submodules are ignored, then skip */
-	else if (S_ISGITLINK(nmode) &&
-			 DIFF_FLAG_IS_SET(diff, GIT_DIFF_IGNORE_SUBMODULES))
+	} else if (S_ISGITLINK(nmode) &&
+			 DIFF_FLAG_IS_SET(diff, GIT_DIFF_IGNORE_SUBMODULES)) {
 		status = GIT_DELTA_UNMODIFIED;
+	}
 
 	/* if we got here and decided that the files are modified, but we
 	 * haven't calculated the OID of the new item, then calculate it now
@@ -847,6 +849,7 @@ static int maybe_modified(
 		const git_oid *update_check =
 			DIFF_FLAG_IS_SET(diff, GIT_DIFF_UPDATE_INDEX) && omode == nmode ?
 			&oitem->id : NULL;
+
 		if ((error = git_diff__oid_for_entry(
 				&noid, diff, nitem, update_check)) < 0)
 			return error;

--- a/src/diff.c
+++ b/src/diff.c
@@ -127,10 +127,12 @@ static int diff_delta__from_one(
 	if (has_old) {
 		delta->old_file.mode = entry->mode;
 		delta->old_file.size = entry->file_size;
+		delta->old_file.flags |= GIT_DIFF_FLAG_EXISTS;
 		git_oid_cpy(&delta->old_file.id, &entry->id);
 	} else /* ADDED, IGNORED, UNTRACKED */ {
 		delta->new_file.mode = entry->mode;
 		delta->new_file.size = entry->file_size;
+		delta->new_file.flags |= GIT_DIFF_FLAG_EXISTS;
 		git_oid_cpy(&delta->new_file.id, &entry->id);
 	}
 
@@ -184,13 +186,16 @@ static int diff_delta__from_two(
 		delta->old_file.size = old_entry->file_size;
 		delta->old_file.mode = old_mode;
 		git_oid_cpy(&delta->old_file.id, old_id);
-		delta->old_file.flags |= GIT_DIFF_FLAG_VALID_ID;
+		delta->old_file.flags |= GIT_DIFF_FLAG_VALID_ID |
+			GIT_DIFF_FLAG_EXISTS;
 	}
 
 	if (!git_index_entry_is_conflict(new_entry)) {
 		git_oid_cpy(&delta->new_file.id, new_id);
 		delta->new_file.size = new_entry->file_size;
 		delta->new_file.mode = new_mode;
+		delta->old_file.flags |= GIT_DIFF_FLAG_EXISTS;
+		delta->new_file.flags |= GIT_DIFF_FLAG_EXISTS;
 
 		if (!git_oid_iszero(&new_entry->id))
 			delta->new_file.flags |= GIT_DIFF_FLAG_VALID_ID;

--- a/src/index.c
+++ b/src/index.c
@@ -2670,7 +2670,8 @@ static int apply_each_file(const git_diff_delta *delta, float progress, void *pa
 	if (error < 0) /* actual error */
 		return error;
 
-	if (delta->status == GIT_DELTA_DELETED)
+	/* If the workdir item does not exist, remove it from the index. */
+	if ((delta->new_file.flags & GIT_DIFF_FLAG_EXISTS) == 0)
 		error = git_index_remove_bypath(data->index, path);
 	else
 		error = git_index_add_bypath(data->index, delta->new_file.path);

--- a/src/index.c
+++ b/src/index.c
@@ -1173,6 +1173,9 @@ int git_index_remove_bypath(git_index *index, const char *path)
 		ret != GIT_ENOTFOUND))
 		return ret;
 
+	if (ret == GIT_ENOTFOUND)
+		giterr_clear();
+
 	return 0;
 }
 

--- a/src/index.c
+++ b/src/index.c
@@ -1317,6 +1317,15 @@ int git_index_conflict_add(git_index *index,
 		(ret = index_entry_dup(&entries[2], INDEX_OWNER(index), their_entry)) < 0)
 		goto on_error;
 
+	/* Validate entries */
+	for (i = 0; i < 3; i++) {
+		if (entries[i] && !valid_filemode(entries[i]->mode)) {
+			giterr_set(GITERR_INDEX, "invalid filemode for stage %d entry",
+				i);
+			return -1;
+		}
+	}
+
 	/* Remove existing index entries for each path */
 	for (i = 0; i < 3; i++) {
 		if (entries[i] == NULL)

--- a/src/index.c
+++ b/src/index.c
@@ -1537,7 +1537,7 @@ int git_index_conflict_next(
 	while (iterator->cur < iterator->index->entries.length) {
 		entry = git_index_get_byindex(iterator->index, iterator->cur);
 
-		if (git_index_entry_stage(entry) > 0) {
+		if (git_index_entry_is_conflict(entry)) {
 			if ((len = index_conflict__get_byindex(
 				ancestor_out,
 				our_out,
@@ -2381,6 +2381,11 @@ static int write_index(git_index *index, git_filebuf *file)
 int git_index_entry_stage(const git_index_entry *entry)
 {
 	return GIT_IDXENTRY_STAGE(entry);
+}
+
+int git_index_entry_is_conflict(const git_index_entry *entry)
+{
+	return (GIT_IDXENTRY_STAGE(entry) > 0);
 }
 
 typedef struct read_tree_data {

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -674,7 +674,7 @@ static const git_index_entry *index_iterator__advance_over_conflicts(index_itera
 	const git_index_entry *ie = index_iterator__index_entry(ii);
 
 	if (!iterator__include_conflicts(ii)) {
-		while (ie && git_index_entry_stage(ie) != 0) {
+		while (ie && git_index_entry_is_conflict(ie)) {
 			ii->current++;
 			ie = index_iterator__index_entry(ii);
 		}

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -33,6 +33,8 @@ typedef enum {
 	GIT_ITERATOR_DONT_AUTOEXPAND  = (1u << 3),
 	/** convert precomposed unicode to decomposed unicode */
 	GIT_ITERATOR_PRECOMPOSE_UNICODE = (1u << 4),
+	/** include conflicts */
+	GIT_ITERATOR_INCLUDE_CONFLICTS = (1u << 5),
 } git_iterator_flag_t;
 
 typedef struct {

--- a/src/merge.c
+++ b/src/merge.c
@@ -2492,7 +2492,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 	for (i = 0; i < git_index_entrycount(index_new); i++) {
 		e = git_index_get_byindex(index_new, i);
 
-		if (git_index_entry_stage(e) != 0 &&
+		if (git_index_entry_is_conflict(e) &&
 			(git_vector_last(&paths) == NULL ||
 			strcmp(git_vector_last(&paths), e->path) != 0)) {
 
@@ -2544,7 +2544,7 @@ int git_merge__append_conflicts_to_merge_msg(
 	for (i = 0; i < git_index_entrycount(index); i++) {
 		const git_index_entry *e = git_index_get_byindex(index, i);
 
-		if (git_index_entry_stage(e) == 0)
+		if (!git_index_entry_is_conflict(e))
 			continue;
 
 		if (last == NULL || strcmp(e->path, last) != 0)

--- a/src/reset.c
+++ b/src/reset.c
@@ -63,6 +63,7 @@ int git_reset_default(
 
 		assert(delta->status == GIT_DELTA_ADDED ||
 			delta->status == GIT_DELTA_MODIFIED ||
+			delta->status == GIT_DELTA_CONFLICTED ||
 			delta->status == GIT_DELTA_DELETED);
 
 		error = git_index_conflict_remove(index, delta->old_file.path);

--- a/src/status.c
+++ b/src/status.c
@@ -44,6 +44,9 @@ static unsigned int index_delta2status(const git_diff_delta *head2idx)
 	case GIT_DELTA_TYPECHANGE:
 		st = GIT_STATUS_INDEX_TYPECHANGE;
 		break;
+	case GIT_DELTA_CONFLICTED:
+		st = GIT_STATUS_CONFLICTED;
+		break;
 	default:
 		break;
 	}
@@ -101,6 +104,9 @@ static unsigned int workdir_delta2status(
 		break;
 	case GIT_DELTA_TYPECHANGE:
 		st = GIT_STATUS_WT_TYPECHANGE;
+		break;
+	case GIT_DELTA_CONFLICTED:
+		st = GIT_STATUS_CONFLICTED;
 		break;
 	default:
 		break;

--- a/tests/checkout/conflict.c
+++ b/tests/checkout/conflict.c
@@ -102,7 +102,7 @@ static void create_index(struct checkout_index_entry *entries, size_t entries_le
 		memset(&entry, 0x0, sizeof(git_index_entry));
 
 		entry.mode = entries[i].mode;
-		entry.flags = entries[i].stage << GIT_IDXENTRY_STAGESHIFT;
+		GIT_IDXENTRY_STAGE_SET(&entry, entries[i].stage);
 		git_oid_fromstr(&entry.id, entries[i].oid_str);
 		entry.path = entries[i].path;
 

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -685,15 +685,15 @@ static void add_conflict(git_index *index, const char *path)
 	entry.path = path;
 
 	git_oid_fromstr(&entry.id, "d427e0b2e138501a3d15cc376077a3631e15bd46");
-	entry.flags = (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 1);
 	cl_git_pass(git_index_add(index, &entry));
 
 	git_oid_fromstr(&entry.id, "4e886e602529caa9ab11d71f86634bd1b6e0de10");
-	entry.flags = (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 2);
 	cl_git_pass(git_index_add(index, &entry));
 
 	git_oid_fromstr(&entry.id, "2bd0a343aeef7a2cf0d158478966a6e587ff3863");
-	entry.flags = (3 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 3);
 	cl_git_pass(git_index_add(index, &entry));
 }
 

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -893,16 +893,16 @@ static void create_conflict(const char *path)
 
 	memset(&entry, 0x0, sizeof(git_index_entry));
 	entry.mode = 0100644;
-	entry.flags = 1 << GIT_IDXENTRY_STAGESHIFT;
+	GIT_IDXENTRY_STAGE_SET(&entry, 1);
 	git_oid_fromstr(&entry.id, "d427e0b2e138501a3d15cc376077a3631e15bd46");
 	entry.path = path;
 	cl_git_pass(git_index_add(index, &entry));
 
-	entry.flags = 2 << GIT_IDXENTRY_STAGESHIFT;
+	GIT_IDXENTRY_STAGE_SET(&entry, 2);
 	git_oid_fromstr(&entry.id, "ee3fa1b8c00aff7fe02065fdb50864bb0d932ccf");
 	cl_git_pass(git_index_add(index, &entry));
 
-	entry.flags = 3 << GIT_IDXENTRY_STAGESHIFT;
+	GIT_IDXENTRY_STAGE_SET(&entry, 3);
 	git_oid_fromstr(&entry.id, "2bd0a343aeef7a2cf0d158478966a6e587ff3863");
 	cl_git_pass(git_index_add(index, &entry));
 

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -197,6 +197,14 @@ git_repository *cl_git_sandbox_init(const char *sandbox)
 	return _cl_repo;
 }
 
+git_repository *cl_git_sandbox_init_new(const char *sandbox)
+{
+	cl_git_pass(git_repository_init(&_cl_repo, sandbox, false));
+	_cl_sandbox = sandbox;
+
+	return _cl_repo;
+}
+
 git_repository *cl_git_sandbox_reopen(void)
 {
 	if (_cl_repo) {

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -127,6 +127,7 @@ int cl_rename(const char *source, const char *dest);
 /* Git sandbox setup helpers */
 
 git_repository *cl_git_sandbox_init(const char *sandbox);
+git_repository *cl_git_sandbox_init_new(const char *name);
 void cl_git_sandbox_cleanup(void);
 git_repository *cl_git_sandbox_reopen(void);
 

--- a/tests/diff/diff_helpers.c
+++ b/tests/diff/diff_helpers.c
@@ -68,7 +68,7 @@ int diff_file_cb(
 	if ((delta->flags & GIT_DIFF_FLAG_BINARY) != 0)
 		e->files_binary++;
 
-	cl_assert(delta->status <= GIT_DELTA_TYPECHANGE);
+	cl_assert(delta->status <= GIT_DELTA_CONFLICTED);
 
 	e->file_status[delta->status] += 1;
 

--- a/tests/diff/diff_helpers.h
+++ b/tests/diff/diff_helpers.h
@@ -8,7 +8,7 @@ typedef struct {
 	int files;
 	int files_binary;
 
-	int file_status[10]; /* indexed by git_delta_t value */
+	int file_status[11]; /* indexed by git_delta_t value */
 
 	int hunks;
 	int hunk_new_lines;

--- a/tests/index/collision.c
+++ b/tests/index/collision.c
@@ -57,7 +57,7 @@ void test_index_collision__add_with_highstage_1(void)
 	git_oid_fromstr(&entry.id, "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
 
 	entry.path = "a/b";
-	entry.flags = (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 2);
 	cl_git_pass(git_index_add(index, &entry));
 
 	/* create a blob beneath the previous tree entry */
@@ -67,7 +67,7 @@ void test_index_collision__add_with_highstage_1(void)
 
 	/* create another tree entry above the blob */
 	entry.path = "a/b";
-	entry.flags = (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 1);
 	cl_git_pass(git_index_add(index, &entry));
 
 	git_index_free(index);
@@ -89,17 +89,17 @@ void test_index_collision__add_with_highstage_2(void)
 	git_oid_fromstr(&entry.id, "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
 
 	entry.path = "a/b/c";
-	entry.flags = (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 1);
 	cl_git_pass(git_index_add(index, &entry));
 
 	/* create a blob beneath the previous tree entry */
 	entry.path = "a/b/c";
-	entry.flags = (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 2);
 	cl_git_pass(git_index_add(index, &entry));
 
 	/* create another tree entry above the blob */
 	entry.path = "a/b";
-	entry.flags = (3 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, 3);
 	cl_git_pass(git_index_add(index, &entry));
 
 	git_index_free(index);

--- a/tests/index/conflicts.c
+++ b/tests/index/conflicts.c
@@ -16,6 +16,7 @@ static git_index *repo_index;
 #define CONFLICTS_TWO_OUR_OID "8b3f43d2402825c200f835ca1762413e386fd0b2"
 #define CONFLICTS_TWO_THEIR_OID "220bd62631c8cf7a83ef39c6b94595f00517211e"
 
+#define TEST_STAGED_OID "beefdadafeedabedcafedeedbabedeadbeaddeaf"
 #define TEST_ANCESTOR_OID "f00ff00ff00ff00ff00ff00ff00ff00ff00ff00f"
 #define TEST_OUR_OID "b44bb44bb44bb44bb44bb44bb44bb44bb44bb44b"
 #define TEST_THEIR_OID "0123456789abcdef0123456789abcdef01234567"
@@ -94,6 +95,55 @@ void test_index_conflicts__add_fixes_incorrect_stage(void)
 	cl_assert(git_index_entry_stage(conflict_entry[0]) == 1);
 	cl_assert(git_index_entry_stage(conflict_entry[1]) == 2);
 	cl_assert(git_index_entry_stage(conflict_entry[2]) == 3);
+}
+
+void test_index_conflicts__add_removes_stage_zero(void)
+{
+	git_index_entry staged, ancestor_entry, our_entry, their_entry;
+	const git_index_entry *conflict_entry[3];
+
+	cl_assert(git_index_entrycount(repo_index) == 8);
+
+	memset(&staged, 0x0, sizeof(git_index_entry));
+	memset(&ancestor_entry, 0x0, sizeof(git_index_entry));
+	memset(&our_entry, 0x0, sizeof(git_index_entry));
+	memset(&their_entry, 0x0, sizeof(git_index_entry));
+
+	staged.mode = 0100644;
+	staged.path = "test-one.txt";
+	git_oid_fromstr(&staged.id, TEST_STAGED_OID);
+	cl_git_pass(git_index_add(repo_index, &staged));
+	cl_assert(git_index_entrycount(repo_index) == 9);
+
+	ancestor_entry.path = "test-one.txt";
+	ancestor_entry.mode = 0100644;
+	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
+	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
+
+	our_entry.path = "test-one.txt";
+	our_entry.mode = 0100644;
+	our_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
+	git_oid_fromstr(&our_entry.id, TEST_OUR_OID);
+
+	their_entry.path = "test-one.txt";
+	their_entry.mode = 0100644;
+	their_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
+	git_oid_fromstr(&their_entry.id, TEST_THEIR_OID);
+
+	cl_git_pass(git_index_conflict_add(repo_index, &ancestor_entry, &our_entry, &their_entry));
+
+	cl_assert(git_index_entrycount(repo_index) == 11);
+
+	cl_assert_equal_p(NULL, git_index_get_bypath(repo_index, "test-one.txt", 0));
+
+	cl_git_pass(git_index_conflict_get(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], repo_index, "test-one.txt"));
+
+	cl_assert_equal_oid(&ancestor_entry.id, &conflict_entry[0]->id);
+	cl_assert_equal_i(1, git_index_entry_stage(conflict_entry[0]));
+	cl_assert_equal_oid(&our_entry.id, &conflict_entry[1]->id);
+	cl_assert_equal_i(2, git_index_entry_stage(conflict_entry[1]));
+	cl_assert_equal_oid(&their_entry.id, &conflict_entry[2]->id);
+	cl_assert_equal_i(3, git_index_entry_stage(conflict_entry[2]));
 }
 
 void test_index_conflicts__get(void)

--- a/tests/index/conflicts.c
+++ b/tests/index/conflicts.c
@@ -48,17 +48,17 @@ void test_index_conflicts__add(void)
 
 	ancestor_entry.path = "test-one.txt";
 	ancestor_entry.mode = 0100644;
-	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&ancestor_entry, 1);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 
 	our_entry.path = "test-one.txt";
 	our_entry.mode = 0100644;
-	ancestor_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&our_entry, 2);
 	git_oid_fromstr(&our_entry.id, TEST_OUR_OID);
 
 	their_entry.path = "test-one.txt";
 	their_entry.mode = 0100644;
-	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&ancestor_entry, 2);
 	git_oid_fromstr(&their_entry.id, TEST_THEIR_OID);
 
 	cl_git_pass(git_index_conflict_add(repo_index, &ancestor_entry, &our_entry, &their_entry));
@@ -79,17 +79,17 @@ void test_index_conflicts__add_fixes_incorrect_stage(void)
 
 	ancestor_entry.path = "test-one.txt";
 	ancestor_entry.mode = 0100644;
-	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&ancestor_entry, 3);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 
 	our_entry.path = "test-one.txt";
 	our_entry.mode = 0100644;
-	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&our_entry, 1);
 	git_oid_fromstr(&our_entry.id, TEST_OUR_OID);
 
 	their_entry.path = "test-one.txt";
 	their_entry.mode = 0100644;
-	ancestor_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&their_entry, 2);
 	git_oid_fromstr(&their_entry.id, TEST_THEIR_OID);
 
 	cl_git_pass(git_index_conflict_add(repo_index, &ancestor_entry, &our_entry, &their_entry));
@@ -123,17 +123,17 @@ void test_index_conflicts__add_removes_stage_zero(void)
 
 	ancestor_entry.path = "test-one.txt";
 	ancestor_entry.mode = 0100644;
-	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&ancestor_entry, 3);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 
 	our_entry.path = "test-one.txt";
 	our_entry.mode = 0100644;
-	our_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&our_entry, 1);
 	git_oid_fromstr(&our_entry.id, TEST_OUR_OID);
 
 	their_entry.path = "test-one.txt";
 	their_entry.mode = 0100644;
-	their_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&their_entry, 2);
 	git_oid_fromstr(&their_entry.id, TEST_THEIR_OID);
 
 	cl_git_pass(git_index_conflict_add(repo_index, &ancestor_entry, &our_entry, &their_entry));
@@ -329,7 +329,7 @@ void test_index_conflicts__partial(void)
 
 	ancestor_entry.path = "test-one.txt";
 	ancestor_entry.mode = 0100644;
-	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&ancestor_entry, 1);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 
 	cl_git_pass(git_index_conflict_add(repo_index, &ancestor_entry, NULL, NULL));

--- a/tests/index/conflicts.c
+++ b/tests/index/conflicts.c
@@ -272,7 +272,7 @@ void test_index_conflicts__moved_to_reuc_on_add(void)
 		cl_assert(entry = git_index_get_byindex(repo_index, i));
 
 		if (strcmp(entry->path, "conflicts-one.txt") == 0)
-			cl_assert(git_index_entry_stage(entry) == 0);
+			cl_assert(!git_index_entry_is_conflict(entry));
 	}
 }
 
@@ -312,7 +312,7 @@ void test_index_conflicts__remove_all_conflicts(void)
 
 	for (i = 0; i < git_index_entrycount(repo_index); i++) {
 		cl_assert(entry = git_index_get_byindex(repo_index, i));
-		cl_assert(git_index_entry_stage(entry) == 0);
+		cl_assert(!git_index_entry_is_conflict(entry));
 	}
 }
 

--- a/tests/index/conflicts.c
+++ b/tests/index/conflicts.c
@@ -47,14 +47,17 @@ void test_index_conflicts__add(void)
 	memset(&their_entry, 0x0, sizeof(git_index_entry));
 
 	ancestor_entry.path = "test-one.txt";
+	ancestor_entry.mode = 0100644;
 	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 
 	our_entry.path = "test-one.txt";
+	our_entry.mode = 0100644;
 	ancestor_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&our_entry.id, TEST_OUR_OID);
 
 	their_entry.path = "test-one.txt";
+	their_entry.mode = 0100644;
 	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&their_entry.id, TEST_THEIR_OID);
 
@@ -75,14 +78,17 @@ void test_index_conflicts__add_fixes_incorrect_stage(void)
 	memset(&their_entry, 0x0, sizeof(git_index_entry));
 
 	ancestor_entry.path = "test-one.txt";
+	ancestor_entry.mode = 0100644;
 	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 
 	our_entry.path = "test-one.txt";
+	our_entry.mode = 0100644;
 	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&our_entry.id, TEST_OUR_OID);
 
 	their_entry.path = "test-one.txt";
+	their_entry.mode = 0100644;
 	ancestor_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&their_entry.id, TEST_THEIR_OID);
 
@@ -109,8 +115,8 @@ void test_index_conflicts__add_removes_stage_zero(void)
 	memset(&our_entry, 0x0, sizeof(git_index_entry));
 	memset(&their_entry, 0x0, sizeof(git_index_entry));
 
-	staged.mode = 0100644;
 	staged.path = "test-one.txt";
+	staged.mode = 0100644;
 	git_oid_fromstr(&staged.id, TEST_STAGED_OID);
 	cl_git_pass(git_index_add(repo_index, &staged));
 	cl_assert(git_index_entrycount(repo_index) == 9);
@@ -322,6 +328,7 @@ void test_index_conflicts__partial(void)
 	memset(&their_entry, 0x0, sizeof(git_index_entry));
 
 	ancestor_entry.path = "test-one.txt";
+	ancestor_entry.mode = 0100644;
 	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
 	git_oid_fromstr(&ancestor_entry.id, TEST_ANCESTOR_OID);
 

--- a/tests/merge/trees/trivial.c
+++ b/tests/merge/trees/trivial.c
@@ -71,7 +71,7 @@ static int merge_trivial_conflict_entrycount(git_index *index)
 	for (i = 0; i < git_index_entrycount(index); i++) {
 		cl_assert(entry = git_index_get_byindex(index, i));
 
-		if (git_index_entry_stage(entry) > 0)
+		if (git_index_entry_is_conflict(entry))
 			count++;
 	}
 

--- a/tests/merge/workdir/trivial.c
+++ b/tests/merge/workdir/trivial.c
@@ -66,7 +66,7 @@ static size_t merge_trivial_conflict_entrycount(void)
 	for (i = 0; i < git_index_entrycount(repo_index); i++) {
 		cl_assert(entry = git_index_get_byindex(repo_index, i));
 
-		if (git_index_entry_stage(entry) > 0)
+		if (git_index_entry_is_conflict(entry))
 			count++;
 	}
 

--- a/tests/object/tree/duplicateentries.c
+++ b/tests/object/tree/duplicateentries.c
@@ -126,17 +126,17 @@ static void add_fake_conflicts(git_index *index)
 
 	ancestor_entry.path = "duplicate";
 	ancestor_entry.mode = GIT_FILEMODE_BLOB;
-	ancestor_entry.flags |= (1 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&ancestor_entry, 1);
 	git_oid_fromstr(&ancestor_entry.id, "a8233120f6ad708f843d861ce2b7228ec4e3dec6");
 
 	our_entry.path = "duplicate";
 	our_entry.mode = GIT_FILEMODE_BLOB;
-	ancestor_entry.flags |= (2 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&our_entry, 2);
 	git_oid_fromstr(&our_entry.id, "45b983be36b73c0788dc9cbcb76cbb80fc7bb057");
 
 	their_entry.path = "duplicate";
 	their_entry.mode = GIT_FILEMODE_BLOB;
-	ancestor_entry.flags |= (3 << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&their_entry, 3);
 	git_oid_fromstr(&their_entry.id, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd");
 
 	cl_git_pass(git_index_conflict_add(index, &ancestor_entry, &our_entry, &their_entry));

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -108,7 +108,7 @@ static void index_entry_init(git_index *index, int side, git_oid *oid)
 	memset(&entry, 0x0, sizeof(git_index_entry));
 
 	entry.path = "conflicting_file";
-	entry.flags = (side << GIT_IDXENTRY_STAGESHIFT);
+	GIT_IDXENTRY_STAGE_SET(&entry, side);
 	entry.mode = 0100644;
 	git_oid_cpy(&entry.id, oid);
 

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -461,14 +461,17 @@ void test_status_worktree__conflict_with_diff3(void)
 	memset(&their_entry, 0x0, sizeof(git_index_entry));
 
 	ancestor_entry.path = "modified_file";
+	ancestor_entry.mode = 0100644;
 	git_oid_fromstr(&ancestor_entry.id,
 		"452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
 
 	our_entry.path = "modified_file";
+	our_entry.mode = 0100644;
 	git_oid_fromstr(&our_entry.id,
 		"452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
 
 	their_entry.path = "modified_file";
+	their_entry.mode = 0100644;
 	git_oid_fromstr(&their_entry.id,
 		"452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
 
@@ -614,14 +617,17 @@ void test_status_worktree__conflicted_item(void)
 	memset(&our_entry, 0x0, sizeof(git_index_entry));
 	memset(&their_entry, 0x0, sizeof(git_index_entry));
 
+	ancestor_entry.mode = 0100644;
 	ancestor_entry.path = "modified_file";
 	git_oid_fromstr(&ancestor_entry.id,
 		"452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
 
+	our_entry.mode = 0100644;
 	our_entry.path = "modified_file";
 	git_oid_fromstr(&our_entry.id,
 		"452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
 
+	their_entry.mode = 0100644;
 	their_entry.path = "modified_file";
 	git_oid_fromstr(&their_entry.id,
 		"452e4244b5d083ddf0460acf1ecc74db9dcfa11a");

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -487,7 +487,7 @@ void test_status_worktree__conflict_with_diff3(void)
 
 	cl_git_pass(git_status_file(&status, repo, "modified_file"));
 
-	cl_assert_equal_i(GIT_STATUS_INDEX_DELETED | GIT_STATUS_WT_NEW, status);
+	cl_assert_equal_i(GIT_STATUS_CONFLICTED, status);
 }
 
 static const char *filemode_paths[] = {
@@ -640,7 +640,7 @@ void test_status_worktree__conflicted_item(void)
 		&our_entry, &their_entry));
 
 	cl_git_pass(git_status_file(&status, repo, "modified_file"));
-	cl_assert_equal_i(GIT_STATUS_INDEX_DELETED|GIT_STATUS_WT_NEW, status);
+	cl_assert_equal_i(GIT_STATUS_CONFLICTED, status);
 
 	git_index_free(index);
 }

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -634,7 +634,7 @@ void test_status_worktree__conflicted_item(void)
 		&our_entry, &their_entry));
 
 	cl_git_pass(git_status_file(&status, repo, "modified_file"));
-	cl_assert_equal_i(GIT_STATUS_WT_MODIFIED, status);
+	cl_assert_equal_i(GIT_STATUS_INDEX_DELETED|GIT_STATUS_WT_NEW, status);
 
 	git_index_free(index);
 }


### PR DESCRIPTION
When diffing a tree with the index, or the index with the working directory, it is useful to know whether you have conflicts.  At present, we only look at zero-stage index entries when iterating the index, which has the effect of pretending as if conflicts don't exist at all.

This has generally been okay (even if bizarre), but by ignoring conflicts, a conflicted file might appear to be ignored (because it does not exist in the index).  This could cause a consumer to fail to add a conflict resolution when [using a mechanism that filters out ignored files during add](https://github.com/libgit2/libgit2sharp/blob/vNext/LibGit2Sharp/Repository.cs#L1640).

Add a new diff delta type, `CONFLICTED`, to return when a conflict exists in the index.  (Do not provide any of the `old_file` or `new_file` data during this case, since determining which ancestor / ours / theirs side to include would be impossible.)

This also updates status to include a new `CONFLICTED` entry.  This does *not* provide any more detailed information about the conflict (eg, "both added" or "both modified"), though I intend to add this later as an addition to the `git_status_entry` structure.  This was an important first-step in this.

I don't think that the lack of that means that we should wait to include this, though; this is a critical bug for consumers (like above) where resolved conflicts may not get added correctly.