### PR TITLE
CMakeLists: Equalize comparisons to CMAKE_SIZEOF_VOID_P

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ IF (WIN32 AND WINHTTP)
 		SET(LIBWINHTTP_PATH "${CMAKE_CURRENT_BINARY_DIR}/deps/winhttp")
 		FILE(MAKE_DIRECTORY ${LIBWINHTTP_PATH})
 
-		IF ("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
+		IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
 			set(WINHTTP_DEF "${CMAKE_CURRENT_SOURCE_DIR}/deps/winhttp/winhttp64.def")
 		ELSE()
 			set(WINHTTP_DEF "${CMAKE_CURRENT_SOURCE_DIR}/deps/winhttp/winhttp.def")
@@ -538,10 +538,8 @@ FILE(GLOB SRC_GIT2 src/*.c src/*.h src/transports/*.c src/transports/*.h src/xdi
 # Determine architecture of the machine
 IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
 	ADD_DEFINITIONS(-DGIT_ARCH_64)
-ELSEIF (CMAKE_SIZEOF_VOID_P EQUAL 4)
-	ADD_DEFINITIONS(-DGIT_ARCH_32)
 ELSE()
-	MESSAGE(FATAL_ERROR "Unsupported architecture")
+	ADD_DEFINITIONS(-DGIT_ARCH_32)
 ENDIF()
 
 # Compile and link libgit2


### PR DESCRIPTION
Compare CMAKE_SIZEOF_VOID_P as a number, not as a string. Also,
consistently use 32-bit as the fallback to work around combinations of
CMake / compiler versions where CMAKE_SIZEOF_VOID_P is unset. This should
be uncritical as there are no relevant architectures (yet) that are
neither 32- nor 64-bit, and even if so, they are still likely to be able
to run 32-bit code, too.