### PR TITLE
Fix MinGW build against openssl on maint/v0.22

### DIFF
--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -8,9 +8,6 @@
 #ifdef GIT_SSL
 
 #include <ctype.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 
 #include "global.h"
 #include "posix.h"
@@ -18,6 +15,12 @@
 #include "socket_stream.h"
 #include "netops.h"
 #include "git2/transport.h"
+
+#ifndef GIT_WIN32
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+#endif
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>


### PR DESCRIPTION
This is a backport of a944c6cc40273b45922fa22949fe6b12ff668889, but it didn't cherry-pick cleanly so I resolved the conflict by hand.