### PR TITLE
tree: mark a tree as already sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ v0.23 + 1
 * You can now set your own user-agent to be sent for HTTP requests by
   using the `GIT_OPT_SET_USER_AGENT` with `git_libgit2_opts()`.
 
+* Tree objects are now assumed to be sorted. If a tree is not
+  correctly formed, it will give bad results. This is the git approach
+  and cuts a significant amount of time when reading the trees.
+
 ### API additions
 
 * `git_config_lock()` has been added, which allow for

--- a/src/tree.c
+++ b/src/tree.c
@@ -476,7 +476,8 @@ int git_tree__parse(void *_tree, git_odb_object *odb_obj)
 		buffer += GIT_OID_RAWSZ;
 	}
 
-	git_vector_sort(&tree->entries);
+	/* The tree is sorted by definition. Bad inputs give bad outputs */
+	tree->entries.flags |= GIT_VECTOR_SORTED;
 
 	return 0;
 }


### PR DESCRIPTION
The trees are sorted on-disk, so we don't have to go over them
again. This cuts almost a fifth of time spent parsing trees.