### PR TITLE
index: canonicalize directory case when adding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ v0.23 + 1
   with which to implement the transactional/atomic semantics for the
   configuration backend.
 
+* `git_index_add` will now use the case as provided by the caller on
+  case insensitive systems.  Previous versions would keep the case as
+  it existed in the index.  This does not affect the higher-level
+  `git_index_add_bypath` or `git_index_add_frombuffer` functions.
+
 v0.23
 ------
 

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -73,6 +73,26 @@ void test_index_bypath__add_hidden(void)
 #endif
 }
 
+void test_index_bypath__add_keeps_existing_case(void)
+{
+	const git_index_entry *entry;
+
+	if (!cl_repo_get_bool(g_repo, "core.ignorecase"))
+		clar__skip();
+
+	cl_git_mkfile("submod2/just_a_dir/file1.txt", "This is a file");
+	cl_git_pass(git_index_add_bypath(g_idx, "just_a_dir/file1.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "just_a_dir/file1.txt", 0));
+	cl_assert_equal_s("just_a_dir/file1.txt", entry->path);
+
+	cl_git_rewritefile("submod2/just_a_dir/file1.txt", "Updated!");
+	cl_git_pass(git_index_add_bypath(g_idx, "just_a_dir/FILE1.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "just_a_dir/FILE1.txt", 0));
+	cl_assert_equal_s("just_a_dir/file1.txt", entry->path);
+}
+
 void test_index_bypath__add_honors_existing_case(void)
 {
 	const git_index_entry *entry;

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -72,3 +72,151 @@ void test_index_bypath__add_hidden(void)
 	cl_assert_equal_i(GIT_FILEMODE_BLOB, entry->mode);
 #endif
 }
+
+void test_index_bypath__add_honors_existing_case(void)
+{
+	const git_index_entry *entry;
+
+	if (!cl_repo_get_bool(g_repo, "core.ignorecase"))
+		clar__skip();
+
+	cl_git_mkfile("submod2/just_a_dir/file1.txt", "This is a file");
+	cl_git_mkfile("submod2/just_a_dir/file2.txt", "This is another file");
+	cl_git_mkfile("submod2/just_a_dir/file3.txt", "This is another file");
+	cl_git_mkfile("submod2/just_a_dir/file4.txt", "And another file");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "just_a_dir/File1.txt"));
+	cl_git_pass(git_index_add_bypath(g_idx, "JUST_A_DIR/file2.txt"));
+	cl_git_pass(git_index_add_bypath(g_idx, "Just_A_Dir/FILE3.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "just_a_dir/File1.txt", 0));
+	cl_assert_equal_s("just_a_dir/File1.txt", entry->path);
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "JUST_A_DIR/file2.txt", 0));
+	cl_assert_equal_s("just_a_dir/file2.txt", entry->path);
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "Just_A_Dir/FILE3.txt", 0));
+	cl_assert_equal_s("just_a_dir/FILE3.txt", entry->path);
+
+	cl_git_rewritefile("submod2/just_a_dir/file3.txt", "Rewritten");
+	cl_git_pass(git_index_add_bypath(g_idx, "Just_A_Dir/file3.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "Just_A_Dir/file3.txt", 0));
+	cl_assert_equal_s("just_a_dir/FILE3.txt", entry->path);
+}
+
+void test_index_bypath__add_honors_existing_case_2(void)
+{
+	git_index_entry dummy = { { 0 } };
+	const git_index_entry *entry;
+
+	if (!cl_repo_get_bool(g_repo, "core.ignorecase"))
+		clar__skip();
+
+	dummy.mode = GIT_FILEMODE_BLOB;
+
+	/* note that `git_index_add` does no checking to canonical directories */
+	dummy.path = "Just_a_dir/file0.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "just_a_dir/fileA.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "Just_A_Dir/fileB.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "JUST_A_DIR/fileC.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "just_A_dir/fileD.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "JUST_a_DIR/fileE.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	cl_git_mkfile("submod2/just_a_dir/file1.txt", "This is a file");
+	cl_git_mkfile("submod2/just_a_dir/file2.txt", "This is another file");
+	cl_git_mkfile("submod2/just_a_dir/file3.txt", "This is another file");
+	cl_git_mkfile("submod2/just_a_dir/file4.txt", "And another file");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "just_a_dir/File1.txt"));
+	cl_git_pass(git_index_add_bypath(g_idx, "JUST_A_DIR/file2.txt"));
+	cl_git_pass(git_index_add_bypath(g_idx, "Just_A_Dir/FILE3.txt"));
+	cl_git_pass(git_index_add_bypath(g_idx, "JusT_A_DIR/FILE4.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "just_a_dir/File1.txt", 0));
+	cl_assert_equal_s("just_a_dir/File1.txt", entry->path);
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "JUST_A_DIR/file2.txt", 0));
+	cl_assert_equal_s("JUST_A_DIR/file2.txt", entry->path);
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "Just_A_Dir/FILE3.txt", 0));
+	cl_assert_equal_s("Just_A_Dir/FILE3.txt", entry->path);
+
+	cl_git_rewritefile("submod2/just_a_dir/file3.txt", "Rewritten");
+	cl_git_pass(git_index_add_bypath(g_idx, "Just_A_Dir/file3.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "Just_A_Dir/file3.txt", 0));
+	cl_assert_equal_s("Just_A_Dir/FILE3.txt", entry->path);
+}
+
+void test_index_bypath__add_honors_existing_case_3(void)
+{
+	git_index_entry dummy = { { 0 } };
+	const git_index_entry *entry;
+
+	if (!cl_repo_get_bool(g_repo, "core.ignorecase"))
+		clar__skip();
+
+	dummy.mode = GIT_FILEMODE_BLOB;
+
+	dummy.path = "just_a_dir/filea.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "Just_A_Dir/fileB.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "just_A_DIR/FILEC.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "Just_a_DIR/FileD.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	cl_git_mkfile("submod2/JuSt_A_DiR/fILEE.txt", "This is a file");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "just_a_dir/fILEE.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "JUST_A_DIR/fILEE.txt", 0));
+	cl_assert_equal_s("just_a_dir/fILEE.txt", entry->path);
+}
+
+void test_index_bypath__add_honors_existing_case_4(void)
+{
+	git_index_entry dummy = { { 0 } };
+	const git_index_entry *entry;
+
+	if (!cl_repo_get_bool(g_repo, "core.ignorecase"))
+		clar__skip();
+
+	dummy.mode = GIT_FILEMODE_BLOB;
+
+	dummy.path = "just_a_dir/a/b/c/d/e/file1.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	dummy.path = "just_a_dir/a/B/C/D/E/file2.txt";
+	cl_git_pass(git_index_add(g_idx, &dummy));
+
+	cl_must_pass(p_mkdir("submod2/just_a_dir/a", 0777));
+	cl_must_pass(p_mkdir("submod2/just_a_dir/a/b", 0777));
+	cl_must_pass(p_mkdir("submod2/just_a_dir/a/b/z", 0777));
+	cl_must_pass(p_mkdir("submod2/just_a_dir/a/b/z/y", 0777));
+	cl_must_pass(p_mkdir("submod2/just_a_dir/a/b/z/y/x", 0777));
+
+	cl_git_mkfile("submod2/just_a_dir/a/b/z/y/x/FOO.txt", "This is a file");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "just_a_dir/A/b/Z/y/X/foo.txt"));
+
+	cl_assert(entry = git_index_get_bypath(g_idx, "just_a_dir/A/b/Z/y/X/foo.txt", 0));
+	cl_assert_equal_s("just_a_dir/a/b/Z/y/X/foo.txt", entry->path);
+}
+

--- a/tests/index/rename.c
+++ b/tests/index/rename.c
@@ -48,3 +48,34 @@ void test_index_rename__single_file(void)
 
 	cl_fixture_cleanup("rename");
 }
+
+void test_index_rename__casechanging(void)
+{
+	git_repository *repo;
+	git_index *index;
+	const git_index_entry *entry;
+	git_index_entry new = {{0}};
+
+	p_mkdir("rename", 0700);
+
+	cl_git_pass(git_repository_init(&repo, "./rename", 0));
+	cl_git_pass(git_repository_index(&index, repo));
+
+	cl_git_mkfile("./rename/lame.name.txt", "new_file\n");
+
+	cl_git_pass(git_index_add_bypath(index, "lame.name.txt"));
+	cl_assert_equal_i(1, git_index_entrycount(index));
+	cl_assert((entry = git_index_get_bypath(index, "lame.name.txt", 0)));
+
+	memcpy(&new, entry, sizeof(git_index_entry));
+	new.path = "LAME.name.TXT";
+
+	cl_git_pass(git_index_add(index, &new));
+	cl_assert((entry = git_index_get_bypath(index, "LAME.name.TXT", 0)));
+
+	if (cl_repo_get_bool(repo, "core.ignorecase"))
+		cl_assert_equal_i(1, git_index_entrycount(index));
+	else
+		cl_assert_equal_i(2, git_index_entrycount(index));
+}
+


### PR DESCRIPTION
On case insensitive systems, when given a user-provided path in the
higher-level index addition functions (eg `git_index_add_bypath` /
`git_index_add_frombuffer`), examine the index to try to match the
given path to an existing directory.

Various mechanisms can cause the on-disk representation of a folder
to not match the representation in HEAD or the index - for example,
a case changing rename of some file `a/file.txt` to `A/file.txt`
will update the paths in the index, but not rename the folder on
disk.

If a user subsequently adds `a/other.txt`, then this should be stored
in the index as `A/other.txt`.

For example:

    % git init .
    % mkdir a
    % echo hello > a/file.txt
    % git add a
    % git commit -mfoo
    % git mv -f a/file.txt A/file.txt
    % git status
    On branch master
    Changes to be committed:
      (use "git reset HEAD <file>..." to unstage)

            renamed:    a/file.txt -> A/file.txt

    % dir
    ...snip...
    08/04/2015  04:54 PM    <DIR>          a

    % echo hi > a/other.txt
    % git add a/other.txt
    % git status
    On branch master
    Changes to be committed:
      (use "git reset HEAD <file>..." to unstage)

            new file:   A/other.txt
