### PR TITLE
Examples: network/fetch.c transfer_progress_cb - should return a value

### DIFF
--- a/examples/network/fetch.c
+++ b/examples/network/fetch.c
@@ -63,6 +63,7 @@ static int transfer_progress_cb(const git_transfer_progress *stats, void *payloa
 		       stats->received_objects, stats->total_objects,
 		       stats->indexed_objects, stats->received_bytes);
 	}
+	return 0;
 }
 
 /** Entry point for this command */


### PR DESCRIPTION
`transfer_progress_cb` should return a value, otherwise the transfer gets aborted sometimes.