### PR TITLE
pool: Never return unaligned buffers

### DIFF
--- a/tests/core/pool.c
+++ b/tests/core/pool.c
@@ -32,7 +32,7 @@ void test_core_pool__1(void)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert_equal_i(590, git_pool__open_pages(&p));
+	cl_assert_equal_i(591, git_pool__open_pages(&p));
 	git_pool_clear(&p);
 
 	git_pool_init(&p, 1);
@@ -42,7 +42,7 @@ void test_core_pool__1(void)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
 	/* with fixed page size, allocation must end up with these values */
-	cl_assert_equal_i(573, git_pool__open_pages(&p));
+	cl_assert_equal_i(sizeof(void *) == 8 ? 575 : 573, git_pool__open_pages(&p));
 	git_pool_clear(&p);
 }
 


### PR DESCRIPTION
Fixes https://github.com/libgit2/libgit2/issues/3504

@logancollins: Could you please verify that this works now in ARM64 & ARM32? I think we're doing alignment properly now for all architectures, but I don't have that hardware to try. :)