### PR TITLE
Fix a couple function signatures

### DIFF
--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -68,7 +68,7 @@ GIT_EXTERN(int) git_stash_save(
 	git_repository *repo,
 	const git_signature *stasher,
 	const char *message,
-	unsigned int flags);
+	uint32_t flags);
 
 /** Stash application flags. */
 typedef enum {

--- a/src/path.c
+++ b/src/path.c
@@ -1399,7 +1399,7 @@ int git_path_dirload(
 	git_vector *contents,
 	const char *path,
 	size_t prefix_len,
-	unsigned int flags)
+	uint32_t flags)
 {
 	git_path_diriter iter = GIT_PATH_DIRITER_INIT;
 	const char *name;


### PR DESCRIPTION
When cross-compiling to ARM, my compiler was complaining about these:

https://github.com/libgit2/libgit2/blob/7f2c146/include/git2/stash.h#L71
https://github.com/libgit2/libgit2/blob/7f2c146/src/stash.c#L510

https://github.com/libgit2/libgit2/blob/7f2c146/src/path.h#L550
https://github.com/libgit2/libgit2/blob/7f2c146/src/path.c#L1402

Seems it was a couple instances of mixing unsigned int with uint32_t. For consistency, just changed them to uint32_t, assuming it's desired to have a guaranteed 32-bit wide flag.