### PR TITLE
push: put the git_oid inline in the test structure

### DIFF
--- a/tests/online/push.c
+++ b/tests/online/push.c
@@ -299,7 +299,7 @@ static void verify_update_tips_callback(git_remote *remote, expected_ref expecte
 			goto failed;
 		}
 
-		if (git_oid_cmp(expected_refs[i].oid, tip->new_oid) != 0) {
+		if (git_oid_cmp(expected_refs[i].oid, &tip->new_oid) != 0) {
 			git_buf_printf(&msg, "Updated tip ID does not match expected ID");
 			failed = 1;
 			goto failed;

--- a/tests/online/push_util.c
+++ b/tests/online/push_util.c
@@ -9,8 +9,6 @@ const git_oid OID_ZERO = {{ 0 }};
 void updated_tip_free(updated_tip *t)
 {
 	git__free(t->name);
-	git__free(t->old_oid);
-	git__free(t->new_oid);
 	git__free(t);
 }
 
@@ -46,14 +44,11 @@ int record_update_tips_cb(const char *refname, const git_oid *a, const git_oid *
 	updated_tip *t;
 	record_callbacks_data *record_data = (record_callbacks_data *)data;
 
-	cl_assert(t = git__malloc(sizeof(*t)));
+	cl_assert(t = git__calloc(1, sizeof(*t)));
 
 	cl_assert(t->name = git__strdup(refname));
-	cl_assert(t->old_oid = git__malloc(sizeof(*t->old_oid)));
-	git_oid_cpy(t->old_oid, a);
-
-	cl_assert(t->new_oid = git__malloc(sizeof(*t->new_oid)));
-	git_oid_cpy(t->new_oid, b);
+	git_oid_cpy(&t->old_oid, a);
+	git_oid_cpy(&t->new_oid, b);
 
 	git_vector_insert(&record_data->updated_tips, t);
 

--- a/tests/online/push_util.h
+++ b/tests/online/push_util.h
@@ -16,8 +16,8 @@ extern const git_oid OID_ZERO;
 
 typedef struct {
 	char *name;
-	git_oid *old_oid;
-	git_oid *new_oid;
+	git_oid old_oid;
+	git_oid new_oid;
 } updated_tip;
 
 typedef struct {


### PR DESCRIPTION
These are small pieces of data, so there is no advantage to allocating
them separately. Include the two ids inline in the struct we use to
check that the expected and actual ids match.

---

I just saw this earlier today an it annoyed me that we were allocating a couple of `git_oid` instead of using them in the struct.