### PR TITLE
Thin packs: don't 

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -325,6 +325,13 @@ on_error:
 	return -1;
 }
 
+GIT_INLINE(bool) has_entry(git_indexer *idx, git_oid *id)
+{
+	khiter_t k;
+	k = kh_get(oid, idx->pack->idx_cache, id);
+	return (k != kh_end(idx->pack->idx_cache));
+}
+
 static int save_entry(git_indexer *idx, struct entry *entry, struct git_pack_entry *pentry, git_off_t entry_start)
 {
 	int i, error;
@@ -339,8 +346,11 @@ static int save_entry(git_indexer *idx, struct entry *entry, struct git_pack_ent
 
 	pentry->offset = entry_start;
 	k = kh_put(oid, idx->pack->idx_cache, &pentry->sha1, &error);
-	if (!error)
+
+	if (error <= 0) {
+		giterr_set(GITERR_INDEXER, "cannot insert object into pack");
 		return -1;
+	}
 
 	kh_value(idx->pack->idx_cache, k) = pentry;
 
@@ -790,6 +800,9 @@ static int fix_thin_pack(git_indexer *idx, git_transfer_progress *stats)
 
 	git_oid_fromraw(&base, base_info);
 	git_mwindow_close(&w);
+
+	if (has_entry(idx, &base))
+		return 0;
 
 	if (inject_object(idx, &base) < 0)
 		return -1;

--- a/src/pack.c
+++ b/src/pack.c
@@ -959,8 +959,15 @@ git_off_t get_delta_base(
 			if (k != kh_end(p->idx_cache)) {
 				*curpos += 20;
 				return ((struct git_pack_entry *)kh_value(p->idx_cache, k))->offset;
+			} else {
+				/* If we're building an index, don't try to find the pack
+				 * entry; we just haven't seen it yet.  We'll make
+				 * progress again in the next loop.
+				 */
+				return GIT_PASSTHROUGH;
 			}
 		}
+
 		/* The base entry _must_ be in the same pack */
 		if (pack_entry_find_offset(&base_offset, &unused, p, (git_oid *)base_info, GIT_OID_HEXSZ) < 0)
 			return packfile_error("base entry delta is not in the same pack");


### PR DESCRIPTION
When fixing a thin pack, we should not try to open an index for the packfile that we are currently writing.  (There is guaranteed to be no index.)  The second commit is really not a big win (we will probably have the base cached), but might prevent some unnecessary mucking around in the object cache.
