### PR TITLE
Fix git_index_add_bypath() crash if git_submodule_lookup() fails

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1254,6 +1254,8 @@ int git_index_add_bypath(git_index *index, const char *path)
 			return giterr_restore(&err);
 		else
 			git__free(err.error_msg.message);
+		if (ret < 0)
+			return ret;
 
 		ret = git_submodule_add_to_index(sm, false);
 		git_submodule_free(sm);

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -33,3 +33,10 @@ void test_index_bypath__add_submodule(void)
 	cl_git_pass(git_submodule_status(&status, g_repo, sm_name, 0));
 	cl_assert_equal_i(0, status & GIT_SUBMODULE_STATUS_WD_MODIFIED);
 }
+
+void test_index_bypath__add_not_submodule(void)
+{
+	const char *sm_name = "not-submodule";
+
+	cl_git_fail_with(GIT_EEXISTS, git_index_add_bypath(g_idx, sm_name));
+}


### PR DESCRIPTION
Fix `git_index_add_bypath()` crash if `git_submodule_lookup()` fails other than `GIT_ENOTFOUND`