### PR TITLE
Fix #3093 - remove declaration of unused function git_fetch__download…

### DIFF
--- a/src/fetch.h
+++ b/src/fetch.h
@@ -13,13 +13,6 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts);
 
 int git_fetch_download_pack(git_remote *remote, const git_remote_callbacks *callbacks);
 
-int git_fetch__download_pack(
-		git_transport *t,
-		git_repository *repo,
-		git_transfer_progress *stats,
-		git_transfer_progress_cb progress_cb,
-		void *progress_payload);
-
 int git_fetch_setup_walk(git_revwalk **out, git_repository *repo);
 
 #endif


### PR DESCRIPTION
Fix #3093 - remove declaration of unused function git_fetch__download_pack

Function was added in commit 2c982daa2eec64b80c7940bfe1142295bd72edd8 on October 5, 2011,
and removed in commit 41fb1ca0ec51ad1d2a14b911aab3215e42965d1b on October 29, 2012.
Given the length of time it's gone unused, it's safe to remove now.