### PR TITLE
index: always queue `remove_entry` for removal

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -3014,7 +3014,7 @@ int git_index_read_index(
 				INSERT_IN_MAP_EX(index, new_entries_map, add_entry, error);
 		}
 
-		if (remove_entry && !error)
+		if (remove_entry && error >= 0)
 			error = git_vector_insert(&remove_entries, remove_entry);
 
 		if (error < 0) {


### PR DESCRIPTION
When replacing an index with a new one, we need to iterate
through all index entries in order to determine which entries are
equal. When it is not possible to re-use old entries for the new
index, we move it into a list of entries that are to be removed
and thus free'd.

When we encounter a non-zero error code, though, we skip adding
the current index entry to the remove-queue. `INSERT_MAP_EX`,
which is the function last run before adding to the remove-queue,
may return a positive non-zero code that indicates what exactly
happened while inserting the element. In this case we skip adding
the entry to the remove-queue but still continue the current
operation, leading to a leak of the current entry.

Fix this by checking for a negative return value instead of a
non-zero one when we want to add the current index entry to the
remove-queue.