### PR TITLE
path: convert diropen's ENOENT to GIT_ENOTFOUND

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -1260,10 +1260,15 @@ int git_path_diriter_init(
 	}
 
 	if ((diriter->dir = opendir(diriter->path.ptr)) == NULL) {
+		int error = -1;
+
 		git_buf_free(&diriter->path);
 
+		if (errno == ENOENT)
+			error = GIT_ENOTFOUND;
+
 		giterr_set(GITERR_OS, "Failed to open directory '%s'", path);
-		return -1;
+		return error;
 	}
 
 #ifdef GIT_USE_ICONV


### PR DESCRIPTION
If a directory is removed between the listing of its parent and the
attempt to traverse it, we need to indicate that through our error code
so the caller knows to continue.

The Windows code seems to have the same issue, but I don't know if it'd be ok to return `ENOTFOUND` every time we get `INVALID_HANDLE_VALUE` (or maybe we should just return that every time.

Or maybe it'd be a better idea/patch to simply treat all errors from `git_path_diriter_init()` as "oh well, let's try the next one" when we're in the iterator. That would also let us ignore permissions issues, which I think would also cause an error right now.