### PR TITLE
Fix ident replacement to match Git behavior

### DIFF
--- a/src/ident.c
+++ b/src/ident.c
@@ -56,7 +56,7 @@ static int ident_insert_id(
 		return GIT_PASSTHROUGH;
 
 	need_size = (size_t)(id_start - from->ptr) +
-		5 /* "$Id: " */ + GIT_OID_HEXSZ + 1 /* "$" */ +
+		5 /* "$Id: " */ + GIT_OID_HEXSZ + 2 /* " $" */ +
 		(size_t)(from_end - id_end);
 
 	if (git_buf_grow(to, need_size) < 0)
@@ -65,7 +65,7 @@ static int ident_insert_id(
 	git_buf_set(to, from->ptr, (size_t)(id_start - from->ptr));
 	git_buf_put(to, "$Id: ", 5);
 	git_buf_put(to, oid, GIT_OID_HEXSZ);
-	git_buf_putc(to, '$');
+	git_buf_put(to, " $", 2);
 	git_buf_put(to, id_end, (size_t)(from_end - id_end));
 
 	return git_buf_oom(to) ? -1 : 0;

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -221,29 +221,29 @@ void test_checkout_crlf__with_ident(void)
 	if (GIT_EOL_NATIVE == GIT_EOL_LF) {
 		cl_assert_equal_file(
 			ALL_LF_TEXT_RAW
-			"\n$Id: fcf6d4d9c212dc66563b1171b1cd99953c756467$\n",
+			"\n$Id: fcf6d4d9c212dc66563b1171b1cd99953c756467 $\n",
 			0, "crlf/lf.ident");
 		cl_assert_equal_file(
 			ALL_CRLF_TEXT_AS_LF
-			"\n$Id: f2c66ad9b2b5a734d9bf00d5000cc10a62b8a857$\n\n",
+			"\n$Id: f2c66ad9b2b5a734d9bf00d5000cc10a62b8a857 $\n\n",
 			0, "crlf/crlf.ident");
 	} else {
 		cl_assert_equal_file(
 			ALL_LF_TEXT_AS_CRLF
-			"\r\n$Id: fcf6d4d9c212dc66563b1171b1cd99953c756467$\r\n",
+			"\r\n$Id: fcf6d4d9c212dc66563b1171b1cd99953c756467 $\r\n",
 			0, "crlf/lf.ident");
 		cl_assert_equal_file(
 			ALL_CRLF_TEXT_RAW
-			"\r\n$Id: f2c66ad9b2b5a734d9bf00d5000cc10a62b8a857$\r\n\r\n",
+			"\r\n$Id: f2c66ad9b2b5a734d9bf00d5000cc10a62b8a857 $\r\n\r\n",
 			0, "crlf/crlf.ident");
 	}
 
 	cl_assert_equal_file(
-		"$Id: f7830382dac1f1583422be5530fdfbd26289431b$\n"
+		"$Id: f7830382dac1f1583422be5530fdfbd26289431b $\n"
 		MORE_LF_TEXT_AS_LF, 0, "crlf/more1.identlf");
 
 	cl_assert_equal_file(
-		"\r\n$Id: 74677a68413012ce8d7e7cfc3f12603df3a3eac4$\r\n"
+		"\r\n$Id: 74677a68413012ce8d7e7cfc3f12603df3a3eac4 $\r\n"
 		MORE_CRLF_TEXT_AS_CRLF, 0, "crlf/more2.identcrlf");
 
 	git_index_free(index);

--- a/tests/filter/blob.c
+++ b/tests/filter/blob.c
@@ -105,11 +105,11 @@ void test_filter_blob__ident(void)
 
 	cl_git_pass(git_blob_filtered_content(&buf, blob, "filter.identcrlf", 1));
 	cl_assert_equal_s(
-		"Some text\r\n$Id: 3164f585d548ac68027d22b104f2d8100b2b6845$\r\nGoes there\r\n", buf.ptr);
+		"Some text\r\n$Id: 3164f585d548ac68027d22b104f2d8100b2b6845 $\r\nGoes there\r\n", buf.ptr);
 
 	cl_git_pass(git_blob_filtered_content(&buf, blob, "filter.identlf", 1));
 	cl_assert_equal_s(
-		"Some text\n$Id: 3164f585d548ac68027d22b104f2d8100b2b6845$\nGoes there\n", buf.ptr);
+		"Some text\n$Id: 3164f585d548ac68027d22b104f2d8100b2b6845 $\nGoes there\n", buf.ptr);
 
 	git_buf_free(&buf);
 	git_blob_free(blob);

--- a/tests/filter/custom.c
+++ b/tests/filter/custom.c
@@ -318,7 +318,7 @@ void test_filter_custom__order_dependency(void)
 	/* expansion because reverse was applied at checkin and at ident time,
 	 * reverse is not applied yet */
 	cl_assert_equal_s(
-		"Another test\n$59001fe193103b1016b27027c0c827d036fd0ac8 :dI$\nCrazy!\n", buf.ptr);
+		"Another test\n$ 59001fe193103b1016b27027c0c827d036fd0ac8 :dI$\nCrazy!\n", buf.ptr);
 	cl_assert_equal_i(0, git_oid_strcmp(
 		git_blob_id(blob), "8ca0df630d728c0c72072b6101b301391ef10095"));
 	git_blob_free(blob);

--- a/tests/filter/ident.c
+++ b/tests/filter/ident.c
@@ -49,22 +49,22 @@ void test_filter_ident__to_worktree(void)
 
 	add_blob_and_filter(
 		"Hello\n$Id$\nFun stuff\n", fl,
-		"Hello\n$Id: b69e2387aafcaf73c4de5b9ab59abe27fdadee30$\nFun stuff\n");
+		"Hello\n$Id: b69e2387aafcaf73c4de5b9ab59abe27fdadee30 $\nFun stuff\n");
 	add_blob_and_filter(
 		"Hello\n$Id: Junky$\nFun stuff\n", fl,
-		"Hello\n$Id: 45cd107a7102911cb2a7df08404674327fa050b9$\nFun stuff\n");
+		"Hello\n$Id: 45cd107a7102911cb2a7df08404674327fa050b9 $\nFun stuff\n");
 	add_blob_and_filter(
 		"$Id$\nAt the start\n", fl,
-		"$Id: b13415c767abc196fb95bd17070e8c1113e32160$\nAt the start\n");
+		"$Id: b13415c767abc196fb95bd17070e8c1113e32160 $\nAt the start\n");
 	add_blob_and_filter(
 		"At the end\n$Id$", fl,
-		"At the end\n$Id: 1344925c6bc65b34c5a7b50f86bf688e48e9a272$");
+		"At the end\n$Id: 1344925c6bc65b34c5a7b50f86bf688e48e9a272 $");
 	add_blob_and_filter(
 		"$Id$", fl,
-		"$Id: b3f5ebfb5843bc43ceecff6d4f26bb37c615beb1$");
+		"$Id: b3f5ebfb5843bc43ceecff6d4f26bb37c615beb1 $");
 	add_blob_and_filter(
 		"$Id: Some sort of junk goes here$", fl,
-		"$Id: ab2dd3853c7c9a4bff55aca2bea077a73c32ac06$");
+		"$Id: ab2dd3853c7c9a4bff55aca2bea077a73c32ac06 $");
 
 	add_blob_and_filter("$Id: ", fl, "$Id: ");
 	add_blob_and_filter("$Id", fl, "$Id");


### PR DESCRIPTION
Git inserts a space after the SHA1 (as of 2.1.4 at least), so do the same for consistency.

This is particularly useful when diffing a filtered blob against a file checked out by Git, as without this the `$Id$` line will be different.

---
Git behavior:
```console
$ git --version 
git version 2.1.4
$ git init .
Initialized empty Git repository in .../.git/
$ echo '$Id$' > foo
$ echo 'foo ident' > .gitattributes
$ git add foo .gitattributes
$ git commit -m "init"
[master (root-commit) 3684894] init
 2 files changed, 2 insertions(+)
 create mode 100644 .gitattributes
 create mode 100644 foo
$ rm -f foo
$ git checkout .
$ cat foo
$Id: 055c8729cdcc372500a08db659c045e16c4409fb $
```
