### PR TITLE
revwalk: make commit list use 64 bits for time

### DIFF
--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -110,7 +110,7 @@ static int commit_quick_parse(
 	const uint8_t *buffer_end = buffer + buffer_len;
 	const uint8_t *parents_start, *committer_start;
 	int i, parents = 0;
-	int commit_time;
+	int64_t commit_time;
 
 	buffer += strlen("tree ") + GIT_OID_HEXSZ + 1;
 
@@ -166,10 +166,10 @@ static int commit_quick_parse(
 			buffer--;
 	}
 
-	if ((buffer == committer_start) || (git__strtol32(&commit_time, (char *)(buffer + 1), NULL, 10) < 0))
+	if ((buffer == committer_start) || (git__strtol64(&commit_time, (char *)(buffer + 1), NULL, 10) < 0))
 		return commit_error(commit, "cannot parse commit time");
 
-	commit->time = (time_t)commit_time;
+	commit->time = commit_time;
 	commit->parsed = 1;
 	return 0;
 }

--- a/src/commit_list.h
+++ b/src/commit_list.h
@@ -22,7 +22,7 @@
 
 typedef struct git_commit_list_node {
 	git_oid oid;
-	uint32_t time;
+	int64_t time;
 	unsigned int seen:1,
 			 uninteresting:1,
 			 topo_delay:1,

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -437,3 +437,38 @@ void test_revwalk_basic__mimic_git_rev_list(void)
 
    cl_git_fail_with(git_revwalk_next(&oid, _walk), GIT_ITEROVER);
 }
+
+void test_revwalk_basic__big_timestamp(void)
+{
+	git_reference *head;
+	git_commit *tip;
+	git_signature *sig;
+	git_tree *tree;
+	git_oid id;
+	int error;
+
+	revwalk_basic_setup_walk("testrepo.git");
+
+	cl_git_pass(git_repository_head(&head, _repo));
+	cl_git_pass(git_reference_peel((git_object **) &tip, head, GIT_OBJ_COMMIT));
+
+	/* Commit with a far-ahead timestamp, we should be able to parse it in the revwalk */
+	cl_git_pass(git_signature_new(&sig, "Joe", "joe@example.com", 2399662595, 0));
+	cl_git_pass(git_commit_tree(&tree, tip));
+
+	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1, &tip));
+
+	cl_git_pass(git_revwalk_push_head(_walk));
+
+	while ((error = git_revwalk_next(&id, _walk)) == 0) {
+		/* nothing */
+	}
+
+	cl_assert_equal_i(GIT_ITEROVER, error);
+
+	git_tree_free(tree);
+	git_commit_free(tip);
+	git_reference_free(head);
+	git_signature_free(sig);
+
+}


### PR DESCRIPTION
We moved the "main" parsing to use 64 bits for the timestamp, but the
quick parsing for the revwalk did not. This means that for large
timestamps we fail to parse the time and thus the walk.

Move this parser to use 64 bits as well.