### PR TITLE
Fix binary diffs

### DIFF
--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -358,6 +358,7 @@ static int format_binary(
 		scan += chunk_len;
 		pi->line.num_lines++;
 	}
+	git_buf_putc(pi->buf, '\n');
 
 	return 0;
 }
@@ -416,7 +417,6 @@ static int diff_print_patch_file_binary(
 
 	if ((error = format_binary(pi, binary->new_file.type, binary->new_file.data,
 		binary->new_file.datalen, binary->new_file.inflatedlen)) < 0 ||
-		(error = git_buf_putc(pi->buf, '\n')) < 0 ||
 		(error = format_binary(pi, binary->old_file.type, binary->old_file.data,
 			binary->old_file.datalen, binary->old_file.inflatedlen)) < 0) {
 

--- a/tests/diff/binary.c
+++ b/tests/diff/binary.c
@@ -96,7 +96,8 @@ void test_diff_binary__add(void)
 		"Kc${Nk-~s>u4FC%O\n"
 		"\n" \
 		"literal 0\n" \
-		"Hc$@<O00001\n";
+		"Hc$@<O00001\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY;
 	opts.id_abbrev = GIT_OID_HEXSZ;
@@ -136,7 +137,8 @@ void test_diff_binary__modify(void)
 		"Mc${NkU}WL~000&M4gdfE\n" \
 		"\n" \
 		"literal 3\n" \
-		"Kc${Nk-~s>u4FC%O\n";
+		"Kc${Nk-~s>u4FC%O\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY;
 
@@ -177,7 +179,8 @@ void test_diff_binary__delete(void)
 		"Hc$@<O00001\n" \
 		"\n" \
 		"literal 3\n" \
-		"Kc${Nk-~s>u4FC%O\n";
+		"Kc${Nk-~s>u4FC%O\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY;
 	opts.id_abbrev = GIT_OID_HEXSZ;
@@ -208,7 +211,8 @@ void test_diff_binary__delta(void)
 		"delta 198\n" \
 		"zc$}LmI8{(0BqLQJI6p64AwNwaIJGP_Pr*5}Br~;mqJ$<Jl;sX*mF<MGCYv&*L7AHu\n" \
 		"zGA1*^gt?gYVN82wTbPO_W)+x<&1+cP;HrPHR>PQ;Y(X&QMK*C5^Br3bjG4d=XI^5@\n" \
-		"JfH567LIF3FM2!Fd\n";
+		"JfH567LIF3FM2!Fd\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY | GIT_DIFF_FORCE_BINARY;
 	opts.id_abbrev = GIT_OID_HEXSZ;
@@ -249,7 +253,8 @@ void test_diff_binary__delta_append(void)
 		"nc%1vf+QYWt3zLL@hC)e3Vu?a>QDRl4f_G*?PG(-ZA}<#J$+QbW\n" \
 		"\n" \
 		"delta 7\n" \
-		"Oc%18D`@*{63ljhg(E~C7\n";
+		"Oc%18D`@*{63ljhg(E~C7\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY | GIT_DIFF_FORCE_BINARY;
 	opts.id_abbrev = GIT_OID_HEXSZ;
@@ -314,7 +319,8 @@ void test_diff_binary__index_to_workdir(void)
 		"nc%1vf+QYWt3zLL@hC)e3Vu?a>QDRl4f_G*?PG(-ZA}<#J$+QbW\n" \
 		"\n" \
 		"delta 7\n" \
-		"Oc%18D`@*{63ljhg(E~C7\n";
+		"Oc%18D`@*{63ljhg(E~C7\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY | GIT_DIFF_FORCE_BINARY;
 	opts.id_abbrev = GIT_OID_HEXSZ;
@@ -379,7 +385,8 @@ void test_diff_binary__print_patch_from_diff(void)
 		"nc%1vf+QYWt3zLL@hC)e3Vu?a>QDRl4f_G*?PG(-ZA}<#J$+QbW\n" \
 		"\n" \
 		"delta 7\n" \
-		"Oc%18D`@*{63ljhg(E~C7\n";
+		"Oc%18D`@*{63ljhg(E~C7\n" \
+		"\n";
 
 	opts.flags = GIT_DIFF_SHOW_BINARY | GIT_DIFF_FORCE_BINARY;
 	opts.id_abbrev = GIT_OID_HEXSZ;


### PR DESCRIPTION
git expects an empty line after the binary data:

    literal X
    ...binary data...
    <empty_line>

The last literal block of the generated patches were not containing the required empty line. Example:

	diff --git a/binary_file b/binary_file
	index 3f1b3f9098131cfecea4a50ff8afab349ea66d22..86e5c1008b5ce635d3e3fffa4434c5eccd8f00b6 100644
	GIT binary patch
	literal 8
	Pc${NM&PdElPvrst3ey5{

	literal 6
	Nc${NM%g@i}0ssZ|0lokL
	diff --git a/binary_file2 b/binary_file2
	index 31be99be19470da4af5b28b21e27896a2f2f9ee2..86e5c1008b5ce635d3e3fffa4434c5eccd8f00b6 100644
	GIT binary patch
	literal 8
	Pc${NM&PdElPvrst3ey5{

	literal 13
	Sc${NMEKbZyOexL+Qd|HZV+4u-

git apply of that diff results in:

	error: corrupt binary patch at line 9: diff --git a/binary_file2 b/binary_file2
	fatal: patch with only garbage at line 10

The proper formating is:

	diff --git a/binary_file b/binary_file
	index 3f1b3f9098131cfecea4a50ff8afab349ea66d22..86e5c1008b5ce635d3e3fffa4434c5eccd8f00b6 100644
	GIT binary patch
	literal 8
	Pc${NM&PdElPvrst3ey5{

	literal 6
	Nc${NM%g@i}0ssZ|0lokL
	                                                 <empty line here!!!>
	diff --git a/binary_file2 b/binary_file2
	index 31be99be19470da4af5b28b21e27896a2f2f9ee2..86e5c1008b5ce635d3e3fffa4434c5eccd8f00b6 100644
	GIT binary patch
	literal 8
	Pc${NM&PdElPvrst3ey5{

	literal 13
	Sc${NMEKbZyOexL+Qd|HZV+4u-
	                                                 <empty line here!!!>