### PR TITLE
pool: Simplify implementation

### DIFF
--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -35,11 +35,7 @@ int git_attr_file__new(
 		return -1;
 	}
 
-	if (git_pool_init(&attrs->pool, 1, 0) < 0) {
-		attr_file_free(attrs);
-		return -1;
-	}
-
+	git_pool_init(&attrs->pool, 1);
 	GIT_REFCOUNT_INC(attrs);
 	attrs->entry  = entry;
 	attrs->source = source;

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -388,9 +388,10 @@ int git_attr_cache__do_init(git_repository *repo)
 	 * hashtable for attribute macros, and string pool
 	 */
 	if ((ret = git_strmap_alloc(&cache->files)) < 0 ||
-		(ret = git_strmap_alloc(&cache->macros)) < 0 ||
-		(ret = git_pool_init(&cache->pool, 1, 0)) < 0)
+		(ret = git_strmap_alloc(&cache->macros)) < 0)
 		goto cancel;
+
+	git_pool_init(&cache->pool, 1);
 
 	cache = git__compare_and_swap(&repo->attrcache, NULL, cache);
 	if (cache)

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1255,10 +1255,12 @@ static int checkout_get_actions(
 	int error = 0, act;
 	const git_index_entry *wditem;
 	git_vector pathspec = GIT_VECTOR_INIT, *deltas;
-	git_pool pathpool = GIT_POOL_INIT_STRINGPOOL;
+	git_pool pathpool;
 	git_diff_delta *delta;
 	size_t i, *counts = NULL;
 	uint32_t *actions = NULL;
+
+	git_pool_init(&pathpool, 1);
 
 	if (data->opts.paths.count > 0 &&
 		git_pathspec__vinit(&pathspec, &data->opts.paths, &pathpool) < 0)
@@ -2439,10 +2441,11 @@ static int checkout_data_init(
 		git_config_entry_free(conflict_style);
 	}
 
+	git_pool_init(&data->pool, 1);
+
 	if ((error = git_vector_init(&data->removes, 0, git__strcmp_cb)) < 0 ||
 		(error = git_vector_init(&data->remove_conflicts, 0, NULL)) < 0 ||
 		(error = git_vector_init(&data->update_conflicts, 0, NULL)) < 0 ||
-		(error = git_pool_init(&data->pool, 1, 0)) < 0 ||
 		(error = git_buf_puts(&data->path, data->opts.target_directory)) < 0 ||
 		(error = git_path_to_dir(&data->path)) < 0 ||
 		(error = git_strmap_alloc(&data->mkdir_map)) < 0)

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -47,7 +47,7 @@ git_commit_list *git_commit_list_insert_by_date(git_commit_list_node *item, git_
 
 git_commit_list_node *git_commit_list_alloc_node(git_revwalk *walk)
 {
-	return (git_commit_list_node *)git_pool_malloc(&walk->commit_pool, COMMIT_ALLOC);
+	return (git_commit_list_node *)git_pool_mallocz(&walk->commit_pool, 1);
 }
 
 static int commit_error(git_commit_list_node *commit, const char *msg)

--- a/src/diff.c
+++ b/src/diff.c
@@ -430,8 +430,9 @@ static git_diff *diff_list_alloc(
 	diff->new_src = new_iter->type;
 	memcpy(&diff->opts, &dflt, sizeof(diff->opts));
 
-	if (git_vector_init(&diff->deltas, 0, git_diff_delta__cmp) < 0 ||
-		git_pool_init(&diff->pool, 1, 0) < 0) {
+	git_pool_init(&diff->pool, 1);
+
+	if (git_vector_init(&diff->deltas, 0, git_diff_delta__cmp) < 0) {
 		git_diff_free(diff);
 		return NULL;
 	}

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -134,10 +134,10 @@ int git_diff__merge(
 		return -1;
 	}
 
-	if (git_vector_init(
-			&onto_new, onto->deltas.length, git_diff_delta__cmp) < 0 ||
-		git_pool_init(&onto_pool, 1, 0) < 0)
+	if (git_vector_init(&onto_new, onto->deltas.length, git_diff_delta__cmp) < 0)
 		return -1;
+
+	git_pool_init(&onto_pool, 1);
 
 	for (i = 0, j = 0; i < onto->deltas.length || j < from->deltas.length; ) {
 		git_diff_delta *o = GIT_VECTOR_GET(&onto->deltas, i);

--- a/src/index.c
+++ b/src/index.c
@@ -439,7 +439,7 @@ int git_index_open(git_index **index_out, const char *index_path)
 		return -1;
 	}
 
-	git_pool_init(&index->tree_pool, 1, 0);
+	git_pool_init(&index->tree_pool, 1);
 
 	if (index_path != NULL) {
 		index->index_file_path = git__strdup(index_path);

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -567,7 +567,7 @@ static bool tree_iterator__pop_frame(tree_iterator *ti, bool final)
 	tree_iterator__move_to_next(ti, tf);
 
 	if (!final) { /* if final, don't bother to clean up */
-		git_pool_free_array(&ti->pool, tf->n_entries, (void **)tf->entries);
+		// TODO: maybe free the pool so far?
 		git_buf_rtruncate_at_char(&ti->path, '/');
 	}
 
@@ -822,8 +822,9 @@ int git_iterator_for_tree(
 	if ((error = iterator__update_ignore_case((git_iterator *)ti, options ? options->flags : 0)) < 0)
 		goto fail;
 
-	if ((error = git_pool_init(&ti->pool, sizeof(tree_iterator_entry),0)) < 0 ||
-		(error = tree_iterator__create_root_frame(ti, tree)) < 0 ||
+	git_pool_init(&ti->pool, sizeof(tree_iterator_entry));
+
+	if ((error = tree_iterator__create_root_frame(ti, tree)) < 0 ||
 		(error = tree_iterator__push_frame(ti)) < 0) /* expand root now */
 		goto fail;
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -1307,7 +1307,6 @@ GIT_INLINE(int) index_entry_dup_pool(
 {
 	if (src != NULL) {
 		memcpy(out, src, sizeof(git_index_entry));
-
 		if ((out->path = git_pool_strdup(pool, src->path)) == NULL)
 			return -1;
 	}
@@ -1442,10 +1441,11 @@ git_merge_diff_list *git_merge_diff_list__alloc(git_repository *repo)
 
 	diff_list->repo = repo;
 
+	git_pool_init(&diff_list->pool, 1);
+
 	if (git_vector_init(&diff_list->staged, 0, NULL) < 0 ||
 		git_vector_init(&diff_list->conflicts, 0, NULL) < 0 ||
-		git_vector_init(&diff_list->resolved, 0, NULL) < 0 ||
-		git_pool_init(&diff_list->pool, 1, 0) < 0) {
+		git_vector_init(&diff_list->resolved, 0, NULL) < 0) {
 		git_merge_diff_list__free(diff_list);
 		return NULL;
 	}

--- a/src/merge.c
+++ b/src/merge.c
@@ -626,7 +626,7 @@ static int merge_conflict_resolve_one_renamed(
 		git_oid__cmp(&conflict->our_entry.id, &conflict->their_entry.id) != 0)
 		return 0;
 
-	if ((merged = git_pool_mallocz(&diff_list->pool, sizeof(git_index_entry))) == NULL)
+	if ((merged = git_pool_malloc(&diff_list->pool, sizeof(git_index_entry))) == NULL)
 		return -1;
 
 	if (ours_changed)
@@ -1383,7 +1383,7 @@ static int merge_diff_list_insert_unmodified(
 	int error = 0;
 	git_index_entry *entry;
 
-	entry = git_pool_mallocz(&diff_list->pool, sizeof(git_index_entry));
+	entry = git_pool_malloc(&diff_list->pool, sizeof(git_index_entry));
 	GITERR_CHECK_ALLOC(entry);
 
 	if ((error = index_entry_dup_pool(entry, &diff_list->pool, tree_items[0])) >= 0)

--- a/src/merge.c
+++ b/src/merge.c
@@ -626,7 +626,7 @@ static int merge_conflict_resolve_one_renamed(
 		git_oid__cmp(&conflict->our_entry.id, &conflict->their_entry.id) != 0)
 		return 0;
 
-	if ((merged = git_pool_malloc(&diff_list->pool, sizeof(git_index_entry))) == NULL)
+	if ((merged = git_pool_mallocz(&diff_list->pool, sizeof(git_index_entry))) == NULL)
 		return -1;
 
 	if (ours_changed)
@@ -711,7 +711,7 @@ static int merge_conflict_resolve_automerge(
 		(error = git_odb_write(&automerge_oid, odb, result.ptr, result.len, GIT_OBJ_BLOB)) < 0)
 		goto done;
 
-	if ((index_entry = git_pool_malloc(&diff_list->pool, sizeof(git_index_entry))) == NULL)
+	if ((index_entry = git_pool_mallocz(&diff_list->pool, sizeof(git_index_entry))) == NULL)
 	GITERR_CHECK_ALLOC(index_entry);
 
 	index_entry->path = git_pool_strdup(&diff_list->pool, result.path);
@@ -1342,7 +1342,7 @@ static git_merge_diff *merge_diff_from_index_entries(
 	git_merge_diff *conflict;
 	git_pool *pool = &diff_list->pool;
 
-	if ((conflict = git_pool_malloc(pool, sizeof(git_merge_diff))) == NULL)
+	if ((conflict = git_pool_mallocz(pool, sizeof(git_merge_diff))) == NULL)
 		return NULL;
 
 	if (index_entry_dup_pool(&conflict->ancestor_entry, pool, entries[TREE_IDX_ANCESTOR]) < 0 ||
@@ -1383,7 +1383,7 @@ static int merge_diff_list_insert_unmodified(
 	int error = 0;
 	git_index_entry *entry;
 
-	entry = git_pool_malloc(&diff_list->pool, sizeof(git_index_entry));
+	entry = git_pool_mallocz(&diff_list->pool, sizeof(git_index_entry));
 	GITERR_CHECK_ALLOC(entry);
 
 	if ((error = index_entry_dup_pool(entry, &diff_list->pool, tree_items[0])) >= 0)

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -135,8 +135,7 @@ int git_packbuilder_new(git_packbuilder **out, git_repository *repo)
 	if (!pb->walk_objects)
 		goto on_error;
 
-	if (git_pool_init(&pb->object_pool, sizeof(git_walk_object), 0) < 0)
-		goto on_error;
+	git_pool_init(&pb->object_pool, sizeof(git_walk_object));
 
 	pb->repo = repo;
 	pb->nr_threads = 1; /* do not spawn any thread by default */

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -237,9 +237,9 @@ int git_pathspec__init(git_pathspec *ps, const git_strarray *paths)
 	memset(ps, 0, sizeof(*ps));
 
 	ps->prefix = git_pathspec_prefix(paths);
+	git_pool_init(&ps->pool, 1);
 
-	if ((error = git_pool_init(&ps->pool, 1, 0)) < 0 ||
-		(error = git_pathspec__vinit(&ps->pathspec, paths, &ps->pool)) < 0)
+	if ((error = git_pathspec__vinit(&ps->pathspec, paths, &ps->pool)) < 0)
 		git_pathspec__clear(ps);
 
 	return error;
@@ -312,14 +312,10 @@ static git_pathspec_match_list *pathspec_match_alloc(
 	git_pathspec *ps, int datatype)
 {
 	git_pathspec_match_list *m = git__calloc(1, sizeof(git_pathspec_match_list));
-
-	if (m != NULL && git_pool_init(&m->pool, 1, 0) < 0) {
-		pathspec_match_free(m);
-		m = NULL;
-	}
-
 	if (!m)
 		return NULL;
+
+	git_pool_init(&m->pool, 1);
 
 	/* need to keep reference to pathspec and increment refcount because
 	 * failures array stores pointers to the pattern strings of the

--- a/src/pool.c
+++ b/src/pool.c
@@ -8,67 +8,49 @@ struct git_pool_page {
 	git_pool_page *next;
 	uint32_t size;
 	uint32_t avail;
-	GIT_ALIGN(char data[GIT_FLEX_ARRAY], 8);
+	char data[GIT_FLEX_ARRAY];
 };
-
-struct pool_freelist {
-	struct pool_freelist *next;
-};
-
-#define GIT_POOL_MIN_USABLE	4
-#define GIT_POOL_MIN_PAGESZ	2 * sizeof(void*)
 
 static void *pool_alloc_page(git_pool *pool, uint32_t size);
-static void pool_insert_page(git_pool *pool, git_pool_page *page);
 
-int git_pool_init(
-	git_pool *pool, uint32_t item_size, uint32_t items_per_page)
+uint32_t git_pool__system_page_size(void)
 {
+	static uint32_t size = 0;
+
+	if (!size) {
+		size_t page_size;
+		if (git__page_size(&page_size) < 0)
+			page_size = 4096;
+		size = page_size - 2 * sizeof(void *); /* allow space for malloc overhead */
+	}
+
+	return size;
+}
+
+void git_pool_init(git_pool *pool, uint32_t item_size)
+{
+	const uint32_t align_size = sizeof(void *) - 1;
 	assert(pool);
 
-	if (!item_size)
-		item_size = 1;
-	/* round up item_size for decent object alignment */
-	if (item_size > 4)
-		item_size = (item_size + 7) & ~7;
-	else if (item_size == 3)
-		item_size = 4;
-
-	if (!items_per_page)
-		items_per_page = git_pool__suggest_items_per_page(item_size);
-	if (item_size * items_per_page < GIT_POOL_MIN_PAGESZ)
-		items_per_page = (GIT_POOL_MIN_PAGESZ + item_size - 1) / item_size;
+	if (item_size > 1)
+		item_size = (item_size + align_size) & ~align_size;
 
 	memset(pool, 0, sizeof(git_pool));
 	pool->item_size = item_size;
-	pool->page_size = item_size * items_per_page;
-
-	return 0;
+	pool->page_size = git_pool__system_page_size();
 }
 
 void git_pool_clear(git_pool *pool)
 {
 	git_pool_page *scan, *next;
 
-	for (scan = pool->open; scan != NULL; scan = next) {
+	for (scan = pool->pages; scan != NULL; scan = next) {
 		next = scan->next;
 		git__free(scan);
 	}
-	pool->open = NULL;
 
-	for (scan = pool->full; scan != NULL; scan = next) {
-		next = scan->next;
-		git__free(scan);
-	}
-	pool->full = NULL;
-
-	pool->free_list = NULL;
-
+	pool->pages = NULL;
 	pool->items = 0;
-
-	pool->has_string_alloc     = 0;
-	pool->has_multi_item_alloc = 0;
-	pool->has_large_page_alloc = 0;
 }
 
 void git_pool_swap(git_pool *a, git_pool *b)
@@ -83,109 +65,39 @@ void git_pool_swap(git_pool *a, git_pool *b)
 	memcpy(b, &temp, sizeof(temp));
 }
 
-static void pool_insert_page(git_pool *pool, git_pool_page *page)
-{
-	git_pool_page *scan;
-
-	/* If there are no open pages or this page has the most open space,
-	 * insert it at the beginning of the list.  This is the common case.
-	 */
-	if (pool->open == NULL || pool->open->avail < page->avail) {
-		page->next = pool->open;
-		pool->open = page;
-		return;
-	}
-
-	/* Otherwise insert into sorted position. */
-	for (scan = pool->open;
-		 scan->next && scan->next->avail > page->avail;
-		 scan = scan->next);
-	page->next = scan->next;
-	scan->next = page;
-}
-
 static void *pool_alloc_page(git_pool *pool, uint32_t size)
 {
 	git_pool_page *page;
-	uint32_t new_page_size;
+	const uint32_t new_page_size = (size <= pool->page_size) ? pool->page_size : size;
 	size_t alloc_size;
-
-	if (size <= pool->page_size)
-		new_page_size = pool->page_size;
-	else {
-		new_page_size = size;
-		pool->has_large_page_alloc = 1;
-	}
 
 	if (GIT_ADD_SIZET_OVERFLOW(&alloc_size, new_page_size, sizeof(git_pool_page)) ||
 		!(page = git__calloc(1, alloc_size)))
 		return NULL;
 
-	page->size  = new_page_size;
+	page->size = new_page_size;
 	page->avail = new_page_size - size;
+	page->next = pool->pages;
 
-	if (page->avail > 0)
-		pool_insert_page(pool, page);
-	else {
-		page->next = pool->full;
-		pool->full = page;
-	}
-
+	pool->pages = page;
 	pool->items++;
 
 	return page->data;
 }
 
-GIT_INLINE(void) pool_remove_page(
-	git_pool *pool, git_pool_page *page, git_pool_page *prev)
-{
-	if (prev == NULL)
-		pool->open = page->next;
-	else
-		prev->next = page->next;
-}
-
 void *git_pool_malloc(git_pool *pool, uint32_t items)
 {
-	git_pool_page *scan = pool->open, *prev;
-	uint32_t size = ((items * pool->item_size) + 7) & ~7;
+	const uint32_t size = items * pool->item_size;
+
+	git_pool_page *page = pool->pages;
 	void *ptr = NULL;
 
-	pool->has_string_alloc = 0;
-	if (items > 1)
-		pool->has_multi_item_alloc = 1;
-	else if (pool->free_list != NULL) {
-		ptr = pool->free_list;
-		pool->free_list = ((struct pool_freelist *)pool->free_list)->next;
-		return ptr;
-	}
-
-	/* just add a block if there is no open one to accommodate this */
-	if (size >= pool->page_size || !scan || scan->avail < size)
+	if (!page || page->avail < size)
 		return pool_alloc_page(pool, size);
 
+	ptr = &page->data[page->size - page->avail];
+	page->avail -= size;
 	pool->items++;
-
-	/* find smallest block in free list with space */
-	for (scan = pool->open, prev = NULL;
-		 scan->next && scan->next->avail >= size;
-		 prev = scan, scan = scan->next);
-
-	/* allocate space from the block */
-	ptr = &scan->data[scan->size - scan->avail];
-	scan->avail -= size;
-
-	/* move to full list if there is almost no space left */
-	if (scan->avail < pool->item_size || scan->avail < GIT_POOL_MIN_USABLE) {
-		pool_remove_page(pool, scan, prev);
-		scan->next = pool->full;
-		pool->full = scan;
-	}
-	/* reorder list if block is now smaller than the one after it */
-	else if (scan->next != NULL && scan->next->avail > scan->avail) {
-		pool_remove_page(pool, scan, prev);
-		pool_insert_page(pool, scan);
-	}
 
 	return ptr;
 }
@@ -204,15 +116,12 @@ char *git_pool_strndup(git_pool *pool, const char *str, size_t n)
 		ptr[n] = '\0';
 	}
 
-	pool->has_string_alloc = 1;
-
 	return ptr;
 }
 
 char *git_pool_strdup(git_pool *pool, const char *str)
 {
 	assert(pool && str && pool->item_size == sizeof(char));
-
 	return git_pool_strndup(pool, str, strlen(str));
 }
 
@@ -238,88 +147,23 @@ char *git_pool_strcat(git_pool *pool, const char *a, const char *b)
 			memcpy(((char *)ptr) + len_a, b, len_b);
 		*(((char *)ptr) + len_a + len_b) = '\0';
 	}
-	pool->has_string_alloc = 1;
-
 	return ptr;
-}
-
-void git_pool_free(git_pool *pool, void *ptr)
-{
-	struct pool_freelist *item = ptr;
-
-	assert(pool && pool->item_size >= sizeof(void*));
-
-	if (item) {
-		item->next = pool->free_list;
-		pool->free_list = item;
-	}
-}
-
-void git_pool_free_array(git_pool *pool, size_t count, void **ptrs)
-{
-	struct pool_freelist **items = (struct pool_freelist **)ptrs;
-	size_t i;
-
-	assert(pool && ptrs && pool->item_size >= sizeof(void*));
-
-	if (!count)
-		return;
-
-	for (i = count - 1; i > 0; --i)
-		items[i]->next = items[i - 1];
-
-	items[i]->next  = pool->free_list;
-	pool->free_list = items[count - 1];
 }
 
 uint32_t git_pool__open_pages(git_pool *pool)
 {
 	uint32_t ct = 0;
 	git_pool_page *scan;
-	for (scan = pool->open; scan != NULL; scan = scan->next) ct++;
-	return ct;
-}
-
-uint32_t git_pool__full_pages(git_pool *pool)
-{
-	uint32_t ct = 0;
-	git_pool_page *scan;
-	for (scan = pool->full; scan != NULL; scan = scan->next) ct++;
+	for (scan = pool->pages; scan != NULL; scan = scan->next) ct++;
 	return ct;
 }
 
 bool git_pool__ptr_in_pool(git_pool *pool, void *ptr)
 {
 	git_pool_page *scan;
-	for (scan = pool->open; scan != NULL; scan = scan->next)
-		if ((void *)scan->data <= ptr &&
-			(void *)(((char *)scan->data) + scan->size) > ptr)
-			return true;
-	for (scan = pool->full; scan != NULL; scan = scan->next)
+	for (scan = pool->pages; scan != NULL; scan = scan->next)
 		if ((void *)scan->data <= ptr &&
 			(void *)(((char *)scan->data) + scan->size) > ptr)
 			return true;
 	return false;
 }
-
-uint32_t git_pool__system_page_size(void)
-{
-	static uint32_t size = 0;
-
-	if (!size) {
-		size_t page_size;
-		if (git__page_size(&page_size) < 0)
-			page_size = 4096;
-		size = page_size - 2 * sizeof(void *); /* allow space for malloc overhead */
-	}
-
-	return size;
-}
-
-uint32_t git_pool__suggest_items_per_page(uint32_t item_size)
-{
-	uint32_t page_bytes =
-		git_pool__system_page_size() - sizeof(git_pool_page);
-	return page_bytes / item_size;
-}
-

--- a/src/pool.c
+++ b/src/pool.c
@@ -21,7 +21,8 @@ uint32_t git_pool__system_page_size(void)
 		size_t page_size;
 		if (git__page_size(&page_size) < 0)
 			page_size = 4096;
-		size = page_size - 2 * sizeof(void *); /* allow space for malloc overhead */
+		/* allow space for malloc overhead */
+		size = page_size - (2 * sizeof(void *)) - sizeof(git_pool_page);
 	}
 
 	return size;

--- a/src/pool.h
+++ b/src/pool.h
@@ -28,7 +28,7 @@ typedef struct git_pool_page git_pool_page;
  * For examples of how to set up a `git_pool` see `git_pool_init`.
  */
 typedef struct {
-	git_pool_page *pages; /* pages with space left */
+	git_pool_page *pages; /* allocated pages */
 	uint32_t item_size;  /* size of single alloc unit in bytes */
 	uint32_t page_size;  /* size of page in bytes */
 } git_pool;

--- a/src/pool.h
+++ b/src/pool.h
@@ -28,18 +28,11 @@ typedef struct git_pool_page git_pool_page;
  * For examples of how to set up a `git_pool` see `git_pool_init`.
  */
 typedef struct {
-	git_pool_page *open; /* pages with space left */
-	git_pool_page *full; /* pages with no space left */
-	void *free_list;     /* optional: list of freed blocks */
+	git_pool_page *pages; /* pages with space left */
 	uint32_t item_size;  /* size of single alloc unit in bytes */
 	uint32_t page_size;  /* size of page in bytes */
 	uint32_t items;
-	unsigned has_string_alloc : 1; /* was the strdup function used */
-	unsigned has_multi_item_alloc : 1; /* was items ever > 1 in malloc */
-	unsigned has_large_page_alloc : 1; /* are any pages > page_size */
 } git_pool;
-
-#define GIT_POOL_INIT_STRINGPOOL { 0, 0, 0, 1, 4000, 0, 0, 0, 0 }
 
 /**
  * Initialize a pool.
@@ -57,8 +50,7 @@ typedef struct {
  * Of course, you can use this in other ways, but those are the
  * two most common patterns.
  */
-extern int git_pool_init(
-	git_pool *pool, uint32_t item_size, uint32_t items_per_page);
+extern void git_pool_init(git_pool *pool, uint32_t item_size);
 
 /**
  * Free all items in pool
@@ -114,35 +106,10 @@ extern char *git_pool_strdup_safe(git_pool *pool, const char *str);
  */
 extern char *git_pool_strcat(git_pool *pool, const char *a, const char *b);
 
-/**
- * Push a block back onto the free list for the pool.
- *
- * This is allowed only if the item_size is >= sizeof(void*).
- *
- * In some cases, it is helpful to "release" an allocated block
- * for reuse.  Pools don't support a general purpose free, but
- * they will keep a simple free blocks linked list provided the
- * native block size is large enough to hold a void pointer
- */
-extern void git_pool_free(git_pool *pool, void *ptr);
-
-/**
- * Push an array of pool allocated blocks efficiently onto the free list.
- *
- * This has the same constraints as `git_pool_free()` above.
- */
-extern void git_pool_free_array(git_pool *pool, size_t count, void **ptrs);
-
 /*
  * Misc utilities
  */
-
 extern uint32_t git_pool__open_pages(git_pool *pool);
-
-extern uint32_t git_pool__full_pages(git_pool *pool);
-
 extern bool git_pool__ptr_in_pool(git_pool *pool, void *ptr);
-
-extern uint32_t git_pool__suggest_items_per_page(uint32_t item_size);
 
 #endif

--- a/src/pool.h
+++ b/src/pool.h
@@ -31,7 +31,6 @@ typedef struct {
 	git_pool_page *pages; /* pages with space left */
 	uint32_t item_size;  /* size of single alloc unit in bytes */
 	uint32_t page_size;  /* size of page in bytes */
-	uint32_t items;
 } git_pool;
 
 /**
@@ -66,17 +65,7 @@ extern void git_pool_swap(git_pool *a, git_pool *b);
  * Allocate space for one or more items from a pool.
  */
 extern void *git_pool_malloc(git_pool *pool, uint32_t items);
-
-/**
- * Allocate space and zero it out.
- */
-GIT_INLINE(void *) git_pool_mallocz(git_pool *pool, uint32_t items)
-{
-	void *ptr = git_pool_malloc(pool, items);
-	if (ptr)
-		memset(ptr, 0, (size_t)items * (size_t)pool->item_size);
-	return ptr;
-}
+extern void *git_pool_mallocz(git_pool *pool, uint32_t items);
 
 /**
  * Allocate space and duplicate string data into it.

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -626,8 +626,9 @@ static int refdb_fs_backend__iterator(
 	iter = git__calloc(1, sizeof(refdb_fs_iter));
 	GITERR_CHECK_ALLOC(iter);
 
-	if (git_pool_init(&iter->pool, 1, 0) < 0 ||
-		git_vector_init(&iter->loose, 8, NULL) < 0)
+	git_pool_init(&iter->pool, 1);
+
+	if (git_vector_init(&iter->loose, 8, NULL) < 0)
 		goto fail;
 
 	if (glob != NULL &&

--- a/src/repository.c
+++ b/src/repository.c
@@ -689,6 +689,7 @@ int git_repository_config__weakptr(git_config **out, git_repository *repo)
 		git_buf_free(&global_buf);
 		git_buf_free(&xdg_buf);
 		git_buf_free(&system_buf);
+		git_buf_free(&programdata_buf);
 	}
 
 	*out = repo->_config;

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -535,12 +535,10 @@ int git_revwalk_new(git_revwalk **revwalk_out, git_repository *repo)
 	walk->commits = git_oidmap_alloc();
 	GITERR_CHECK_ALLOC(walk->commits);
 
-	if (git_pqueue_init(
-			&walk->iterator_time, 0, 8, git_commit_list_time_cmp) < 0 ||
-		git_pool_init(&walk->commit_pool, 1,
-			git_pool__suggest_items_per_page(COMMIT_ALLOC) * COMMIT_ALLOC) < 0)
+	if (git_pqueue_init(&walk->iterator_time, 0, 8, git_commit_list_time_cmp) < 0)
 		return -1;
 
+	git_pool_init(&walk->commit_pool, COMMIT_ALLOC);
 	walk->get_next = &revwalk_next_unsorted;
 	walk->enqueue = &revwalk_enqueue_unsorted;
 

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -20,8 +20,9 @@ int git_sortedcache_new(
 	sc = git__calloc(1, alloclen);
 	GITERR_CHECK_ALLOC(sc);
 
-	if (git_pool_init(&sc->pool, 1, 0) < 0 ||
-		git_vector_init(&sc->items, 4, item_cmp) < 0 ||
+	git_pool_init(&sc->pool, 1);
+
+	if (git_vector_init(&sc->items, 4, item_cmp) < 0 ||
 		git_strmap_alloc(&sc->map) < 0)
 		goto fail;
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -77,8 +77,7 @@ int git_transaction_new(git_transaction **out, git_repository *repo)
 
 	assert(out && repo);
 
-	if ((error = git_pool_init(&pool, 1, 0)) < 0)
-		return error;
+	git_pool_init(&pool, 1);
 
 	tx = git_pool_mallocz(&pool, sizeof(git_transaction));
 	if (!tx) {

--- a/tests/core/pool.c
+++ b/tests/core/pool.c
@@ -70,7 +70,7 @@ void test_core_pool__2(void)
 	}
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert_equal_i(55, git_pool__open_pages(&p));
+	cl_assert_equal_i(sizeof(void *) == 8 ? 55 : 45, git_pool__open_pages(&p));
 	git_pool_clear(&p);
 }
 

--- a/tests/core/pool.c
+++ b/tests/core/pool.c
@@ -8,7 +8,7 @@ void test_core_pool__0(void)
 	git_pool p;
 	void *ptr;
 
-	cl_git_pass(git_pool_init(&p, 1, 4000));
+	git_pool_init(&p, 1);
 
 	for (i = 1; i < 10000; i *= 2) {
 		ptr = git_pool_malloc(&p, i);
@@ -16,13 +16,6 @@ void test_core_pool__0(void)
 		cl_assert(git_pool__ptr_in_pool(&p, ptr));
 		cl_assert(!git_pool__ptr_in_pool(&p, &i));
 	}
-
-	/* 1+2+4+8+16+32+64+128+256+512+1024 -> original block */
-	/* 2048 -> 1 block */
-	/* 4096 -> 1 block */
-	/* 8192 -> 1 block */
-
-	cl_assert(git_pool__open_pages(&p) + git_pool__full_pages(&p) == 4);
 
 	git_pool_clear(&p);
 }
@@ -32,26 +25,24 @@ void test_core_pool__1(void)
 	int i;
 	git_pool p;
 
-	cl_git_pass(git_pool_init(&p, 1, 4000));
+	git_pool_init(&p, 1);
+	p.page_size = 4000;
 
 	for (i = 2010; i > 0; i--)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert_equal_i(1, git_pool__open_pages(&p));
-	cl_assert_equal_i(507, git_pool__full_pages(&p));
-
+	cl_assert_equal_i(590, git_pool__open_pages(&p));
 	git_pool_clear(&p);
 
-	cl_git_pass(git_pool_init(&p, 1, 4120));
+	git_pool_init(&p, 1);
+	p.page_size = 4120;
 
 	for (i = 2010; i > 0; i--)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert_equal_i(1, git_pool__open_pages(&p));
-	cl_assert_equal_i(492, git_pool__full_pages(&p));
-
+	cl_assert_equal_i(573, git_pool__open_pages(&p));
 	git_pool_clear(&p);
 }
 
@@ -66,7 +57,8 @@ void test_core_pool__2(void)
 
 	memset(oid_hex, '0', sizeof(oid_hex));
 
-	cl_git_pass(git_pool_init(&p, sizeof(git_oid), 100));
+	git_pool_init(&p, sizeof(git_oid));
+	p.page_size = 4000;
 
 	for (i = 1000; i < 10000; i++) {
 		oid = git_pool_malloc(&p, 1);
@@ -78,59 +70,7 @@ void test_core_pool__2(void)
 	}
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert(git_pool__open_pages(&p) == 0);
-	cl_assert(git_pool__full_pages(&p) == 90);
-
-	git_pool_clear(&p);
-}
-
-void test_core_pool__free_list(void)
-{
-	int i;
-	git_pool p;
-	void *ptr, *ptrs[50];
-
-	cl_git_pass(git_pool_init(&p, 100, 100));
-
-	for (i = 0; i < 10; ++i) {
-		ptr = git_pool_malloc(&p, 1);
-		cl_assert(ptr != NULL);
-	}
-	cl_assert_equal_i(10, (int)p.items);
-
-	for (i = 0; i < 50; ++i) {
-		ptrs[i] = git_pool_malloc(&p, 1);
-		cl_assert(ptrs[i] != NULL);
-	}
-	cl_assert_equal_i(60, (int)p.items);
-
-	git_pool_free(&p, ptr);
-	cl_assert_equal_i(60, (int)p.items);
-
-	git_pool_free_array(&p, 50, ptrs);
-	cl_assert_equal_i(60, (int)p.items);
-
-	for (i = 0; i < 50; ++i) {
-		ptrs[i] = git_pool_malloc(&p, 1);
-		cl_assert(ptrs[i] != NULL);
-	}
-	cl_assert_equal_i(60, (int)p.items);
-
-	for (i = 0; i < 111; ++i) {
-		ptr = git_pool_malloc(&p, 1);
-		cl_assert(ptr != NULL);
-	}
-	cl_assert_equal_i(170, (int)p.items);
-
-	git_pool_free_array(&p, 50, ptrs);
-	cl_assert_equal_i(170, (int)p.items);
-
-	for (i = 0; i < 50; ++i) {
-		ptrs[i] = git_pool_malloc(&p, 1);
-		cl_assert(ptrs[i] != NULL);
-	}
-	cl_assert_equal_i(170, (int)p.items);
-
+	cl_assert_equal_i(55, git_pool__open_pages(&p));
 	git_pool_clear(&p);
 }
 
@@ -138,7 +78,7 @@ void test_core_pool__strndup_limit(void)
 {
 	git_pool p;
 
-	cl_git_pass(git_pool_init(&p, 1, 100));
+	git_pool_init(&p, 1);
 	/* ensure 64 bit doesn't overflow */
 	cl_assert(git_pool_strndup(&p, "foo", (size_t)-1) == NULL);
 	git_pool_clear(&p);


### PR DESCRIPTION
So, here's the deal: the existing pool implementation is terribly slow. For some merge cases, you can see more than 70% of the runtime dominated by pool allocations!

Why is it so slow? Because it does a lot of very complex calculations & pointer wrangling just for the sake of keeping a "free list" and trying to squeeze some bytes out of each allocation. IMO this basically defeats the point of a memory pool/slab allocator.

I've re-implemented the pool to look more like a slab allocator. There's always an existing slab; when the existing slab has not enough space to fulfill the requested allocation, we allocate a new slab.

This implementation is hundreds of times faster than the old pool for most cases. For instance: a particular merge of the `cdnjs` repository that I discussed with @ethomson used to take 17s on my machine. 10 of those seconds were spent in the pool (lol wtf?).

With the new implementation, the merge finishes in 5.2s.

### Questions

- **How does the new aggressive slab algorithm impact memory usage?** This is hard to guess. For the specific case I'm testing, it doesn't, because all the allocated strings are of similar size. For some pathological cases with very large strings, I could see this wasting a little bit of memory. Frankly, given the terrible performance of the old pool, I'm confident the tradeoff will always be positive.

- **What happens with the APIs that allowed freeing pointers from the pool?** They are gone -- it's not possible to free specific pointers from a traditional slab allocator because there's no free-list. Fortunately, only one place of the existing code was calling the pool `free` API: the iterators code. Removing the call will increase memory usage on the intermediate steps of the iterator, until the pool is fully freed. I think this will be acceptable too.

- **What can possibly go wrong?** I am not sure. It's a pretty large change in a critical code path of the library, but the resulting code is so significantly simpler that I'm pretty confident I haven't introduced any regressions. I'd appreciate @carlosmn and @ethomson's careful eyes on this. 