### PR TITLE
index: canonicalize inserted paths safely

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -1167,7 +1167,7 @@ static int canonicalize_directory_path(
 		while ((match = git_vector_get(&index->entries, pos))) {
 			if (GIT_IDXENTRY_STAGE(match) != 0) {
 				/* conflicts do not contribute to canonical paths */
-			} else if (memcmp(search, match->path, search_len) == 0) {
+			} else if (strncmp(search, match->path, search_len) == 0) {
 				/* prefer an exact match to the input filename */
 				best = match;
 				best_len = search_len;


### PR DESCRIPTION
When adding to the index, we look to see if a portion of the given
path matches a portion of a path in the index.  If so, we will use
the existing path information.  For example, when adding `foo/bar.c`,
if there is an index entry to `FOO/other` and the filesystem is case
insensitive, then we will put `bar.c` into the existing tree instead
of creating a new one with a different case.

Use `strncmp` to do that instead of `memcmp`.  When we `bsearch`
into the index, we locate the position where the new entry would
go.  The index entry at that position does not necessarily have
a relation to the entry we're adding, so we cannot make assumptions
and use `memcmp`.  Instead, compare them as strings.

When canonicalizing paths, we look for the first index entry that
matches a given substring.

FIxes #3533 