### PR TITLE
Fix <0 unsigned comparison (stat.st_size should be an off_t)

### DIFF
--- a/src/win32/win32-compat.h
+++ b/src/win32/win32-compat.h
@@ -28,7 +28,7 @@ struct p_stat {
 	short st_uid;
 	short st_gid;
 	_dev_t st_rdev;
-	uint64_t st_size;
+	__int64 st_size;
 	struct timespec st_atim;
 	struct timespec st_mtim;
 	struct timespec st_ctim;


### PR DESCRIPTION
Turns out that the error code path will never be entered seeing that assigning an ```int``` of value ```-1``` to a ```uint64_t``` will give you 18446744073709551615.