### PR TITLE
Errors: drop the error "class", use a string instead of a `git_error` structure

### DIFF
--- a/examples/common.c
+++ b/examples/common.c
@@ -16,16 +16,13 @@
 
 void check_lg2(int error, const char *message, const char *extra)
 {
-	const git_error *lg2err;
 	const char *lg2msg = "", *lg2spacer = "";
 
 	if (!error)
 		return;
 
-	if ((lg2err = giterr_last()) != NULL && lg2err->message != NULL) {
-		lg2msg = lg2err->message;
+	if ((lg2msg = giterr_last()) != NULL)
 		lg2spacer = " - ";
-	}
 
 	if (extra)
 		fprintf(stderr, "%s '%s' [%d]%s%s\n",

--- a/examples/general.c
+++ b/examples/general.c
@@ -47,12 +47,12 @@
 // as an example.
 static void check_error(int error_code, const char *action)
 {
-	const git_error *error = giterr_last();
+	const char *error = giterr_last();
 	if (!error_code)
 		return;
 
 	printf("Error %d %s - %s\n", error_code, action,
-		   (error && error->message) ? error->message : "???");
+		error ? error : "???");
 
 	exit(1);
 }

--- a/examples/network/clone.c
+++ b/examples/network/clone.c
@@ -102,8 +102,8 @@ int do_clone(git_repository *repo, int argc, char **argv)
 	error = git_clone(&cloned_repo, url, path, &clone_opts);
 	printf("\n");
 	if (error != 0) {
-		const git_error *err = giterr_last();
-		if (err) printf("ERROR %d: %s\n", err->klass, err->message);
+		const char *err = giterr_last();
+		if (err) printf("ERROR: %s\n", err);
 		else printf("ERROR %d: no detailed info\n", error);
 	}
 	else if (cloned_repo) git_repository_free(cloned_repo);

--- a/examples/network/git2.c
+++ b/examples/network/git2.c
@@ -36,7 +36,7 @@ static int run_command(git_cb fn, int argc, char **argv)
 		if (giterr_last() == NULL)
 			fprintf(stderr, "Error without message");
 		else
-			fprintf(stderr, "Bad news:\n %s\n", giterr_last()->message);
+			fprintf(stderr, "Bad news:\n %s\n", giterr_last());
 	}
 
 	if(repo)

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -60,43 +60,7 @@ typedef enum {
  */
 typedef struct {
 	char *message;
-	int klass;
 } git_error;
-
-/** Error classes */
-typedef enum {
-	GITERR_NONE = 0,
-	GITERR_NOMEMORY,
-	GITERR_OS,
-	GITERR_INVALID,
-	GITERR_REFERENCE,
-	GITERR_ZLIB,
-	GITERR_REPOSITORY,
-	GITERR_CONFIG,
-	GITERR_REGEX,
-	GITERR_ODB,
-	GITERR_INDEX,
-	GITERR_OBJECT,
-	GITERR_NET,
-	GITERR_TAG,
-	GITERR_TREE,
-	GITERR_INDEXER,
-	GITERR_SSL,
-	GITERR_SUBMODULE,
-	GITERR_THREAD,
-	GITERR_STASH,
-	GITERR_CHECKOUT,
-	GITERR_FETCHHEAD,
-	GITERR_MERGE,
-	GITERR_SSH,
-	GITERR_FILTER,
-	GITERR_REVERT,
-	GITERR_CALLBACK,
-	GITERR_CHERRYPICK,
-	GITERR_DESCRIBE,
-	GITERR_REBASE,
-	GITERR_FILESYSTEM
-} git_error_t;
 
 /**
  * Return the last `git_error` object that was generated for the
@@ -144,7 +108,7 @@ GIT_EXTERN(int) giterr_detach(git_error *cpy);
  *                    general subsystem that is responsible for the error.
  * @param string The formatted error message to keep
  */
-GIT_EXTERN(void) giterr_set_str(int error_class, const char *string);
+GIT_EXTERN(void) giterr_set(const char *string, ...);
 
 /**
  * Set the error message to a special value for memory allocation failure.

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -53,39 +53,17 @@ typedef enum {
 } git_error_code;
 
 /**
- * Structure to store extra details of the last error that occurred.
+ * Return the last error message that was generated for the current
+ * thread or NULL if no error has occurred.
  *
- * This is kept on a per-thread basis if GIT_THREADS was defined when the
- * library was build, otherwise one is kept globally for the library
+ * @return A string describing the error or NULL.
  */
-typedef struct {
-	char *message;
-} git_error;
-
-/**
- * Return the last `git_error` object that was generated for the
- * current thread or NULL if no error has occurred.
- *
- * @return A git_error object.
- */
-GIT_EXTERN(const git_error *) giterr_last(void);
+GIT_EXTERN(const char *) giterr_last(void);
 
 /**
  * Clear the last library error that occurred for this thread.
  */
 GIT_EXTERN(void) giterr_clear(void);
-
-/**
- * Get the last error data and clear it.
- *
- * This copies the last error into the given `git_error` struct
- * and returns 0 if the copy was successful, leaving the error
- * cleared as if `giterr_clear` had been called.
- *
- * If there was no existing error in the library, -1 will be returned
- * and the contents of `cpy` will be left unmodified.
- */
-GIT_EXTERN(int) giterr_detach(git_error *cpy);
 
 /**
  * Set the error message string for this thread.
@@ -99,13 +77,6 @@ GIT_EXTERN(int) giterr_detach(git_error *cpy);
  * This error message is stored in thread-local storage and only applies
  * to the particular thread that this libgit2 call is made from.
  *
- * NOTE: Passing the `error_class` as GITERR_OS has a special behavior: we
- * attempt to append the system default error message for the last OS error
- * that occurred and then clear the last error.  The specific implementation
- * of looking up and clearing this last OS error will vary by platform.
- *
- * @param error_class One of the `git_error_t` enum above describing the
- *                    general subsystem that is responsible for the error.
  * @param string The formatted error message to keep
  */
 GIT_EXTERN(void) giterr_set(const char *string, ...);

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -30,7 +30,7 @@ int git_attr_file__new(
 	GITERR_CHECK_ALLOC(attrs);
 
 	if (git_mutex_init(&attrs->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to initialize lock");
+		giterr_set_os("Failed to initialize lock");
 		git__free(attrs);
 		return -1;
 	}
@@ -53,7 +53,7 @@ int git_attr_file__clear_rules(git_attr_file *file, bool need_lock)
 	git_attr_rule *rule;
 
 	if (need_lock && git_mutex_lock(&file->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock attribute file");
+		giterr_set_os("Failed to lock attribute file");
 		return -1;
 	}
 
@@ -143,7 +143,7 @@ int git_attr_file__load(
 		break;
 	}
 	default:
-		giterr_set(GITERR_INVALID, "Unknown file source %d", source);
+		giterr_set("Unknown file source %d", source);
 		return -1;
 	}
 
@@ -215,7 +215,7 @@ int git_attr_file__out_of_date(
 	}
 
 	default:
-		giterr_set(GITERR_INVALID, "Invalid file type %d", file->source);
+		giterr_set("Invalid file type %d", file->source);
 		return -1;
 	}
 }
@@ -241,7 +241,7 @@ int git_attr_file__parse_buffer(
 		context = attrs->entry->path;
 
 	if (git_mutex_lock(&attrs->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock attribute file");
+		giterr_set_os("Failed to lock attribute file");
 		return -1;
 	}
 

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -12,7 +12,7 @@ GIT_INLINE(int) attr_cache_lock(git_attr_cache *cache)
 	GIT_UNUSED(cache); /* avoid warning if threading is off */
 
 	if (git_mutex_lock(&cache->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to get attr cache lock");
+		giterr_set_os("Unable to get attr cache lock");
 		return -1;
 	}
 	return 0;
@@ -365,7 +365,7 @@ int git_attr_cache__do_init(git_repository *repo)
 
 	/* set up lock */
 	if (git_mutex_init(&cache->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to initialize lock for attr cache");
+		giterr_set_os("Unable to initialize lock for attr cache");
 		git__free(cache);
 		return -1;
 	}
@@ -429,7 +429,7 @@ int git_attr_cache__insert_macro(git_repository *repo, git_attr_rule *macro)
 		return 0;
 
 	if (git_mutex_lock(&cache->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to get attr cache lock");
+		giterr_set_os("Unable to get attr cache lock");
 		error = -1;
 	} else {
 		git_strmap_insert(macros, macro->match.pattern, macro, error);

--- a/src/blob.c
+++ b/src/blob.c
@@ -96,7 +96,7 @@ static int write_file_stream(
 	p_close(fd);
 
 	if (written != file_size || read_len < 0) {
-		giterr_set(GITERR_OS, "Failed to read file into stream");
+		giterr_set_os("Failed to read file into stream");
 		error = -1;
 	}
 
@@ -142,7 +142,7 @@ static int write_symlink(
 
 	read_len = p_readlink(path, link_data, link_size);
 	if (read_len != (ssize_t)link_size) {
-		giterr_set(GITERR_OS, "Failed to create blob.  Can't read symlink '%s'", path);
+		giterr_set_os("Failed to create blob.  Can't read symlink '%s'", path);
 		git__free(link_data);
 		return -1;
 	}
@@ -302,7 +302,7 @@ int git_blob_create_fromchunks(
 			break;
 
 		if (read_bytes > BUFFER_SIZE) {
-			giterr_set(GITERR_OBJECT, "Invalid chunk size while creating blob");
+			giterr_set("Invalid chunk size while creating blob");
 			error = GIT_EBUFS;
 		} else if (read_bytes < 0) {
 			error = giterr_set_after_callback(read_bytes);

--- a/src/branch.c
+++ b/src/branch.c
@@ -33,7 +33,7 @@ static int retrieve_branch_reference(
 		/* OOM */;
 	else if ((error = git_reference_lookup(&branch, repo, ref_name.ptr)) < 0)
 		giterr_set(
-			GITERR_REFERENCE, "Cannot locate %s branch '%s'",
+			"Cannot locate %s branch '%s'",
 			is_remote ? "remote-tracking" : "local", branch_name);
 
 	*branch_reference_out = branch; /* will be NULL on error */
@@ -45,7 +45,6 @@ static int retrieve_branch_reference(
 static int not_a_local_branch(const char *reference_name)
 {
 	giterr_set(
-		GITERR_INVALID,
 		"Reference '%s' is not a local branch.", reference_name);
 	return -1;
 }
@@ -79,7 +78,7 @@ static int create_branch(
 	}
 
 	if (is_head && force) {
-		giterr_set(GITERR_REFERENCE, "Cannot force update branch '%s' as it is "
+		giterr_set("Cannot force update branch '%s' as it is "
 			"the current HEAD of the repository.", branch_name);
 		error = -1;
 		goto cleanup;
@@ -133,7 +132,7 @@ int git_branch_delete(git_reference *branch)
 	assert(branch);
 
 	if (!git_reference_is_branch(branch) && !git_reference_is_remote(branch)) {
-		giterr_set(GITERR_INVALID, "Reference '%s' is not a valid branch.",
+		giterr_set("Reference '%s' is not a valid branch.",
 			git_reference_name(branch));
 		return GIT_ENOTFOUND;
 	}
@@ -142,7 +141,7 @@ int git_branch_delete(git_reference *branch)
 		return is_head;
 
 	if (is_head) {
-		giterr_set(GITERR_REFERENCE, "Cannot delete branch '%s' as it is "
+		giterr_set("Cannot delete branch '%s' as it is "
 			"the current HEAD of the repository.", git_reference_name(branch));
 		return -1;
 	}
@@ -314,7 +313,7 @@ int git_branch_name(
 	} else if (git_reference_is_remote(ref)) {
 		branch_name += strlen(GIT_REFS_REMOTES_DIR);
 	} else {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 				"Reference '%s' is neither a local nor a remote branch.", ref->name);
 		return -1;
 	}
@@ -372,7 +371,7 @@ int git_branch_upstream_name(
 			goto cleanup;
 
 	if (git_buf_len(&remote_name) == 0 || git_buf_len(&merge_name) == 0) {
-		giterr_set(GITERR_REFERENCE,
+		giterr_set(
 			"branch '%s' does not have an upstream", refname);
 		error = GIT_ENOTFOUND;
 		goto cleanup;
@@ -422,7 +421,7 @@ int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *r
 		return error;
 
 	if (git_buf_len(buf) == 0) {
-		giterr_set(GITERR_REFERENCE, "branch '%s' does not have an upstream remote", refname);
+		giterr_set("branch '%s' does not have an upstream remote", refname);
 		error = GIT_ENOTFOUND;
 		git_buf_clear(buf);
 	}
@@ -445,7 +444,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 
 	/* Verify that this is a remote branch */
 	if (!git_reference__is_remote(refname)) {
-		giterr_set(GITERR_INVALID, "Reference '%s' is not a remote branch.",
+		giterr_set("Reference '%s' is not a remote branch.",
 			refname);
 		error = GIT_ERROR;
 		goto cleanup;
@@ -471,7 +470,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 			} else {
 				git_remote_free(remote);
 
-				giterr_set(GITERR_REFERENCE,
+				giterr_set(
 					"Reference '%s' is ambiguous", refname);
 				error = GIT_EAMBIGUOUS;
 				goto cleanup;
@@ -485,7 +484,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 		git_buf_clear(buf);
 		error = git_buf_puts(buf, remote_name);
 	} else {
-		giterr_set(GITERR_REFERENCE,
+		giterr_set(
 			"Could not determine remote for '%s'", refname);
 		error = GIT_ENOTFOUND;
 	}
@@ -574,7 +573,7 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 	else if (git_branch_lookup(&upstream, repo, upstream_name, GIT_BRANCH_REMOTE) == 0)
 		local = 0;
 	else {
-		giterr_set(GITERR_REFERENCE,
+		giterr_set(
 			"Cannot set upstream for branch '%s'", shortname);
 		return GIT_ENOTFOUND;
 	}

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -42,7 +42,7 @@ int git_buf_try_grow(
 		return -1;
 
 	if (buf->asize == 0 && buf->size != 0) {
-		giterr_set(GITERR_INVALID, "cannot grow a borrowed buffer");
+		giterr_set("cannot grow a borrowed buffer");
 		return GIT_EINVALID;
 	}
 
@@ -308,7 +308,7 @@ int git_buf_decode_base64(git_buf *buf, const char *base64, size_t len)
 			buf->size = orig_size;
 			buf->ptr[buf->size] = '\0';
 
-			giterr_set(GITERR_INVALID, "Invalid base64 input");
+			giterr_set("Invalid base64 input");
 			return -1;
 		}
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -35,7 +35,7 @@ static size_t git_cache__max_object_size[8] = {
 int git_cache_set_max_object_size(git_otype type, size_t size)
 {
 	if (type < 0 || (size_t)type >= ARRAY_SIZE(git_cache__max_object_size)) {
-		giterr_set(GITERR_INVALID, "type out of range");
+		giterr_set("type out of range");
 		return -1;
 	}
 
@@ -70,7 +70,7 @@ int git_cache_init(git_cache *cache)
 	cache->map = git_oidmap_alloc();
 	GITERR_CHECK_ALLOC(cache->map);
 	if (git_rwlock_init(&cache->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize cache rwlock");
+		giterr_set_os("Failed to initialize cache rwlock");
 		return -1;
 	}
 	return 0;

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -991,20 +991,20 @@ static int checkout_conflicts_load_byname_entry(
 	*theirs_out = NULL;
 
 	if (!name_entry->ancestor) {
-		giterr_set(GITERR_INDEX, "A NAME entry exists without an ancestor");
+		giterr_set("A NAME entry exists without an ancestor");
 		error = -1;
 		goto done;
 	}
 
 	if (!name_entry->ours && !name_entry->theirs) {
-		giterr_set(GITERR_INDEX, "A NAME entry exists without an ours or theirs");
+		giterr_set("A NAME entry exists without an ours or theirs");
 		error = -1;
 		goto done;
 	}
 
 	if ((ancestor = checkout_conflicts_search_ancestor(data,
 		name_entry->ancestor)) == NULL) {
-		giterr_set(GITERR_INDEX,
+		giterr_set(
 			"A NAME entry referenced ancestor entry '%s' which does not exist in the main index",
 			name_entry->ancestor);
 		error = -1;
@@ -1016,7 +1016,7 @@ static int checkout_conflicts_load_byname_entry(
 			ours = ancestor;
 		else if ((ours = checkout_conflicts_search_branch(data, name_entry->ours)) == NULL ||
 			ours->ours == NULL) {
-			giterr_set(GITERR_INDEX,
+			giterr_set(
 				"A NAME entry referenced our entry '%s' which does not exist in the main index",
 				name_entry->ours);
 			error = -1;
@@ -1031,7 +1031,7 @@ static int checkout_conflicts_load_byname_entry(
 			theirs = ours;
 		else if ((theirs = checkout_conflicts_search_branch(data, name_entry->theirs)) == NULL ||
 			theirs->theirs == NULL) {
-			giterr_set(GITERR_INDEX,
+			giterr_set(
 				"A NAME entry referenced their entry '%s' which does not exist in the main index",
 				name_entry->theirs);
 			error = -1;
@@ -1130,7 +1130,7 @@ static int checkout_conflicts_mark_directoryfile(
 
 		if ((error = git_index_find(&j, index, path)) < 0) {
 			if (error == GIT_ENOTFOUND)
-				giterr_set(GITERR_INDEX,
+				giterr_set(
 					"Index inconsistency, could not find entry for expected conflict '%s'", path);
 
 			goto done;
@@ -1138,7 +1138,7 @@ static int checkout_conflicts_mark_directoryfile(
 
 		for (; j < len; j++) {
 			if ((entry = git_index_get_byindex(index, j)) == NULL) {
-				giterr_set(GITERR_INDEX,
+				giterr_set(
 					"Index inconsistency, truncated index while loading expected conflict '%s'", path);
 				error = -1;
 				goto done;
@@ -1224,14 +1224,14 @@ static int checkout_verify_paths(
 
 	if (action & CHECKOUT_ACTION__REMOVE) {
 		if (!git_path_isvalid(repo, delta->old_file.path, flags)) {
-			giterr_set(GITERR_CHECKOUT, "Cannot remove invalid path '%s'", delta->old_file.path);
+			giterr_set("Cannot remove invalid path '%s'", delta->old_file.path);
 			return -1;
 		}
 	}
 
 	if (action & ~CHECKOUT_ACTION__REMOVE) {
 		if (!git_path_isvalid(repo, delta->new_file.path, flags)) {
-			giterr_set(GITERR_CHECKOUT, "Cannot checkout to invalid path '%s'", delta->new_file.path);
+			giterr_set("Cannot checkout to invalid path '%s'", delta->new_file.path);
 			return -1;
 		}
 	}
@@ -1299,7 +1299,7 @@ static int checkout_get_actions(
 	if (counts[CHECKOUT_ACTION__CONFLICT] > 0 &&
 		(data->strategy & GIT_CHECKOUT_ALLOW_CONFLICTS) == 0)
 	{
-		giterr_set(GITERR_CHECKOUT, "%d %s checkout",
+		giterr_set("%d %s checkout",
 			(int)counts[CHECKOUT_ACTION__CONFLICT],
 			counts[CHECKOUT_ACTION__CONFLICT] == 1 ?
 			"conflict prevents" : "conflicts prevent");
@@ -1396,7 +1396,7 @@ static int mkpath2file(
 			 */
 			error = git_futils_rmdir_r(path, NULL, GIT_RMDIR_REMOVE_FILES);
 		} else if (errno != ENOENT) {
-			giterr_set(GITERR_OS, "Failed to stat file '%s'", path);
+			giterr_set_os("Failed to stat file '%s'", path);
 			return GIT_EEXISTS;
 		} else {
 			giterr_clear();
@@ -1420,7 +1420,7 @@ static int checkout_stream_write(
 	int ret;
 
 	if ((ret = p_write(stream->fd, buffer, len)) < 0)
-		giterr_set(GITERR_OS, "Could not write to '%s'", stream->path);
+		giterr_set_os("Could not write to '%s'", stream->path);
 
 	return ret;
 }
@@ -1469,7 +1469,7 @@ static int blob_content_to_file(
 		mode = GIT_FILEMODE_BLOB;
 
 	if ((fd = p_open(path, flags, mode)) < 0) {
-		giterr_set(GITERR_OS, "Could not open '%s' for writing", path);
+		giterr_set_os("Could not open '%s' for writing", path);
 		return fd;
 	}
 
@@ -1504,7 +1504,7 @@ static int blob_content_to_file(
 		data->perfdata.chmod_calls++;
 
 		if ((error = p_chmod(path, mode)) < 0) {
-			giterr_set(GITERR_OS, "Failed to set permissions on '%s'", path);
+			giterr_set_os("Failed to set permissions on '%s'", path);
 			return error;
 		}
 	}
@@ -1513,7 +1513,7 @@ static int blob_content_to_file(
 		data->perfdata.stat_calls++;
 
 		if ((error = p_stat(path, st)) < 0) {
-			giterr_set(GITERR_OS, "Error statting '%s'", path);
+			giterr_set_os("Error statting '%s'", path);
 			return error;
 		}
 
@@ -1540,7 +1540,7 @@ static int blob_content_to_link(
 
 	if (data->can_symlink) {
 		if ((error = p_symlink(git_buf_cstr(&linktarget), path)) < 0)
-			giterr_set(GITERR_OS, "Could not create symlink %s", path);
+			giterr_set_os("Could not create symlink %s", path);
 	} else {
 		error = git_futils_fake_symlink(git_buf_cstr(&linktarget), path);
 	}
@@ -1549,7 +1549,7 @@ static int blob_content_to_link(
 		data->perfdata.stat_calls++;
 
 		if ((error = p_lstat(path, st)) < 0)
-			giterr_set(GITERR_CHECKOUT, "Could not stat symlink %s", path);
+			giterr_set("Could not stat symlink %s", path);
 
 		st->st_mode = GIT_FILEMODE_LINK;
 	}
@@ -1594,7 +1594,7 @@ static int checkout_submodule_update_index(
 	data->perfdata.stat_calls++;
 	if (p_stat(git_buf_cstr(&data->path), &st) < 0) {
 		giterr_set(
-			GITERR_CHECKOUT, "Could not stat submodule %s\n", file->path);
+			"Could not stat submodule %s\n", file->path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1667,7 +1667,7 @@ static int checkout_safe_for_update_only(
 			return 0;
 
 		/* otherwise, stat error and no update */
-		giterr_set(GITERR_OS, "Failed to stat file '%s'", path);
+		giterr_set_os("Failed to stat file '%s'", path);
 		return -1;
 	}
 
@@ -1935,7 +1935,7 @@ static int checkout_path_suffixed(git_buf *path, const char *suffix)
 	if (i == INT_MAX) {
 		git_buf_truncate(path, path_len);
 
-		giterr_set(GITERR_CHECKOUT, "Could not write '%s': working directory file exists", path);
+		giterr_set("Could not write '%s': working directory file exists", path);
 		return GIT_EEXISTS;
 	}
 
@@ -2066,7 +2066,7 @@ static int checkout_write_merge(
 		goto done;
 
 	if (result.path == NULL || result.mode == 0) {
-		giterr_set(GITERR_CHECKOUT, "Could not merge contents of file");
+		giterr_set("Could not merge contents of file");
 		error = GIT_ECONFLICT;
 		goto done;
 	}
@@ -2314,7 +2314,7 @@ static int checkout_data_init(
 	memset(data, 0, sizeof(*data));
 
 	if (!repo) {
-		giterr_set(GITERR_CHECKOUT, "Cannot checkout nothing");
+		giterr_set("Cannot checkout nothing");
 		return -1;
 	}
 
@@ -2363,7 +2363,7 @@ static int checkout_data_init(
 			if ((data->opts.checkout_strategy & GIT_CHECKOUT_FORCE) == 0 &&
 				git_index_has_conflicts(data->index)) {
 				error = GIT_ECONFLICT;
-				giterr_set(GITERR_CHECKOUT,
+				giterr_set(
 					"unresolved conflicts exist in the index");
 				goto cleanup;
 			}
@@ -2432,7 +2432,7 @@ static int checkout_data_init(
 		else if (strcmp(conflict_style->value, "diff3") == 0)
 			data->opts.checkout_strategy |= GIT_CHECKOUT_CONFLICT_STYLE_DIFF3;
 		else {
-			giterr_set(GITERR_CHECKOUT, "unknown style '%s' given for 'merge.conflictstyle'",
+			giterr_set("unknown style '%s' given for 'merge.conflictstyle'",
 				conflict_style);
 			error = -1;
 			git_config_entry_free(conflict_style);
@@ -2602,7 +2602,7 @@ int git_checkout_index(
 	git_iterator *index_i;
 
 	if (!index && !repo) {
-		giterr_set(GITERR_CHECKOUT,
+		giterr_set(
 			"Must provide either repository or index to checkout");
 		return -1;
 	}
@@ -2610,7 +2610,7 @@ int git_checkout_index(
 	if (index && repo &&
 		git_index_owner(index) &&
 		git_index_owner(index) != repo) {
-		giterr_set(GITERR_CHECKOUT,
+		giterr_set(
 			"Index to checkout does not match repository");
 		return -1;
 	} else if(index && repo && !git_index_owner(index)) {
@@ -2648,12 +2648,12 @@ int git_checkout_tree(
 	git_iterator *tree_i = NULL;
 
 	if (!treeish && !repo) {
-		giterr_set(GITERR_CHECKOUT,
+		giterr_set(
 			"Must provide either repository or tree to checkout");
 		return -1;
 	}
 	if (treeish && repo && git_object_owner(treeish) != repo) {
-		giterr_set(GITERR_CHECKOUT,
+		giterr_set(
 			"Object to checkout does not match repository");
 		return -1;
 	}
@@ -2664,7 +2664,7 @@ int git_checkout_tree(
 	if (treeish) {
 		if (git_object_peel((git_object **)&tree, treeish, GIT_OBJ_TREE) < 0) {
 			giterr_set(
-				GITERR_CHECKOUT, "Provided object cannot be peeled to a tree");
+				"Provided object cannot be peeled to a tree");
 			return -1;
 		}
 	}
@@ -2672,7 +2672,6 @@ int git_checkout_tree(
 		if ((error = checkout_lookup_head_tree(&tree, repo)) < 0) {
 			if (error != GIT_EUNBORNBRANCH)
 				giterr_set(
-					GITERR_CHECKOUT,
 					"HEAD could not be peeled to a tree and no treeish given");
 			return error;
 		}

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -107,7 +107,7 @@ static int cherrypick_seterr(git_commit *commit, const char *fmt)
 {
 	char commit_oidstr[GIT_OID_HEXSZ + 1];
 
-	giterr_set(GITERR_CHERRYPICK, fmt,
+	giterr_set(fmt,
 		git_oid_tostr(commit_oidstr, GIT_OID_HEXSZ + 1, git_commit_id(commit)));
 
 	return -1;

--- a/src/clone.c
+++ b/src/clone.c
@@ -175,7 +175,7 @@ static int update_head_to_remote(
 	refspec = git_remote__matching_refspec(remote, git_buf_cstr(&branch));
 
 	if (refspec == NULL) {
-		giterr_set(GITERR_NET, "the remote's default branch does not fit the refspec configuration");
+		giterr_set("the remote's default branch does not fit the refspec configuration");
 		error = GIT_EINVALIDSPEC;
 		goto cleanup;
 	}
@@ -331,7 +331,7 @@ static int clone_into(git_repository *repo, git_remote *_remote, const git_fetch
 	assert(repo && _remote);
 
 	if (!git_repository_is_empty(repo)) {
-		giterr_set(GITERR_INVALID, "the repository is not empty");
+		giterr_set("the repository is not empty");
 		return -1;
 	}
 
@@ -403,7 +403,7 @@ int git_clone(
 
 	/* Only clone to a new directory or an empty directory */
 	if (git_path_exists(local_path) && !git_path_is_empty_dir(local_path)) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"'%s' exists and is not an empty directory", local_path);
 		return GIT_EEXISTS;
 	}
@@ -503,7 +503,7 @@ static int clone_local_into(git_repository *repo, git_remote *remote, const git_
 	assert(repo && remote);
 
 	if (!git_repository_is_empty(repo)) {
-		giterr_set(GITERR_INVALID, "the repository is not empty");
+		giterr_set("the repository is not empty");
 		return -1;
 	}
 

--- a/src/commit.c
+++ b/src/commit.c
@@ -79,7 +79,7 @@ int git_commit_create_from_callback(
 	if (ref && !matched_parent) {
 		git_reference_free(ref);
 		git_buf_free(&commit);
-		giterr_set(GITERR_OBJECT, "failed to create commit: current tip is not the first parent");
+		giterr_set("failed to create commit: current tip is not the first parent");
 		return GIT_EMODIFIED;
 	}
 
@@ -113,7 +113,7 @@ int git_commit_create_from_callback(
 
 on_error:
 	git_buf_free(&commit);
-	giterr_set(GITERR_OBJECT, "Failed to create commit.");
+	giterr_set("Failed to create commit.");
 	return -1;
 }
 
@@ -284,7 +284,7 @@ int git_commit_amend(
 
 		if (git_oid_cmp(git_commit_id(commit_to_amend), git_reference_target(ref))) {
 			git_reference_free(ref);
-			giterr_set(GITERR_REFERENCE, "commit to amend is not the tip of the given branch");
+			giterr_set("commit to amend is not the tip of the given branch");
 			return -1;
 		}
 	}
@@ -391,7 +391,7 @@ int git_commit__parse(void *_commit, git_odb_object *odb_obj)
 	return 0;
 
 bad_buffer:
-	giterr_set(GITERR_OBJECT, "Failed to parse bad commit object");
+	giterr_set("Failed to parse bad commit object");
 	return -1;
 }
 
@@ -479,7 +479,7 @@ int git_commit_parent(
 
 	parent_id = git_commit_parent_id(commit, n);
 	if (parent_id == NULL) {
-		giterr_set(GITERR_INVALID, "Parent %u does not exist", n);
+		giterr_set("Parent %u does not exist", n);
 		return GIT_ENOTFOUND;
 	}
 
@@ -567,7 +567,7 @@ int git_commit_header_field(git_buf *out, const git_commit *commit, const char *
 	return GIT_ENOTFOUND;
 
 malformed:
-	giterr_set(GITERR_OBJECT, "malformed header");
+	giterr_set("malformed header");
 	return -1;
 oom:
 	giterr_set_oom();

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -56,7 +56,7 @@ static int commit_error(git_commit_list_node *commit, const char *msg)
 	git_oid_fmt(commit_oid, &commit->oid);
 	commit_oid[GIT_OID_HEXSZ] = '\0';
 
-	giterr_set(GITERR_ODB, "Failed to parse commit %s - %s", commit_oid, msg);
+	giterr_set("Failed to parse commit %s - %s", commit_oid, msg);
 
 	return -1;
 }
@@ -186,7 +186,7 @@ int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit)
 		return error;
 
 	if (obj->cached.type != GIT_OBJ_COMMIT) {
-		giterr_set(GITERR_INVALID, "Object is no commit object");
+		giterr_set("Object is no commit object");
 		error = -1;
 	} else
 		error = commit_quick_parse(

--- a/src/common.h
+++ b/src/common.h
@@ -108,8 +108,8 @@ GIT_INLINE(int) giterr_set_after_callback_function(
 	int error_code, const char *action)
 {
 	if (error_code) {
-		const git_error *e = giterr_last();
-		if (!e || !e->message)
+		const char *e = giterr_last();
+		if (!e)
 			giterr_set(
 				"%s callback returned %d", action, error_code);
 	}
@@ -138,8 +138,8 @@ void giterr_system_set(int code);
  * Structure to preserve libgit2 error state
  */
 typedef struct {
-	int       error_code;
-	git_error error_msg;
+	int error_code;
+	char *error_msg;
 } git_error_state;
 
 /**
@@ -154,7 +154,7 @@ int giterr_capture(git_error_state *state, int error_code);
 int giterr_restore(git_error_state *state);
 
 /** Returns true if the given error state is from an OOM */
-int giterr_is_oom(const git_error *err);
+int giterr_is_oom(const char *err);
 
 /**
  * Check a versioned structure for validity

--- a/src/common.h
+++ b/src/common.h
@@ -10,7 +10,7 @@
 #include "git2/common.h"
 #include "cc-compat.h"
 
-/** Declare a function as always inlined. */
+ /** Declare a function as always inlined. */
 #if defined(_MSC_VER)
 # define GIT_INLINE(type) static __inline type
 #else
@@ -63,8 +63,10 @@
 
 #include "git2/types.h"
 #include "git2/errors.h"
+#include "git2/buffer.h"
 #include "thread-utils.h"
 #include "integer.h"
+#include "buffer.h"
 
 #include <regex.h>
 
@@ -139,7 +141,8 @@ void giterr_system_set(int code);
  */
 typedef struct {
 	int error_code;
-	char *error_msg;
+	const char *last_error;
+	git_buf error_buf;
 } git_error_state;
 
 /**

--- a/src/common.h
+++ b/src/common.h
@@ -85,9 +85,10 @@
 	do { int _err = (code); if (_err) return _err; } while (0)
 
 /**
- * Set the error message for this thread, formatting as needed.
+ * Set the error message for this thread to an operating system
+ * error message.
  */
-void giterr_set(int error_class, const char *string, ...);
+void giterr_set_os(const char *fmt, ...);
 
 /**
  * Set the error message for a regex failure, using the internal regex
@@ -109,7 +110,7 @@ GIT_INLINE(int) giterr_set_after_callback_function(
 	if (error_code) {
 		const git_error *e = giterr_last();
 		if (!e || !e->message)
-			giterr_set(e ? e->klass : GITERR_CALLBACK,
+			giterr_set(
 				"%s callback returned %d", action, error_code);
 	}
 	return error_code;
@@ -152,6 +153,9 @@ int giterr_capture(git_error_state *state, int error_code);
  */
 int giterr_restore(git_error_state *state);
 
+/** Returns true if the given error state is from an OOM */
+int giterr_is_oom(const git_error *err);
+
 /**
  * Check a versioned structure for validity
  */
@@ -166,7 +170,7 @@ GIT_INLINE(int) giterr__check_version(const void *structure, unsigned int expect
 	if (actual > 0 && actual <= expected_max)
 		return 0;
 
-	giterr_set(GITERR_INVALID, "Invalid version %d on %s", actual, name);
+	giterr_set("invalid version %d on %s", actual, name);
 	return -1;
 }
 #define GITERR_CHECK_VERSION(S,V,N) if (giterr__check_version(S,V,N) < 0) return -1

--- a/src/config.c
+++ b/src/config.c
@@ -108,7 +108,7 @@ int git_config_add_file_ondisk(
 
 	res = p_stat(path, &st);
 	if (res < 0 && errno != ENOENT) {
-		giterr_set(GITERR_CONFIG, "Error stat'ing config file '%s'", path);
+		giterr_set("Error stat'ing config file '%s'", path);
 		return -1;
 	}
 
@@ -201,7 +201,7 @@ static int find_internal_file_by_level(
 	}
 
 	if (pos == -1) {
-		giterr_set(GITERR_CONFIG,
+		giterr_set(
 			"No config file exists for the given level '%i'", (int)level);
 		return GIT_ENOTFOUND;
 	}
@@ -217,7 +217,7 @@ static int duplicate_level(void **old_raw, void *new_raw)
 
 	GIT_UNUSED(new_raw);
 
-	giterr_set(GITERR_CONFIG, "A file with the same level (%i) has already been added to the config", (int)(*old)->level);
+	giterr_set("A file with the same level (%i) has already been added to the config", (int)(*old)->level);
 	return GIT_EEXISTS;
 }
 
@@ -577,7 +577,7 @@ int git_config_foreach_match(
 
 static int config_error_nofiles(const char *name)
 {
-	giterr_set(GITERR_CONFIG,
+	giterr_set(
 		"Cannot set value for '%s' when no config files exist", name);
 	return GIT_ENOTFOUND;
 }
@@ -619,7 +619,7 @@ int git_config_set_string(git_config *cfg, const char *name, const char *value)
 	file_internal *internal;
 
 	if (!value) {
-		giterr_set(GITERR_CONFIG, "The value to set cannot be NULL");
+		giterr_set("The value to set cannot be NULL");
 		return -1;
 	}
 
@@ -673,7 +673,7 @@ int git_config__update_entry(
 
 static int config_error_notfound(const char *name)
 {
-	giterr_set(GITERR_CONFIG, "Config value '%s' was not found", name);
+	giterr_set("Config value '%s' was not found", name);
 	return GIT_ENOTFOUND;
 }
 
@@ -841,7 +841,7 @@ int git_config_get_string(
 	int ret;
 
 	if (!is_readonly(cfg)) {
-		giterr_set(GITERR_CONFIG, "get_string called on a live config object");
+		giterr_set("get_string called on a live config object");
 		return -1;
 	}
 
@@ -1190,7 +1190,7 @@ int git_config_lookup_map_value(
 	}
 
 fail_parse:
-	giterr_set(GITERR_CONFIG, "Failed to map '%s'", value);
+	giterr_set("Failed to map '%s'", value);
 	return -1;
 }
 
@@ -1210,7 +1210,7 @@ int git_config_lookup_map_enum(git_cvar_t *type_out, const char **str_out,
 		return 0;
 	}
 
-	giterr_set(GITERR_CONFIG, "invalid enum value");
+	giterr_set("invalid enum value");
 	return GIT_ENOTFOUND;
 }
 
@@ -1224,7 +1224,7 @@ int git_config_parse_bool(int *out, const char *value)
 		return 0;
 	}
 
-	giterr_set(GITERR_CONFIG, "Failed to parse '%s' as a boolean value", value);
+	giterr_set("Failed to parse '%s' as a boolean value", value);
 	return -1;
 }
 
@@ -1267,7 +1267,7 @@ int git_config_parse_int64(int64_t *out, const char *value)
 	}
 
 fail_parse:
-	giterr_set(GITERR_CONFIG, "Failed to parse '%s' as an integer", value ? value : "(null)");
+	giterr_set("Failed to parse '%s' as an integer", value ? value : "(null)");
 	return -1;
 }
 
@@ -1287,7 +1287,7 @@ int git_config_parse_int32(int32_t *out, const char *value)
 	return 0;
 
 fail_parse:
-	giterr_set(GITERR_CONFIG, "Failed to parse '%s' as a 32-bit integer", value ? value : "(null)");
+	giterr_set("Failed to parse '%s' as a 32-bit integer", value ? value : "(null)");
 	return -1;
 }
 
@@ -1302,7 +1302,7 @@ int git_config_parse_path(git_buf *out, const char *value)
 
 	if (value[0] == '~') {
 		if (value[1] != '\0' && value[1] != '/') {
-			giterr_set(GITERR_CONFIG, "retrieving a homedir by name is not supported");
+			giterr_set("retrieving a homedir by name is not supported");
 			return -1;
 		}
 
@@ -1352,7 +1352,7 @@ int git_config__normalize_name(const char *in, char **out)
 
 invalid:
 	git__free(name);
-	giterr_set(GITERR_CONFIG, "Invalid config item name '%s'", in);
+	giterr_set("Invalid config item name '%s'", in);
 	return GIT_EINVALIDSPEC;
 }
 
@@ -1414,8 +1414,7 @@ int git_config_rename_section(
 		(error = git_config_file_normalize_section(
 			replace.ptr, strchr(replace.ptr, '.'))) < 0)
 	{
-		giterr_set(
-			GITERR_CONFIG, "Invalid config section '%s'", new_section_name);
+		giterr_set("Invalid config section '%s'", new_section_name);
 		goto cleanup;
 	}
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -123,13 +123,13 @@ static int config_snapshot(git_config_backend **out, git_config_backend *in);
 
 static void set_parse_error(struct reader *reader, int col, const char *error_str)
 {
-	giterr_set(GITERR_CONFIG, "Failed to parse config file: %s (in %s:%d, column %d)",
+	giterr_set("Failed to parse config file: %s (in %s:%d, column %d)",
 		error_str, reader->file_path, reader->line_number, col);
 }
 
 static int config_error_readonly(void)
 {
-	giterr_set(GITERR_CONFIG, "this backend is read-only");
+	giterr_set("this backend is read-only");
 	return -1;
 }
 
@@ -469,7 +469,7 @@ static int config_set(git_config_backend *cfg, const char *name, const char *val
 		cvar_t *existing = git_strmap_value_at(values, pos);
 
 		if (existing->next != NULL) {
-			giterr_set(GITERR_CONFIG, "Multivar incompatible with simple set");
+			giterr_set("Multivar incompatible with simple set");
 			ret = -1;
 			goto out;
 		}
@@ -615,7 +615,7 @@ static int config_delete(git_config_backend *cfg, const char *name)
 
 	if (!git_strmap_valid_index(values, pos)) {
 		refcounted_strmap_free(map);
-		giterr_set(GITERR_CONFIG, "Could not find key '%s' to delete", name);
+		giterr_set("Could not find key '%s' to delete", name);
 		return GIT_ENOTFOUND;
 	}
 
@@ -623,7 +623,7 @@ static int config_delete(git_config_backend *cfg, const char *name)
 	refcounted_strmap_free(map);
 
 	if (var->next != NULL) {
-		giterr_set(GITERR_CONFIG, "Cannot delete multivar with a single delete");
+		giterr_set("Cannot delete multivar with a single delete");
 		return -1;
 	}
 
@@ -654,7 +654,7 @@ static int config_delete_multivar(git_config_backend *cfg, const char *name, con
 	if (!git_strmap_valid_index(values, pos)) {
 		refcounted_strmap_free(map);
 		git__free(key);
-		giterr_set(GITERR_CONFIG, "Could not find key '%s' to delete", name);
+		giterr_set("Could not find key '%s' to delete", name);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1267,7 +1267,7 @@ static int unescape_line(
 				*fixed++ = escaped[esc - escapes];
 			} else {
 				git__free(str);
-				giterr_set(GITERR_CONFIG, "Invalid escape at %s", ptr);
+				giterr_set("Invalid escape at %s", ptr);
 				return -1;
 			}
 		}
@@ -1581,7 +1581,7 @@ static int config_read(git_strmap *values, diskfile_backend *cfg_file, struct re
 	struct parse_data parse_data;
 
 	if (depth >= MAX_INCLUDE_DEPTH) {
-		giterr_set(GITERR_CONFIG, "Maximum config include depth reached");
+		giterr_set("Maximum config include depth reached");
 		return -1;
 	}
 

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -147,7 +147,7 @@ static int crlf_apply_to_odb(
 			switch (ca->safe_crlf) {
 			case GIT_SAFE_CRLF_FAIL:
 				giterr_set(
-					GITERR_FILTER, "LF would be replaced by CRLF in '%s'",
+					"LF would be replaced by CRLF in '%s'",
 					git_filter_source_path(src));
 				return -1;
 			case GIT_SAFE_CRLF_WARN:
@@ -218,7 +218,7 @@ static const char *line_ending(struct crlf_attrs *ca)
 		return "\r\n";
 
 line_ending_error:
-	giterr_set(GITERR_INVALID, "Invalid input to line ending filter");
+	giterr_set("Invalid input to line ending filter");
 	return NULL;
 }
 

--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -25,7 +25,7 @@ typedef struct {
 
 static int seterr_curl(curl_stream *s)
 {
-	giterr_set(GITERR_NET, "curl error: %s\n", s->curl_error);
+	giterr_set("curl error: %s\n", s->curl_error);
 	return -1;
 }
 
@@ -121,7 +121,7 @@ static int wait_for(curl_socket_t fd, bool reading)
 		FD_SET(fd, &outfd);
 
 	if ((ret = select(fd + 1, &infd, &outfd, &errfd, NULL)) < 0) {
-		giterr_set(GITERR_OS, "error in select");
+		giterr_set_os("error in select");
 		return -1;
 	}
 
@@ -206,7 +206,7 @@ int git_curl_stream_new(git_stream **out, const char *host, const char *port)
 
 	handle = curl_easy_init();
 	if (handle == NULL) {
-		giterr_set(GITERR_NET, "failed to create curl handle");
+		giterr_set("failed to create curl handle");
 		return -1;
 	}
 
@@ -249,7 +249,7 @@ int git_curl_stream_new(git_stream **out, const char *host, const char *port)
 	GIT_UNUSED(host);
 	GIT_UNUSED(port);
 
-	giterr_set(GITERR_NET, "curl is not supported in this version");
+	giterr_set("curl is not supported in this version");
 	return -1;
 }
 

--- a/src/delta-apply.c
+++ b/src/delta-apply.c
@@ -65,12 +65,12 @@ int git__delta_apply(
 	 * base object, resulting in data corruption or segfault.
 	 */
 	if ((hdr_sz(&base_sz, &delta, delta_end) < 0) || (base_sz != base_len)) {
-		giterr_set(GITERR_INVALID, "Failed to apply delta. Base size does not match given data");
+		giterr_set("Failed to apply delta. Base size does not match given data");
 		return -1;
 	}
 
 	if (hdr_sz(&res_sz, &delta, delta_end) < 0) {
-		giterr_set(GITERR_INVALID, "Failed to apply delta. Base size does not match given data");
+		giterr_set("Failed to apply delta. Base size does not match given data");
 		return -1;
 	}
 
@@ -130,6 +130,6 @@ int git__delta_apply(
 fail:
 	git__free(out->data);
 	out->data = NULL;
-	giterr_set(GITERR_INVALID, "Failed to apply delta");
+	giterr_set("Failed to apply delta");
 	return -1;
 }

--- a/src/delta.c
+++ b/src/delta.c
@@ -131,7 +131,7 @@ static int lookup_index_alloc(
 	GITERR_CHECK_ALLOC_ADD(&index_len, index_len, hash_len);
 
 	if (!git__is_ulong(index_len)) {
-		giterr_set(GITERR_NOMEMORY, "Overly large delta");
+		giterr_set("Overly large delta");
 		return -1;
 	}
 

--- a/src/describe.c
+++ b/src/describe.c
@@ -335,14 +335,14 @@ static int display_name(git_buf *buf, git_repository *repo, struct commit_name *
 {
 	if (n->prio == 2 && !n->tag) {
 		if (git_tag_lookup(&n->tag, repo, &n->sha1) < 0) {
-			giterr_set(GITERR_TAG, "Annotated tag '%s' not available", n->path);
+			giterr_set("Annotated tag '%s' not available", n->path);
 			return -1;
 		}
 	}
 
 	if (n->tag && !n->name_checked) {
 		if (!git_tag_name(n->tag)) {
-			giterr_set(GITERR_TAG, "Annotated tag '%s' has no embedded name", n->path);
+			giterr_set("Annotated tag '%s' has no embedded name", n->path);
 			return -1;
 		}
 
@@ -425,7 +425,7 @@ static int describe_not_found(const git_oid *oid, const char *message_format) {
 	char oid_str[GIT_OID_HEXSZ + 1];
 	git_oid_tostr(oid_str, sizeof(oid_str), oid);
 
-	giterr_set(GITERR_DESCRIBE, message_format, oid_str);
+	giterr_set(message_format, oid_str);
 	return GIT_ENOTFOUND;
 }
 
@@ -694,7 +694,7 @@ int git_describe_commit(
 				goto cleanup;
 
 	if (git_oidmap_size(data.names) == 0 && !opts->show_commit_oid_as_fallback) {
-		giterr_set(GITERR_DESCRIBE, "Cannot describe - "
+		giterr_set("Cannot describe - "
 			"No reference found, cannot describe anything.");
 		error = -1;
 		goto cleanup;
@@ -792,7 +792,7 @@ int git_describe_format(git_buf *out, const git_describe_result *result, const g
 
 
 	if (opts.always_use_long_format && opts.abbreviated_size == 0) {
-		giterr_set(GITERR_DESCRIBE, "Cannot describe - "
+		giterr_set("Cannot describe - "
 			"'always_use_long_format' is incompatible with a zero"
 			"'abbreviated_size'");
 		return -1;

--- a/src/diff.c
+++ b/src/diff.c
@@ -635,7 +635,7 @@ int git_diff__oid_for_entry(
 		error = git_odb__hashlink(out, full_path.ptr);
 		diff->perf.oid_calculations++;
 	} else if (!git__is_sizet(entry.file_size)) {
-		giterr_set(GITERR_OS, "File size overflow (for 32-bits) on '%s'",
+		giterr_set_os("File size overflow (for 32-bits) on '%s'",
 			entry.path);
 		error = -1;
 	} else if (!(error = git_filter_list_load(
@@ -1566,7 +1566,7 @@ int git_diff__commit(
 		char commit_oidstr[GIT_OID_HEXSZ + 1];
 
 		error = -1;
-		giterr_set(GITERR_INVALID, "Commit %s is a merge commit",
+		giterr_set("Commit %s is a merge commit",
 			git_oid_tostr(commit_oidstr, GIT_OID_HEXSZ + 1, git_commit_id(commit)));
 		goto on_error;
 	}
@@ -1680,12 +1680,12 @@ int git_diff_format_email(
 
 	if ((ignore_marker = opts->flags & GIT_DIFF_FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER) == false) {
 		if (opts->patch_no > opts->total_patches) {
-			giterr_set(GITERR_INVALID, "patch %"PRIuZ" out of range. max %"PRIuZ, opts->patch_no, opts->total_patches);
+			giterr_set("patch %"PRIuZ" out of range. max %"PRIuZ, opts->patch_no, opts->total_patches);
 			return -1;
 		}
 
 		if (opts->patch_no == 0) {
-			giterr_set(GITERR_INVALID, "invalid patch no %"PRIuZ". should be >0", opts->patch_no);
+			giterr_set("invalid patch no %"PRIuZ". should be >0", opts->patch_no);
 			return -1;
 		}
 	}
@@ -1697,7 +1697,7 @@ int git_diff_format_email(
 		size_t offset = 0;
 
 		if ((offset = (loc - opts->summary)) == 0) {
-			giterr_set(GITERR_INVALID, "summary is empty");
+			giterr_set("summary is empty");
 			error = -1;
 			goto on_error;
 		}

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -153,7 +153,7 @@ static git_diff_driver_registry *git_repository_driver_registry(
 	}
 
 	if (!repo->diff_drivers)
-		giterr_set(GITERR_REPOSITORY, "Unable to create diff driver registry");
+		giterr_set("Unable to create diff driver registry");
 
 	return repo->diff_drivers;
 }

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -276,7 +276,7 @@ static int diff_file_content_load_workdir_symlink(
 
 	read_len = p_readlink(git_buf_cstr(path), fc->map.data, alloc_len);
 	if (read_len < 0) {
-		giterr_set(GITERR_OS, "Failed to read symlink '%s'", fc->file->path);
+		giterr_set_os("Failed to read symlink '%s'", fc->file->path);
 		return -1;
 	}
 

--- a/src/diff_patch.c
+++ b/src/diff_patch.c
@@ -385,7 +385,7 @@ static int diff_required(git_diff *diff, const char *action)
 {
 	if (diff)
 		return 0;
-	giterr_set(GITERR_INVALID, "Must provide valid diff to %s", action);
+	giterr_set("Must provide valid diff to %s", action);
 	return -1;
 }
 
@@ -735,7 +735,7 @@ int git_patch_from_diff(
 
 	delta = git_vector_get(&diff->deltas, idx);
 	if (!delta) {
-		giterr_set(GITERR_INVALID, "Index out of range for delta in diff");
+		giterr_set("Index out of range for delta in diff");
 		return GIT_ENOTFOUND;
 	}
 
@@ -830,7 +830,7 @@ int git_patch_line_stats(
 
 static int diff_error_outofrange(const char *thing)
 {
-	giterr_set(GITERR_INVALID, "Diff patch %s index out of range", thing);
+	giterr_set("Diff patch %s index out of range", thing);
 	return GIT_ENOTFOUND;
 }
 

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -565,7 +565,7 @@ int git_diff_print(
 		print_file = diff_print_one_name_status;
 		break;
 	default:
-		giterr_set(GITERR_INVALID, "Unknown diff output format (%d)", format);
+		giterr_set("Unknown diff output format (%d)", format);
 		return -1;
 	}
 
@@ -622,7 +622,7 @@ int git_diff_print_callback__to_buf(
 	GIT_UNUSED(delta); GIT_UNUSED(hunk);
 
 	if (!output) {
-		giterr_set(GITERR_INVALID, "Buffer pointer must be provided");
+		giterr_set("Buffer pointer must be provided");
 		return -1;
 	}
 

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -129,7 +129,7 @@ int git_diff__merge(
 
 	if (ignore_case != ((from->opts.flags & GIT_DIFF_IGNORE_CASE) != 0) ||
 		reversed    != ((from->opts.flags & GIT_DIFF_REVERSE) != 0)) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"Attempt to merge diffs created with conflicting options");
 		return -1;
 	}

--- a/src/diff_xdiff.c
+++ b/src/diff_xdiff.c
@@ -49,7 +49,7 @@ static int git_xdiff_parse_hunk(git_diff_hunk *hunk, const char *header)
 	return 0;
 
 fail:
-	giterr_set(GITERR_INVALID, "Malformed hunk header from xdiff");
+	giterr_set("Malformed hunk header from xdiff");
 	return -1;
 }
 
@@ -98,7 +98,7 @@ static int diff_update_lines(
 		info->new_lineno += (int)line->num_lines;
 		break;
 	default:
-		giterr_set(GITERR_INVALID, "Unknown diff line origin %02x",
+		giterr_set("Unknown diff line origin %02x",
 			(unsigned int)line->origin);
 		return -1;
 	}

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -113,7 +113,7 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 	remote->need_pack = 0;
 
 	if (filter_wants(remote, opts) < 0) {
-		giterr_set(GITERR_NET, "Failed to filter the reference list for wants");
+		giterr_set("Failed to filter the reference list for wants");
 		return -1;
 	}
 

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -168,11 +168,10 @@ static int fetchhead_ref_parse(
 	}
 
 	if (git_oid_fromstr(oid, oid_str) < 0) {
-		const git_error *oid_err = giterr_last();
-		const char *err_msg = oid_err ? oid_err->message : "Invalid object ID";
+		const char *oid_err = giterr_last();
+		const char *err_msg = oid_err ? oid_err : "Invalid object ID";
 
-		giterr_set("%s in FETCH_HEAD line %d",
-			err_msg, line_num);
+		giterr_set("%s in FETCH_HEAD line %d", err_msg, line_num);
 		return -1;
 	}
 

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -148,7 +148,7 @@ static int fetchhead_ref_parse(
 	*remote_url = NULL;
 
 	if (!*line) {
-		giterr_set(GITERR_FETCHHEAD,
+		giterr_set(
 			"Empty line in FETCH_HEAD line %d", line_num);
 		return -1;
 	}
@@ -162,7 +162,7 @@ static int fetchhead_ref_parse(
 	}
 
 	if (strlen(oid_str) != GIT_OID_HEXSZ) {
-		giterr_set(GITERR_FETCHHEAD,
+		giterr_set(
 			"Invalid object ID in FETCH_HEAD line %d", line_num);
 		return -1;
 	}
@@ -171,7 +171,7 @@ static int fetchhead_ref_parse(
 		const git_error *oid_err = giterr_last();
 		const char *err_msg = oid_err ? oid_err->message : "Invalid object ID";
 
-		giterr_set(GITERR_FETCHHEAD, "%s in FETCH_HEAD line %d",
+		giterr_set("%s in FETCH_HEAD line %d",
 			err_msg, line_num);
 		return -1;
 	}
@@ -179,7 +179,7 @@ static int fetchhead_ref_parse(
 	/* Parse new data from newer git clients */
 	if (*line) {
 		if ((is_merge_str = git__strsep(&line, "\t")) == NULL) {
-			giterr_set(GITERR_FETCHHEAD,
+			giterr_set(
 				"Invalid description data in FETCH_HEAD line %d", line_num);
 			return -1;
 		}
@@ -189,13 +189,13 @@ static int fetchhead_ref_parse(
 		else if (strcmp(is_merge_str, "not-for-merge") == 0)
 			*is_merge = 0;
 		else {
-			giterr_set(GITERR_FETCHHEAD,
+			giterr_set(
 				"Invalid for-merge entry in FETCH_HEAD line %d", line_num);
 			return -1;
 		}
 
 		if ((desc = line) == NULL) {
-			giterr_set(GITERR_FETCHHEAD,
+			giterr_set(
 				"Invalid description in FETCH_HEAD line %d", line_num);
 			return -1;
 		}
@@ -212,7 +212,7 @@ static int fetchhead_ref_parse(
 		if (name) {
 			if ((desc = strstr(name, "' ")) == NULL ||
 				git__prefixcmp(desc, "' of ") != 0) {
-				giterr_set(GITERR_FETCHHEAD,
+				giterr_set(
 					"Invalid description in FETCH_HEAD line %d", line_num);
 				return -1;
 			}
@@ -277,7 +277,7 @@ int git_repository_fetchhead_foreach(git_repository *repo,
 	}
 
 	if (*buffer) {
-		giterr_set(GITERR_FETCHHEAD, "No EOL at line %d", line_num+1);
+		giterr_set("No EOL at line %d", line_num+1);
 		error = -1;
 		goto done;
 	}

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -23,7 +23,7 @@ static int verify_last_error(git_filebuf *file)
 {
 	switch (file->last_error) {
 	case BUFERR_WRITE:
-		giterr_set(GITERR_OS, "Failed to write out file");
+		giterr_set_os("Failed to write out file");
 		return -1;
 
 	case BUFERR_MEM:
@@ -31,7 +31,7 @@ static int verify_last_error(git_filebuf *file)
 		return -1;
 
 	case BUFERR_ZLIB:
-		giterr_set(GITERR_ZLIB,
+		giterr_set(
 			"Buffer error when writing out ZLib data");
 		return -1;
 
@@ -47,7 +47,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 			p_unlink(file->path_lock);
 		else {
 			giterr_clear(); /* actual OS error code just confuses */
-			giterr_set(GITERR_OS,
+			giterr_set_os(
 				"Failed to lock file '%s' for writing", file->path_lock);
 			return GIT_ELOCKED;
 		}
@@ -73,7 +73,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 
 		source = p_open(file->path_original, O_RDONLY);
 		if (source < 0) {
-			giterr_set(GITERR_OS,
+			giterr_set_os(
 				"Failed to open file '%s' for reading",
 				file->path_original);
 			return -1;
@@ -88,7 +88,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		p_close(source);
 
 		if (read_bytes < 0) {
-			giterr_set(GITERR_OS, "Failed to read file '%s'", file->path_original);
+			giterr_set_os("Failed to read file '%s'", file->path_original);
 			return -1;
 		}
 	}
@@ -231,7 +231,7 @@ int git_filebuf_open(git_filebuf *file, const char *path, int flags, mode_t mode
 	if (compression != 0) {
 		/* Initialize the ZLib stream */
 		if (deflateInit(&file->zs, compression) != Z_OK) {
-			giterr_set(GITERR_ZLIB, "Failed to initialize zlib");
+			giterr_set("Failed to initialize zlib");
 			goto cleanup;
 		}
 
@@ -329,14 +329,14 @@ int git_filebuf_commit(git_filebuf *file)
 	file->fd_is_open = false;
 
 	if (p_close(file->fd) < 0) {
-		giterr_set(GITERR_OS, "Failed to close file at '%s'", file->path_lock);
+		giterr_set_os("Failed to close file at '%s'", file->path_lock);
 		goto on_error;
 	}
 
 	file->fd = -1;
 
 	if (p_rename(file->path_lock, file->path_original) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename lockfile to '%s'", file->path_original);
+		giterr_set_os("Failed to rename lockfile to '%s'", file->path_original);
 		goto on_error;
 	}
 
@@ -472,7 +472,7 @@ int git_filebuf_stats(time_t *mtime, size_t *size, git_filebuf *file)
 		res = p_stat(file->path_original, &st);
 
 	if (res < 0) {
-		giterr_set(GITERR_OS, "Could not get stat info for '%s'",
+		giterr_set_os("Could not get stat info for '%s'",
 			file->path_original);
 		return res;
 	}

--- a/src/filter.c
+++ b/src/filter.c
@@ -240,7 +240,7 @@ int git_filter_register(
 
 	if (!filter_registry_find(NULL, name)) {
 		giterr_set(
-			GITERR_FILTER, "Attempt to reregister existing filter '%s'", name);
+			"Attempt to reregister existing filter '%s'", name);
 		return GIT_EEXISTS;
 	}
 
@@ -285,12 +285,12 @@ int git_filter_unregister(const char *name)
 
 	/* cannot unregister default filters */
 	if (!strcmp(GIT_FILTER_CRLF, name) || !strcmp(GIT_FILTER_IDENT, name)) {
-		giterr_set(GITERR_FILTER, "Cannot unregister filter '%s'", name);
+		giterr_set("Cannot unregister filter '%s'", name);
 		return -1;
 	}
 
 	if ((fdef = filter_registry_lookup(&pos, name)) == NULL) {
-		giterr_set(GITERR_FILTER, "Cannot find filter '%s' to unregister", name);
+		giterr_set("Cannot find filter '%s' to unregister", name);
 		return GIT_ENOTFOUND;
 	}
 
@@ -609,7 +609,7 @@ int git_filter_list_push(
 	if (git_vector_search2(
 			&pos, &git__filter_registry->filters,
 			filter_def_filter_key_check, filter) < 0) {
-		giterr_set(GITERR_FILTER, "Cannot use an unregistered filter");
+		giterr_set("Cannot use an unregistered filter");
 		return -1;
 	}
 
@@ -724,7 +724,7 @@ static int buf_from_blob(git_buf *out, git_blob *blob)
 	git_off_t rawsize = git_blob_rawsize(blob);
 
 	if (!git__is_sizet(rawsize)) {
-		giterr_set(GITERR_OS, "Blob is too large to filter");
+		giterr_set_os("Blob is too large to filter");
 		return -1;
 	}
 

--- a/src/global.c
+++ b/src/global.c
@@ -142,7 +142,7 @@ int git_openssl_set_locking(void)
 
 	for (i = 0; i < num_locks; i++) {
 		if (git_mutex_init(&openssl_locks[i]) != 0) {
-			giterr_set(GITERR_SSL, "failed to initialize openssl locks");
+			giterr_set("failed to initialize openssl locks");
 			return -1;
 		}
 	}
@@ -151,11 +151,11 @@ int git_openssl_set_locking(void)
 	git__on_shutdown(shutdown_ssl_locking);
 	return 0;
 # else
-	giterr_set(GITERR_THREAD, "libgit2 as not built with threads");
+	giterr_set("libgit2 as not built with threads");
 	return -1;
 # endif
 #else
-	giterr_set(GITERR_SSL, "libgit2 was not built with OpenSSL support");
+	giterr_set("libgit2 was not built with OpenSSL support");
 	return -1;
 #endif
 }

--- a/src/global.c
+++ b/src/global.c
@@ -41,8 +41,8 @@ static void git__global_state_cleanup(git_global_st *st)
 	if (!st)
 		return;
 
-	git__free(st->error_t.message);
-	st->error_t.message = NULL;
+	git__free(st->error_buf);
+	st->error_buf = NULL;
 }
 
 static void git__shutdown(void)

--- a/src/global.c
+++ b/src/global.c
@@ -41,8 +41,7 @@ static void git__global_state_cleanup(git_global_st *st)
 	if (!st)
 		return;
 
-	git__free(st->error_buf);
-	st->error_buf = NULL;
+	git_buf_free(&st->error_buf);
 }
 
 static void git__shutdown(void)

--- a/src/global.h
+++ b/src/global.h
@@ -16,7 +16,7 @@ typedef struct {
 	const char *last_error;
 
 	/* last error message allocated, should be freed */
-	char *error_buf;
+	git_buf error_buf;
 
 	char oid_fmt[GIT_OID_HEXSZ+1];
 } git_global_st;

--- a/src/global.h
+++ b/src/global.h
@@ -12,8 +12,12 @@
 #include "hash.h"
 
 typedef struct {
-	git_error *last_error;
-	git_error error_t;
+	/* last error that occurred, may be the static OOM message */
+	const char *last_error;
+
+	/* last error message allocated, should be freed */
+	char *error_buf;
+
 	char oid_fmt[GIT_OID_HEXSZ+1];
 } git_global_st;
 

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -213,7 +213,7 @@ static int hashsig_finalize_hashes(git_hashsig *sig)
 {
 	if (sig->mins.size < HASHSIG_HEAP_MIN_SIZE &&
 		!(sig->opt & GIT_HASHSIG_ALLOW_SMALL_FILES)) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"File too small for similarity signature calculation");
 		return GIT_EBUFS;
 	}
@@ -285,7 +285,7 @@ int git_hashsig_create_fromfile(
 	while (!error) {
 		if ((buflen = p_read(fd, buf, sizeof(buf))) <= 0) {
 			if ((error = (int)buflen) < 0)
-				giterr_set(GITERR_OS,
+				giterr_set_os(
 					"Read error on '%s' calculating similarity hashes", path);
 			break;
 		}

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -106,7 +106,7 @@ static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match
 			goto out;
 
 		if ((error = p_fnmatch(git_buf_cstr(&buf), path, FNM_PATHNAME)) < 0) {
-			giterr_set(GITERR_INVALID, "error matching pattern");
+			giterr_set("error matching pattern");
 			goto out;
 		}
 
@@ -144,7 +144,7 @@ static int parse_ignore_file(
 		context = attrs->entry->path;
 
 	if (git_mutex_lock(&attrs->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock ignore file");
+		giterr_set_os("Failed to lock ignore file");
 		return -1;
 	}
 
@@ -558,7 +558,7 @@ int git_ignore__check_pathspec_for_exact_ignores(
 			break;
 
 		if (ignored) {
-			giterr_set(GITERR_INVALID, "pathspec contains ignored file '%s'",
+			giterr_set("pathspec contains ignored file '%s'",
 				filename);
 			error = GIT_EINVALIDSPEC;
 			break;

--- a/src/index.c
+++ b/src/index.c
@@ -338,7 +338,7 @@ static int index_sort_if_needed(git_index *index, bool need_lock)
 		return 0;
 
 	if (need_lock && git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to lock index");
+		giterr_set_os("Unable to lock index");
 		return -1;
 	}
 
@@ -407,7 +407,7 @@ int git_index_open(git_index **index_out, const char *index_path)
 	GITERR_CHECK_ALLOC(index);
 
 	if (git_mutex_init(&index->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize lock");
+		giterr_set_os("Failed to initialize lock");
 		git__free(index);
 		return -1;
 	}
@@ -531,7 +531,7 @@ int git_index_clear(git_index *index)
 	git_pool_clear(&index->tree_pool);
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock index");
+		giterr_set_os("Failed to lock index");
 		return -1;
 	}
 
@@ -551,7 +551,7 @@ int git_index_clear(git_index *index)
 
 static int create_index_error(int error, const char *msg)
 {
-	giterr_set(GITERR_INDEX, msg);
+	giterr_set(msg);
 	return error;
 }
 
@@ -617,7 +617,7 @@ static int compare_checksum(git_index *index)
 
 	if ((error = p_lseek(fd, -20, SEEK_END)) < 0) {
 		p_close(fd);
-		giterr_set(GITERR_OS, "failed to seek to end of file");
+		giterr_set("failed to seek to end of file");
 		return -1;
 	}
 
@@ -651,7 +651,6 @@ int git_index_read(git_index *index, int force)
 	if ((updated = git_futils_filestamp_check(&stamp, index->index_file_path) < 0) ||
 	    ((updated = compare_checksum(index)) < 0)) {
 		giterr_set(
-			GITERR_INDEX,
 			"Failed to read index: '%s' no longer exists",
 			index->index_file_path);
 		return updated;
@@ -809,7 +808,7 @@ const git_index_entry *git_index_get_bypath(
 	assert(index);
 
 	if (index_find(&pos, index, path, 0, stage, true) < 0) {
-		giterr_set(GITERR_INDEX, "Index does not contain %s", path);
+		giterr_set("Index does not contain %s", path);
 		return NULL;
 	}
 
@@ -842,7 +841,7 @@ static int index_entry_create(
 
 	if (!git_path_isvalid(repo, path,
 		GIT_PATH_REJECT_DEFAULTS | GIT_PATH_REJECT_DOT_GIT)) {
-		giterr_set(GITERR_INDEX, "Invalid path: '%s'", path);
+		giterr_set("Invalid path: '%s'", path);
 		return -1;
 	}
 
@@ -1057,7 +1056,7 @@ static int check_file_directory_collision(git_index *index,
 	retval = retval + has_dir_name(index, entry, ok_to_replace);
 
 	if (retval) {
-		giterr_set(GITERR_INDEX,
+		giterr_set(
 			"'%s' appears as both a file and a directory", entry->path);
 		return -1;
 	}
@@ -1069,7 +1068,7 @@ static int index_no_dups(void **old, void *new)
 {
 	const git_index_entry *entry = new;
 	GIT_UNUSED(old);
-	giterr_set(GITERR_INDEX, "'%s' appears multiple times at stage %d",
+	giterr_set("'%s' appears multiple times at stage %d",
 		entry->path, GIT_IDXENTRY_STAGE(entry));
 	return GIT_EEXISTS;
 }
@@ -1102,7 +1101,7 @@ static int index_insert(
 		entry->flags |= GIT_IDXENTRY_NAMEMASK;
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to acquire index lock");
+		giterr_set_os("Unable to acquire index lock");
 		return -1;
 	}
 
@@ -1201,7 +1200,7 @@ int git_index_add_frombuffer(
 			"Index is not backed up by an existing repository.");
 
 	if (!valid_filemode(source_entry->mode)) {
-		giterr_set(GITERR_INDEX, "invalid filemode");
+		giterr_set("invalid filemode");
 		return -1;
 	}
 
@@ -1275,7 +1274,7 @@ int git_index_add(git_index *index, const git_index_entry *source_entry)
 	assert(index && source_entry && source_entry->path);
 
 	if (!valid_filemode(source_entry->mode)) {
-		giterr_set(GITERR_INDEX, "invalid filemode");
+		giterr_set("invalid filemode");
 		return -1;
 	}
 
@@ -1293,13 +1292,13 @@ int git_index_remove(git_index *index, const char *path, int stage)
 	size_t position;
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock index");
+		giterr_set_os("Failed to lock index");
 		return -1;
 	}
 
 	if (index_find(&position, index, path, 0, stage, false) < 0) {
 		giterr_set(
-			GITERR_INDEX, "Index does not contain %s at stage %d", path, stage);
+			"Index does not contain %s at stage %d", path, stage);
 		error = GIT_ENOTFOUND;
 	} else {
 		error = index_remove_entry(index, position);
@@ -1317,7 +1316,7 @@ int git_index_remove_directory(git_index *index, const char *dir, int stage)
 	git_index_entry *entry;
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock index");
+		giterr_set_os("Failed to lock index");
 		return -1;
 	}
 
@@ -1360,14 +1359,14 @@ int git_index_find(size_t *at_pos, git_index *index, const char *path)
 	assert(index && path);
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock index");
+		giterr_set_os("Failed to lock index");
 		return -1;
 	}
 
 	if (git_vector_bsearch2(
 			&pos, &index->entries, index->entries_search_path, path) < 0) {
 		git_mutex_unlock(&index->lock);
-		giterr_set(GITERR_INDEX, "Index does not contain %s", path);
+		giterr_set("Index does not contain %s", path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1407,7 +1406,7 @@ int git_index_conflict_add(git_index *index,
 	/* Validate entries */
 	for (i = 0; i < 3; i++) {
 		if (entries[i] && !valid_filemode(entries[i]->mode)) {
-			giterr_set(GITERR_INDEX, "invalid filemode for stage %d entry",
+			giterr_set("invalid filemode for stage %d entry",
 				i);
 			return -1;
 		}
@@ -1538,7 +1537,7 @@ static int index_conflict_remove(git_index *index, const char *path)
 		return GIT_ENOTFOUND;
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to lock index");
+		giterr_set_os("Unable to lock index");
 		return -1;
 	}
 
@@ -1819,7 +1818,7 @@ void git_index_reuc_clear(git_index *index)
 
 static int index_error_invalid(const char *message)
 {
-	giterr_set(GITERR_INDEX, "Invalid data in index - %s", message);
+	giterr_set("Invalid data in index - %s", message);
 	return -1;
 }
 
@@ -2101,7 +2100,7 @@ static int parse_index(git_index *index, const char *buffer, size_t buffer_size)
 	seek_forward(INDEX_HEADER_SIZE);
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to acquire index lock");
+		giterr_set_os("Unable to acquire index lock");
 		return -1;
 	}
 
@@ -2262,7 +2261,7 @@ static int write_entries(git_index *index, git_filebuf *file)
 	git_index_entry *entry;
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock index");
+		giterr_set_os("Failed to lock index");
 		return -1;
 	}
 
@@ -2560,7 +2559,7 @@ int git_index_read_tree(git_index *index, const git_tree *tree)
 		if ((error = git_index_clear(index)) < 0)
 			/* well, this isn't good */;
 		else if (git_mutex_lock(&index->lock) < 0) {
-			giterr_set(GITERR_OS, "Unable to acquire index lock");
+			giterr_set_os("Unable to acquire index lock");
 			error = -1;
 		} else {
 			git_vector_swap(&entries, &index->entries);
@@ -2891,7 +2890,7 @@ static int index_apply_to_all(
 				i--; /* back up foreach if we removed this */
 			break;
 		default:
-			giterr_set(GITERR_INVALID, "Unknown index action %d", action);
+			giterr_set("Unknown index action %d", action);
 			error = -1;
 			break;
 		}
@@ -2938,7 +2937,7 @@ int git_index_snapshot_new(git_vector *snap, git_index *index)
 	GIT_REFCOUNT_INC(index);
 
 	if (git_mutex_lock(&index->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock index");
+		giterr_set_os("Failed to lock index");
 		return -1;
 	}
 
@@ -2994,7 +2993,7 @@ int git_indexwriter_init(
 		&writer->file, index->index_file_path, GIT_FILEBUF_HASH_CONTENTS, GIT_INDEX_FILE_MODE)) < 0) {
 
 		if (error == GIT_ELOCKED)
-			giterr_set(GITERR_INDEX, "The index is locked. This might be due to a concurrent or crashed process");
+			giterr_set("The index is locked. This might be due to a concurrent or crashed process");
 
 		return error;
 	}
@@ -3045,7 +3044,7 @@ int git_indexwriter_commit(git_indexwriter *writer)
 
 	if ((error = git_futils_filestamp_check(
 		&writer->index->stamp, writer->index->index_file_path)) < 0) {
-		giterr_set(GITERR_OS, "Could not read index timestamp");
+		giterr_set_os("Could not read index timestamp");
 		return -1;
 	}
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -83,12 +83,12 @@ static int parse_header(struct git_pack_header *hdr, struct git_pack_file *pack)
 
 	/* Verify we recognize this pack file format. */
 	if (hdr->hdr_signature != ntohl(PACK_SIGNATURE)) {
-		giterr_set(GITERR_INDEXER, "Wrong pack signature");
+		giterr_set("Wrong pack signature");
 		return -1;
 	}
 
 	if (!pack_version_ok(hdr->hdr_version)) {
-		giterr_set(GITERR_INDEXER, "Wrong pack version");
+		giterr_set("Wrong pack version");
 		return -1;
 	}
 
@@ -296,7 +296,7 @@ static int store_object(git_indexer *idx)
 	}
 
 	if (error == 0) {
-		giterr_set(GITERR_INDEXER, "duplicate object %s found in pack", git_oid_tostr_s(&pentry->sha1));
+		giterr_set("duplicate object %s found in pack", git_oid_tostr_s(&pentry->sha1));
 		git__free(pentry);
 		goto on_error;
 	}
@@ -348,7 +348,7 @@ static int save_entry(git_indexer *idx, struct entry *entry, struct git_pack_ent
 	k = kh_put(oid, idx->pack->idx_cache, &pentry->sha1, &error);
 
 	if (error <= 0) {
-		giterr_set(GITERR_INDEXER, "cannot insert object into pack");
+		giterr_set("cannot insert object into pack");
 		return -1;
 	}
 
@@ -376,7 +376,7 @@ static int hash_and_save(git_indexer *idx, git_rawobj *obj, git_off_t entry_star
 	GITERR_CHECK_ALLOC(entry);
 
 	if (git_odb__hashobj(&oid, obj) < 0) {
-		giterr_set(GITERR_INDEXER, "Failed to hash object");
+		giterr_set("Failed to hash object");
 		goto on_error;
 	}
 
@@ -485,7 +485,7 @@ static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 
 	if (p_lseek(fd, current_size + size - 1, SEEK_SET) < 0 ||
 	    p_write(idx->pack->mwf.fd, data, 1) < 0) {
-		giterr_set(GITERR_OS, "cannot extend packfile '%s'", idx->pack->pack_name);
+		giterr_set_os("cannot extend packfile '%s'", idx->pack->pack_name);
 		return -1;
 	}
 
@@ -693,7 +693,7 @@ static int inject_object(git_indexer *idx, git_oid *id)
 	entry_start = idx->pack->mwf.size;
 
 	if (git_odb_read(&obj, idx->odb, id) < 0) {
-		giterr_set(GITERR_INDEXER, "missing delta bases");
+		giterr_set("missing delta bases");
 		return -1;
 	}
 
@@ -766,7 +766,7 @@ static int fix_thin_pack(git_indexer *idx, git_transfer_progress *stats)
 	assert(git_vector_length(&idx->deltas) > 0);
 
 	if (idx->odb == NULL) {
-		giterr_set(GITERR_INDEXER, "cannot fix a thin pack without an ODB");
+		giterr_set("cannot fix a thin pack without an ODB");
 		return -1;
 	}
 
@@ -788,14 +788,14 @@ static int fix_thin_pack(git_indexer *idx, git_transfer_progress *stats)
 	}
 
 	if (!found_ref_delta) {
-		giterr_set(GITERR_INDEXER, "no REF_DELTA found, cannot inject object");
+		giterr_set("no REF_DELTA found, cannot inject object");
 		return -1;
 	}
 
 	/* curpos now points to the base information, which is an OID */
 	base_info = git_mwindow_open(&idx->pack->mwf, &w, curpos, GIT_OID_RAWSZ, &left);
 	if (base_info == NULL) {
-		giterr_set(GITERR_INDEXER, "failed to map delta information");
+		giterr_set("failed to map delta information");
 		return -1;
 	}
 
@@ -919,7 +919,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 
 	/* Test for this before resolve_deltas(), as it plays with idx->off */
 	if (idx->off < idx->pack->mwf.size - 20) {
-		giterr_set(GITERR_INDEXER, "Unexpected data at the end of the pack");
+		giterr_set("Unexpected data at the end of the pack");
 		return -1;
 	}
 
@@ -935,7 +935,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 
 	git_hash_final(&trailer_hash, &idx->trailer);
 	if (git_oid_cmp(&file_hash, &trailer_hash)) {
-		giterr_set(GITERR_INDEXER, "packfile trailer mismatch");
+		giterr_set("packfile trailer mismatch");
 		return -1;
 	}
 
@@ -946,7 +946,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 		return error;
 
 	if (stats->indexed_objects != stats->total_objects) {
-		giterr_set(GITERR_INDEXER, "early EOF");
+		giterr_set("early EOF");
 		return -1;
 	}
 
@@ -1039,7 +1039,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	git_mwindow_free_all(&idx->pack->mwf);
 	/* We need to close the descriptor here so Windows doesn't choke on commit_at */
 	if (p_close(idx->pack->mwf.fd) < 0) {
-		giterr_set(GITERR_OS, "failed to close packfile");
+		giterr_set_os("failed to close packfile");
 		goto on_error;
 	}
 

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1103,7 +1103,7 @@ static int fs_iterator__expand_dir(fs_iterator *fi)
 	fs_iterator_frame *ff;
 
 	if (fi->depth > FS_MAX_DEPTH) {
-		giterr_set(GITERR_REPOSITORY,
+		giterr_set(
 			"Directory nesting is too deep (%d)", fi->depth);
 		return -1;
 	}
@@ -1636,7 +1636,7 @@ int git_iterator_set_ignore_case(git_iterator *iter, bool ignore_case)
 		else
 			iter->flags &= ~GIT_ITERATOR_IGNORE_CASE;
 	} else {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"Cannot currently set ignore case on non-empty iterators");
 		return -1;
 	}

--- a/src/merge.c
+++ b/src/merge.c
@@ -79,7 +79,7 @@ int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_reposito
 	unsigned int i;
 
 	if (length < 2) {
-		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %u.", length);
+		giterr_set("At least two commits are required to find an ancestor. Provided 'length' was %u.", length);
 		return -1;
 	}
 
@@ -105,7 +105,7 @@ int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_reposito
 		goto on_error;
 
 	if (!result) {
-		giterr_set(GITERR_MERGE, "No merge base found");
+		giterr_set("No merge base found");
 		error = GIT_ENOTFOUND;
 		goto on_error;
 	}
@@ -185,7 +185,7 @@ int git_merge_base_octopus(git_oid *out, git_repository *repo, size_t length, co
 	assert(out && repo && input_array);
 
 	if (length < 2) {
-		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %u.", length);
+		giterr_set("At least two commits are required to find an ancestor. Provided 'length' was %u.", length);
 		return -1;
 	}
 
@@ -231,7 +231,7 @@ static int merge_bases(git_commit_list **out, git_revwalk **walk_out, git_reposi
 
 	if (!result) {
 		git_revwalk_free(walk);
-		giterr_set(GITERR_MERGE, "No merge base found");
+		giterr_set("No merge base found");
 		return GIT_ENOTFOUND;
 	}
 
@@ -427,7 +427,7 @@ int git_repository_mergehead_foreach(
 
 	while ((line = git__strsep(&buffer, "\n")) != NULL) {
 		if (strlen(line) != GIT_OID_HEXSZ) {
-			giterr_set(GITERR_INVALID, "Unable to parse OID - invalid length");
+			giterr_set("Unable to parse OID - invalid length");
 			error = -1;
 			goto cleanup;
 		}
@@ -444,7 +444,7 @@ int git_repository_mergehead_foreach(
 	}
 
 	if (*buffer) {
-		giterr_set(GITERR_MERGE, "No EOL at line %d", line_num);
+		giterr_set("No EOL at line %d", line_num);
 		error = -1;
 		goto cleanup;
 	}
@@ -2507,7 +2507,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 		goto done;
 
 	if ((conflicts = index_conflicts + wd_conflicts) > 0) {
-		giterr_set(GITERR_MERGE, "%d uncommitted change%s would be overwritten by merge",
+		giterr_set("%d uncommitted change%s would be overwritten by merge",
 			conflicts, (conflicts != 1) ? "s" : "");
 		error = GIT_ECONFLICT;
 	}
@@ -2664,7 +2664,7 @@ int git_merge_analysis(
 	assert(analysis_out && preference_out && repo && their_heads);
 
 	if (their_heads_len != 1) {
-		giterr_set(GITERR_MERGE, "Can only merge a single branch");
+		giterr_set("Can only merge a single branch");
 		error = -1;
 		goto done;
 	}
@@ -2721,7 +2721,7 @@ int git_merge(
 	assert(repo && their_heads);
 
 	if (their_heads_len != 1) {
-		giterr_set(GITERR_MERGE, "Can only merge a single branch");
+		giterr_set("Can only merge a single branch");
 		return -1;
 	}
 

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -166,7 +166,7 @@ static int git_merge_file__from_inputs(
 
 	if ((xdl_result = xdl_merge(&ancestor_mmfile, &our_mmfile,
 		&their_mmfile, &xmparam, &mmbuffer)) < 0) {
-		giterr_set(GITERR_MERGE, "Failed to merge files.");
+		giterr_set("Failed to merge files.");
 		error = -1;
 		goto done;
 	}

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -65,7 +65,7 @@ int git_mwindow_get_pack(struct git_pack_file **out, const char *path)
 		return error;
 
 	if (git_mutex_lock(&git__mwindow_mutex) < 0) {
-		giterr_set(GITERR_OS, "failed to lock mwindow mutex");
+		giterr_set_os("failed to lock mwindow mutex");
 		return -1;
 	}
 
@@ -135,7 +135,7 @@ void git_mwindow_put_pack(struct git_pack_file *pack)
 void git_mwindow_free_all(git_mwindow_file *mwf)
 {
 	if (git_mutex_lock(&git__mwindow_mutex)) {
-		giterr_set(GITERR_THREAD, "unable to lock mwindow mutex");
+		giterr_set("unable to lock mwindow mutex");
 		return;
 	}
 
@@ -242,7 +242,7 @@ static int git_mwindow_close_lru(git_mwindow_file *mwf)
 	}
 
 	if (!lru_w) {
-		giterr_set(GITERR_OS, "Failed to close memory window. Couldn't find LRU");
+		giterr_set_os("Failed to close memory window. Couldn't find LRU");
 		return -1;
 	}
 
@@ -327,7 +327,7 @@ unsigned char *git_mwindow_open(
 	git_mwindow *w = *cursor;
 
 	if (git_mutex_lock(&git__mwindow_mutex)) {
-		giterr_set(GITERR_THREAD, "unable to lock mwindow mutex");
+		giterr_set("unable to lock mwindow mutex");
 		return NULL;
 	}
 
@@ -379,7 +379,7 @@ int git_mwindow_file_register(git_mwindow_file *mwf)
 	int ret;
 
 	if (git_mutex_lock(&git__mwindow_mutex)) {
-		giterr_set(GITERR_THREAD, "unable to lock mwindow mutex");
+		giterr_set("unable to lock mwindow mutex");
 		return -1;
 	}
 
@@ -419,7 +419,7 @@ void git_mwindow_close(git_mwindow **window)
 	git_mwindow *w = *window;
 	if (w) {
 		if (git_mutex_lock(&git__mwindow_mutex)) {
-			giterr_set(GITERR_THREAD, "unable to lock mwindow mutex");
+			giterr_set("unable to lock mwindow mutex");
 			return;
 		}
 

--- a/src/netops.c
+++ b/src/netops.c
@@ -144,7 +144,7 @@ int gitno_connection_data_from_url(
 		default_port = "80";
 
 		if (data->use_ssl) {
-			giterr_set(GITERR_NET, "Redirect from HTTPS to HTTP is not allowed");
+			giterr_set("Redirect from HTTPS to HTTP is not allowed");
 			goto cleanup;
 		}
 	} else if (!git__prefixcmp(url, prefix_https)) {
@@ -155,7 +155,7 @@ int gitno_connection_data_from_url(
 		default_port = data->use_ssl ? "443" : "80";
 
 	if (!default_port) {
-		giterr_set(GITERR_NET, "Unrecognized URL prefix");
+		giterr_set("Unrecognized URL prefix");
 		goto cleanup;
 	}
 
@@ -187,7 +187,7 @@ int gitno_connection_data_from_url(
 
 		/* Check for errors in the resulting data */
 		if (original_host && url[0] != '/' && strcmp(original_host, data->host)) {
-			giterr_set(GITERR_NET, "Cross host redirect not allowed");
+			giterr_set("Cross host redirect not allowed");
 			error = -1;
 		}
 	}
@@ -237,7 +237,7 @@ int gitno_extract_url_parts(
 	const char *_host, *_port, *_path, *_userinfo;
 
 	if (http_parser_parse_url(url, strlen(url), false, &u)) {
-		giterr_set(GITERR_NET, "Malformed URL '%s'", url);
+		giterr_set("Malformed URL '%s'", url);
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -261,7 +261,7 @@ int gitno_extract_url_parts(
 		*path = git__substrdup(_path, u.field_data[UF_PATH].len);
 		GITERR_CHECK_ALLOC(*path);
 	} else {
-		giterr_set(GITERR_NET, "invalid url, missing path");
+		giterr_set("invalid url, missing path");
 		return GIT_EINVALIDSPEC;
 	}
 

--- a/src/notes.c
+++ b/src/notes.c
@@ -15,7 +15,7 @@
 
 static int note_error_notfound(void)
 {
-	giterr_set(GITERR_INVALID, "Note could not be found");
+	giterr_set("Note could not be found");
 	return GIT_ENOTFOUND;
 }
 
@@ -226,7 +226,7 @@ static int remove_note_in_tree_enotfound_cb(
 	GIT_UNUSED(note_oid);
 	GIT_UNUSED(fanout);
 
-	giterr_set(GITERR_REPOSITORY, "Object '%s' has no note", annotated_object_sha);
+	giterr_set("Object '%s' has no note", annotated_object_sha);
 	return current_error;
 }
 
@@ -244,7 +244,7 @@ static int insert_note_in_tree_eexists_cb(git_tree **out,
 	GIT_UNUSED(note_oid);
 	GIT_UNUSED(fanout);
 
-	giterr_set(GITERR_REPOSITORY, "Note for '%s' exists already", annotated_object_sha);
+	giterr_set("Note for '%s' exists already", annotated_object_sha);
 	return current_error;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -64,13 +64,13 @@ int git_object__from_odb_object(
 
 	/* Validate type match */
 	if (type != GIT_OBJ_ANY && type != odb_obj->cached.type) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"The requested type does not match the type in the ODB");
 		return GIT_ENOTFOUND;
 	}
 
 	if ((object_size = git_object__size(odb_obj->cached.type)) == 0) {
-		giterr_set(GITERR_INVALID, "The requested type is invalid");
+		giterr_set("The requested type is invalid");
 		return GIT_ENOTFOUND;
 	}
 
@@ -121,7 +121,7 @@ int git_object_lookup_prefix(
 	assert(repo && object_out && id);
 
 	if (len < GIT_OID_MINPREFIXLEN) {
-		giterr_set(GITERR_OBJECT, "Ambiguous lookup - OID prefix is too short");
+		giterr_set("Ambiguous lookup - OID prefix is too short");
 		return GIT_EAMBIGUOUS;
 	}
 
@@ -145,7 +145,7 @@ int git_object_lookup_prefix(
 
 				if (type != GIT_OBJ_ANY && type != object->cached.type) {
 					git_object_free(object);
-					giterr_set(GITERR_INVALID,
+					giterr_set(
 						"The requested type does not match the type in ODB");
 					return GIT_ENOTFOUND;
 				}
@@ -295,7 +295,7 @@ static int peel_error(int error, const git_oid *oid, git_otype type)
 	git_oid_fmt(hex_oid, oid);
 	hex_oid[GIT_OID_HEXSZ] = '\0';
 
-	giterr_set(GITERR_OBJECT, "The git_object of id '%s' can not be "
+	giterr_set("The git_object of id '%s' can not be "
 		"successfully peeled into a %s (git_otype=%i).", hex_oid, type_name, type);
 
 	return error;
@@ -410,7 +410,7 @@ int git_object_lookup_bypath(
 
 	if (type != GIT_OBJ_ANY && git_tree_entry_type(entry) != type)
 	{
-		giterr_set(GITERR_OBJECT,
+		giterr_set(
 				"object at path '%s' is not of the asked-for type %d",
 				path, type);
 		error = GIT_EINVALIDSPEC;

--- a/src/odb.c
+++ b/src/odb.c
@@ -151,7 +151,7 @@ int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 	int error = 0;
 
 	if (!git_object_typeisloose(type)) {
-		giterr_set(GITERR_INVALID, "Invalid object type for hash");
+		giterr_set("Invalid object type for hash");
 		return -1;
 	}
 
@@ -174,7 +174,7 @@ int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 	 * If size is not zero, the file was truncated after we originally
 	 * stat'd it, so we consider this a read failure too */
 	if (read_len < 0 || size > 0) {
-		giterr_set(GITERR_OS, "Error reading file for hashing");
+		giterr_set_os("Error reading file for hashing");
 		error = -1;
 
 		goto done;
@@ -226,7 +226,7 @@ int git_odb__hashlink(git_oid *out, const char *path)
 		return -1;
 
 	if (!git__is_int(st.st_size) || (int)st.st_size < 0) {
-		giterr_set(GITERR_FILESYSTEM, "File size overflow for 32-bit systems");
+		giterr_set("File size overflow for 32-bit systems");
 		return -1;
 	}
 
@@ -244,7 +244,7 @@ int git_odb__hashlink(git_oid *out, const char *path)
 		read_len = p_readlink(path, link_data, size);
 		link_data[size] = '\0';
 		if (read_len != size) {
-			giterr_set(GITERR_OS, "Failed to read symlink data for '%s'", path);
+			giterr_set_os("Failed to read symlink data for '%s'", path);
 			git__free(link_data);
 			return -1;
 		}
@@ -270,7 +270,7 @@ int git_odb_hashfile(git_oid *out, const char *path, git_otype type)
 		return fd;
 
 	if ((size = git_futils_filesize(fd)) < 0 || !git__is_sizet(size)) {
-		giterr_set(GITERR_OS, "File size overflow for 32-bit systems");
+		giterr_set_os("File size overflow for 32-bit systems");
 		p_close(fd);
 		return -1;
 	}
@@ -335,7 +335,7 @@ static int init_fake_wstream(git_odb_stream **stream_p, git_odb_backend *backend
 	fake_wstream *stream;
 
 	if (!git__is_ssizet(size)) {
-		giterr_set(GITERR_ODB, "object size too large to keep in memory");
+		giterr_set("object size too large to keep in memory");
 		return -1;
 	}
 
@@ -445,7 +445,7 @@ size_t git_odb_num_backends(git_odb *odb)
 
 static int git_odb__error_unsupported_in_backend(const char *action)
 {
-	giterr_set(GITERR_ODB,
+	giterr_set(
 		"Cannot %s - unsupported in the loaded odb backends", action);
 	return -1;
 }
@@ -463,7 +463,7 @@ int git_odb_get_backend(git_odb_backend **out, git_odb *odb, size_t pos)
 		return 0;
 	}
 
-	giterr_set(GITERR_ODB, "No ODB backend loaded at index %" PRIuZ, pos);
+	giterr_set("No ODB backend loaded at index %" PRIuZ, pos);
 	return GIT_ENOTFOUND;
 }
 
@@ -488,7 +488,7 @@ static int add_default_backends(
 		if (as_alternates)
 			return 0;
 
-		giterr_set(GITERR_ODB, "Failed to load object database in '%s'", objects_dir);
+		giterr_set("Failed to load object database in '%s'", objects_dir);
 		return -1;
 	}
 
@@ -1009,7 +1009,7 @@ static int git_odb_stream__invalid_length(
 	const git_odb_stream *stream,
 	const char *action)
 {
-	giterr_set(GITERR_ODB,
+	giterr_set(
 		"Cannot %s - "
 		"Invalid length. %"PRIuZ" was expected. The "
 		"total size of the received chunks amounts to %"PRIuZ".",
@@ -1144,16 +1144,16 @@ int git_odb__error_notfound(const char *message, const git_oid *oid)
 	if (oid != NULL) {
 		char oid_str[GIT_OID_HEXSZ + 1];
 		git_oid_tostr(oid_str, sizeof(oid_str), oid);
-		giterr_set(GITERR_ODB, "Object not found - %s (%s)", message, oid_str);
+		giterr_set("Object not found - %s (%s)", message, oid_str);
 	} else
-		giterr_set(GITERR_ODB, "Object not found - %s", message);
+		giterr_set("Object not found - %s", message);
 
 	return GIT_ENOTFOUND;
 }
 
 int git_odb__error_ambiguous(const char *message)
 {
-	giterr_set(GITERR_ODB, "Ambiguous SHA1 prefix - %s", message);
+	giterr_set("Ambiguous SHA1 prefix - %s", message);
 	return GIT_EAMBIGUOUS;
 }
 

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -214,7 +214,7 @@ static int finish_inflate(z_stream *s)
 	inflateEnd(s);
 
 	if ((status != Z_STREAM_END) || (s->avail_in != 0)) {
-		giterr_set(GITERR_ZLIB, "Failed to finish ZLib inflation. Stream aborted prematurely");
+		giterr_set("Failed to finish ZLib inflation. Stream aborted prematurely");
 		return -1;
 	}
 
@@ -243,7 +243,7 @@ static int inflate_buffer(void *in, size_t inlen, void *out, size_t outlen)
 	zs.avail_in = (uInt)inlen;
 
 	if (inflateInit(&zs) < Z_OK) {
-		giterr_set(GITERR_ZLIB, "Failed to inflate buffer");
+		giterr_set("Failed to inflate buffer");
 		return -1;
 	}
 
@@ -255,7 +255,7 @@ static int inflate_buffer(void *in, size_t inlen, void *out, size_t outlen)
 	if (status != Z_STREAM_END /* || zs.avail_in != 0 */ ||
 		zs.total_out != outlen)
 	{
-		giterr_set(GITERR_ZLIB, "Failed to inflate buffer. Stream aborted prematurely");
+		giterr_set("Failed to inflate buffer. Stream aborted prematurely");
 		return -1;
 	}
 
@@ -319,7 +319,7 @@ static int inflate_packlike_loose_disk_obj(git_rawobj *out, git_buf *obj)
 	 */
 	if ((used = get_binary_object_header(&hdr, obj)) == 0 ||
 		!git_object_typeisloose(hdr.type)) {
-		giterr_set(GITERR_ODB, "Failed to inflate loose object.");
+		giterr_set("Failed to inflate loose object.");
 		return -1;
 	}
 
@@ -366,7 +366,7 @@ static int inflate_disk_obj(git_rawobj *out, git_buf *obj)
 		(used = get_object_header(&hdr, head)) == 0 ||
 		!git_object_typeisloose(hdr.type))
 	{
-		giterr_set(GITERR_ODB, "Failed to inflate disk object.");
+		giterr_set("Failed to inflate disk object.");
 		return -1;
 	}
 
@@ -455,7 +455,7 @@ static int read_header_loose(git_rawobj *out, git_buf *loc)
 		|| get_object_header(&header_obj, inflated_buffer) == 0
 		|| git_object_typeisloose(header_obj.type) == 0)
 	{
-		giterr_set(GITERR_ZLIB, "Failed to read loose object header");
+		giterr_set("Failed to read loose object header");
 		error = -1;
 	} else {
 		out->len = header_obj.size;

--- a/src/oid.c
+++ b/src/oid.c
@@ -16,7 +16,7 @@ static char to_hex[] = "0123456789abcdef";
 
 static int oid_error_invalid(const char *msg)
 {
-	giterr_set(GITERR_INVALID, "Unable to parse OID - %s", msg);
+	giterr_set("Unable to parse OID - %s", msg);
 	return -1;
 }
 
@@ -380,7 +380,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 	node_index idx;
 
 	if (os->full) {
-		giterr_set(GITERR_INVALID, "Unable to shorten OID - OID set full");
+		giterr_set("Unable to shorten OID - OID set full");
 		return -1;
 	}
 
@@ -395,7 +395,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 		trie_node *node;
 
 		if (c == -1) {
-			giterr_set(GITERR_INVALID, "Unable to shorten OID - invalid hex value");
+			giterr_set("Unable to shorten OID - invalid hex value");
 			return -1;
 		}
 
@@ -410,7 +410,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 			node = push_leaf(os, idx, git__fromhex(tail[0]), &tail[1]);
 			if (node == NULL) {
 				if (os->full)
-					giterr_set(GITERR_INVALID, "Unable to shorten OID - OID set full");
+					giterr_set("Unable to shorten OID - OID set full");
 				return -1;
 			}
 		}
@@ -418,7 +418,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 		if (node->children[c] == 0) {
 			if (push_leaf(os, idx, c, &text_oid[i + 1]) == NULL) {
 				if (os->full)
-					giterr_set(GITERR_INVALID, "Unable to shorten OID - OID set full");
+					giterr_set("Unable to shorten OID - OID set full");
 				return -1;
 			}
 			break;

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -116,33 +116,33 @@ static int ssl_set_error(SSL *ssl, int error)
 	switch (err) {
 	case SSL_ERROR_WANT_CONNECT:
 	case SSL_ERROR_WANT_ACCEPT:
-		giterr_set(GITERR_NET, "SSL error: connection failure\n");
+		giterr_set("SSL error: connection failure\n");
 		break;
 	case SSL_ERROR_WANT_X509_LOOKUP:
-		giterr_set(GITERR_NET, "SSL error: x509 error\n");
+		giterr_set("SSL error: x509 error\n");
 		break;
 	case SSL_ERROR_SYSCALL:
 		e = ERR_get_error();
 		if (e > 0) {
-			giterr_set(GITERR_NET, "SSL error: %s",
+			giterr_set("SSL error: %s",
 					ERR_error_string(e, NULL));
 			break;
 		} else if (error < 0) {
-			giterr_set(GITERR_OS, "SSL error: syscall failure");
+			giterr_set_os("SSL error: syscall failure");
 			break;
 		}
-		giterr_set(GITERR_NET, "SSL error: received early EOF");
+		giterr_set("SSL error: received early EOF");
 		return GIT_EEOF;
 		break;
 	case SSL_ERROR_SSL:
 		e = ERR_get_error();
-		giterr_set(GITERR_NET, "SSL error: %s",
+		giterr_set("SSL error: %s",
 				ERR_error_string(e, NULL));
 		break;
 	case SSL_ERROR_NONE:
 	case SSL_ERROR_ZERO_RETURN:
 	default:
-		giterr_set(GITERR_NET, "SSL error: unknown error");
+		giterr_set("SSL error: unknown error");
 		break;
 	}
 	return -1;
@@ -187,7 +187,7 @@ static int verify_server_cert(SSL *ssl, const char *host)
 	int i = -1,j;
 
 	if (SSL_get_verify_result(ssl) != X509_V_OK) {
-		giterr_set(GITERR_SSL, "The SSL certificate is invalid");
+		giterr_set("The SSL certificate is invalid");
 		return GIT_ECERTIFICATE;
 	}
 
@@ -205,7 +205,7 @@ static int verify_server_cert(SSL *ssl, const char *host)
 
 	cert = SSL_get_peer_certificate(ssl);
 	if (!cert) {
-		giterr_set(GITERR_SSL, "the server did not provide a certificate");
+		giterr_set("the server did not provide a certificate");
 		return -1;
 	}
 
@@ -295,7 +295,7 @@ on_error:
 
 cert_fail_name:
 	OPENSSL_free(peer_cn);
-	giterr_set(GITERR_SSL, "hostname does not match certificate");
+	giterr_set("hostname does not match certificate");
 	return GIT_ECERTIFICATE;
 }
 
@@ -342,7 +342,7 @@ int openssl_certificate(git_cert **out, git_stream *stream)
 	/* Retrieve the length of the certificate first */
 	len = i2d_X509(cert, NULL);
 	if (len < 0) {
-		giterr_set(GITERR_NET, "failed to retrieve certificate information");
+		giterr_set("failed to retrieve certificate information");
 		return -1;
 	}
 
@@ -354,7 +354,7 @@ int openssl_certificate(git_cert **out, git_stream *stream)
 	len = i2d_X509(cert, &guard);
 	if (len < 0) {
 		git__free(encoded_cert);
-		giterr_set(GITERR_NET, "failed to retrieve certificate information");
+		giterr_set("failed to retrieve certificate information");
 		return -1;
 	}
 
@@ -437,7 +437,7 @@ int git_openssl_stream_new(git_stream **out, const char *host, const char *port)
 
 	st->ssl = SSL_new(git__ssl_ctx);
 	if (st->ssl == NULL) {
-		giterr_set(GITERR_SSL, "failed to create ssl object");
+		giterr_set("failed to create ssl object");
 		return -1;
 	}
 
@@ -469,7 +469,7 @@ int git_openssl_stream_new(git_stream **out, const char *host, const char *port)
 	GIT_UNUSED(host);
 	GIT_UNUSED(port);
 
-	giterr_set(GITERR_SSL, "openssl is not supported in this version");
+	giterr_set("openssl is not supported in this version");
 	return -1;
 }
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -153,7 +153,7 @@ int git_packbuilder_new(git_packbuilder **out, git_repository *repo)
 		git_mutex_init(&pb->progress_mutex) ||
 		git_cond_init(&pb->progress_cond))
 	{
-		giterr_set(GITERR_OS, "Failed to initialize packbuilder mutex");
+		giterr_set_os("Failed to initialize packbuilder mutex");
 		goto on_error;
 	}
 
@@ -216,7 +216,7 @@ int git_packbuilder_insert(git_packbuilder *pb, const git_oid *oid,
 		GITERR_CHECK_ALLOC_MULTIPLY(&newsize, newsize, 3 / 2);
 
 		if (!git__is_uint32(newsize)) {
-			giterr_set(GITERR_NOMEMORY, "Packfile too large to fit in memory.");
+			giterr_set("Packfile too large to fit in memory.");
 			return -1;
 		}
 
@@ -285,7 +285,7 @@ static int get_delta(void **out, git_odb *odb, git_pobject *po)
 		&delta_size, 0);
 
 	if (!delta_buf || delta_size != po->delta_size) {
-		giterr_set(GITERR_INVALID, "Delta size changed");
+		giterr_set("Delta size changed");
 		goto on_error;
 	}
 
@@ -606,7 +606,7 @@ static git_pobject **compute_write_order(git_packbuilder *pb)
 	}
 
 	if (wo_end != pb->nr_objects) {
-		giterr_set(GITERR_INVALID, "invalid write order");
+		giterr_set("invalid write order");
 		return NULL;
 	}
 
@@ -784,7 +784,7 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 		git_odb_object_free(obj);
 
 		if (sz != trg_size) {
-			giterr_set(GITERR_INVALID,
+			giterr_set(
 				   "Inconsistent target object length");
 			return -1;
 		}
@@ -806,7 +806,7 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 		git_odb_object_free(obj);
 
 		if (sz != src_size) {
-			giterr_set(GITERR_INVALID,
+			giterr_set(
 				   "Inconsistent source object length");
 			return -1;
 		}
@@ -1105,7 +1105,7 @@ static void *threaded_find_deltas(void *arg)
 		git_packbuilder__progress_unlock(me->pb);
 
 		if (git_mutex_lock(&me->mutex)) {
-			giterr_set(GITERR_THREAD, "unable to lock packfile condition mutex");
+			giterr_set("unable to lock packfile condition mutex");
 			return NULL;
 		}
 
@@ -1184,7 +1184,7 @@ static int ll_find_deltas(git_packbuilder *pb, git_pobject **list,
 		ret = git_thread_create(&p[i].thread, NULL,
 					threaded_find_deltas, &p[i]);
 		if (ret) {
-			giterr_set(GITERR_THREAD, "unable to create thread");
+			giterr_set("unable to create thread");
 			return -1;
 		}
 		active_threads++;
@@ -1253,7 +1253,7 @@ static int ll_find_deltas(git_packbuilder *pb, git_pobject **list,
 		git_packbuilder__progress_unlock(pb);
 
 		if (git_mutex_lock(&target->mutex)) {
-			giterr_set(GITERR_THREAD, "unable to lock packfile condition mutex");
+			giterr_set("unable to lock packfile condition mutex");
 			git__free(p);
 			return -1;
 		}
@@ -1459,7 +1459,7 @@ int git_packbuilder_insert_recur(git_packbuilder *pb, const git_oid *id, const c
 		break;
 
 	default:
-		giterr_set(GITERR_INVALID, "unknown object type");
+		giterr_set("unknown object type");
 		error = -1;
 	}
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -45,7 +45,7 @@ static int pack_entry_find_offset(
 
 static int packfile_error(const char *message)
 {
-	giterr_set(GITERR_ODB, "Invalid pack file - %s", message);
+	giterr_set("Invalid pack file - %s", message);
 	return -1;
 }
 
@@ -99,7 +99,7 @@ static int cache_init(git_pack_cache *cache)
 	cache->memory_limit = GIT_PACK_CACHE_MEMORY_LIMIT;
 
 	if (git_mutex_init(&cache->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize pack cache mutex");
+		giterr_set_os("Failed to initialize pack cache mutex");
 
 		git__free(cache->entries);
 		cache->entries = NULL;
@@ -165,7 +165,7 @@ static int cache_add(
 	entry = new_cache_object(base);
 	if (entry) {
 		if (git_mutex_lock(&cache->lock) < 0) {
-			giterr_set(GITERR_OS, "failed to lock cache");
+			giterr_set_os("failed to lock cache");
 			git__free(entry);
 			return -1;
 		}
@@ -226,7 +226,7 @@ static int pack_index_check(const char *path, struct git_pack_file *p)
 
 	if (p_fstat(fd, &st) < 0) {
 		p_close(fd);
-		giterr_set(GITERR_OS, "Unable to stat pack index '%s'", path);
+		giterr_set_os("Unable to stat pack index '%s'", path);
 		return -1;
 	}
 
@@ -235,7 +235,7 @@ static int pack_index_check(const char *path, struct git_pack_file *p)
 		(idx_size = (size_t)st.st_size) < 4 * 256 + 20 + 20)
 	{
 		p_close(fd);
-		giterr_set(GITERR_ODB, "Invalid pack index '%s'", path);
+		giterr_set("Invalid pack index '%s'", path);
 		return -1;
 	}
 
@@ -421,13 +421,13 @@ static int packfile_unpack_header1(
 	shift = 4;
 	while (c & 0x80) {
 		if (len <= used) {
-			giterr_set(GITERR_ODB, "buffer too small");
+			giterr_set("buffer too small");
 			return GIT_EBUFS;
 		}
 
 		if (bitsizeof(long) <= shift) {
 			*usedp = 0;
-			giterr_set(GITERR_ODB, "packfile corrupted");
+			giterr_set("packfile corrupted");
 			return -1;
 		}
 
@@ -791,7 +791,7 @@ int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, 
 	st = inflateInit(&obj->zstream);
 	if (st != Z_OK) {
 		git__free(obj);
-		giterr_set(GITERR_ZLIB, "failed to init packfile stream");
+		giterr_set("failed to init packfile stream");
 		return -1;
 	}
 
@@ -822,7 +822,7 @@ ssize_t git_packfile_stream_read(git_packfile_stream *obj, void *buffer, size_t 
 	written = len - obj->zstream.avail_out;
 
 	if (st != Z_OK && st != Z_STREAM_END) {
-		giterr_set(GITERR_ZLIB, "error reading from the zlib stream");
+		giterr_set("error reading from the zlib stream");
 		return -1;
 	}
 
@@ -869,7 +869,7 @@ int packfile_unpack_compressed(
 	st = inflateInit(&stream);
 	if (st != Z_OK) {
 		git__free(buffer);
-		giterr_set(GITERR_ZLIB, "failed to init zlib stream on unpack");
+		giterr_set("failed to init zlib stream on unpack");
 
 		return -1;
 	}
@@ -896,7 +896,7 @@ int packfile_unpack_compressed(
 
 	if ((st != Z_STREAM_END) || stream.total_out != size) {
 		git__free(buffer);
-		giterr_set(GITERR_ZLIB, "error inflating zlib stream");
+		giterr_set("error inflating zlib stream");
 		return -1;
 	}
 
@@ -1076,7 +1076,7 @@ static int packfile_open(struct git_pack_file *p)
 	return 0;
 
 cleanup:
-	giterr_set(GITERR_OS, "Invalid packfile '%s'", p->pack_name);
+	giterr_set_os("Invalid packfile '%s'", p->pack_name);
 
 	if (p->mwf.fd >= 0)
 		p_close(p->mwf.fd);
@@ -1152,7 +1152,7 @@ int git_packfile_alloc(struct git_pack_file **pack_out, const char *path)
 	p->index_version = -1;
 
 	if (git_mutex_init(&p->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize packfile mutex");
+		giterr_set_os("Failed to initialize packfile mutex");
 		git__free(p);
 		return -1;
 	}

--- a/src/path.c
+++ b/src/path.c
@@ -321,7 +321,7 @@ int git_path_prettify(git_buf *path_out, const char *path, const char *base)
 	if (p_realpath(path, buf) == NULL) {
 		/* giterr_set resets the errno when dealing with a GITERR_OS kind of error */
 		int error = (errno == ENOENT || errno == ENOTDIR) ? GIT_ENOTFOUND : -1;
-		giterr_set(GITERR_OS, "Failed to resolve path '%s'", path);
+		giterr_set_os("Failed to resolve path '%s'", path);
 
 		git_buf_clear(path_out);
 
@@ -394,7 +394,7 @@ append:
 
 static int error_invalid_local_file_uri(const char *uri)
 {
-	giterr_set(GITERR_CONFIG, "'%s' is not a valid local file URI", uri);
+	giterr_set("'%s' is not a valid local file URI", uri);
 	return -1;
 }
 
@@ -601,20 +601,20 @@ int git_path_set_error(int errno_value, const char *path, const char *action)
 	switch (errno_value) {
 	case ENOENT:
 	case ENOTDIR:
-		giterr_set(GITERR_OS, "Could not find '%s' to %s", path, action);
+		giterr_set_os("Could not find '%s' to %s", path, action);
 		return GIT_ENOTFOUND;
 
 	case EINVAL:
 	case ENAMETOOLONG:
-		giterr_set(GITERR_OS, "Invalid path for filesystem '%s'", path);
+		giterr_set_os("Invalid path for filesystem '%s'", path);
 		return GIT_EINVALIDSPEC;
 
 	case EEXIST:
-		giterr_set(GITERR_OS, "Failed %s - '%s' already exists", action, path);
+		giterr_set_os("Failed %s - '%s' already exists", action, path);
 		return GIT_EEXISTS;
 
 	default:
-		giterr_set(GITERR_OS, "Could not %s '%s'", action, path);
+		giterr_set_os("Could not %s '%s'", action, path);
 		return -1;
 	}
 }
@@ -723,7 +723,7 @@ int git_path_resolve_relative(git_buf *path, size_t ceiling)
 		else if (len == 2 && from[0] == '.' && from[1] == '.') {
 			/* error out if trying to up one from a hard base */
 			if (to == base && ceiling != 0) {
-				giterr_set(GITERR_INVALID,
+				giterr_set(
 					"Cannot strip root component off url");
 				return -1;
 			}
@@ -816,7 +816,7 @@ int git_path_make_relative(git_buf *path, const char *parent)
 	/* need at least 1 common path segment */
 	if ((p_dirsep == path->ptr || q_dirsep == parent) &&
 		(*p_dirsep != '/' || *q_dirsep != '/')) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"%s is not a parent of %s", parent, path->ptr);
 		return GIT_ENOTFOUND;
 	}
@@ -939,7 +939,7 @@ int git_path_iconv(git_path_iconv_t *ic, const char **in, size_t *inlen)
 	return 0;
 
 fail:
-	giterr_set(GITERR_OS, "Unable to convert unicode path data");
+	giterr_set_os("Unable to convert unicode path data");
 	return -1;
 }
 
@@ -1032,7 +1032,7 @@ int git_path_direach(
 	wd_len = git_buf_len(path);
 
 	if ((dir = opendir(path->ptr)) == NULL) {
-		giterr_set(GITERR_OS, "Failed to open directory '%s'", path->ptr);
+		giterr_set_os("Failed to open directory '%s'", path->ptr);
 		if (errno == ENOENT)
 			return GIT_ENOTFOUND;
 
@@ -1110,13 +1110,13 @@ int git_path_diriter_init(
 	git_path_trim_slashes(&diriter->path_utf8);
 
 	if (diriter->path_utf8.size == 0) {
-		giterr_set(GITERR_FILESYSTEM, "Could not open directory '%s'", path);
+		giterr_set("Could not open directory '%s'", path);
 		return -1;
 	}
 
 	if ((diriter->parent_len = git_win32_path_from_utf8(diriter->path, diriter->path_utf8.ptr)) < 0 ||
 			!git_win32__findfirstfile_filter(path_filter, diriter->path_utf8.ptr)) {
-		giterr_set(GITERR_OS, "Could not parse the directory path '%s'", path);
+		giterr_set_os("Could not parse the directory path '%s'", path);
 		return -1;
 	}
 
@@ -1129,7 +1129,7 @@ int git_path_diriter_init(
 		FIND_FIRST_EX_LARGE_FETCH);
 
 	if (diriter->handle == INVALID_HANDLE_VALUE) {
-		giterr_set(GITERR_OS, "Could not open directory '%s'", path);
+		giterr_set_os("Could not open directory '%s'", path);
 		return -1;
 	}
 
@@ -1149,7 +1149,7 @@ static int diriter_update_paths(git_path_diriter *diriter)
 		return -1;
 
 	if (path_len > GIT_WIN_PATH_UTF16) {
-		giterr_set(GITERR_FILESYSTEM,
+		giterr_set(
 			"invalid path '%.*ls\\%ls' (path too long)",
 			diriter->parent_len, diriter->path, diriter->current.cFileName);
 		return -1;
@@ -1255,14 +1255,14 @@ int git_path_diriter_init(
 	git_path_trim_slashes(&diriter->path);
 
 	if (diriter->path.size == 0) {
-		giterr_set(GITERR_FILESYSTEM, "Could not open directory '%s'", path);
+		giterr_set("Could not open directory '%s'", path);
 		return -1;
 	}
 
 	if ((diriter->dir = opendir(diriter->path.ptr)) == NULL) {
 		git_buf_free(&diriter->path);
 
-		giterr_set(GITERR_OS, "Failed to open directory '%s'", path);
+		giterr_set_os("Failed to open directory '%s'", path);
 		return -1;
 	}
 
@@ -1294,7 +1294,7 @@ int git_path_diriter_next(git_path_diriter *diriter)
 			if (!errno)
 				return GIT_ITEROVER;
 
-			giterr_set(GITERR_OS,
+			giterr_set_os(
 				"Could not read directory '%s'", diriter->path);
 			return -1;
 		}

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -491,7 +491,7 @@ static int pathspec_match_from_iterator(
 
 	/* if every pattern failed to match, then we have failed */
 	if ((flags & GIT_PATHSPEC_NO_MATCH_ERROR) != 0 && !found_files) {
-		giterr_set(GITERR_INVALID, "No matching files were found");
+		giterr_set("No matching files were found");
 		error = GIT_ENOTFOUND;
 	}
 
@@ -662,7 +662,7 @@ int git_pathspec_match_diff(
 
 	/* if every pattern failed to match, then we have failed */
 	if ((flags & GIT_PATHSPEC_NO_MATCH_ERROR) != 0 && !found_deltas) {
-		giterr_set(GITERR_INVALID, "No matching deltas were found");
+		giterr_set("No matching deltas were found");
 		error = GIT_ENOTFOUND;
 	}
 

--- a/src/posix.c
+++ b/src/posix.c
@@ -230,7 +230,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	out->len = 0;
 
 	if ((prot & GIT_PROT_WRITE) && ((flags & GIT_MAP_TYPE) == GIT_MAP_SHARED)) {
-		giterr_set(GITERR_OS, "Trying to map shared-writeable");
+		giterr_set_os("Trying to map shared-writeable");
 		return -1;
 	}
 
@@ -240,7 +240,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	if (!git__is_ssizet(len) ||
 		(p_lseek(fd, offset, SEEK_SET) < 0) ||
 		(p_read(fd, out->data, len) != (ssize_t)len)) {
-		giterr_set(GITERR_OS, "mmap emulation failed");
+		giterr_set_os("mmap emulation failed");
 		return -1;
 	}
 

--- a/src/push.c
+++ b/src/push.c
@@ -89,7 +89,7 @@ static void free_refspec(push_spec *spec)
 static int check_rref(char *ref)
 {
 	if (git__prefixcmp(ref, "refs/")) {
-		giterr_set(GITERR_INVALID, "Not a valid reference '%s'", ref);
+		giterr_set("Not a valid reference '%s'", ref);
 		return -1;
 	}
 
@@ -107,10 +107,10 @@ static int check_lref(git_push *push, char *ref)
 		return 0;
 
 	if (error == GIT_ENOTFOUND)
-		giterr_set(GITERR_REFERENCE,
+		giterr_set(
 			"src refspec '%s' does not match any existing object", ref);
 	else
-		giterr_set(GITERR_INVALID, "Not a valid reference '%s'", ref);
+		giterr_set("Not a valid reference '%s'", ref);
 	return -1;
 }
 
@@ -124,7 +124,7 @@ static int parse_refspec(git_push *push, push_spec **spec, const char *str)
 	GITERR_CHECK_ALLOC(s);
 
 	if (git_refspec__parse(&s->refspec, str, false) < 0) {
-		giterr_set(GITERR_INVALID, "invalid refspec %s", str);
+		giterr_set("invalid refspec %s", str);
 		goto on_error;
 	}
 
@@ -319,7 +319,7 @@ static int revwalk(git_vector *commits, git_push *push)
 				continue;
 
 			if (!git_odb_exists(push->repo->_odb, &spec->roid)) {
-				giterr_set(GITERR_REFERENCE, 
+				giterr_set(
 					"Cannot push because a reference that you are trying to update on the remote contains commits that are not present locally.");
 				error = GIT_ENONFASTFORWARD;
 				goto on_error;
@@ -330,7 +330,7 @@ static int revwalk(git_vector *commits, git_push *push)
 
 			if (error == GIT_ENOTFOUND ||
 				(!error && !git_oid_equal(&base, &spec->roid))) {
-				giterr_set(GITERR_REFERENCE,
+				giterr_set(
 					"Cannot push non-fastforwardable reference");
 				error = GIT_ENONFASTFORWARD;
 				goto on_error;
@@ -552,7 +552,7 @@ static int calculate_work(git_push *push)
 			/* This is a create or update.  Local ref must exist. */
 			if (git_reference_name_to_id(
 					&spec->loid, push->repo, spec->refspec.src) < 0) {
-				giterr_set(GITERR_REFERENCE, "No such reference '%s'", spec->refspec.src);
+				giterr_set("No such reference '%s'", spec->refspec.src);
 				return -1;
 			}
 		}
@@ -578,7 +578,7 @@ static int do_push(git_push *push, const git_remote_callbacks *callbacks)
 	git_transport *transport = push->remote->transport;
 
 	if (!transport->push) {
-		giterr_set(GITERR_NET, "Remote transport doesn't support push");
+		giterr_set("Remote transport doesn't support push");
 		error = -1;
 		goto on_error;
 	}
@@ -647,7 +647,7 @@ int git_push_finish(git_push *push, const git_remote_callbacks *callbacks)
 
 	if (!push->unpack_ok) {
 		error = -1;
-		giterr_set(GITERR_NET, "unpacking the sent packfile failed on the remote");
+		giterr_set("unpacking the sent packfile failed on the remote");
 	}
 
 	return error;

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -146,7 +146,7 @@ GIT_INLINE(int) rebase_readint(
 		return error;
 
 	if (git__strtol32(&num, asc_out->ptr, &eol, 10) < 0 || num < 0 || *eol) {
-		giterr_set(GITERR_REBASE, "The file '%s' contains an invalid numeric value", filename);
+		giterr_set("The file '%s' contains an invalid numeric value", filename);
 		return -1;
 	}
 
@@ -164,7 +164,7 @@ GIT_INLINE(int) rebase_readoid(
 		return error;
 
 	if (str_out->size != GIT_OID_HEXSZ || git_oid_fromstr(out, str_out->ptr) < 0) {
-		giterr_set(GITERR_REBASE, "The file '%s' contains an invalid object ID", filename);
+		giterr_set("The file '%s' contains an invalid object ID", filename);
 		return -1;
 	}
 
@@ -308,7 +308,7 @@ int git_rebase_open(
 		goto done;
 
 	if (rebase->type == GIT_REBASE_TYPE_NONE) {
-		giterr_set(GITERR_REBASE, "There is no rebase in progress");
+		giterr_set("There is no rebase in progress");
 		error = GIT_ENOTFOUND;
 		goto done;
 	}
@@ -364,14 +364,14 @@ int git_rebase_open(
 
 	switch (rebase->type) {
 	case GIT_REBASE_TYPE_INTERACTIVE:
-		giterr_set(GITERR_REBASE, "Interactive rebase is not supported");
+		giterr_set("Interactive rebase is not supported");
 		error = -1;
 		break;
 	case GIT_REBASE_TYPE_MERGE:
 		error = rebase_open_merge(rebase);
 		break;
 	case GIT_REBASE_TYPE_APPLY:
-		giterr_set(GITERR_REBASE, "Patch application rebase is not supported");
+		giterr_set("Patch application rebase is not supported");
 		error = -1;
 		break;
 	default:
@@ -466,7 +466,7 @@ static int rebase_setupfiles(git_rebase *rebase)
 	git_oid_fmt(orig_head, &rebase->orig_head_id);
 
 	if (p_mkdir(rebase->state_path, REBASE_DIR_MODE) < 0) {
-		giterr_set(GITERR_OS, "Failed to create rebase directory '%s'", rebase->state_path);
+		giterr_set_os("Failed to create rebase directory '%s'", rebase->state_path);
 		return -1;
 	}
 
@@ -496,7 +496,7 @@ static int rebase_ensure_not_in_progress(git_repository *repo)
 		return error;
 
 	if (type != GIT_REBASE_TYPE_NONE) {
-		giterr_set(GITERR_REBASE, "There is an existing rebase in progress");
+		giterr_set("There is an existing rebase in progress");
 		return -1;
 	}
 
@@ -521,7 +521,7 @@ static int rebase_ensure_not_dirty(
 			goto done;
 
 		if (git_diff_num_deltas(diff) > 0) {
-			giterr_set(GITERR_REBASE, "Uncommitted changes exist in index");
+			giterr_set("Uncommitted changes exist in index");
 			error = fail_with;
 			goto done;
 		}
@@ -535,7 +535,7 @@ static int rebase_ensure_not_dirty(
 			goto done;
 
 		if (git_diff_num_deltas(diff) > 0) {
-			giterr_set(GITERR_REBASE, "Unstaged changes exist in workdir");
+			giterr_set("Unstaged changes exist in workdir");
 			error = fail_with;
 			goto done;
 		}
@@ -775,7 +775,7 @@ static int rebase_next_merge(
 		goto done;
 
 	if ((parent_count = git_commit_parentcount(current_commit)) > 1) {
-		giterr_set(GITERR_REBASE, "Cannot rebase a merge commit");
+		giterr_set("Cannot rebase a merge commit");
 		error = -1;
 		goto done;
 	} else if (parent_count) {
@@ -857,7 +857,7 @@ static int rebase_commit_merge(
 		goto done;
 
 	if (git_index_has_conflicts(index)) {
-		giterr_set(GITERR_REBASE, "Conflicts have not been resolved");
+		giterr_set("Conflicts have not been resolved");
 		error = GIT_EUNMERGED;
 		goto done;
 	}
@@ -871,7 +871,7 @@ static int rebase_commit_merge(
 		goto done;
 
 	if (git_diff_num_deltas(diff) == 0) {
-		giterr_set(GITERR_REBASE, "This patch has already been applied");
+		giterr_set("This patch has already been applied");
 		error = GIT_EAPPLIED;
 		goto done;
 	}
@@ -1102,7 +1102,7 @@ static int rebase_copy_notes(
 	goto done;
 
 on_error:
-	giterr_set(GITERR_REBASE, "Invalid rewritten file at line %d", linenum);
+	giterr_set("Invalid rewritten file at line %d", linenum);
 	error = -1;
 
 done:

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -130,7 +130,7 @@ int git_refdb_lookup(git_reference **out, git_refdb *db, const char *ref_name)
 int git_refdb_iterator(git_reference_iterator **out, git_refdb *db, const char *glob)
 {
 	if (!db->backend || !db->backend->iterator) {
-		giterr_set(GITERR_REFERENCE, "This backend doesn't support iterators");
+		giterr_set("This backend doesn't support iterators");
 		return -1;
 	}
 
@@ -248,7 +248,7 @@ int git_refdb_lock(void **payload, git_refdb *db, const char *refname)
 	assert(payload && db && refname);
 
 	if (!db->backend->lock) {
-		giterr_set(GITERR_REFERENCE, "backend does not support locking");
+		giterr_set("backend does not support locking");
 		return -1;
 	}
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -183,7 +183,7 @@ static int packed_reload(refdb_fs_backend *backend)
 	return 0;
 
 parse_failed:
-	giterr_set(GITERR_REFERENCE, "Corrupted packed references file");
+	giterr_set("Corrupted packed references file");
 
 	git_sortedcache_clear(backend->refcache, false);
 	git_sortedcache_wunlock(backend->refcache);
@@ -210,7 +210,7 @@ static int loose_parse_oid(
 		return 0;
 
 corrupted:
-	giterr_set(GITERR_REFERENCE, "Corrupted loose reference file: %s", filename);
+	giterr_set("Corrupted loose reference file: %s", filename);
 	return -1;
 }
 
@@ -346,7 +346,7 @@ static const char *loose_parse_symbolic(git_buf *file_content)
 	refname_start = (const char *)file_content->ptr;
 
 	if (git_buf_len(file_content) < header_len + 1) {
-		giterr_set(GITERR_REFERENCE, "Corrupted loose reference file");
+		giterr_set("Corrupted loose reference file");
 		return NULL;
 	}
 
@@ -395,7 +395,7 @@ static int loose_lookup(
 
 static int ref_error_notfound(const char *name)
 {
-	giterr_set(GITERR_REFERENCE, "Reference '%s' not found", name);
+	giterr_set("Reference '%s' not found", name);
 	return GIT_ENOTFOUND;
 }
 
@@ -681,7 +681,7 @@ static int reference_path_available(
 			return -1;
 
 		if (exists) {
-			giterr_set(GITERR_REFERENCE,
+			giterr_set(
 				"Failed to write reference '%s': a reference with "
 				"that name already exists.", new_ref);
 			return GIT_EEXISTS;
@@ -695,7 +695,7 @@ static int reference_path_available(
 
 		if (ref && !ref_is_available(old_ref, new_ref, ref->name)) {
 			git_sortedcache_runlock(backend->refcache);
-			giterr_set(GITERR_REFERENCE,
+			giterr_set(
 				"Path to reference '%s' collides with existing one", new_ref);
 			return -1;
 		}
@@ -713,7 +713,7 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 	assert(file && backend && name);
 
 	if (!git_path_isvalid(backend->repo, name, GIT_PATH_REJECT_DEFAULTS)) {
-		giterr_set(GITERR_INVALID, "Invalid reference name '%s'.", name);
+		giterr_set("Invalid reference name '%s'.", name);
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -911,7 +911,7 @@ static int packed_remove_loose(refdb_fs_backend *backend)
 			if (failed)
 				continue;
 
-			giterr_set(GITERR_REFERENCE,
+			giterr_set(
 				"Failed to remove loose reference '%s' after packing: %s",
 				full_path.ptr, strerror(errno));
 			failed = 1;
@@ -1164,7 +1164,7 @@ static int refdb_fs_backend__write_tail(
 		goto on_error;
 
 	if (cmp) {
-		giterr_set(GITERR_REFERENCE, "old reference value does not match");
+		giterr_set("old reference value does not match");
 		error = GIT_EMODIFIED;
 		goto on_error;
 	}
@@ -1237,7 +1237,7 @@ static int refdb_fs_backend__delete_tail(
 		goto cleanup;
 
 	if (cmp) {
-		giterr_set(GITERR_REFERENCE, "old reference value does not match");
+		giterr_set("old reference value does not match");
 		error = GIT_EMODIFIED;
 		goto cleanup;
 	}
@@ -1442,7 +1442,7 @@ static int reflog_parse(git_reflog *log, const char *buf, size_t buf_size)
 
 #define seek_forward(_increase) do { \
 	if (_increase >= buf_size) { \
-		giterr_set(GITERR_INVALID, "Ran out of data while parsing reflog"); \
+		giterr_set("Ran out of data while parsing reflog"); \
 		goto fail; \
 	} \
 	buf += _increase; \
@@ -1659,7 +1659,7 @@ static int lock_reflog(git_filebuf *file, refdb_fs_backend *backend, const char 
 	repo = backend->repo;
 
 	if (!git_path_isvalid(backend->repo, refname, GIT_PATH_REJECT_DEFAULTS)) {
-		giterr_set(GITERR_INVALID, "Invalid reference name '%s'.", refname);
+		giterr_set("Invalid reference name '%s'.", refname);
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -1667,7 +1667,7 @@ static int lock_reflog(git_filebuf *file, refdb_fs_backend *backend, const char 
 		return -1;
 
 	if (!git_path_isfile(git_buf_cstr(&log_path))) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"Log file for reference '%s' doesn't exist.", refname);
 		error = -1;
 		goto cleanup;
@@ -1840,7 +1840,7 @@ static int refdb_reflog_fs__rename(git_refdb_backend *_backend, const char *old_
 	p_close(fd);
 
 	if (p_rename(git_buf_cstr(&old_path), git_buf_cstr(&temp_path)) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename reflog for %s", new_name);
+		giterr_set_os("Failed to rename reflog for %s", new_name);
 		error = -1;
 		goto cleanup;
 	}
@@ -1857,7 +1857,7 @@ static int refdb_reflog_fs__rename(git_refdb_backend *_backend, const char *old_
 	}
 
 	if (p_rename(git_buf_cstr(&temp_path), git_buf_cstr(&new_path)) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename reflog for %s", new_name);
+		giterr_set_os("Failed to rename reflog for %s", new_name);
 		error = -1;
 	}
 

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -93,7 +93,7 @@ int git_reflog_append(git_reflog *reflog, const git_oid *new_oid, const git_sign
 
 		if (newline) {
 			if (newline[1] != '\0') {
-				giterr_set(GITERR_INVALID, "Reflog message cannot contain newline");
+				giterr_set("Reflog message cannot contain newline");
 				goto cleanup;
 			}
 
@@ -193,7 +193,7 @@ int git_reflog_drop(git_reflog *reflog, size_t idx, int rewrite_previous_entry)
 	entry = (git_reflog_entry *)git_reflog_entry_byindex(reflog, idx);
 
 	if (entry == NULL) {
-		giterr_set(GITERR_REFERENCE, "No reflog entry at index %"PRIuZ, idx);
+		giterr_set("No reflog entry at index %"PRIuZ, idx);
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -223,7 +223,7 @@ int git_reference_lookup_resolved(
 	}
 
 	if (scan_type != GIT_REF_OID && max_nesting != 0) {
-		giterr_set(GITERR_REFERENCE,
+		giterr_set(
 			"Cannot resolve reference (>%u levels deep)", max_nesting);
 		git_reference_free(ref);
 		return -1;
@@ -285,7 +285,7 @@ int git_reference_dwim(git_reference **out, git_repository *repo, const char *re
 cleanup:
 	if (error && !foundvalid) {
 		/* never found a valid reference name */
-		giterr_set(GITERR_REFERENCE,
+		giterr_set(
 			"Could not use '%s' as valid reference name", git_buf_cstr(&name));
 	}
 
@@ -386,7 +386,7 @@ static int reference__create(
 			return error;
 
 		if (!git_odb_exists(odb, oid)) {
-			giterr_set(GITERR_REFERENCE,
+			giterr_set(
 				"Target OID for the reference doesn't exist on the repository");
 			return -1;
 		}
@@ -515,7 +515,7 @@ static int ensure_is_an_updatable_direct_reference(git_reference *ref)
 	if (ref->type == GIT_REF_OID)
 		return 0;
 
-	giterr_set(GITERR_REFERENCE, "Cannot set OID on symbolic reference");
+	giterr_set("Cannot set OID on symbolic reference");
 	return -1;
 }
 
@@ -543,7 +543,7 @@ static int ensure_is_an_updatable_symbolic_reference(git_reference *ref)
 	if (ref->type == GIT_REF_SYMBOLIC)
 		return 0;
 
-	giterr_set(GITERR_REFERENCE, "Cannot set symbolic target on a direct reference");
+	giterr_set("Cannot set symbolic target on a direct reference");
 	return -1;
 }
 
@@ -590,7 +590,7 @@ static int reference__rename(git_reference **out, git_reference *ref, const char
 	/* Update HEAD it was pointing to the reference being renamed */
 	if (should_head_be_updated &&
 		(error = git_repository_set_head(ref->db->repo, normalized)) < 0) {
-		giterr_set(GITERR_REFERENCE, "Failed to update HEAD after renaming reference");
+		giterr_set("Failed to update HEAD after renaming reference");
 		return error;
 	}
 
@@ -627,7 +627,7 @@ int git_reference_resolve(git_reference **ref_out, const git_reference *ref)
 		return git_reference_lookup_resolved(ref_out, ref->db->repo, ref->target.symbolic, -1);
 
 	default:
-		giterr_set(GITERR_REFERENCE, "Invalid reference");
+		giterr_set("Invalid reference");
 		return -1;
 	}
 }
@@ -963,7 +963,6 @@ int git_reference__normalize_name(
 cleanup:
 	if (error == GIT_EINVALIDSPEC)
 		giterr_set(
-			GITERR_REFERENCE,
 			"The given reference name '%s' is not valid", name);
 
 	if (error && normalize)
@@ -990,8 +989,7 @@ int git_reference_normalize_name(
 
 	if (git_buf_len(&buf) > buffer_size - 1) {
 		giterr_set(
-		GITERR_REFERENCE,
-		"The provided buffer is too short to hold the normalization of '%s'", name);
+			"The provided buffer is too short to hold the normalization of '%s'", name);
 		error = GIT_EBUFS;
 		goto cleanup;
 	}
@@ -1037,7 +1035,7 @@ static int get_terminal(git_reference **out, git_repository *repo, const char *r
 	int error = 0;
 
 	if (nesting > MAX_NESTING_LEVEL) {
-		giterr_set(GITERR_REFERENCE, "Reference chain too deep (%d)", nesting);
+		giterr_set("Reference chain too deep (%d)", nesting);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1219,7 +1217,6 @@ int git_reference_is_note(const git_reference *ref)
 static int peel_error(int error, git_reference *ref, const char* msg)
 {
 	giterr_set(
-		GITERR_INVALID,
 		"The reference '%s' cannot be peeled - %s", git_reference_name(ref), msg);
 	return error;
 }

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -139,9 +139,7 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 	return 0;
 
  invalid:
-        giterr_set(
-                GITERR_INVALID,
-                "'%s' is not a valid refspec.", input);
+        giterr_set("'%s' is not a valid refspec.", input);
 	return -1;
 }
 
@@ -242,7 +240,7 @@ int git_refspec_transform(git_buf *out, const git_refspec *spec, const char *nam
 	git_buf_sanitize(out);
 
 	if (!git_refspec_src_matches(spec, name)) {
-		giterr_set(GITERR_INVALID, "ref '%s' doesn't match the source", name);
+		giterr_set("ref '%s' doesn't match the source", name);
 		return -1;
 	}
 
@@ -258,7 +256,7 @@ int git_refspec_rtransform(git_buf *out, const git_refspec *spec, const char *na
 	git_buf_sanitize(out);
 
 	if (!git_refspec_dst_matches(spec, name)) {
-		giterr_set(GITERR_INVALID, "ref '%s' doesn't match the destination", name);
+		giterr_set("ref '%s' doesn't match the destination", name);
 		return -1;
 	}
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -86,7 +86,6 @@ static int ensure_remote_name_is_valid(const char *name)
 
 	if (!git_remote_is_valid_name(name)) {
 		giterr_set(
-			GITERR_CONFIG,
 			"'%s' is not a valid remote name.", name ? name : "(null)");
 		error = GIT_EINVALIDSPEC;
 	}
@@ -111,7 +110,7 @@ static int write_add_refspec(git_repository *repo, const char *name, const char 
 		return error;
 
 	if ((error = git_refspec__parse(&spec, refspec, fetch)) < 0) {
-		if (giterr_last()->klass != GITERR_NOMEMORY)
+		if (!giterr_is_oom(giterr_last()))
 			error = GIT_EINVALIDSPEC;
 
 		return error;
@@ -168,7 +167,7 @@ static int get_check_cert(int *out, git_repository *repo)
 static int canonicalize_url(git_buf *out, const char *in)
 {
 	if (in == NULL || strlen(in) == 0) {
-		giterr_set(GITERR_INVALID, "cannot set empty URL");
+		giterr_set("cannot set empty URL");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -282,7 +281,6 @@ static int ensure_remote_doesnot_exist(git_repository *repo, const char *name)
 	git_remote_free(remote);
 
 	giterr_set(
-		GITERR_CONFIG,
 		"Remote '%s' already exists.", name);
 
 	return GIT_EEXISTS;
@@ -476,7 +474,7 @@ int git_remote_lookup(git_remote **out, git_repository *repo, const char *name)
 
 	if (!optional_setting_found) {
 		error = GIT_ENOTFOUND;
-		giterr_set(GITERR_CONFIG, "Remote '%s' does not exist.", name);
+		giterr_set("Remote '%s' does not exist.", name);
 		goto cleanup;
 	}
 
@@ -710,7 +708,7 @@ int git_remote_connect(git_remote *remote, git_direction direction, const git_re
 
 	url = git_remote__urlfordirection(remote, direction);
 	if (url == NULL) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"Malformed remote '%s' - missing URL", remote->name);
 		return -1;
 	}
@@ -748,7 +746,7 @@ int git_remote_ls(const git_remote_head ***out, size_t *size, git_remote *remote
 	assert(remote);
 
 	if (!remote->transport) {
-		giterr_set(GITERR_NET, "this remote has never connected");
+		giterr_set("this remote has never connected");
 		return -1;
 	}
 
@@ -1722,7 +1720,7 @@ int git_remote_set_autotag(git_repository *repo, const char *remote, git_remote_
 			error = 0;
 		break;
 	default:
-		giterr_set(GITERR_INVALID, "Invalid value for the tagopt setting");
+		giterr_set("Invalid value for the tagopt setting");
 		error = -1;
 	}
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -331,7 +331,7 @@ static int read_gitfile(git_buf *path_out, const char *file_path)
 	if (git_buf_len(&file) <= prefix_len ||
 		memcmp(git_buf_cstr(&file), GIT_FILE_CONTENT_PREFIX, prefix_len) != 0)
 	{
-		giterr_set(GITERR_REPOSITORY,
+		giterr_set(
 			"The `.git` file at '%s' is malformed", file_path);
 		error = -1;
 	}
@@ -441,7 +441,7 @@ static int find_repo(
 	git_buf_free(&path);
 
 	if (!git_buf_len(repo_path) && !error) {
-		giterr_set(GITERR_REPOSITORY,
+		giterr_set(
 			"Could not find repository from '%s'", start_path);
 		error = GIT_ENOTFOUND;
 	}
@@ -462,7 +462,7 @@ int git_repository_open_bare(
 
 	if (!valid_repository_path(&path)) {
 		git_buf_free(&path);
-		giterr_set(GITERR_REPOSITORY, "Path is not a repository: %s", bare_path);
+		giterr_set("Path is not a repository: %s", bare_path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -958,7 +958,7 @@ static int check_repositoryformatversion(git_config *config)
 		return -1;
 
 	if (GIT_REPO_VERSION < version) {
-		giterr_set(GITERR_REPOSITORY,
+		giterr_set(
 			"Unsupported repository version %d. Only versions up to %d are supported.",
 			version, GIT_REPO_VERSION);
 		return -1;
@@ -1053,12 +1053,12 @@ static int create_empty_file(const char *path, mode_t mode)
 	int fd;
 
 	if ((fd = p_creat(path, mode)) < 0) {
-		giterr_set(GITERR_OS, "Error while creating '%s'", path);
+		giterr_set_os("Error while creating '%s'", path);
 		return -1;
 	}
 
 	if (p_close(fd) < 0) {
-		giterr_set(GITERR_OS, "Error while closing '%s'", path);
+		giterr_set_os("Error while closing '%s'", path);
 		return -1;
 	}
 
@@ -1286,7 +1286,7 @@ static int repo_write_template(
 	git_buf_free(&path);
 
 	if (error)
-		giterr_set(GITERR_OS,
+		giterr_set_os(
 			"Failed to initialize repository with template '%s'", file);
 
 	return error;
@@ -1317,7 +1317,7 @@ static int repo_write_gitlink(
 		goto cleanup;
 
 	if (!p_stat(buf.ptr, &st) && !S_ISREG(st.st_mode)) {
-		giterr_set(GITERR_REPOSITORY,
+		giterr_set(
 			"Cannot overwrite gitlink file into path '%s'", in_dir);
 		error = GIT_EEXISTS;
 		goto cleanup;
@@ -1371,7 +1371,7 @@ static int repo_init_structure(
 #ifdef GIT_WIN32
 	if ((opts->flags & GIT_REPOSITORY_INIT__HAS_DOTGIT) != 0) {
 		if (git_win32__sethidden(repo_dir) < 0) {
-			giterr_set(GITERR_OS,
+			giterr_set_os(
 				"Failed to mark Git repository folder as hidden");
 			return -1;
 		}
@@ -1524,7 +1524,7 @@ static int repo_init_directories(
 			if (git_path_dirname_r(wd_path, repo_path->ptr) < 0)
 				return -1;
 		} else {
-			giterr_set(GITERR_REPOSITORY, "Cannot pick working directory"
+			giterr_set("Cannot pick working directory"
 				" for non-bare repository that isn't a '.git' directory");
 			return -1;
 		}
@@ -1643,7 +1643,7 @@ int git_repository_init_ext(
 	if (valid_repository_path(&repo_path)) {
 
 		if ((opts->flags & GIT_REPOSITORY_INIT_NO_REINIT) != 0) {
-			giterr_set(GITERR_REPOSITORY,
+			giterr_set(
 				"Attempt to reinitialize '%s'", given_repo);
 			error = GIT_EEXISTS;
 			goto cleanup;
@@ -1926,7 +1926,7 @@ int git_repository_message(git_buf *out, git_repository *repo)
 	if ((error = p_stat(git_buf_cstr(&path), &st)) < 0) {
 		if (errno == ENOENT)
 			error = GIT_ENOTFOUND;
-		giterr_set(GITERR_OS, "Could not access message file");
+		giterr_set_os("Could not access message file");
 	} else {
 		error = git_futils_readbuffer(out, git_buf_cstr(&path));
 	}
@@ -2004,7 +2004,7 @@ int git_repository_hashfile(
 	}
 
 	if (!git__is_sizet(len)) {
-		giterr_set(GITERR_OS, "File size overflow for 32-bit systems");
+		giterr_set_os("File size overflow for 32-bit systems");
 		error = -1;
 		goto cleanup;
 	}

--- a/src/repository.h
+++ b/src/repository.h
@@ -181,7 +181,6 @@ GIT_INLINE(int) git_repository__ensure_not_bare(
 		return 0;
 
 	giterr_set(
-		GITERR_REPOSITORY,
 		"Cannot %s. This operation is not allowed against bare repositories.",
 		operation_name);
 

--- a/src/reset.c
+++ b/src/reset.c
@@ -41,7 +41,7 @@ int git_reset_default(
 
 	if (target) {
 		if (git_object_owner(target) != repo) {
-			giterr_set(GITERR_OBJECT,
+			giterr_set(
 				"%s_default - The given target does not belong to this repository.", ERROR_MSG);
 			return -1;
 		}
@@ -118,7 +118,7 @@ static int reset(
 		opts = *checkout_opts;
 
 	if (git_object_owner(target) != repo) {
-		giterr_set(GITERR_OBJECT,
+		giterr_set(
 			"%s - The given target does not belong to this repository.", ERROR_MSG);
 		return -1;
 	}
@@ -137,7 +137,7 @@ static int reset(
 		(git_repository_state(repo) == GIT_REPOSITORY_STATE_MERGE ||
 		 git_index_has_conflicts(index)))
 	{
-		giterr_set(GITERR_OBJECT, "%s (soft) in the middle of a merge.", ERROR_MSG);
+		giterr_set("%s (soft) in the middle of a merge.", ERROR_MSG);
 		error = GIT_EUNMERGED;
 		goto cleanup;
 	}
@@ -166,7 +166,7 @@ static int reset(
 			goto cleanup;
 
 		if ((error = git_repository_state_cleanup(repo)) < 0) {
-			giterr_set(GITERR_INDEX, "%s - failed to clean up merge data", ERROR_MSG);
+			giterr_set("%s - failed to clean up merge data", ERROR_MSG);
 			goto cleanup;
 		}
 	}

--- a/src/revert.c
+++ b/src/revert.c
@@ -111,7 +111,7 @@ static int revert_seterr(git_commit *commit, const char *fmt)
 	git_oid_fmt(commit_oidstr, git_commit_id(commit));
 	commit_oidstr[GIT_OID_HEXSZ] = '\0';
 
-	giterr_set(GITERR_REVERT, fmt, commit_oidstr);
+	giterr_set(fmt, commit_oidstr);
 
 	return -1;
 }

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -46,7 +46,7 @@ static int build_regex(regex_t *regex, const char *pattern)
 	int error;
 
 	if (*pattern == '\0') {
-		giterr_set(GITERR_REGEX, "Empty pattern");
+		giterr_set("Empty pattern");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -118,7 +118,7 @@ static int revparse_lookup_object(
 	if ((error = maybe_describe(object_out, repo, spec)) != GIT_ENOTFOUND)
 		return error;
 
-	giterr_set(GITERR_REFERENCE, "Revspec '%s' not found.", spec);
+	giterr_set("Revspec '%s' not found.", spec);
 	return GIT_ENOTFOUND;
 }
 
@@ -244,7 +244,6 @@ static int retrieve_oid_from_reflog(git_oid *oid, git_reference *ref, size_t ide
 
 notfound:
 	giterr_set(
-		GITERR_REFERENCE,
 		"Reflog for '%s' has only %"PRIuZ" entries, asked for %"PRIuZ,
 		git_reference_name(ref), numentries, identifier);
 
@@ -757,7 +756,7 @@ int revparse__ext(
 					 * TODO: support merge-stage path lookup (":2:Makefile")
 					 * and plain index blob lookup (:i-am/a/blob)
 					 */
-					giterr_set(GITERR_INVALID, "Unimplemented");
+					giterr_set("Unimplemented");
 					error = GIT_ERROR;
 					goto cleanup;
 				}
@@ -815,7 +814,7 @@ int revparse__ext(
 cleanup:
 	if (error) {
 		if (error == GIT_EINVALIDSPEC)
-			giterr_set(GITERR_INVALID,
+			giterr_set(
 				"Failed to parse revision specifier - Invalid pattern '%s'", spec);
 
 		git_object_free(base_rev);

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -151,7 +151,7 @@ static int push_commit(git_revwalk *walk, const git_oid *oid, int uninteresting,
 		if (from_glob)
 			return 0;
 
-		giterr_set(GITERR_INVALID, "Object is not a committish");
+		giterr_set("Object is not a committish");
 		return -1;
 	}
 	if (error < 0)
@@ -289,7 +289,7 @@ int git_revwalk_push_range(git_revwalk *walk, const char *range)
 
 	if (revspec.flags & GIT_REVPARSE_MERGE_BASE) {
 		/* TODO: support "<commit>...<commit>" */
-		giterr_set(GITERR_INVALID, "Symmetric differences not implemented in revwalk");
+		giterr_set("Symmetric differences not implemented in revwalk");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -660,7 +660,7 @@ int git_revwalk_add_hide_cb(
 
 	if (walk->hide_cb) {
 		/* There is already a callback added */
-		giterr_set(GITERR_INVALID, "There is already a callback added to hide commits in revision walker.");
+		giterr_set("There is already a callback added to hide commits in revision walker.");
 		return -1;
 	}
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -50,8 +50,7 @@ static int config_level_to_sysdir(int config_level)
 	case GIT_CONFIG_LEVEL_XDG:    val = GIT_SYSDIR_XDG; break;
 	case GIT_CONFIG_LEVEL_GLOBAL: val = GIT_SYSDIR_GLOBAL; break;
 	default:
-		giterr_set(
-			GITERR_INVALID, "Invalid config path selector %d", config_level);
+		giterr_set("Invalid config path selector %d", config_level);
 	}
 
 	return val;
@@ -143,13 +142,13 @@ int git_libgit2_opts(int key, ...)
 			const char *file = va_arg(ap, const char *);
 			const char *path = va_arg(ap, const char *);
 			if (!SSL_CTX_load_verify_locations(git__ssl_ctx, file, path)) {
-				giterr_set(GITERR_NET, "SSL error: %s",
+				giterr_set("SSL error: %s",
 					ERR_error_string(ERR_get_error(), NULL));
 				error = -1;
 			}
 		}
 #else
-		giterr_set(GITERR_NET, "Cannot set certificate locations: OpenSSL is not enabled");
+		giterr_set("Cannot set certificate locations: OpenSSL is not enabled");
 		error = -1;
 #endif
 		break;

--- a/src/sha1_lookup.c
+++ b/src/sha1_lookup.c
@@ -206,7 +206,7 @@ int sha1_entry_pos(const void *table,
 #endif
 
 		if (!(lo <= mi && mi < hi)) {
-			giterr_set(GITERR_INVALID, "Assertion failure. Binary search invariant is false");
+			giterr_set("Assertion failure. Binary search invariant is false");
 			return -1;
 		}
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -25,7 +25,7 @@ void git_signature_free(git_signature *sig)
 
 static int signature_error(const char *msg)
 {
-	giterr_set(GITERR_INVALID, "Failed to parse signature - %s", msg);
+	giterr_set("Failed to parse signature - %s", msg);
 	return -1;
 }
 

--- a/src/socket_stream.c
+++ b/src/socket_stream.c
@@ -34,16 +34,16 @@ static void net_set_error(const char *str)
 	char * win32_error = git_win32_get_error_message(error);
 
 	if (win32_error) {
-		giterr_set(GITERR_NET, "%s: %s", str, win32_error);
+		giterr_set("%s: %s", str, win32_error);
 		git__free(win32_error);
 	} else {
-		giterr_set(GITERR_NET, str);
+		giterr_set(str);
 	}
 }
 #else
 static void net_set_error(const char *str)
 {
-	giterr_set(GITERR_NET, "%s: %s", str, strerror(errno));
+	giterr_set("%s: %s", str, strerror(errno));
 }
 #endif
 
@@ -57,7 +57,7 @@ static int close_socket(GIT_SOCKET s)
 		return -1;
 
 	if (0 != WSACleanup()) {
-		giterr_set(GITERR_OS, "Winsock cleanup failed");
+		giterr_set_os("Winsock cleanup failed");
 		return -1;
 	}
 
@@ -82,13 +82,13 @@ int socket_connect(git_stream *stream)
 	WSADATA wsd;
 
 	if (WSAStartup(MAKEWORD(2,2), &wsd) != 0) {
-		giterr_set(GITERR_OS, "Winsock init failed");
+		giterr_set_os("Winsock init failed");
 		return -1;
 	}
 
 	if (LOBYTE(wsd.wVersion) != 2 || HIBYTE(wsd.wVersion) != 2) {
 		WSACleanup();
-		giterr_set(GITERR_OS, "Winsock init failed");
+		giterr_set_os("Winsock init failed");
 		return -1;
 	}
 #endif
@@ -98,7 +98,7 @@ int socket_connect(git_stream *stream)
 	hints.ai_family = AF_UNSPEC;
 
 	if ((ret = p_getaddrinfo(st->host, st->port, &hints, &info)) != 0) {
-		giterr_set(GITERR_NET,
+		giterr_set(
 			   "Failed to resolve address for %s: %s", st->host, p_gai_strerror(ret));
 		return -1;
 	}
@@ -121,7 +121,7 @@ int socket_connect(git_stream *stream)
 
 	/* Oops, we couldn't connect to any address */
 	if (s == INVALID_SOCKET && p == NULL) {
-		giterr_set(GITERR_OS, "Failed to connect to %s", st->host);
+		giterr_set_os("Failed to connect to %s", st->host);
 		p_freeaddrinfo(info);
 		return -1;
 	}

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -26,7 +26,7 @@ int git_sortedcache_new(
 		goto fail;
 
 	if (git_rwlock_init(&sc->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize lock");
+		giterr_set_os("Failed to initialize lock");
 		goto fail;
 	}
 
@@ -161,7 +161,7 @@ int git_sortedcache_wlock(git_sortedcache *sc)
 	GIT_UNUSED(sc); /* prevent warning when compiled w/o threads */
 
 	if (git_rwlock_wrlock(&sc->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to acquire write lock on cache");
+		giterr_set_os("Unable to acquire write lock on cache");
 		return -1;
 	}
 	return 0;
@@ -180,7 +180,7 @@ int git_sortedcache_rlock(git_sortedcache *sc)
 	GIT_UNUSED(sc); /* prevent warning when compiled w/o threads */
 
 	if (git_rwlock_rdlock(&sc->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to acquire read lock on cache");
+		giterr_set_os("Unable to acquire read lock on cache");
 		return -1;
 	}
 	return 0;
@@ -207,7 +207,7 @@ int git_sortedcache_lockandload(git_sortedcache *sc, git_buf *buf)
 		goto unlock;
 
 	if (!git__is_sizet(sc->stamp.size)) {
-		giterr_set(GITERR_INVALID, "Unable to load file larger than size_t");
+		giterr_set("Unable to load file larger than size_t");
 		error = -1;
 		goto unlock;
 	}
@@ -363,7 +363,7 @@ int git_sortedcache_remove(git_sortedcache *sc, size_t pos)
 	 */
 
 	if ((item = git_vector_get(&sc->items, pos)) == NULL) {
-		giterr_set(GITERR_INVALID, "Removing item out of range");
+		giterr_set("Removing item out of range");
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -26,7 +26,7 @@
 
 static int create_error(int error, const char *msg)
 {
-	giterr_set(GITERR_STASH, "Cannot stash changes - %s", msg);
+	giterr_set("Cannot stash changes - %s", msg);
 	return error;
 }
 
@@ -196,7 +196,6 @@ static int stash_update_index_from_diff(
 		default:
 			/* Unimplemented */
 			giterr_set(
-				GITERR_INVALID,
 				"Cannot update index. Unimplemented status (%d)",
 				delta->status);
 			return -1;
@@ -592,7 +591,7 @@ static int retrieve_stash_commit(
 	max = git_reflog_entrycount(reflog);
 	if (!max || index > max - 1) {
 		error = GIT_ENOTFOUND;
-		giterr_set(GITERR_STASH, "No stashed state at position %" PRIuZ, index);
+		giterr_set("No stashed state at position %" PRIuZ, index);
 		goto cleanup;
 	}
 
@@ -927,7 +926,7 @@ int git_stash_drop(
 
 	if (!max || index > max - 1) {
 		error = GIT_ENOTFOUND;
-		giterr_set(GITERR_STASH, "No stashed state at position %" PRIuZ, index);
+		giterr_set("No stashed state at position %" PRIuZ, index);
 		goto cleanup;
 	}
 

--- a/src/status.c
+++ b/src/status.c
@@ -242,13 +242,13 @@ static int status_validate_options(const git_status_options *opts)
 	GITERR_CHECK_VERSION(opts, GIT_STATUS_OPTIONS_VERSION, "git_status_options");
 
 	if (opts->show > GIT_STATUS_SHOW_WORKDIR_ONLY) {
-		giterr_set(GITERR_INVALID, "Unknown status 'show' option");
+		giterr_set("Unknown status 'show' option");
 		return -1;
 	}
 
 	if ((opts->flags & GIT_STATUS_OPT_NO_REFRESH) != 0 &&
 		(opts->flags & GIT_STATUS_OPT_UPDATE_INDEX) != 0) {
-		giterr_set(GITERR_INVALID, "Updating index from status "
+		giterr_set("Updating index from status "
 			"is not allowed when index refresh is disabled");
 		return -1;
 	}
@@ -508,13 +508,13 @@ int git_status_file(
 	error = git_status_foreach_ext(repo, &opts, get_one_status, &sfi);
 
 	if (error < 0 && sfi.ambiguous) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"Ambiguous path '%s' given to git_status_file", sfi.expected);
 		error = GIT_EAMBIGUOUS;
 	}
 
 	if (!error && !sfi.count) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"Attempt to get status of nonexistent file '%s'", path);
 		error = GIT_ENOTFOUND;
 	}

--- a/src/stransport_stream.c
+++ b/src/stransport_stream.c
@@ -29,10 +29,10 @@ int stransport_error(OSStatus ret)
 	message = SecCopyErrorMessageString(ret, NULL);
 	GITERR_CHECK_ALLOC(message);
 
-	giterr_set(GITERR_NET, "SecureTransport error: %s", CFStringGetCStringPtr(message, kCFStringEncodingUTF8));
+	giterr_set("SecureTransport error: %s", CFStringGetCStringPtr(message, kCFStringEncodingUTF8));
 	CFRelease(message);
 #else
-    giterr_set(GITERR_NET, "SecureTransport error: OSStatus %d", (unsigned int)ret);
+    giterr_set("SecureTransport error: OSStatus %d", (unsigned int)ret);
 #endif
 
 	return -1;
@@ -59,7 +59,7 @@ int stransport_connect(git_stream *stream)
 
 	ret = SSLHandshake(st->ctx);
 	if (ret != errSSLServerAuthCompleted) {
-		giterr_set(GITERR_SSL, "unexpected return value from ssl handshake %d", ret);
+		giterr_set("unexpected return value from ssl handshake %d", ret);
 		return -1;
 	}
 
@@ -72,7 +72,7 @@ int stransport_connect(git_stream *stream)
 	CFRelease(trust);
 
 	if (sec_res == kSecTrustResultInvalid || sec_res == kSecTrustResultOtherError) {
-		giterr_set(GITERR_SSL, "internal security trust error");
+		giterr_set("internal security trust error");
 		return -1;
 	}
 
@@ -104,7 +104,7 @@ int stransport_certificate(git_cert **out, git_stream *stream)
 	CFRelease(trust);
 
 	if (st->der_data == NULL) {
-		giterr_set(GITERR_SSL, "retrieved invalid certificate data");
+		giterr_set("retrieved invalid certificate data");
 		return -1;
 	}
 
@@ -254,7 +254,7 @@ int git_stransport_stream_new(git_stream **out, const char *host, const char *po
 
 	st->ctx = SSLCreateContext(NULL, kSSLClientSide, kSSLStreamType);
 	if (!st->ctx) {
-		giterr_set(GITERR_NET, "failed to create SSL context");
+		giterr_set("failed to create SSL context");
 		return -1;
 	}
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -23,7 +23,7 @@ GIT_INLINE(int) git_stream_is_encrypted(git_stream *st)
 GIT_INLINE(int) git_stream_certificate(git_cert **out, git_stream *st)
 {
 	if (!st->encrypted) {
-		giterr_set(GITERR_INVALID, "an unencrypted stream does not have a certificate");
+		giterr_set("an unencrypted stream does not have a certificate");
 		return -1;
 	}
 
@@ -38,7 +38,7 @@ GIT_INLINE(int) git_stream_supports_proxy(git_stream *st)
 GIT_INLINE(int) git_stream_set_proxy(git_stream *st, const char *proxy_url)
 {
 	if (!st->proxy_support) {
-		giterr_set(GITERR_INVALID, "proxy not supported on this stream");
+		giterr_set("proxy not supported on this stream");
 		return -1;
 	}
 

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -119,7 +119,7 @@ static void submodule_set_lookup_error(int error, const char *name)
 	if (!error)
 		return;
 
-	giterr_set(GITERR_SUBMODULE, (error == GIT_ENOTFOUND) ?
+	giterr_set((error == GIT_ENOTFOUND) ?
 		"No submodule named '%s'" :
 		"Submodule '%s' has not been added yet", name);
 }
@@ -550,7 +550,7 @@ int git_submodule_add_setup(
 	if (git_submodule_lookup(NULL, repo, path) < 0)
 		giterr_clear();
 	else {
-		giterr_set(GITERR_SUBMODULE,
+		giterr_set(
 			"Attempt to add submodule '%s' that already exists", path);
 		return GIT_EEXISTS;
 	}
@@ -561,7 +561,7 @@ int git_submodule_add_setup(
 		path += strlen(git_repository_workdir(repo));
 
 	if (git_path_root(path) >= 0) {
-		giterr_set(GITERR_SUBMODULE, "Submodule path must be a relative path");
+		giterr_set("Submodule path must be a relative path");
 		error = -1;
 		goto cleanup;
 	}
@@ -569,7 +569,7 @@ int git_submodule_add_setup(
 	/* update .gitmodules */
 
 	if (!(mods = open_gitmodules(repo, GITMODULES_CREATE))) {
-		giterr_set(GITERR_SUBMODULE,
+		giterr_set(
 			"Adding submodules to a bare repository is not supported");
 		return -1;
 	}
@@ -690,7 +690,7 @@ int git_submodule_add_to_index(git_submodule *sm, int write_index)
 
 	/* read stat information for submodule working directory */
 	if (p_stat(path.ptr, &st) < 0) {
-		giterr_set(GITERR_SUBMODULE,
+		giterr_set(
 			"Cannot add submodule without working directory");
 		error = -1;
 		goto cleanup;
@@ -703,7 +703,7 @@ int git_submodule_add_to_index(git_submodule *sm, int write_index)
 
 	/* calling git_submodule_open will have set sm->wd_oid if possible */
 	if ((sm->flags & GIT_SUBMODULE_STATUS__WD_OID_VALID) == 0) {
-		giterr_set(GITERR_SUBMODULE,
+		giterr_set(
 			"Cannot add submodule without HEAD to index");
 		error = -1;
 		goto cleanup;
@@ -784,7 +784,7 @@ int git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *ur
 	} else if (strchr(url, ':') != NULL || url[0] == '/') {
 		error = git_buf_sets(out, url);
 	} else {
-		giterr_set(GITERR_SUBMODULE, "Invalid format for submodule URL");
+		giterr_set("Invalid format for submodule URL");
 		error = -1;
 	}
 
@@ -822,7 +822,7 @@ static int write_mapped_var(git_repository *repo, const char *name, git_cvar_map
 	const char *val;
 
 	if (git_config_lookup_map_enum(&type, &val, maps, nmaps, ival) < 0) {
-		giterr_set(GITERR_SUBMODULE, "invalid value for %s", var);
+		giterr_set("invalid value for %s", var);
 		return -1;
 	}
 
@@ -1055,7 +1055,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 				goto done;
 
 			if (error == GIT_ENOTFOUND && !init) {
-				giterr_set(GITERR_SUBMODULE, "Submodule is not initialized.");
+				giterr_set("Submodule is not initialized.");
 				error = GIT_ERROR;
 				goto done;
 			}
@@ -1125,7 +1125,7 @@ int git_submodule_init(git_submodule *sm, int overwrite)
 	git_config *cfg = NULL;
 
 	if (!sm->url) {
-		giterr_set(GITERR_SUBMODULE,
+		giterr_set(
 			"No URL configured for submodule '%s'", sm->name);
 		return -1;
 	}
@@ -1169,7 +1169,7 @@ int git_submodule_sync(git_submodule *sm)
 	git_repository *smrepo = NULL;
 
 	if (!sm->url) {
-		giterr_set(GITERR_SUBMODULE,
+		giterr_set(
 			"No URL configured for submodule '%s'", sm->name);
 		return -1;
 	}
@@ -1510,7 +1510,7 @@ static int submodule_alloc(
 	git_submodule *sm;
 
 	if (!name || !(namelen = strlen(name))) {
-		giterr_set(GITERR_SUBMODULE, "Invalid submodule name");
+		giterr_set("Invalid submodule name");
 		return -1;
 	}
 
@@ -1561,7 +1561,7 @@ void git_submodule_free(git_submodule *sm)
 
 static int submodule_config_error(const char *property, const char *value)
 {
-	giterr_set(GITERR_INVALID,
+	giterr_set(
 		"Invalid value for submodule '%s' property: '%s'", property, value);
 	return -1;
 }
@@ -1824,7 +1824,7 @@ static int lookup_head_remote_key(git_buf *remote_name, git_repository *repo)
 	 * a remote key for the local tracking branch HEAD points to.
 	 **/
 	if (!git_reference_is_branch(head)) {
-		giterr_set(GITERR_INVALID,
+		giterr_set(
 			"HEAD does not refer to a branch.");
 		error = GIT_ENOTFOUND;
 		goto done;
@@ -1874,7 +1874,6 @@ static int lookup_default_remote(git_remote **remote, git_repository *repo)
 
 	if (error == GIT_ENOTFOUND)
 		giterr_set(
-			GITERR_SUBMODULE,
 			"Cannot get default remote for submodule - no local tracking "
 			"branch for HEAD and origin does not exist");
 

--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -99,7 +99,7 @@ static int git_sysdir_check_selector(git_sysdir_t which)
 	if (which < GIT_SYSDIR__MAX)
 		return 0;
 
-	giterr_set(GITERR_INVALID, "config directory selector out of range");
+	giterr_set("config directory selector out of range");
 	return -1;
 }
 
@@ -138,7 +138,7 @@ int git_sysdir_get_str(
 	GITERR_CHECK_ERROR(git_sysdir_get(&path, which));
 
 	if (!out || path->size >= outlen) {
-		giterr_set(GITERR_NOMEMORY, "Buffer is too short for the path");
+		giterr_set("Buffer is too short for the path");
 		return GIT_EBUFS;
 	}
 
@@ -222,7 +222,7 @@ static int git_sysdir_find_in_dirlist(
 
 done:
 	git_buf_free(path);
-	giterr_set(GITERR_OS, "The %s file '%s' doesn't exist", label, name);
+	giterr_set_os("The %s file '%s' doesn't exist", label, name);
 	return GIT_ENOTFOUND;
 }
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -61,7 +61,7 @@ const char *git_tag_message(const git_tag *t)
 
 static int tag_error(const char *str)
 {
-	giterr_set(GITERR_TAG, "Failed to parse tag. %s", str);
+	giterr_set("Failed to parse tag. %s", str);
 	return -1;
 }
 
@@ -228,7 +228,7 @@ static int write_tag_annotation(
 
 on_error:
 	git_buf_free(&tag);
-	giterr_set(GITERR_OBJECT, "Failed to create tag annotation.");
+	giterr_set("Failed to create tag annotation.");
 	return -1;
 }
 
@@ -251,7 +251,7 @@ static int git_tag_create__internal(
 	assert(!create_tag_annotation || (tagger && message));
 
 	if (git_object_owner(target) != repo) {
-		giterr_set(GITERR_INVALID, "The given target does not belong to this repository");
+		giterr_set("The given target does not belong to this repository");
 		return -1;
 	}
 
@@ -263,7 +263,7 @@ static int git_tag_create__internal(
 	 *	reference unless overwriting has explicitly been requested **/
 	if (error == 0 && !allow_ref_overwrite) {
 		git_buf_free(&ref_name);
-		giterr_set(GITERR_TAG, "Tag already exists");
+		giterr_set("Tag already exists");
 		return GIT_EEXISTS;
 	}
 
@@ -343,7 +343,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 		goto on_error;
 
 	if (tag.type != target_obj->cached.type) {
-		giterr_set(GITERR_TAG, "The type for the given target is invalid");
+		giterr_set("The type for the given target is invalid");
 		goto on_error;
 	}
 
@@ -360,7 +360,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 	/** Ensure the tag name doesn't conflict with an already existing
 	 *	reference unless overwriting has explictly been requested **/
 	if (error == 0 && !allow_ref_overwrite) {
-		giterr_set(GITERR_TAG, "Tag already exists");
+		giterr_set("Tag already exists");
 		return GIT_EEXISTS;
 	}
 

--- a/src/tls_stream.c
+++ b/src/tls_stream.c
@@ -22,7 +22,7 @@ int git_tls_stream_new(git_stream **out, const char *host, const char *port)
 	GIT_UNUSED(host);
 	GIT_UNUSED(port);
 
-	giterr_set(GITERR_SSL, "there is no TLS stream available");
+	giterr_set("there is no TLS stream available");
 	return -1;
 #endif
 }

--- a/src/trace.c
+++ b/src/trace.c
@@ -31,7 +31,7 @@ int git_trace_set(git_trace_level_t level, git_trace_callback callback)
 	GIT_UNUSED(level);
 	GIT_UNUSED(callback);
 
-	giterr_set(GITERR_INVALID,
+	giterr_set(
 		"This version of libgit2 was not built with tracing.");
 	return -1;
 #endif

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -116,7 +116,7 @@ static int find_locked(transaction_node **out, git_transaction *tx, const char *
 
 	pos = git_strmap_lookup_index(tx->locks, refname);
 	if (!git_strmap_valid_index(tx->locks, pos)) {
-		giterr_set(GITERR_REFERENCE, "the specified reference is not locked");
+		giterr_set("the specified reference is not locked");
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -121,7 +121,7 @@ int git_transport_new(git_transport **out, git_remote *owner, const char *url)
 	int error;
 
 	if ((error = transport_find_fn(&fn, url, &param)) == GIT_ENOTFOUND) {
-		giterr_set(GITERR_NET, "Unsupported URL protocol");
+		giterr_set("Unsupported URL protocol");
 		return -1;
 	} else if (error < 0)
 		return error;

--- a/src/transports/auth.c
+++ b/src/transports/auth.c
@@ -19,7 +19,7 @@ static int basic_next_token(
 	GIT_UNUSED(ctx);
 
 	if (c->credtype != GIT_CREDTYPE_USERPASS_PLAINTEXT) {
-		giterr_set(GITERR_INVALID, "invalid credential type for basic auth");
+		giterr_set("invalid credential type for basic auth");
 		goto on_error;
 	}
 

--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -43,12 +43,12 @@ static void negotiate_err_set(
 
 	if (gss_display_status(&status_display, status_major, GSS_C_GSS_CODE,
 		GSS_C_NO_OID, &context, &buffer) == GSS_S_COMPLETE) {
-		giterr_set(GITERR_NET, "%s: %.*s (%d.%d)",
+		giterr_set("%s: %.*s (%d.%d)",
 			message, (int)buffer.length, (const char *)buffer.value,
 			status_major, status_minor);
 		gss_release_buffer(&status_minor, &buffer);
 	} else {
-		giterr_set(GITERR_NET, "%s: unknown negotiate error (%d.%d)",
+		giterr_set("%s: unknown negotiate error (%d.%d)",
 			message, status_major, status_minor);
 	}
 }
@@ -107,13 +107,13 @@ static int negotiate_next_token(
 	challenge_len = ctx->challenge ? strlen(ctx->challenge) : 0;
 
 	if (challenge_len < 9) {
-		giterr_set(GITERR_NET, "No negotiate challenge sent from server");
+		giterr_set("No negotiate challenge sent from server");
 		error = -1;
 		goto done;
 	} else if (challenge_len > 9) {
 		if (git_buf_decode_base64(&input_buf,
 				ctx->challenge + 10, challenge_len - 10) < 0) {
-			giterr_set(GITERR_NET, "Invalid negotiate challenge from server");
+			giterr_set("Invalid negotiate challenge from server");
 			error = -1;
 			goto done;
 		}
@@ -122,7 +122,7 @@ static int negotiate_next_token(
 		input_token.length = input_buf.size;
 		input_token_ptr = &input_token;
 	} else if (ctx->gss_context != GSS_C_NO_CONTEXT) {
-		giterr_set(GITERR_NET, "Could not restart authentication");
+		giterr_set("Could not restart authentication");
 		error = -1;
 		goto done;
 	}
@@ -228,7 +228,7 @@ static int negotiate_init_context(
 	gss_release_oid_set(&status_minor, &mechanism_list);
 
 	if (!ctx->oid) {
-		giterr_set(GITERR_NET, "Negotiate authentication is not supported");
+		giterr_set("Negotiate authentication is not supported");
 		return -1;
 	}
 

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -215,7 +215,7 @@ int git_cred_ssh_key_memory_new(
 	GIT_UNUSED(privatekey);
 	GIT_UNUSED(passphrase);
 
-	giterr_set(GITERR_INVALID,
+	giterr_set(
 		"This version of libgit2 was not built with ssh memory credentials.");
 	return -1;
 #endif

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -45,7 +45,7 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 
 	delim = strchr(url, '/');
 	if (delim == NULL) {
-		giterr_set(GITERR_NET, "Malformed URL");
+		giterr_set("Malformed URL");
 		return -1;
 	}
 
@@ -235,7 +235,7 @@ static int _git_uploadpack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK");
+	giterr_set("Must call UPLOADPACK_LS before UPLOADPACK");
 	return -1;
 }
 
@@ -291,7 +291,7 @@ static int _git_receivepack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK");
+	giterr_set("Must call RECEIVEPACK_LS before RECEIVEPACK");
 	return -1;
 }
 

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -353,7 +353,7 @@ static int on_headers_complete(http_parser *parser)
 					assert(t->cred);
 
 					if (!(t->cred->credtype & allowed_auth_types)) {
-						giterr_set(GITERR_NET, "credentials callback returned an invalid cred type");
+						giterr_set("credentials callback returned an invalid cred type");
 						return t->parse_error = PARSE_ERROR_GENERIC;
 					}
 
@@ -365,7 +365,7 @@ static int on_headers_complete(http_parser *parser)
 		}
 
 		if (no_callback) {
-			giterr_set(GITERR_NET, "authentication required but no callback set");
+			giterr_set("authentication required but no callback set");
 			return t->parse_error = PARSE_ERROR_GENERIC;
 		}
 	}
@@ -379,7 +379,7 @@ static int on_headers_complete(http_parser *parser)
 	    t->location) {
 
 		if (s->redirect_count >= 7) {
-			giterr_set(GITERR_NET, "Too many redirects");
+			giterr_set("Too many redirects");
 			return t->parse_error = PARSE_ERROR_GENERIC;
 		}
 
@@ -403,7 +403,7 @@ static int on_headers_complete(http_parser *parser)
 
 	/* Check for a 200 HTTP status code. */
 	if (parser->status_code != 200) {
-		giterr_set(GITERR_NET,
+		giterr_set(
 			"Unexpected HTTP status code: %d",
 			parser->status_code);
 		return t->parse_error = PARSE_ERROR_GENERIC;
@@ -411,7 +411,7 @@ static int on_headers_complete(http_parser *parser)
 
 	/* The response must contain a Content-Type header. */
 	if (!t->content_type) {
-		giterr_set(GITERR_NET, "No Content-Type header in response");
+		giterr_set("No Content-Type header in response");
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
 
@@ -430,7 +430,7 @@ static int on_headers_complete(http_parser *parser)
 
 	if (strcmp(t->content_type, git_buf_cstr(&buf))) {
 		git_buf_free(&buf);
-		giterr_set(GITERR_NET,
+		giterr_set(
 			"Invalid Content-Type: %s",
 			t->content_type);
 		return t->parse_error = PARSE_ERROR_GENERIC;
@@ -464,7 +464,7 @@ static int on_body_fill_buffer(http_parser *parser, const char *str, size_t len)
 		return 0;
 
 	if (ctx->buf_size < len) {
-		giterr_set(GITERR_NET, "Can't fit data in the buffer");
+		giterr_set("Can't fit data in the buffer");
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
 
@@ -588,7 +588,7 @@ static int http_connect(http_subtransport *t)
 
 		if (error < 0) {
 			if (!giterr_last())
-				giterr_set(GITERR_NET, "user cancelled certificate check");
+				giterr_set("user cancelled certificate check");
 
 			return error;
 		}
@@ -713,7 +713,7 @@ replay:
 			return -1;
 
 		if (bytes_parsed != t->parse_buffer.offset - data_offset) {
-			giterr_set(GITERR_NET,
+			giterr_set(
 				"HTTP parser error: %s",
 				http_errno_description((enum http_errno)t->parser.http_errno));
 			return -1;
@@ -806,7 +806,7 @@ static int http_stream_write_single(
 	assert(t->connected);
 
 	if (s->sent_request) {
-		giterr_set(GITERR_NET, "Subtransport configured for only one write");
+		giterr_set("Subtransport configured for only one write");
 		return -1;
 	}
 

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -385,7 +385,7 @@ static int local_push(
 
 	git_vector_foreach(&push->specs, j, spec) {
 		push_status *status;
-		const git_error *last;
+		const char *error_last;
 		char *ref = spec->refspec.dst;
 
 		status = git__calloc(1, sizeof(push_status));
@@ -411,10 +411,10 @@ static int local_push(
 				status->msg = git__strdup("Remote branch not found to delete");
 				break;
 			default:
-				last = giterr_last();
+				error_last = giterr_last();
 
-				if (last && last->message)
-					status->msg = git__strdup(last->message);
+				if (error_last)
+					status->msg = git__strdup(error_last);
 				else
 					status->msg = git__strdup("Unspecified error encountered");
 				break;

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -249,7 +249,7 @@ static int local_ls(const git_remote_head ***out, size_t *size, git_transport *t
 	transport_local *t = (transport_local *)transport;
 
 	if (!t->have_refs) {
-		giterr_set(GITERR_NET, "The transport has not yet loaded the refs");
+		giterr_set("The transport has not yet loaded the refs");
 		return -1;
 	}
 
@@ -368,7 +368,7 @@ static int local_push(
 	   but we forbid all pushes just in case */
 	if (!remote_repo->is_bare) {
 		error = GIT_EBAREREPO;
-		giterr_set(GITERR_INVALID, "Local push doesn't (yet) support pushing to non-bare repos.");
+		giterr_set("Local push doesn't (yet) support pushing to non-bare repos.");
 		goto on_error;
 	}
 

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -148,7 +148,7 @@ static int git_smart__connect(
 	else if (GIT_DIRECTION_PUSH == t->direction)
 		service = GIT_SERVICE_RECEIVEPACK_LS;
 	else {
-		giterr_set(GITERR_NET, "Invalid direction");
+		giterr_set("Invalid direction");
 		return -1;
 	}
 
@@ -169,7 +169,7 @@ static int git_smart__connect(
 		pkt = (git_pkt *)git_vector_get(&t->refs, 0);
 
 		if (!pkt || GIT_PKT_COMMENT != pkt->type) {
-			giterr_set(GITERR_NET, "Invalid response");
+			giterr_set("Invalid response");
 			return -1;
 		} else {
 			/* Remove the comment pkt from the list */
@@ -216,7 +216,7 @@ static int git_smart__ls(const git_remote_head ***out, size_t *size, git_transpo
 	transport_smart *t = (transport_smart *)transport;
 
 	if (!t->have_refs) {
-		giterr_set(GITERR_NET, "The transport has not yet loaded the refs");
+		giterr_set("The transport has not yet loaded the refs");
 		return -1;
 	}
 
@@ -236,7 +236,7 @@ int git_smart__negotiation_step(git_transport *transport, void *data, size_t len
 		return -1;
 
 	if (GIT_DIRECTION_FETCH != t->direction) {
-		giterr_set(GITERR_NET, "This operation is only valid for fetch");
+		giterr_set("This operation is only valid for fetch");
 		return -1;
 	}
 
@@ -265,7 +265,7 @@ int git_smart__get_push_stream(transport_smart *t, git_smart_subtransport_stream
 		return -1;
 
 	if (GIT_DIRECTION_PUSH != t->direction) {
-		giterr_set(GITERR_NET, "This operation is only valid for push");
+		giterr_set("This operation is only valid for push");
 		return -1;
 	}
 

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -226,7 +226,7 @@ static int ref_pkt(git_pkt **out, const char *line, size_t len)
 
 	/* Check for a bit of consistency */
 	if (line[GIT_OID_HEXSZ] != ' ') {
-		giterr_set(GITERR_NET, "Error parsing pkt-line");
+		giterr_set("Error parsing pkt-line");
 		error = -1;
 		goto error_out;
 	}
@@ -270,7 +270,7 @@ static int ok_pkt(git_pkt **out, const char *line, size_t len)
 
 	line += 3; /* skip "ok " */
 	if (!(ptr = strchr(line, '\n'))) {
-		giterr_set(GITERR_NET, "Invalid packet line");
+		giterr_set("Invalid packet line");
 		return -1;
 	}
 	len = ptr - line;
@@ -299,7 +299,7 @@ static int ng_pkt(git_pkt **out, const char *line, size_t len)
 
 	line += 3; /* skip "ng " */
 	if (!(ptr = strchr(line, ' '))) {
-		giterr_set(GITERR_NET, "Invalid packet line");
+		giterr_set("Invalid packet line");
 		return -1;
 	}
 	len = ptr - line;
@@ -313,7 +313,7 @@ static int ng_pkt(git_pkt **out, const char *line, size_t len)
 
 	line = ptr + 1;
 	if (!(ptr = strchr(line, '\n'))) {
-		giterr_set(GITERR_NET, "Invalid packet line");
+		giterr_set("Invalid packet line");
 		return -1;
 	}
 	len = ptr - line;
@@ -360,7 +360,7 @@ static int32_t parse_len(const char *line)
 
 	for (i = 0; i < PKT_LEN_SIZE; ++i) {
 		if (!isxdigit(num[i])) {
-			giterr_set(GITERR_NET, "Found invalid hex digit in length");
+			giterr_set("Found invalid hex digit in length");
 			return -1;
 		}
 	}
@@ -522,7 +522,7 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
 		 git_buf_len(&str) + 1 /* LF */;
 
 	if (len > 0xffff) {
-		giterr_set(GITERR_NET,
+		giterr_set(
 			"Tried to produce packet with invalid length %d", len);
 		return -1;
 	}

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -51,7 +51,7 @@ int git_smart__store_refs(transport_smart *t, int flushes)
 				return recvd;
 
 			if (recvd == 0 && !flush) {
-				giterr_set(GITERR_NET, "early EOF");
+				giterr_set("early EOF");
 				return GIT_EEOF;
 			}
 
@@ -60,7 +60,7 @@ int git_smart__store_refs(transport_smart *t, int flushes)
 
 		gitno_consume(buf, line_end);
 		if (pkt->type == GIT_PKT_ERR) {
-			giterr_set(GITERR_NET, "Remote error: %s", ((git_pkt_err *)pkt)->error);
+			giterr_set("Remote error: %s", ((git_pkt_err *)pkt)->error);
 			git__free(pkt);
 			return -1;
 		}
@@ -105,7 +105,7 @@ static int append_symref(const char **out, git_vector *symrefs, const char *ptr)
 
 	/* if the error isn't OOM, then it's a parse error; let's use a nicer message */
 	if (error < 0) {
-		if (giterr_last()->klass != GITERR_NOMEMORY)
+		if (!giterr_is_oom(giterr_last()))
 			goto on_invalid;
 
 		return error;
@@ -118,7 +118,7 @@ static int append_symref(const char **out, git_vector *symrefs, const char *ptr)
 	return 0;
 
 on_invalid:
-	giterr_set(GITERR_NET, "remote sent invalid symref");
+	giterr_set("remote sent invalid symref");
 	git_refspec__free(mapping);
 	return -1;
 }
@@ -364,7 +364,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 		i++;
 		if (i % 20 == 0) {
 			if (t->cancelled.val) {
-				giterr_set(GITERR_NET, "The fetch was cancelled by the user");
+				giterr_set("The fetch was cancelled by the user");
 				error = GIT_EUSER;
 				goto on_error;
 			}
@@ -394,7 +394,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 					error = pkt_type;
 					goto on_error;
 				} else {
-					giterr_set(GITERR_NET, "Unexpected pkt type");
+					giterr_set("Unexpected pkt type");
 					error = -1;
 					goto on_error;
 				}
@@ -446,7 +446,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 		goto on_error;
 
 	if (t->cancelled.val) {
-		giterr_set(GITERR_NET, "The fetch was cancelled by the user");
+		giterr_set("The fetch was cancelled by the user");
 		error = GIT_EUSER;
 		goto on_error;
 	}
@@ -463,7 +463,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 		if (pkt_type < 0) {
 			return pkt_type;
 		} else if (pkt_type != GIT_PKT_ACK && pkt_type != GIT_PKT_NAK) {
-			giterr_set(GITERR_NET, "Unexpected pkt type");
+			giterr_set("Unexpected pkt type");
 			return -1;
 		}
 	} else {
@@ -484,7 +484,7 @@ static int no_sideband(transport_smart *t, struct git_odb_writepack *writepack, 
 
 	do {
 		if (t->cancelled.val) {
-			giterr_set(GITERR_NET, "The fetch was cancelled by the user");
+			giterr_set("The fetch was cancelled by the user");
 			return GIT_EUSER;
 		}
 
@@ -712,7 +712,7 @@ static int add_push_report_pkt(git_push *push, git_pkt *pkt)
 		case GIT_PKT_FLUSH:
 			return GIT_ITEROVER;
 		default:
-			giterr_set(GITERR_NET, "report-status: protocol error");
+			giterr_set("report-status: protocol error");
 			return -1;
 	}
 
@@ -769,7 +769,7 @@ static int parse_report(transport_smart *transport, git_push *push)
 				return recvd;
 
 			if (recvd == 0) {
-				giterr_set(GITERR_NET, "early EOF");
+				giterr_set("early EOF");
 				return GIT_EEOF;
 			}
 			continue;
@@ -785,7 +785,7 @@ static int parse_report(transport_smart *transport, git_push *push)
 				error = add_push_report_sideband_pkt(push, (git_pkt_data *)pkt);
 				break;
 			case GIT_PKT_ERR:
-				giterr_set(GITERR_NET, "report-status: Error reported: %s",
+				giterr_set("report-status: Error reported: %s",
 					((git_pkt_err *)pkt)->error);
 				error = -1;
 				break;
@@ -843,7 +843,7 @@ static int update_refs_from_report(
 	/* For each push spec we sent to the server, we should have
 	 * gotten back a status packet in the push report */
 	if (push_specs->length != push_report->length) {
-		giterr_set(GITERR_NET, "report-status: protocol error");
+		giterr_set("report-status: protocol error");
 		return -1;
 	}
 
@@ -858,7 +858,7 @@ static int update_refs_from_report(
 		/* For each push spec we sent to the server, we should have
 		 * gotten back a status packet in the push report which matches */
 		if (strcmp(push_spec->refspec.dst, push_status->ref)) {
-			giterr_set(GITERR_NET, "report-status: protocol error");
+			giterr_set("report-status: protocol error");
 			return -1;
 		}
 	}

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -50,7 +50,7 @@ static void ssh_error(LIBSSH2_SESSION *session, const char *errmsg)
 	char *ssherr;
 	libssh2_session_last_error(session, &ssherr, NULL, 0);
 
-	giterr_set(GITERR_SSH, "%s: %s", errmsg, ssherr);
+	giterr_set("%s: %s", errmsg, ssherr);
 }
 
 /*
@@ -72,7 +72,7 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 	}
 
 	if (!repo) {
-		giterr_set(GITERR_NET, "Malformed git protocol URL");
+		giterr_set("Malformed git protocol URL");
 		return -1;
 	}
 
@@ -135,7 +135,7 @@ static int ssh_stream_read(
 	 * stderr.
 	 */
 	if (rc == 0 && (rc = libssh2_channel_read_stderr(s->channel, buffer, buf_size)) > 0) {
-		giterr_set(GITERR_SSH, "%*s", rc, buffer);
+		giterr_set("%*s", rc, buffer);
 		return GIT_EEOF;
 	}
 
@@ -258,7 +258,7 @@ static int git_ssh_extract_url_parts(
 	}
 
 	if (colon == NULL || (colon < start)) {
-		giterr_set(GITERR_NET, "Malformed URL");
+		giterr_set("Malformed URL");
 		return -1;
 	}
 
@@ -429,19 +429,19 @@ static int request_creds(git_cred **out, ssh_subtransport *t, const char *user, 
 		else if (error < 0)
 			return error;
 		else if (!cred) {
-			giterr_set(GITERR_SSH, "Callback failed to initialize SSH credentials");
+			giterr_set("Callback failed to initialize SSH credentials");
 			return -1;
 		}
 	}
 
 	if (no_callback) {
-		giterr_set(GITERR_SSH, "authentication required but no callback set");
+		giterr_set("authentication required but no callback set");
 		return -1;
 	}
 
 	if (!(cred->credtype & auth_methods)) {
 		cred->free(cred);
-		giterr_set(GITERR_SSH, "callback returned unsupported credentials type");
+		giterr_set("callback returned unsupported credentials type");
 		return -1;
 	}
 
@@ -462,7 +462,7 @@ static int _git_ssh_session_create(
 
 	s = libssh2_session_init();
 	if (!s) {
-		giterr_set(GITERR_NET, "Failed to initialize SSH session");
+		giterr_set("Failed to initialize SSH session");
 		return -1;
 	}
 
@@ -543,7 +543,7 @@ static int _git_ssh_setup_conn(
 		}
 
 		if (cert.type == 0) {
-			giterr_set(GITERR_SSH, "unable to get the host key");
+			giterr_set("unable to get the host key");
 			error = -1;
 			goto done;
 		}
@@ -556,7 +556,7 @@ static int _git_ssh_setup_conn(
 		error = t->owner->certificate_check_cb((git_cert *) cert_ptr, 0, host, t->owner->message_cb_payload);
 		if (error < 0) {
 			if (!giterr_last())
-				giterr_set(GITERR_NET, "user cancelled hostkey check");
+				giterr_set("user cancelled hostkey check");
 
 			goto done;
 		}
@@ -595,7 +595,7 @@ static int _git_ssh_setup_conn(
 			goto done;
 
 		if (strcmp(user, git_cred__username(cred))) {
-			giterr_set(GITERR_SSH, "username does not match previous request");
+			giterr_set("username does not match previous request");
 			error = -1;
 			goto done;
 		}
@@ -662,7 +662,7 @@ static int ssh_uploadpack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK");
+	giterr_set("Must call UPLOADPACK_LS before UPLOADPACK");
 	return -1;
 }
 
@@ -689,7 +689,7 @@ static int ssh_receivepack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK");
+	giterr_set("Must call RECEIVEPACK_LS before RECEIVEPACK");
 	return -1;
 }
 
@@ -819,7 +819,7 @@ int git_smart_subtransport_ssh(
 	assert(out);
 	*out = NULL;
 
-	giterr_set(GITERR_INVALID, "Cannot create SSH transport. Library was built without SSH support");
+	giterr_set("Cannot create SSH transport. Library was built without SSH support");
 	return -1;
 #endif
 }
@@ -839,7 +839,7 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 	};
 
 	if (paths->count != 2) {
-		giterr_set(GITERR_SSH, "invalid ssh paths, must be two strings");
+		giterr_set("invalid ssh paths, must be two strings");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -863,7 +863,7 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 	assert(out);
 	*out = NULL;
 
-	giterr_set(GITERR_INVALID, "Cannot create SSH transport. Library was built without SSH support");
+	giterr_set("Cannot create SSH transport. Library was built without SSH support");
 	return -1;
 #endif
 }

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -107,12 +107,12 @@ static int apply_basic_credential(HINTERNET request, git_cred *cred)
 		goto on_error;
 
 	if ((wide_len = git__utf8_to_16_alloc(&wide, git_buf_cstr(&buf))) < 0) {
-		giterr_set(GITERR_OS, "Failed to convert string to wide form");
+		giterr_set_os("Failed to convert string to wide form");
 		goto on_error;
 	}
 
 	if (!WinHttpAddRequestHeaders(request, wide, (ULONG) -1L, WINHTTP_ADDREQ_FLAG_ADD)) {
-		giterr_set(GITERR_OS, "Failed to add a header to the request");
+		giterr_set_os("Failed to add a header to the request");
 		goto on_error;
 	}
 
@@ -170,7 +170,7 @@ static int fallback_cred_acquire_cb(
 
 		/* Convert URL to wide characters */
 		if (git__utf8_to_16_alloc(&wide_url, url) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert string to wide form");
+			giterr_set_os("Failed to convert string to wide form");
 			return -1;
 		}
 
@@ -223,7 +223,7 @@ static int certificate_check(winhttp_stream *s, int valid)
 		return 0;
 
 	if (!WinHttpQueryOption(s->request, WINHTTP_OPTION_SERVER_CERT_CONTEXT, &cert_ctx, &cert_ctx_size)) {
-		giterr_set(GITERR_OS, "failed to get server certificate");
+		giterr_set_os("failed to get server certificate");
 		return -1;
 	}
 
@@ -235,7 +235,7 @@ static int certificate_check(winhttp_stream *s, int valid)
 	CertFreeCertificateContext(cert_ctx);
 
 	if (error < 0 && !giterr_last())
-		giterr_set(GITERR_NET, "user cancelled certificate check");
+		giterr_set("user cancelled certificate check");
 
 	return error;
 }
@@ -286,7 +286,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 
 	/* Convert URL to wide characters */
 	if (git__utf8_to_16_alloc(&s->request_uri, git_buf_cstr(&buf)) < 0) {
-		giterr_set(GITERR_OS, "Failed to convert string to wide form");
+		giterr_set_os("Failed to convert string to wide form");
 		goto on_error;
 	}
 
@@ -301,12 +301,12 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			t->connection_data.use_ssl ? WINHTTP_FLAG_SECURE : 0);
 
 	if (!s->request) {
-		giterr_set(GITERR_OS, "Failed to open request");
+		giterr_set_os("Failed to open request");
 		goto on_error;
 	}
 
 	if (!WinHttpSetTimeouts(s->request, default_timeout, default_connect_timeout, default_timeout, default_timeout)) {
-		giterr_set(GITERR_OS, "Failed to set timeouts for WinHTTP");
+		giterr_set_os("Failed to set timeouts for WinHTTP");
 		goto on_error;
 	}
 
@@ -322,7 +322,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 		int proxy_wide_len = git__utf8_to_16_alloc(&proxy_wide, proxy_url);
 
 		if (proxy_wide_len < 0) {
-			giterr_set(GITERR_OS, "Failed to convert string to wide form");
+			giterr_set_os("Failed to convert string to wide form");
 			goto on_error;
 		}
 
@@ -339,7 +339,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			WINHTTP_OPTION_PROXY,
 			&proxy_info,
 			sizeof(WINHTTP_PROXY_INFO))) {
-			giterr_set(GITERR_OS, "Failed to set proxy");
+			giterr_set_os("Failed to set proxy");
 			git__free(proxy_wide);
 			goto on_error;
 		}
@@ -354,7 +354,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 		WINHTTP_OPTION_DISABLE_FEATURE,
 		&disable_redirects,
 		sizeof(disable_redirects))) {
-			giterr_set(GITERR_OS, "Failed to disable redirects");
+			giterr_set_os("Failed to disable redirects");
 			goto on_error;
 	}
 
@@ -368,7 +368,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 
 	/* Send Pragma: no-cache header */
 	if (!WinHttpAddRequestHeaders(s->request, pragma_nocache, (ULONG) -1L, WINHTTP_ADDREQ_FLAG_ADD)) {
-		giterr_set(GITERR_OS, "Failed to add a header to the request");
+		giterr_set_os("Failed to add a header to the request");
 		goto on_error;
 	}
 
@@ -381,13 +381,13 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			goto on_error;
 
 		if (git__utf8_to_16(ct, MAX_CONTENT_TYPE_LEN, git_buf_cstr(&buf)) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert content-type to wide characters");
+			giterr_set_os("Failed to convert content-type to wide characters");
 			goto on_error;
 		}
 
 		if (!WinHttpAddRequestHeaders(s->request, ct, (ULONG)-1L,
 			WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE)) {
-			giterr_set(GITERR_OS, "Failed to add a header to the request");
+			giterr_set_os("Failed to add a header to the request");
 			goto on_error;
 		}
 
@@ -398,13 +398,13 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			goto on_error;
 
 		if (git__utf8_to_16(ct, MAX_CONTENT_TYPE_LEN, git_buf_cstr(&buf)) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert accept header to wide characters");
+			giterr_set_os("Failed to convert accept header to wide characters");
 			goto on_error;
 		}
 
 		if (!WinHttpAddRequestHeaders(s->request, ct, (ULONG)-1L,
 			WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE)) {
-			giterr_set(GITERR_OS, "Failed to add a header to the request");
+			giterr_set_os("Failed to add a header to the request");
 			goto on_error;
 		}
 	}
@@ -466,7 +466,7 @@ static int parse_unauthorized_response(
 	 * We can assume this was already done, since we know we are unauthorized. 
 	 */
 	if (!WinHttpQueryAuthSchemes(request, &supported, &first, &target)) {
-		giterr_set(GITERR_OS, "Failed to parse supported auth schemes"); 
+		giterr_set_os("Failed to parse supported auth schemes"); 
 		return -1;
 	}
 
@@ -499,7 +499,7 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 		git_buf_cstr(&buf),	(DWORD)git_buf_len(&buf),
 		&bytes_written)) {
 		git_buf_free(&buf);
-		giterr_set(GITERR_OS, "Failed to write chunk header");
+		giterr_set_os("Failed to write chunk header");
 		return -1;
 	}
 
@@ -509,7 +509,7 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 	if (!WinHttpWriteData(request,
 		buffer, (DWORD)len,
 		&bytes_written)) {
-		giterr_set(GITERR_OS, "Failed to write chunk");
+		giterr_set_os("Failed to write chunk");
 		return -1;
 	}
 
@@ -517,7 +517,7 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 	if (!WinHttpWriteData(request,
 		"\r\n", 2,
 		&bytes_written)) {
-		giterr_set(GITERR_OS, "Failed to write chunk footer");
+		giterr_set_os("Failed to write chunk footer");
 		return -1;
 	}
 
@@ -530,7 +530,7 @@ static int winhttp_close_connection(winhttp_subtransport *t)
 
 	if (t->connection) {
 		if (!WinHttpCloseHandle(t->connection)) {
-			giterr_set(GITERR_OS, "Unable to close connection");
+			giterr_set_os("Unable to close connection");
 			ret = -1;
 		}
 
@@ -539,7 +539,7 @@ static int winhttp_close_connection(winhttp_subtransport *t)
 
 	if (t->session) {
 		if (!WinHttpCloseHandle(t->session)) {
-			giterr_set(GITERR_OS, "Unable to close session");
+			giterr_set_os("Unable to close session");
 			ret = -1;
 		}
 
@@ -568,7 +568,7 @@ static int winhttp_connect(
 
 	/* Prepare host */
 	if (git__utf8_to_16_alloc(&wide_host, t->connection_data.host) < 0) {
-		giterr_set(GITERR_OS, "Unable to convert host to wide characters");
+		giterr_set_os("Unable to convert host to wide characters");
 		return -1;
 	}
 
@@ -581,12 +581,12 @@ static int winhttp_connect(
 		0);
 
 	if (!t->session) {
-		giterr_set(GITERR_OS, "Failed to init WinHTTP");
+		giterr_set_os("Failed to init WinHTTP");
 		goto on_error;
 	}
 
 	if (!WinHttpSetTimeouts(t->session, default_timeout, default_connect_timeout, default_timeout, default_timeout)) {
-		giterr_set(GITERR_OS, "Failed to set timeouts for WinHTTP");
+		giterr_set_os("Failed to set timeouts for WinHTTP");
 		goto on_error;
 	}
 
@@ -599,7 +599,7 @@ static int winhttp_connect(
 		0);
 
 	if (!t->connection) {
-		giterr_set(GITERR_OS, "Failed to connect to host");
+		giterr_set_os("Failed to connect to host");
 		goto on_error;
 	}
 
@@ -645,7 +645,7 @@ static int send_request(winhttp_stream *s, size_t len, int ignore_length)
 
 	if (request_failed) {
 		if (GetLastError() != ERROR_WINHTTP_SECURE_FAILURE) {
-			giterr_set(GITERR_OS, "failed to send request");
+			giterr_set_os("failed to send request");
 			return -1;
 		} else {
 			cert_valid = 0;
@@ -655,7 +655,7 @@ static int send_request(winhttp_stream *s, size_t len, int ignore_length)
 	giterr_clear();
 	if ((error = certificate_check(s, cert_valid)) < 0) {
 		if (!giterr_last())
-			giterr_set(GITERR_OS, "user cancelled certificate check");
+			giterr_set_os("user cancelled certificate check");
 
 		return error;
 	}
@@ -667,12 +667,12 @@ static int send_request(winhttp_stream *s, size_t len, int ignore_length)
 	ignore_flags = no_check_cert_flags;
 	
 	if (!WinHttpSetOption(s->request, WINHTTP_OPTION_SECURITY_FLAGS, &ignore_flags, sizeof(ignore_flags))) {
-		giterr_set(GITERR_OS, "failed to set security options");
+		giterr_set_os("failed to set security options");
 		return -1;
 	}
 
 	if ((error = do_send_request(s, len, ignore_length)) < 0)
-		giterr_set(GITERR_OS, "failed to send request");
+		giterr_set_os("failed to send request");
 
 	return error;
 }
@@ -692,7 +692,7 @@ static int winhttp_stream_read(
 replay:
 	/* Enforce a reasonable cap on the number of replays */
 	if (++replay_count >= 7) {
-		giterr_set(GITERR_NET, "Too many redirects or authentication replays");
+		giterr_set("Too many redirects or authentication replays");
 		return -1;
 	}
 
@@ -727,7 +727,7 @@ replay:
 			if (!WinHttpWriteData(s->request,
 				"0\r\n\r\n", 5,
 				&bytes_written)) {
-				giterr_set(GITERR_OS, "Failed to write final chunk");
+				giterr_set_os("Failed to write final chunk");
 				return -1;
 			}
 		}
@@ -738,7 +738,7 @@ replay:
 			if (INVALID_SET_FILE_POINTER == SetFilePointer(s->post_body,
 					0, 0, FILE_BEGIN) &&
 				NO_ERROR != GetLastError()) {
-				giterr_set(GITERR_OS, "Failed to reset file pointer");
+				giterr_set_os("Failed to reset file pointer");
 				return -1;
 			}
 
@@ -752,14 +752,14 @@ replay:
 					&bytes_read, NULL) ||
 					!bytes_read) {
 					git__free(buffer);
-					giterr_set(GITERR_OS, "Failed to read from temp file");
+					giterr_set_os("Failed to read from temp file");
 					return -1;
 				}
 
 				if (!WinHttpWriteData(s->request, buffer,
 					bytes_read, &bytes_written)) {
 					git__free(buffer);
-					giterr_set(GITERR_OS, "Failed to write data");
+					giterr_set_os("Failed to write data");
 					return -1;
 				}
 
@@ -775,7 +775,7 @@ replay:
 		}
 
 		if (!WinHttpReceiveResponse(s->request, 0)) {
-			giterr_set(GITERR_OS, "Failed to receive response");
+			giterr_set_os("Failed to receive response");
 			return -1;
 		}
 
@@ -787,7 +787,7 @@ replay:
 			WINHTTP_HEADER_NAME_BY_INDEX,
 			&status_code, &status_code_length,
 			WINHTTP_NO_HEADER_INDEX)) {
-				giterr_set(GITERR_OS, "Failed to retrieve status code");
+				giterr_set_os("Failed to retrieve status code");
 				return -1;
 		}
 
@@ -817,7 +817,7 @@ replay:
 				&location_length,
 				WINHTTP_NO_HEADER_INDEX) ||
 				GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-				giterr_set(GITERR_OS, "Failed to read Location header");
+				giterr_set_os("Failed to read Location header");
 				return -1;
 			}
 
@@ -830,14 +830,14 @@ replay:
 				location,
 				&location_length,
 				WINHTTP_NO_HEADER_INDEX)) {
-				giterr_set(GITERR_OS, "Failed to read Location header");
+				giterr_set_os("Failed to read Location header");
 				git__free(location);
 				return -1;
 			}
 
 			/* Convert the Location header to UTF-8 */
 			if (git__utf16_to_8_alloc(&location8, location) < 0) {
-				giterr_set(GITERR_OS, "Failed to convert Location header to UTF-8");
+				giterr_set_os("Failed to convert Location header to UTF-8");
 				git__free(location);
 				return -1;
 			}
@@ -905,7 +905,7 @@ replay:
 		}
 
 		if (HTTP_STATUS_OK != status_code) {
-			giterr_set(GITERR_NET, "Request failed with status code: %d", status_code);
+			giterr_set("Request failed with status code: %d", status_code);
 			return -1;
 		}
 
@@ -916,7 +916,7 @@ replay:
 			p_snprintf(expected_content_type_8, MAX_CONTENT_TYPE_LEN, "application/x-git-%s-advertisement", s->service);
 
 		if (git__utf8_to_16(expected_content_type, MAX_CONTENT_TYPE_LEN, expected_content_type_8) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert expected content-type to wide characters");
+			giterr_set_os("Failed to convert expected content-type to wide characters");
 			return -1;
 		}
 
@@ -927,12 +927,12 @@ replay:
 			WINHTTP_HEADER_NAME_BY_INDEX,
 			&content_type, &content_type_length,
 			WINHTTP_NO_HEADER_INDEX)) {
-				giterr_set(GITERR_OS, "Failed to retrieve response content-type");
+				giterr_set_os("Failed to retrieve response content-type");
 				return -1;
 		}
 
 		if (wcscmp(expected_content_type, content_type)) {
-			giterr_set(GITERR_NET, "Received unexpected content-type");
+			giterr_set("Received unexpected content-type");
 			return -1;
 		}
 
@@ -944,7 +944,7 @@ replay:
 		(DWORD)buf_size,
 		&dw_bytes_read))
 	{
-		giterr_set(GITERR_OS, "Failed to read data");
+		giterr_set_os("Failed to read data");
 		return -1;
 	}
 
@@ -967,7 +967,7 @@ static int winhttp_stream_write_single(
 
 	/* This implementation of write permits only a single call. */
 	if (s->sent_request) {
-		giterr_set(GITERR_NET, "Subtransport configured for only one write");
+		giterr_set("Subtransport configured for only one write");
 		return -1;
 	}
 
@@ -980,7 +980,7 @@ static int winhttp_stream_write_single(
 			(LPCVOID)buffer,
 			(DWORD)len,
 			&bytes_written)) {
-		giterr_set(GITERR_OS, "Failed to write data");
+		giterr_set_os("Failed to write data");
 		return -1;
 	}
 
@@ -998,12 +998,12 @@ static int put_uuid_string(LPWSTR buffer, size_t buffer_len_cch)
 	if (RPC_S_OK != status &&
 		RPC_S_UUID_LOCAL_ONLY != status &&
 		RPC_S_UUID_NO_ADDRESS != status) {
-		giterr_set(GITERR_NET, "Unable to generate name for temp file");
+		giterr_set("Unable to generate name for temp file");
 		return -1;
 	}
 
 	if (buffer_len_cch < UUID_LENGTH_CCH + 1) {
-		giterr_set(GITERR_NET, "Buffer too small for name of temp file");
+		giterr_set("Buffer too small for name of temp file");
 		return -1;
 	}
 
@@ -1018,7 +1018,7 @@ static int put_uuid_string(LPWSTR buffer, size_t buffer_len_cch)
 		uuid.Data4[4], uuid.Data4[5], uuid.Data4[6], uuid.Data4[7]);
 
 	if (result < UUID_LENGTH_CCH) {
-		giterr_set(GITERR_OS, "Unable to generate name for temp file");
+		giterr_set_os("Unable to generate name for temp file");
 		return -1;
 	}
 
@@ -1030,7 +1030,7 @@ static int get_temp_file(LPWSTR buffer, DWORD buffer_len_cch)
 	size_t len;
 
 	if (!GetTempPathW(buffer_len_cch, buffer)) {
-		giterr_set(GITERR_OS, "Failed to get temp path");
+		giterr_set_os("Failed to get temp path");
 		return -1;
 	}
 
@@ -1073,13 +1073,13 @@ static int winhttp_stream_write_buffered(
 
 		if (INVALID_HANDLE_VALUE == s->post_body) {
 			s->post_body = NULL;
-			giterr_set(GITERR_OS, "Failed to create temporary file");
+			giterr_set_os("Failed to create temporary file");
 			return -1;
 		}
 	}
 
 	if (!WriteFile(s->post_body, buffer, (DWORD)len, &bytes_written, NULL)) {
-		giterr_set(GITERR_OS, "Failed to write to temporary file");
+		giterr_set_os("Failed to write to temporary file");
 		return -1;
 	}
 
@@ -1107,7 +1107,7 @@ static int winhttp_stream_write_chunked(
 		if (!WinHttpAddRequestHeaders(s->request,
 			transfer_encoding, (ULONG) -1L,
 			WINHTTP_ADDREQ_FLAG_ADD)) {
-			giterr_set(GITERR_OS, "Failed to add a header to the request");
+			giterr_set_os("Failed to add a header to the request");
 			return -1;
 		}
 

--- a/src/tree-cache.c
+++ b/src/tree-cache.c
@@ -137,7 +137,7 @@ static int read_tree_internal(git_tree_cache **out,
 	return 0;
 
  corrupted:
-	giterr_set(GITERR_INDEX, "Corrupted TREE extension in index");
+	giterr_set("Corrupted TREE extension in index");
 	return -1;
 }
 
@@ -149,7 +149,7 @@ int git_tree_cache_read(git_tree_cache **tree, const char *buffer, size_t buffer
 		return -1;
 
 	if (buffer < buffer_end) {
-		giterr_set(GITERR_INDEX, "Corrupted TREE extension in index (unexpected trailing data)");
+		giterr_set("Corrupted TREE extension in index (unexpected trailing data)");
 		return -1;
 	}
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -373,9 +373,9 @@ unsigned int git_treebuilder_entrycount(git_treebuilder *bld)
 static int tree_error(const char *str, const char *path)
 {
 	if (path)
-		giterr_set(GITERR_TREE, "%s - %s", str, path);
+		giterr_set("%s - %s", str, path);
 	else
-		giterr_set(GITERR_TREE, "%s", str);
+		giterr_set("%s", str);
 	return -1;
 }
 
@@ -466,7 +466,7 @@ static int append_entry(
 	git_strmap_insert(bld->map, entry->filename, entry, error);
 	if (error < 0) {
 		git_tree_entry_free(entry);
-		giterr_set(GITERR_TREE, "failed to append entry %s to the tree builder", filename);
+		giterr_set("failed to append entry %s to the tree builder", filename);
 		return -1;
 	}
 
@@ -584,7 +584,7 @@ int git_tree__write_index(
 	assert(oid && index && repo);
 
 	if (git_index_has_conflicts(index)) {
-		giterr_set(GITERR_INDEX,
+		giterr_set(
 			"Cannot create a tree from a not fully merged index.");
 		return GIT_EUNMERGED;
 	}
@@ -696,7 +696,7 @@ int git_treebuilder_insert(
 
 		if (error < 0) {
 			git_tree_entry_free(entry);
-			giterr_set(GITERR_TREE, "failed to insert %s", filename);
+			giterr_set("failed to insert %s", filename);
 			return -1;
 		}
 	}
@@ -850,14 +850,14 @@ int git_tree_entry_bypath(
 	filename_len = subpath_len(path);
 
 	if (filename_len == 0) {
-		giterr_set(GITERR_TREE, "Invalid tree path given");
+		giterr_set("Invalid tree path given");
 		return GIT_ENOTFOUND;
 	}
 
 	entry = entry_fromname(root, path, filename_len);
 
 	if (entry == NULL) {
-		giterr_set(GITERR_TREE,
+		giterr_set(
 			   "the path '%.*s' does not exist in the given tree", filename_len, path);
 		return GIT_ENOTFOUND;
 	}
@@ -867,7 +867,7 @@ int git_tree_entry_bypath(
 		/* If there are more components in the path...
 		 * then this entry *must* be a tree */
 		if (!git_tree_entry__is_tree(entry)) {
-			giterr_set(GITERR_TREE,
+			giterr_set(
 				   "the path '%.*s' exists but is not a tree", filename_len, path);
 			return GIT_ENOTFOUND;
 		}
@@ -968,7 +968,7 @@ int git_tree_walk(
 	git_buf root_path = GIT_BUF_INIT;
 
 	if (mode != GIT_TREEWALK_POST && mode != GIT_TREEWALK_PRE) {
-		giterr_set(GITERR_INVALID, "Invalid walking mode for tree walk");
+		giterr_set("Invalid walking mode for tree walk");
 		return -1;
 	}
 

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -17,7 +17,7 @@ int git__page_size(size_t *page_size)
 {
 	long sc_page_size = sysconf(_SC_PAGE_SIZE);
 	if (sc_page_size < 0) {
-		giterr_set_str(GITERR_OS, "Can't determine system page size");
+		giterr_set_os("Can't determine system page size");
 		return -1;
 	}
 	*page_size = (size_t) sc_page_size;
@@ -47,7 +47,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	out->data = mmap(NULL, len, mprot, mflag, fd, offset);
 
 	if (!out->data || out->data == MAP_FAILED) {
-		giterr_set(GITERR_OS, "Failed to mmap. Could not write data");
+		giterr_set_os("Failed to mmap. Could not write data");
 		return -1;
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -126,7 +126,7 @@ int git__strtol64(int64_t *result, const char *nptr, const char **endptr, int ba
 
 Return:
 	if (ndig == 0) {
-		giterr_set(GITERR_INVALID, "Failed to convert string to long. Not a number");
+		giterr_set("Failed to convert string to long. Not a number");
 		return -1;
 	}
 
@@ -134,7 +134,7 @@ Return:
 		*endptr = p;
 
 	if (ovfl) {
-		giterr_set(GITERR_INVALID, "Failed to convert string to long. Overflow error");
+		giterr_set("Failed to convert string to long. Overflow error");
 		return -1;
 	}
 
@@ -153,7 +153,7 @@ int git__strtol32(int32_t *result, const char *nptr, const char **endptr, int ba
 
 	tmp_int = tmp_long & 0xFFFFFFFF;
 	if (tmp_int != tmp_long) {
-		giterr_set(GITERR_INVALID, "Failed to convert. '%s' is too large", nptr);
+		giterr_set("Failed to convert. '%s' is too large", nptr);
 		return -1;
 	}
 

--- a/src/win32/dir.c
+++ b/src/win32/dir.c
@@ -28,7 +28,7 @@ git__DIR *git__opendir(const char *dir)
 	new->h = FindFirstFileW(filter_w, &new->f);
 
 	if (new->h == INVALID_HANDLE_VALUE) {
-		giterr_set(GITERR_OS, "Could not open directory '%s'", dir);
+		giterr_set_os("Could not open directory '%s'", dir);
 		git__free(new);
 		return NULL;
 	}
@@ -53,7 +53,7 @@ int git__readdir_ext(
 	else if (!FindNextFileW(d->h, &d->f)) {
 		if (GetLastError() == ERROR_NO_MORE_FILES)
 			return 0;
-		giterr_set(GITERR_OS, "Could not read from directory '%s'", d->dir);
+		giterr_set_os("Could not read from directory '%s'", d->dir);
 		return -1;
 	}
 
@@ -98,7 +98,7 @@ void git__rewinddir(git__DIR *d)
 	d->h = FindFirstFileW(filter_w, &d->f);
 
 	if (d->h == INVALID_HANDLE_VALUE)
-		giterr_set(GITERR_OS, "Could not open directory '%s'", d->dir);
+		giterr_set_os("Could not open directory '%s'", d->dir);
 	else
 		d->first = 1;
 }

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -38,7 +38,7 @@ static int win32_path_to_8(git_buf *dest, const wchar_t *src)
 	git_win32_utf8_path utf8_path;
 
 	if (git_win32_path_to_utf8(utf8_path, src) < 0) {
-		giterr_set(GITERR_OS, "Unable to convert path to UTF-8");
+		giterr_set_os("Unable to convert path to UTF-8");
 		return -1;
 	}
 

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -48,7 +48,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 
 	if (fh == INVALID_HANDLE_VALUE) {
 		errno = EBADF;
-		giterr_set(GITERR_OS, "Failed to mmap. Invalid handle value");
+		giterr_set_os("Failed to mmap. Invalid handle value");
 		return -1;
 	}
 
@@ -67,13 +67,13 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 
 	if (page_offset != 0) { /* offset must be multiple of page size */
 		errno = EINVAL;
-		giterr_set(GITERR_OS, "Failed to mmap. Offset must be multiple of page size");
+		giterr_set_os("Failed to mmap. Offset must be multiple of page size");
 		return -1;
 	}
 
 	out->fmh = CreateFileMapping(fh, NULL, fmap_prot, 0, 0, NULL);
 	if (!out->fmh || out->fmh == INVALID_HANDLE_VALUE) {
-		giterr_set(GITERR_OS, "Failed to mmap. Invalid handle value");
+		giterr_set_os("Failed to mmap. Invalid handle value");
 		out->fmh = NULL;
 		return -1;
 	}
@@ -84,7 +84,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	off_hi = (DWORD)(page_start >> 32);
 	out->data = MapViewOfFile(out->fmh, view_prot, off_hi, off_low, len);
 	if (!out->data) {
-		giterr_set(GITERR_OS, "Failed to mmap. No data written");
+		giterr_set_os("Failed to mmap. No data written");
 		CloseHandle(out->fmh);
 		out->fmh = NULL;
 		return -1;
@@ -102,7 +102,7 @@ int p_munmap(git_map *map)
 
 	if (map->data) {
 		if (!UnmapViewOfFile(map->data)) {
-			giterr_set(GITERR_OS, "Failed to munmap. Could not unmap view of file");
+			giterr_set_os("Failed to munmap. Could not unmap view of file");
 			error = -1;
 		}
 		map->data = NULL;
@@ -110,7 +110,7 @@ int p_munmap(git_map *map)
 
 	if (map->fmh) {
 		if (!CloseHandle(map->fmh)) {
-			giterr_set(GITERR_OS, "Failed to munmap. Could not close handle");
+			giterr_set_os("Failed to munmap. Could not close handle");
 			error = -1;
 		}
 		map->fmh = NULL;

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -565,7 +565,7 @@ static int ensure_writable(wchar_t *fpath)
 		if (GetLastError() == ERROR_FILE_NOT_FOUND)
 			return 0;
 
-		giterr_set(GITERR_OS, "failed to get attributes");
+		giterr_set_os("failed to get attributes");
 		return -1;
 	}
 
@@ -574,7 +574,7 @@ static int ensure_writable(wchar_t *fpath)
 
 	attrs &= ~FILE_ATTRIBUTE_READONLY;
 	if (!SetFileAttributesW(fpath, attrs)) {
-		giterr_set(GITERR_OS, "failed to set attributes");
+		giterr_set_os("failed to set attributes");
 		return -1;
 	}
 

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -125,7 +125,7 @@ GIT_INLINE(int) git_win32__file_attribute_to_stat(
 			/* st_size gets the UTF-8 length of the target name, in bytes,
 				* not counting the NULL terminator */
 			if ((st->st_size = git__utf16_to_8(NULL, 0, target)) < 0) {
-				giterr_set(GITERR_OS, "Could not convert reparse point name for '%s'", path);
+				giterr_set_os("Could not convert reparse point name for '%s'", path);
 				return -1;
 			}
 		}

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -21,9 +21,9 @@ static int zstream_seterr(git_zstream *zs)
 	if (zs->zerr == Z_MEM_ERROR)
 		giterr_set_oom();
 	else if (zs->z.msg)
-		giterr_set(GITERR_ZLIB, zs->z.msg);
+		giterr_set(zs->z.msg);
 	else
-		giterr_set(GITERR_ZLIB, "Unknown compression error");
+		giterr_set("Unknown compression error");
 
 	return -1;
 }

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -493,20 +493,13 @@ void test_checkout_index__can_overcome_name_clashes(void)
 void test_checkout_index__validates_struct_version(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
-	const git_error *err;
 
 	opts.version = 1024;
 	cl_git_fail(git_checkout_index(g_repo, NULL, &opts));
 
-	err = giterr_last();
-	cl_assert_equal_i(err->klass, GITERR_INVALID);
-
 	opts.version = 0;
 	giterr_clear();
 	cl_git_fail(git_checkout_index(g_repo, NULL, &opts));
-
-	err = giterr_last();
-	cl_assert_equal_i(err->klass, GITERR_INVALID);
 }
 
 void test_checkout_index__can_update_prefixed_files(void)

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -7,9 +7,9 @@ void cl_git_report_failure(
 	int error, const char *file, int line, const char *fncall)
 {
 	char msg[4096];
-	const git_error *last = giterr_last();
+	const char *error_last = giterr_last();
 	p_snprintf(msg, 4096, "error %d - %s",
-		error, last ? last->message : "<no message>");
+		error, error_last ? error_last : "<no message>");
 	clar__assert(0, file, line, fncall, msg, 1);
 }
 

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -36,7 +36,7 @@
 #define cl_win32_pass(expr) do { \
 	int _win32_res; \
 	if ((_win32_res = (expr)) == 0) { \
-		giterr_set(GITERR_OS, "Returned: %d, system error code: %d", _win32_res, GetLastError()); \
+		giterr_set_os("Returned: %d, system error code: %d", _win32_res, GetLastError()); \
 		cl_git_report_failure(_win32_res, __FILE__, __LINE__, "System call failed: " #expr); \
 	} \
 	} while(0)

--- a/tests/config/backend.c
+++ b/tests/config/backend.c
@@ -5,18 +5,15 @@ void test_config_backend__checks_version(void)
 {
 	git_config *cfg;
 	git_config_backend backend = GIT_CONFIG_BACKEND_INIT;
-	const git_error *err;
 
 	backend.version = 1024;
 
 	cl_git_pass(git_config_new(&cfg));
 	cl_git_fail(git_config_add_backend(cfg, &backend, 0, false));
-	err = giterr_last();
 
 	giterr_clear();
 	backend.version = 1024;
 	cl_git_fail(git_config_add_backend(cfg, &backend, 0, false));
-	err = giterr_last();
 
 	git_config_free(cfg);
 }

--- a/tests/config/backend.c
+++ b/tests/config/backend.c
@@ -12,13 +12,11 @@ void test_config_backend__checks_version(void)
 	cl_git_pass(git_config_new(&cfg));
 	cl_git_fail(git_config_add_backend(cfg, &backend, 0, false));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	giterr_clear();
 	backend.version = 1024;
 	cl_git_fail(git_config_add_backend(cfg, &backend, 0, false));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	git_config_free(cfg);
 }

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -10,13 +10,13 @@ void test_core_errors__public_api(void)
 	giterr_set_oom();
 
 	cl_assert(giterr_last() != NULL);
-	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
+	cl_assert(giterr_is_oom(giterr_last()));
 	str_in_error = strstr(giterr_last()->message, "memory");
 	cl_assert(str_in_error != NULL);
 
 	giterr_clear();
 
-	giterr_set_str(GITERR_REPOSITORY, "This is a test");
+	giterr_set("This is a test");
 
 	cl_assert(giterr_last() != NULL);
 	str_in_error = strstr(giterr_last()->message, "This is a test");
@@ -40,13 +40,13 @@ void test_core_errors__new_school(void)
 	giterr_set_oom(); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
-	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
+	cl_assert(giterr_is_oom(giterr_last()));
 	str_in_error = strstr(giterr_last()->message, "memory");
 	cl_assert(str_in_error != NULL);
 
 	giterr_clear();
 
-	giterr_set(GITERR_REPOSITORY, "This is a test"); /* internal fn */
+	giterr_set("This is a test"); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
 	str_in_error = strstr(giterr_last()->message, "This is a test");
@@ -61,7 +61,7 @@ void test_core_errors__new_school(void)
 		cl_assert(p_lstat("this_file_does_not_exist", &st) < 0);
 		GIT_UNUSED(st);
 	} while (false);
-	giterr_set(GITERR_OS, "stat failed"); /* internal fn */
+	giterr_set_os("stat failed"); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
 	str_in_error = strstr(giterr_last()->message, "stat failed");
@@ -74,7 +74,7 @@ void test_core_errors__new_school(void)
 
 	/* The MSDN docs use this to generate a sample error */
 	cl_assert(GetProcessId(NULL) == 0);
-	giterr_set(GITERR_OS, "GetProcessId failed"); /* internal fn */
+	giterr_set_os("GetProcessId failed"); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
 	str_in_error = strstr(giterr_last()->message, "GetProcessId failed");
@@ -97,16 +97,15 @@ void test_core_errors__restore(void)
 
 	memset(&err_state, 0x0, sizeof(git_error_state));
 
-	giterr_set(42, "Foo: %s", "bar");
+	giterr_set("Foo: %s", "bar");
 	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
 
 	cl_assert(giterr_last() == NULL);
 
-	giterr_set(99, "Bar: %s", "foo");
+	giterr_set("Bar: %s", "foo");
 
 	giterr_restore(&err_state);
 
-	cl_assert_equal_i(42, giterr_last()->klass);
 	cl_assert_equal_s("Foo: bar", giterr_last()->message);
 }
 
@@ -128,7 +127,7 @@ void test_core_errors__integer_overflow_alloc_multiply(void)
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX-1, sizeof(void *)));
 	cl_git_fail(test_arraysize_multiply((SIZE_MAX/sizeof(void *))+1, sizeof(void *)));
 
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
+	cl_assert(giterr_is_oom(giterr_last()));
 	cl_assert_equal_s("Out of memory", giterr_last()->message);
 }
 
@@ -148,7 +147,7 @@ void test_core_errors__integer_overflow_alloc_add(void)
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX-1, 2));
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX, SIZE_MAX));
 
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
+	cl_assert(giterr_is_oom(giterr_last()));
 	cl_assert_equal_s("Out of memory", giterr_last()->message);
 }
 
@@ -166,11 +165,11 @@ void test_core_errors__integer_overflow_sets_oom(void)
 
 	giterr_clear();
 	cl_assert(GIT_ADD_SIZET_OVERFLOW(&out, SIZE_MAX, SIZE_MAX));
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
+	cl_assert(giterr_is_oom(giterr_last()));
 	cl_assert_equal_s("Out of memory", giterr_last()->message);
 
 	giterr_clear();
 	cl_assert(GIT_ADD_SIZET_OVERFLOW(&out, SIZE_MAX, SIZE_MAX));
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
+	cl_assert(giterr_is_oom(giterr_last()));
 	cl_assert_equal_s("Out of memory", giterr_last()->message);
 }

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -11,7 +11,7 @@ void test_core_errors__public_api(void)
 
 	cl_assert(giterr_last() != NULL);
 	cl_assert(giterr_is_oom(giterr_last()));
-	str_in_error = strstr(giterr_last()->message, "memory");
+	str_in_error = strstr(giterr_last(), "memory");
 	cl_assert(str_in_error != NULL);
 
 	giterr_clear();
@@ -19,7 +19,7 @@ void test_core_errors__public_api(void)
 	giterr_set("This is a test");
 
 	cl_assert(giterr_last() != NULL);
-	str_in_error = strstr(giterr_last()->message, "This is a test");
+	str_in_error = strstr(giterr_last(), "This is a test");
 	cl_assert(str_in_error != NULL);
 
 	giterr_clear();
@@ -41,7 +41,7 @@ void test_core_errors__new_school(void)
 
 	cl_assert(giterr_last() != NULL);
 	cl_assert(giterr_is_oom(giterr_last()));
-	str_in_error = strstr(giterr_last()->message, "memory");
+	str_in_error = strstr(giterr_last(), "memory");
 	cl_assert(str_in_error != NULL);
 
 	giterr_clear();
@@ -49,7 +49,7 @@ void test_core_errors__new_school(void)
 	giterr_set("This is a test"); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
-	str_in_error = strstr(giterr_last()->message, "This is a test");
+	str_in_error = strstr(giterr_last(), "This is a test");
 	cl_assert(str_in_error != NULL);
 
 	giterr_clear();
@@ -64,7 +64,7 @@ void test_core_errors__new_school(void)
 	giterr_set_os("stat failed"); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
-	str_in_error = strstr(giterr_last()->message, "stat failed");
+	str_in_error = strstr(giterr_last(), "stat failed");
 	cl_assert(str_in_error != NULL);
 	cl_assert(git__prefixcmp(str_in_error, "stat failed: ") == 0);
 	cl_assert(strlen(str_in_error) > strlen("stat failed: "));
@@ -77,7 +77,7 @@ void test_core_errors__new_school(void)
 	giterr_set_os("GetProcessId failed"); /* internal fn */
 
 	cl_assert(giterr_last() != NULL);
-	str_in_error = strstr(giterr_last()->message, "GetProcessId failed");
+	str_in_error = strstr(giterr_last(), "GetProcessId failed");
 	cl_assert(str_in_error != NULL);
 	cl_assert(git__prefixcmp(str_in_error, "GetProcessId failed: ") == 0);
 	cl_assert(strlen(str_in_error) > strlen("GetProcessId failed: "));
@@ -106,7 +106,7 @@ void test_core_errors__restore(void)
 
 	giterr_restore(&err_state);
 
-	cl_assert_equal_s("Foo: bar", giterr_last()->message);
+	cl_assert_equal_s("Foo: bar", giterr_last());
 }
 
 static int test_arraysize_multiply(size_t nelem, size_t size)
@@ -128,7 +128,7 @@ void test_core_errors__integer_overflow_alloc_multiply(void)
 	cl_git_fail(test_arraysize_multiply((SIZE_MAX/sizeof(void *))+1, sizeof(void *)));
 
 	cl_assert(giterr_is_oom(giterr_last()));
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_s("Out of memory", giterr_last());
 }
 
 static int test_arraysize_add(size_t one, size_t two)
@@ -148,7 +148,7 @@ void test_core_errors__integer_overflow_alloc_add(void)
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX, SIZE_MAX));
 
 	cl_assert(giterr_is_oom(giterr_last()));
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_s("Out of memory", giterr_last());
 }
 
 void test_core_errors__integer_overflow_sets_oom(void)
@@ -166,10 +166,10 @@ void test_core_errors__integer_overflow_sets_oom(void)
 	giterr_clear();
 	cl_assert(GIT_ADD_SIZET_OVERFLOW(&out, SIZE_MAX, SIZE_MAX));
 	cl_assert(giterr_is_oom(giterr_last()));
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_s("Out of memory", giterr_last());
 
 	giterr_clear();
 	cl_assert(GIT_ADD_SIZET_OVERFLOW(&out, SIZE_MAX, SIZE_MAX));
 	cl_assert(giterr_is_oom(giterr_last()));
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_s("Out of memory", giterr_last());
 }

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -537,24 +537,18 @@ void test_diff_blob__comparing_two_text_blobs_honors_interhunkcontext(void)
 
 void test_diff_blob__checks_options_version_too_low(void)
 {
-	const git_error *err;
-
 	opts.version = 0;
 	cl_git_fail(git_diff_blobs(
 		d, NULL, alien, NULL, &opts,
 		diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &expected));
-	err = giterr_last();
 }
 
 void test_diff_blob__checks_options_version_too_high(void)
 {
-	const git_error *err;
-
 	opts.version = 1024;
 	cl_git_fail(git_diff_blobs(
 		d, NULL, alien, NULL, &opts,
 		diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &expected));
-	err = giterr_last();
 }
 
 void test_diff_blob__can_correctly_detect_a_binary_blob_as_binary(void)

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -544,7 +544,6 @@ void test_diff_blob__checks_options_version_too_low(void)
 		d, NULL, alien, NULL, &opts,
 		diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &expected));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 }
 
 void test_diff_blob__checks_options_version_too_high(void)
@@ -556,7 +555,6 @@ void test_diff_blob__checks_options_version_too_high(void)
 		d, NULL, alien, NULL, &opts,
 		diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &expected));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 }
 
 void test_diff_blob__can_correctly_detect_a_binary_blob_as_binary(void)

--- a/tests/diff/diffiter.c
+++ b/tests/diff/diffiter.c
@@ -435,17 +435,13 @@ void test_diff_diffiter__checks_options_version(void)
 	git_repository *repo = cl_git_sandbox_init("status");
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff = NULL;
-	const git_error *err;
 
 	opts.version = 0;
 	opts.flags |= GIT_DIFF_INCLUDE_IGNORED | GIT_DIFF_INCLUDE_UNTRACKED;
 
 	cl_git_fail(git_diff_index_to_workdir(&diff, repo, NULL, &opts));
-	err = giterr_last();
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_index_to_workdir(&diff, repo, NULL, &opts));
-	err = giterr_last();
 }
-

--- a/tests/diff/diffiter.c
+++ b/tests/diff/diffiter.c
@@ -442,12 +442,10 @@ void test_diff_diffiter__checks_options_version(void)
 
 	cl_git_fail(git_diff_index_to_workdir(&diff, repo, NULL, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_index_to_workdir(&diff, repo, NULL, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 }
 

--- a/tests/diff/index.c
+++ b/tests/diff/index.c
@@ -145,17 +145,14 @@ void test_diff_index__checks_options_version(void)
 	git_tree *a = resolve_commit_oid_to_tree(g_repo, a_commit);
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff *diff = NULL;
-	const git_error *err;
 
 	opts.version = 0;
 	cl_git_fail(git_diff_tree_to_index(&diff, g_repo, a, NULL, &opts));
-	err = giterr_last();
 	cl_assert_equal_p(diff, NULL);
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_tree_to_index(&diff, g_repo, a, NULL, &opts));
-	err = giterr_last();
 	cl_assert_equal_p(diff, NULL);
 
 	git_tree_free(a);

--- a/tests/diff/index.c
+++ b/tests/diff/index.c
@@ -150,14 +150,12 @@ void test_diff_index__checks_options_version(void)
 	opts.version = 0;
 	cl_git_fail(git_diff_tree_to_index(&diff, g_repo, a, NULL, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 	cl_assert_equal_p(diff, NULL);
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_tree_to_index(&diff, g_repo, a, NULL, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 	cl_assert_equal_p(diff, NULL);
 
 	git_tree_free(a);

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -156,13 +156,11 @@ void test_diff_rename__checks_options_version(void)
 	opts.version = 0;
 	cl_git_fail(git_diff_find_similar(diff, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_find_similar(diff, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	git_diff_free(diff);
 	git_tree_free(old_tree);

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -145,7 +145,6 @@ void test_diff_rename__checks_options_version(void)
 	git_diff *diff;
 	git_diff_options diffopts = GIT_DIFF_OPTIONS_INIT;
 	git_diff_find_options opts = GIT_DIFF_FIND_OPTIONS_INIT;
-	const git_error *err;
 
 	old_tree = resolve_commit_oid_to_tree(g_repo, old_sha);
 	new_tree = resolve_commit_oid_to_tree(g_repo, new_sha);
@@ -155,12 +154,10 @@ void test_diff_rename__checks_options_version(void)
 
 	opts.version = 0;
 	cl_git_fail(git_diff_find_similar(diff, &opts));
-	err = giterr_last();
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_find_similar(diff, &opts));
-	err = giterr_last();
 
 	git_diff_free(diff);
 	git_tree_free(old_tree);

--- a/tests/diff/tree.c
+++ b/tests/diff/tree.c
@@ -312,7 +312,6 @@ void test_diff_tree__checks_options_version(void)
 	opts.version = 0;
 	cl_git_fail(git_diff_tree_to_tree(&diff, g_repo, a, b, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	giterr_clear();
 	opts.version = 1024;

--- a/tests/diff/tree.c
+++ b/tests/diff/tree.c
@@ -302,7 +302,6 @@ void test_diff_tree__checks_options_version(void)
 {
 	const char *a_commit = "8496071c1b46c85";
 	const char *b_commit = "be3563ae3f79";
-	const git_error *err;
 
 	g_repo = cl_git_sandbox_init("testrepo.git");
 
@@ -311,12 +310,10 @@ void test_diff_tree__checks_options_version(void)
 
 	opts.version = 0;
 	cl_git_fail(git_diff_tree_to_tree(&diff, g_repo, a, b, &opts));
-	err = giterr_last();
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_tree_to_tree(&diff, g_repo, a, b, &opts));
-	err = giterr_last();
 }
 
 void process_tree_to_tree_diffing(

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -1010,13 +1010,11 @@ void test_diff_workdir__checks_options_version(void)
 	opts.version = 0;
 	cl_git_fail(git_diff_tree_to_workdir(&diff, g_repo, NULL, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_tree_to_workdir(&diff, g_repo, NULL, &opts));
 	err = giterr_last();
-	cl_assert_equal_i(GITERR_INVALID, err->klass);
 }
 
 void test_diff_workdir__can_diff_empty_file(void)

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -1003,18 +1003,15 @@ void test_diff_workdir__checks_options_version(void)
 {
 	git_diff *diff;
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
-	const git_error *err;
 
 	g_repo = cl_git_sandbox_init("status");
 
 	opts.version = 0;
 	cl_git_fail(git_diff_tree_to_workdir(&diff, g_repo, NULL, &opts));
-	err = giterr_last();
 
 	giterr_clear();
 	opts.version = 1024;
 	cl_git_fail(git_diff_tree_to_workdir(&diff, g_repo, NULL, &opts));
-	err = giterr_last();
 }
 
 void test_diff_workdir__can_diff_empty_file(void)

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -293,7 +293,7 @@ void test_fetchhead_nonetwork__invalid_for_merge(void)
 	cl_git_rewritefile("./test1/.git/FETCH_HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0\tinvalid-merge\t\n");
 	cl_git_fail(git_repository_fetchhead_foreach(g_repo, read_noop, NULL));
 
-	cl_assert(git__prefixcmp(giterr_last()->message, "Invalid for-merge") == 0);
+	cl_assert(git__prefixcmp(giterr_last(), "Invalid for-merge") == 0);
 }
 
 void test_fetchhead_nonetwork__invalid_description(void)
@@ -304,7 +304,7 @@ void test_fetchhead_nonetwork__invalid_description(void)
 	cl_git_rewritefile("./test1/.git/FETCH_HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0\tnot-for-merge\n");
 	cl_git_fail(git_repository_fetchhead_foreach(g_repo, read_noop, NULL));
 
-	cl_assert(git__prefixcmp(giterr_last()->message, "Invalid description") == 0);
+	cl_assert(git__prefixcmp(giterr_last(), "Invalid description") == 0);
 }
 
 static int assert_master_for_merge(const char *ref, const char *url, const git_oid *id, unsigned int is_merge, void *data)

--- a/tests/filter/crlf.c
+++ b/tests/filter/crlf.c
@@ -97,7 +97,6 @@ void test_filter_crlf__with_safecrlf(void)
 	in.size = strlen(in.ptr);
 
 	cl_git_fail(git_filter_list_apply_to_data(&out, fl, &in));
-	cl_assert_equal_i(giterr_last()->klass, GITERR_FILTER);
 
 	/* Normalized \n is reversible, so does not fail with safecrlf */
 	in.ptr = "Normal\nLF\nonly\nline-endings.\n";

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -716,7 +716,6 @@ void test_index_tests__elocked(void)
 	cl_assert_equal_i(GIT_ELOCKED, error);
 
 	err = giterr_last();
-	cl_assert_equal_i(err->klass, GITERR_INDEX);
 
 	git_filebuf_cleanup(&file);
 	git_index_free(index);

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -702,7 +702,6 @@ void test_index_tests__elocked(void)
 	git_repository *repo;
 	git_index *index;
 	git_filebuf file = GIT_FILEBUF_INIT;
-	const git_error *err;
 	int error;
 
 	cl_set_cleanup(&cleanup_myrepo, NULL);
@@ -714,8 +713,6 @@ void test_index_tests__elocked(void)
 	cl_git_pass(git_filebuf_open(&file, index->index_file_path, 0, 0666));
 	error = git_index_write(index);
 	cl_assert_equal_i(GIT_ELOCKED, error);
-
-	err = giterr_last();
 
 	git_filebuf_cleanup(&file);
 	git_index_free(index);

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -74,7 +74,6 @@ void test_network_remote_remotes__error_when_not_found(void)
 	cl_git_fail_with(git_remote_lookup(&r, _repo, "does-not-exist"), GIT_ENOTFOUND);
 
 	cl_assert(giterr_last() != NULL);
-	cl_assert(giterr_last()->klass == GITERR_CONFIG);
 }
 
 void test_network_remote_remotes__error_when_no_push_available(void)
@@ -362,7 +361,6 @@ void test_network_remote_remotes__can_load_with_an_empty_url(void)
 	cl_git_fail(git_remote_connect(remote, GIT_DIRECTION_FETCH, NULL));
 
 	cl_assert(giterr_last() != NULL);
-	cl_assert(giterr_last()->klass == GITERR_INVALID);
 
 	git_remote_free(remote);
 }

--- a/tests/odb/backend/nobackend.c
+++ b/tests/odb/backend/nobackend.c
@@ -34,13 +34,11 @@ void test_odb_backend_nobackend__write_fails_gracefully(void)
 {
 	git_oid id;
 	git_odb *odb;
-	const git_error *err;
 
 	git_repository_odb(&odb, _repo);
 	cl_git_fail(git_odb_write(&id, odb, "Hello world!\n", 13, GIT_OBJ_BLOB));
 
-	err = giterr_last();
-	cl_assert_equal_s(err->message, "Cannot write object - unsupported in the loaded odb backends");
+	cl_assert_equal_s("Cannot write object - unsupported in the loaded odb backends", giterr_last());
 
 	git_odb_free(odb);
 }

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -348,7 +348,7 @@ static int cred_cb(git_cred **cred, const char *url, const char *user_from_url,
 	if (allowed_types & GIT_CREDTYPE_SSH_KEY)
 		return git_cred_ssh_key_new(cred, remote_user, pubkey, privkey, passphrase);
 
-	giterr_set(GITERR_NET, "unexpected cred type");
+	giterr_set("unexpected cred type");
 	return -1;
 }
 
@@ -549,7 +549,7 @@ static int ssh_memory_cred_cb(git_cred **cred, const char *url, const char *user
 		return ret;
 	}
 
-	giterr_set(GITERR_NET, "unexpected cred type");
+	giterr_set("unexpected cred type");
 	return -1;
 }
 

--- a/tests/refs/branches/move.c
+++ b/tests/refs/branches/move.c
@@ -84,7 +84,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_assert_equal_i(GIT_EEXISTS,
 		git_branch_move(&new_ref, original_ref, "master", 0));
 
-	cl_assert(giterr_last()->message != NULL);
+	cl_assert(giterr_last() != NULL);
 
 	cl_git_pass(git_repository_config_snapshot(&config, repo));
 	cl_git_pass(git_config_get_string(&str, config, "branch.master.remote"));
@@ -96,7 +96,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_assert_equal_i(GIT_EEXISTS,
 		git_branch_move(&new_ref, original_ref, "cannot-fetch", 0));
 
-	cl_assert(giterr_last()->message != NULL);
+	cl_assert(giterr_last() != NULL);
 
 	cl_git_pass(git_repository_config_snapshot(&config, repo));
 	cl_git_pass(git_config_get_string(&str, config, "branch.master.remote"));
@@ -111,7 +111,7 @@ void test_refs_branches_move__can_not_move_a_branch_if_its_destination_name_coll
 	cl_assert_equal_i(GIT_EEXISTS,
 		git_branch_move(&new_ref, original_ref, "master", 0));
 
-	cl_assert(giterr_last()->message != NULL);
+	cl_assert(giterr_last() != NULL);
 
 	cl_git_pass(git_repository_config_snapshot(&config, repo));
 	cl_git_pass(git_config_get_string(&str, config, "branch.master.remote"));

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -176,7 +176,7 @@ void test_refs_branches_upstream__no_fetch_refspec(void)
 	cl_git_pass(git_reference_create(&ref, repo, "refs/remotes/matching/master", git_reference_target(branch), 1, "fetch"));
 	cl_git_fail(git_branch_set_upstream(branch, "matching/master"));
 	cl_assert_equal_s("Could not determine remote for 'refs/remotes/matching/master'",
-			  giterr_last()->message);
+			  giterr_last());
 
 	/* we can't set it automatically, so let's test the user setting it by hand */
 	cl_git_pass(git_repository_config(&cfg, repo));

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -952,7 +952,6 @@ void test_repo_iterator__fs_preserves_error(void)
 	cl_git_pass(git_iterator_advance(&e, i)); /* a */
 	cl_git_fail(git_iterator_advance(&e, i)); /* b */
 	cl_assert(giterr_last());
-	cl_assert(giterr_last()->message != NULL);
 	/* skip 'c/' empty directory */
 	cl_git_pass(git_iterator_advance(&e, i)); /* d */
 	cl_assert_equal_i(GIT_ITEROVER, git_iterator_advance(&e, i));

--- a/tests/threads/basic.c
+++ b/tests/threads/basic.c
@@ -38,7 +38,7 @@ void test_threads_basic__multiple_init(void)
 
 static void *set_error(void *dummy)
 {
-	giterr_set(GITERR_INVALID, "oh no, something happened!\n");
+	giterr_set("oh no, something happened!\n");
 
 	return dummy;
 }


### PR DESCRIPTION
So...  I've never really found the error classes particularly useful.  At some point I was talking to someone (I think @carlosmn ?) and mentioned this and we talked about removing them.  Here's a spike to do so, and now we give callers error messages (in the form of a string) instead of a struct that has an integer that they likely won't do anything with.

Also moved the actual error message to be in a `git_buf` per TLS, which hopefully reduces the number of allocations that we do (we set error messages a lot that never wind up going to the caller.)

Outstanding questions while I'm breaking shit:

* Why `giterr`...  All our other everythings are `git_` prefixed - should this be `git_err` or `git_error`?
* The likely useful class was probably the one that indicated OOM.  Should there be a `GIT_ENOMEM` or similar return code?