### PR TITLE
Stash workdir correctly when added in the index, modified in the workdir

### DIFF
--- a/src/diff.h
+++ b/src/diff.h
@@ -133,6 +133,15 @@ typedef git_diff_delta *(*git_diff__merge_cb)(
 extern int git_diff__merge(
 	git_diff *onto, const git_diff *from, git_diff__merge_cb cb);
 
+extern git_diff_delta *git_diff__merge_like_cgit(
+	const git_diff_delta *a,
+	const git_diff_delta *b,
+	git_pool *pool);
+
+/* Duplicate a `git_diff_delta` out of the `git_pool` */
+extern git_diff_delta *git_diff__delta_dup(
+	const git_diff_delta *d, git_pool *pool);
+
 /*
  * Sometimes a git_diff_file will have a zero size; this attempts to
  * fill in the size without loading the blob if possible.  If that is

--- a/src/diff.h
+++ b/src/diff.h
@@ -123,6 +123,16 @@ extern int git_diff_find_similar__calc_similarity(
 extern int git_diff__commit(
 	git_diff **diff, git_repository *repo, const git_commit *commit, const git_diff_options *opts);
 
+/* Merge two `git_diff`s according to the callback given by `cb`. */
+
+typedef git_diff_delta *(*git_diff__merge_cb)(
+	const git_diff_delta *left,
+	const git_diff_delta *right,
+	git_pool *pool);
+
+extern int git_diff__merge(
+	git_diff *onto, const git_diff *from, git_diff__merge_cb cb);
+
 /*
  * Sometimes a git_diff_file will have a zero size; this attempts to
  * fill in the size without loading the blob if possible.  If that is

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -15,7 +15,7 @@
 #include "fileops.h"
 #include "config.h"
 
-static git_diff_delta *diff_delta__dup(
+git_diff_delta *git_diff__delta_dup(
 	const git_diff_delta *d, git_pool *pool)
 {
 	git_diff_delta *delta = git__malloc(sizeof(git_diff_delta));
@@ -46,7 +46,7 @@ fail:
 	return NULL;
 }
 
-static git_diff_delta *diff_delta__merge_like_cgit(
+git_diff_delta *git_diff__merge_like_cgit(
 	const git_diff_delta *a,
 	const git_diff_delta *b,
 	git_pool *pool)
@@ -67,16 +67,16 @@ static git_diff_delta *diff_delta__merge_like_cgit(
 
 	/* If one of the diffs is a conflict, just dup it */
 	if (b->status == GIT_DELTA_CONFLICTED)
-		return diff_delta__dup(b, pool);
+		return git_diff__delta_dup(b, pool);
 	if (a->status == GIT_DELTA_CONFLICTED)
-		return diff_delta__dup(a, pool);
+		return git_diff__delta_dup(a, pool);
 
 	/* if f2 == f3 or f2 is deleted, then just dup the 'a' diff */
 	if (b->status == GIT_DELTA_UNMODIFIED || a->status == GIT_DELTA_DELETED)
-		return diff_delta__dup(a, pool);
+		return git_diff__delta_dup(a, pool);
 
 	/* otherwise, base this diff on the 'b' diff */
-	if ((dup = diff_delta__dup(b, pool)) == NULL)
+	if ((dup = git_diff__delta_dup(b, pool)) == NULL)
 		return NULL;
 
 	/* If 'a' status is uninteresting, then we're done */
@@ -109,7 +109,7 @@ static git_diff_delta *diff_delta__merge_like_cgit(
 	return dup;
 }
 
-int git_diff__merge_deltas(
+int git_diff__merge(
 	git_diff *onto, const git_diff *from, git_diff__merge_cb cb)
 {
 	int error = 0;
@@ -146,10 +146,10 @@ int git_diff__merge_deltas(
 			STRCMP_CASESELECT(ignore_case, o->old_file.path, f->old_file.path);
 
 		if (cmp < 0) {
-			delta = diff_delta__dup(o, &onto_pool);
+			delta = git_diff__delta_dup(o, &onto_pool);
 			i++;
 		} else if (cmp > 0) {
-			delta = diff_delta__dup(f, &onto_pool);
+			delta = git_diff__delta_dup(f, &onto_pool);
 			j++;
 		} else {
 			const git_diff_delta *left = reversed ? f : o;
@@ -196,7 +196,7 @@ int git_diff__merge_deltas(
 
 int git_diff_merge(git_diff *onto, const git_diff *from)
 {
-	return git_diff__merge_deltas(onto, from, diff_delta__merge_like_cgit);
+	return git_diff__merge(onto, from, git_diff__merge_like_cgit);
 }
 
 int git_diff_find_similar__hashsig_for_file(
@@ -347,7 +347,7 @@ static int insert_delete_side_of_split(
 	git_diff *diff, git_vector *onto, const git_diff_delta *delta)
 {
 	/* make new record for DELETED side of split */
-	git_diff_delta *deleted = diff_delta__dup(delta, &diff->pool);
+	git_diff_delta *deleted = git_diff__delta_dup(delta, &diff->pool);
 	GITERR_CHECK_ALLOC(deleted);
 
 	deleted->status = GIT_DELTA_DELETED;

--- a/tests/stash/foreach.c
+++ b/tests/stash/foreach.c
@@ -69,16 +69,16 @@ void test_stash_foreach__enumerating_a_empty_repository_doesnt_fail(void)
 void test_stash_foreach__can_enumerate_a_repository(void)
 {
 	char *oids_default[] = {
-		"1d91c842a7cdfc25872b3a763e5c31add8816c25", NULL };
+		"493568b7a2681187aaac8a58d3f1eab1527cba84", NULL };
 
 	char *oids_untracked[] = {
 		"7f89a8b15c878809c5c54d1ff8f8c9674154017b",
-		"1d91c842a7cdfc25872b3a763e5c31add8816c25", NULL };
+		"493568b7a2681187aaac8a58d3f1eab1527cba84", NULL };
 
 	char *oids_ignored[] = {
 		"c95599a8fef20a7e57582c6727b1a0d02e0a5828",
 		"7f89a8b15c878809c5c54d1ff8f8c9674154017b",
-		"1d91c842a7cdfc25872b3a763e5c31add8816c25", NULL };
+		"493568b7a2681187aaac8a58d3f1eab1527cba84", NULL };
 
 	cl_git_pass(git_repository_init(&repo, REPO_NAME, 0));
 
@@ -96,9 +96,7 @@ void test_stash_foreach__can_enumerate_a_repository(void)
 	cl_git_pass(git_stash_foreach(repo, callback_cb, &data));
 	cl_assert_equal_i(1, data.invokes);
 
-	data.oids = oids_untracked;
-	data.invokes = 0;
-
+	/* ensure stash_foreach operates with INCLUDE_UNTRACKED */
 	cl_git_pass(git_stash_save(
 		&stash_tip_oid,
 		repo,
@@ -106,18 +104,22 @@ void test_stash_foreach__can_enumerate_a_repository(void)
 		NULL,
 		GIT_STASH_INCLUDE_UNTRACKED));
 
+	data.oids = oids_untracked;
+	data.invokes = 0;
+
 	cl_git_pass(git_stash_foreach(repo, callback_cb, &data));
 	cl_assert_equal_i(2, data.invokes);
 
-	data.oids = oids_ignored;
-	data.invokes = 0;
-
+	/* ensure stash_foreach operates with INCLUDE_IGNORED */
 	cl_git_pass(git_stash_save(
 		&stash_tip_oid,
 		repo,
 		signature,
 		NULL,
 		GIT_STASH_INCLUDE_IGNORED));
+
+	data.oids = oids_ignored;
+	data.invokes = 0;
 
 	cl_git_pass(git_stash_foreach(repo, callback_cb, &data));
 	cl_assert_equal_i(3, data.invokes);

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -100,12 +100,18 @@ $ git status --short
 	assert_blob_oid("refs/stash:how", "e6d64adb2c7f3eb8feb493b556cc8070dca379a3");	/* not so small and */
 	assert_blob_oid("refs/stash:who", "a0400d4954659306a976567af43125a0b1aa8595");	/* funky world */
 	assert_blob_oid("refs/stash:when", NULL);
+	assert_blob_oid("refs/stash:why", "88c2533e21f098b89c91a431d8075cbdbe422a51"); /* would anybody use stash? */
+	assert_blob_oid("refs/stash:where", "e3d6434ec12eb76af8dfa843a64ba6ab91014a0b"); /* .... */
+	assert_blob_oid("refs/stash:.gitignore", "ac4d88de61733173d9959e4b77c69b9f17a00980");
 	assert_blob_oid("refs/stash:just.ignore", NULL);
 
 	assert_blob_oid("refs/stash^2:what", "dd7e1c6f0fefe118f0b63d9f10908c460aa317a6");	/* goodbye */
 	assert_blob_oid("refs/stash^2:how", "e6d64adb2c7f3eb8feb493b556cc8070dca379a3");	/* not so small and */
 	assert_blob_oid("refs/stash^2:who", "cc628ccd10742baea8241c5924df992b5c019f71");	/* world */
 	assert_blob_oid("refs/stash^2:when", NULL);
+	assert_blob_oid("refs/stash^2:why", "88c2533e21f098b89c91a431d8075cbdbe422a51"); /* would anybody use stash? */
+	assert_blob_oid("refs/stash^2:where", "e08f7fbb9a42a0c5367cf8b349f1f08c3d56bd72"); /* ???? */
+	assert_blob_oid("refs/stash^2:.gitignore", "ac4d88de61733173d9959e4b77c69b9f17a00980");
 	assert_blob_oid("refs/stash^2:just.ignore", NULL);
 
 	assert_blob_oid("refs/stash^3", NULL);
@@ -243,11 +249,13 @@ void test_stash_save__cannot_stash_when_there_are_no_local_change(void)
 	cl_git_pass(git_repository_index(&index, repo));
 
 	/*
-	 * 'what' and 'who' are being committed.
-	 * 'when' remain untracked.
+	 * 'what', 'where' and 'who' are being committed.
+	 * 'when' remains untracked.
 	 */
 	cl_git_pass(git_index_add_bypath(index, "what"));
+	cl_git_pass(git_index_add_bypath(index, "where"));
 	cl_git_pass(git_index_add_bypath(index, "who"));
+
 	cl_repo_commit_from_index(NULL, repo, signature, 0, "Initial commit");
 	git_index_free(index);
 

--- a/tests/stash/stash_helpers.c
+++ b/tests/stash/stash_helpers.c
@@ -26,12 +26,17 @@ void setup_stash(git_repository *repo, git_signature *signature)
 	cl_git_rewritefile("stash/what", "goodbye\n");			/* dd7e1c6f0fefe118f0b63d9f10908c460aa317a6 */
 	cl_git_rewritefile("stash/how", "not so small and\n");	/* e6d64adb2c7f3eb8feb493b556cc8070dca379a3 */
 	cl_git_rewritefile("stash/who", "funky world\n");		/* a0400d4954659306a976567af43125a0b1aa8595 */
+	cl_git_mkfile("stash/why", "would anybody use stash?\n"); /* 88c2533e21f098b89c91a431d8075cbde422a51 */
+	cl_git_mkfile("stash/where", "????\n");					/* e08f7fbb9a42a0c5367cf8b349f1f08c3d56bd72 */
 
 	cl_git_pass(git_index_add_bypath(index, "what"));
 	cl_git_pass(git_index_add_bypath(index, "how"));
+	cl_git_pass(git_index_add_bypath(index, "why"));
+	cl_git_pass(git_index_add_bypath(index, "where"));
 	cl_git_pass(git_index_write(index));
 
 	cl_git_rewritefile("stash/what", "see you later\n");	/* bc99dc98b3eba0e9157e94769cd4d49cb49de449 */
+	cl_git_mkfile("stash/where", "....\n");					/* e3d6434ec12eb76af8dfa843a64ba6ab91014a0b */
 
 	git_index_free(index);
 }


### PR DESCRIPTION
We do not presently stash files correctly when a file is added in the index and then modified in the working directory.  We are examining only the working directory with regard to the HEAD, and without examining the index as well (with that file staged) we treat that file as untracked and thus do not include it in the workdir tree.

Correct that by using a diff that includes the index similar to `git_diff_tree_to_workdir_with_index` but with different special cases.  (`git_diff_tree_to_workdir_with_index` is aimed at producing something like `git diff` and so collapses some cases - we differ in that we want to ensure that we still pay attention to the workdir side when the index side is deleted.)