### PR TITLE
checkout: only consider nsecs when built that way

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -200,8 +200,7 @@ static bool checkout_is_workdir_modified(
 	 * out.)
 	 */
 	if ((ie = git_index_get_bypath(data->index, wditem->path, 0)) != NULL) {
-		if (wditem->mtime.seconds == ie->mtime.seconds &&
-			wditem->mtime.nanoseconds == ie->mtime.nanoseconds &&
+		if (git_index_time_eq(&wditem->mtime, &ie->mtime) &&
 			wditem->file_size == ie->file_size)
 			return !is_workdir_base_or_new(&ie->id, baseitem, newitem);
 	}

--- a/src/diff.h
+++ b/src/diff.h
@@ -28,7 +28,6 @@ enum {
 	GIT_DIFFCAPS_TRUST_MODE_BITS  = (1 << 2), /* use st_mode? */
 	GIT_DIFFCAPS_TRUST_CTIME      = (1 << 3), /* use st_ctime? */
 	GIT_DIFFCAPS_USE_DEV          = (1 << 4), /* use st_dev? */
-	GIT_DIFFCAPS_TRUST_NANOSECS   = (1 << 5), /* use stat time nanoseconds */
 };
 
 #define DIFF_FLAGS_KNOWN_BINARY (GIT_DIFF_FLAG_BINARY|GIT_DIFF_FLAG_NOT_BINARY)


### PR DESCRIPTION
When examining the working directory and determining whether it's
up-to-date, only consider the nanoseconds in the index entry when
built with `GIT_USE_NSEC`.  This prevents us from believing that
the working directory is always dirty when the index was originally
written with a git client that uinderstands nsecs (like git 2.x).