### PR TITLE
Fix bug in git_smart__push: push_transfer_progress cb is only called at end

### DIFF
--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -957,7 +957,7 @@ int git_smart__push(git_transport *transport, git_push *push, const git_remote_c
 
 	packbuilder_payload.pb = push->pb;
 
-	if (cbs && cbs->transfer_progress) {
+	if (cbs && cbs->push_transfer_progress) {
 		packbuilder_payload.cb = cbs->push_transfer_progress;
 		packbuilder_payload.cb_payload = cbs->payload;
 	}


### PR DESCRIPTION
The conditional checked cbs->transfer_progress then used the value in cbs->push_transfer_progress. In both cases it should be push_transfer_progress