### PR TITLE
reset: perform the checkout before moving HEAD or the index

### DIFF
--- a/src/reset.c
+++ b/src/reset.c
@@ -145,18 +145,18 @@ static int reset(
 	if ((error = git_buf_printf(&log_message, "reset: moving to %s", to)) < 0)
 		return error;
 
-	/* move HEAD to the new target */
-	if ((error = git_reference__update_terminal(repo, GIT_HEAD_FILE,
-		git_object_id(commit), NULL, git_buf_cstr(&log_message))) < 0)
-		goto cleanup;
-
 	if (reset_type == GIT_RESET_HARD) {
-		/* overwrite working directory with HEAD */
+		/* overwrite working directory with the new tree */
 		opts.checkout_strategy = GIT_CHECKOUT_FORCE;
 
 		if ((error = git_checkout_tree(repo, (git_object *)tree, &opts)) < 0)
 			goto cleanup;
 	}
+
+	/* move HEAD to the new target */
+	if ((error = git_reference__update_terminal(repo, GIT_HEAD_FILE,
+		git_object_id(commit), NULL, git_buf_cstr(&log_message))) < 0)
+		goto cleanup;
 
 	if (reset_type > GIT_RESET_SOFT) {
 		/* reset index to the target content */

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -235,3 +235,55 @@ void test_reset_hard__reflog_is_correct(void)
 	git_annotated_commit_free(annotated);
 
 }
+
+void test_reset_hard__switch_file_to_dir(void)
+{
+	git_index_entry entry = { 0 };
+	git_index *idx;
+	git_object *commit;
+	git_tree *tree;
+	git_signature *sig;
+	git_oid src_tree_id, tgt_tree_id;
+	git_oid src_id, tgt_id;
+
+	entry.mode = GIT_FILEMODE_BLOB;
+	cl_git_pass(git_oid_fromstr(&entry.id, "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"));
+	cl_git_pass(git_index_new(&idx));
+	cl_git_pass(git_signature_now(&sig, "foo", "bar"));
+
+	/* Create the old tree */
+	entry.path = "README";
+	cl_git_pass(git_index_add(idx, &entry));
+	entry.path = "dir";
+	cl_git_pass(git_index_add(idx, &entry));
+
+	cl_git_pass(git_index_write_tree_to(&src_tree_id, idx, repo));
+	cl_git_pass(git_index_clear(idx));
+
+	cl_git_pass(git_tree_lookup(&tree, repo, &src_tree_id));
+	cl_git_pass(git_commit_create(&src_id, repo, NULL, sig, sig, NULL, "foo", tree, 0, NULL));
+	git_tree_free(tree);
+
+	/* Create the new tree */
+	entry.path = "README";
+	cl_git_pass(git_index_add(idx, &entry));
+	entry.path = "dir/FILE";
+	cl_git_pass(git_index_add(idx, &entry));
+
+	cl_git_pass(git_index_write_tree_to(&tgt_tree_id, idx, repo));
+	cl_git_pass(git_tree_lookup(&tree, repo, &tgt_tree_id));
+	cl_git_pass(git_commit_create(&tgt_id, repo, NULL, sig, sig, NULL, "foo", tree, 0, NULL));
+	git_tree_free(tree);
+	git_index_free(idx);
+	git_signature_free(sig);
+
+	/* Let's go to a known state of the src commit with the file named 'dir' */
+	cl_git_pass(git_object_lookup(&commit, repo, &src_id, GIT_OBJ_COMMIT));
+	cl_git_pass(git_reset(repo, commit, GIT_RESET_HARD, NULL));
+	git_object_free(commit);
+
+	/* And now we move over to the commit with the directory named 'dir' */
+	cl_git_pass(git_object_lookup(&commit, repo, &tgt_id, GIT_OBJ_COMMIT));
+	cl_git_pass(git_reset(repo, commit, GIT_RESET_HARD, NULL));
+	git_object_free(commit);
+}


### PR DESCRIPTION
This keeps the state of the workdir the same as one from HEAD, removing
a source of possible confusion when calculating the work that is to be
done.

This should handle  #3541 and bring us close to what we generally should be doing when switching the current commit.

/cc @vmg 