### PR TITLE
Handle ssh:// and git:// urls containing a '~' character.

### DIFF
--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -50,6 +50,8 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 	}
 
 	repo = delim;
+	if (repo[1] == '~')
+		++repo;
 
 	delim = strchr(url, ':');
 	if (delim == NULL)

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -66,6 +66,8 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 	if (!git__prefixcmp(url, prefix_ssh)) {
 		url = url + strlen(prefix_ssh);
 		repo = strchr(url, '/');
+		if (repo && repo[1] == '~')
+			++repo;
 	} else {
 		repo = strchr(url, ':');
 		if (repo) repo++;


### PR DESCRIPTION
For such a path '/~/...' the leading '/' is stripped so the server will
get a path starting with '~' and correctly handle it.

solution for issue #3345