### PR TITLE
tree: mark cloned tree entries as un-pooled

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -253,6 +253,8 @@ int git_tree_entry_dup(git_tree_entry **dest, const git_tree_entry *source)
 
 	memcpy(copy, source, total_size);
 
+	copy->pooled = 0;
+
 	*dest = copy;
 	return 0;
 }


### PR DESCRIPTION
When duplicating a `struct git_tree_entry` with
`git_tree_entry_dup` the resulting structure is not allocated
inside a memory pool. As we do a 1:1 copy of the original struct,
though, we also copy the `pooled` field, which is set to `true`
for pooled entries. This results in a huge memory leak as we
never free tree entries that were duplicated from a pooled
tree entry.

Fix this by marking the newly duplicated entry as un-pooled.