### PR TITLE
Use checksums to detect config file changes

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -153,11 +153,12 @@ int git_futils_readbuffer_fd(git_buf *buf, git_file fd, size_t len)
 }
 
 int git_futils_readbuffer_updated(
-	git_buf *buf, const char *path, time_t *mtime, size_t *size, int *updated)
+	git_buf *buf, const char *path, git_oid *checksum, int *updated)
 {
+	int error;
 	git_file fd;
 	struct stat st;
-	bool changed = false;
+	git_oid checksum_new;
 
 	assert(buf && path && *path);
 
@@ -178,26 +179,6 @@ int git_futils_readbuffer_updated(
 		return -1;
 	}
 
-	/*
-	 * If we were given a time and/or a size, we only want to read the file
-	 * if it has been modified.
-	 */
-	if (size && *size != (size_t)st.st_size)
-		changed = true;
-	if (mtime && *mtime != (time_t)st.st_mtime)
-		changed = true;
-	if (!size && !mtime)
-		changed = true;
-
-	if (!changed) {
-		return 0;
-	}
-
-	if (mtime != NULL)
-		*mtime = st.st_mtime;
-	if (size != NULL)
-		*size = (size_t)st.st_size;
-
 	if ((fd = git_futils_open_ro(path)) < 0)
 		return fd;
 
@@ -208,6 +189,28 @@ int git_futils_readbuffer_updated(
 
 	p_close(fd);
 
+	if ((error = git_hash_buf(&checksum_new, buf->ptr, buf->size)) < 0) {
+		git_buf_free(buf);
+		return error;
+	}
+
+	/*
+	 * If we were given a checksum, we only want to use it if it's different
+	 */
+	if (checksum && !git_oid__cmp(checksum, &checksum_new)) {
+		git_buf_free(buf);
+		if (updated)
+			*updated = 0;
+
+		return 0;
+	}
+
+	/*
+	 * If we're here, the file did change, or the user didn't have an old version
+	 */
+	if (checksum)
+		git_oid_cpy(checksum, &checksum_new);
+
 	if (updated != NULL)
 		*updated = 1;
 
@@ -216,7 +219,7 @@ int git_futils_readbuffer_updated(
 
 int git_futils_readbuffer(git_buf *buf, const char *path)
 {
-	return git_futils_readbuffer_updated(buf, path, NULL, NULL, NULL);
+	return git_futils_readbuffer_updated(buf, path, NULL, NULL);
 }
 
 int git_futils_writebuffer(

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -13,6 +13,7 @@
 #include "path.h"
 #include "pool.h"
 #include "strmap.h"
+#include "oid.h"
 
 /**
  * Filebuffer methods
@@ -21,7 +22,7 @@
  */
 extern int git_futils_readbuffer(git_buf *obj, const char *path);
 extern int git_futils_readbuffer_updated(
-	git_buf *obj, const char *path, time_t *mtime, size_t *size, int *updated);
+	git_buf *obj, const char *path, git_oid *checksum, int *updated);
 extern int git_futils_readbuffer_fd(git_buf *obj, git_file fd, size_t len);
 
 extern int git_futils_writebuffer(

--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -107,3 +107,23 @@ void test_config_stress__complex(void)
 
 	git_config_free(config);
 }
+
+void test_config_stress__quick_write(void)
+{
+	git_config *config_w, *config_r;
+	const char *path = "./config-quick-write";
+	const char *key = "quick.write";
+	int32_t i;
+
+	/* Create an external writer for one instance with the other one */
+	cl_git_pass(git_config_open_ondisk(&config_w, path));
+	cl_git_pass(git_config_open_ondisk(&config_r, path));
+
+	/* Write and read in the same second (repeat to increase the chance of it happening) */
+	for (i = 0; i < 10; i++) {
+		int32_t val;
+		cl_git_pass(git_config_set_int32(config_w, key, i));
+		cl_git_pass(git_config_get_int32(&val, config_r, key));
+		cl_assert_equal_i(i, val);
+	}
+}


### PR DESCRIPTION
Instead of using the file size and timestamp, which can lead us to ignore changes performed in the same second, use a checksum of the file contents to detect when it has changed.