### PR TITLE
Handle binary DIFFABLEness properly

### DIFF
--- a/src/diff_patch.h
+++ b/src/diff_patch.h
@@ -24,7 +24,9 @@ enum {
 	GIT_DIFF_PATCH_ALLOCATED = (1 << 0),
 	GIT_DIFF_PATCH_INITIALIZED = (1 << 1),
 	GIT_DIFF_PATCH_LOADED = (1 << 2),
+	/* the two sides are different */
 	GIT_DIFF_PATCH_DIFFABLE = (1 << 3),
+	/* the difference between the two sides has been computed */
 	GIT_DIFF_PATCH_DIFFED = (1 << 4),
 	GIT_DIFF_PATCH_FLATTENED = (1 << 5),
 };

--- a/tests/diff/binary.c
+++ b/tests/diff/binary.c
@@ -269,6 +269,36 @@ void test_diff_binary__delta_append(void)
 	git_index_free(index);
 }
 
+void test_diff_binary__empty_for_no_diff(void)
+{
+	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+	git_oid id;
+	git_commit *commit;
+	git_tree *tree;
+	git_diff *diff;
+	git_buf actual = GIT_BUF_INIT;
+	const char *expected = "";
+
+	opts.flags = GIT_DIFF_SHOW_BINARY | GIT_DIFF_FORCE_BINARY;
+	opts.id_abbrev = GIT_OID_HEXSZ;
+
+	repo = cl_git_sandbox_init("renames");
+
+	cl_git_pass(git_oid_fromstr(&id, "19dd32dfb1520a64e5bbaae8dce6ef423dfa2f13"));
+	cl_git_pass(git_commit_lookup(&commit, repo, &id));
+	cl_git_pass(git_commit_tree(&tree, commit));
+
+	cl_git_pass(git_diff_tree_to_tree(&diff, repo, tree, tree, &opts));
+	cl_git_pass(git_diff_print(diff, GIT_DIFF_FORMAT_PATCH, git_diff_print_callback__to_buf, &actual));
+
+	cl_assert_equal_s("", actual.ptr);
+
+	git_buf_free(&actual);
+	git_diff_free(diff);
+	git_commit_free(commit);
+	git_tree_free(tree);
+}
+
 void test_diff_binary__index_to_workdir(void)
 {
 	git_index *index;

--- a/tests/diff/binary.c
+++ b/tests/diff/binary.c
@@ -1,5 +1,7 @@
 #include "clar_libgit2.h"
 
+#include "git2/sys/diff.h"
+
 #include "buffer.h"
 #include "filebuf.h"
 
@@ -46,6 +48,11 @@ void test_patch(
 
 	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
 	cl_git_pass(git_patch_to_buf(&actual, patch));
+
+	cl_assert_equal_s(expected, actual.ptr);
+
+	git_buf_clear(&actual);
+	cl_git_pass(git_diff_print(diff, GIT_DIFF_FORMAT_PATCH, git_diff_print_callback__to_buf, &actual));
 
 	cl_assert_equal_s(expected, actual.ptr);
 


### PR DESCRIPTION
Set `GIT_DIFF_PATCH_DIFFABLE` correctly for all files that differ, regardless of binary-ness.  It's up to the callbacks what to do about diffable files - either producing an actual binary delta diff, or simply saying "Binary files differ".

Binary files need some deeper inspection into this, since we have avoided loading their data if we knew we wouldn't need it (eg, `SHOW_BINARY` was not provided).  This means we look at the actual file sizes to determine difference, not the file map data size.  Note that we cannot do this for all deltas since some (like submodules) populate the file map data but do not actually have files backing them.

Ugh.