### PR TITLE
Include the 4 characters not recognised as hex-number in parse_len

### DIFF
--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -351,7 +351,7 @@ static int unpack_pkt(git_pkt **out, const char *line, size_t len)
 static int32_t parse_len(const char *line)
 {
 	char num[PKT_LEN_SIZE + 1];
-	int i, error;
+	int i, k, error;
 	int32_t len;
 	const char *num_end;
 
@@ -360,7 +360,14 @@ static int32_t parse_len(const char *line)
 
 	for (i = 0; i < PKT_LEN_SIZE; ++i) {
 		if (!isxdigit(num[i])) {
-			giterr_set(GITERR_NET, "Found invalid hex digit in length");
+			/* Make sure there are no special characters before passing to error message */
+			for (k = 0; k < PKT_LEN_SIZE; ++k) {
+				if(!isprint(num[k])) {
+					num[k] = '.';
+				}
+			}
+			
+			giterr_set(GITERR_NET, "invalid hex digit in length: '%s'", num);
 			return -1;
 		}
 	}


### PR DESCRIPTION
Improve error messages as described in issue #2830 by including the 4 characters not recognised as hexadecimal digit.

If there are any control characters among these, we stop at the first one found to avoid garbage in error string.