### PR TITLE
Fix visibility of transaction symbol

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -13,6 +13,7 @@
 #include "reflog.h"
 #include "signature.h"
 
+#include "git2/transaction.h"
 #include "git2/signature.h"
 #include "git2/sys/refs.h"
 #include "git2/sys/refdb_backend.h"


### PR DESCRIPTION
Transaction.c did not include the visibility definition of its symbol
(that are in git2/transaction.h) and so was by default hidden.