### PR TITLE
index: stage an unregistered submodule as well

### DIFF
--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -33,3 +33,10 @@ void test_index_bypath__add_submodule(void)
 	cl_git_pass(git_submodule_status(&status, g_repo, sm_name, 0));
 	cl_assert_equal_i(0, status & GIT_SUBMODULE_STATUS_WD_MODIFIED);
 }
+
+void test_index_bypath__add_submodule_old_style(void)
+{
+	const char *sm_name = "not-submodule";
+
+	cl_git_pass(git_index_add_bypath(g_idx, sm_name));
+}

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -34,9 +34,15 @@ void test_index_bypath__add_submodule(void)
 	cl_assert_equal_i(0, status & GIT_SUBMODULE_STATUS_WD_MODIFIED);
 }
 
-void test_index_bypath__add_submodule_old_style(void)
+void test_index_bypath__add_submodule_unregistered(void)
 {
 	const char *sm_name = "not-submodule";
+	const char *sm_head = "68e92c611b80ee1ed8f38314ff9577f0d15b2444";
+	const git_index_entry *entry;
 
 	cl_git_pass(git_index_add_bypath(g_idx, sm_name));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, sm_name, 0));
+	cl_assert_equal_s(sm_head, git_oid_tostr_s(&entry->id));
+	cl_assert_equal_s(sm_name, entry->path);
 }


### PR DESCRIPTION
index: stage an unregistered submodule as well
    
We previously added logic to `_add_bypath()` to update a submodule. Go
further and stage the submodule even if it's not registered to behave
like git.

This is an alternative to #3326 and #3336 which mimics git's behaviour while not changing the behaviour of the submodule API, so we can easily backport it.