### PR TITLE
Ensure the index owner is set.

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -1805,6 +1805,7 @@ int git_merge_trees(
 		git__free(opts.metric);
 
 	error = index_from_diff_list(out, diff_list);
+	GIT_REFCOUNT_OWN(*out, repo);
 
 done:
 	git_merge_diff_list__free(diff_list);

--- a/tests/merge/trees/trivial.c
+++ b/tests/merge/trees/trivial.c
@@ -50,6 +50,7 @@ static int merge_trivial(git_index **index, const char *ours, const char *theirs
 	cl_git_pass(git_commit_tree(&their_tree, their_commit));
 
 	cl_git_pass(git_merge_trees(index, repo, ancestor_tree, our_tree, their_tree, &opts));
+	cl_assert(git_index_owner(*index) == repo);
 
 	git_buf_free(&branch_buf);
 	git_tree_free(our_tree);


### PR DESCRIPTION
The index returned by `git_merge_trees` should be owned by the repository. Otherwise things like `git_diff_index_to_workdir` will crash when trying to generate a diff with the returned index.

Fixes libgit2/rugged#420.