### PR TITLE
Quick diff

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1014,9 +1014,9 @@ static int handle_unmatched_new_item(
 		/* check if user requests recursion into this type of dir */
 		recurse_into_dir = contains_oitem ||
 			(delta_type == GIT_DELTA_UNTRACKED &&
-			 DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_UNTRACKED_DIRS)) ||
+			DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_UNTRACKED_DIRS)) ||
 			(delta_type == GIT_DELTA_IGNORED &&
-			 DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_IGNORED_DIRS));
+			DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_IGNORED_DIRS));
 
 		/* do not advance into directories that contain a .git file */
 		if (recurse_into_dir && !contains_oitem) {
@@ -1050,7 +1050,7 @@ static int handle_unmatched_new_item(
 
 			/* iterate into dir looking for an actual untracked file */
 			if ((error = iterator_advance_over_with_status(
-					&info->nitem, &untracked_state, info->new_iter)) < 0)
+				&info->nitem, &untracked_state, info->new_iter)) < 0)
 				return error;
 
 			/* if we found nothing or just ignored items, update the record */
@@ -1067,10 +1067,12 @@ static int handle_unmatched_new_item(
 
 			return 0;
 		}
-		
-		if (!git_pathspec__match_partial(&diff->pathspec, nitem->path)) {
- 			recurse_into_dir = false;
- 		}
+
+		if (diff->opts.flags & GIT_DIFF_DISABLE_PATHSPEC_MATCH) {
+			if (!git_pathspec__match_partial(&diff->opts.pathspec, nitem->path)) {
+				recurse_into_dir = false;
+			}
+		}
 
 		/* try to advance into directory if necessary */
 		if (recurse_into_dir) {

--- a/src/diff.c
+++ b/src/diff.c
@@ -1067,6 +1067,10 @@ static int handle_unmatched_new_item(
 
 			return 0;
 		}
+		
+		if (!git_pathspec__match_partial(&diff->pathspec, nitem->path)) {
+ 			recurse_into_dir = false;
+ 		}
 
 		/* try to advance into directory if necessary */
 		if (recurse_into_dir) {

--- a/src/diff.c
+++ b/src/diff.c
@@ -1014,9 +1014,9 @@ static int handle_unmatched_new_item(
 		/* check if user requests recursion into this type of dir */
 		recurse_into_dir = contains_oitem ||
 			(delta_type == GIT_DELTA_UNTRACKED &&
-			DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_UNTRACKED_DIRS)) ||
+			 DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_UNTRACKED_DIRS)) ||
 			(delta_type == GIT_DELTA_IGNORED &&
-			DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_IGNORED_DIRS));
+			 DIFF_FLAG_IS_SET(diff, GIT_DIFF_RECURSE_IGNORED_DIRS));
 
 		/* do not advance into directories that contain a .git file */
 		if (recurse_into_dir && !contains_oitem) {
@@ -1050,7 +1050,7 @@ static int handle_unmatched_new_item(
 
 			/* iterate into dir looking for an actual untracked file */
 			if ((error = iterator_advance_over_with_status(
-				&info->nitem, &untracked_state, info->new_iter)) < 0)
+						&info->nitem, &untracked_state, info->new_iter)) < 0)
 				return error;
 
 			/* if we found nothing or just ignored items, update the record */

--- a/src/diff.c
+++ b/src/diff.c
@@ -1050,7 +1050,7 @@ static int handle_unmatched_new_item(
 
 			/* iterate into dir looking for an actual untracked file */
 			if ((error = iterator_advance_over_with_status(
-						&info->nitem, &untracked_state, info->new_iter)) < 0)
+					&info->nitem, &untracked_state, info->new_iter)) < 0)
 				return error;
 
 			/* if we found nothing or just ignored items, update the record */

--- a/src/index.c
+++ b/src/index.c
@@ -2813,6 +2813,10 @@ static int index_apply_to_wd_diff(git_index *index, int action, const git_strarr
 			opts.flags |= GIT_DIFF_INCLUDE_IGNORED;
 	}
 
+	if (paths && paths->count > 0) {
+		opts.pathspec = *paths;
+	}
+
 	if ((error = git_diff_index_to_workdir(&diff, repo, index, &opts)) < 0)
 		goto cleanup;
 

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -231,17 +231,16 @@ bool git_pathspec__match(
 
 /* match a path against the vectorized pathspec */
 bool git_pathspec__match_partial(
-	const git_vector *vspec,
+	const git_strarray *strspec,
 	const char *path)
 {
-	size_t pos = 0;
-	const git_attr_fnmatch *match;
+	size_t i;
 
-	if (!vspec || !vspec->length)
+	if (!strspec || !strspec->count)
 		return true;
 
-	git_vector_foreach(vspec, pos, match) {
-		if (strstr(match->pattern, path)) {
+	for (i = 0; i < strspec->count; ++i) {
+		if (strstr(strspec->strings[i], path) || strstr(path, strspec->strings[i])) {
 			return true;
 		}
 	}

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -229,6 +229,25 @@ bool git_pathspec__match(
 	return (result > 0);
 }
 
+/* match a path against the vectorized pathspec */
+bool git_pathspec__match_partial(
+	const git_vector *vspec,
+	const char *path)
+{
+	size_t pos = 0;
+	const git_attr_fnmatch *match;
+
+	if (!vspec || !vspec->length)
+		return true;
+
+	git_vector_foreach(vspec, pos, match) {
+		if (strstr(match->pattern, path)) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 int git_pathspec__init(git_pathspec *ps, const git_strarray *paths)
 {

--- a/src/pathspec.h
+++ b/src/pathspec.h
@@ -71,7 +71,7 @@ extern bool git_pathspec__match(
  * Match a path partially against the vectorized pathspec.
  */ 
 extern bool git_pathspec__match_partial(
-	const git_vector *vspec,
+	const git_strarray *strspec,
 	const char *path);
 
 /* easy pathspec setup */

--- a/src/pathspec.h
+++ b/src/pathspec.h
@@ -65,6 +65,14 @@ extern bool git_pathspec__match(
 	bool casefold,
 	const char **matched_pathspec,
 	size_t *matched_at);
+	
+	
+/*
+ * Match a path partially against the vectorized pathspec.
+ */ 
+extern bool git_pathspec__match_partial(
+	const git_vector *vspec,
+	const char *path);
 
 /* easy pathspec setup */
 


### PR DESCRIPTION
Sped up diffing large work trees when using non-fnmatch pathspecs to see if the path we're analysing is part of a provided pathspec before recursion.

Rationale: On my system I had a folder with over 100,000 files in spread over 100s of folders - diffing and index status checks took forever. Now it doesn't!