### PR TITLE
Don't propagate workdir's mode to the index during diff's update index

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -211,7 +211,7 @@ static bool checkout_is_workdir_modified(
 	if (baseitem->size && wditem->file_size != baseitem->size)
 		return true;
 
-	if (git_diff__oid_for_entry(&oid, data->diff, wditem, NULL) < 0)
+	if (git_diff__oid_for_entry(&oid, data->diff, wditem, wditem->mode, NULL) < 0)
 		return false;
 
 	/* Allow the checkout if the workdir is not modified *or* if the checkout

--- a/src/diff.h
+++ b/src/diff.h
@@ -94,7 +94,7 @@ extern int git_diff_delta__format_file_header(
 extern int git_diff__oid_for_file(
 	git_oid *out, git_diff *, const char *, uint16_t, git_off_t);
 extern int git_diff__oid_for_entry(
-	git_oid *out, git_diff *, const git_index_entry *, const git_oid *update);
+	git_oid *out, git_diff *, const git_index_entry *, uint16_t, const git_oid *update);
 
 extern int git_diff__from_iterators(
 	git_diff **diff_ptr,


### PR DESCRIPTION
When diff updates the index, it updates based on the *workdir* mode.  It should instead preserve the original mode to ensure that symlinks on Windows are not treated as regular files (which is their workdir mode).