### PR TITLE
Repository Format v1 is coming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ support for HTTPS connections insead of OpenSSL.
 * If libcurl is installed, we will use it to connect to HTTP(S)
   servers.
 
+* Support for `core.repositoryformatversion = 1` has been added. libgit2
+  will now load optional extensions from the `extensions.` namespace.
+
+* The `extensions.preciousObject` extension is now understood, although
+  no action is taken by libgit2 because all objects are precious to us.
+
 ### API additions
 
 * The `git_merge_options` gained a `file_flags` member.

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -46,6 +46,7 @@ typedef enum {
 	GIT_EAPPLIED        = -18,	/**< Patch/merge has already been applied */
 	GIT_EPEEL           = -19,      /**< The requested peel operation is not possible */
 	GIT_EEOF            = -20,      /**< Unexpected EOF */
+	GIT_EUNSUPPORTED	= -21, /**< Requested feature is not supported */
 
 	GIT_PASSTHROUGH     = -30,	/**< Internal only */
 	GIT_ITEROVER        = -31,	/**< Signals end of iteration with iterator */

--- a/src/repository.c
+++ b/src/repository.c
@@ -528,7 +528,6 @@ int git_repository_open_ext(
 		goto cleanup;
 
 	if (version >= 1) {
-		repo->has_extensions = 1;
 		if ((error = check_extensions(repo, config)) < 0)
 			goto cleanup;
 	}
@@ -980,10 +979,15 @@ static int check_repositoryformatversion(int *version, git_config *config)
 static int extension_each_cb(const git_config_entry *entry, void *payload)
 {
 	const char *name = entry->name + strlen("extensions.");
-	(void)payload;
+	git_repository *repo = payload;
 
 	if (!strcmp(name, "noop"))
 		return 0;
+
+	if (!strcmp(name, "preciousobjects")) {
+		repo->extensions |= GIT_REPOSITORY_EXT_PRECIOUS_OBJECTS;
+		return 0;
+	}
 
 	giterr_set(GITERR_REPOSITORY, "Unknown Git repository extension: %s", name);
 	return GIT_EUNSUPPORTED;

--- a/src/repository.c
+++ b/src/repository.c
@@ -971,7 +971,7 @@ static int check_repositoryformatversion(int *version, git_config *config)
 		giterr_set(GITERR_REPOSITORY,
 			"Unsupported repository version %d. Only versions up to %d are supported.",
 			*version, GIT_REPO_VERSION_MAX_ALLOWED);
-		return -1;
+		return GIT_EUNSUPPORTED;
 	}
 
 	return 0;
@@ -986,7 +986,7 @@ static int extension_each_cb(const git_config_entry *entry, void *payload)
 		return 0;
 
 	giterr_set(GITERR_REPOSITORY, "Unknown Git repository extension: %s", name);
-	return -1;
+	return GIT_EUNSUPPORTED;
 }
 
 static int check_extensions(git_repository *repo, git_config *config)

--- a/src/repository.h
+++ b/src/repository.h
@@ -115,6 +115,10 @@ enum {
 	GIT_REPOSITORY_INIT__IS_REINIT  = (1u << 18),
 };
 
+enum {
+	GIT_REPOSITORY_EXT_PRECIOUS_OBJECTS = (1u << 1)
+};
+
 /** Internal structure for repository object */
 struct git_repository {
 	git_odb *_odb;
@@ -136,9 +140,9 @@ struct git_repository {
 
 	git_array_t(git_buf) reserved_names;
 
-	unsigned is_bare:1,
-			 has_extensions:1;
+	unsigned is_bare:1;
 
+	unsigned int extensions;
 	unsigned int lru_counter;
 
 	git_atomic attr_session_key;

--- a/src/repository.h
+++ b/src/repository.h
@@ -136,7 +136,8 @@ struct git_repository {
 
 	git_array_t(git_buf) reserved_names;
 
-	unsigned is_bare:1;
+	unsigned is_bare:1,
+			 has_extensions:1;
 
 	unsigned int lru_counter;
 

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -48,6 +48,15 @@ void test_repo_open__format_version_1(void)
 
 	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
 
+	/* Set preciousObjects extension, try to open (should pass) */
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_bool(config, "extensions.preciousObjects", true));
+
+	git_config_free(config);
+	git_repository_free(repo);
+
+	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
+
 
 	/* Set unknown extension, try to open (should fail) */
 	cl_git_pass(git_repository_config(&config, repo));

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -26,14 +26,36 @@ void test_repo_open__format_version_1(void)
 	git_config *config;
 
 	repo = cl_git_sandbox_init("empty_bare.git");
-
 	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
-	cl_git_pass(git_repository_config(&config, repo));
 
+
+	/* Set repo format version to 1, try to open (should pass) */
+	cl_git_pass(git_repository_config(&config, repo));
 	cl_git_pass(git_config_set_int32(config, "core.repositoryformatversion", 1));
 
 	git_config_free(config);
 	git_repository_free(repo);
+
+	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
+
+
+	/* Set noop extension, try to open (should pass) */
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_bool(config, "extensions.noop", true));
+
+	git_config_free(config);
+	git_repository_free(repo);
+
+	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
+
+
+	/* Set unknown extension, try to open (should fail) */
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_bool(config, "extensions.foobar", true));
+
+	git_config_free(config);
+	git_repository_free(repo);
+
 	cl_git_fail(git_repository_open(&repo, "empty_bare.git"));
 }
 


### PR DESCRIPTION
The following patch by @peff is making its way upstream: http://thread.gmane.org/gmane.comp.version-control.git/272447/focus=272450

It allows Git to start accepting repository version v1, which is the same as v0 except it now reads optional extensions from the config file and fails to load the repository if an extension is not known (because it could affect the behaviour of git in unexpected ways). @peff does a much better job at explaining this on his commit message. Please check it out.

This PR brings libgit2 in-par with the upstream changes.

cc @peff @ethomson @carlosmn 
