### PR TITLE
http: return GIT_EAUTH if auth tried but failed

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -34,6 +34,7 @@ static const char *post_verb = "POST";
 
 #define PARSE_ERROR_GENERIC	-1
 #define PARSE_ERROR_REPLAY	-2
+#define PARSE_ERROR_AUTHFAIL	-3
 
 #define CHUNK_SIZE	4096
 
@@ -359,6 +360,9 @@ static int on_headers_complete(http_parser *parser)
 					t->parse_error = PARSE_ERROR_REPLAY;
 					return 0;
 				}
+			} else {
+				giterr_set(GITERR_NET, "authentication failed, incorrect credentials");
+				return t->parse_error = PARSE_ERROR_AUTHFAIL;
 			}
 		}
 
@@ -692,6 +696,9 @@ replay:
 
 			goto replay;
 		}
+
+		if (PARSE_ERROR_AUTHFAIL == t->parse_error)
+			return GIT_EAUTH;
 
 		if (t->parse_error < 0)
 			return -1;


### PR DESCRIPTION
My code currently has to detect HTTP auth failures by checking the error string for "Unexpected HTTP status code: 401" because http (unlike ssh) does not return GIT_EAUTH. This change (should) address that.

Submitted against the master branch because I assumed changing error codes would be a breaking change inappropriate for maint.