### PR TITLE
Normalize submodule urls before looking at them

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -1671,3 +1671,19 @@ bool git_path_isvalid(
 
 	return verify_component(repo, start, (c - start), flags);
 }
+
+int git_path_normalize_slashes(git_buf *out, const char *path)
+{
+	int error;
+	char *p;
+
+	if ((error = git_buf_puts(out, path)) < 0)
+		return error;
+
+	for (p = out->ptr; *p; p++) {
+		if (*p == '\\')
+			*p = '/';
+	}
+
+	return 0;
+}

--- a/src/path.h
+++ b/src/path.h
@@ -591,4 +591,9 @@ extern bool git_path_isvalid(
 	const char *path,
 	unsigned int flags);
 
+/**
+ * Convert any backslashes into slashes
+ */
+int git_path_normalize_slashes(git_buf *out, const char *path);
+
 #endif

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -787,18 +787,14 @@ int git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *ur
 
 	git_buf_sanitize(out);
 
+	/* We do this in all platforms in case someone on Windows created the .gitmodules */
 	if (strchr(url, '\\')) {
-		char *p;
-		if ((error = git_buf_puts(&normalized, url)) < 0)
+		if ((error = git_path_normalize_slashes(&normalized, url)) < 0)
 			return error;
-
-		for (p = normalized.ptr; *p; p++) {
-			if (*p == '\\')
-				*p = '/';
-		}
 
 		url = normalized.ptr;
 	}
+
 
 	if (git_path_is_relative(url)) {
 		if (!(error = get_url_base(out, repo)))

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -133,6 +133,29 @@ void test_submodule_lookup__lookup_even_with_missing_index(void)
 	test_submodule_lookup__simple_lookup(); /* baseline should still pass */
 }
 
+void test_submodule_lookup__backslashes(void)
+{
+	git_config *cfg;
+	git_submodule *sm;
+	git_repository *subrepo;
+	git_buf buf = GIT_BUF_INIT;
+	const char *backslashed_path = "..\\submod2_target";
+
+	cl_git_pass(git_config_open_ondisk(&cfg, "submod2/.gitmodules"));
+	cl_git_pass(git_config_set_string(cfg, "submodule.sm_unchanged.url", backslashed_path));
+	git_config_free(cfg);
+
+	cl_git_pass(git_submodule_lookup(&sm, g_repo, "sm_unchanged"));
+	cl_assert_equal_s(backslashed_path, git_submodule_url(sm));
+	cl_git_pass(git_submodule_open(&subrepo, sm));
+
+	cl_git_pass(git_submodule_resolve_url(&buf, g_repo, backslashed_path));
+
+	git_buf_free(&buf);
+	git_submodule_free(sm);
+	git_repository_free(subrepo);
+}
+
 static void baseline_tests(void)
 {
 	/* small baseline that should work even if we change the index or make


### PR DESCRIPTION
Our functions expect slashes in the url, so convert backslashes before looking at it. This is a similar though distinct problem to what we have when fetching. There we act on the url/path so we can ask the filesystem for a realpath. Here we're just acting on the string, so we can't rely on that.

This fixes #2248 and possibly #2706.