### PR TITLE
filebuf: ensure we can lock a hidden file

### DIFF
--- a/tests/core/filebuf.c
+++ b/tests/core/filebuf.c
@@ -204,3 +204,29 @@ void test_core_filebuf__symlink_depth(void)
 
 	cl_git_pass(git_futils_rmdir_r(dir, NULL, GIT_RMDIR_REMOVE_FILES));
 }
+
+void test_core_filebuf__hidden_file(void)
+{
+#ifndef GIT_WIN32
+	cl_skip();
+#else
+	git_filebuf file = GIT_FILEBUF_INIT;
+	char *dir = "hidden", *test = "hidden/test";
+	bool hidden;
+
+	cl_git_pass(p_mkdir(dir, 0666));
+	cl_git_mkfile(test, "dummy content");
+
+	cl_git_pass(git_win32__set_hidden(test, true));
+	cl_git_pass(git_win32__hidden(&hidden, test));
+	cl_assert(hidden);
+
+	cl_git_pass(git_filebuf_open(&file, test, 0, 0666));
+
+	cl_git_pass(git_filebuf_printf(&file, "%s\n", "libgit2 rocks"));
+
+	cl_git_pass(git_filebuf_commit(&file));
+
+	git_filebuf_cleanup(&file);
+#endif
+}

--- a/tests/core/futils.c
+++ b/tests/core/futils.c
@@ -1,0 +1,68 @@
+#include "clar_libgit2.h"
+#include "fileops.h"
+
+// Fixture setup and teardown
+void test_core_futils__initialize(void)
+{
+	cl_must_pass(p_mkdir("futils", 0777));
+}
+
+void test_core_futils__cleanup(void)
+{
+	cl_fixture_cleanup("futils");
+}
+
+void test_core_futils__writebuffer(void)
+{
+	git_buf out = GIT_BUF_INIT,
+		append = GIT_BUF_INIT;
+
+	/* create a new file */
+	git_buf_puts(&out, "hello!\n");
+	git_buf_printf(&out, "this is a %s\n", "test");
+
+	cl_git_pass(git_futils_writebuffer(&out, "futils/test-file", O_RDWR|O_CREAT, 0666));
+
+	cl_assert_equal_file(out.ptr, out.size, "futils/test-file");
+
+	/* append some more data */
+	git_buf_puts(&append, "And some more!\n");
+	git_buf_put(&out, append.ptr, append.size);
+
+	cl_git_pass(git_futils_writebuffer(&append, "futils/test-file", O_RDWR|O_APPEND, 0666));
+
+	cl_assert_equal_file(out.ptr, out.size, "futils/test-file");
+
+	git_buf_free(&out);
+	git_buf_free(&append);
+}
+
+void test_core_futils__write_hidden_file(void)
+{
+#ifndef GIT_WIN32
+	cl_skip();
+#else
+	git_buf out = GIT_BUF_INIT, append = GIT_BUF_INIT;
+	bool hidden;
+
+	git_buf_puts(&out, "hidden file.\n");
+	git_futils_writebuffer(&out, "futils/test-file", O_RDWR | O_CREAT, 0666);
+
+	cl_git_pass(git_win32__set_hidden("futils/test-file", true));
+
+	/* append some more data */
+	git_buf_puts(&append, "And some more!\n");
+	git_buf_put(&out, append.ptr, append.size);
+
+	cl_git_pass(git_futils_writebuffer(&append, "futils/test-file", O_RDWR | O_APPEND, 0666));
+
+	cl_assert_equal_file(out.ptr, out.size, "futils/test-file");
+
+	cl_git_pass(git_win32__hidden(&hidden, "futils/test-file"));
+	cl_assert(hidden);
+
+	git_buf_free(&out);
+	git_buf_free(&append);
+#endif
+}
+


### PR DESCRIPTION
Tests the alternate method by which #3310 might be failing.