### PR TITLE
New feature: add the ablility to iterate through a directory in index

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -643,6 +643,17 @@ GIT_EXTERN(int) git_index_update_all(
  */
 GIT_EXTERN(int) git_index_find(size_t *at_pos, git_index *index, const char *path);
 
+/**
+ * Find the first position of any entries matching a prefix. To find the first position
+ * of a path inside a given folder, suffix the prefix with a '/'.
+ *
+ * @param at_pos the address to which the position of the index entry is written (optional)
+ * @param index an existing index object
+ * @param prefix the prefix to search for
+ * @return 0 with valid value in at_pos; an error code otherwise
+ */
+GIT_EXTERN(int) git_index_find_prefix(size_t *at_pos, git_index *index, const char *prefix);
+
 /**@}*/
 
 /** @name Conflict Index Entry Functions

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -155,6 +155,27 @@ void test_index_tests__find_in_empty(void)
    git_index_free(index);
 }
 
+void test_index_tests__find_prefix(void)
+{
+   git_index *index;
+   const git_index_entry *entry;
+   size_t pos;
+
+   cl_git_pass(git_index_open(&index, TEST_INDEX_PATH));
+
+   cl_git_pass(git_index_find_prefix(&pos, index, "src"));
+   entry = git_index_get_byindex(index, pos);
+   cl_assert(git__strcmp(entry->path, "src/block-sha1/sha1.c") == 0);
+
+   cl_git_pass(git_index_find_prefix(&pos, index, "src/co"));
+   entry = git_index_get_byindex(index, pos);
+   cl_assert(git__strcmp(entry->path, "src/commit.c") == 0);
+
+   cl_assert(GIT_ENOTFOUND == git_index_find_prefix(NULL, index, "blah"));
+
+   git_index_free(index);
+}
+
 void test_index_tests__write(void)
 {
    git_index *index;


### PR DESCRIPTION
git_index_directory_iterator, git_index_directory_iterator_new,
git_index_directory_iterator_next and git_index_directory_iterator_free
are added.

I know we could achieve this by going through git_tree_entry recursively for stage 0.
But I think my patch here is more efficient compared to that approach. Further this patch
also support going through a directory in other stages.