### PR TITLE
Allow adding a submodule through git_index_add_bypath

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -48,6 +48,7 @@ typedef enum {
 	GIT_EEOF            = -20,      /**< Unexpected EOF */
 	GIT_EINVALID        = -21,      /**< Invalid operation or input */
 	GIT_EUNCOMMITTED    = -22,	/**< Uncommitted changes in index prevented operation */
+	GIT_EDIRECTORY      = -23,      /**< The operation is not valid for a directory */
 
 	GIT_PASSTHROUGH     = -30,	/**< Internal only */
 	GIT_ITEROVER        = -31,	/**< Signals end of iteration with iterator */

--- a/src/blob.c
+++ b/src/blob.c
@@ -185,6 +185,12 @@ int git_blob__create_from_paths(
 		(error = git_repository_odb(&odb, repo)) < 0)
 		goto done;
 
+	if (S_ISDIR(st.st_mode)) {
+		giterr_set(GITERR_ODB, "cannot create blob from '%s'; it is a directory", content_path);
+		error = GIT_EDIRECTORY;
+		goto done;
+	}
+
 	if (out_st)
 		memcpy(out_st, &st, sizeof(st));
 

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -1,0 +1,23 @@
+#include "clar_libgit2.h"
+#include "repository.h"
+#include "../submodule/submodule_helpers.h"
+
+static git_repository *g_repo;
+static git_index *g_idx;
+
+void test_index_bypath__initialize(void)
+{
+	g_repo = setup_fixture_submod2();
+	cl_git_pass(git_repository_index__weakptr(&g_idx, g_repo));
+}
+
+void test_index_bypath__cleanup(void)
+{
+	g_repo = NULL;
+	g_idx = NULL;
+}
+
+void test_index_bypath__add_directory(void)
+{
+	cl_git_fail_with(GIT_EDIRECTORY, git_index_add_bypath(g_idx, "just_a_dir"));
+}

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -21,3 +21,15 @@ void test_index_bypath__add_directory(void)
 {
 	cl_git_fail_with(GIT_EDIRECTORY, git_index_add_bypath(g_idx, "just_a_dir"));
 }
+
+void test_index_bypath__add_submodule(void)
+{
+	unsigned int status;
+	const char *sm_name = "sm_changed_head";
+
+	cl_git_pass(git_submodule_status(&status, g_repo, sm_name, 0));
+	cl_assert_equal_i(GIT_SUBMODULE_STATUS_WD_MODIFIED, status & GIT_SUBMODULE_STATUS_WD_MODIFIED);
+	cl_git_pass(git_index_add_bypath(g_idx, sm_name));
+	cl_git_pass(git_submodule_status(&status, g_repo, sm_name, 0));
+	cl_assert_equal_i(0, status & GIT_SUBMODULE_STATUS_WD_MODIFIED);
+}

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -4,6 +4,7 @@
 #include "submodule_helpers.h"
 #include "config/config_helpers.h"
 #include "fileops.h"
+#include "repository.h"
 
 static git_repository *g_repo = NULL;
 


### PR DESCRIPTION
Just like git allows you to do `git add some_submodule` to update the entry in the index. ~~~This still needs some work extracting the submodule-entry code from the submodule and making sure we invalidate the tree right (wrt casing).~~~ We use a function which does the invalidation, so it's fine.

This also adds `GIT_EDIRECTORY` as an error code and provides a nicer error message when trying to add a directory.
