### PR TITLE
Correctly delimit the keys for submodule lookup

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1385,7 +1385,7 @@ int git_submodule_reload(git_submodule *sm, int force)
 
 		git_buf_sets(&path, "submodule\\.");
 		git_buf_text_puts_escape_regex(&path, sm->name);
-		git_buf_puts(&path, ".*");
+		git_buf_puts(&path, "\\..*");
 
 		if (git_buf_oom(&path)) {
 			error = -1;

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -269,3 +269,26 @@ void test_submodule_lookup__just_added(void)
 	refute_submodule_exists(g_repo, "sm_just_added_head", GIT_EEXISTS);
 }
 
+/* Test_App and Test_App2 are fairly similar names, make sure we load the right one */
+void test_submodule_lookup__prefix_name(void)
+{
+	git_submodule *sm;
+
+	cl_git_rewritefile("submod2/.gitmodules",
+			   "[submodule \"Test_App\"]\n"
+			   "    path = Test_App\n"
+			   "    url = ../Test_App\n"
+			   "[submodule \"Test_App2\"]\n"
+			   "    path = Test_App2\n"
+			   "    url = ../Test_App\n");
+
+	cl_git_pass(git_submodule_lookup(&sm, g_repo, "Test_App"));
+	cl_assert_equal_s("Test_App", git_submodule_name(sm));
+
+	git_submodule_free(sm);
+
+	cl_git_pass(git_submodule_lookup(&sm, g_repo, "Test_App2"));
+	cl_assert_equal_s("Test_App2", git_submodule_name(sm));
+
+	git_submodule_free(sm);
+}


### PR DESCRIPTION
Oh my, regex.

We were missing the pattern to match a full stop just after the submodule name, so when we wanted to look for 'Test_App' , we would create the lookup rule `submodule\.Test_App.*` which is obviously wrong. We want `submodule\.Test_App\..*` or we end up looking up the 'Test_App2' submodule as well.

This fixes #3284 