### PR TITLE
racy-git, the missing link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ support for HTTPS connections insead of OpenSSL.
   and `git_diff_buffers` now accept a new binary callback of type
   `git_diff_binary_cb` that includes the binary diff information.
 
+* The race condition mitigations described in `racy-git.txt` have been
+  implemented.
+
 ### API additions
 
 * The `git_merge_options` gained a `file_flags` member.

--- a/src/diff.c
+++ b/src/diff.c
@@ -816,10 +816,10 @@ static int maybe_modified(
 	} else if (git_oid_iszero(&nitem->id) && new_is_workdir) {
 		bool use_ctime = ((diff->diffcaps & GIT_DIFFCAPS_TRUST_CTIME) != 0);
 		bool use_nanos = ((diff->diffcaps & GIT_DIFFCAPS_TRUST_NANOSECS) != 0);
+		git_index *index;
+		git_iterator_index(&index, info->new_iter);
 
 		status = GIT_DELTA_UNMODIFIED;
-
-		/* TODO: add check against index file st_mtime to avoid racy-git */
 
 		if (S_ISGITLINK(nmode)) {
 			if ((error = maybe_modified_submodule(&status, &noid, diff, info)) < 0)
@@ -839,7 +839,8 @@ static int maybe_modified(
 			 !diff_time_eq(&oitem->ctime, &nitem->ctime, use_nanos)) ||
 			oitem->ino != nitem->ino ||
 			oitem->uid != nitem->uid ||
-			oitem->gid != nitem->gid)
+			oitem->gid != nitem->gid ||
+			(index && nitem->mtime.seconds >= index->stamp.mtime))
 		{
 			status = GIT_DELTA_MODIFIED;
 			modified_uncertain = true;

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1762,6 +1762,18 @@ int git_iterator_current_workdir_path(git_buf **path, git_iterator *iter)
 	return 0;
 }
 
+int git_iterator_index(git_index **out, git_iterator *iter)
+{
+	workdir_iterator *wi = (workdir_iterator *)iter;
+
+	if (iter->type != GIT_ITERATOR_TYPE_WORKDIR)
+		*out = NULL;
+
+	*out = wi->index;
+
+	return 0;
+}
+
 int git_iterator_advance_over_with_status(
 	const git_index_entry **entryptr,
 	git_iterator_status_t *status,

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -11,6 +11,7 @@
 #include "git2/index.h"
 #include "vector.h"
 #include "buffer.h"
+#include "ignore.h"
 
 typedef struct git_iterator git_iterator;
 
@@ -285,5 +286,12 @@ typedef enum {
  */
 extern int git_iterator_advance_over_with_status(
 	const git_index_entry **entry, git_iterator_status_t *status, git_iterator *iter);
+
+/**
+ * Retrieve the index stored in the iterator.
+ *
+ * Only implemented for the workdir iterator
+ */
+extern int git_iterator_index(git_index **out, git_iterator *iter);
 
 #endif

--- a/tests/diff/racy.c
+++ b/tests/diff/racy.c
@@ -2,6 +2,7 @@
 #include "../checkout/checkout_helpers.h"
 
 #include "buffer.h"
+#include "index.h"
 
 static git_repository *g_repo;
 
@@ -52,29 +53,48 @@ void test_diff_racy__write_index_just_after_file(void)
 	git_index *index;
 	git_diff *diff;
 	git_buf path = GIT_BUF_INIT;
+	struct timeval times[2];
 
 	/* Make sure we do have a timestamp */
 	cl_git_pass(git_repository_index(&index, g_repo));
 	cl_git_pass(git_index_write(index));
-	/* The timestamp will be one second before we change the file */
-	sleep(1);
 
 	cl_git_pass(git_buf_joinpath(&path, git_repository_workdir(g_repo), "A"));
 	cl_git_mkfile(path.ptr, "A");
+	/* Force the file's timestamp to be a second after we wrote the index */
+	times[0].tv_sec = index->stamp.mtime + 1;
+	times[0].tv_usec = 0;
+	times[1].tv_sec = index->stamp.mtime + 1;
+	times[1].tv_usec = 0;
+	cl_git_pass(p_utimes(path.ptr, times));
 
 	/*
 	 * Put 'A' into the index, the size field will be filled,
 	 * because the index' on-disk timestamp does not match the
-	 * file's timestamp. Both timestamps will however match after
-	 * writing out the index.
+	 * file's timestamp.
 	 */
-	cl_git_pass(git_repository_index(&index, g_repo));
 	cl_git_pass(git_index_add_bypath(index, "A"));
 	cl_git_pass(git_index_write(index));
 
-	/* Change its contents quickly, so we get the same timestamp */
 	cl_git_mkfile(path.ptr, "B");
+	/*
+	 * Pretend this index' modification happend a second after the
+	 * file update, and rewrite the file in that same second.
+	 */
+	times[0].tv_sec = index->stamp.mtime + 2;
+	times[0].tv_usec = 0;
+	times[1].tv_sec = index->stamp.mtime + 2;
+	times[0].tv_usec = 0;
+
+	cl_git_pass(p_utimes(git_index_path(index), times));
+	cl_git_pass(p_utimes(path.ptr, times));
+
+	cl_git_pass(git_index_read(index, true));
 
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
 	cl_assert_equal_i(1, git_diff_num_deltas(diff));
+
+	git_buf_free(&path);
+	git_diff_free(diff);
+	git_index_free(index);
 }

--- a/tests/diff/racy.c
+++ b/tests/diff/racy.c
@@ -12,7 +12,10 @@ void test_diff_racy__initialize(void)
 
 void test_diff_racy__cleanup(void)
 {
-	cl_git_sandbox_cleanup();
+	git_repository_free(g_repo);
+	g_repo = NULL;
+
+	cl_fixture_cleanup("diff_racy");
 }
 
 void test_diff_racy__diff(void)
@@ -31,12 +34,17 @@ void test_diff_racy__diff(void)
 
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
 	cl_assert_equal_i(0, git_diff_num_deltas(diff));
+	git_diff_free(diff);
 
 	/* Change its contents quickly, so we get the same timestamp */
 	cl_git_mkfile(path.ptr, "B");
 
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
 	cl_assert_equal_i(1, git_diff_num_deltas(diff));
+
+	git_index_free(index);
+	git_diff_free(diff);
+	git_buf_free(&path);
 }
 
 void test_diff_racy__write_index_just_after_file(void)

--- a/tests/diff/racy.c
+++ b/tests/diff/racy.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "../checkout/checkout_helpers.h"
 
 #include "buffer.h"
 
@@ -30,6 +31,38 @@ void test_diff_racy__diff(void)
 
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
 	cl_assert_equal_i(0, git_diff_num_deltas(diff));
+
+	/* Change its contents quickly, so we get the same timestamp */
+	cl_git_mkfile(path.ptr, "B");
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
+	cl_assert_equal_i(1, git_diff_num_deltas(diff));
+}
+
+void test_diff_racy__write_index_just_after_file(void)
+{
+	git_index *index;
+	git_diff *diff;
+	git_buf path = GIT_BUF_INIT;
+
+	/* Make sure we do have a timestamp */
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_write(index));
+	/* The timestamp will be one second before we change the file */
+	sleep(1);
+
+	cl_git_pass(git_buf_joinpath(&path, git_repository_workdir(g_repo), "A"));
+	cl_git_mkfile(path.ptr, "A");
+
+	/*
+	 * Put 'A' into the index, the size field will be filled,
+	 * because the index' on-disk timestamp does not match the
+	 * file's timestamp. Both timestamps will however match after
+	 * writing out the index.
+	 */
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "A"));
+	cl_git_pass(git_index_write(index));
 
 	/* Change its contents quickly, so we get the same timestamp */
 	cl_git_mkfile(path.ptr, "B");

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -1623,6 +1623,8 @@ void test_diff_workdir__can_update_index(void)
 
 	/* now if we do it again, we should see fewer OID calculations */
 
+	/* tick again as the index updating from the previous diff might have reset the timestamp */
+	tick_index(index);
 	basic_diff_status(&diff, &opts);
 
 	cl_git_pass(git_diff_get_perfdata(&perf, diff));

--- a/tests/index/racy.c
+++ b/tests/index/racy.c
@@ -6,12 +6,12 @@
 
 static git_repository *g_repo;
 
-void test_diff_racy__initialize(void)
+void test_index_racy__initialize(void)
 {
 	cl_git_pass(git_repository_init(&g_repo, "diff_racy", false));
 }
 
-void test_diff_racy__cleanup(void)
+void test_index_racy__cleanup(void)
 {
 	git_repository_free(g_repo);
 	g_repo = NULL;
@@ -19,7 +19,7 @@ void test_diff_racy__cleanup(void)
 	cl_fixture_cleanup("diff_racy");
 }
 
-void test_diff_racy__diff(void)
+void test_index_racy__diff(void)
 {
 	git_index *index;
 	git_diff *diff;
@@ -48,7 +48,7 @@ void test_diff_racy__diff(void)
 	git_buf_free(&path);
 }
 
-void test_diff_racy__write_index_just_after_file(void)
+void test_index_racy__write_index_just_after_file(void)
 {
 	git_index *index;
 	git_diff *diff;

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -985,6 +985,8 @@ void test_status_worktree__update_stat_cache_0(void)
 
 	opts.flags &= ~GIT_STATUS_OPT_UPDATE_INDEX;
 
+	/* tick again as the index updating from the previous diff might have reset the timestamp */
+	tick_index(index);
 	cl_git_pass(git_status_list_new(&status, repo, &opts));
 	check_status0(status);
 	cl_git_pass(git_status_list_get_perfdata(&perf, status));


### PR DESCRIPTION
It turns out that the description in racy-git is deceptively simple, and the implementation for the smudging of racily-clean entries goes all the way to performing a diff check which we were not doing.

---

I'm not too thrilled with the use of `sleep()` but the alternative is changing the timestamp for both the index and file in unison, which we may actually want to do, but it's good enough for PoC.