### PR TITLE
http: fixed leak when asking for credentials again

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -337,6 +337,10 @@ static int on_headers_complete(http_parser *parser)
 			no_callback = 1;
 		} else {
 			if (allowed_auth_types) {
+				if (t->cred) {
+					t->cred->free(t->cred);
+					t->cred = NULL;
+				}
 
 				error = t->owner->cred_acquire_cb(&t->cred,
 								  t->owner->url,


### PR DESCRIPTION
t->cred might have been allocated the previous time and needs to be
freed before asking caller for credentials again.