### PR TITLE
List a submodule only once when the path matches a submodule in the index

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1647,7 +1647,7 @@ static int submodule_load_from_config(
 	} else {
 		khiter_t pos;
 		git_strmap *map = data->map;
-		pos = git_strmap_lookup_index(map, name.ptr);
+		pos = git_strmap_lookup_index(map, path ? path : name.ptr);
 		if (git_strmap_valid_index(map, pos)) {
 			sm = git_strmap_value_at(map, pos);
 		} else {


### PR DESCRIPTION
This solution is probably fragile, but it'll do until the config-loading gets moved to something less callback-based.

This fixes #3293 