### PR TITLE
gitattributes: let clients use native line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-*.c eol=lf
-*.h eol=lf
+* text=auto


### PR DESCRIPTION
Use "text=auto" to ensure that we get LFs in the repository, but
let clients have their native line endings in their worktree.