### PR TITLE
commit: ignore multiple author fields

### DIFF
--- a/tests/commit/parse.c
+++ b/tests/commit/parse.c
@@ -262,6 +262,13 @@ gpgsig -----BEGIN PGP SIGNATURE-----\n\
  -----END PGP SIGNATURE-----\n\
 \n\
 a simple commit which works\n",
+/* some tools create two author entries */
+"tree 1810dff58d8a660512d4832e740f692884338ccd\n\
+author Vicent Marti <tanoku@gmail.com> 1273848544 +0200\n\
+author Helpful Coworker <helpful@coworker> 1273848544 +0200\n\
+committer Vicent Marti <tanoku@gmail.com> 1273848544 +0200\n\
+\n\
+a simple commit which works",
 };
 
 static int parse_commit(git_commit **out, const char *buffer)


### PR DESCRIPTION
Some tools create multiple author fields. git is rather lax when parsing
them, although fsck does complain about them. This means that they exist
in the wild.

As it's not too taxing to check for them, and there shouldn't be a
noticeable slowdown when dealing with correct commits, add logic to skip
over these extra fields when parsing the commit.

----

The size check may look a bit awkward. It's done this way because we don't have `git__prefixncmp()` and I didn't quite feel this deserved adding more util functions.

This fixes #3182 