### PR TITLE
merge: Use `git_index__fill` to populate the index

### DIFF
--- a/src/index.h
+++ b/src/index.h
@@ -113,6 +113,8 @@ GIT_INLINE(bool) git_index_entry_newer_than_index(
 extern int git_index__find_pos(
 	size_t *at_pos, git_index *index, const char *path, size_t path_len, int stage);
 
+extern int git_index__fill(git_index *index, const git_vector *source_entries);
+
 extern void git_index__set_ignore_case(git_index *index, bool ignore_case);
 
 extern unsigned int git_index__create_mode(unsigned int mode);

--- a/src/merge.c
+++ b/src/merge.c
@@ -1739,7 +1739,6 @@ static int index_from_diff_list(git_index **out,
 {
 	git_index *index;
 	size_t i;
-	git_index_entry *entry;
 	git_merge_diff *conflict;
 	int error = 0;
 
@@ -1748,10 +1747,8 @@ static int index_from_diff_list(git_index **out,
 	if ((error = git_index_new(&index)) < 0)
 		return error;
 
-	git_vector_foreach(&diff_list->staged, i, entry) {
-		if ((error = git_index_add(index, entry)) < 0)
-			goto on_error;
-	}
+	if ((error = git_index__fill(index, &diff_list->staged)) < 0)
+		goto on_error;
 
 	git_vector_foreach(&diff_list->conflicts, i, conflict) {
 		const git_index_entry *ancestor =


### PR DESCRIPTION
See the commit message for details. This fixes a performance issue when merging _truly_ large trees (roughly 1.5 million entries).

cc @carlosmn @ethomson (HAH how's that for a sabbatical)
cc @piki @simonsj 