### PR TITLE
Windows hidden file support

### DIFF
--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -71,6 +71,21 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		char buffer[FILEIO_BUFSIZE];
 		ssize_t read_bytes;
 
+#ifdef GIT_WIN32
+		bool hidden = false;
+		if (strstr(file->path_original, ".git") == NULL) {
+			if (git_win32__ishidden(file->path_original) == 1) {
+				if (git_win32__setvisible(file->path_original) == -1) {
+					giterr_set(GITERR_OS,
+						"Failed to unhide filebuf '%s'",
+						file->path_original);
+					return -1;
+				}
+
+				hidden = true;
+			}
+		}
+#endif
 		source = p_open(file->path_original, O_RDONLY);
 		if (source < 0) {
 			giterr_set(GITERR_OS,
@@ -86,7 +101,11 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		}
 
 		p_close(source);
-
+#ifdef GIT_WIN32
+		if (hidden) {
+			git_win32__sethidden(file->path_original);
+		}
+#endif
 		if (read_bytes < 0) {
 			giterr_set(GITERR_OS, "Failed to read file '%s'", file->path_original);
 			return -1;

--- a/src/win32/w32_util.c
+++ b/src/win32/w32_util.c
@@ -86,12 +86,13 @@ int git_win32__ishidden(const char *path)
 
 	attrs = GetFileAttributesW(buf);
 
-	if ((attrs | FILE_ATTRIBUTE_HIDDEN) == 0)
-	{
+	if (attrs == INVALID_FILE_ATTRIBUTES)
 		return -1;
-	}
 
-	return 1;
+	if (attrs & FILE_ATTRIBUTE_HIDDEN)
+		return 1;
+
+	return -1;
 }
 
 /**

--- a/src/win32/w32_util.c
+++ b/src/win32/w32_util.c
@@ -71,6 +71,58 @@ int git_win32__sethidden(const char *path)
 }
 
 /**
+* Checks if the given path (file or folder) has the +H (hidden) attribute set.
+*
+* @param path The path which should receive the +H bit.
+* @return True if hidden, false if visible
+*/
+int git_win32__ishidden(const char *path)
+{
+	git_win32_path buf;
+	DWORD attrs;
+
+	if (git_win32_path_from_utf8(buf, path) < 0)
+		return 0;
+
+	attrs = GetFileAttributesW(buf);
+
+	if ((attrs | FILE_ATTRIBUTE_HIDDEN) == 0)
+	{
+		return -1;
+	}
+
+	return 1;
+}
+
+/**
+* Ensures the given path (file or folder) does not have the +H (hidden) attribute set.
+*
+* @param path The path which should not have the +H bit.
+* @return 0 on success; -1 on failure
+*/
+int git_win32__setvisible(const char *path)
+{
+	git_win32_path buf;
+	DWORD attrs;
+
+	if (git_win32_path_from_utf8(buf, path) < 0)
+		return -1;
+
+	attrs = GetFileAttributesW(buf);
+
+	/* Ensure the path exists */
+	if (attrs == INVALID_FILE_ATTRIBUTES)
+		return -1;
+
+	/* If the item is already +H, remove the bit */
+	if ((attrs & FILE_ATTRIBUTE_HIDDEN) == FILE_ATTRIBUTE_HIDDEN &&
+		!SetFileAttributesW(buf, attrs & ~FILE_ATTRIBUTE_HIDDEN))
+		return -1;
+
+	return 0;
+}
+
+/**
  * Removes any trailing backslashes from a path, except in the case of a drive
  * letter path (C:\, D:\, etc.). This function cannot fail.
  *

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -48,6 +48,22 @@ bool git_win32__findfirstfile_filter(git_win32_path dest, const char *src);
 int git_win32__sethidden(const char *path);
 
 /**
+* Checks if the given path (file or folder) has the +H (hidden) attribute set.
+*
+* @param path The path which should receive the +H bit.
+* @return True if hidden, false if visible
+*/
+int git_win32__ishidden(const char *path);
+
+/**
+* Ensures the given path (file or folder) does not have the +H (hidden) attribute set.
+*
+* @param path The path which should not have the +H bit.
+* @return 0 on success; -1 on failure
+*/
+int git_win32__setvisible(const char *path);
+
+/**
  * Removes any trailing backslashes from a path, except in the case of a drive
  * letter path (C:\, D:\, etc.). This function cannot fail.
  *


### PR DESCRIPTION
Hopefully this one will go a bit smoother! 

This PR implements Windows hidden file support. Before, adding a hidden file to the index caused "access denied" errors, and would also cause git_index_add_all to fall over when providing a pathspec that would include hidden files/directories containing hidden files.

I understand this might be a bit of an edge case, but it caused me a few problems!