### PR TITLE
Only write index if updated when passing GIT_DIFF_UPDATE_INDEX

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -661,6 +661,7 @@ int git_diff__oid_for_entry(
 		if (!(error = git_repository_index__weakptr(&idx, diff->repo))) {
 			git_oid_cpy(&entry.id, out);
 			error = git_index_add(idx, &entry);
+			diff->index_updated = true;
 		}
  	}
 
@@ -1353,7 +1354,7 @@ int git_diff_index_to_workdir(
 			&b, repo, index, NULL, GIT_ITERATOR_DONT_AUTOEXPAND, pfx, pfx)
 	);
 
-	if (!error && DIFF_FLAG_IS_SET(*diff, GIT_DIFF_UPDATE_INDEX))
+	if (!error && DIFF_FLAG_IS_SET(*diff, GIT_DIFF_UPDATE_INDEX) && (*diff)->index_updated)
 		error = git_index_write(index);
 
 	return error;

--- a/src/diff.h
+++ b/src/diff.h
@@ -64,6 +64,7 @@ struct git_diff {
 	git_iterator_type_t new_src;
 	uint32_t diffcaps;
 	git_diff_perfdata perf;
+	bool index_updated;
 
 	int (*strcomp)(const char *, const char *);
 	int (*strncomp)(const char *, const char *, size_t);


### PR DESCRIPTION
When diffing the index with the workdir and GIT_DIFF_UPDATE_INDEX has been passed,
the previous implementation was always writing the index to disk even if it wasn't
modified.