### PR TITLE
Handle `git_path_diriter` instances at the drive root on Windows

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -1166,7 +1166,11 @@ static int diriter_update_paths(git_path_diriter *diriter)
 	diriter->path[path_len-1] = L'\0';
 
 	git_buf_truncate(&diriter->path_utf8, diriter->parent_utf8_len);
-	git_buf_putc(&diriter->path_utf8, '/');
+
+	if (diriter->parent_utf8_len > 0 &&
+		diriter->path_utf8.ptr[diriter->parent_utf8_len-1] != '/')
+		git_buf_putc(&diriter->path_utf8, '/');
+
 	git_buf_put_w(&diriter->path_utf8, diriter->current.cFileName, filename_len);
 
 	if (git_buf_oom(&diriter->path_utf8))

--- a/src/path.c
+++ b/src/path.c
@@ -1319,7 +1319,11 @@ int git_path_diriter_next(git_path_diriter *diriter)
 #endif
 
 	git_buf_truncate(&diriter->path, diriter->parent_len);
-	git_buf_putc(&diriter->path, '/');
+
+	if (diriter->parent_len > 0 &&
+		diriter->path.ptr[diriter->parent_len-1] != '/')
+		git_buf_putc(&diriter->path, '/');
+
 	git_buf_put(&diriter->path, filename, filename_len);
 
 	if (git_buf_oom(&diriter->path))

--- a/tests/core/dirent.c
+++ b/tests/core/dirent.c
@@ -275,3 +275,32 @@ void test_core_dirent__diriter_with_fullname(void)
 
 	check_counts(&sub);
 }
+
+void test_core_dirent__diriter_at_directory_root(void)
+{
+	git_path_diriter diriter = GIT_PATH_DIRITER_INIT;
+	const char *sandbox_path, *path;
+	char *root_path;
+	size_t path_len;
+	int root_offset, error;
+
+	sandbox_path = clar_sandbox_path();
+	cl_assert((root_offset = git_path_root(sandbox_path)) >= 0);
+
+	cl_assert(root_path = git__calloc(1, root_offset + 2));
+	strncpy(root_path, sandbox_path, root_offset + 1);
+
+	cl_git_pass(git_path_diriter_init(&diriter, root_path, 0));
+
+	while ((error = git_path_diriter_next(&diriter)) == 0) {
+		cl_git_pass(git_path_diriter_fullpath(&path, &path_len, &diriter));
+
+		cl_assert(path_len > (size_t)(root_offset + 1));
+		cl_assert(path[root_offset+1] != '/');
+	}
+
+	cl_assert_equal_i(error, GIT_ITEROVER);
+
+	git_path_diriter_free(&diriter);
+	git__free(root_path);
+}


### PR DESCRIPTION
On Windows, our `git_path_diriter` adds a '/' to combine the path being queried with a filesystem entry.  For example, when iterating a directory `c:/foo` that contains some file `bar.txt`, we create a path `c:/foo/bar.txt`.  (Yay!)

We need to not do this on the root of a volume (eg, `c:/`) since it is already, correctly, suffixed with a `/`.

Fixes #3417 