### PR TITLE
Make libgit2 add old-style submodule without .gitmodules

### DIFF
--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -204,7 +204,7 @@ GIT_EXTERN(int) git_submodule_update(git_submodule *submodule, int init, git_sub
  * @param repo The parent repository
  * @param name The name of or path to the submodule; trailing slashes okay
  * @return 0 on success, GIT_ENOTFOUND if submodule does not exist,
- *         GIT_EEXISTS if a repository is found in working directory only,
+ *         GIT_EEXISTS if a repository is found in working directory only, but Output ptr is still set,
  *         -1 on other errors.
  */
 GIT_EXTERN(int) git_submodule_lookup(

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -33,3 +33,10 @@ void test_index_bypath__add_submodule(void)
 	cl_git_pass(git_submodule_status(&status, g_repo, sm_name, 0));
 	cl_assert_equal_i(0, status & GIT_SUBMODULE_STATUS_WD_MODIFIED);
 }
+
+void test_index_bypath__add_submodule_old_style(void)
+{
+	const char *sm_name = "not-submodule";
+
+	cl_git_pass(git_index_add_bypath(g_idx, sm_name));
+}


### PR DESCRIPTION
Make libgit2 add old-style submodule (with its own .git dir) without `.gitmodules`.
core-git allows this.