### PR TITLE
Use a typedef for the submodule_foreach callback.

### DIFF
--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -110,11 +110,10 @@ typedef enum {
 /**
  * Function pointer to receive each submodule
  *
- * `sm` is the `git_submodule` currently being visited.
- *
- * `name` is the name of the submodule.
- *
- * `payload` is the value you passed to the foreach function as payload.
+ * @param sm git_submodule currently being visited
+ * @param name name of the submodule
+ * @param payload value you passed to the foreach function as payload
+ * @return 0 on success or error code
  */
 typedef int (*git_submodule_cb)(
 	git_submodule *sm, const char *name, void *payload);

--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -108,6 +108,18 @@ typedef enum {
 	GIT_SUBMODULE_STATUS_WD_UNTRACKED)) != 0)
 
 /**
+ * Function pointer to receive each submodule
+ *
+ * `sm` is the `git_submodule` currently being visited.
+ *
+ * `name` is the name of the submodule.
+ *
+ * `payload` is the value you passed to the foreach function as payload.
+ */
+typedef int (*git_submodule_cb)(
+	git_submodule *sm, const char *name, void *payload);
+
+/**
  * Submodule update options structure
  *
  * Use the GIT_SUBMODULE_UPDATE_OPTIONS_INIT to get the default settings,
@@ -239,7 +251,7 @@ GIT_EXTERN(void) git_submodule_free(git_submodule *submodule);
  */
 GIT_EXTERN(int) git_submodule_foreach(
 	git_repository *repo,
-	int (*callback)(git_submodule *sm, const char *name, void *payload),
+	git_submodule_cb callback,
 	void *payload);
 
 /**

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -495,7 +495,7 @@ cleanup:
 
 int git_submodule_foreach(
 	git_repository *repo,
-	int (*callback)(git_submodule *sm, const char *name, void *payload),
+	git_submodule_cb callback,
 	void *payload)
 {
 	git_vector snapshot = GIT_VECTOR_INIT;


### PR DESCRIPTION
This fits with the style of the rest of the project, but more importantly makes life easier for bindings authors who auto-generate code.