### PR TITLE
Check the repository version

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -931,9 +931,14 @@ bool git_repository__reserved_names(
 
 static int check_repositoryformatversion(git_config *config)
 {
-	int version;
+	int version, error;
 
-	if (git_config_get_int32(&version, config, "core.repositoryformatversion") < 0)
+	error = git_config_get_int32(&version, config, "core.repositoryformatversion");
+	/* git ignores this if the config variable isn't there */
+	if (error == GIT_ENOTFOUND)
+		return 0;
+
+	if (error < 0)
 		return -1;
 
 	if (GIT_REPO_VERSION < version) {

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -20,6 +20,23 @@ void test_repo_open__bare_empty_repo(void)
 	cl_assert(git_repository_workdir(repo) == NULL);
 }
 
+void test_repo_open__format_version_1(void)
+{
+	git_buf path = GIT_BUF_INIT;
+	git_repository *repo;
+	git_config *config;
+
+	repo = cl_git_sandbox_init("empty_bare.git");
+
+	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
+	cl_git_pass(git_repository_config__weakptr(&config, repo));
+
+	cl_git_pass(git_config_set_int32(config, "core.repositoryformatversion", 1));
+
+	git_repository_free(repo);
+	cl_git_fail(git_repository_open(&repo, "empty_bare.git"));
+}
+
 void test_repo_open__standard_empty_repo_through_gitdir(void)
 {
 	git_repository *repo;


### PR DESCRIPTION
It hasn't mattered that we don't check for it on open, as it has been 0 since the first release of git, way back when; but times, they're a-changing and we will soon(ish) see version 1in the wild and we must take care that we don't open those and possibly break something (or just produce uncomprehensible results).