### PR TITLE
Fix git_commit_summary to collapse whitespace around newlines

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -436,17 +436,23 @@ const char *git_commit_summary(git_commit *commit)
 
 	if (!commit->summary) {
 		for (msg = git_commit_message(commit), space = NULL; *msg; ++msg) {
-			if (msg[0] == '\n' && (!msg[1] || msg[1] == '\n'))
+			char next_character = msg[0];
+			/* stop processing at the end of the first paragraph */
+			if (next_character == '\n' && (!msg[1] || msg[1] == '\n'))
 				break;
-			else if (msg[0] == '\n')
-				git_buf_putc(&summary, ' ');
-			else if (git__isspace(msg[0]))
+			/* record the beginning of contiguous whitespace runs */
+			else if (git__isspace_nonlf(next_character))
 				space = space ? space : msg;
-			else if (space) {
-				git_buf_put(&summary, space, (msg - space) + 1);
-				space = NULL;
-			} else
-				git_buf_putc(&summary, *msg);
+			/* the next character is non-space */
+			else {
+				/* copy any recorded whitespace */
+				if (space) {
+					git_buf_put(&summary, space, (msg - space));
+					space = NULL;
+				}
+				/* copy the next character, but convert newlines to spaces */
+				git_buf_putc(&summary, next_character == '\n' ? ' ' : next_character);
+			}
 		}
 
 		commit->summary = git_buf_detach(&summary);

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -76,6 +76,8 @@ void test_commit_commit__summary(void)
 	assert_commit_summary("Trailing spaces  are removed", "Trailing spaces  are removed  ");
 	assert_commit_summary("Trailing tabs", "Trailing tabs\t\n\nare removed");
 	assert_commit_summary("Trailing spaces", "Trailing spaces \n\nare removed");
+	assert_commit_summary("Newline is removed", "Newline\nis removed");
+	assert_commit_summary("Newline after space  is removed", "Newline after space \nis removed");
 	assert_commit_summary("", "");
 	assert_commit_summary("", " ");
 	assert_commit_summary("", "\n");

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -70,14 +70,16 @@ void test_commit_commit__summary(void)
 	assert_commit_summary("Trimmed leading&trailing newlines", "\n\nTrimmed leading&trailing newlines\n\n");
 	assert_commit_summary("First paragraph only", "\nFirst paragraph only\n\n(There are more!)");
 	assert_commit_summary("First paragraph with  unwrapped trailing\tlines", "\nFirst paragraph\nwith  unwrapped\ntrailing\tlines\n\n(Yes, unwrapped!)");
-	assert_commit_summary("\tLeading \ttabs", "\tLeading\n\ttabs\n\nis preserved");
-	assert_commit_summary(" Leading  Spaces", " Leading\n Spaces\n\nare preserved");
+	assert_commit_summary("\tLeading tabs", "\tLeading\n\ttabs\n\nare preserved"); /* tabs around newlines are collapsed down to a single space */
+	assert_commit_summary(" Leading Spaces", " Leading\n Spaces\n\nare preserved"); /* spaces around newlines are collapsed down to a single space */
 	assert_commit_summary("Trailing tabs\tare removed", "Trailing tabs\tare removed\t\t");
 	assert_commit_summary("Trailing spaces  are removed", "Trailing spaces  are removed  ");
 	assert_commit_summary("Trailing tabs", "Trailing tabs\t\n\nare removed");
 	assert_commit_summary("Trailing spaces", "Trailing spaces \n\nare removed");
-	assert_commit_summary("Newline is removed", "Newline\nis removed");
-	assert_commit_summary("Newline after space  is removed", "Newline after space \nis removed");
+	assert_commit_summary("Newlines are replaced by spaces", "Newlines\nare\nreplaced by spaces\n");
+	assert_commit_summary("  Spaces after newlines are collapsed", "\n  Spaces after newlines\n  are\n  collapsed\n  "); /* newlines at the very beginning are ignored and not collapsed */
+	assert_commit_summary(" Spaces before newlines are collapsed", "  \nSpaces before newlines  \nare  \ncollapsed  \n");
+	assert_commit_summary(" Spaces around newlines are collapsed", "  \n  Spaces around newlines  \n  are  \n  collapsed  \n  ");
 	assert_commit_summary("", "");
 	assert_commit_summary("", " ");
 	assert_commit_summary("", "\n");

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -8,7 +8,7 @@ static const char *tree_oid = "1810dff58d8a660512d4832e740f692884338ccd";
 static const char *root_commit_message = "This is a root commit\n\
    This is a root commit and should be the only one in this branch\n";
 static const char *root_reflog_message = "commit (initial): This is a root commit \
-   This is a root commit and should be the only one in this branch";
+This is a root commit and should be the only one in this branch";
 static char *head_old;
 static git_reference *head, *branch;
 static git_commit *commit;


### PR DESCRIPTION
This addresses the issue mentioned in #3458 where `git_commit_summary` returns newlines when they occur following whitespace.  `git_commit_summary` now collapses all whitespace around a newline into a single space, as per the discussion in #3458.

Broken out from #3463 as a separate PR.