### PR TITLE
Fill the pointers for matching refspecs

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -551,7 +551,7 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 	git_remote *remote = NULL;
 	git_config *config;
 	const char *name, *shortname;
-	int local;
+	int local, error;
 	const git_refspec *fetchspec;
 
 	name = git_reference_name(branch);
@@ -586,9 +586,12 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 	 * that.
 	 */
 	if (local)
-		git_buf_puts(&value, ".");
+		error = git_buf_puts(&value, ".");
 	else
-		git_branch_remote_name(&value, repo, git_reference_name(upstream));
+		error = git_branch_remote_name(&value, repo, git_reference_name(upstream));
+
+	if (error < 0)
+		goto on_error;
 
 	if (git_buf_printf(&key, "branch.%s.remote", shortname) < 0)
 		goto on_error;

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -42,6 +42,12 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 	 */
 	if (!is_fetch && rhs == lhs && rhs[1] == '\0') {
 		refspec->matching = 1;
+		refspec->string = git__strdup(input);
+		GITERR_CHECK_ALLOC(refspec->string);
+		refspec->src = git__strdup("");
+		GITERR_CHECK_ALLOC(refspec->src);
+		refspec->dst = git__strdup("");
+		GITERR_CHECK_ALLOC(refspec->dst);
 		return 0;
 	}
 

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -146,3 +146,13 @@ void test_network_refspecs__invalid_reverse(void)
 	assert_invalid_rtransform("refs/heads/*:refs/remotes/origin/*", "master");
 	assert_invalid_rtransform("refs/heads/*:refs/remotes/origin/*", "refs/remotes/o/master");
 }
+
+void test_network_refspecs__matching(void)
+{
+	git_refspec spec;
+
+	cl_git_pass(git_refspec__parse(&spec, ":", false));
+	cl_assert_equal_s(":", spec.string);
+	cl_assert_equal_s("", spec.src);
+	cl_assert_equal_s("", spec.dst);
+}


### PR DESCRIPTION
We currently leave all strings `NULL` when we find a matching refspec. This means that you can't treat all refspecs the same. Let's fill in these strings so a consumer/transformer doesn't have to care whether they're dealing with a matching refspec or not.

The extra test came about because of #3140 where I realised that we don't return the right error message.

This fixes #3140 