### PR TITLE
cred_helpers: Add 'const' qualifiers to git_cred_userpass_payload

### DIFF
--- a/include/git2/cred_helpers.h
+++ b/include/git2/cred_helpers.h
@@ -22,8 +22,8 @@ GIT_BEGIN_DECL
  * Payload for git_cred_stock_userpass_plaintext.
  */
 typedef struct git_cred_userpass_payload {
-	char *username;
-	char *password;
+	const char *username;
+	const char *password;
 } git_cred_userpass_payload;
 
 


### PR DESCRIPTION
Make both `username` & `password` in `git_cred_userpass_payload` `const`. The values are not altered anywhere, and the extra qualifier allows clients to assign `const` values there.

I've checked most of the bindings listed on homepage and none of them seem to use `git_cred_userpass_payload`. The tests pass. Also confirmed that gitg & subsurface (two random packages using libgit2) don't rely on the lack of `const`. So it should be safe to change.