### PR TITLE
transport: provide a way to get the callbacks

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -211,6 +211,28 @@ GIT_EXTERN(int) git_transport_smart(
 	git_remote *owner,
 	/* (git_smart_subtransport_definition *) */ void *payload);
 
+/**
+ * Call the certificate check for this transport.
+ *
+ * @param transport a smart transport
+ * @param cert the certificate to pass to the caller
+ * @param valid whether we believe the certificate is valid
+ * @param hostname the hostname we connected to
+ * @return the return value of the callback
+ */
+GIT_EXTERN(int) git_transport_smart_certificate_check(git_transport *transport, git_cert *cert, int valid, const char *hostname);
+
+/**
+ * Call the credentials callback for this transport
+ *
+ * @param out the pointer where the creds are to be stored
+ * @param transport a smart transport
+ * @param user the user we saw on the url (if any)
+ * @param methods available methods for authentication
+ * @return the return value of the callback
+ */
+GIT_EXTERN(int) git_transport_smart_credentials(git_cred **out, git_transport *transport, const char *user, int methods);
+
 /*
  *** End of base transport interface ***
  *** Begin interface for subtransports for the smart transport ***

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -307,6 +307,17 @@ GIT_EXTERN(int) git_cred_ssh_key_memory_new(
 	const char *privatekey,
 	const char *passphrase);
 
+
+/**
+ * Free a credential.
+ *
+ * This is only necessary if you own the object; that is, if you are a
+ * transport.
+ *
+ * @param cred the object to free
+ */
+GIT_EXTERN(void) git_cred_free(git_cred *cred);
+
 /**
  * Signature of a function which acquires a credential object.
  *

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -378,3 +378,11 @@ int git_cred_username_new(git_cred **cred, const char *username)
 	*cred = (git_cred *) c;
 	return 0;
 }
+
+void git_cred_free(git_cred *cred)
+{
+	if (!cred)
+		return;
+
+	cred->free(cred);
+}

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -372,6 +372,20 @@ static int ref_name_cmp(const void *a, const void *b)
 	return strcmp(ref_a->head.name, ref_b->head.name);
 }
 
+int git_transport_smart_certificate_check(git_transport *transport, git_cert *cert, int valid, const char *hostname)
+{
+	transport_smart *t = (transport_smart *)transport;
+
+	return t->certificate_check_cb(cert, valid, hostname, t->message_cb_payload);
+}
+
+int git_transport_smart_credentials(git_cred **out, git_transport *transport, const char *user, int methods)
+{
+	transport_smart *t = (transport_smart *)transport;
+
+	return t->cred_acquire_cb(out, t->url, user, methods, t->cred_acquire_payload);
+}
+
 int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 {
 	transport_smart *t;


### PR DESCRIPTION
libgit2 implementations of smart subtransports can simply reach through
the structure, but external implementors cannot. Provide this functions
as a way for the smart subtransports to get the callbacks as set by the
user.

---

The current external implementors I know of don't need this, either because it's just for testing, or because their purpose is to bypass the libgit2 authentication bits.

But if you want to write one which behaves just like the built-in ones, we need access to these functions.