### PR TITLE
Fix attempt to free static OOM error message

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -114,18 +114,6 @@ GIT_EXTERN(const git_error *) giterr_last(void);
 GIT_EXTERN(void) giterr_clear(void);
 
 /**
- * Get the last error data and clear it.
- *
- * This copies the last error into the given `git_error` struct
- * and returns 0 if the copy was successful, leaving the error
- * cleared as if `giterr_clear` had been called.
- *
- * If there was no existing error in the library, -1 will be returned
- * and the contents of `cpy` will be left unmodified.
- */
-GIT_EXTERN(int) giterr_detach(git_error *cpy);
-
-/**
  * Set the error message string for this thread.
  *
  * This function is public so that custom ODB backends and the like can

--- a/src/errors.c
+++ b/src/errors.c
@@ -116,7 +116,7 @@ void giterr_clear(void)
 #endif
 }
 
-int giterr_detach(git_error *cpy)
+static int giterr_detach(git_error *cpy)
 {
 	git_error *error = GIT_GLOBAL->last_error;
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -125,10 +125,14 @@ int giterr_detach(git_error *cpy)
 	if (!error)
 		return -1;
 
-	cpy->message = error->message;
+	if (error == &g_git_oom_error) {
+		cpy->message = git__strdup(error->message);
+	} else {
+		cpy->message = error->message;
+		error->message = NULL;
+	}
 	cpy->klass = error->klass;
 
-	error->message = NULL;
 	giterr_clear();
 
 	return 0;

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -110,6 +110,29 @@ void test_core_errors__restore(void)
 	cl_assert_equal_s("Foo: bar", giterr_last()->message);
 }
 
+void test_core_errors__restore_oom(void)
+{
+	git_error_state err_state = {0};
+	const char *static_message = NULL;
+
+	giterr_clear();
+
+	giterr_set_oom(); /* internal fn */
+	static_message = giterr_last()->message;
+
+	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
+
+	cl_assert(giterr_last() == NULL);
+
+	cl_assert_(err_state.error_msg.message != static_message, "pointer to static buffer exposed");
+
+	giterr_restore(&err_state);
+
+	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
+
+	giterr_clear();
+}
+
 static int test_arraysize_multiply(size_t nelem, size_t size)
 {
 	size_t out;

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -113,22 +113,22 @@ void test_core_errors__restore(void)
 void test_core_errors__restore_oom(void)
 {
 	git_error_state err_state = {0};
-	const char *static_message = NULL;
+	const git_error *oom_error = NULL;
 
 	giterr_clear();
 
 	giterr_set_oom(); /* internal fn */
-	static_message = giterr_last()->message;
+	oom_error = giterr_last();
+	cl_assert(oom_error);
 
 	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
 
 	cl_assert(giterr_last() == NULL);
 
-	cl_assert_(err_state.error_msg.message != static_message, "pointer to static buffer exposed");
-
 	giterr_restore(&err_state);
 
 	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
+	cl_assert_(giterr_last() == oom_error, "static oom error not restored");
 
 	giterr_clear();
 }


### PR DESCRIPTION
I noticed a mechanism that can lead to attempts to free the statically allocated OOM error message (whilst trying to reproduce #3313).  The function `giterr_detach` assumes that any error message it detaches is dynamically allocated.  This PR fixes that, so that it becomes safe to detach an OOM error.

I have also added a test that performs the full `giterr_capture`/`giterr_restore` cycle, checking to ensure that the static pointer is not saved in the `git_error_state` structure.

Comments welcome!