### PR TITLE
ignore: clear the error when matching a pattern negation

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -80,6 +80,7 @@ static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match
 	git_vector_foreach(rules, i, rule) {
 		if (!(rule->flags & GIT_ATTR_FNMATCH_HASWILD)) {
 			if (does_negate_pattern(rule, match)) {
+				error = 0;
 				*out = 1;
 				goto out;
 			}

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -1010,3 +1010,15 @@ void test_status_ignore__subdir_doesnt_match_above(void)
 	cl_git_pass(git_ignore_path_is_ignored(&ignored, g_repo, "src/SRC/test.txt"));
 	cl_assert_equal_i(icase, ignored);
 }
+
+void test_status_ignore__negate_exact_previous(void)
+{
+	int ignored;
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+
+	cl_git_mkfile("empty_standard_repo/.gitignore", "*.com\ntags\n!tags/\n.buildpath");
+	cl_git_mkfile("empty_standard_repo/.buildpath", "");
+	cl_git_pass(git_ignore_path_is_ignored(&ignored, g_repo, ".buildpath"));
+	cl_assert_equal_i(1, ignored);
+}


### PR DESCRIPTION
When we discover that we want to keep a negative rule, make sure to
clear the error variable, as it we otherwise return whatever was left by
the previous loop iteration.

This fixes #3143 