### PR TITLE
submodule: refactor to be more explicit in the search

### DIFF
--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -333,3 +333,58 @@ void test_submodule_lookup__prefix_name(void)
 
 	git_submodule_free(sm);
 }
+
+void test_submodule_lookup__renamed(void)
+{
+	const char *newpath = "sm_actually_changed";
+	git_index *idx;
+	sm_lookup_data data;
+
+	cl_git_pass(git_repository_index__weakptr(&idx, g_repo));
+
+	/* We're replicating 'git mv sm_unchanged sm_actually_changed' in this test */
+
+	cl_git_pass(p_rename("submod2/sm_unchanged", "submod2/sm_actually_changed"));
+
+	/* Change the path in .gitmodules and stage it*/
+	{
+		git_config *cfg;
+
+		cl_git_pass(git_config_open_ondisk(&cfg, "submod2/.gitmodules"));
+		cl_git_pass(git_config_set_string(cfg, "submodule.sm_unchanged.path", newpath));
+		git_config_free(cfg);
+
+		cl_git_pass(git_index_add_bypath(idx, ".gitmodules"));
+	}
+
+	/* Change the worktree info in the the submodule's config */
+	{
+		git_config *cfg;
+
+		cl_git_pass(git_config_open_ondisk(&cfg, "submod2/.git/modules/sm_unchanged/config"));
+		cl_git_pass(git_config_set_string(cfg, "core.worktree", "../../../sm_actually_changed"));
+		git_config_free(cfg);
+	}
+
+	/* Rename the entry in the index */
+	{
+		const git_index_entry *e;
+		git_index_entry entry = { 0 };
+
+		e = git_index_get_bypath(idx, "sm_unchanged", 0);
+		cl_assert(e);
+		cl_assert_equal_i(GIT_FILEMODE_COMMIT, e->mode);
+
+		entry.path = newpath;
+		entry.mode = GIT_FILEMODE_COMMIT;
+		git_oid_cpy(&entry.id, &e->id);
+
+		cl_git_pass(git_index_remove(idx, "sm_unchanged", 0));
+		cl_git_pass(git_index_add(idx, &entry));
+		cl_git_pass(git_index_write(idx));
+	}
+
+	memset(&data, 0, sizeof(data));
+	cl_git_pass(git_submodule_foreach(g_repo, sm_lookup_cb, &data));
+	cl_assert_equal_i(8, data.count);
+}


### PR DESCRIPTION
When searching for information about a submdoule, let's be more explicit
in what we expect to find. We currently insert a submodule into the map
and change certain parameters when the config callback gets called.

Switch to asking for the configuration we're interested in, rather than
taking it in an arbitrary order.

---

Not as many minuses as I'd hoped, but a bunch of the code is rather repetitive. This may handle #3365 as a side-effect, but there's currently no test for explicitly such a case.