### PR TITLE
Preserve modes from a conflict in `git_index_insert`

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -154,13 +154,27 @@ typedef enum {
 	GIT_INDEX_ADD_CHECK_PATHSPEC = (1u << 2),
 } git_index_add_option_t;
 
-/**
- * Match any index stage.
- *
- * Some index APIs take a stage to match; pass this value to match
- * any entry matching the path regardless of stage.
- */
-#define GIT_INDEX_STAGE_ANY -1
+typedef enum {
+	/**
+	 * Match any index stage.
+	 *
+	 * Some index APIs take a stage to match; pass this value to match
+	 * any entry matching the path regardless of stage.
+	 */
+	GIT_INDEX_STAGE_ANY = -1,
+
+	/** A normal staged file in the index. */
+	GIT_INDEX_STAGE_NORMAL = 0,
+
+	/** The ancestor side of a conflict. */
+	GIT_INDEX_STAGE_ANCESTOR = 1,
+
+	/** The "ours" side of a conflict. */
+	GIT_INDEX_STAGE_OURS = 2,
+
+	/** The "theirs" side of a conflict. */
+	GIT_INDEX_STAGE_THEIRS = 3,
+} git_index_stage_t;
 
 /** @name Index File Functions
  *

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -240,3 +240,26 @@ void test_index_bypath__add_honors_existing_case_4(void)
 	cl_assert_equal_s("just_a_dir/a/b/Z/y/X/foo.txt", entry->path);
 }
 
+void test_index_bypath__add_honors_mode(void)
+{
+	git_index_entry *entry, new_entry;
+
+	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
+
+	memcpy(&new_entry, entry, sizeof(git_index_entry));
+	new_entry.path = "README.txt";
+	new_entry.mode = GIT_FILEMODE_BLOB_EXECUTABLE;
+
+	cl_must_pass(p_chmod("submod2/README.txt", GIT_FILEMODE_BLOB_EXECUTABLE));
+
+	cl_git_pass(git_index_add(g_idx, &new_entry));
+	cl_git_pass(git_index_write(g_idx));
+
+	cl_git_rewritefile("submod2/README.txt", "Modified but still executable");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "README.txt"));
+	cl_git_pass(git_index_write(g_idx));
+
+	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
+	cl_assert_equal_i(GIT_FILEMODE_BLOB_EXECUTABLE, entry->mode);
+}

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -242,7 +242,8 @@ void test_index_bypath__add_honors_existing_case_4(void)
 
 void test_index_bypath__add_honors_mode(void)
 {
-	git_index_entry *entry, new_entry;
+	const git_index_entry *entry;
+	git_index_entry new_entry;
 
 	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
 
@@ -253,6 +254,70 @@ void test_index_bypath__add_honors_mode(void)
 	cl_must_pass(p_chmod("submod2/README.txt", GIT_FILEMODE_BLOB_EXECUTABLE));
 
 	cl_git_pass(git_index_add(g_idx, &new_entry));
+	cl_git_pass(git_index_write(g_idx));
+
+	cl_git_rewritefile("submod2/README.txt", "Modified but still executable");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "README.txt"));
+	cl_git_pass(git_index_write(g_idx));
+
+	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
+	cl_assert_equal_i(GIT_FILEMODE_BLOB_EXECUTABLE, entry->mode);
+}
+
+void test_index_bypath__add_honors_conflict_mode(void)
+{
+	const git_index_entry *entry;
+	git_index_entry new_entry;
+	int stage = 0;
+
+	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
+
+	memcpy(&new_entry, entry, sizeof(git_index_entry));
+	new_entry.path = "README.txt";
+	new_entry.mode = GIT_FILEMODE_BLOB_EXECUTABLE;
+
+	cl_must_pass(p_chmod("submod2/README.txt", GIT_FILEMODE_BLOB_EXECUTABLE));
+
+	cl_git_pass(git_index_remove_bypath(g_idx, "README.txt"));
+
+	for (stage = 1; stage <= 3; stage++) {
+		new_entry.flags = stage << GIT_IDXENTRY_STAGESHIFT;
+		cl_git_pass(git_index_add(g_idx, &new_entry));
+	}
+
+	cl_git_pass(git_index_write(g_idx));
+
+	cl_git_rewritefile("submod2/README.txt", "Modified but still executable");
+
+	cl_git_pass(git_index_add_bypath(g_idx, "README.txt"));
+	cl_git_pass(git_index_write(g_idx));
+
+	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
+	cl_assert_equal_i(GIT_FILEMODE_BLOB_EXECUTABLE, entry->mode);
+}
+
+void test_index_bypath__add_honors_conflict_case(void)
+{
+	const git_index_entry *entry;
+	git_index_entry new_entry;
+	int stage = 0;
+
+	cl_assert((entry = git_index_get_bypath(g_idx, "README.txt", 0)) != NULL);
+
+	memcpy(&new_entry, entry, sizeof(git_index_entry));
+	new_entry.path = "README.txt";
+	new_entry.mode = GIT_FILEMODE_BLOB_EXECUTABLE;
+
+	cl_must_pass(p_chmod("submod2/README.txt", GIT_FILEMODE_BLOB_EXECUTABLE));
+
+	cl_git_pass(git_index_remove_bypath(g_idx, "README.txt"));
+
+	for (stage = 1; stage <= 3; stage++) {
+		new_entry.flags = stage << GIT_IDXENTRY_STAGESHIFT;
+		cl_git_pass(git_index_add(g_idx, &new_entry));
+	}
+
 	cl_git_pass(git_index_write(g_idx));
 
 	cl_git_rewritefile("submod2/README.txt", "Modified but still executable");


### PR DESCRIPTION
When we are on a filesystem where we do not trust the mode (ie, Windows), we presently preserve the modes from a given file when adding entries to the index by looking at the existing index entry for that path.

If we are resolving a conflict, we should also look at *those* entries to try to take their mode.  (If you had a file that was executable and are resolving the conflict on Windows, you would not want to lose the executableness.)