### PR TITLE
Lock around encrypted I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ support for HTTPS connections insead of OpenSSL.
   the error message, which allows you to get the "repository not
   found" messages.
 
+* OpenSSL and libssh2 code now locks by default as a way to have safe
+  defaults. Use `git_openssl_set_threadsafe()` and
+  `git_libssh2_set_threadsafe()` resp. to disable the locks if you
+  have made sure their locking is set up.
+
 
 ### API additions
 
@@ -97,6 +102,10 @@ support for HTTPS connections insead of OpenSSL.
   server. This typically indicates an error with the URL or
   configuration of the server, and tools can use this to show messages
   about failing to communicate with the server.
+
+* `git_openssl_set_threadsafe()` and `git_libssh2_set_threadsafe()`
+  have been added to allow the user to specify that they have taken
+  care of setting up the threading for these libraries.
 
 ### API removals
 

--- a/THREADING.md
+++ b/THREADING.md
@@ -64,6 +64,13 @@ it should use. This means that libgit2 cannot know what to set as the
 user of libgit2 may use OpenSSL independently and the locking settings
 must survive libgit2 shutting down.
 
+As using these libraries without taking extra steps is unsafe, we err
+on the side of caution and lock around operations with these
+libraries. If you have set up thread safety for these librarires, you
+may call `git_openssl_set_threadafe()` and/or
+`git_libssh2_set_threadsafe()` which tell libgit2 that the libraries
+are thread-safe themselves and there is no need to take these locks.
+
 libgit2 does provide a last-resort convenience function
 `git_openssl_set_locking()` (available in `sys/openssl.h`) to use the
 platform-native mutex mechanisms to perform the locking, which you may

--- a/include/git2/sys/libssh2.h
+++ b/include/git2/sys/libssh2.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_libssh2_h__
+#define INCLUDE_git_libssh2_h__
+
+#include "git2/common.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * Mark the libssh2 code as thread-safe
+ *
+ * By default we take a lock around libssh2 operations, as the
+ * thread-safety depends on the caller setting up the threading for
+ * the crytographic library it uses. If you have set up its threading,
+ * you may call this function to disable the lock, which would enable
+ * concurrent work.
+ *
+ * These locks are only used if the library was built with threading
+ * support.
+ */
+GIT_EXTERN(void) git_libssh2_set_threadsafe(void);
+
+GIT_END_DECL
+#endif

--- a/include/git2/sys/openssl.h
+++ b/include/git2/sys/openssl.h
@@ -28,10 +28,26 @@ GIT_BEGIN_DECL
  * likely sets up locking. You should very strongly prefer that over
  * this function.
  *
+ * This calls `git_openssl_set_threadsafe()` enabling concurrent
+ * OpenSSL operations.
+ *
  * @return 0 on success, -1 if there are errors or if libgit2 was not
  * built with OpenSSL and threading support.
  */
 GIT_EXTERN(int) git_openssl_set_locking(void);
+
+/**
+ * Mark the OpenSSL code as thread-safe
+ *
+ * By default we take a lock around OpenSSL operations. If you have
+ * set up OpenSSL threading in your application, you may call this
+ * function to avoid taking these locks, which would enable concurrent
+ * work.
+ *
+ * These locks are only used if the library was built with threading
+ * support.
+ */
+GIT_EXTERN(void) git_openssl_set_threadsafe(void);
 
 GIT_END_DECL
 #endif

--- a/src/global.h
+++ b/src/global.h
@@ -25,6 +25,7 @@ extern SSL_CTX *git__ssl_ctx;
 git_global_st *git__global_state(void);
 
 extern git_mutex git__mwindow_mutex;
+extern git_mutex git__io_mutex;
 
 #define GIT_GLOBAL (git__global_state())
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -50,4 +50,14 @@ GIT_INLINE(void) git_stream_free(git_stream *st)
 	st->free(st);
 }
 
+/* Macros for locking around OpenSSL and libssh2; it assumes you have a static 'should_lock' variable */
+#define LOCK do {						   \
+	if (should_lock && git_mutex_lock(&git__io_mutex) < 0) {   \
+		giterr_set(GITERR_NET, "failed to lock IO mutex"); \
+		return -1;					   \
+	}							   \
+} while(0)
+
+#define UNLOCK git_mutex_unlock(&git__io_mutex)
+
 #endif


### PR DESCRIPTION
OpenSSL and often whatever libssh2 is using require their own set-up for
concurrent operations to be safe. This means that by default, using both
of these libraries in a threaded context is unsafe.

Lock by default, and allow the user to tell us that they've set up
threading for the underlying libraries.

---

I'm quite conflicted about this approach. It does make use safer by default. E.g. even if you run `git_openssl_set_locking()` on Debian, you're still not safe to perform multiple ssh operations in parallel, but it feels like a huge hack around something we shouldn't be handling at all in the library.

More rationale is at #2702 