### PR TITLE
Zero out racily-clean entries' file_size

### DIFF
--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -19,6 +19,9 @@ typedef int GIT_SOCKET;
 #define p_lstat(p,b) lstat(p,b)
 #define p_stat(p,b) stat(p, b)
 
+#define p_utimes(f, t) utimes(f, t)
+#define p_futimes(f, t) futimes(f, t)
+
 #define p_readlink(a, b, c) readlink(a, b, c)
 #define p_symlink(o,n) symlink(o, n)
 #define p_link(o,n) link(o, n)
@@ -26,7 +29,6 @@ typedef int GIT_SOCKET;
 #define p_mkdir(p,m) mkdir(p, m)
 #define p_fsync(fd) fsync(fd)
 extern char *p_realpath(const char *, char *);
-#define p_utimensat(fd, path, times, flags) utimensat(fd, path, times, flags)
 
 #define p_recv(s,b,l,f) recv(s,b,l,f)
 #define p_send(s,b,l,f) send(s,b,l,f)

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -26,6 +26,7 @@ typedef int GIT_SOCKET;
 #define p_mkdir(p,m) mkdir(p, m)
 #define p_fsync(fd) fsync(fd)
 extern char *p_realpath(const char *, char *);
+#define p_utimensat(fd, path, times, flags) utimensat(fd, path, times, flags)
 
 #define p_recv(s,b,l,f) recv(s,b,l,f)
 #define p_send(s,b,l,f) send(s,b,l,f)

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -20,6 +20,9 @@ typedef SOCKET GIT_SOCKET;
 extern int p_lstat(const char *file_name, struct stat *buf);
 extern int p_stat(const char* path, struct stat* buf);
 
+extern int p_utimes(const char *filename, const struct timeval times[2]);
+extern int p_futimes(int fd, const struct timeval times[2]);
+
 extern int p_readlink(const char *path, char *buf, size_t bufsiz);
 extern int p_symlink(const char *old, const char *new);
 extern int p_link(const char *old, const char *new);

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -79,6 +79,16 @@ GIT_INLINE(time_t) git_win32__filetime_to_time_t(const FILETIME *ft)
 	return (time_t)winTime;
 }
 
+GIT_INLINE(void) git_win32__timeval_to_filetime(
+	FILETIME *ft, const struct timeval tv)
+{
+	long long ticks = (tv.tv_sec * 10000000LL) +
+		(tv.tv_usec * 10LL) + 116444736000000000LL;
+
+	ft->dwHighDateTime = ((ticks >> 32) & 0xffffffffLL);
+	ft->dwLowDateTime = (ticks & 0xffffffffLL);
+}
+
 GIT_INLINE(int) git_win32__file_attribute_to_stat(
 	struct stat *st,
 	const WIN32_FILE_ATTRIBUTE_DATA *attrdata,

--- a/tests/checkout/checkout_helpers.c
+++ b/tests/checkout/checkout_helpers.c
@@ -132,8 +132,9 @@ int checkout_count_callback(
 
 void tick_index(git_index *index)
 {
+	int index_fd;
 	git_time_t ts;
-	struct timespec times[2];
+	struct timeval times[2];
 
 	cl_assert(index->on_disk);
 	cl_assert(git_index_path(index));
@@ -141,10 +142,11 @@ void tick_index(git_index *index)
 	cl_git_pass(git_index_read(index, true));
 	ts = index->stamp.mtime;
 
-	times[0].tv_sec  = UTIME_OMIT; /* dont' change the atime */
-	times[0].tv_nsec = UTIME_OMIT; /* dont' change the atime */
+	times[0].tv_sec  = ts;
+	times[0].tv_usec = 0;
 	times[1].tv_sec  = ts + 1;
-	times[1].tv_nsec = 0;
-	cl_git_pass(p_utimensat(AT_FDCWD, git_index_path(index), times, 0));
+	times[1].tv_usec = 0;
+
+	cl_git_pass(p_utimes(git_index_path(index), times));
 	cl_git_pass(git_index_read(index, true));
 }

--- a/tests/checkout/checkout_helpers.h
+++ b/tests/checkout/checkout_helpers.h
@@ -27,3 +27,5 @@ extern int checkout_count_callback(
 	const git_diff_file *target,
 	const git_diff_file *workdir,
 	void *payload);
+
+extern void tick_index(git_index *index);

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -32,25 +32,6 @@ void test_checkout_crlf__detect_crlf_autocrlf_false(void)
 	check_file_contents("./crlf/all-crlf", ALL_CRLF_TEXT_RAW);
 }
 
-static void tick_index(git_index *index)
-{
-	git_time_t ts;
-	struct timespec times[2];
-
-	cl_assert(index->on_disk);
-	cl_assert(git_index_path(index));
-
-	cl_git_pass(git_index_read(index, true));
-	ts = index->stamp.mtime;
-
-	times[0].tv_sec  = UTIME_OMIT; /* dont' change the atime */
-	times[0].tv_nsec = UTIME_OMIT; /* dont' change the atime */
-	times[1].tv_sec  = ts + 1;
-	times[1].tv_nsec = 0;
-	cl_git_pass(p_utimensat(AT_FDCWD, git_index_path(index), times, 0));
-	cl_git_pass(git_index_read(index, true));
-}
-
 void test_checkout_crlf__autocrlf_false_index_size_is_unfiltered_size(void)
 {
 	git_index *index;

--- a/tests/diff/racy.c
+++ b/tests/diff/racy.c
@@ -1,0 +1,39 @@
+#include "clar_libgit2.h"
+
+#include "buffer.h"
+
+static git_repository *g_repo;
+
+void test_diff_racy__initialize(void)
+{
+	cl_git_pass(git_repository_init(&g_repo, "diff_racy", false));
+}
+
+void test_diff_racy__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_diff_racy__diff(void)
+{
+	git_index *index;
+	git_diff *diff;
+	git_buf path = GIT_BUF_INIT;
+
+	cl_git_pass(git_buf_joinpath(&path, git_repository_workdir(g_repo), "A"));
+	cl_git_mkfile(path.ptr, "A");
+
+	/* Put 'A' into the index */
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "A"));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
+	cl_assert_equal_i(0, git_diff_num_deltas(diff));
+
+	/* Change its contents quickly, so we get the same timestamp */
+	cl_git_mkfile(path.ptr, "B");
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
+	cl_assert_equal_i(1, git_diff_num_deltas(diff));
+}

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -2,6 +2,7 @@
 #include "diff_helpers.h"
 #include "repository.h"
 #include "git2/sys/diff.h"
+#include "../checkout/checkout_helpers.h"
 
 static git_repository *g_repo = NULL;
 
@@ -1583,6 +1584,7 @@ void test_diff_workdir__can_update_index(void)
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff = NULL;
 	git_diff_perfdata perf = GIT_DIFF_PERFDATA_INIT;
+	git_index *index;
 
 	g_repo = cl_git_sandbox_init("status");
 
@@ -1606,6 +1608,10 @@ void test_diff_workdir__can_update_index(void)
 
 	/* now allow diff to update stat cache */
 	opts.flags |= GIT_DIFF_UPDATE_INDEX;
+
+	/* advance a tick for the index so we don't re-calculate racily-clean entries */
+	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
+	tick_index(index);
 
 	basic_diff_status(&diff, &opts);
 

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -6,6 +6,7 @@
 #include "util.h"
 #include "path.h"
 #include "../diff/diff_helpers.h"
+#include "../checkout/checkout_helpers.h"
 #include "git2/sys/diff.h"
 
 /**
@@ -956,6 +957,7 @@ void test_status_worktree__update_stat_cache_0(void)
 	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
 	git_status_list *status;
 	git_diff_perfdata perf = GIT_DIFF_PERFDATA_INIT;
+	git_index *index;
 
 	opts.flags = GIT_STATUS_OPT_DEFAULTS;
 
@@ -966,6 +968,10 @@ void test_status_worktree__update_stat_cache_0(void)
 	cl_assert_equal_sz(5, perf.oid_calculations);
 
 	git_status_list_free(status);
+
+	/* tick the index so we avoid recalculating racily-clean entries */
+	cl_git_pass(git_repository_index__weakptr(&index, repo));
+	tick_index(index);
 
 	opts.flags |= GIT_STATUS_OPT_UPDATE_INDEX;
 


### PR DESCRIPTION
This is a part of racy-git which we have not implemented, and can lead to diffs between the index and the workdir that do not include files which were modified immediately after the index was written.