### PR TITLE
index_add_all: include untracked files in new subdirs

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -2683,7 +2683,10 @@ static int index_apply_to_wd_diff(git_index *index, int action, const git_strarr
 
 	opts.flags = GIT_DIFF_INCLUDE_TYPECHANGE;
 	if (action == INDEX_ACTION_ADDALL) {
-		opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_RECURSE_IGNORED_DIRS;
+		opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED |
+			GIT_DIFF_RECURSE_UNTRACKED_DIRS |
+			GIT_DIFF_RECURSE_IGNORED_DIRS;
+
 		if (flags == GIT_INDEX_ADD_FORCE)
 			opts.flags |= GIT_DIFF_INCLUDE_IGNORED;
 	}

--- a/src/index.c
+++ b/src/index.c
@@ -2684,8 +2684,7 @@ static int index_apply_to_wd_diff(git_index *index, int action, const git_strarr
 	opts.flags = GIT_DIFF_INCLUDE_TYPECHANGE;
 	if (action == INDEX_ACTION_ADDALL) {
 		opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED |
-			GIT_DIFF_RECURSE_UNTRACKED_DIRS |
-			GIT_DIFF_RECURSE_IGNORED_DIRS;
+			GIT_DIFF_RECURSE_UNTRACKED_DIRS;
 
 		if (flags == GIT_INDEX_ADD_FORCE)
 			opts.flags |= GIT_DIFF_INCLUDE_IGNORED;

--- a/tests/index/addall.c
+++ b/tests/index/addall.c
@@ -282,6 +282,29 @@ void test_index_addall__repo_lifecycle(void)
 	git_index_free(index);
 }
 
+void test_index_addall__files_in_folders(void)
+{
+	git_index *index;
+	git_strarray paths = { NULL, 0 };
+
+	addall_create_test_repo(true);
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_pass(git_index_add_all(index, NULL, 0, NULL, NULL));
+	check_stat_data(index, TEST_DIR "/file.bar", true);
+	check_status(g_repo, 2, 0, 0, 0, 0, 0, 1);
+
+	cl_must_pass(p_mkdir(TEST_DIR "/subdir", 0777));
+	cl_git_mkfile(TEST_DIR "/subdir/file", "hello!\n");
+	check_status(g_repo, 2, 0, 0, 1, 0, 0, 1);
+
+	cl_git_pass(git_index_add_all(index, NULL, 0, NULL, NULL));
+	check_status(g_repo, 3, 0, 0, 0, 0, 0, 1);
+
+	git_index_free(index);
+}
+
 static int addall_match_prefix(
 	const char *path, const char *matched_pathspec, void *payload)
 {


### PR DESCRIPTION
By default, diff will collapse a new directory that contains only untracked files into a single delta for the whole directory.  (This is akin to `git status` on the command line's behavior.)

Make `git_index_add_all` ask for the individual untracked files, so it can add each of them.