### PR TITLE
Fix memory leak on windows in diriter.

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -1231,6 +1231,8 @@ void git_path_diriter_free(git_path_diriter *diriter)
 	if (diriter == NULL)
 		return;
 
+	git_buf_free(&diriter->path_utf8);
+
 	if (diriter->handle != INVALID_HANDLE_VALUE) {
 		FindClose(diriter->handle);
 		diriter->handle = INVALID_HANDLE_VALUE;


### PR DESCRIPTION
Memory leak in git_path_diriter on Windows.