### PR TITLE
Submodule and http fixes

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1691,26 +1691,7 @@ static int submodule_load_from_config(
 
 	/* Deregister under name being replaced */
 	if (replaced) {
-		git_submodule_free(sm);
 		git__free(replaced);
-	}
-
-	/* Insert under alternate key */
-	if (alternate) {
-		void *old_sm = NULL;
-
-		if (error < 0)
-			goto done;
-		if (error > 0)
-			error = 0;
-
-		GIT_REFCOUNT_INC(sm); /* increase refcount for new key */
-
-		/* if we replaced an old module under this key, release the old one */
-		if (old_sm && ((git_submodule *)old_sm) != sm) {
-			git_submodule_free(old_sm);
-			/* TODO: log warning about multiple submodules with same path */
-		}
 	}
 
 	/* TODO: Look up path in index and if it is present but not a GITLINK

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -168,11 +168,18 @@ int git_submodule_lookup(
 		return error;
 	}
 
-	/* If it's not configured, we need to check for the path */
+	/* If it's not configured or we're looking by path  */
 	if (location == 0 || location == GIT_SUBMODULE_STATUS_IN_WD) {
 		git_config_backend *mods;
 		const char *pattern = "submodule\\..*\\.path";
-		fbp_data data = { name, NULL };
+		git_buf path = GIT_BUF_INIT;
+		fbp_data data = { NULL, NULL };
+
+		git_buf_puts(&path, name);
+		while (path.ptr[path.size-1] == '/') {
+			path.ptr[--path.size] = '\0';
+		}
+		data.path = path.ptr;
 
 		mods = open_gitmodules(repo, GITMODULES_EXISTING);
 
@@ -189,8 +196,7 @@ int git_submodule_lookup(
 		if (data.name) {
 			git__free(sm->name);
 			sm->name = data.name;
-			sm->path = git__strdup(name);
-			GITERR_CHECK_ALLOC(sm->path);
+			sm->path = git_buf_detach(&path);
 
 			/* Try to load again with the right name */
 			if ((error = git_submodule_reload(sm, false)) < 0) {
@@ -198,6 +204,8 @@ int git_submodule_lookup(
 				return error;
 			}
 		}
+
+		git_buf_free(&path);
 	}
 
 	if ((error = git_submodule_location(&location, sm)) < 0) {

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -336,8 +336,7 @@ static int on_headers_complete(http_parser *parser)
 		if (!t->owner->cred_acquire_cb) {
 			no_callback = 1;
 		} else {
-			if (allowed_auth_types &&
-			    (!t->cred || 0 == (t->cred->credtype & allowed_auth_types))) {
+			if (allowed_auth_types) {
 
 				error = t->owner->cred_acquire_cb(&t->cred,
 								  t->owner->url,

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -31,6 +31,9 @@ void test_submodule_lookup__simple_lookup(void)
 
 	/* lookup non-existent item */
 	refute_submodule_exists(g_repo, "no_such_file", GIT_ENOTFOUND);
+
+	/* lookup a submodule by path with a trailing slash */
+	assert_submodule_exists(g_repo, "sm_added_and_uncommited/");
 }
 
 void test_submodule_lookup__accessors(void)


### PR DESCRIPTION
Plug a leak in submodules and re-allow trainling slashes for looking up submodules.

Let the HTTP transport ask the caller again if the server rejected authentication.