### PR TITLE
Racy fixes for writing new indexes

### DIFF
--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -278,6 +278,7 @@ void test_checkout_crlf__autocrlf_true_index_size_is_filtered_size(void)
 void test_checkout_crlf__with_ident(void)
 {
 	git_index *index;
+	git_index_entry *entry;
 	git_blob *blob;
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
@@ -310,14 +311,14 @@ void test_checkout_crlf__with_ident(void)
 
 	/* check that blobs have $Id$ */
 
-	cl_git_pass(git_blob_lookup(&blob, g_repo,
-		& git_index_get_bypath(index, "lf.ident", 0)->id));
+	cl_assert((entry = git_index_get_bypath(index, "lf.ident", 0)));
+	cl_git_pass(git_blob_lookup(&blob, g_repo, &entry->id));
 	cl_assert_equal_s(
 		ALL_LF_TEXT_RAW "\n$Id$\n", git_blob_rawcontent(blob));
 	git_blob_free(blob);
 
-	cl_git_pass(git_blob_lookup(&blob, g_repo,
-		& git_index_get_bypath(index, "more2.identcrlf", 0)->id));
+	cl_assert((entry = git_index_get_bypath(index, "more2.identcrlf", 0)));
+	cl_git_pass(git_blob_lookup(&blob, g_repo, &entry->id));
 	cl_assert_equal_s(
 		"\n$Id$\n" MORE_CRLF_TEXT_AS_LF, git_blob_rawcontent(blob));
 	git_blob_free(blob);

--- a/tests/index/racy.c
+++ b/tests/index/racy.c
@@ -250,3 +250,31 @@ void test_index_racy__reading_clears_uptodate_bit(void)
 
 	git_index_free(index);
 }
+
+void test_index_racy__read_tree_clears_uptodate_bit(void)
+{
+	git_index *index;
+	git_tree *tree;
+	const git_index_entry *entry;
+	git_oid id;
+
+	setup_uptodate_files();
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_write_tree_to(&id, index, g_repo));
+	cl_git_pass(git_tree_lookup(&tree, g_repo, &id));
+	cl_git_pass(git_index_read_tree(index, tree));
+
+	/* ensure that no files are uptodate */
+	cl_assert((entry = git_index_get_bypath(index, "A", 0)));
+	cl_assert_equal_i(0, (entry->flags_extended & GIT_IDXENTRY_UPTODATE));
+
+	cl_assert((entry = git_index_get_bypath(index, "B", 0)));
+	cl_assert_equal_i(0, (entry->flags_extended & GIT_IDXENTRY_UPTODATE));
+
+	cl_assert((entry = git_index_get_bypath(index, "C", 0)));
+	cl_assert_equal_i(0, (entry->flags_extended & GIT_IDXENTRY_UPTODATE));
+
+	git_tree_free(tree);
+	git_index_free(index);
+}


### PR DESCRIPTION
At present, when we go to write a new index, we look for index entries that have racy timestamps (entry timestamps that are the same or newer than the index's timestamp) and examine them, so that we can zero their file size if they are actually not clean.  This prevents future git clients from accidentally believing that the files are up to date.

However, we do not take into account when *we're* the ones who write new files.  That means that in checkout, we load an index, write a bunch of files and update their index entries.  When we go to write the new index, we detect that every file we've written as part of checkout is newer than the index that we loaded.  Thus we inspect every file that we just checked out to see if it's up to date or not.  Yet we *know* that the files are up to date, since we were the ones that wrote it.

The first commit changes the racy detection to do a single index to workdir diff with all the racily clean paths.  This is a significant gain over doing a diff per file - on my machine the current implementation is ~70 seconds for checking out 15,000 files while doing a single diff is ~10 seconds.

This improves the performance when there are a large number of racily timestamped files, but we still shouldn't be in this scenario.  So we take advantage of the `GIT_IDXENTRY_UPTODATE` bit for index entries that *we* add to the index.  We then skip racy detection for up-to-date entries.  Then we only do racy detection for index entries that had the timestamp (or newer) of the index's timestamp when we read the index.

This will continue to smudge entries that were racily clean when we ready them, but avoid unnecessarily examining files that we were the ones who read.
