### PR TITLE
Call the proper openssl API to be able to work with SNI servers

### DIFF
--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -243,10 +243,9 @@ int openssl_connect(git_stream *stream)
 		return ssl_set_error(st->ssl, ret);
 	}
 
-#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
-	// specify the host
-        SSL_set_tlsext_host_name(st->ssl, st->socket->host);
-#endif
+	/* specify the host in case SNI is needed */
+	SSL_set_tlsext_host_name(st->ssl, st->socket->host);
+
 	if ((ret = SSL_connect(st->ssl)) <= 0)
 		return ssl_set_error(st->ssl, ret);
 

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -243,6 +243,10 @@ int openssl_connect(git_stream *stream)
 		return ssl_set_error(st->ssl, ret);
 	}
 
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+	// specify the host
+        SSL_set_tlsext_host_name(st->ssl, st->socket->host);
+#endif
 	if ((ret = SSL_connect(st->ssl)) <= 0)
 		return ssl_set_error(st->ssl, ret);
 


### PR DESCRIPTION
This is an attempt to fix #3091. If you know a better place for that function call please let me know.