### PR TITLE
Improvements to tree parsing speed

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -414,10 +414,8 @@ int git_tree__parse(void *_tree, git_odb_object *odb_obj)
 			entry->attr = attr;
 		}
 
-		while (buffer < buffer_end && *buffer != 0)
-			buffer++;
-
-		buffer++;
+		/* Advance to the ID just after the path */
+		buffer += entry->filename_len + 1;
 
 		git_oid_fromraw(&entry->oid, (const unsigned char *)buffer);
 		buffer += GIT_OID_RAWSZ;

--- a/src/tree.c
+++ b/src/tree.c
@@ -125,7 +125,7 @@ static git_tree_entry *alloc_entry(const char *filename)
 
 struct tree_key_search {
 	const char *filename;
-	size_t filename_len;
+	uint16_t filename_len;
 };
 
 static int homing_search_cmp(const void *key, const void *array_member)

--- a/src/tree.h
+++ b/src/tree.h
@@ -16,9 +16,9 @@
 
 struct git_tree_entry {
 	uint16_t attr;
+	uint16_t filename_len;
 	git_oid oid;
 	bool pooled;
-	size_t filename_len;
 	char filename[GIT_FLEX_ARRAY];
 };
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -12,17 +12,20 @@
 #include "odb.h"
 #include "vector.h"
 #include "strmap.h"
+#include "pool.h"
 
 struct git_tree_entry {
 	uint16_t attr;
 	git_oid oid;
+	bool pooled;
 	size_t filename_len;
-	char filename[1];
+	char filename[GIT_FLEX_ARRAY];
 };
 
 struct git_tree {
 	git_object object;
 	git_vector entries;
+	git_pool pool;
 };
 
 struct git_treebuilder {


### PR DESCRIPTION
Here's a couple of simple changes to the way we parse trees which gives us significant improvements.

The first one is just silly, really. We've already calculated how long the filename is, so we can just skip over it instead of looking for the terminator again. This gives us about half the gains.

Then, we can also very easily avoid constantly asking the system for memory by allocating the entries in a pool owned by the tree. The lifetime of the entries is tied to the tree already, so this is a great place to use a pool. Those entries for which we give ownership to the user don't need to change, as we already perform an extra allocation to give them their own lifetime.

I checked the speedup by parsing the top-level tree for `git.git` for ~41k commits. The timing is a bit rough, but the speedup ends up being a bit under 1/3, which is not bad, considering. The most expensive thing right now is parsing the filemode number; and using libc's (presumably) optimised one doesn't really help.

|             |  master | this |
-----------|-----------|--------
| Debug | 4.7s | 3.8s |
| Release | 2.7s | 2.0 s |

I've also tested by grabbing the parent's tree for each commit we walk and diffing it with a pathspec of "README" (I initially tried with a full diff but that takes over two minutes, which is also pretty bad but a different story). The speedup isn't quite as drastic since we're still doing the diff, which I haven't touched here, but still noticeable, especially in release mode.

|             |  master | this |
-----------|-----------|--------
| Debug | 11.5s | 9.5s |
| Release | 6.0s | 4.3 s |
