### PR TITLE
Rename struct entry

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -24,7 +24,7 @@ extern git_mutex git__mwindow_mutex;
 
 #define UINT31_MAX (0x7FFFFFFF)
 
-struct entry {
+struct idx_entry {
 	git_oid oid;
 	uint32_t crc;
 	uint32_t offset;
@@ -97,8 +97,8 @@ static int parse_header(struct git_pack_header *hdr, struct git_pack_file *pack)
 
 static int objects_cmp(const void *a, const void *b)
 {
-	const struct entry *entrya = a;
-	const struct entry *entryb = b;
+	const struct idx_entry *entrya = a;
+	const struct idx_entry *entryb = b;
 
 	return git_oid__cmp(&entrya->oid, &entryb->oid);
 }
@@ -265,7 +265,7 @@ static int store_object(git_indexer *idx)
 	int i, error;
 	khiter_t k;
 	git_oid oid;
-	struct entry *entry;
+	struct idx_entry *entry;
 	git_off_t entry_size;
 	struct git_pack_entry *pentry;
 	git_off_t entry_start = idx->entry_start;
@@ -332,7 +332,7 @@ GIT_INLINE(bool) has_entry(git_indexer *idx, git_oid *id)
 	return (k != kh_end(idx->pack->idx_cache));
 }
 
-static int save_entry(git_indexer *idx, struct entry *entry, struct git_pack_entry *pentry, git_off_t entry_start)
+static int save_entry(git_indexer *idx, struct idx_entry *entry, struct git_pack_entry *pentry, git_off_t entry_start)
 {
 	int i, error;
 	khiter_t k;
@@ -369,7 +369,7 @@ static int hash_and_save(git_indexer *idx, git_rawobj *obj, git_off_t entry_star
 {
 	git_oid oid;
 	size_t entry_size;
-	struct entry *entry;
+	struct idx_entry *entry;
 	struct git_pack_entry *pentry = NULL;
 
 	entry = git__calloc(1, sizeof(*entry));
@@ -679,7 +679,7 @@ static void seek_back_trailer(git_indexer *idx)
 static int inject_object(git_indexer *idx, git_oid *id)
 {
 	git_odb_object *obj;
-	struct entry *entry;
+	struct idx_entry *entry;
 	struct git_pack_entry *pentry = NULL;
 	git_oid foo = {{0}};
 	unsigned char hdr[64];
@@ -908,7 +908,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	int error;
 	struct git_pack_idx_header hdr;
 	git_buf filename = GIT_BUF_INIT;
-	struct entry *entry;
+	struct idx_entry *entry;
 	git_oid trailer_hash, file_hash;
 	git_hash_ctx ctx;
 	git_filebuf index_file = {0};

--- a/src/xdiff/xpatience.c
+++ b/src/xdiff/xpatience.c
@@ -48,7 +48,7 @@
  */
 struct hashmap {
 	int nr, alloc;
-	struct entry {
+	struct map_entry {
 		unsigned long hash;
 		/*
 		 * 0 = unused entry, 1 = first line, 2 = second, etc.
@@ -61,7 +61,7 @@ struct hashmap {
 		 * sequence;
 		 * initially, "next" reflects only the order in file1.
 		 */
-		struct entry *next, *previous;
+		struct map_entry *next, *previous;
 	} *entries, *first, *last;
 	/* were common records found? */
 	unsigned long has_matches;
@@ -139,11 +139,11 @@ static int fill_hashmap(mmfile_t *file1, mmfile_t *file2,
 
 	/* We know exactly how large we want the hash map */
 	result->alloc = count1 * 2;
-	result->entries = (struct entry *)
-		xdl_malloc(result->alloc * sizeof(struct entry));
+	result->entries = (struct map_entry *)
+		xdl_malloc(result->alloc * sizeof(struct map_entry));
 	if (!result->entries)
 		return -1;
-	memset(result->entries, 0, result->alloc * sizeof(struct entry));
+	memset(result->entries, 0, result->alloc * sizeof(struct map_entry));
 
 	/* First, fill with entries from the first file */
 	while (count1--)
@@ -160,8 +160,8 @@ static int fill_hashmap(mmfile_t *file1, mmfile_t *file2,
  * Find the longest sequence with a smaller last element (meaning a smaller
  * line2, as we construct the sequence with entries ordered by line1).
  */
-static int binary_search(struct entry **sequence, int longest,
-		struct entry *entry)
+static int binary_search(struct map_entry **sequence, int longest,
+		struct map_entry *entry)
 {
 	int left = -1, right = longest;
 
@@ -186,11 +186,11 @@ static int binary_search(struct entry **sequence, int longest,
  * item per sequence length: the sequence with the smallest last
  * element (in terms of line2).
  */
-static struct entry *find_longest_common_sequence(struct hashmap *map)
+static struct map_entry *find_longest_common_sequence(struct hashmap *map)
 {
-	struct entry **sequence = xdl_malloc(map->nr * sizeof(struct entry *));
+	struct map_entry **sequence = xdl_malloc(map->nr * sizeof(struct map_entry *));
 	int longest = 0, i;
-	struct entry *entry;
+	struct map_entry *entry;
 
 	for (entry = map->first; entry; entry = entry->next) {
 		if (!entry->line2 || entry->line2 == NON_UNIQUE)
@@ -231,7 +231,7 @@ static int patience_diff(mmfile_t *file1, mmfile_t *file2,
 		xpparam_t const *xpp, xdfenv_t *env,
 		int line1, int count1, int line2, int count2);
 
-static int walk_common_sequence(struct hashmap *map, struct entry *first,
+static int walk_common_sequence(struct hashmap *map, struct map_entry *first,
 		int line1, int count1, int line2, int count2)
 {
 	int end1 = line1 + count1, end2 = line2 + count2;
@@ -305,7 +305,7 @@ static int patience_diff(mmfile_t *file1, mmfile_t *file2,
 		int line1, int count1, int line2, int count2)
 {
 	struct hashmap map;
-	struct entry *first;
+	struct map_entry *first;
 	int result = 0;
 
 	/* trivial case: one side is empty */


### PR DESCRIPTION
I'm experimenting with building libgit2 as a [dynamic framework](https://github.com/phatblat/git2.framework) in Xcode instead of cmake.

One of the issues I've run into is that two structs called `entry` conflict with another `entry` struct in [Darwin.POSIX.search (search.h)](http://www.freebsd.org/cgi/man.cgi?query=hcreate&manpath=SuSE+Linux/i386+11.3) that is included in Apple's SDKs.

```c
typedef struct entry	{
	char *key;
	void *data;
} ENTRY;
```

I'm proposing changing the struct names here in libgit2 since getting Apple to change this in their SDK is next to impossible. This may be a terrible idea, with impacts I'm not aware of. But, it's enough to get Xcode to be happy.