### PR TITLE
curl: use the most secure auth method for the proxy

### DIFF
--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -220,6 +220,7 @@ int git_curl_stream_new(git_stream **out, const char *host, const char *port)
 	curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1);
 	curl_easy_setopt(handle, CURLOPT_CERTINFO, 1);
 	curl_easy_setopt(handle, CURLOPT_HTTPPROXYTUNNEL, 1);
+	curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
 
 	/* curl_easy_setopt(handle, CURLOPT_VERBOSE, 1); */
 


### PR DESCRIPTION
When curl uses a proxy, it will only use Basic unless we prompt it to
try to use the most secure on it has available.

This is something which git did recently, and it seems like a good idea.