### PR TITLE
diff: don't error out on an invalid regex

### DIFF
--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -97,8 +97,7 @@ static int diff_driver_add_patterns(
 	for (scan = regex_str; scan; scan = end) {
 		/* get pattern to fill in */
 		if ((pat = git_array_alloc(drv->fn_patterns)) == NULL) {
-			error = -1;
-			break;
+			return -1;
 		}
 
 		pat->flags = regex_flags;
@@ -117,10 +116,9 @@ static int diff_driver_add_patterns(
 			break;
 
 		if ((error = regcomp(&pat->re, buf.ptr, regex_flags)) != 0) {
-			/* if regex fails to compile, warn? fail? */
-			error = giterr_set_regex(&pat->re, error);
-			regfree(&pat->re);
-			break;
+			/*
+			 * TODO: issue a warning
+			 */
 		}
 	}
 
@@ -128,7 +126,8 @@ static int diff_driver_add_patterns(
 		(void)git_array_pop(drv->fn_patterns); /* release last item */
 	git_buf_free(&buf);
 
-	return error;
+	/* We want to ignore bad patterns, so return success regardless */
+	return 0;
 }
 
 static int diff_driver_xfuncname(const git_config_entry *entry, void *payload)


### PR DESCRIPTION
When parsing user-provided regex patterns for functions, we must not
fail to provide a diff just because a pattern is not well
formed. Ignore it instead.

--

This fixes #3235 