### PR TITLE
`mkdir`: split into `mkdir` and `mkdir_relative`

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1366,7 +1366,7 @@ static int checkout_mkdir(
 	mkdir_opts.dir_map = data->mkdir_map;
 	mkdir_opts.pool = &data->pool;
 
-	error = git_futils_mkdir_ext(
+	error = git_futils_mkdir_relative(
 		path, base, mode, flags, &mkdir_opts);
 
 	data->perfdata.mkdir_calls += mkdir_opts.perfdata.mkdir_calls;

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -408,13 +408,15 @@ int git_futils_mkdir(
 	struct git_futils_mkdir_options opts = { 0 };
 	struct stat st;
 	size_t depth = 0;
-	int len = 0, error;
+	int len = 0, root_len, error;
 
 	if ((error = git_buf_puts(&make_path, path)) < 0 ||
 		(error = mkdir_canonicalize(&make_path, flags)) < 0 ||
 		(error = git_buf_puts(&parent_path, make_path.ptr)) < 0 ||
 		make_path.size == 0)
 		goto done;
+
+	root_len = git_path_root(make_path.ptr);
 
 	/* find the first parent directory that exists.  this will be used
 	 * as the base to dirname_relative.
@@ -442,8 +444,7 @@ int git_futils_mkdir(
 		/* we've walked all the given path's parents and it's either relative
 		 * or rooted.  either way, give up and make the entire path.
 		 */
-		if (len == 1 &&
-			(parent_path.ptr[0] == '.' || parent_path.ptr[0] == '/')) {
+		if ((len == 1 && parent_path.ptr[0] == '.') || len == root_len+1) {
 			relative = make_path.ptr;
 			break;
 		}

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -55,12 +55,9 @@ extern int git_futils_creat_locked(const char *path, const mode_t mode);
 extern int git_futils_creat_locked_withpath(const char *path, const mode_t dirmode, const mode_t mode);
 
 /**
- * Create a path recursively
- *
- * If a base parameter is being passed, it's expected to be valued with a
- * path pointing to an already existing directory.
+ * Create a path recursively.
  */
-extern int git_futils_mkdir_r(const char *path, const char *base, const mode_t mode);
+extern int git_futils_mkdir_r(const char *path, const mode_t mode);
 
 /**
  * Flags to pass to `git_futils_mkdir`.
@@ -111,20 +108,20 @@ struct git_futils_mkdir_options
  * and optionally chmods the directory immediately after (or each part of the
  * path if requested).
  *
- * @param path The path to create.
+ * @param path The path to create, relative to base.
  * @param base Root for relative path.  These directories will never be made.
  * @param mode The mode to use for created directories.
  * @param flags Combination of the mkdir flags above.
- * @param opts Extended options, use `git_futils_mkdir` if you are not interested.
+ * @param opts Extended options, or null.
  * @return 0 on success, else error code
  */
-extern int git_futils_mkdir_ext(const char *path, const char *base, mode_t mode, uint32_t flags, struct git_futils_mkdir_options *opts);
+extern int git_futils_mkdir_relative(const char *path, const char *base, mode_t mode, uint32_t flags, struct git_futils_mkdir_options *opts);
 
 /**
- * Create a directory or entire path.  Similar to `git_futils_mkdir_withperf`
+ * Create a directory or entire path.  Similar to `git_futils_mkdir_relative`
  * without performance data.
  */
-extern int git_futils_mkdir(const char *path, const char *base, mode_t mode, uint32_t flags);
+extern int git_futils_mkdir(const char *path, mode_t mode, uint32_t flags);
 
 /**
  * Create all the folders required to contain

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -84,9 +84,9 @@ static int object_file_name(
 
 static int object_mkdir(const git_buf *name, const loose_backend *be)
 {
-	return git_futils_mkdir(
+	return git_futils_mkdir_relative(
 		name->ptr + be->objects_dirlen, be->objects_dir, be->object_dir_mode,
-		GIT_MKDIR_PATH | GIT_MKDIR_SKIP_LAST | GIT_MKDIR_VERIFY_DIR);
+		GIT_MKDIR_PATH | GIT_MKDIR_SKIP_LAST | GIT_MKDIR_VERIFY_DIR, NULL);
 }
 
 static size_t get_binary_object_header(obj_hdr *hdr, git_buf *obj)

--- a/src/path.c
+++ b/src/path.c
@@ -526,6 +526,17 @@ bool git_path_isfile(const char *path)
 	return S_ISREG(st.st_mode) != 0;
 }
 
+bool git_path_islink(const char *path)
+{
+	struct stat st;
+
+	assert(path);
+	if (p_lstat(path, &st) < 0)
+		return false;
+
+	return S_ISLNK(st.st_mode) != 0;
+}
+
 #ifdef GIT_WIN32
 
 bool git_path_is_empty_dir(const char *path)

--- a/src/path.h
+++ b/src/path.h
@@ -72,7 +72,7 @@ extern const char *git_path_topdir(const char *path);
  * This will return a number >= 0 which is the offset to the start of the
  * path, if the path is rooted (i.e. "/rooted/path" returns 0 and
  * "c:/windows/rooted/path" returns 2).  If the path is not rooted, this
- * returns < 0.
+ * returns -1.
  */
 extern int git_path_root(const char *path);
 

--- a/src/path.h
+++ b/src/path.h
@@ -169,6 +169,12 @@ extern bool git_path_isdir(const char *path);
 extern bool git_path_isfile(const char *path);
 
 /**
+ * Check if the given path points to a symbolic link.
+ * @return true or false
+ */
+extern bool git_path_islink(const char *path);
+
+/**
  * Check if the given path is a directory, and is empty.
  */
 extern bool git_path_is_empty_dir(const char *path);

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1413,7 +1413,8 @@ static int setup_namespace(git_buf *path, git_repository *repo)
 	git__free(parts);
 
 	/* Make sure that the folder with the namespace exists */
-	if (git_futils_mkdir_r(git_buf_cstr(path), repo->path_repository, 0777) < 0)
+	if (git_futils_mkdir_relative(git_buf_cstr(path), repo->path_repository,
+			0777, GIT_MKDIR_PATH, NULL) < 0)
 		return -1;
 
 	/* Return root of the namespaced path, i.e. without the trailing '/refs' */

--- a/src/repository.c
+++ b/src/repository.c
@@ -1441,8 +1441,8 @@ static int repo_init_structure(
 			if (chmod)
 				mkdir_flags |= GIT_MKDIR_CHMOD;
 
-			error = git_futils_mkdir(
-				tpl->path, repo_dir, dmode, mkdir_flags);
+			error = git_futils_mkdir_relative(
+				tpl->path, repo_dir, dmode, mkdir_flags, NULL);
 		}
 		else if (!external_tpl) {
 			const char *content = tpl->content;
@@ -1464,7 +1464,7 @@ static int mkdir_parent(git_buf *buf, uint32_t mode, bool skip2)
 	 * don't try to set gid or grant world write access
 	 */
 	return git_futils_mkdir(
-		buf->ptr, NULL, mode & ~(S_ISGID | 0002),
+		buf->ptr, mode & ~(S_ISGID | 0002),
 		GIT_MKDIR_PATH | GIT_MKDIR_VERIFY_DIR |
 		(skip2 ? GIT_MKDIR_SKIP_LAST2 : GIT_MKDIR_SKIP_LAST));
 }
@@ -1568,14 +1568,14 @@ static int repo_init_directories(
 		/* create path #4 */
 		if (wd_path->size > 0 &&
 			(error = git_futils_mkdir(
-				wd_path->ptr, NULL, dirmode & ~S_ISGID,
+				wd_path->ptr, dirmode & ~S_ISGID,
 				GIT_MKDIR_VERIFY_DIR)) < 0)
 			return error;
 
 		/* create path #2 (if not the same as #4) */
 		if (!natural_wd &&
 			(error = git_futils_mkdir(
-				repo_path->ptr, NULL, dirmode & ~S_ISGID,
+				repo_path->ptr, dirmode & ~S_ISGID,
 				GIT_MKDIR_VERIFY_DIR | GIT_MKDIR_SKIP_LAST)) < 0)
 			return error;
 	}
@@ -1585,7 +1585,7 @@ static int repo_init_directories(
 		has_dotgit)
 	{
 		/* create path #1 */
-		error = git_futils_mkdir(repo_path->ptr, NULL, dirmode,
+		error = git_futils_mkdir(repo_path->ptr, dirmode,
 			GIT_MKDIR_VERIFY_DIR | ((dirmode & S_ISGID) ? GIT_MKDIR_CHMOD : 0));
 	}
 

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -63,7 +63,7 @@ void test_checkout_index__can_remove_untracked_files(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-	git_futils_mkdir("./testrepo/dir/subdir/subsubdir", NULL, 0755, GIT_MKDIR_PATH);
+	git_futils_mkdir("./testrepo/dir/subdir/subsubdir", 0755, GIT_MKDIR_PATH);
 	cl_git_mkfile("./testrepo/dir/one", "one\n");
 	cl_git_mkfile("./testrepo/dir/subdir/two", "two\n");
 

--- a/tests/config/global.c
+++ b/tests/config/global.c
@@ -6,17 +6,17 @@ void test_config_global__initialize(void)
 {
 	git_buf path = GIT_BUF_INIT;
 
-	cl_git_pass(git_futils_mkdir_r("home", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("home", 0777));
 	cl_git_pass(git_path_prettify(&path, "home", NULL));
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, path.ptr));
 
-	cl_git_pass(git_futils_mkdir_r("xdg/git", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("xdg/git", 0777));
 	cl_git_pass(git_path_prettify(&path, "xdg/git", NULL));
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, path.ptr));
 
-	cl_git_pass(git_futils_mkdir_r("etc", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("etc", 0777));
 	cl_git_pass(git_path_prettify(&path, "etc", NULL));
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, path.ptr));

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -929,7 +929,7 @@ void test_core_buffer__similarity_metric(void)
 	cl_git_pass(git_buf_sets(&buf, SIMILARITY_TEST_DATA_1));
 	cl_git_pass(git_hashsig_create(&a, buf.ptr, buf.size, GIT_HASHSIG_NORMAL));
 
-	cl_git_pass(git_futils_mkdir("scratch", NULL, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("scratch", 0755, GIT_MKDIR_PATH));
 	cl_git_mkfile("scratch/testdata", SIMILARITY_TEST_DATA_1);
 	cl_git_pass(git_hashsig_create_fromfile(
 		&b, "scratch/testdata", GIT_HASHSIG_NORMAL));

--- a/tests/core/copy.c
+++ b/tests/core/copy.c
@@ -25,7 +25,7 @@ void test_core_copy__file_in_dir(void)
 	struct stat st;
 	const char *content = "This is some other stuff to copy\n";
 
-	cl_git_pass(git_futils_mkdir("an_dir/in_a_dir", NULL, 0775, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("an_dir/in_a_dir", 0775, GIT_MKDIR_PATH));
 	cl_git_mkfile("an_dir/in_a_dir/copy_me", content);
 	cl_assert(git_path_isdir("an_dir"));
 
@@ -60,9 +60,9 @@ void test_core_copy__tree(void)
 	struct stat st;
 	const char *content = "File content\n";
 
-	cl_git_pass(git_futils_mkdir("src/b", NULL, 0775, GIT_MKDIR_PATH));
-	cl_git_pass(git_futils_mkdir("src/c/d", NULL, 0775, GIT_MKDIR_PATH));
-	cl_git_pass(git_futils_mkdir("src/c/e", NULL, 0775, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("src/b", 0775, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("src/c/d", 0775, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("src/c/e", 0775, GIT_MKDIR_PATH));
 
 	cl_git_mkfile("src/f1", content);
 	cl_git_mkfile("src/b/f2", content);

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -13,6 +13,41 @@ static void cleanup_basic_dirs(void *ref)
 	git_futils_rmdir_r("d4", NULL, GIT_RMDIR_EMPTY_HIERARCHY);
 }
 
+void test_core_mkdir__absolute(void)
+{
+	git_buf path = GIT_BUF_INIT;
+
+	cl_set_cleanup(cleanup_basic_dirs, NULL);
+
+	git_buf_joinpath(&path, clar_sandbox_path(), "d0");
+
+	/* make a directory */
+	cl_assert(!git_path_isdir(path.ptr));
+	cl_git_pass(git_futils_mkdir(path.ptr, 0755, 0));
+	cl_assert(git_path_isdir(path.ptr));
+
+	git_buf_joinpath(&path, path.ptr, "subdir");
+
+	/* make a directory */
+	cl_assert(!git_path_isdir(path.ptr));
+	cl_git_pass(git_futils_mkdir(path.ptr, 0755, 0));
+	cl_assert(git_path_isdir(path.ptr));
+
+	git_buf_joinpath(&path, path.ptr, "another");
+
+	/* make a directory */
+	cl_assert(!git_path_isdir(path.ptr));
+	cl_git_pass(git_futils_mkdir_r(path.ptr, 0755));
+	cl_assert(git_path_isdir(path.ptr));
+
+	git_buf_joinpath(&path, clar_sandbox_path(), "d1/foo/bar/asdf");
+
+	/* make a directory */
+	cl_assert(!git_path_isdir(path.ptr));
+	cl_git_pass(git_futils_mkdir_r(path.ptr, 0755));
+	cl_assert(git_path_isdir(path.ptr));
+}
+
 void test_core_mkdir__basic(void)
 {
 	cl_set_cleanup(cleanup_basic_dirs, NULL);

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -27,25 +27,27 @@ void test_core_mkdir__absolute(void)
 	cl_assert(git_path_isdir(path.ptr));
 
 	git_buf_joinpath(&path, path.ptr, "subdir");
-
-	/* make a directory */
 	cl_assert(!git_path_isdir(path.ptr));
 	cl_git_pass(git_futils_mkdir(path.ptr, 0755, 0));
 	cl_assert(git_path_isdir(path.ptr));
 
+	/* ensure mkdir_r works for a single subdir */
 	git_buf_joinpath(&path, path.ptr, "another");
-
-	/* make a directory */
 	cl_assert(!git_path_isdir(path.ptr));
 	cl_git_pass(git_futils_mkdir_r(path.ptr, 0755));
 	cl_assert(git_path_isdir(path.ptr));
 
+	/* ensure mkdir_r works */
 	git_buf_joinpath(&path, clar_sandbox_path(), "d1/foo/bar/asdf");
-
-	/* make a directory */
 	cl_assert(!git_path_isdir(path.ptr));
 	cl_git_pass(git_futils_mkdir_r(path.ptr, 0755));
 	cl_assert(git_path_isdir(path.ptr));
+
+	/* ensure we don't imply recursive */
+	git_buf_joinpath(&path, clar_sandbox_path(), "d2/foo/bar/asdf");
+	cl_assert(!git_path_isdir(path.ptr));
+	cl_git_fail(git_futils_mkdir(path.ptr, 0755, 0));
+	cl_assert(!git_path_isdir(path.ptr));
 }
 
 void test_core_mkdir__basic(void)
@@ -285,4 +287,3 @@ void test_core_mkdir__mkdir_path_inside_unwriteable_parent(void)
 
 	cl_must_pass(p_chmod("r/mode", 0777));
 }
-

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -222,6 +222,40 @@ void test_core_mkdir__chmods(void)
 	check_mode(0777, st.st_mode);
 }
 
+void test_core_mkdir__keeps_parent_symlinks(void)
+{
+#ifndef GIT_WIN32
+	git_buf path = GIT_BUF_INIT;
+
+	cl_set_cleanup(cleanup_basic_dirs, NULL);
+
+	/* make a directory */
+	cl_assert(!git_path_isdir("d0"));
+	cl_git_pass(git_futils_mkdir("d0", 0755, 0));
+	cl_assert(git_path_isdir("d0"));
+
+	cl_must_pass(symlink("d0", "d1"));
+	cl_assert(git_path_islink("d1"));
+
+	cl_git_pass(git_futils_mkdir("d1/foo/bar", 0755, GIT_MKDIR_PATH|GIT_MKDIR_REMOVE_SYMLINKS));
+	cl_assert(git_path_islink("d1"));
+	cl_assert(git_path_isdir("d1/foo/bar"));
+	cl_assert(git_path_isdir("d0/foo/bar"));
+
+	cl_must_pass(symlink("d0", "d2"));
+	cl_assert(git_path_islink("d2"));
+
+	git_buf_joinpath(&path, clar_sandbox_path(), "d2/other/dir");
+
+	cl_git_pass(git_futils_mkdir(path.ptr, 0755, GIT_MKDIR_PATH|GIT_MKDIR_REMOVE_SYMLINKS));
+	cl_assert(git_path_islink("d2"));
+	cl_assert(git_path_isdir("d2/other/dir"));
+	cl_assert(git_path_isdir("d0/other/dir"));
+
+	git_buf_free(&path);
+#endif
+}
+
 void test_core_mkdir__mkdir_path_inside_unwriteable_parent(void)
 {
 	struct stat st;

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -19,37 +19,37 @@ void test_core_mkdir__basic(void)
 
 	/* make a directory */
 	cl_assert(!git_path_isdir("d0"));
-	cl_git_pass(git_futils_mkdir("d0", NULL, 0755, 0));
+	cl_git_pass(git_futils_mkdir("d0", 0755, 0));
 	cl_assert(git_path_isdir("d0"));
 
 	/* make a path */
 	cl_assert(!git_path_isdir("d1"));
-	cl_git_pass(git_futils_mkdir("d1/d1.1/d1.2", NULL, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("d1/d1.1/d1.2", 0755, GIT_MKDIR_PATH));
 	cl_assert(git_path_isdir("d1"));
 	cl_assert(git_path_isdir("d1/d1.1"));
 	cl_assert(git_path_isdir("d1/d1.1/d1.2"));
 
 	/* make a dir exclusively */
 	cl_assert(!git_path_isdir("d2"));
-	cl_git_pass(git_futils_mkdir("d2", NULL, 0755, GIT_MKDIR_EXCL));
+	cl_git_pass(git_futils_mkdir("d2", 0755, GIT_MKDIR_EXCL));
 	cl_assert(git_path_isdir("d2"));
 
 	/* make exclusive failure */
-	cl_git_fail(git_futils_mkdir("d2", NULL, 0755, GIT_MKDIR_EXCL));
+	cl_git_fail(git_futils_mkdir("d2", 0755, GIT_MKDIR_EXCL));
 
 	/* make a path exclusively */
 	cl_assert(!git_path_isdir("d3"));
-	cl_git_pass(git_futils_mkdir("d3/d3.1/d3.2", NULL, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
+	cl_git_pass(git_futils_mkdir("d3/d3.1/d3.2", 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
 	cl_assert(git_path_isdir("d3"));
 	cl_assert(git_path_isdir("d3/d3.1/d3.2"));
 
 	/* make exclusive path failure */
-	cl_git_fail(git_futils_mkdir("d3/d3.1/d3.2", NULL, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
+	cl_git_fail(git_futils_mkdir("d3/d3.1/d3.2", 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
 	/* ??? Should EXCL only apply to the last item in the path? */
 
 	/* path with trailing slash? */
 	cl_assert(!git_path_isdir("d4"));
-	cl_git_pass(git_futils_mkdir("d4/d4.1/", NULL, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("d4/d4.1/", 0755, GIT_MKDIR_PATH));
 	cl_assert(git_path_isdir("d4/d4.1"));
 }
 
@@ -65,38 +65,38 @@ void test_core_mkdir__with_base(void)
 
 	cl_set_cleanup(cleanup_basedir, NULL);
 
-	cl_git_pass(git_futils_mkdir(BASEDIR, NULL, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir(BASEDIR, 0755, GIT_MKDIR_PATH));
 
-	cl_git_pass(git_futils_mkdir("a", BASEDIR, 0755, 0));
+	cl_git_pass(git_futils_mkdir_relative("a", BASEDIR, 0755, 0, NULL));
 	cl_assert(git_path_isdir(BASEDIR "/a"));
 
-	cl_git_pass(git_futils_mkdir("b/b1/b2", BASEDIR, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir_relative("b/b1/b2", BASEDIR, 0755, GIT_MKDIR_PATH, NULL));
 	cl_assert(git_path_isdir(BASEDIR "/b/b1/b2"));
 
 	/* exclusive with existing base */
-	cl_git_pass(git_futils_mkdir("c/c1/c2", BASEDIR, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
+	cl_git_pass(git_futils_mkdir_relative("c/c1/c2", BASEDIR, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL, NULL));
 
 	/* fail: exclusive with duplicated suffix */
-	cl_git_fail(git_futils_mkdir("c/c1/c3", BASEDIR, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
+	cl_git_fail(git_futils_mkdir_relative("c/c1/c3", BASEDIR, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL, NULL));
 
 	/* fail: exclusive with any duplicated component */
-	cl_git_fail(git_futils_mkdir("c/cz/cz", BASEDIR, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
+	cl_git_fail(git_futils_mkdir_relative("c/cz/cz", BASEDIR, 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL, NULL));
 
 	/* success: exclusive without path */
-	cl_git_pass(git_futils_mkdir("c/c1/c3", BASEDIR, 0755, GIT_MKDIR_EXCL));
+	cl_git_pass(git_futils_mkdir_relative("c/c1/c3", BASEDIR, 0755, GIT_MKDIR_EXCL, NULL));
 
 	/* path with shorter base and existing dirs */
-	cl_git_pass(git_futils_mkdir("dir/here/d/", "base", 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir_relative("dir/here/d/", "base", 0755, GIT_MKDIR_PATH, NULL));
 	cl_assert(git_path_isdir("base/dir/here/d"));
 
 	/* fail: path with shorter base and existing dirs */
-	cl_git_fail(git_futils_mkdir("dir/here/e/", "base", 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL));
+	cl_git_fail(git_futils_mkdir_relative("dir/here/e/", "base", 0755, GIT_MKDIR_PATH | GIT_MKDIR_EXCL, NULL));
 
 	/* fail: base with missing components */
-	cl_git_fail(git_futils_mkdir("f/", "base/missing", 0755, GIT_MKDIR_PATH));
+	cl_git_fail(git_futils_mkdir_relative("f/", "base/missing", 0755, GIT_MKDIR_PATH, NULL));
 
 	/* success: shift missing component to path */
-	cl_git_pass(git_futils_mkdir("missing/f/", "base/", 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir_relative("missing/f/", "base/", 0755, GIT_MKDIR_PATH, NULL));
 }
 
 static void cleanup_chmod_root(void *ref)
@@ -135,9 +135,9 @@ void test_core_mkdir__chmods(void)
 
 	cl_set_cleanup(cleanup_chmod_root, old);
 
-	cl_git_pass(git_futils_mkdir("r", NULL, 0777, 0));
+	cl_git_pass(git_futils_mkdir("r", 0777, 0));
 
-	cl_git_pass(git_futils_mkdir("mode/is/important", "r", 0777, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir_relative("mode/is/important", "r", 0777, GIT_MKDIR_PATH, NULL));
 
 	cl_git_pass(git_path_lstat("r/mode", &st));
 	check_mode(0755, st.st_mode);
@@ -146,7 +146,7 @@ void test_core_mkdir__chmods(void)
 	cl_git_pass(git_path_lstat("r/mode/is/important", &st));
 	check_mode(0755, st.st_mode);
 
-	cl_git_pass(git_futils_mkdir("mode2/is2/important2", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD));
+	cl_git_pass(git_futils_mkdir_relative("mode2/is2/important2", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD, NULL));
 
 	cl_git_pass(git_path_lstat("r/mode2", &st));
 	check_mode(0755, st.st_mode);
@@ -155,7 +155,7 @@ void test_core_mkdir__chmods(void)
 	cl_git_pass(git_path_lstat("r/mode2/is2/important2", &st));
 	check_mode(0777, st.st_mode);
 
-	cl_git_pass(git_futils_mkdir("mode3/is3/important3", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD_PATH));
+	cl_git_pass(git_futils_mkdir_relative("mode3/is3/important3", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD_PATH, NULL));
 
 	cl_git_pass(git_path_lstat("r/mode3", &st));
 	check_mode(0777, st.st_mode);
@@ -166,7 +166,7 @@ void test_core_mkdir__chmods(void)
 
 	/* test that we chmod existing dir */
 
-	cl_git_pass(git_futils_mkdir("mode/is/important", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD));
+	cl_git_pass(git_futils_mkdir_relative("mode/is/important", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD, NULL));
 
 	cl_git_pass(git_path_lstat("r/mode", &st));
 	check_mode(0755, st.st_mode);
@@ -177,7 +177,7 @@ void test_core_mkdir__chmods(void)
 
 	/* test that we chmod even existing dirs if CHMOD_PATH is set */
 
-	cl_git_pass(git_futils_mkdir("mode2/is2/important2.1", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD_PATH));
+	cl_git_pass(git_futils_mkdir_relative("mode2/is2/important2.1", "r", 0777, GIT_MKDIR_PATH | GIT_MKDIR_CHMOD_PATH, NULL));
 
 	cl_git_pass(git_path_lstat("r/mode2", &st));
 	check_mode(0777, st.st_mode);
@@ -200,8 +200,8 @@ void test_core_mkdir__mkdir_path_inside_unwriteable_parent(void)
 	*old = p_umask(022);
 	cl_set_cleanup(cleanup_chmod_root, old);
 
-	cl_git_pass(git_futils_mkdir("r", NULL, 0777, 0));
-	cl_git_pass(git_futils_mkdir("mode/is/important", "r", 0777, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("r", 0777, 0));
+	cl_git_pass(git_futils_mkdir_relative("mode/is/important", "r", 0777, GIT_MKDIR_PATH, NULL));
 	cl_git_pass(git_path_lstat("r/mode", &st));
 	check_mode(0755, st.st_mode);
 
@@ -210,7 +210,7 @@ void test_core_mkdir__mkdir_path_inside_unwriteable_parent(void)
 	check_mode(0111, st.st_mode);
 
 	cl_git_pass(
-		git_futils_mkdir("mode/is/okay/inside", "r", 0777, GIT_MKDIR_PATH));
+		git_futils_mkdir_relative("mode/is/okay/inside", "r", 0777, GIT_MKDIR_PATH, NULL));
 	cl_git_pass(git_path_lstat("r/mode/is/okay/inside", &st));
 	check_mode(0755, st.st_mode);
 

--- a/tests/core/stat.c
+++ b/tests/core/stat.c
@@ -5,7 +5,7 @@
 
 void test_core_stat__initialize(void)
 {
-	cl_git_pass(git_futils_mkdir("root/d1/d2", NULL, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("root/d1/d2", 0755, GIT_MKDIR_PATH));
 	cl_git_mkfile("root/file", "whatever\n");
 	cl_git_mkfile("root/d1/file", "whatever\n");
 }

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -752,7 +752,7 @@ void test_index_tests__reload_from_disk(void)
 
 	cl_set_cleanup(&cleanup_myrepo, NULL);
 
-	cl_git_pass(git_futils_mkdir("./myrepo", NULL, 0777, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir("./myrepo", 0777, GIT_MKDIR_PATH));
 	cl_git_mkfile("./myrepo/a.txt", "a\n");
 	cl_git_mkfile("./myrepo/b.txt", "b\n");
 

--- a/tests/odb/alternates.c
+++ b/tests/odb/alternates.c
@@ -29,7 +29,7 @@ static void init_linked_repo(const char *path, const char *alternate)
 	cl_git_pass(git_path_prettify(&destpath, alternate, NULL));
 	cl_git_pass(git_buf_joinpath(&destpath, destpath.ptr, "objects"));
 	cl_git_pass(git_buf_joinpath(&filepath, git_repository_path(repo), "objects/info"));
-	cl_git_pass(git_futils_mkdir(filepath.ptr, NULL, 0755, GIT_MKDIR_PATH));
+	cl_git_pass(git_futils_mkdir(filepath.ptr, 0755, GIT_MKDIR_PATH));
 	cl_git_pass(git_buf_joinpath(&filepath, filepath.ptr , "alternates"));
 
 	cl_git_pass(git_filebuf_open(&file, git_buf_cstr(&filepath), 0, 0666));

--- a/tests/refs/pack.c
+++ b/tests/refs/pack.c
@@ -36,7 +36,7 @@ void test_refs_pack__empty(void)
 	git_buf temp_path = GIT_BUF_INIT;
 
 	cl_git_pass(git_buf_join_n(&temp_path, '/', 3, git_repository_path(g_repo), GIT_REFS_HEADS_DIR, "empty_dir"));
-	cl_git_pass(git_futils_mkdir_r(temp_path.ptr, NULL, GIT_REFS_DIR_MODE));
+	cl_git_pass(git_futils_mkdir_r(temp_path.ptr, GIT_REFS_DIR_MODE));
 	git_buf_free(&temp_path);
 
 	packall();

--- a/tests/repo/discover.c
+++ b/tests/repo/discover.c
@@ -77,7 +77,7 @@ void test_repo_discover__0(void)
 	const char *ceiling_dirs;
 	const mode_t mode = 0777;
 
-	git_futils_mkdir_r(DISCOVER_FOLDER, NULL, mode);
+	git_futils_mkdir_r(DISCOVER_FOLDER, mode);
 	append_ceiling_dir(&ceiling_dirs_buf, TEMP_REPO_FOLDER);
 	ceiling_dirs = git_buf_cstr(&ceiling_dirs_buf);
 
@@ -88,15 +88,15 @@ void test_repo_discover__0(void)
 	git_repository_free(repo);
 
 	cl_git_pass(git_repository_init(&repo, SUB_REPOSITORY_FOLDER, 0));
-	cl_git_pass(git_futils_mkdir_r(SUB_REPOSITORY_FOLDER_SUB_SUB_SUB, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(SUB_REPOSITORY_FOLDER_SUB_SUB_SUB, mode));
 	cl_git_pass(git_repository_discover(&sub_repository_path, SUB_REPOSITORY_FOLDER, 0, ceiling_dirs));
 
-	cl_git_pass(git_futils_mkdir_r(SUB_REPOSITORY_FOLDER_SUB_SUB_SUB, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(SUB_REPOSITORY_FOLDER_SUB_SUB_SUB, mode));
 	ensure_repository_discover(SUB_REPOSITORY_FOLDER_SUB, ceiling_dirs, &sub_repository_path);
 	ensure_repository_discover(SUB_REPOSITORY_FOLDER_SUB_SUB, ceiling_dirs, &sub_repository_path);
 	ensure_repository_discover(SUB_REPOSITORY_FOLDER_SUB_SUB_SUB, ceiling_dirs, &sub_repository_path);
 
-	cl_git_pass(git_futils_mkdir_r(REPOSITORY_ALTERNATE_FOLDER_SUB_SUB_SUB, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(REPOSITORY_ALTERNATE_FOLDER_SUB_SUB_SUB, mode));
 	write_file(REPOSITORY_ALTERNATE_FOLDER "/" DOT_GIT, "gitdir: ../" SUB_REPOSITORY_FOLDER_NAME "/" DOT_GIT);
 	write_file(REPOSITORY_ALTERNATE_FOLDER_SUB_SUB "/" DOT_GIT, "gitdir: ../../../" SUB_REPOSITORY_FOLDER_NAME "/" DOT_GIT);
 	write_file(REPOSITORY_ALTERNATE_FOLDER_SUB_SUB_SUB "/" DOT_GIT, "gitdir: ../../../../");
@@ -105,13 +105,13 @@ void test_repo_discover__0(void)
 	ensure_repository_discover(REPOSITORY_ALTERNATE_FOLDER_SUB_SUB, ceiling_dirs, &sub_repository_path);
 	ensure_repository_discover(REPOSITORY_ALTERNATE_FOLDER_SUB_SUB_SUB, ceiling_dirs, &repository_path);
 
-	cl_git_pass(git_futils_mkdir_r(ALTERNATE_MALFORMED_FOLDER1, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(ALTERNATE_MALFORMED_FOLDER1, mode));
 	write_file(ALTERNATE_MALFORMED_FOLDER1 "/" DOT_GIT, "Anything but not gitdir:");
-	cl_git_pass(git_futils_mkdir_r(ALTERNATE_MALFORMED_FOLDER2, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(ALTERNATE_MALFORMED_FOLDER2, mode));
 	write_file(ALTERNATE_MALFORMED_FOLDER2 "/" DOT_GIT, "gitdir:");
-	cl_git_pass(git_futils_mkdir_r(ALTERNATE_MALFORMED_FOLDER3, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(ALTERNATE_MALFORMED_FOLDER3, mode));
 	write_file(ALTERNATE_MALFORMED_FOLDER3 "/" DOT_GIT, "gitdir: \n\n\n");
-	cl_git_pass(git_futils_mkdir_r(ALTERNATE_NOT_FOUND_FOLDER, NULL, mode));
+	cl_git_pass(git_futils_mkdir_r(ALTERNATE_NOT_FOUND_FOLDER, mode));
 	write_file(ALTERNATE_NOT_FOUND_FOLDER "/" DOT_GIT, "gitdir: a_repository_that_surely_does_not_exist");
 	cl_git_fail(git_repository_discover(&found_path, ALTERNATE_MALFORMED_FOLDER1, 0, ceiling_dirs));
 	cl_git_fail(git_repository_discover(&found_path, ALTERNATE_MALFORMED_FOLDER2, 0, ceiling_dirs));

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -99,7 +99,7 @@ void test_repo_init__bare_repo_escaping_current_workdir(void)
 	cl_git_pass(git_path_prettify_dir(&path_current_workdir, ".", NULL));
 
 	cl_git_pass(git_buf_joinpath(&path_repository, git_buf_cstr(&path_current_workdir), "a/b/c"));
-	cl_git_pass(git_futils_mkdir_r(git_buf_cstr(&path_repository), NULL, GIT_DIR_MODE));
+	cl_git_pass(git_futils_mkdir_r(git_buf_cstr(&path_repository), GIT_DIR_MODE));
 
 	/* Change the current working directory */
 	cl_git_pass(chdir(git_buf_cstr(&path_repository)));
@@ -312,7 +312,7 @@ void test_repo_init__extended_0(void)
 	cl_git_fail(git_repository_init_ext(&_repo, "extended", &opts));
 
 	/* make the directory first, then it should succeed */
-	cl_git_pass(git_futils_mkdir("extended", NULL, 0775, 0));
+	cl_git_pass(git_futils_mkdir("extended", 0775, 0));
 	cl_git_pass(git_repository_init_ext(&_repo, "extended", &opts));
 
 	cl_assert(!git__suffixcmp(git_repository_workdir(_repo), "/extended/"));
@@ -631,7 +631,7 @@ void test_repo_init__can_reinit_an_initialized_repository(void)
 
 	cl_set_cleanup(&cleanup_repository, "extended");
 
-	cl_git_pass(git_futils_mkdir("extended", NULL, 0775, 0));
+	cl_git_pass(git_futils_mkdir("extended", 0775, 0));
 	cl_git_pass(git_repository_init(&_repo, "extended", false));
 
 	cl_git_pass(git_repository_init(&reinit, "extended", false));

--- a/tests/repo/iterator.c
+++ b/tests/repo/iterator.c
@@ -848,14 +848,14 @@ static void build_workdir_tree(const char *root, int dirs, int subs)
 	for (i = 0; i < dirs; ++i) {
 		if (i % 2 == 0) {
 			p_snprintf(buf, sizeof(buf), "%s/dir%02d", root, i);
-			cl_git_pass(git_futils_mkdir(buf, NULL, 0775, GIT_MKDIR_PATH));
+			cl_git_pass(git_futils_mkdir(buf, 0775, GIT_MKDIR_PATH));
 
 			p_snprintf(buf, sizeof(buf), "%s/dir%02d/file", root, i);
 			cl_git_mkfile(buf, buf);
 			buf[strlen(buf) - 5] = '\0';
 		} else {
 			p_snprintf(buf, sizeof(buf), "%s/DIR%02d", root, i);
-			cl_git_pass(git_futils_mkdir(buf, NULL, 0775, GIT_MKDIR_PATH));
+			cl_git_pass(git_futils_mkdir(buf, 0775, GIT_MKDIR_PATH));
 		}
 
 		for (j = 0; j < subs; ++j) {
@@ -865,7 +865,7 @@ static void build_workdir_tree(const char *root, int dirs, int subs)
 			case 2: p_snprintf(sub, sizeof(sub), "%s/Sub%02d", buf, j); break;
 			case 3: p_snprintf(sub, sizeof(sub), "%s/SUB%02d", buf, j); break;
 			}
-			cl_git_pass(git_futils_mkdir(sub, NULL, 0775, GIT_MKDIR_PATH));
+			cl_git_pass(git_futils_mkdir(sub, 0775, GIT_MKDIR_PATH));
 
 			if (j % 2 == 0) {
 				size_t sublen = strlen(sub);

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -91,7 +91,7 @@ static void make_gitlink_dir(const char *dir, const char *linktext)
 {
 	git_buf path = GIT_BUF_INIT;
 
-	cl_git_pass(git_futils_mkdir(dir, NULL, 0777, GIT_MKDIR_VERIFY_DIR));
+	cl_git_pass(git_futils_mkdir(dir, 0777, GIT_MKDIR_VERIFY_DIR));
 	cl_git_pass(git_buf_joinpath(&path, dir, ".git"));
 	cl_git_rewritefile(path.ptr, linktext);
 	git_buf_free(&path);
@@ -222,7 +222,7 @@ void test_repo_open__bad_gitlinks(void)
 	cl_git_sandbox_init("attr");
 
 	cl_git_pass(p_mkdir("invalid", 0777));
-	cl_git_pass(git_futils_mkdir_r("invalid2/.git", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("invalid2/.git", 0777));
 
 	for (scan = bad_links; *scan != NULL; scan++) {
 		make_gitlink_dir("alternate", *scan);

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -148,7 +148,7 @@ void test_status_ignore__ignore_pattern_contains_space(void)
 	cl_git_pass(git_status_file(&flags, g_repo, "foo bar.txt"));
 	cl_assert(flags == GIT_STATUS_IGNORED);
 
-	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/foo", NULL, mode));
+	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/foo", mode));
 	cl_git_mkfile("empty_standard_repo/foo/look-ma.txt", "I'm not going to be ignored!");
 
 	cl_git_pass(git_status_file(&flags, g_repo, "foo/look-ma.txt"));
@@ -206,7 +206,7 @@ void test_status_ignore__subdirectories(void)
 	 * used a rooted path for an ignore, so I changed this behavior.
 	 */
 	cl_git_pass(git_futils_mkdir_r(
-		"empty_standard_repo/test/ignore_me", NULL, 0775));
+		"empty_standard_repo/test/ignore_me", 0775));
 	cl_git_mkfile(
 		"empty_standard_repo/test/ignore_me/file", "I'm going to be ignored!");
 	cl_git_mkfile(
@@ -230,9 +230,9 @@ static void make_test_data(const char *reponame, const char **files)
 	g_repo = cl_git_sandbox_init(reponame);
 
 	for (scan = files; *scan != NULL; ++scan) {
-		cl_git_pass(git_futils_mkdir(
+		cl_git_pass(git_futils_mkdir_relative(
 			*scan + repolen, reponame,
-			0777, GIT_MKDIR_PATH | GIT_MKDIR_SKIP_LAST));
+			0777, GIT_MKDIR_PATH | GIT_MKDIR_SKIP_LAST, NULL));
 		cl_git_mkfile(*scan, "contents");
 	}
 }
@@ -612,7 +612,7 @@ void test_status_ignore__issue_1766_negated_ignores(void)
 	g_repo = cl_git_sandbox_init("empty_standard_repo");
 
 	cl_git_pass(git_futils_mkdir_r(
-		"empty_standard_repo/a", NULL, 0775));
+		"empty_standard_repo/a", 0775));
 	cl_git_mkfile(
 		"empty_standard_repo/a/.gitignore", "*\n!.gitignore\n");
 	cl_git_mkfile(
@@ -622,7 +622,7 @@ void test_status_ignore__issue_1766_negated_ignores(void)
 	assert_is_ignored("a/ignoreme");
 
 	cl_git_pass(git_futils_mkdir_r(
-		"empty_standard_repo/b", NULL, 0775));
+		"empty_standard_repo/b", 0775));
 	cl_git_mkfile(
 		"empty_standard_repo/b/.gitignore", "*\n!.gitignore\n");
 	cl_git_mkfile(
@@ -1033,7 +1033,7 @@ void test_status_ignore__negate_starstar(void)
               "code/projects/**/packages/*\n"
               "!code/projects/**/packages/repositories.config");
 
-    cl_git_pass(git_futils_mkdir_r("code/projects/foo/bar/packages", "empty_standard_repo", 0777));
+    cl_git_pass(git_futils_mkdir_r("empty_standard_repo/code/projects/foo/bar/packages", 0777));
     cl_git_mkfile("empty_standard_repo/code/projects/foo/bar/packages/repositories.config", "");
 
     cl_git_pass(git_ignore_path_is_ignored(&ignored, g_repo, "code/projects/foo/bar/packages/repositories.config"));

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -195,7 +195,7 @@ void test_status_worktree__swap_subdir_with_recurse_and_pathspec(void)
 	cl_git_pass(p_rename("status/subdir", "status/current_file"));
 	cl_git_pass(p_rename("status/swap", "status/subdir"));
 	cl_git_mkfile("status/.new_file", "dummy");
-	cl_git_pass(git_futils_mkdir_r("status/zzz_new_dir", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("status/zzz_new_dir", 0777));
 	cl_git_mkfile("status/zzz_new_dir/new_file", "dummy");
 	cl_git_mkfile("status/zzz_new_file", "dummy");
 
@@ -917,7 +917,7 @@ void test_status_worktree__long_filenames(void)
 
 	// Create directory with amazingly long filename
 	sprintf(path, "empty_standard_repo/%s", longname);
-	cl_git_pass(git_futils_mkdir_r(path, NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r(path, 0777));
 	sprintf(path, "empty_standard_repo/%s/foo", longname);
 	cl_git_mkfile(path, "dummy");
 
@@ -1007,7 +1007,7 @@ void test_status_worktree__unreadable(void)
 	status_entry_counts counts = {0};
 
 	/* Create directory with no read permission */
-	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", 0777));
 	cl_git_mkfile("empty_standard_repo/no_permission/foo", "dummy");
 	p_chmod("empty_standard_repo/no_permission", 0644);
 
@@ -1041,7 +1041,7 @@ void test_status_worktree__unreadable_not_included(void)
 	status_entry_counts counts = {0};
 
 	/* Create directory with no read permission */
-	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", 0777));
 	cl_git_mkfile("empty_standard_repo/no_permission/foo", "dummy");
 	p_chmod("empty_standard_repo/no_permission", 0644);
 
@@ -1074,7 +1074,7 @@ void test_status_worktree__unreadable_as_untracked(void)
 	status_entry_counts counts = {0};
 
 	/* Create directory with no read permission */
-	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", NULL, 0777));
+	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", 0777));
 	cl_git_mkfile("empty_standard_repo/no_permission/foo", "dummy");
 	p_chmod("empty_standard_repo/no_permission", 0644);
 

--- a/tests/submodule/status.c
+++ b/tests/submodule/status.c
@@ -92,7 +92,7 @@ void test_submodule_status__ignore_none(void)
 	cl_assert((status & GIT_SUBMODULE_STATUS_WD_DELETED) != 0);
 
 	/* now mkdir sm_unchanged to test uninitialized */
-	cl_git_pass(git_futils_mkdir("sm_unchanged", "submod2", 0755, 0));
+	cl_git_pass(git_futils_mkdir_relative("sm_unchanged", "submod2", 0755, 0, NULL));
 	status = get_submodule_status(g_repo, "sm_unchanged");
 	cl_assert((status & GIT_SUBMODULE_STATUS_WD_UNINITIALIZED) != 0);
 
@@ -141,7 +141,7 @@ void test_submodule_status__ignore_untracked(void)
 	cl_assert((status & GIT_SUBMODULE_STATUS_WD_DELETED) != 0);
 
 	/* now mkdir sm_unchanged to test uninitialized */
-	cl_git_pass(git_futils_mkdir("sm_unchanged", "submod2", 0755, 0));
+	cl_git_pass(git_futils_mkdir_relative("sm_unchanged", "submod2", 0755, 0, NULL));
 	cl_git_pass(git_submodule_status(&status, g_repo,"sm_unchanged", ign));
 	cl_assert((status & GIT_SUBMODULE_STATUS_WD_UNINITIALIZED) != 0);
 
@@ -185,7 +185,7 @@ void test_submodule_status__ignore_dirty(void)
 	cl_assert((status & GIT_SUBMODULE_STATUS_WD_DELETED) != 0);
 
 	/* now mkdir sm_unchanged to test uninitialized */
-	cl_git_pass(git_futils_mkdir("sm_unchanged", "submod2", 0755, 0));
+	cl_git_pass(git_futils_mkdir_relative("sm_unchanged", "submod2", 0755, 0, NULL));
 	cl_git_pass(git_submodule_status(&status, g_repo,"sm_unchanged", ign));
 	cl_assert((status & GIT_SUBMODULE_STATUS_WD_UNINITIALIZED) != 0);
 
@@ -229,7 +229,7 @@ void test_submodule_status__ignore_all(void)
 	cl_assert(GIT_SUBMODULE_STATUS_IS_UNMODIFIED(status));
 
 	/* now mkdir sm_unchanged to test uninitialized */
-	cl_git_pass(git_futils_mkdir("sm_unchanged", "submod2", 0755, 0));
+	cl_git_pass(git_futils_mkdir_relative("sm_unchanged", "submod2", 0755, 0, NULL));
 	cl_git_pass(git_submodule_status(&status, g_repo,"sm_unchanged", ign));
 	cl_assert(GIT_SUBMODULE_STATUS_IS_UNMODIFIED(status));
 
@@ -338,7 +338,7 @@ void test_submodule_status__untracked_dirs_containing_ignored_files(void)
 		"submod2/.git/modules/sm_unchanged/info/exclude", "\n*.ignored\n");
 
 	cl_git_pass(
-		git_futils_mkdir("sm_unchanged/directory", "submod2", 0755, 0));
+		git_futils_mkdir_relative("sm_unchanged/directory", "submod2", 0755, 0, NULL));
 	cl_git_mkfile(
 		"submod2/sm_unchanged/directory/i_am.ignored",
 		"ignore this file, please\n");


### PR DESCRIPTION
When attempting to create a directory recursive (eg, matching `mkdir -p` semantics), we walk *up* from the given `base` to determine what directories need to be created.  For checkout, this is right and good and true as we may stumble across a symbolic link within the working directory, and this needs to be *deleted* and re-created as a proper directory.

However, we should only do this walk up when we have a `base` to build relative paths from (eg, when operating in the repository or working directory).  Otherwise, we'll end up trying to walk all the way up from the directory root to the path that we're trying to create.  This is not correct.  For example: we shouldn't be examining `/home` to create a repository in `/home/user/foo/myrepo.git` - we may get hung up trying to stat `/home`.

This PR splits `git_futils_mkdir` into two functions:  `git_futils_mkdir`, which is a general use `mkdir` type function that creates a directory (perhaps creating intermediate directories ala `mkdir -p`) and `git_futils_mkdir_relative`, which creates a directory relative to a given base directory.

`git_futils_mkdir` - when in recursive creation mode - now examines the requested path and walks toward the root to determine the paths to create, then invokes `git_futils_mkdir_relative` to do the work.

This could have been performed keeping `git_futils_mkdir` a single function and switching on a `NULL` base, but the added complexity was becoming quite horrible to understand.  The `mkdir` function(s) already change behavior significantly based on options like `GIT_MKDIR_SKIP_LAST2` and `GIT_MKDIR_CHMOD_PATH`.  Adding yet another significant behavioral change based on the presence or absence of `base` was complex and an invitation to use the function wrong.

I think that there's opportunity to remove some of these options (and thus clean up the implementation) in the future, but this should be both helpful and correct in the meantime.

Fixes #3068, #3308.