### PR TITLE
pkg-config: Sort the different sections

### DIFF
--- a/libgit2.pc.in
+++ b/libgit2.pc.in
@@ -4,7 +4,9 @@ includedir=@CMAKE_INSTALL_PREFIX@/@INCLUDE_INSTALL_DIR@
 Name: libgit2
 Description: The git library, take 2
 Version: @LIBGIT2_VERSION_STRING@
-Requires.private: @LIBGIT2_PC_REQUIRES@
-Libs.private: @LIBGIT2_PC_LIBS@
+
 Libs: -L${libdir} -lgit2
+Libs.private: @LIBGIT2_PC_LIBS@
+Requires.private: @LIBGIT2_PC_REQUIRES@
+
 Cflags: -I${includedir}


### PR DESCRIPTION
Because of the fact that pkg-config is pants-on-head retarded and that
the Linux linker *requires* a static library to come before all its
dynamic dependencies in the link path, calling `pkg-config --libs
--static` was generating the wrong flags for linking.

Before this patch:

	-Wl,-Bsymbolic-functions -Wl,-z,relro -L/usr/local/lib -lcurl -lssh2
	-lrt -lgit2 -lssl -lcrypto -ldl -lz

After this patch:

	-Wl,-Bsymbolic-functions -Wl,-z,relro -L/usr/local/lib -lgit2 -lcurl
	-lssh2 -lrt -lssl -lcrypto -ldl -lz

By setting the "Libs" line before all other rules, we make sure that
`-lgit2` is the first library in the link path and that it gets its
symbols resolved with the libraries coming after it.

This fix (ab)uses an implementation detail in `pkg-config` (namely, that
flags are output as they are found on the file), but this detail seems
to be stable between releases and always gives a stable output.