### PR TITLE
Checkout: handle mode changes

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -243,6 +243,12 @@ static int checkout_action_common(
 		if (delta->new_file.mode == GIT_FILEMODE_LINK && wd != NULL)
 			*action |= CHECKOUT_ACTION__REMOVE;
 
+		/* if the file is on disk and doesn't match our mode, force update */
+		if (wd &&
+			GIT_PERMS_IS_EXEC(wd->mode) !=
+			GIT_PERMS_IS_EXEC(delta->new_file.mode))
+				*action |= CHECKOUT_ACTION__REMOVE;
+
 		notify = GIT_CHECKOUT_NOTIFY_UPDATED;
 	}
 
@@ -1499,15 +1505,6 @@ static int blob_content_to_file(
 
 	if (error < 0)
 		return error;
-
-	if (GIT_PERMS_IS_EXEC(mode)) {
-		data->perfdata.chmod_calls++;
-
-		if ((error = p_chmod(path, mode)) < 0) {
-			giterr_set(GITERR_OS, "Failed to set permissions on '%s'", path);
-			return error;
-		}
-	}
 
 	if (st) {
 		data->perfdata.stat_calls++;

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -973,6 +973,17 @@ void test_checkout_tree__filemode_preserved_in_index(void)
 	git_commit_free(commit);
 
 
+	/* Finally, check out the text file again and check that the exec bit is cleared */
+	cl_git_pass(git_oid_fromstr(&executable_oid, "cf80f8de9f1185bf3a05f993f6121880dd0cfbc9"));
+	cl_git_pass(git_commit_lookup(&commit, g_repo, &executable_oid));
+
+	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
+	cl_assert(entry = git_index_get_bypath(index, "a/b.txt", 0));
+	cl_assert_equal_i(0100644, entry->mode);
+
+	git_commit_free(commit);
+
+
 	git_index_free(index);
 }
 

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -946,7 +946,7 @@ void test_checkout_tree__filemode_preserved_in_index(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
 	cl_assert(entry = git_index_get_bypath(index, "executable.txt", 0));
-	cl_assert_equal_i(0100755, entry->mode);
+	cl_assert(GIT_PERMS_IS_EXEC(entry->mode));
 
 	git_commit_free(commit);
 
@@ -957,7 +957,7 @@ void test_checkout_tree__filemode_preserved_in_index(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
 	cl_assert(entry = git_index_get_bypath(index, "a/b.txt", 0));
-	cl_assert_equal_i(0100644, entry->mode);
+	cl_assert(!GIT_PERMS_IS_EXEC(entry->mode));
 
 	git_commit_free(commit);
 
@@ -968,7 +968,7 @@ void test_checkout_tree__filemode_preserved_in_index(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
 	cl_assert(entry = git_index_get_bypath(index, "a/b.txt", 0));
-	cl_assert_equal_i(0100755, entry->mode);
+	cl_assert(GIT_PERMS_IS_EXEC(entry->mode));
 
 	git_commit_free(commit);
 
@@ -979,7 +979,7 @@ void test_checkout_tree__filemode_preserved_in_index(void)
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
 	cl_assert(entry = git_index_get_bypath(index, "a/b.txt", 0));
-	cl_assert_equal_i(0100644, entry->mode);
+	cl_assert(!GIT_PERMS_IS_EXEC(entry->mode));
 
 	git_commit_free(commit);
 
@@ -1017,7 +1017,7 @@ void test_checkout_tree__filemode_preserved_in_workdir(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &executable_oid));
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
-	cl_assert_equal_i(0100755, read_filemode("executable.txt"));
+	cl_assert(GIT_PERMS_IS_EXEC(read_filemode("executable.txt")));
 
 	git_commit_free(commit);
 
@@ -1027,7 +1027,7 @@ void test_checkout_tree__filemode_preserved_in_workdir(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &executable_oid));
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
-	cl_assert_equal_i(0100644, read_filemode("a/b.txt"));
+	cl_assert(!GIT_PERMS_IS_EXEC(read_filemode("a/b.txt")));
 
 	git_commit_free(commit);
 
@@ -1037,7 +1037,7 @@ void test_checkout_tree__filemode_preserved_in_workdir(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &executable_oid));
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
-	cl_assert_equal_i(0100755, read_filemode("a/b.txt"));
+	cl_assert(GIT_PERMS_IS_EXEC(read_filemode("a/b.txt")));
 
 	git_commit_free(commit);
 
@@ -1047,7 +1047,7 @@ void test_checkout_tree__filemode_preserved_in_workdir(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &executable_oid));
 
 	cl_git_pass(git_checkout_tree(g_repo, (const git_object *)commit, &opts));
-	cl_assert_equal_i(0100644, read_filemode("a/b.txt"));
+	cl_assert(!GIT_PERMS_IS_EXEC(read_filemode("a/b.txt")));
 
 	git_commit_free(commit);
 #endif

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -996,7 +996,8 @@ mode_t read_filemode(const char *path)
 	git_buf_joinpath(&fullpath, "testrepo", path);
 	cl_must_pass(p_stat(fullpath.ptr, &st));
 
-	result = GIT_PERMS_IS_EXEC(st.st_mode) ? 0100755 : 0100644;
+	result = GIT_PERMS_IS_EXEC(st.st_mode) ?
+		GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB;
 
 	git_buf_free(&fullpath);
 

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -989,15 +989,18 @@ void test_checkout_tree__filemode_preserved_in_index(void)
 
 mode_t read_filemode(const char *path)
 {
+	git_buf fullpath = GIT_BUF_INIT;
 	struct stat st;
-	char pathabs[256] = {0};
+	mode_t result;
 
-	strcat(pathabs, clar_sandbox_path());
-	strcat(pathabs, "/testrepo/");
-	strcat(pathabs, path);
-	cl_must_pass(p_stat(pathabs, &st));
+	git_buf_joinpath(&fullpath, "testrepo", path);
+	cl_must_pass(p_stat(fullpath.ptr, &st));
 
-	return st.st_mode;
+	result = GIT_PERMS_IS_EXEC(st.st_mode) ? 0100755 : 0100644;
+
+	git_buf_free(&fullpath);
+
+	return result;
 }
 
 void test_checkout_tree__filemode_preserved_in_workdir(void)


### PR DESCRIPTION
As reported in #3158, we do not quite handle mode changes correctly in checkout.  We will always set execute bits properly, but we fail to *unset* execute bits.

This ports the unit tests that were mentioned in #3158.  It does not take the fix that was mentioned in that issue, though, as it was heavy-handed.  Instead, we simply delete the old file and let `p_open` set the mode for us and drop any notion of trying to `chmod`.  (This is handy since we were not providing the umask properly, nor is there a sane way to query the umask in a thread safe manner across architectures.)  

Fixes #3158 
