### PR TITLE
Locking and transactional/atomic updates for config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ v0.23 + 1
 
 ### API additions
 
-* `git_config_lock()` and `git_config_unlock()` have been added, which
-  allow for transactional/atomic complex updates to the configuration,
-  removing the opportunity for concurrent operations and not
-  committing any changes until the unlock.
-
+* `git_config_lock()` has been added, which allow for
+  transactional/atomic complex updates to the configuration, removing
+  the opportunity for concurrent operations and not committing any
+  changes until the unlock.
 
 ### API removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ v0.23 + 1
 
 ### API additions
 
+* `git_config_lock()` and `git_config_unlock()` have been added, which
+  allow for transactional/atomic complex updates to the configuration,
+  removing the opportunity for concurrent operations and not
+  committing any changes until the unlock.
+
+
 ### API removals
 
 ### Breaking API changes
@@ -18,6 +24,10 @@ v0.23 + 1
 * It is the responsibility fo the refdb backend to decide what to do
   with the reflog on ref deletion. The file-based backend must delete
   it, a database-backed one may wish to archive it.
+
+* `git_config_backend` has gained two entries. `lock` and `unlock`
+  with which to implement the transactional/atomic semantics for the
+  configuration backend.
 
 v0.23
 ------

--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -689,6 +689,33 @@ GIT_EXTERN(int) git_config_backend_foreach_match(
 	void *payload);
 
 
+/**
+ * Lock the backend with the highest priority
+ *
+ * Locking disallows anybody else from writing to that backend. Any
+ * updates made after locking will not be visible to a reader until
+ * the file is unlocked.
+ *
+ * @param cfg the configuration in which to lock
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_config_lock(git_config *cfg);
+
+/**
+ * Unlock the backend with the highest priority
+ *
+ * Unlocking will allow other writers to updat the configuration
+ * file. Optionally, any changes performed since the lock will be
+ * applied to the configuration.
+ *
+ * @param cfg the configuration
+ * @param commit boolean which indicates whether to commit any changes
+ * done since locking
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_config_unlock(git_config *cfg, int commit);
+
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -696,25 +696,16 @@ GIT_EXTERN(int) git_config_backend_foreach_match(
  * updates made after locking will not be visible to a reader until
  * the file is unlocked.
  *
+ * You can apply the changes by calling `git_transaction_commit()`
+ * before freeing the transaction. Either of these actions will unlock
+ * the config.
+ *
+ * @param tx the resulting transaction, use this to commit or undo the
+ * changes
  * @param cfg the configuration in which to lock
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_config_lock(git_config *cfg);
-
-/**
- * Unlock the backend with the highest priority
- *
- * Unlocking will allow other writers to updat the configuration
- * file. Optionally, any changes performed since the lock will be
- * applied to the configuration.
- *
- * @param cfg the configuration
- * @param commit boolean which indicates whether to commit any changes
- * done since locking
- * @return 0 or an error code
- */
-GIT_EXTERN(int) git_config_unlock(git_config *cfg, int commit);
-
+GIT_EXTERN(int) git_config_lock(git_transaction **tx, git_config *cfg);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/sys/config.h
+++ b/include/git2/sys/config.h
@@ -67,6 +67,20 @@ struct git_config_backend {
 	int (*iterator)(git_config_iterator **, struct git_config_backend *);
 	/** Produce a read-only version of this backend */
 	int (*snapshot)(struct git_config_backend **, struct git_config_backend *);
+	/**
+	 * Lock this backend.
+	 *
+	 * Prevent any writes to the data store backing this
+	 * backend. Any updates must not be visible to any other
+	 * readers.
+	 */
+	int (*lock)(struct git_config_backend *);
+	/**
+	 * Unlock the data store backing this backend. If success is
+	 * true, the changes should be committed, otherwise rolled
+	 * back.
+	 */
+	int (*unlock)(struct git_config_backend *, int success);
 	void (*free)(struct git_config_backend *);
 };
 #define GIT_CONFIG_BACKEND_VERSION 1

--- a/src/config.c
+++ b/src/config.c
@@ -1144,8 +1144,9 @@ int git_config_open_default(git_config **out)
 	return error;
 }
 
-int git_config_lock(git_config *cfg)
+int git_config_lock(git_transaction **out, git_config *cfg)
 {
+	int error;
 	git_config_backend *file;
 	file_internal *internal;
 
@@ -1156,7 +1157,10 @@ int git_config_lock(git_config *cfg)
 	}
 	file = internal->file;
 
-	return file->lock(file);
+	if ((error = file->lock(file)) < 0)
+		return error;
+
+	return git_transaction_config_new(out, cfg);
 }
 
 int git_config_unlock(git_config *cfg, int commit)

--- a/src/config.c
+++ b/src/config.c
@@ -1144,6 +1144,37 @@ int git_config_open_default(git_config **out)
 	return error;
 }
 
+int git_config_lock(git_config *cfg)
+{
+	git_config_backend *file;
+	file_internal *internal;
+
+	internal = git_vector_get(&cfg->files, 0);
+	if (!internal || !internal->file) {
+		giterr_set(GITERR_CONFIG, "cannot lock; the config has no backends/files");
+		return -1;
+	}
+	file = internal->file;
+
+	return file->lock(file);
+}
+
+int git_config_unlock(git_config *cfg, int commit)
+{
+	git_config_backend *file;
+	file_internal *internal;
+
+	internal = git_vector_get(&cfg->files, 0);
+	if (!internal || !internal->file) {
+		giterr_set(GITERR_CONFIG, "cannot lock; the config has no backends/files");
+		return -1;
+	}
+
+	file = internal->file;
+
+	return file->unlock(file, commit);
+}
+
 /***********
  * Parsers
  ***********/

--- a/src/config.h
+++ b/src/config.h
@@ -88,4 +88,19 @@ extern int git_config__cvar(
  */
 int git_config_lookup_map_enum(git_cvar_t *type_out, const char **str_out,
 			       const git_cvar_map *maps, size_t map_n, int enum_val);
+
+/**
+ * Unlock the backend with the highest priority
+ *
+ * Unlocking will allow other writers to updat the configuration
+ * file. Optionally, any changes performed since the lock will be
+ * applied to the configuration.
+ *
+ * @param cfg the configuration
+ * @param commit boolean which indicates whether to commit any changes
+ * done since locking
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_config_unlock(git_config *cfg, int commit);
+
 #endif

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -55,6 +55,16 @@ GIT_INLINE(int) git_config_file_foreach_match(
 	return git_config_backend_foreach_match(cfg, regexp, fn, data);
 }
 
+GIT_INLINE(int) git_config_file_lock(git_config_backend *cfg)
+{
+	return cfg->lock(cfg);
+}
+
+GIT_INLINE(int) git_config_file_unlock(git_config_backend *cfg, int success)
+{
+	return cfg->unlock(cfg, success);
+}
+
 extern int git_config_file_normalize_section(char *start, char *end);
 
 #endif

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -12,6 +12,7 @@
 #include "pool.h"
 #include "reflog.h"
 #include "signature.h"
+#include "config.h"
 
 #include "git2/transaction.h"
 #include "git2/signature.h"
@@ -19,6 +20,12 @@
 #include "git2/sys/refdb_backend.h"
 
 GIT__USE_STRMAP
+
+typedef enum {
+	TRANSACTION_NONE,
+	TRANSACTION_REFS,
+	TRANSACTION_CONFIG,
+} transaction_t;
 
 typedef struct {
 	const char *name;
@@ -39,12 +46,28 @@ typedef struct {
 } transaction_node;
 
 struct git_transaction {
+	transaction_t type;
 	git_repository *repo;
 	git_refdb *db;
+	git_config *cfg;
 
 	git_strmap *locks;
 	git_pool pool;
 };
+
+int git_transaction_config_new(git_transaction **out, git_config *cfg)
+{
+	git_transaction *tx;
+	assert(out && cfg);
+
+	tx = git__calloc(1, sizeof(git_transaction));
+	GITERR_CHECK_ALLOC(tx);
+
+	tx->type = TRANSACTION_CONFIG;
+	tx->cfg = cfg;
+	*out = tx;
+	return 0;
+}
 
 int git_transaction_new(git_transaction **out, git_repository *repo)
 {
@@ -71,6 +94,7 @@ int git_transaction_new(git_transaction **out, git_repository *repo)
 	if ((error = git_repository_refdb(&tx->db, repo)) < 0)
 		goto on_error;
 
+	tx->type = TRANSACTION_REFS;
 	memcpy(&tx->pool, &pool, sizeof(git_pool));
 	tx->repo = repo;
 	*out = tx;
@@ -305,6 +329,14 @@ int git_transaction_commit(git_transaction *tx)
 
 	assert(tx);
 
+	if (tx->type == TRANSACTION_CONFIG) {
+		error = git_config_unlock(tx->cfg, true);
+		git_config_free(tx->cfg);
+		tx->cfg = NULL;
+
+		return error;
+	}
+
 	for (pos = kh_begin(tx->locks); pos < kh_end(tx->locks); pos++) {
 		if (!git_strmap_has_data(tx->locks, pos))
 			continue;
@@ -331,6 +363,16 @@ void git_transaction_free(git_transaction *tx)
 	git_strmap_iter pos;
 
 	assert(tx);
+
+	if (tx->type == TRANSACTION_CONFIG) {
+		if (tx->cfg) {
+			git_config_unlock(tx->cfg, false);
+			git_config_free(tx->cfg);
+		}
+
+		git__free(tx);
+		return;
+	}
 
 	/* start by unlocking the ones we've left hanging, if any */
 	for (pos = kh_begin(tx->locks); pos < kh_end(tx->locks); pos++) {

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_transaction_h__
+#define INCLUDE_transaction_h__
+
+#include "common.h"
+
+int git_transaction_config_new(git_transaction **out, git_config *cfg);
+
+#endif

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -1,6 +1,9 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
 #include "fileops.h"
+#include "git2/sys/config.h"
+#include "config_file.h"
+#include "config.h"
 
 void test_config_write__initialize(void)
 {
@@ -630,3 +633,46 @@ void test_config_write__to_file_with_only_comment(void)
 	git_buf_free(&result);
 }
 
+void test_config_write__locking(void)
+{
+	git_config_backend *cfg, *cfg2;
+	git_config_entry *entry;
+	const char *filename = "locked-file";
+
+	/* Open the config and lock it */
+	cl_git_mkfile(filename, "[section]\n\tname = value\n");
+	cl_git_pass(git_config_file__ondisk(&cfg, filename));
+	cl_git_pass(git_config_file_open(cfg, GIT_CONFIG_LEVEL_APP));
+	cl_git_pass(git_config_file_get_string(&entry, cfg, "section.name"));
+	cl_assert_equal_s("value", entry->value);
+	git_config_entry_free(entry);
+	cl_git_pass(git_config_file_lock(cfg));
+
+	/* Change entries in the locked backend */
+	cl_git_pass(git_config_file_set_string(cfg, "section.name", "other value"));
+	cl_git_pass(git_config_file_set_string(cfg, "section2.name3", "more value"));
+
+	/* We can see that the file we read from hasn't changed */
+	cl_git_pass(git_config_file__ondisk(&cfg2, filename));
+	cl_git_pass(git_config_file_open(cfg2, GIT_CONFIG_LEVEL_APP));
+	cl_git_pass(git_config_file_get_string(&entry, cfg2, "section.name"));
+	cl_assert_equal_s("value", entry->value);
+	git_config_entry_free(entry);
+	cl_git_fail_with(GIT_ENOTFOUND, git_config_file_get_string(&entry, cfg2, "section2.name3"));
+	git_config_file_free(cfg2);
+
+	git_config_file_unlock(cfg, true);
+	git_config_file_free(cfg);
+
+	/* Now that we've unlocked it, we should see both updates */
+	cl_git_pass(git_config_file__ondisk(&cfg, filename));
+	cl_git_pass(git_config_file_open(cfg, GIT_CONFIG_LEVEL_APP));
+	cl_git_pass(git_config_file_get_string(&entry, cfg, "section.name"));
+	cl_assert_equal_s("other value", entry->value);
+	git_config_entry_free(entry);
+	cl_git_pass(git_config_file_get_string(&entry, cfg, "section2.name3"));
+	cl_assert_equal_s("more value", entry->value);
+	git_config_entry_free(entry);
+
+	git_config_file_free(cfg);
+}


### PR DESCRIPTION
You sometimes want to update more than a single entry in the configuration. This is not possible currently, which is why exposing a couple of new functions is necessary.

These allow you to lock a configuration file, locking out concurrent writers, and perform many operations without any readers seeing them (and as an implementation detail, without doing any I/O) until you commit it.

I wanted to do this via `git_transaction` but it turns out the API doesn't really fit what we do here, or we'd have to add more namespacing.

/cc @jamill who mentioned the need for something like this when users prefer clicking to opening up `.git/config` with their editor.