### PR TITLE
signature: Strip crud

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1193,13 +1193,13 @@ static int index_no_dups(void **old, void *new)
 }
 
 static void index_existing_and_best(
-	const git_index_entry **existing,
+	git_index_entry **existing,
 	size_t *existing_position,
-	const git_index_entry **best,
+	git_index_entry **best,
 	git_index *index,
 	const git_index_entry *entry)
 {
-	const git_index_entry *e;
+	git_index_entry *e;
 	size_t pos;
 	int error;
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -34,13 +34,27 @@ static bool contains_angle_brackets(const char *input)
 	return strchr(input, '<') != NULL || strchr(input, '>') != NULL;
 }
 
+static bool is_crud(unsigned char c)
+{
+	return  c <= 32  ||
+		c == '.' ||
+		c == ',' ||
+		c == ':' ||
+		c == ';' ||
+		c == '<' ||
+		c == '>' ||
+		c == '"' ||
+		c == '\\' ||
+		c == '\'';
+}
+
 static char *extract_trimmed(const char *ptr, size_t len)
 {
-	while (len && git__isspace(ptr[0])) {
+	while (len && is_crud((unsigned char)ptr[0])) {
 		ptr++; len--;
 	}
 
-	while (len && git__isspace(ptr[len - 1])) {
+	while (len && is_crud((unsigned char)ptr[len - 1])) {
 		len--;
 	}
 

--- a/tests/commit/signature.c
+++ b/tests/commit/signature.c
@@ -35,6 +35,13 @@ void test_commit_signature__leading_and_trailing_spaces_are_trimmed(void)
 	assert_name_and_email("nulltoken", "emeric.fermas@gmail.com", " \t nulltoken \n", " \n  emeric.fermas@gmail.com  \n");
 }
 
+void test_commit_signature__leading_and_trailing_crud_is_trimmed(void)
+{
+	assert_name_and_email("nulltoken", "emeric.fermas@gmail.com", "\"nulltoken\"", "\"emeric.fermas@gmail.com\"");
+	assert_name_and_email("nulltoken w", "emeric.fermas@gmail.com", "nulltoken w.", "emeric.fermas@gmail.com");
+	assert_name_and_email("nulltoken \xe2\x98\xba", "emeric.fermas@gmail.com", "nulltoken \xe2\x98\xba", "emeric.fermas@gmail.com");
+}
+
 void test_commit_signature__angle_brackets_in_names_are_not_supported(void)
 {
 	cl_git_fail(try_build_signature("<Phil Haack", "phil@haack", 1234567890, 60));

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -2080,7 +2080,7 @@ void test_diff_workdir__to_index_pathlist(void)
 	cl_git_pass(git_repository_index(&index, g_repo));
 
 	opts.flags = GIT_DIFF_INCLUDE_IGNORED;
-	opts.pathspec.strings = pathlist.contents;
+	opts.pathspec.strings = (char **)pathlist.contents;
 	opts.pathspec.count = pathlist.length;
 
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, &opts));

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -456,7 +456,8 @@ void test_revwalk_basic__big_timestamp(void)
 	cl_git_pass(git_signature_new(&sig, "Joe", "joe@example.com", 2399662595, 0));
 	cl_git_pass(git_commit_tree(&tree, tip));
 
-	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1, &tip));
+	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1,
+		(const git_commit **)&tip));
 
 	cl_git_pass(git_revwalk_push_head(_walk));
 

--- a/tests/revwalk/signatureparsing.c
+++ b/tests/revwalk/signatureparsing.c
@@ -38,7 +38,7 @@ void test_revwalk_signatureparsing__do_not_choke_when_name_contains_angle_bracke
 
 	signature = git_commit_committer(commit);
 	cl_assert_equal_s("foo@example.com", signature->email);
-	cl_assert_equal_s("<Yu V. Bin Haacked>", signature->name);
+	cl_assert_equal_s("Yu V. Bin Haacked", signature->name);
 	cl_assert_equal_i(1323847743, (int)signature->when.time);
 	cl_assert_equal_i(60, signature->when.offset);
 


### PR DESCRIPTION
So, Git does this: https://github.com/github/git/blob/github/ident.c#L137-L155

And we don't. So I feel we should be doing this. As to do the same thing that Git does. Even though whatever Git does is weird. But this is causing commits to differ from my experiments. So it would make my life easier if we did the same thing that Git does.

cc @carlosmn @ethomson 