### PR TITLE
Protect windows SYSDIR when running tests

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -174,9 +174,9 @@ typedef enum {
  *	* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)
  *
  *		> Get the search path for a given level of config data.  "level" must
- *		> be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`, or
- *		> `GIT_CONFIG_LEVEL_XDG`.  The search path is written to the `out`
- *		> buffer.
+ *		> be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,
+ *		> `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.
+ *		> The search path is written to the `out` buffer.
  *
  *	* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)
  *
@@ -188,8 +188,9 @@ typedef enum {
  *		>   variables).  Use magic path `$PATH` to include the old value
  *		>   of the path (if you want to prepend or append, for instance).
  *		>
- *		> - `level` must be GIT_CONFIG_LEVEL_SYSTEM, GIT_CONFIG_LEVEL_GLOBAL,
- *		>   or GIT_CONFIG_LEVEL_XDG.
+ *		> - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,
+ *		>   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or
+ *		>   `GIT_CONFIG_LEVEL_PROGRAMDATA`.
  *
  *	* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_otype type, size_t size)
  *

--- a/src/settings.c
+++ b/src/settings.c
@@ -49,9 +49,18 @@ static int config_level_to_sysdir(int config_level)
 	int val = -1;
 
 	switch (config_level) {
-	case GIT_CONFIG_LEVEL_SYSTEM: val = GIT_SYSDIR_SYSTEM; break;
-	case GIT_CONFIG_LEVEL_XDG:    val = GIT_SYSDIR_XDG; break;
-	case GIT_CONFIG_LEVEL_GLOBAL: val = GIT_SYSDIR_GLOBAL; break;
+	case GIT_CONFIG_LEVEL_SYSTEM:
+		val = GIT_SYSDIR_SYSTEM;
+		break;
+	case GIT_CONFIG_LEVEL_XDG:
+		val = GIT_SYSDIR_XDG;
+		break;
+	case GIT_CONFIG_LEVEL_GLOBAL:
+		val = GIT_SYSDIR_GLOBAL;
+		break;
+	case GIT_CONFIG_LEVEL_PROGRAMDATA:
+		val = GIT_SYSDIR_PROGRAMDATA;
+		break;
 	default:
 		giterr_set(
 			GITERR_INVALID, "Invalid config path selector %d", config_level);

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -541,16 +541,23 @@ void cl_fake_home(void)
 
 void cl_sandbox_set_search_path_defaults(void)
 {
-	const char *sandbox_path = clar_sandbox_path();
+	git_buf path = GIT_BUF_INIT;
+
+	git_buf_joinpath(&path, clar_sandbox_path(), "__config");
+
+	if (!git_path_exists(path.ptr))
+		cl_must_pass(p_mkdir(path.ptr, 0777));
 
 	git_libgit2_opts(
-		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, sandbox_path);
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, path.ptr);
 	git_libgit2_opts(
-		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, sandbox_path);
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, path.ptr);
 	git_libgit2_opts(
-		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, sandbox_path);
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, path.ptr);
 	git_libgit2_opts(
-		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_PROGRAMDATA, sandbox_path);
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_PROGRAMDATA, path.ptr);
+
+	git_buf_free(&path);
 }
 
 #ifdef GIT_WIN32

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -549,6 +549,8 @@ void cl_sandbox_set_search_path_defaults(void)
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, sandbox_path);
 	git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, sandbox_path);
+	git_libgit2_opts(
+		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_PROGRAMDATA, sandbox_path);
 }
 
 #ifdef GIT_WIN32

--- a/tests/config/global.c
+++ b/tests/config/global.c
@@ -68,7 +68,6 @@ void test_config_global__open_xdg(void)
 
 void test_config_global__open_programdata(void)
 {
-	char *programdata;
 	git_config *cfg;
 	git_repository *repo;
 	git_buf config_path = GIT_BUF_INIT;
@@ -77,9 +76,12 @@ void test_config_global__open_programdata(void)
 	if (!cl_getenv("GITTEST_INVASIVE_FS_STRUCTURE"))
 		cl_skip();
 
-	programdata = cl_getenv("PROGRAMDATA");
-	cl_git_pass(git_buf_printf(&config_path, "%s/Git", programdata));
-	cl_git_pass(p_mkdir(config_path.ptr, 0777));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH,
+		GIT_CONFIG_LEVEL_PROGRAMDATA, &config_path));
+
+	if (!git_path_isdir(config_path.ptr))
+		cl_git_pass(p_mkdir(config_path.ptr, 0777));
+
 	cl_git_pass(git_buf_puts(&config_path, "/config"));
 
 	cl_git_pass(git_config_open_ondisk(&cfg, config_path.ptr));


### PR DESCRIPTION
Protect the windows SYSDIR when running tests, like we protect the other configuration levels, setting their paths to our sandbox path.  