### PR TITLE
branch: make cleanup labels consistent

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -245,11 +245,11 @@ int git_branch_move(
 		return not_a_local_branch(git_reference_name(branch));
 
 	if ((error = git_buf_joinpath(&new_reference_name, GIT_REFS_HEADS_DIR, new_branch_name)) < 0)
-		goto done;
+		goto cleanup;
 
 	if ((error = git_buf_printf(&log_message, "branch: renamed %s to %s",
 				    git_reference_name(branch), git_buf_cstr(&new_reference_name))) < 0)
-			goto done;
+			goto cleanup;
 
 	/* first update ref then config so failure won't trash config */
 
@@ -257,7 +257,7 @@ int git_branch_move(
 		out, branch, git_buf_cstr(&new_reference_name), force,
 		git_buf_cstr(&log_message));
 	if (error < 0)
-		goto done;
+		goto cleanup;
 
 	git_buf_join(&old_config_section, '.', "branch",
 		git_reference_name(branch) + strlen(GIT_REFS_HEADS_DIR));
@@ -268,7 +268,7 @@ int git_branch_move(
 		git_buf_cstr(&old_config_section),
 		git_buf_cstr(&new_config_section));
 
-done:
+cleanup:
 	git_buf_free(&new_reference_name);
 	git_buf_free(&old_config_section);
 	git_buf_free(&new_config_section);


### PR DESCRIPTION
All the other cleanup labels are named "cleanup"  other than this one called "done", so this makes everything nice and consistent. 