### PR TITLE
xdiff: reference util.h in parent directory

### DIFF
--- a/src/xdiff/xdiff.h
+++ b/src/xdiff/xdiff.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include "util.h"
+#include "../util.h"
 
 #if !defined(XDIFF_H)
 #define XDIFF_H


### PR DESCRIPTION
Although CMake will correctly configure include directories for us,
some people may use their own build system, and we should reference
`util.h` based on where it actually lives.