### PR TITLE
checkout test: Apply umask to file-mode test as well

### DIFF
--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -298,7 +298,7 @@ void test_checkout_index__options_dir_modes(void)
 
 	/* File-mode test, since we're on the 'dir' branch */
 	cl_git_pass(p_stat("./testrepo/a/b.txt", &st));
-	cl_assert_equal_i_fmt(st.st_mode, GIT_FILEMODE_BLOB_EXECUTABLE, "%07o");
+	cl_assert_equal_i_fmt(st.st_mode, GIT_FILEMODE_BLOB_EXECUTABLE & ~um, "%07o");
 
 	git_commit_free(commit);
 }


### PR DESCRIPTION
Fix the file-mode test to expect system umask being applied to the created file as well (it is currently applied to the directory only). This fixes the test on systems where umask != 022.