### PR TITLE
Error handling: use buffers, improved OOM handling

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -114,18 +114,6 @@ GIT_EXTERN(const git_error *) giterr_last(void);
 GIT_EXTERN(void) giterr_clear(void);
 
 /**
- * Get the last error data and clear it.
- *
- * This copies the last error into the given `git_error` struct
- * and returns 0 if the copy was successful, leaving the error
- * cleared as if `giterr_clear` had been called.
- *
- * If there was no existing error in the library, -1 will be returned
- * and the contents of `cpy` will be left unmodified.
- */
-GIT_EXTERN(int) giterr_detach(git_error *cpy);
-
-/**
  * Set the error message string for this thread.
  *
  * This function is public so that custom ODB backends and the like can

--- a/src/clone.c
+++ b/src/clone.c
@@ -440,14 +440,14 @@ int git_clone(
 
 	if (error != 0) {
 		git_error_state last_error = {0};
-		giterr_capture(&last_error, error);
+		giterr_state_capture(&last_error, error);
 
 		git_repository_free(repo);
 		repo = NULL;
 
 		(void)git_futils_rmdir_r(local_path, NULL, rmdir_flags);
 
-		giterr_restore(&last_error);
+		giterr_state_restore(&last_error);
 	}
 
 	*out = repo;

--- a/src/common.h
+++ b/src/common.h
@@ -141,20 +141,25 @@ void giterr_system_set(int code);
  * Structure to preserve libgit2 error state
  */
 typedef struct {
-	int       error_code;
+	int error_code;
+	unsigned int oom : 1;
 	git_error error_msg;
 } git_error_state;
 
 /**
  * Capture current error state to restore later, returning error code.
- * If `error_code` is zero, this does nothing and returns zero.
+ * If `error_code` is zero, this does not clear the current error state.
+ * You must either restore this error state, or free it.
  */
-int giterr_capture(git_error_state *state, int error_code);
+extern int giterr_state_capture(git_error_state *state, int error_code);
 
 /**
  * Restore error state to a previous value, returning saved error code.
  */
-int giterr_restore(git_error_state *state);
+extern int giterr_state_restore(git_error_state *state);
+
+/** Free an error state. */
+extern void giterr_state_free(git_error_state *state);
 
 /**
  * Check a versioned structure for validity

--- a/src/errors.c
+++ b/src/errors.c
@@ -116,7 +116,7 @@ void giterr_clear(void)
 #endif
 }
 
-int giterr_detach(git_error *cpy)
+static int giterr_detach(git_error *cpy)
 {
 	git_error *error = GIT_GLOBAL->last_error;
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -125,10 +125,14 @@ int giterr_detach(git_error *cpy)
 	if (!error)
 		return -1;
 
-	cpy->message = error->message;
+	if (error == &g_git_oom_error) {
+		cpy->message = git__strdup(error->message);
+	} else {
+		cpy->message = error->message;
+		error->message = NULL;
+	}
 	cpy->klass = error->klass;
 
-	error->message = NULL;
 	giterr_clear();
 
 	return 0;

--- a/src/global.c
+++ b/src/global.c
@@ -279,18 +279,19 @@ int git_libgit2_shutdown(void)
 
 git_global_st *git__global_state(void)
 {
-	void *ptr;
+	git_global_st *ptr;
 
 	assert(git_atomic_get(&git__n_inits) > 0);
 
 	if ((ptr = TlsGetValue(_tls_index)) != NULL)
 		return ptr;
 
-	ptr = git__malloc(sizeof(git_global_st));
+	ptr = git__calloc(1, sizeof(git_global_st));
 	if (!ptr)
 		return NULL;
 
-	memset(ptr, 0x0, sizeof(git_global_st));
+	git_buf_init(&ptr->error_buf, 0);
+
 	TlsSetValue(_tls_index, ptr);
 	return ptr;
 }
@@ -378,18 +379,18 @@ int git_libgit2_shutdown(void)
 
 git_global_st *git__global_state(void)
 {
-	void *ptr;
+	git_global_st *ptr;
 
 	assert(git_atomic_get(&git__n_inits) > 0);
 
 	if ((ptr = pthread_getspecific(_tls_key)) != NULL)
 		return ptr;
 
-	ptr = git__malloc(sizeof(git_global_st));
+	ptr = git__calloc(1, sizeof(git_global_st));
 	if (!ptr)
 		return NULL;
 
-	memset(ptr, 0x0, sizeof(git_global_st));
+	git_buf_init(&ptr->error_buf, 0);
 	pthread_setspecific(_tls_key, ptr);
 	return ptr;
 }
@@ -407,6 +408,7 @@ int git_libgit2_init(void)
 		ssl_inited = 1;
 	}
 
+	git_buf_init(&__state.error_buf, 0);
 	return git_atomic_inc(&git__n_inits);
 }
 

--- a/src/global.h
+++ b/src/global.h
@@ -14,6 +14,7 @@
 typedef struct {
 	git_error *last_error;
 	git_error error_t;
+	git_buf error_buf;
 	char oid_fmt[GIT_OID_HEXSZ+1];
 } git_global_st;
 

--- a/src/index.c
+++ b/src/index.c
@@ -1286,13 +1286,13 @@ int git_index_add_bypath(git_index *index, const char *path)
 		git_submodule *sm;
 		git_error_state err;
 
-		giterr_capture(&err, ret);
+		giterr_state_capture(&err, ret);
 
 		ret = git_submodule_lookup(&sm, INDEX_OWNER(index), path);
 		if (ret == GIT_ENOTFOUND)
-			return giterr_restore(&err);
+			return giterr_state_restore(&err);
 
-		git__free(err.error_msg.message);
+		giterr_state_free(&err);
 
 		/*
 		 * EEXISTS means that there is a repository at that path, but it's not known

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1120,7 +1120,7 @@ static int fs_iterator__expand_dir(fs_iterator *fi)
 
 	if (error < 0) {
 		git_error_state last_error = { 0 };
-		giterr_capture(&last_error, error);
+		giterr_state_capture(&last_error, error);
 
 		/* these callbacks may clear the error message */
 		fs_iterator__free_frame(ff);
@@ -1128,7 +1128,7 @@ static int fs_iterator__expand_dir(fs_iterator *fi)
 		/* next time return value we skipped to */
 		fi->base.flags &= ~GIT_ITERATOR_FIRST_ACCESS;
 
-		return giterr_restore(&last_error);
+		return giterr_state_restore(&last_error);
 	}
 
 	if (ff->entries.length == 0) {

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -110,6 +110,29 @@ void test_core_errors__restore(void)
 	cl_assert_equal_s("Foo: bar", giterr_last()->message);
 }
 
+void test_core_errors__restore_oom(void)
+{
+	git_error_state err_state = {0};
+	const char *static_message = NULL;
+
+	giterr_clear();
+
+	giterr_set_oom(); /* internal fn */
+	static_message = giterr_last()->message;
+
+	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
+
+	cl_assert(giterr_last() == NULL);
+
+	cl_assert_(err_state.error_msg.message != static_message, "pointer to static buffer exposed");
+
+	giterr_restore(&err_state);
+
+	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
+
+	giterr_clear();
+}
+
 static int test_arraysize_multiply(size_t nelem, size_t size)
 {
 	size_t out;

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -93,21 +93,42 @@ void test_core_errors__restore(void)
 	giterr_clear();
 	cl_assert(giterr_last() == NULL);
 
-	cl_assert_equal_i(0, giterr_capture(&err_state, 0));
+	cl_assert_equal_i(0, giterr_state_capture(&err_state, 0));
 
 	memset(&err_state, 0x0, sizeof(git_error_state));
 
 	giterr_set(42, "Foo: %s", "bar");
-	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
+	cl_assert_equal_i(-1, giterr_state_capture(&err_state, -1));
 
 	cl_assert(giterr_last() == NULL);
 
 	giterr_set(99, "Bar: %s", "foo");
 
-	giterr_restore(&err_state);
+	giterr_state_restore(&err_state);
 
 	cl_assert_equal_i(42, giterr_last()->klass);
 	cl_assert_equal_s("Foo: bar", giterr_last()->message);
+}
+
+void test_core_errors__free_state(void)
+{
+	git_error_state err_state = {0};
+
+	giterr_clear();
+
+	giterr_set(42, "Foo: %s", "bar");
+	cl_assert_equal_i(-1, giterr_state_capture(&err_state, -1));
+
+	giterr_set(99, "Bar: %s", "foo");
+
+	giterr_state_free(&err_state);
+
+	cl_assert_equal_i(99, giterr_last()->klass);
+	cl_assert_equal_s("Bar: foo", giterr_last()->message);
+
+	giterr_state_restore(&err_state);
+
+	cl_assert(giterr_last() == NULL);
 }
 
 void test_core_errors__restore_oom(void)
@@ -121,11 +142,13 @@ void test_core_errors__restore_oom(void)
 	oom_error = giterr_last();
 	cl_assert(oom_error);
 
-	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
+	cl_assert_equal_i(-1, giterr_state_capture(&err_state, -1));
 
 	cl_assert(giterr_last() == NULL);
+	cl_assert_equal_i(GITERR_NOMEMORY, err_state.error_msg.klass);
+	cl_assert_equal_s("Out of memory", err_state.error_msg.message);
 
-	giterr_restore(&err_state);
+	giterr_state_restore(&err_state);
 
 	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
 	cl_assert_(giterr_last() == oom_error, "static oom error not restored");

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -113,22 +113,22 @@ void test_core_errors__restore(void)
 void test_core_errors__restore_oom(void)
 {
 	git_error_state err_state = {0};
-	const char *static_message = NULL;
+	const git_error *oom_error = NULL;
 
 	giterr_clear();
 
 	giterr_set_oom(); /* internal fn */
-	static_message = giterr_last()->message;
+	oom_error = giterr_last();
+	cl_assert(oom_error);
 
 	cl_assert_equal_i(-1, giterr_capture(&err_state, -1));
 
 	cl_assert(giterr_last() == NULL);
 
-	cl_assert_(err_state.error_msg.message != static_message, "pointer to static buffer exposed");
-
 	giterr_restore(&err_state);
 
 	cl_assert(giterr_last()->klass == GITERR_NOMEMORY);
+	cl_assert_(giterr_last() == oom_error, "static oom error not restored");
 
 	giterr_clear();
 }


### PR DESCRIPTION
Merges #3329 and #3323 and tightens up the sloppiness where we blindly free the detached error message (which may be the static OOM string) by providing a free function.  Move everything to the `giterr_state` namespace, lest `giterr_free` be confusing.