### PR TITLE
Index fill: Small fixups

### DIFF
--- a/src/idxmap.h
+++ b/src/idxmap.h
@@ -70,6 +70,7 @@ static kh_inline khint_t idxentry_hash(const git_index_entry *e)
 #define git_idxmap_valid_index(h, idx) (idx != kh_end(h))
 #define git_idxmap_has_data(h, idx) kh_exist(h, idx)
 
+#define git_idxmap_resize(h,s)  kh_resize(idx, h, s)
 #define git_idxmap_free(h)  kh_destroy(idx, h), h = NULL
 #define git_idxmap_clear(h) kh_clear(idx, h)
 

--- a/src/index.c
+++ b/src/index.c
@@ -1564,10 +1564,8 @@ int git_index__fill(git_index *index, const git_vector *source_entries)
 		return -1;
 	}
 
-	if (git_vector_size_hint(&index->entries, source_entries->length) < 0) {
-		git_mutex_unlock(&index->lock);
-		return -1;
-	}
+	git_vector_size_hint(&index->entries, source_entries->length);
+	git_idxmap_resize(index->entries_map, source_entries->length * 1.3);
 
 	git_vector_foreach(source_entries, i, source_entry) {
 		git_index_entry *entry = NULL;

--- a/src/index.c
+++ b/src/index.c
@@ -1556,8 +1556,16 @@ int git_index__fill(git_index *index, const git_vector *source_entries)
 
 	assert(index);
 
+	if (!source_entries->length)
+		return 0;
+
 	if (git_mutex_lock(&index->lock) < 0) {
 		giterr_set(GITERR_OS, "Unable to acquire index lock");
+		return -1;
+	}
+
+	if (git_vector_size_hint(&index->entries, source_entries->length) < 0) {
+		git_mutex_unlock(&index->lock);
 		return -1;
 	}
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -40,6 +40,13 @@ GIT_INLINE(int) resize_vector(git_vector *v, size_t new_size)
 	return 0;
 }
 
+int git_vector_size_hint(git_vector *v, size_t size_hint)
+{
+	if (v->_alloc_size >= size_hint)
+		return 0;
+	return resize_vector(v, size_hint);
+}
+
 int git_vector_dup(git_vector *v, const git_vector *src, git_vector_cmp cmp)
 {
 	size_t bytes;

--- a/src/vector.h
+++ b/src/vector.h
@@ -32,6 +32,7 @@ void git_vector_free_deep(git_vector *v); /* free each entry and self */
 void git_vector_clear(git_vector *v);
 int git_vector_dup(git_vector *v, const git_vector *src, git_vector_cmp cmp);
 void git_vector_swap(git_vector *a, git_vector *b);
+int git_vector_size_hint(git_vector *v, size_t size_hint);
 
 void **git_vector_detach(size_t *size, size_t *asize, git_vector *v);
 


### PR DESCRIPTION
- Adjust the namemask for the index entry (just in case!)
- Normalize the filemode (also just in case!)
- Pre-allocate the entries array (since we already know the final size!)

cc @carlosmn @ethomson 