### PR TITLE
Provide path matching in the iterators (for faster diffs)

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -130,7 +130,9 @@ typedef enum {
 	GIT_DIFF_INCLUDE_CASECHANGE = (1u << 11),
 
 	/** If the pathspec is set in the diff options, this flags means to
-	 *  apply it as an exact match instead of as an fnmatch pattern.
+	 *  use exact prefix matches instead of an fnmatch pattern.  Each
+	 *  path in the list must either be a full filename or a subdirectory
+	 *  prefix.
 	 */
 	GIT_DIFF_DISABLE_PATHSPEC_MATCH = (1u << 12),
 

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -163,6 +163,13 @@ typedef enum {
 	/** Include unreadable files in the diff */
 	GIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED = (1u << 17),
 
+	/** Use literal path matching in the iterators.  This is more broad
+	*  than the DISABLE_PATHSPEC_MATCH flag.  The caller must provide an
+	*  array of paths (no patterns or prefixes).  Only values included in
+	*  that list will be returned.
+	*/
+	GIT_DIFF_ENABLE_FILELIST_MATCH = (1u << 18),
+
 	/*
 	 * Options controlling how output will be generated
 	 */

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -165,13 +165,6 @@ typedef enum {
 	/** Include unreadable files in the diff */
 	GIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED = (1u << 17),
 
-	/** Use literal path matching in the iterators.  This is more broad
-	*  than the DISABLE_PATHSPEC_MATCH flag.  The caller must provide an
-	*  array of paths (no patterns or prefixes).  Only values included in
-	*  that list will be returned.
-	*/
-	GIT_DIFF_ENABLE_FILELIST_MATCH = (1u << 18),
-
 	/*
 	 * Options controlling how output will be generated
 	 */

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -129,10 +129,12 @@ typedef enum {
 	 */
 	GIT_DIFF_INCLUDE_CASECHANGE = (1u << 11),
 
-	/** If the pathspec is set in the diff options, this flags means to
-	 *  use exact prefix matches instead of an fnmatch pattern.  Each
-	 *  path in the list must either be a full filename or a subdirectory
-	 *  prefix.
+	/** If the pathspec is set in the diff options, this flags indicates
+	 *  that the paths will be treated as literal paths instead of
+	 *  fnmatch patterns.  Each path in the list must either be a full
+	 *  path to a file or a directory.  (A trailing slash indicates that
+	 *  the path will _only_ match a directory).  If a directory is
+	 *  specified, all children will be included.
 	 */
 	GIT_DIFF_DISABLE_PATHSPEC_MATCH = (1u << 12),
 

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2652,6 +2652,7 @@ int git_checkout_tree(
 	git_index *index;
 	git_tree *tree = NULL;
 	git_iterator *tree_i = NULL;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	if (!treeish && !repo) {
 		giterr_set(GITERR_CHECKOUT,
@@ -2687,7 +2688,12 @@ int git_checkout_tree(
 	if ((error = git_repository_index(&index, repo)) < 0)
 		return error;
 
-	if (!(error = git_iterator_for_tree(&tree_i, tree, NULL)))
+	if ((opts->checkout_strategy & GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH)) {
+		iter_opts.pathlist.count = opts->paths.count;
+		iter_opts.pathlist.strings = opts->paths.strings;
+	}
+
+	if (!(error = git_iterator_for_tree(&tree_i, tree, &iter_opts)))
 		error = git_checkout_iterator(tree_i, index, opts);
 
 	git_iterator_free(tree_i);

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2471,11 +2471,12 @@ int git_checkout_iterator(
 {
 	int error = 0;
 	git_iterator *baseline = NULL, *workdir = NULL;
+	git_iterator_options baseline_opts = GIT_ITERATOR_OPTIONS_INIT,
+		workdir_opts = GIT_ITERATOR_OPTIONS_INIT;
 	checkout_data data = {0};
 	git_diff_options diff_opts = GIT_DIFF_OPTIONS_INIT;
 	uint32_t *actions = NULL;
 	size_t *counts = NULL;
-	git_iterator_flag_t iterflags = 0;
 
 	/* initialize structures and options */
 	error = checkout_data_init(&data, target, opts);
@@ -2499,25 +2500,30 @@ int git_checkout_iterator(
 
 	/* set up iterators */
 
-	iterflags = git_iterator_ignore_case(target) ?
+	workdir_opts.flags = git_iterator_ignore_case(target) ?
 		GIT_ITERATOR_IGNORE_CASE : GIT_ITERATOR_DONT_IGNORE_CASE;
+	workdir_opts.flags |= GIT_ITERATOR_DONT_AUTOEXPAND;
+	workdir_opts.start = data.pfx;
+	workdir_opts.end = data.pfx;
 
 	if ((error = git_iterator_reset(target, data.pfx, data.pfx)) < 0 ||
 		(error = git_iterator_for_workdir_ext(
 			&workdir, data.repo, data.opts.target_directory, index, NULL,
-			iterflags | GIT_ITERATOR_DONT_AUTOEXPAND,
-			data.pfx, data.pfx)) < 0)
+			&workdir_opts)) < 0)
 		goto cleanup;
+
+	baseline_opts.flags = git_iterator_ignore_case(target) ?
+		GIT_ITERATOR_IGNORE_CASE : GIT_ITERATOR_DONT_IGNORE_CASE;
+	baseline_opts.start = data.pfx;
+	baseline_opts.end = data.pfx;
 
 	if (data.opts.baseline_index) {
 		if ((error = git_iterator_for_index(
-				&baseline, data.opts.baseline_index,
-				iterflags, data.pfx, data.pfx)) < 0)
+				&baseline, data.opts.baseline_index, &baseline_opts)) < 0)
 			goto cleanup;
 	} else {
 		if ((error = git_iterator_for_tree(
-				&baseline, data.opts.baseline,
-				iterflags, data.pfx, data.pfx)) < 0)
+				&baseline, data.opts.baseline, &baseline_opts)) < 0)
 			goto cleanup;
 	}
 
@@ -2625,7 +2631,7 @@ int git_checkout_index(
 		return error;
 	GIT_REFCOUNT_INC(index);
 
-	if (!(error = git_iterator_for_index(&index_i, index, 0, NULL, NULL)))
+	if (!(error = git_iterator_for_index(&index_i, index, NULL)))
 		error = git_checkout_iterator(index_i, index, opts);
 
 	if (owned)
@@ -2681,7 +2687,7 @@ int git_checkout_tree(
 	if ((error = git_repository_index(&index, repo)) < 0)
 		return error;
 
-	if (!(error = git_iterator_for_tree(&tree_i, tree, 0, NULL, NULL)))
+	if (!(error = git_iterator_for_tree(&tree_i, tree, NULL)))
 		error = git_checkout_iterator(tree_i, index, opts);
 
 	git_iterator_free(tree_i);

--- a/src/index.c
+++ b/src/index.c
@@ -728,6 +728,7 @@ static int truncate_racily_clean(git_index *index)
 		if (!is_racy_timestamp(ts, entry))
 			continue;
 
+		/* TODO: use the (non-fnmatching) filelist iterator */
 		diff_opts.pathspec.count = 1;
 		diff_opts.pathspec.strings = (char **) &entry->path;
 

--- a/src/index.c
+++ b/src/index.c
@@ -2658,6 +2658,7 @@ int git_index_read_index(
 		remove_entries = GIT_VECTOR_INIT;
 	git_iterator *index_iterator = NULL;
 	git_iterator *new_iterator = NULL;
+	git_iterator_options opts = GIT_ITERATOR_OPTIONS_INIT;
 	const git_index_entry *old_entry, *new_entry;
 	git_index_entry *entry;
 	size_t i;
@@ -2667,10 +2668,10 @@ int git_index_read_index(
 		(error = git_vector_init(&remove_entries, index->entries.length, NULL)) < 0)
 		goto done;
 
-	if ((error = git_iterator_for_index(&index_iterator,
-			index, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&new_iterator,
-			(git_index *)new_index, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0)
+	opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	if ((error = git_iterator_for_index(&index_iterator, index, &opts)) < 0 ||
+		(error = git_iterator_for_index(&new_iterator, (git_index *)new_index, &opts)) < 0)
 		goto done;
 
 	if (((error = git_iterator_current(&old_entry, index_iterator)) < 0 && 

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -38,6 +38,17 @@ typedef enum {
 	GIT_ITERATOR_INCLUDE_CONFLICTS = (1u << 5),
 } git_iterator_flag_t;
 
+
+typedef struct {
+	const char *start;
+	const char *end;
+
+	/* flags, from above */
+	unsigned int flags;
+} git_iterator_options;
+
+#define GIT_ITERATOR_OPTIONS_INIT {0}
+
 typedef struct {
 	int (*current)(const git_index_entry **, git_iterator *);
 	int (*advance)(const git_index_entry **, git_iterator *);
@@ -61,9 +72,7 @@ struct git_iterator {
 
 extern int git_iterator_for_nothing(
 	git_iterator **out,
-	git_iterator_flag_t flags,
-	const char *start,
-	const char *end);
+	git_iterator_options *options);
 
 /* tree iterators will match the ignore_case value from the index of the
  * repository, unless you override with a non-zero flag value
@@ -71,9 +80,7 @@ extern int git_iterator_for_nothing(
 extern int git_iterator_for_tree(
 	git_iterator **out,
 	git_tree *tree,
-	git_iterator_flag_t flags,
-	const char *start,
-	const char *end);
+	git_iterator_options *options);
 
 /* index iterators will take the ignore_case value from the index; the
  * ignore_case flags are not used
@@ -81,9 +88,7 @@ extern int git_iterator_for_tree(
 extern int git_iterator_for_index(
 	git_iterator **out,
 	git_index *index,
-	git_iterator_flag_t flags,
-	const char *start,
-	const char *end);
+	git_iterator_options *options);
 
 extern int git_iterator_for_workdir_ext(
 	git_iterator **out,
@@ -91,9 +96,7 @@ extern int git_iterator_for_workdir_ext(
 	const char *repo_workdir,
 	git_index *index,
 	git_tree *tree,
-	git_iterator_flag_t flags,
-	const char *start,
-	const char *end);
+	git_iterator_options *options);
 
 /* workdir iterators will match the ignore_case value from the index of the
  * repository, unless you override with a non-zero flag value
@@ -103,11 +106,9 @@ GIT_INLINE(int) git_iterator_for_workdir(
 	git_repository *repo,
 	git_index *index,
 	git_tree *tree,
-	git_iterator_flag_t flags,
-	const char *start,
-	const char *end)
+	git_iterator_options *options)
 {
-	return git_iterator_for_workdir_ext(out, repo, NULL, index, tree, flags, start, end);
+	return git_iterator_for_workdir_ext(out, repo, NULL, index, tree, options);
 }
 
 /* for filesystem iterators, you have to explicitly pass in the ignore_case
@@ -116,9 +117,7 @@ GIT_INLINE(int) git_iterator_for_workdir(
 extern int git_iterator_for_filesystem(
 	git_iterator **out,
 	const char *root,
-	git_iterator_flag_t flags,
-	const char *start,
-	const char *end);
+	git_iterator_options *options);
 
 extern void git_iterator_free(git_iterator *iter);
 

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -43,6 +43,11 @@ typedef struct {
 	const char *start;
 	const char *end;
 
+	/* paths to include in the iterator (literal).  any paths not listed
+	 * will be excluded.  note that this vector may be resorted!
+	 */
+	git_vector *pathlist;
+
 	/* flags, from above */
 	unsigned int flags;
 } git_iterator_options;
@@ -65,6 +70,8 @@ struct git_iterator {
 	git_repository *repo;
 	char *start;
 	char *end;
+	git_vector *pathlist;
+	size_t pathlist_idx;
 	int (*prefixcomp)(const char *str, const char *prefix);
 	size_t stat_calls;
 	unsigned int flags;

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -38,15 +38,14 @@ typedef enum {
 	GIT_ITERATOR_INCLUDE_CONFLICTS = (1u << 5),
 } git_iterator_flag_t;
 
-
 typedef struct {
 	const char *start;
 	const char *end;
 
-	/* paths to include in the iterator (literal).  any paths not listed
-	 * will be excluded.  note that this vector may be resorted!
+	/* paths to include in the iterator (literal).  if set, any paths not
+	 * listed here will be excluded from iteration.
 	 */
-	git_vector *pathlist;
+	git_strarray pathlist;
 
 	/* flags, from above */
 	unsigned int flags;
@@ -70,8 +69,9 @@ struct git_iterator {
 	git_repository *repo;
 	char *start;
 	char *end;
-	git_vector *pathlist;
-	size_t pathlist_idx;
+	git_vector pathlist;
+	int (*strcomp)(const char *a, const char *b);
+	int (*strncomp)(const char *a, const char *b, size_t n);
 	int (*prefixcomp)(const char *str, const char *prefix);
 	size_t stat_calls;
 	unsigned int flags;
@@ -277,7 +277,8 @@ extern git_index *git_iterator_get_index(git_iterator *iter);
 typedef enum {
 	GIT_ITERATOR_STATUS_NORMAL = 0,
 	GIT_ITERATOR_STATUS_IGNORED = 1,
-	GIT_ITERATOR_STATUS_EMPTY = 2
+	GIT_ITERATOR_STATUS_EMPTY = 2,
+	GIT_ITERATOR_STATUS_FILTERED = 3
 } git_iterator_status_t;
 
 /* Advance over a directory and check if it contains no files or just

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -70,6 +70,7 @@ struct git_iterator {
 	char *start;
 	char *end;
 	git_vector pathlist;
+	size_t pathlist_walk_idx;
 	int (*strcomp)(const char *a, const char *b);
 	int (*strncomp)(const char *a, const char *b, size_t n);
 	int (*prefixcomp)(const char *str, const char *prefix);

--- a/src/merge.c
+++ b/src/merge.c
@@ -2356,10 +2356,8 @@ static int merge_check_index(size_t *conflicts, git_repository *repo, git_index 
 			goto done;
 	}
 
-	opts.pathspec.count = staged_paths.length;
-	opts.pathspec.strings = (char **)staged_paths.contents;
-
 	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+	iter_opts.pathlist = &staged_paths;
 
 	if ((error = git_iterator_for_index(&iter_repo, index_repo, &iter_opts)) < 0 ||
 		(error = git_iterator_for_index(&iter_new, index_new, &iter_opts)) < 0 ||
@@ -2406,6 +2404,7 @@ static int merge_check_workdir(size_t *conflicts, git_repository *repo, git_inde
 	 * will be applied by the merge (including conflicts).  Ensure that there
 	 * are no changes in the workdir to these paths.
 	 */
+	opts.flags |= GIT_DIFF_ENABLE_FILELIST_MATCH;
 	opts.pathspec.count = merged_paths->length;
 	opts.pathspec.strings = (char **)merged_paths->contents;
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -2357,7 +2357,8 @@ static int merge_check_index(size_t *conflicts, git_repository *repo, git_index 
 	}
 
 	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
-	iter_opts.pathlist = &staged_paths;
+	iter_opts.pathlist.strings = (char **)staged_paths.contents;
+	iter_opts.pathlist.count = staged_paths.length;
 
 	if ((error = git_iterator_for_index(&iter_repo, index_repo, &iter_opts)) < 0 ||
 		(error = git_iterator_for_index(&iter_new, index_new, &iter_opts)) < 0 ||

--- a/src/merge.c
+++ b/src/merge.c
@@ -2405,7 +2405,7 @@ static int merge_check_workdir(size_t *conflicts, git_repository *repo, git_inde
 	 * will be applied by the merge (including conflicts).  Ensure that there
 	 * are no changes in the workdir to these paths.
 	 */
-	opts.flags |= GIT_DIFF_ENABLE_FILELIST_MATCH;
+	opts.flags |= GIT_DIFF_DISABLE_PATHSPEC_MATCH;
 	opts.pathspec.count = merged_paths->length;
 	opts.pathspec.strings = (char **)merged_paths->contents;
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -1695,10 +1695,14 @@ on_error:
 
 static git_iterator *iterator_given_or_empty(git_iterator **empty, git_iterator *given)
 {
+	git_iterator_options opts = GIT_ITERATOR_OPTIONS_INIT;
+
 	if (given)
 		return given;
 
-	if (git_iterator_for_nothing(empty, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL) < 0)
+	opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	if (git_iterator_for_nothing(empty, &opts) < 0)
 		return NULL;
 
 	return *empty;
@@ -1780,14 +1784,17 @@ int git_merge_trees(
 	const git_merge_options *merge_opts)
 {
 	git_iterator *ancestor_iter = NULL, *our_iter = NULL, *their_iter = NULL;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	int error;
 
-	if ((error = git_iterator_for_tree(&ancestor_iter, (git_tree *)ancestor_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_tree(&our_iter, (git_tree *)our_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_tree(&their_iter, (git_tree *)their_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0)
+	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	if ((error = git_iterator_for_tree(
+			&ancestor_iter, (git_tree *)ancestor_tree, &iter_opts)) < 0 ||
+		(error = git_iterator_for_tree(
+			&our_iter, (git_tree *)our_tree, &iter_opts)) < 0 ||
+		(error = git_iterator_for_tree(
+			&their_iter, (git_tree *)their_tree, &iter_opts)) < 0)
 		goto done;
 
 	error = git_merge__iterators(
@@ -2319,6 +2326,7 @@ static int merge_check_index(size_t *conflicts, git_repository *repo, git_index 
 	git_tree *head_tree = NULL;
 	git_index *index_repo = NULL;
 	git_iterator *iter_repo = NULL, *iter_new = NULL;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_diff *staged_diff_list = NULL, *index_diff_list = NULL;
 	git_diff_delta *delta;
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
@@ -2351,8 +2359,10 @@ static int merge_check_index(size_t *conflicts, git_repository *repo, git_index 
 	opts.pathspec.count = staged_paths.length;
 	opts.pathspec.strings = (char **)staged_paths.contents;
 
-	if ((error = git_iterator_for_index(&iter_repo, index_repo, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&iter_new, index_new, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
+	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	if ((error = git_iterator_for_index(&iter_repo, index_repo, &iter_opts)) < 0 ||
+		(error = git_iterator_for_index(&iter_new, index_new, &iter_opts)) < 0 ||
 		(error = git_diff__from_iterators(&index_diff_list, repo, iter_repo, iter_new, &opts)) < 0)
 		goto done;
 
@@ -2414,6 +2424,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 {
 	git_tree *head_tree = NULL;
 	git_iterator *iter_head = NULL, *iter_new = NULL;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_diff *merged_list = NULL;
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_diff_delta *delta;
@@ -2422,9 +2433,11 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 	const git_index_entry *e;
 	int error = 0;
 
+	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
 	if ((error = git_repository_head_tree(&head_tree, repo)) < 0 ||
-		(error = git_iterator_for_tree(&iter_head, head_tree, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&iter_new, index_new, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
+		(error = git_iterator_for_tree(&iter_head, head_tree, &iter_opts)) < 0 ||
+		(error = git_iterator_for_index(&iter_new, index_new, &iter_opts)) < 0 ||
 		(error = git_diff__from_iterators(&merged_list, repo, iter_head, iter_new, &opts)) < 0)
 		goto done;
 

--- a/src/notes.c
+++ b/src/notes.c
@@ -663,7 +663,7 @@ int git_note_iterator_new(
 	if (error < 0)
 		goto cleanup;
 
-	if ((error = git_iterator_for_tree(it, tree, 0, NULL, NULL)) < 0)
+	if ((error = git_iterator_for_tree(it, tree, NULL)) < 0)
 		git_iterator_free(*it);
 
 cleanup:

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -524,16 +524,16 @@ int git_pathspec_match_workdir(
 	uint32_t flags,
 	git_pathspec *ps)
 {
-	int error = 0;
 	git_iterator *iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
+	int error = 0;
 
 	assert(repo);
 
-	if (!(error = git_iterator_for_workdir(
-			&iter, repo, NULL, NULL, pathspec_match_iter_flags(flags), NULL, NULL))) {
+	iter_opts.flags = pathspec_match_iter_flags(flags);
 
+	if (!(error = git_iterator_for_workdir(&iter, repo, NULL, NULL, &iter_opts))) {
 		error = pathspec_match_from_iterator(out, iter, flags, ps);
-
 		git_iterator_free(iter);
 	}
 
@@ -546,16 +546,16 @@ int git_pathspec_match_index(
 	uint32_t flags,
 	git_pathspec *ps)
 {
-	int error = 0;
 	git_iterator *iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
+	int error = 0;
 
 	assert(index);
 
-	if (!(error = git_iterator_for_index(
-			&iter, index, pathspec_match_iter_flags(flags), NULL, NULL))) {
+	iter_opts.flags = pathspec_match_iter_flags(flags);
 
+	if (!(error = git_iterator_for_index(&iter, index, &iter_opts))) {
 		error = pathspec_match_from_iterator(out, iter, flags, ps);
-
 		git_iterator_free(iter);
 	}
 
@@ -568,16 +568,16 @@ int git_pathspec_match_tree(
 	uint32_t flags,
 	git_pathspec *ps)
 {
-	int error = 0;
 	git_iterator *iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
+	int error = 0;
 
 	assert(tree);
 
-	if (!(error = git_iterator_for_tree(
-			&iter, tree, pathspec_match_iter_flags(flags), NULL, NULL))) {
+	iter_opts.flags = pathspec_match_iter_flags(flags);
 
+	if (!(error = git_iterator_for_tree(&iter, tree, &iter_opts))) {
 		error = pathspec_match_from_iterator(out, iter, flags, ps);
-
 		git_iterator_free(iter);
 	}
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -480,14 +480,16 @@ static int iter_load_loose_paths(refdb_fs_backend *backend, refdb_fs_iter *iter)
 	int error = 0;
 	git_buf path = GIT_BUF_INIT;
 	git_iterator *fsit = NULL;
+	git_iterator_options fsit_opts = GIT_ITERATOR_OPTIONS_INIT;
 	const git_index_entry *entry = NULL;
 
 	if (!backend->path) /* do nothing if no path for loose refs */
 		return 0;
 
+	fsit_opts.flags = backend->iterator_flags;
+
 	if ((error = git_buf_printf(&path, "%s/refs", backend->path)) < 0 ||
-		(error = git_iterator_for_filesystem(
-			&fsit, path.ptr, backend->iterator_flags, NULL, NULL)) < 0) {
+		(error = git_iterator_for_filesystem(&fsit, path.ptr, &fsit_opts)) < 0) {
 		git_buf_free(&path);
 		return error;
 	}

--- a/src/stash.c
+++ b/src/stash.c
@@ -679,12 +679,14 @@ static int merge_indexes(
 	git_index *theirs_index)
 {
 	git_iterator *ancestor = NULL, *ours = NULL, *theirs = NULL;
-	const git_iterator_flag_t flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	int error;
 
-	if ((error = git_iterator_for_tree(&ancestor, ancestor_tree, flags, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&ours, ours_index, flags, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&theirs, theirs_index, flags, NULL, NULL)) < 0)
+	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	if ((error = git_iterator_for_tree(&ancestor, ancestor_tree, &iter_opts)) < 0 ||
+		(error = git_iterator_for_index(&ours, ours_index, &iter_opts)) < 0 ||
+		(error = git_iterator_for_index(&theirs, theirs_index, &iter_opts)) < 0)
 		goto done;
 
 	error = git_merge__iterators(out, repo, ancestor, ours, theirs, NULL);
@@ -704,12 +706,14 @@ static int merge_index_and_tree(
 	git_tree *theirs_tree)
 {
 	git_iterator *ancestor = NULL, *ours = NULL, *theirs = NULL;
-	const git_iterator_flag_t flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	int error;
 
-	if ((error = git_iterator_for_tree(&ancestor, ancestor_tree, flags, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_index(&ours, ours_index, flags, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_tree(&theirs, theirs_tree, flags, NULL, NULL)) < 0)
+	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	if ((error = git_iterator_for_tree(&ancestor, ancestor_tree, &iter_opts)) < 0 ||
+		(error = git_iterator_for_index(&ours, ours_index, &iter_opts)) < 0 ||
+		(error = git_iterator_for_tree(&theirs, theirs_tree, &iter_opts)) < 0)
 		goto done;
 
 	error = git_merge__iterators(out, repo, ancestor, ours, theirs, NULL);
@@ -797,14 +801,15 @@ static int stage_new_files(
 	git_tree *tree)
 {
 	git_iterator *iterators[2] = { NULL, NULL };
+	git_iterator_options iterator_options = GIT_ITERATOR_OPTIONS_INIT;
 	git_index *index = NULL;
 	int error;
 
 	if ((error = git_index_new(&index)) < 0 ||
-		(error = git_iterator_for_tree(&iterators[0], parent_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0 ||
-		(error = git_iterator_for_tree(&iterators[1], tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL)) < 0)
+		(error = git_iterator_for_tree(
+			&iterators[0], parent_tree, &iterator_options)) < 0 ||
+		(error = git_iterator_for_tree(
+			&iterators[1], tree, &iterator_options)) < 0)
 		goto done;
 
 	error = git_iterator_walk(iterators, 2, stage_new_file, index);

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -286,7 +286,7 @@ static int submodules_from_index(git_strmap *map, git_index *idx)
        git_iterator *i;
        const git_index_entry *entry;
 
-       if ((error = git_iterator_for_index(&i, idx, 0, NULL, NULL)) < 0)
+       if ((error = git_iterator_for_index(&i, idx, NULL)) < 0)
                return error;
 
        while (!(error = git_iterator_advance(&entry, i))) {
@@ -322,7 +322,7 @@ static int submodules_from_head(git_strmap *map, git_tree *head)
        git_iterator *i;
        const git_index_entry *entry;
 
-       if ((error = git_iterator_for_tree(&i, head, 0, NULL, NULL)) < 0)
+       if ((error = git_iterator_for_tree(&i, head, NULL)) < 0)
                return error;
 
        while (!(error = git_iterator_advance(&entry, i))) {

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -581,30 +581,6 @@ void test_diff_workdir__to_index_with_pathlist_disabling_fnmatch(void)
 
 	git_diff_free(diff);
 
-	/* ensure that multiple trailing slashes are ignored */
-	pathspec = "subdir//////";
-
-	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
-
-	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
-		memset(&exp, 0, sizeof(exp));
-
-		if (use_iterator)
-			cl_git_pass(diff_foreach_via_iterator(
-				diff, diff_file_cb, NULL, NULL, NULL, &exp));
-		else
-			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
-
-		cl_assert_equal_i(3, exp.files);
-		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
-		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_DELETED]);
-		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_MODIFIED]);
-		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
-		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_UNTRACKED]);
-	}
-
-	git_diff_free(diff);
-
 	/* ensure that fnmatching is completely disabled */
 	pathspec = "subdir/*";
 

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -444,6 +444,216 @@ void test_diff_workdir__to_index_with_pathspec(void)
 	git_diff_free(diff);
 }
 
+void test_diff_workdir__to_index_with_pathlist_disabling_fnmatch(void)
+{
+	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+	git_diff *diff = NULL;
+	diff_expects exp;
+	char *pathspec = NULL;
+	int use_iterator;
+
+	g_repo = cl_git_sandbox_init("status");
+
+	opts.context_lines = 3;
+	opts.interhunk_lines = 1;
+	opts.flags |= GIT_DIFF_INCLUDE_IGNORED | GIT_DIFF_INCLUDE_UNTRACKED |
+		GIT_DIFF_DISABLE_PATHSPEC_MATCH;
+	opts.pathspec.strings = &pathspec;
+	opts.pathspec.count   = 0;
+
+	/* ensure that an empty pathspec list is ignored */
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(13, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(4, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(4, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(4, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	/* ensure that a single NULL pathspec is filtered out (like when using
+	 * fnmatch filtering)
+	 */
+	opts.pathspec.strings = &pathspec;
+	opts.pathspec.count   = 1;
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(13, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(4, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(4, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(4, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	pathspec = "modified_file";
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(1, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	/* ensure that subdirs can be specified */
+	pathspec = "subdir";
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(3, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	/* ensure that subdirs can be specified with a trailing slash */
+	pathspec = "subdir/";
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(3, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(1, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	/* ensure that fnmatching is completely disabled */
+	pathspec = "subdir/*";
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(0, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	/* ensure that the prefix matching isn't completely braindead */
+	pathspec = "subdi";
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(0, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+
+	/* ensure that fnmatching isn't working at all */
+	pathspec = "*_deleted";
+
+	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, NULL, &opts));
+
+	for (use_iterator = 0; use_iterator <= 1; use_iterator++) {
+		memset(&exp, 0, sizeof(exp));
+
+		if (use_iterator)
+			cl_git_pass(diff_foreach_via_iterator(
+				diff, diff_file_cb, NULL, NULL, NULL, &exp));
+		else
+			cl_git_pass(git_diff_foreach(diff, diff_file_cb, NULL, NULL, NULL, &exp));
+
+		cl_assert_equal_i(0, exp.files);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_ADDED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_DELETED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_MODIFIED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_IGNORED]);
+		cl_assert_equal_i(0, exp.file_status[GIT_DELTA_UNTRACKED]);
+	}
+
+	git_diff_free(diff);
+}
+
 void test_diff_workdir__filemode_changes(void)
 {
 	git_diff *diff = NULL;

--- a/tests/merge/trees/treediff.c
+++ b/tests/merge/trees/treediff.c
@@ -44,6 +44,7 @@ static void test_find_differences(
     git_oid ancestor_oid, ours_oid, theirs_oid;
     git_tree *ancestor_tree, *ours_tree, *theirs_tree;
 	git_iterator *ancestor_iter, *ours_iter, *theirs_iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	git_merge_options opts = GIT_MERGE_OPTIONS_INIT;
 	opts.tree_flags |= GIT_MERGE_TREE_FIND_RENAMES;
@@ -67,12 +68,11 @@ static void test_find_differences(
 	cl_git_pass(git_tree_lookup(&ours_tree, repo, &ours_oid));
 	cl_git_pass(git_tree_lookup(&theirs_tree, repo, &theirs_oid));
 
-	cl_git_pass(git_iterator_for_tree(&ancestor_iter, ancestor_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
-	cl_git_pass(git_iterator_for_tree(&ours_iter, ours_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
-	cl_git_pass(git_iterator_for_tree(&theirs_iter, theirs_tree,
-			GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+	iter_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	cl_git_pass(git_iterator_for_tree(&ancestor_iter, ancestor_tree, &iter_opts));
+	cl_git_pass(git_iterator_for_tree(&ours_iter, ours_tree, &iter_opts));
+	cl_git_pass(git_iterator_for_tree(&theirs_iter, theirs_tree, &iter_opts));
 
 	cl_git_pass(git_merge_diff_list__find_differences(merge_diff_list, ancestor_iter, ours_iter, theirs_iter));
 	cl_git_pass(git_merge_diff_list__find_renames(repo, merge_diff_list, &opts));

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -26,7 +26,7 @@ static void expect_iterator_items(
 	const git_index_entry *entry;
 	int count, error;
 	int no_trees = !(git_iterator_flags(i) & GIT_ITERATOR_INCLUDE_TREES);
-	bool v = false;
+	bool v = true;
 
 	if (expected_flat < 0) { v = true; expected_flat = -expected_flat; }
 	if (expected_total < 0) { v = true; expected_total = -expected_total; }
@@ -1236,8 +1236,11 @@ void test_repo_iterator__workdirfilelist(void)
 	cl_git_pass(git_vector_insert(&filelist, "c"));
 	cl_git_pass(git_vector_insert(&filelist, "D"));
 	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k.a"));
+	cl_git_pass(git_vector_insert(&filelist, "k.b"));
 	cl_git_pass(git_vector_insert(&filelist, "k/1"));
 	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+	cl_git_pass(git_vector_insert(&filelist, "kZZZZZZZ"));
 	cl_git_pass(git_vector_insert(&filelist, "L/1"));
 
 	g_repo = cl_git_sandbox_init("icase");
@@ -1284,8 +1287,11 @@ void test_repo_iterator__workdirfilelist_icase(void)
 	cl_git_pass(git_vector_insert(&filelist, "c"));
 	cl_git_pass(git_vector_insert(&filelist, "D"));
 	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k.a"));
+	cl_git_pass(git_vector_insert(&filelist, "k.b"));
 	cl_git_pass(git_vector_insert(&filelist, "k/1"));
 	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+	cl_git_pass(git_vector_insert(&filelist, "kZZZZ"));
 	cl_git_pass(git_vector_insert(&filelist, "L/1"));
 
 	g_repo = cl_git_sandbox_init("icase");

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -1162,6 +1162,76 @@ void test_repo_iterator__indexfilelist_2(void)
 	git_vector_free(&filelist);
 }
 
+void test_repo_iterator__indexfilelist_3(void)
+{
+	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
+	git_index *index;
+	git_vector filelist = GIT_VECTOR_INIT;
+
+	g_repo = cl_git_sandbox_init("icase");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_pass(git_vector_init(&filelist, 100, &git__strcmp_cb));
+	cl_git_pass(git_vector_insert(&filelist, "0"));
+	cl_git_pass(git_vector_insert(&filelist, "c"));
+	cl_git_pass(git_vector_insert(&filelist, "D"));
+	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k/"));
+	cl_git_pass(git_vector_insert(&filelist, "k.a"));
+	cl_git_pass(git_vector_insert(&filelist, "k.b"));
+	cl_git_pass(git_vector_insert(&filelist, "kZZZZZZZ"));
+
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
+
+	i_opts.start = "b";
+	i_opts.end = "k/D";
+
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
+	expect_iterator_items(i, 8, NULL, 8, NULL);
+	git_iterator_free(i);
+
+	git_index_free(index);
+	git_vector_free(&filelist);
+}
+
+void test_repo_iterator__indexfilelist_4(void)
+{
+	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
+	git_index *index;
+	git_vector filelist = GIT_VECTOR_INIT;
+
+	g_repo = cl_git_sandbox_init("icase");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	cl_git_pass(git_vector_init(&filelist, 100, &git__strcmp_cb));
+	cl_git_pass(git_vector_insert(&filelist, "0"));
+	cl_git_pass(git_vector_insert(&filelist, "c"));
+	cl_git_pass(git_vector_insert(&filelist, "D"));
+	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k"));
+	cl_git_pass(git_vector_insert(&filelist, "k.a"));
+	cl_git_pass(git_vector_insert(&filelist, "k.b"));
+	cl_git_pass(git_vector_insert(&filelist, "kZZZZZZZ"));
+
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
+
+	i_opts.start = "b";
+	i_opts.end = "k/D";
+
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
+	expect_iterator_items(i, 8, NULL, 8, NULL);
+	git_iterator_free(i);
+
+	git_index_free(index);
+	git_vector_free(&filelist);
+}
+
 void test_repo_iterator__indexfilelist_icase(void)
 {
 	git_iterator *i;

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -126,6 +126,7 @@ static void expect_iterator_items(
 void test_repo_iterator__index(void)
 {
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_index *index;
 
 	g_repo = cl_git_sandbox_init("icase");
@@ -133,19 +134,19 @@ void test_repo_iterator__index(void)
 	cl_git_pass(git_repository_index(&index, g_repo));
 
 	/* autoexpand with no tree entries for index */
-	cl_git_pass(git_iterator_for_index(&i, index, 0, NULL, NULL));
+	cl_git_pass(git_iterator_for_index(&i, index, NULL));
 	expect_iterator_items(i, 20, NULL, 20, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 22, NULL, 22, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 12, NULL, 22, NULL);
 	git_iterator_free(i);
 
@@ -155,6 +156,7 @@ void test_repo_iterator__index(void)
 void test_repo_iterator__index_icase(void)
 {
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_index *index;
 	int caps;
 
@@ -167,32 +169,45 @@ void test_repo_iterator__index_icase(void)
 	cl_git_pass(git_index_set_caps(index, caps & ~GIT_INDEXCAP_IGNORE_CASE));
 
 	/* autoexpand with no tree entries over range */
-	cl_git_pass(git_iterator_for_index(&i, index, 0, "c", "k/D"));
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 7, NULL, 7, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_index(&i, index, 0, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 3, NULL, 3, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_INCLUDE_TREES, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_INCLUDE_TREES, "k", "k/Z"));
+
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 4, NULL, 4, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_DONT_AUTOEXPAND, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 5, NULL, 8, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_DONT_AUTOEXPAND, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 1, NULL, 4, NULL);
 	git_iterator_free(i);
 
@@ -200,33 +215,47 @@ void test_repo_iterator__index_icase(void)
 	cl_git_pass(git_index_set_caps(index, caps | GIT_INDEXCAP_IGNORE_CASE));
 
 	/* autoexpand with no tree entries over range */
-	cl_git_pass(git_iterator_for_index(&i, index, 0, "c", "k/D"));
+	i_opts.flags = 0;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 13, NULL, 13, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_index(&i, index, 0, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 5, NULL, 5, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_INCLUDE_TREES, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 14, NULL, 14, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_INCLUDE_TREES, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 6, NULL, 6, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_DONT_AUTOEXPAND, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 9, NULL, 14, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_index(
-		&i, index, GIT_ITERATOR_DONT_AUTOEXPAND, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
 	expect_iterator_items(i, 1, NULL, 6, NULL);
 	git_iterator_free(i);
 
@@ -237,6 +266,7 @@ void test_repo_iterator__index_icase(void)
 void test_repo_iterator__tree(void)
 {
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_tree *head;
 
 	g_repo = cl_git_sandbox_init("icase");
@@ -244,19 +274,21 @@ void test_repo_iterator__tree(void)
 	cl_git_pass(git_repository_head_tree(&head, g_repo));
 
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_tree(&i, head, 0, NULL, NULL));
+	cl_git_pass(git_iterator_for_tree(&i, head, NULL));
 	expect_iterator_items(i, 20, NULL, 20, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 22, NULL, 22, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 12, NULL, 22, NULL);
 	git_iterator_free(i);
 
@@ -267,75 +299,98 @@ void test_repo_iterator__tree_icase(void)
 {
 	git_iterator *i;
 	git_tree *head;
-	git_iterator_flag_t flag;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	g_repo = cl_git_sandbox_init("icase");
 
 	cl_git_pass(git_repository_head_tree(&head, g_repo));
 
-	flag = GIT_ITERATOR_DONT_IGNORE_CASE;
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
 
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_tree(&i, head, flag, "c", "k/D"));
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 7, NULL, 7, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(&i, head, flag, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 3, NULL, 3, NULL);
 	git_iterator_free(i);
 
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_INCLUDE_TREES, "c", "k/D"));
+	i_opts.start = "c";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_INCLUDE_TREES, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 4, NULL, 4, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE | GIT_ITERATOR_DONT_AUTOEXPAND;
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 5, NULL, 8, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 1, NULL, 4, NULL);
 	git_iterator_free(i);
 
-	flag = GIT_ITERATOR_IGNORE_CASE;
-
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_tree(&i, head, flag, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 13, NULL, 13, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(&i, head, flag, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 5, NULL, 5, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_INCLUDE_TREES, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 14, NULL, 14, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_INCLUDE_TREES, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 6, NULL, 6, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 9, NULL, 14, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 1, NULL, 6, NULL);
 	git_iterator_free(i);
 
@@ -345,6 +400,7 @@ void test_repo_iterator__tree_icase(void)
 void test_repo_iterator__tree_more(void)
 {
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_tree *head;
 	static const char *expect_basic[] = {
 		"current_file",
@@ -396,19 +452,21 @@ void test_repo_iterator__tree_more(void)
 	cl_git_pass(git_repository_head_tree(&head, g_repo));
 
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_tree(&i, head, 0, NULL, NULL));
+	cl_git_pass(git_iterator_for_tree(&i, head, NULL));
 	expect_iterator_items(i, 12, expect_basic, 12, expect_basic);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 13, expect_trees, 13, expect_trees);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_tree(
-		&i, head, GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	cl_git_pass(git_iterator_for_tree(&i, head, &i_opts));
 	expect_iterator_items(i, 10, expect_noauto, 13, expect_trees);
 	git_iterator_free(i);
 
@@ -463,6 +521,8 @@ void test_repo_iterator__tree_case_conflicts_0(void)
 	git_tree *tree;
 	git_oid blob_id, biga_id, littlea_id, tree_id;
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
+
 	const char *expect_cs[] = {
 		"A/1.file", "A/3.file", "a/2.file", "a/4.file" };
 	const char *expect_ci[] = {
@@ -486,25 +546,23 @@ void test_repo_iterator__tree_case_conflicts_0(void)
 
 	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 4, expect_cs, 4, expect_cs);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 4, expect_ci, 4, expect_ci);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_DONT_IGNORE_CASE |
-		GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 6, expect_cs_trees, 6, expect_cs_trees);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_IGNORE_CASE |
-		GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 5, expect_ci_trees, 5, expect_ci_trees);
 	git_iterator_free(i);
 
@@ -517,6 +575,8 @@ void test_repo_iterator__tree_case_conflicts_1(void)
 	git_tree *tree;
 	git_oid blob_id, Ab_id, biga_id, littlea_id, tree_id;
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
+
 	const char *expect_cs[] = {
 		"A/a", "A/b/1", "A/c", "a/C", "a/a", "a/b" };
 	const char *expect_ci[] = {
@@ -541,25 +601,23 @@ void test_repo_iterator__tree_case_conflicts_1(void)
 
 	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 6, expect_cs, 6, expect_cs);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 4, expect_ci, 4, expect_ci);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_DONT_IGNORE_CASE |
-		GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 9, expect_cs_trees, 9, expect_cs_trees);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_IGNORE_CASE |
-		GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 6, expect_ci_trees, 6, expect_ci_trees);
 	git_iterator_free(i);
 
@@ -572,6 +630,8 @@ void test_repo_iterator__tree_case_conflicts_2(void)
 	git_tree *tree;
 	git_oid blob_id, d1, d2, c1, c2, b1, b2, a1, a2, tree_id;
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
+
 	const char *expect_cs[] = {
 		"A/B/C/D/16", "A/B/C/D/foo", "A/B/C/d/15",  "A/B/C/d/FOO",
 		"A/B/c/D/14", "A/B/c/D/foo", "A/B/c/d/13",  "A/B/c/d/FOO",
@@ -639,19 +699,18 @@ void test_repo_iterator__tree_case_conflicts_2(void)
 
 	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_DONT_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 32, expect_cs, 32, expect_cs);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 17, expect_ci, 17, expect_ci);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_tree(
-		&i, tree, GIT_ITERATOR_IGNORE_CASE |
-		GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_tree(&i, tree, &i_opts));
 	expect_iterator_items(i, 21, expect_ci_trees, 21, expect_ci_trees);
 	git_iterator_free(i);
 
@@ -661,23 +720,24 @@ void test_repo_iterator__tree_case_conflicts_2(void)
 void test_repo_iterator__workdir(void)
 {
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	g_repo = cl_git_sandbox_init("icase");
 
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, 0, NULL, NULL));
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 20, NULL, 20, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 22, NULL, 22, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 12, NULL, 22, NULL);
 	git_iterator_free(i);
 }
@@ -685,73 +745,97 @@ void test_repo_iterator__workdir(void)
 void test_repo_iterator__workdir_icase(void)
 {
 	git_iterator *i;
-	git_iterator_flag_t flag;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	g_repo = cl_git_sandbox_init("icase");
 
-	flag = GIT_ITERATOR_DONT_IGNORE_CASE;
-
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, flag, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 7, NULL, 7, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, flag, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 3, NULL, 3, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_INCLUDE_TREES, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 8, NULL, 8, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_INCLUDE_TREES, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 4, NULL, 4, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE | GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 5, NULL, 8, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 1, NULL, 4, NULL);
 	git_iterator_free(i);
 
-	flag = GIT_ITERATOR_IGNORE_CASE;
-
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, flag, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 13, NULL, 13, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, flag, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 5, NULL, 5, NULL);
 	git_iterator_free(i);
 
 	/* auto expand with tree entries */
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_INCLUDE_TREES, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 14, NULL, 14, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_INCLUDE_TREES, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 6, NULL, 6, NULL);
 	git_iterator_free(i);
 
 	/* no auto expand (implies trees included) */
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "c", "k/D"));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_DONT_AUTOEXPAND;
+
+	i_opts.start = "c";
+	i_opts.end = "k/D";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 9, NULL, 14, NULL);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_workdir(
-		&i, g_repo, NULL, NULL, flag | GIT_ITERATOR_DONT_AUTOEXPAND, "k", "k/Z"));
+	i_opts.start = "k";
+	i_opts.end = "k/Z";
+	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 1, NULL, 6, NULL);
 	git_iterator_free(i);
 }
@@ -796,6 +880,7 @@ static void build_workdir_tree(const char *root, int dirs, int subs)
 void test_repo_iterator__workdir_depth(void)
 {
 	git_iterator *iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	g_repo = cl_git_sandbox_init("icase");
 
@@ -804,13 +889,13 @@ void test_repo_iterator__workdir_depth(void)
 	build_workdir_tree("icase/dir02/sUB01", 50, 0);
 
 	/* auto expand with no tree entries */
-	cl_git_pass(git_iterator_for_workdir(&iter, g_repo, NULL, NULL, 0, NULL, NULL));
+	cl_git_pass(git_iterator_for_workdir(&iter, g_repo, NULL, NULL, &iter_opts));
 	expect_iterator_items(iter, 125, NULL, 125, NULL);
 	git_iterator_free(iter);
 
 	/* auto expand with tree entries (empty dirs silently skipped) */
-	cl_git_pass(git_iterator_for_workdir(
-		&iter, g_repo, NULL, NULL, GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	iter_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_workdir(&iter, g_repo, NULL, NULL, &iter_opts));
 	expect_iterator_items(iter, 337, NULL, 337, NULL);
 	git_iterator_free(iter);
 }
@@ -818,6 +903,8 @@ void test_repo_iterator__workdir_depth(void)
 void test_repo_iterator__fs(void)
 {
 	git_iterator *i;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
+
 	static const char *expect_base[] = {
 		"DIR01/Sub02/file",
 		"DIR01/sub00/file",
@@ -863,18 +950,17 @@ void test_repo_iterator__fs(void)
 
 	build_workdir_tree("status/subdir", 2, 4);
 
-	cl_git_pass(git_iterator_for_filesystem(
-		&i, "status/subdir", 0, NULL, NULL));
+	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", NULL));
 	expect_iterator_items(i, 8, expect_base, 8, expect_base);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_filesystem(
-		&i, "status/subdir", GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", &i_opts));
 	expect_iterator_items(i, 18, expect_trees, 18, expect_trees);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_filesystem(
-		&i, "status/subdir", GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", &i_opts));
 	expect_iterator_items(i, 5, expect_noauto, 18, expect_trees);
 	git_iterator_free(i);
 
@@ -882,20 +968,18 @@ void test_repo_iterator__fs(void)
 	git__tsort((void **)expect_trees, 18, (git__tsort_cmp)git__strcasecmp);
 	git__tsort((void **)expect_noauto, 5, (git__tsort_cmp)git__strcasecmp);
 
-	cl_git_pass(git_iterator_for_filesystem(
-		&i, "status/subdir", GIT_ITERATOR_IGNORE_CASE, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
+	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", &i_opts));
 	expect_iterator_items(i, 8, expect_base, 8, expect_base);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_filesystem(
-		&i, "status/subdir", GIT_ITERATOR_IGNORE_CASE |
-		GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", &i_opts));
 	expect_iterator_items(i, 18, expect_trees, 18, expect_trees);
 	git_iterator_free(i);
 
-	cl_git_pass(git_iterator_for_filesystem(
-		&i, "status/subdir", GIT_ITERATOR_IGNORE_CASE |
-		GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+	i_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_DONT_AUTOEXPAND;
+	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", &i_opts));
 	expect_iterator_items(i, 5, expect_noauto, 18, expect_trees);
 	git_iterator_free(i);
 }
@@ -923,7 +1007,7 @@ void test_repo_iterator__fs2(void)
 	g_repo = cl_git_sandbox_init("testrepo");
 
 	cl_git_pass(git_iterator_for_filesystem(
-		&i, "testrepo/.git/refs", 0, NULL, NULL));
+		&i, "testrepo/.git/refs", NULL));
 	expect_iterator_items(i, 13, expect_base, 13, expect_base);
 	git_iterator_free(i);
 }
@@ -947,7 +1031,7 @@ void test_repo_iterator__unreadable_dir(void)
 	cl_git_mkfile("empty_standard_repo/r/d", "final");
 
 	cl_git_pass(git_iterator_for_filesystem(
-		&i, "empty_standard_repo/r", 0, NULL, NULL));
+		&i, "empty_standard_repo/r", NULL));
 
 	cl_git_pass(git_iterator_advance(&e, i)); /* a */
 	cl_git_fail(git_iterator_advance(&e, i)); /* b */

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -1047,6 +1047,7 @@ void test_repo_iterator__skips_fifos_and_such(void)
 #ifndef GIT_WIN32
 	git_iterator *i;
 	const git_index_entry *e;
+	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 
 	g_repo = cl_git_sandbox_init("empty_standard_repo");
 
@@ -1056,9 +1057,11 @@ void test_repo_iterator__skips_fifos_and_such(void)
 	cl_assert(!mkfifo("empty_standard_repo/fifo", 0777));
 	cl_assert(!access("empty_standard_repo/fifo", F_OK));
 
+	i_opts.flags = GIT_ITERATOR_INCLUDE_TREES |
+		GIT_ITERATOR_DONT_AUTOEXPAND;
+
 	cl_git_pass(git_iterator_for_filesystem(
-		&i, "empty_standard_repo", GIT_ITERATOR_INCLUDE_TREES |
-		GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+		&i, "empty_standard_repo", &i_opts));
 
 	cl_git_pass(git_iterator_advance(&e, i)); /* .git */
 	cl_assert(S_ISDIR(e->mode));

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -26,7 +26,7 @@ static void expect_iterator_items(
 	const git_index_entry *entry;
 	int count, error;
 	int no_trees = !(git_iterator_flags(i) & GIT_ITERATOR_INCLUDE_TREES);
-	bool v = true;
+	bool v = false;
 
 	if (expected_flat < 0) { v = true; expected_flat = -expected_flat; }
 	if (expected_total < 0) { v = true; expected_total = -expected_total; }
@@ -1099,7 +1099,8 @@ void test_repo_iterator__indexfilelist(void)
 	/* In this test we DO NOT force a case setting on the index. */
 	default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
 
-	i_opts.pathlist = &filelist;
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
 
 	/* All indexfilelist iterator tests are "autoexpand with no tree entries" */
 
@@ -1147,7 +1148,8 @@ void test_repo_iterator__indexfilelist_2(void)
 	cl_git_pass(git_vector_insert(&filelist, "e"));
 	cl_git_pass(git_vector_insert(&filelist, "k/a"));
 
-	i_opts.pathlist = &filelist;
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
 
 	i_opts.start = "b";
 	i_opts.end = "k/D";
@@ -1188,7 +1190,8 @@ void test_repo_iterator__indexfilelist_icase(void)
 
 	/* All indexfilelist iterator tests are "autoexpand with no tree entries" */
 
-	i_opts.pathlist = &filelist;
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
 
 	i_opts.start = "c";
 	i_opts.end = "k/D";
@@ -1248,7 +1251,8 @@ void test_repo_iterator__workdirfilelist(void)
 	/* All indexfilelist iterator tests are "autoexpand with no tree entries" */
 	/* In this test we DO NOT force a case on the iteratords and verify default behavior. */
 
-	i_opts.pathlist = &filelist;
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
 
 	cl_git_pass(git_iterator_for_workdir(&i, g_repo, NULL, NULL, &i_opts));
 	expect_iterator_items(i, 8, NULL, 8, NULL);
@@ -1297,7 +1301,8 @@ void test_repo_iterator__workdirfilelist_icase(void)
 	g_repo = cl_git_sandbox_init("icase");
 
 	i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
-	i_opts.pathlist = &filelist;
+	i_opts.pathlist.strings = (char **)filelist.contents;
+	i_opts.pathlist.count = filelist.length;
 
 	i_opts.start = "c";
 	i_opts.end = "k/D";

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -1099,6 +1099,7 @@ void test_repo_iterator__indexfilelist(void)
 	g_repo = cl_git_sandbox_init("icase");
 
 	cl_git_pass(git_repository_index(&index, g_repo));
+
 	/* In this test we DO NOT force a case setting on the index. */
 	default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
 
@@ -1139,6 +1140,7 @@ void test_repo_iterator__indexfilelist_2(void)
 	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_index *index;
 	git_vector filelist = GIT_VECTOR_INIT;
+	int default_icase, expect;
 
 	g_repo = cl_git_sandbox_init("icase");
 
@@ -1149,7 +1151,11 @@ void test_repo_iterator__indexfilelist_2(void)
 	cl_git_pass(git_vector_insert(&filelist, "c"));
 	cl_git_pass(git_vector_insert(&filelist, "D"));
 	cl_git_pass(git_vector_insert(&filelist, "e"));
+	cl_git_pass(git_vector_insert(&filelist, "k/1"));
 	cl_git_pass(git_vector_insert(&filelist, "k/a"));
+
+	/* In this test we DO NOT force a case setting on the index. */
+	default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
 
 	i_opts.pathlist.strings = (char **)filelist.contents;
 	i_opts.pathlist.count = filelist.length;
@@ -1157,8 +1163,11 @@ void test_repo_iterator__indexfilelist_2(void)
 	i_opts.start = "b";
 	i_opts.end = "k/D";
 
+	/* (c D e k/1 k/a ==> 5) vs (c e k/1 ==> 3) */
+	expect = default_icase ? 5 : 3;
+
 	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
-	expect_iterator_items(i, 4, NULL, 4, NULL);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
 	git_iterator_free(i);
 
 	git_index_free(index);
@@ -1171,6 +1180,7 @@ void test_repo_iterator__indexfilelist_3(void)
 	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_index *index;
 	git_vector filelist = GIT_VECTOR_INIT;
+	int default_icase, expect;
 
 	g_repo = cl_git_sandbox_init("icase");
 
@@ -1186,14 +1196,20 @@ void test_repo_iterator__indexfilelist_3(void)
 	cl_git_pass(git_vector_insert(&filelist, "k.b"));
 	cl_git_pass(git_vector_insert(&filelist, "kZZZZZZZ"));
 
+	/* In this test we DO NOT force a case setting on the index. */
+	default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
+
 	i_opts.pathlist.strings = (char **)filelist.contents;
 	i_opts.pathlist.count = filelist.length;
 
 	i_opts.start = "b";
 	i_opts.end = "k/D";
 
+	/* (c D e k/1 k/a k/B k/c k/D) vs (c e k/1 k/B k/D) */
+	expect = default_icase ? 8 : 5;
+
 	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
-	expect_iterator_items(i, 8, NULL, 8, NULL);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
 	git_iterator_free(i);
 
 	git_index_free(index);
@@ -1206,6 +1222,7 @@ void test_repo_iterator__indexfilelist_4(void)
 	git_iterator_options i_opts = GIT_ITERATOR_OPTIONS_INIT;
 	git_index *index;
 	git_vector filelist = GIT_VECTOR_INIT;
+	int default_icase, expect;
 
 	g_repo = cl_git_sandbox_init("icase");
 
@@ -1221,14 +1238,20 @@ void test_repo_iterator__indexfilelist_4(void)
 	cl_git_pass(git_vector_insert(&filelist, "k.b"));
 	cl_git_pass(git_vector_insert(&filelist, "kZZZZZZZ"));
 
+	/* In this test we DO NOT force a case setting on the index. */
+	default_icase = ((git_index_caps(index) & GIT_INDEXCAP_IGNORE_CASE) != 0);
+
 	i_opts.pathlist.strings = (char **)filelist.contents;
 	i_opts.pathlist.count = filelist.length;
 
 	i_opts.start = "b";
 	i_opts.end = "k/D";
 
+	/* (c D e k/1 k/a k/B k/c k/D) vs (c e k/1 k/B k/D) */
+	expect = default_icase ? 8 : 5;
+
 	cl_git_pass(git_iterator_for_index(&i, index, &i_opts));
-	expect_iterator_items(i, 8, NULL, 8, NULL);
+	expect_iterator_items(i, expect, NULL, expect, NULL);
 	git_iterator_free(i);
 
 	git_index_free(index);

--- a/tests/status/worktree_init.c
+++ b/tests/status/worktree_init.c
@@ -191,10 +191,10 @@ void test_status_worktree_init__bracket_in_filename(void)
 	cl_git_pass(git_status_file(&status_flags, repo, FILE_WITHOUT_BRACKET));
 	cl_assert(status_flags == GIT_STATUS_WT_NEW);
 
-	cl_git_pass(git_status_file(&status_flags, repo, "LICENSE\\[1\\].md"));
-	cl_assert(status_flags == GIT_STATUS_INDEX_NEW);
+	cl_git_fail_with(git_status_file(&status_flags, repo, "LICENSE\\[1\\].md"), GIT_ENOTFOUND);
 
 	cl_git_pass(git_status_file(&status_flags, repo, FILE_WITH_BRACKET));
+	cl_assert(status_flags == GIT_STATUS_INDEX_NEW);
 
 	git_index_free(index);
 	git_repository_free(repo);

--- a/tests/submodule/status.c
+++ b/tests/submodule/status.c
@@ -264,6 +264,7 @@ static int confirm_submodule_status(
 void test_submodule_status__iterator(void)
 {
 	git_iterator *iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	const git_index_entry *entry;
 	size_t i;
 	static const char *expected[] = {
@@ -308,9 +309,10 @@ void test_submodule_status__iterator(void)
 	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
 	git_index *index;
 
+	iter_opts.flags = GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES;
+
 	cl_git_pass(git_repository_index(&index, g_repo));
-	cl_git_pass(git_iterator_for_workdir(&iter, g_repo, index, NULL,
-		GIT_ITERATOR_IGNORE_CASE | GIT_ITERATOR_INCLUDE_TREES, NULL, NULL));
+	cl_git_pass(git_iterator_for_workdir(&iter, g_repo, index, NULL, &iter_opts));
 
 	for (i = 0; !git_iterator_advance(&entry, iter); ++i)
 		cl_assert_equal_s(expected[i], entry->path);

--- a/tests/threads/iterator.c
+++ b/tests/threads/iterator.c
@@ -13,10 +13,13 @@ static void *run_workdir_iterator(void *arg)
 {
 	int error = 0;
 	git_iterator *iter;
+	git_iterator_options iter_opts = GIT_ITERATOR_OPTIONS_INIT;
 	const git_index_entry *entry = NULL;
 
+	iter_opts.flags = GIT_ITERATOR_DONT_AUTOEXPAND;
+
 	cl_git_pass(git_iterator_for_workdir(
-		&iter, _repo, NULL, NULL, GIT_ITERATOR_DONT_AUTOEXPAND, NULL, NULL));
+		&iter, _repo, NULL, NULL, &iter_opts));
 
 	while (!error) {
 		if (entry && entry->mode == GIT_FILEMODE_TREE) {


### PR DESCRIPTION
I rebased #2888 onto master and was faced with mega conflicts.  In resolving these I:

1. Wanted the filelists to be part of the general iterator mechanism, instead of having a workdir iterator and a workdir+filelist iterator
2. Did not want a third diff path maching mechanism (pathspecs, non-pathspecs and slightly more literal iterator filelists).

So this moves the filelists into the general iterator mechanisms, and it expands the filelist handling to deal with directory prefixes (eg, `foo/`) instead of requiring that patches be listed explicitly.

Note that this should be generally adequate and a huge perf benefit for index and workdir iterators (like the original was), and tree iterators are working, but they expand all trees unnecessarily.  We could perform tree iteration without necessarily expanding all trees (like we do with the filesystem iterator) but this should be correct and still more performant in that case.  We can handle that in the future, though with more aggressive refactoring in that iterator.