### PR TITLE
Remove extra semicolon outside of a function

### DIFF
--- a/src/describe.c
+++ b/src/describe.c
@@ -19,7 +19,7 @@
 #include "vector.h"
 #include "repository.h"
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 /* Ported from https://github.com/git/git/blob/89dde7882f71f846ccd0359756d27bebc31108de/builtin/describe.c */
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -18,7 +18,7 @@
 #include "oidmap.h"
 #include "zstream.h"
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 extern git_mutex git__mwindow_mutex;
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -41,7 +41,7 @@ struct pack_write_context {
 	git_transfer_progress *stats;
 };
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 #ifdef GIT_THREADS
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -16,8 +16,8 @@
 
 #include <zlib.h>
 
-GIT__USE_OFFMAP;
-GIT__USE_OIDMAP;
+GIT__USE_OFFMAP
+GIT__USE_OIDMAP
 
 static int packfile_open(struct git_pack_file *p);
 static git_off_t nth_packed_object_offset(const struct git_pack_file *p, uint32_t n);

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -14,7 +14,7 @@
 #include "git2/revparse.h"
 #include "merge.h"
 
-GIT__USE_OIDMAP;
+GIT__USE_OIDMAP
 
 git_commit_list_node *git_revwalk__commit_lookup(
 	git_revwalk *walk, const git_oid *oid)


### PR DESCRIPTION
This pull request is related to the R bindings [git2r](https://github.com/ropensci/git2r). When I run the R package check on `git2r` I get the following warnings without this change:

```
* checking whether package ‘git2r’ can be installed ... WARNING
Found the following significant warnings:
  libgit2/describe.c:22:16: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
  libgit2/indexer.c:21:16: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
  libgit2/pack.c:19:16: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
  libgit2/pack.c:20:16: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
  libgit2/pack-objects.c:44:16: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
  libgit2/revwalk.c:17:16: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
```

This changes removes `;` outside of a function, which generates the warning with gcc and pedantic.
