### PR TITLE
Fix build for custom transport users

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -10,6 +10,7 @@
 
 #include "git2/net.h"
 #include "git2/types.h"
+#include "git2/strarray.h"
 
 /**
  * @file git2/sys/transport.h


### PR DESCRIPTION
We should explicitly include the declaration of git_strarray
from "include/git2/sys/transport.h"