### PR TITLE
Fix undefined reference with old versions of openssl

### DIFF
--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -324,7 +324,9 @@ int openssl_connect(git_stream *stream)
 
 	SSL_set_bio(st->ssl, bio, bio);
 	/* specify the host in case SNI is needed */
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 	SSL_set_tlsext_host_name(st->ssl, st->host);
+#endif
 
 	if ((ret = SSL_connect(st->ssl)) <= 0)
 		return ssl_set_error(st->ssl, ret);


### PR DESCRIPTION
Versions prior to 0.9.8f  did not have this function, rhel/centos5 are still on a
heavily backported version of 0.9.8e and theoretically supported until March 2017

Without this ifdef, I get the following link failure:
```
CMakeFiles/libgit2_clar.dir/src/openssl_stream.c.o: In function `openssl_connect':
openssl_stream.c:(.text+0x45a): undefined reference to `SSL_set_tlsext_host_name'
collect2: error: ld returned 1 exit status
make[6]: *** [libgit2_clar] Error 1
```