### PR TITLE
Fix #3094 - improve use of portable size_t/ssize_t format specifiers.

### DIFF
--- a/examples/general.c
+++ b/examples/general.c
@@ -142,8 +142,8 @@ int main (int argc, char** argv)
   // We provide methods to convert from the object type which is an enum, to
   // a string representation of that value (and vice-versa).
   str_type = git_object_type2string(otype);
-  printf("object length and type: %d, %s\n",
-      (int)git_odb_object_size(obj),
+  printf("object length and type: %"PRIuZ", %s\n",
+      git_odb_object_size(obj),
       str_type);
 
   // For proper memory management, close the object when you are done with
@@ -324,7 +324,7 @@ int main (int argc, char** argv)
   // Getting the count of entries in the tree so you can iterate over them
   // if you want to.
   size_t cnt = git_tree_entrycount(tree); // 3
-  printf("tree entries: %d\n", (int)cnt);
+  printf("tree entries: %"PRIuZ"\n", cnt);
 
   entry = git_tree_entry_byindex(tree, 0);
   printf("Entry name: %s\n", git_tree_entry_name(entry)); // "hello.c"

--- a/examples/network/fetch.c
+++ b/examples/network/fetch.c
@@ -143,10 +143,10 @@ int fetch(git_repository *repo, int argc, char **argv)
 	 * network.
 	 */
 	if (stats->local_objects > 0) {
-		printf("\rReceived %d/%d objects in %zu bytes (used %d local objects)\n",
+		printf("\rReceived %d/%d objects in %" PRIuZ " bytes (used %d local objects)\n",
 		       stats->indexed_objects, stats->total_objects, stats->received_bytes, stats->local_objects);
 	} else{
-		printf("\rReceived %d/%d objects in %zu bytes\n",
+		printf("\rReceived %d/%d objects in %" PRIuZ "bytes\n",
 			stats->indexed_objects, stats->total_objects, stats->received_bytes);
 	}
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -50,16 +50,16 @@ void git_cache_dump_stats(git_cache *cache)
 	if (kh_size(cache->map) == 0)
 		return;
 
-	printf("Cache %p: %d items cached, %d bytes\n",
-		cache, kh_size(cache->map), (int)cache->used_memory);
+	printf("Cache %p: %d items cached, %"PRIdZ" bytes\n",
+		cache, kh_size(cache->map), cache->used_memory);
 
 	kh_foreach_value(cache->map, object, {
 		char oid_str[9];
-		printf(" %s%c %s (%d)\n",
+		printf(" %s%c %s (%"PRIuZ")\n",
 			git_object_type2string(object->type),
 			object->flags == GIT_CACHE_STORE_PARSED ? '*' : ' ',
 			git_oid_tostr(oid_str, sizeof(oid_str), &object->oid),
-			(int)object->size
+			object->size
 		);
 	});
 }

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1299,8 +1299,8 @@ static int checkout_get_actions(
 	if (counts[CHECKOUT_ACTION__CONFLICT] > 0 &&
 		(data->strategy & GIT_CHECKOUT_ALLOW_CONFLICTS) == 0)
 	{
-		giterr_set(GITERR_CHECKOUT, "%d %s checkout",
-			(int)counts[CHECKOUT_ACTION__CONFLICT],
+		giterr_set(GITERR_CHECKOUT, "%"PRIuZ" %s checkout",
+			counts[CHECKOUT_ACTION__CONFLICT],
 			counts[CHECKOUT_ACTION__CONFLICT] == 1 ?
 			"conflict prevents" : "conflicts prevent");
 		error = GIT_ECONFLICT;

--- a/src/merge.c
+++ b/src/merge.c
@@ -79,7 +79,7 @@ int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_reposito
 	unsigned int i;
 
 	if (length < 2) {
-		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %u.", length);
+		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %" PRIuZ ".", length);
 		return -1;
 	}
 
@@ -185,7 +185,7 @@ int git_merge_base_octopus(git_oid *out, git_repository *repo, size_t length, co
 	assert(out && repo && input_array);
 
 	if (length < 2) {
-		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %u.", length);
+		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %" PRIuZ ".", length);
 		return -1;
 	}
 
@@ -2451,7 +2451,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 		goto done;
 
 	if ((conflicts = index_conflicts + wd_conflicts) > 0) {
-		giterr_set(GITERR_MERGE, "%d uncommitted change%s would be overwritten by merge",
+		giterr_set(GITERR_MERGE, "%" PRIuZ " uncommitted change%s would be overwritten by merge",
 			conflicts, (conflicts != 1) ? "s" : "");
 		error = GIT_ECONFLICT;
 	}

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -436,7 +436,7 @@ static int rebase_setupfiles_merge(git_rebase *rebase)
 	size_t i;
 	int error = 0;
 
-	if ((error = rebase_setupfile(rebase, END_FILE, -1, "%d\n", git_array_size(rebase->operations))) < 0 ||
+	if ((error = rebase_setupfile(rebase, END_FILE, -1, "%" PRIuZ "\n", git_array_size(rebase->operations))) < 0 ||
 		(error = rebase_setupfile(rebase, ONTO_NAME_FILE, -1, "%s\n", rebase->onto_name)) < 0)
 		goto done;
 
@@ -789,7 +789,7 @@ static int rebase_next_merge(
 	normalize_checkout_options_for_apply(&checkout_opts, rebase, current_commit);
 
 	if ((error = git_indexwriter_init_for_operation(&indexwriter, rebase->repo, &checkout_opts.checkout_strategy)) < 0 ||
-		(error = rebase_setupfile(rebase, MSGNUM_FILE, -1, "%d\n", rebase->current+1)) < 0 ||
+		(error = rebase_setupfile(rebase, MSGNUM_FILE, -1, "%" PRIuZ "\n", rebase->current+1)) < 0 ||
 		(error = rebase_setupfile(rebase, CURRENT_FILE, -1, "%.*s\n", GIT_OID_HEXSZ, current_idstr)) < 0 ||
 		(error = git_merge_trees(&index, rebase->repo, parent_tree, head_tree, current_tree, NULL)) < 0 ||
 		(error = git_merge__check_result(rebase->repo, index)) < 0 ||

--- a/src/stash.c
+++ b/src/stash.c
@@ -770,7 +770,7 @@ static int ensure_clean_index(git_repository *repo, git_index *index)
 		goto done;
 
 	if (git_diff_num_deltas(index_diff) > 0) {
-		giterr_set(GITERR_STASH, "%d uncommitted changes exist in the index",
+		giterr_set(GITERR_STASH, "%" PRIuZ " uncommitted changes exist in the index",
 			git_diff_num_deltas(index_diff));
 		error = GIT_EUNCOMMITTED;
 	}

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -511,7 +511,7 @@ static int write_chunk(git_stream *io, const char *buffer, size_t len)
 	git_buf buf = GIT_BUF_INIT;
 
 	/* Chunk header */
-	git_buf_printf(&buf, "%X\r\n", (unsigned)len);
+	git_buf_printf(&buf, "%" PRIxZ "\r\n", len);
 
 	if (git_buf_oom(&buf))
 		return -1;

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -523,7 +523,7 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
 
 	if (len > 0xffff) {
 		giterr_set(GITERR_NET,
-			"Tried to produce packet with invalid length %d", len);
+			"Tried to produce packet with invalid length %" PRIuZ, len);
 		return -1;
 	}
 

--- a/tests/blame/blame_helpers.c
+++ b/tests/blame/blame_helpers.c
@@ -4,7 +4,7 @@ void hunk_message(size_t idx, const git_blame_hunk *hunk, const char *fmt, ...)
 {
 	va_list arglist;
 
-	printf("Hunk %zd (line %d +%d): ", idx,
+	printf("Hunk %"PRIuZ" (line %d +%d): ", idx,
 			hunk->final_start_line_number, hunk->lines_in_hunk-1);
 
 	va_start(arglist, fmt);

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -483,8 +483,8 @@ void clar__assert_equal_file(
 			for (pos = 0; pos < bytes && expected_data[pos] == buf[pos]; ++pos)
 				/* find differing byte offset */;
 			p_snprintf(
-				buf, sizeof(buf), "file content mismatch at byte %d",
-				(int)(total_bytes + pos));
+				buf, sizeof(buf), "file content mismatch at byte %"PRIdZ,
+				(ssize_t)(total_bytes + pos));
 			p_close(fd);
 			clar__fail(file, line, path, buf, 1);
 		}

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -110,7 +110,7 @@ void merge__dump_index_entries(git_vector *index_entries)
 	size_t i;
 	const git_index_entry *index_entry;
 
-	printf ("\nINDEX [%d]:\n", (int)index_entries->length);
+	printf ("\nINDEX [%"PRIuZ"]:\n", index_entries->length);
 	for (i = 0; i < index_entries->length; i++) {
 		index_entry = index_entries->contents[i];
 


### PR DESCRIPTION
The header src/cc-compat.h defines portable format specifiers PRIuZ, PRIdZ, and PRIxZ. The original report highlighted the need to use these specifiers in examples/network/fetch.c.  For this commit, I checked all C source and header files not in deps/ and transitioned to the appropriate format specifier where appropriate.