### PR TITLE
Treat GIT_PASSTHROUGH as though git_cred_acquire_cb isn't set.

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -930,7 +930,10 @@ replay:
 					cred_error = t->owner->cred_acquire_cb(&t->cred, t->owner->url,
 						t->connection_data.user, allowed_types,	t->owner->cred_acquire_payload);
 
-					if (cred_error < 0)
+					/* Treat GIT_PASSTHROUGH as though git_cred_acquire_cb isn't set */
+					if (cred_error == GIT_PASSTHROUGH)
+						cred_error = 1;
+					else if (cred_error < 0)
 						return cred_error;
 				}
 


### PR DESCRIPTION
Have the winhttp transport treat a GIT_PASSTHROUGH returned from the credential handler the same as if there was no handler.  This matches the [documentation for `git_remote_callbacks.credentials`](https://libgit2.github.com/libgit2/#HEAD/type/git_remote_callbacks) and the implementations of the http and ssl transports.  
