### PR TITLE
meta: Add Antoine Pelisse to hall-of-fame list

### DIFF
--- a/git.git-authors
+++ b/git.git-authors
@@ -39,6 +39,7 @@ ok	Adam Simpkins <adam@adamsimpkins.net> (http transport)
 ok	Adrian Johnson <ajohnson@redneon.com>
 ok	Alexey Shumkin <alex.crezoff@gmail.com>
 ok	Andreas Ericsson <ae@op5.se>
+ok	Antoine Pelisse <apelisse@gmail.com>
 ok	Boyd Lynn Gerber <gerberb@zenez.com>
 ok	Brandon Casey <drafnel@gmail.com>
 ok	Brian Downing <bdowning@lavos.net>


### PR DESCRIPTION
Antoine Pelisse <apelisse@gmail.com> has kindly allowed his contributions to core git to be used under the libgit2 license.