### PR TITLE
 filebuf: remove lockfile upon rename errors

### DIFF
--- a/src/filebuf.h
+++ b/src/filebuf.h
@@ -44,6 +44,8 @@ struct git_filebuf {
 	size_t buf_size, buf_pos;
 	git_file fd;
 	bool fd_is_open;
+	bool created_lock;
+	bool did_rename;
 	bool do_not_buffer;
 	int last_error;
 };

--- a/tests/core/filebuf.c
+++ b/tests/core/filebuf.c
@@ -148,6 +148,6 @@ void test_core_filebuf__rename_error(void)
 	p_close(fd);
 
 	git_filebuf_cleanup(&file);
-	cl_assert_equal_i(false, git_path_exists(test_lock));
 
+	cl_assert_equal_i(false, git_path_exists(test_lock));
 }

--- a/tests/core/filebuf.c
+++ b/tests/core/filebuf.c
@@ -124,3 +124,30 @@ void test_core_filebuf__umask(void)
 	cl_must_pass(p_unlink(test));
 }
 
+void test_core_filebuf__rename_error(void)
+{
+	git_filebuf file = GIT_FILEBUF_INIT;
+	char *dir = "subdir",  *test = "subdir/test", *test_lock = "subdir/test.lock";
+	int fd;
+
+#ifndef GIT_WIN32
+	cl_skip();
+#endif
+
+	cl_git_pass(p_mkdir(dir, 0666));
+	cl_git_mkfile(test, "dummy content");
+	fd = p_open(test, O_RDONLY);
+	cl_assert(fd > 0);
+	cl_git_pass(git_filebuf_open(&file, test, 0, 0666));
+
+	cl_git_pass(git_filebuf_printf(&file, "%s\n", "libgit2 rocks"));
+
+	cl_assert_equal_i(true, git_path_exists(test_lock));
+
+	cl_git_fail(git_filebuf_commit(&file));
+	p_close(fd);
+
+	git_filebuf_cleanup(&file);
+	cl_assert_equal_i(false, git_path_exists(test_lock));
+
+}


### PR DESCRIPTION
When we have an error renaming the lockfile, we need to make sure
that we remove it upon cleanup. For this, we need to keep track of
whether we opened the file and whether the rename succeeded.

If we did create the lockfile but the rename did not succeed, we
remove the lockfile. This won't protect against all errors, but
the most common ones (target file is open) does get handled.

This test is only active for Windows because that's where it happens. The reasons this would fail to rename on unix (no write permission on the parent) would also prevent us from removing the file (if not from creating it outright).