### PR TITLE
Fixing dangling pointers in git_mempack_reset

### DIFF
--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -161,8 +161,12 @@ void git_mempack_reset(git_odb_backend *_backend)
 
 static void impl__free(git_odb_backend *_backend)
 {
-	git_mempack_reset(_backend);
-	git__free(_backend);
+	struct memory_packer_db *db = (struct memory_packer_db *)_backend;
+
+	git_mempack_reset(db);
+	git_oidmap_free(db->objects);
+
+	git__free(db);
 }
 
 int git_mempack_new(git_odb_backend **out)

--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -154,6 +154,9 @@ void git_mempack_reset(git_odb_backend *_backend)
 	});
 
 	git_array_clear(db->commits);
+
+	git_oidmap_free(db->objects);
+	db->objects = git_oidmap_alloc();
 }
 
 static void impl__free(git_odb_backend *_backend)


### PR DESCRIPTION
The first time `git_mempack_reset` is called it frees the objects in `db->objects` but the pointers to those objects are left in place. So if an attempt is made to reset the mempack again, a “double free” occurs.