### PR TITLE
Rename GIT_EMERGECONFLICT to GIT_ECONFLICT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,9 @@ support for HTTPS connections insead of OpenSSL.
   index. Specifically, time and file size are 32 bits intead of 64, as
   these values are truncated.
 
+* `GIT_EMERGECONFLICT` is now `GIT_ECONFLICT`, which more accurately
+  describes the nature of the error.
+
 v0.22
 ------
 

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -38,7 +38,7 @@ typedef enum {
 	GIT_EUNMERGED       = -10,	/**< Merge in progress prevented operation */
 	GIT_ENONFASTFORWARD = -11,	/**< Reference was not fast-forwardable */
 	GIT_EINVALIDSPEC    = -12,	/**< Name/ref spec was not in a valid format */
-	GIT_EMERGECONFLICT  = -13,	/**< Merge conflicts prevented operation */
+	GIT_ECONFLICT       = -13,	/**< Checkout conflicts prevented operation */
 	GIT_ELOCKED         = -14,	/**< Lock file prevented operation */
 	GIT_EMODIFIED       = -15,	/**< Reference value does not match expected */
 	GIT_EAUTH           = -16,      /**< Authentication error */

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1292,7 +1292,7 @@ static int checkout_get_actions(
 			(int)counts[CHECKOUT_ACTION__CONFLICT],
 			counts[CHECKOUT_ACTION__CONFLICT] == 1 ?
 			"conflict prevents" : "conflicts prevent");
-		error = GIT_EMERGECONFLICT;
+		error = GIT_ECONFLICT;
 		goto fail;
 	}
 
@@ -2062,7 +2062,7 @@ static int checkout_write_merge(
 
 	if (result.path == NULL || result.mode == 0) {
 		giterr_set(GITERR_CHECKOUT, "Could not merge contents of file");
-		error = GIT_EMERGECONFLICT;
+		error = GIT_ECONFLICT;
 		goto done;
 	}
 
@@ -2357,7 +2357,7 @@ static int checkout_data_init(
 			/* cannot checkout if unresolved conflicts exist */
 			if ((data->opts.checkout_strategy & GIT_CHECKOUT_FORCE) == 0 &&
 				git_index_has_conflicts(data->index)) {
-				error = GIT_EMERGECONFLICT;
+				error = GIT_ECONFLICT;
 				giterr_set(GITERR_CHECKOUT,
 					"unresolved conflicts exist in the index");
 				goto cleanup;

--- a/src/merge.c
+++ b/src/merge.c
@@ -2509,7 +2509,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 	if ((conflicts = index_conflicts + wd_conflicts) > 0) {
 		giterr_set(GITERR_MERGE, "%d uncommitted change%s would be overwritten by merge",
 			conflicts, (conflicts != 1) ? "s" : "");
-		error = GIT_EMERGECONFLICT;
+		error = GIT_ECONFLICT;
 	}
 
 done:

--- a/src/stash.c
+++ b/src/stash.c
@@ -761,7 +761,7 @@ int git_stash_apply(
 			goto cleanup;
 
 		if (git_index_has_conflicts(unstashed_index)) {
-			error = GIT_EMERGECONFLICT;
+			error = GIT_ECONFLICT;
 			goto cleanup;
 		}
 	}

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -306,7 +306,7 @@ void test_checkout_tree__conflict_on_ignored_when_not_overwriting(void)
 	cl_git_fail(error = checkout_tree_with_blob_ignored_in_workdir(
 		GIT_CHECKOUT_SAFE | GIT_CHECKOUT_DONT_OVERWRITE_IGNORED, false));
 
-	cl_assert_equal_i(GIT_EMERGECONFLICT, error);
+	cl_assert_equal_i(GIT_ECONFLICT, error);
 }
 
 void test_checkout_tree__can_overwrite_ignored_by_default(void)
@@ -327,7 +327,7 @@ void test_checkout_tree__conflict_on_ignored_folder_when_not_overwriting(void)
 	cl_git_fail(error = checkout_tree_with_blob_ignored_in_workdir(
 		GIT_CHECKOUT_SAFE | GIT_CHECKOUT_DONT_OVERWRITE_IGNORED, true));
 
-	cl_assert_equal_i(GIT_EMERGECONFLICT, error);
+	cl_assert_equal_i(GIT_ECONFLICT, error);
 }
 
 void test_checkout_tree__can_overwrite_ignored_folder_by_default(void)
@@ -512,7 +512,7 @@ void assert_conflict(
 
 	g_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	cl_assert_equal_i(
-		GIT_EMERGECONFLICT, git_checkout_tree(g_repo, g_object, &g_opts));
+		GIT_ECONFLICT, git_checkout_tree(g_repo, g_object, &g_opts));
 
 	/* Stage the conflicting change */
 	cl_git_pass(git_index_add_bypath(index, entry_path));
@@ -520,10 +520,10 @@ void assert_conflict(
 	git_index_free(index);
 
 	cl_assert_equal_i(
-		GIT_EMERGECONFLICT, git_checkout_tree(g_repo, g_object, &g_opts));
+		GIT_ECONFLICT, git_checkout_tree(g_repo, g_object, &g_opts));
 }
 
-void test_checkout_tree__checking_out_a_conflicting_type_change_returns_EMERGECONFLICT(void)
+void test_checkout_tree__checking_out_a_conflicting_type_change_returns_ECONFLICT(void)
 {
 	/*
 	 * 099faba adds a symlink named 'link_to_new.txt'
@@ -533,7 +533,7 @@ void test_checkout_tree__checking_out_a_conflicting_type_change_returns_EMERGECO
 	assert_conflict("link_to_new.txt", "old.txt", "a65fedf", "099faba");
 }
 
-void test_checkout_tree__checking_out_a_conflicting_type_change_returns_EMERGECONFLICT_2(void)
+void test_checkout_tree__checking_out_a_conflicting_type_change_returns_ECONFLICT_2(void)
 {
 	/*
 	 * cf80f8d adds a directory named 'a/'
@@ -543,7 +543,7 @@ void test_checkout_tree__checking_out_a_conflicting_type_change_returns_EMERGECO
 	assert_conflict("a", "hello\n", "a4a7dce", "cf80f8d");
 }
 
-void test_checkout_tree__checking_out_a_conflicting_content_change_returns_EMERGECONFLICT(void)
+void test_checkout_tree__checking_out_a_conflicting_content_change_returns_ECONFLICT(void)
 {
 	/*
 	 * c47800c adds a symlink named 'branch_file.txt'

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -118,7 +118,7 @@ void test_stash_apply__conflict_index_with_reinstate_index(void)
 	cl_git_pass(git_index_add_bypath(repo_index, "who"));
 	cl_git_pass(git_index_write(repo_index));
 
-	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_ECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -133,7 +133,7 @@ void test_stash_apply__conflict_untracked_with_default(void)
 
 	cl_git_mkfile("stash/when", "nothing\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_ECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -150,7 +150,7 @@ void test_stash_apply__conflict_untracked_with_reinstate_index(void)
 
 	cl_git_mkfile("stash/when", "nothing\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_ECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_CURRENT);
@@ -163,7 +163,7 @@ void test_stash_apply__conflict_workdir_with_default(void)
 {
 	cl_git_rewritefile("stash/what", "ciao\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, NULL), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, NULL), GIT_ECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);
@@ -180,7 +180,7 @@ void test_stash_apply__conflict_workdir_with_reinstate_index(void)
 
 	cl_git_rewritefile("stash/what", "ciao\n");
 
-	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_EMERGECONFLICT);
+	cl_git_fail_with(git_stash_apply(repo, 0, &opts), GIT_ECONFLICT);
 
 	cl_assert_equal_i(git_index_has_conflicts(repo_index), 0);
 	assert_status(repo, "what", GIT_STATUS_WT_MODIFIED);


### PR DESCRIPTION
We do not error on "merge conflicts"; on the contrary, merge conflicts
are a normal part of merging.  We only error on "checkout conflicts",
where a change exists in the index or the working directory that would
otherwise be overwritten by performing the checkout.

This *may* happen during merge (after the production of the new index
that we're going to checkout) but it could happen during any checkout.