### PR TITLE
Add a cmake option to require openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ ENDIF()
 
 IF (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	OPTION( USE_OPENSSL                     "Link with and use openssl library"             ON )
+	OPTION( REQUIRE_OPENSSL                 "Fail configuration if openssl not found"       OFF )
 ENDIF()
 
 # This variable will contain the libraries we need to put into
@@ -246,7 +247,11 @@ ELSE ()
 	ENDIF ()
 
 	IF (NOT AMIGA AND USE_OPENSSL)
-		FIND_PACKAGE(OpenSSL)
+		IF (REQUIRE_OPENSSL)
+			FIND_PACKAGE(OpenSSL REQUIRED)
+		ELSE ()
+			FIND_PACKAGE(OpenSSL)
+		ENDIF ()
 	ENDIF ()
 
 	IF (CURL_FOUND)


### PR DESCRIPTION
This could be useful in some cases to ensure at build time that the library gets built with https support, on systems that need openssl to do so.

On a somewhat related note, would maintainers here be receptive to a PR that implements optional support for [MbedTLS](https://tls.mbed.org/) as an alternative backend?