### PR TITLE
buffer: Fix growing non-allocated buffers to modulo 8 sizes

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -48,7 +48,7 @@ int git_buf_try_grow(
 		return 0;
 
 	if (buf->asize == 0) {
-		new_size = target_size;
+		new_size = target_size + 1;
 		new_ptr = NULL;
 	} else {
 		new_size = buf->asize;

--- a/tests/buf/basic.c
+++ b/tests/buf/basic.c
@@ -15,6 +15,45 @@ void test_buf_basic__resize(void)
 	git_buf_free(&buf1);
 }
 
+void test_buf_basic__auto_grow(void)
+{
+	git_buf buf1 = GIT_BUF_INIT_CONST("1234567890", 10);
+	git_buf buf2 = buf1;
+
+	cl_git_pass(git_buf_grow(&buf1, 0));
+	cl_assert(git_buf_oom(&buf1) == 0);
+	cl_assert_equal_i(buf1.size, buf2.size);
+	cl_assert(memcmp(buf1.ptr, buf2.ptr, buf1.size) == 0);
+
+	git_buf_free(&buf1);
+}
+
+void test_buf_basic__auto_grow_8(void)
+{
+	git_buf buf1 = GIT_BUF_INIT_CONST("1234567890", 8);
+	git_buf buf2 = buf1;
+
+	cl_git_pass(git_buf_grow(&buf1, 0));
+	cl_assert(git_buf_oom(&buf1) == 0);
+	cl_assert_equal_i(buf1.size, buf2.size);
+	cl_assert(memcmp(buf1.ptr, buf2.ptr, buf1.size) == 0);
+
+	git_buf_free(&buf1);
+}
+
+void test_buf_basic__grow_8(void)
+{
+	git_buf buf1 = GIT_BUF_INIT_CONST("1234567890", 8);
+	git_buf buf2 = buf1;
+
+	cl_git_pass(git_buf_grow(&buf1, buf1.size));
+	cl_assert(git_buf_oom(&buf1) == 0);
+	cl_assert_equal_i(buf1.size, buf2.size);
+	cl_assert(memcmp(buf1.ptr, buf2.ptr, buf1.size) == 0);
+
+	git_buf_free(&buf1);
+}
+
 void test_buf_basic__resize_incremental(void)
 {
 	git_buf buf1 = GIT_BUF_INIT;


### PR DESCRIPTION
`git_buf_grow()` ensures the buffer is terminated with a NUL byte, but dares to truncate the buffer if it is too short.  So, allocation has to always be 1 more than the required content size.

This is generally not a problem because for already allocated buffers the grow logic makes it impossible for the content size to be equal to the allocated size -- unless the target size is the same as the allocated size, but this has a special early-out handling.

However, for non-allocated buffers, the allocation is exactly the requested target size if the target size is a multiple of the alignment (8), in which case truncation will occur if the content size is the same as the requested target size (which is especially the case when passing `target_size=0` for automatic growth).

Fix this by allocating one more byte than actually requested when the buffer isn't already allocated.

---

While this fixes the issue, I wonder if it is sane for `git_buf_try_grow()` to even have code for shrinking the buffer.  OK, it tries to always keep a NUL byte at the end, but I'm not sure this should really be a check, but rather an assertion (as AFAIU, there should never have been any code path leading to the shrinking).

BTW, 0.22.2 *can* sometimes return buffers that aren't NUL-terminated, at least through a `git_blob_filtered_content()` when no transformation happens.  I'm not sure if it's considered a bug (the same function in master apparently grows the buffer properly no matter what), but if non-NUL-terminated buffers are not a bug `git_buf_grow()` probably shouldn't enforce a NUL, especially if there isn't room for it.