### PR TITLE
git_cert: child types use proper base type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ v0.23 + 1
 
 ### API removals
 
+### Breaking API changes
+
+* `git_cert` descendent types now have a proper `parent` member
+
 v0.23
 ------
 

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -37,39 +37,32 @@ typedef enum {
  * Hostkey information taken from libssh2
  */
 typedef struct {
+	git_cert parent;
+
 	/**
-	 * Type of certificate. Here to share the header with
-	 * `git_cert`.
+	 * A hostkey type from libssh2, either
+	 * `GIT_CERT_SSH_MD5` or `GIT_CERT_SSH_SHA1`
 	 */
-	git_cert_t cert_type;
-        /**
-         * A hostkey type from libssh2, either
-         * `GIT_CERT_SSH_MD5` or `GIT_CERT_SSH_SHA1`
-         */
 	git_cert_ssh_t type;
 
-        /**
-         * Hostkey hash. If type has `GIT_CERT_SSH_MD5` set, this will
-         * have the MD5 hash of the hostkey.
-         */
+	/**
+	 * Hostkey hash. If type has `GIT_CERT_SSH_MD5` set, this will
+	 * have the MD5 hash of the hostkey.
+	 */
 	unsigned char hash_md5[16];
 
-        /**
-         * Hostkey hash. If type has `GIT_CERT_SSH_SHA1` set, this will
-         * have the SHA-1 hash of the hostkey.
-         */
-        unsigned char hash_sha1[20];
+	/**
+	 * Hostkey hash. If type has `GIT_CERT_SSH_SHA1` set, this will
+	 * have the SHA-1 hash of the hostkey.
+	 */
+	unsigned char hash_sha1[20];
 } git_cert_hostkey;
 
 /**
  * X.509 certificate information
  */
 typedef struct {
-	/**
-	 * Type of certificate. Here to share the header with
-	 * `git_cert`.
-	 */
-	git_cert_t cert_type;
+	git_cert parent;
 	/**
 	 * Pointer to the X.509 certificate data
 	 */

--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -67,9 +67,9 @@ static int curls_certificate(git_cert **out, git_stream *stream)
 
 	/* No information is available, can happen with SecureTransport */
 	if (certinfo->num_of_certs == 0) {
-		s->cert_info.cert_type = GIT_CERT_NONE;
-		s->cert_info.data      = NULL;
-		s->cert_info.len       = 0;
+		s->cert_info.parent.cert_type = GIT_CERT_NONE;
+		s->cert_info.data             = NULL;
+		s->cert_info.len              = 0;
 		return 0;
 	}
 
@@ -85,11 +85,11 @@ static int curls_certificate(git_cert **out, git_stream *stream)
 	s->cert_info_strings.strings = (char **) strings.contents;
 	s->cert_info_strings.count   = strings.length;
 
-	s->cert_info.cert_type = GIT_CERT_STRARRAY;
-	s->cert_info.data      = &s->cert_info_strings;
-	s->cert_info.len       = strings.length;
+	s->cert_info.parent.cert_type = GIT_CERT_STRARRAY;
+	s->cert_info.data             = &s->cert_info_strings;
+	s->cert_info.len              = strings.length;
 
-	*out = (git_cert *) &s->cert_info;
+	*out = &s->cert_info.parent;
 
 	return 0;
 }

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -358,11 +358,12 @@ int openssl_certificate(git_cert **out, git_stream *stream)
 		return -1;
 	}
 
-	st->cert_info.cert_type = GIT_CERT_X509;
+	st->cert_info.parent.cert_type = GIT_CERT_X509;
 	st->cert_info.data = encoded_cert;
 	st->cert_info.len = len;
 
-	*out = (git_cert *)&st->cert_info;
+	*out = &st->cert_info.parent;
+
 	return 0;
 }
 

--- a/src/stransport_stream.c
+++ b/src/stransport_stream.c
@@ -108,7 +108,7 @@ int stransport_certificate(git_cert **out, git_stream *stream)
 		return -1;
 	}
 
-	st->cert_info.cert_type = GIT_CERT_X509;
+	st->cert_info.parent.cert_type = GIT_CERT_X509;
 	st->cert_info.data = (void *) CFDataGetBytePtr(st->der_data);
 	st->cert_info.len = CFDataGetLength(st->der_data);
 

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -525,10 +525,10 @@ static int _git_ssh_setup_conn(
 		goto done;
 
 	if (t->owner->certificate_check_cb != NULL) {
-		git_cert_hostkey cert = { 0 }, *cert_ptr;
+		git_cert_hostkey cert = {{ 0 }}, *cert_ptr;
 		const char *key;
 
-		cert.cert_type = GIT_CERT_HOSTKEY_LIBSSH2;
+		cert.parent.cert_type = GIT_CERT_HOSTKEY_LIBSSH2;
 
 		key = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
 		if (key != NULL) {

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -228,7 +228,7 @@ static int certificate_check(winhttp_stream *s, int valid)
 	}
 
 	giterr_clear();
-	cert.cert_type = GIT_CERT_X509;
+	cert.parent.cert_type = GIT_CERT_X509;
 	cert.data = cert_ctx->pbCertEncoded;
 	cert.len = cert_ctx->cbCertEncoded;
 	error = t->owner->certificate_check_cb((git_cert *) &cert, valid, t->connection_data.host, t->owner->cred_acquire_payload);


### PR DESCRIPTION
Add a proper `parent` member to the `git_cert` descendants to prevent type punning.