### PR TITLE
Support for ssh+git and git+ssh protocols

### DIFF
--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -451,7 +451,7 @@ parse_url_char(enum state s, const char ch)
       break;
 
     case s_req_schema:
-      if (IS_ALPHA(ch)) {
+      if (IS_ALPHA(ch) || ch == '+') {
         return s;
       }
 

--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -99,7 +99,7 @@ do {                                                                 \
     FOR##_mark = NULL;                                               \
   }                                                                  \
 } while (0)
-  
+
 /* Run the data callback FOR and consume the current byte */
 #define CALLBACK_DATA(FOR)                                           \
     CALLBACK_DATA_(FOR, p - FOR##_mark, p - data + 1)
@@ -444,6 +444,9 @@ parse_url_char(enum state s, const char ch)
         return s_req_path;
       }
 
+      /* The schema must start with an alpha character. After that, it may
+       * consist of digits, '+', '-' or '.', followed by a ':'.
+       */
       if (IS_ALPHA(ch)) {
         return s_req_schema;
       }
@@ -451,7 +454,7 @@ parse_url_char(enum state s, const char ch)
       break;
 
     case s_req_schema:
-      if (IS_ALPHA(ch) || ch == '+') {
+      if (IS_ALPHANUM(ch) || ch == '+' || ch == '-' || ch == '.') {
         return s;
       }
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -35,8 +35,8 @@ static transport_definition transports[] = {
 	{ "file://",  git_transport_local, NULL },
 #ifdef GIT_SSH
 	{ "ssh://",   git_transport_smart, &ssh_subtransport_definition },
-  { "ssh+git://",   git_transport_smart, &ssh_subtransport_definition },
-  { "git+ssh://",   git_transport_smart, &ssh_subtransport_definition },
+	{ "ssh+git://",   git_transport_smart, &ssh_subtransport_definition },
+	{ "git+ssh://",   git_transport_smart, &ssh_subtransport_definition },
 #endif
 	{ NULL, 0, 0 }
 };

--- a/src/transport.c
+++ b/src/transport.c
@@ -35,6 +35,8 @@ static transport_definition transports[] = {
 	{ "file://",  git_transport_local, NULL },
 #ifdef GIT_SSH
 	{ "ssh://",   git_transport_smart, &ssh_subtransport_definition },
+  { "ssh+git://",   git_transport_smart, &ssh_subtransport_definition },
+  { "git+ssh://",   git_transport_smart, &ssh_subtransport_definition },
 #endif
 	{ NULL, 0, 0 }
 };

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -20,8 +20,7 @@
 
 #define OWNING_SUBTRANSPORT(s) ((ssh_subtransport *)(s)->parent.subtransport)
 
-static const char * ssh_prefixes[] = { "ssh://", "ssh+git://", "git+ssh://" };
-#define SSH_PREFIX_COUNT (sizeof(ssh_prefixes) / sizeof(ssh_prefixes[0]))
+static const char *ssh_prefixes[] = { "ssh://", "ssh+git://", "git+ssh://" };
 
 static const char cmd_uploadpack[] = "git-upload-pack";
 static const char cmd_receivepack[] = "git-receive-pack";
@@ -64,9 +63,9 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 {
 	char *repo;
 	int len;
+	size_t i;
 
-	size_t i = 0;
-	for (i = 0; i < SSH_PREFIX_COUNT; ++i) {
+	for (i = 0; i < ARRAY_SIZE(ssh_prefixes); ++i) {
 		const char *p = ssh_prefixes[i];
 
 		if (!git__prefixcmp(url, p)) {
@@ -503,6 +502,7 @@ static int _git_ssh_setup_conn(
 	char *host=NULL, *port=NULL, *path=NULL, *user=NULL, *pass=NULL;
 	const char *default_port="22";
 	int auth_methods, error = 0;
+	size_t i;
 	ssh_stream *s;
 	git_cred *cred = NULL;
 	LIBSSH2_SESSION* session=NULL;
@@ -518,8 +518,7 @@ static int _git_ssh_setup_conn(
 	s->session = NULL;
 	s->channel = NULL;
 
-	size_t i = 0;
-	for (i = 0; i < SSH_PREFIX_COUNT; ++i) {
+	for (i = 0; i < ARRAY_SIZE(ssh_prefixes); ++i) {
 		const char *p = ssh_prefixes[i];
 
 		if (!git__prefixcmp(url, p)) {

--- a/tests/transport/register.c
+++ b/tests/transport/register.c
@@ -44,6 +44,8 @@ void test_transport_register__custom_transport_ssh(void)
 
 #ifndef GIT_SSH
 	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));
@@ -60,6 +62,8 @@ void test_transport_register__custom_transport_ssh(void)
 
 #ifndef GIT_SSH
 	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));

--- a/tests/transport/register.c
+++ b/tests/transport/register.c
@@ -48,6 +48,9 @@ void test_transport_register__custom_transport_ssh(void)
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
+	cl_git_pass(git_transport_new(&transport, NULL, "ssh://somehost:somepath"));
+	cl_git_pass(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"));
+	cl_git_pass(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"));
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));
 	transport->free(transport);
 #endif
@@ -66,6 +69,9 @@ void test_transport_register__custom_transport_ssh(void)
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
+	cl_git_pass(git_transport_new(&transport, NULL, "ssh://somehost:somepath"));
+	cl_git_pass(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"));
+	cl_git_pass(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"));
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));
 	transport->free(transport);
 #endif


### PR DESCRIPTION
This should add support for the `ssh+git://` and `git+ssh://` protocol schemes. The behavior is to pass directly through to the `ssh://` protocol scheme.

So, as atrocious as this is, this is a protocol that people use. From everything I can tell, they're both functionally identical to `ssh://` and are treated as such in this PR. [Here](http://git.kernel.org/cgit/git/git.git/commit/?id=c05186cc38ca4605bff1f275619d7d0faeaf2fa5) is an example of it being used in ~~the linux kernel~~ git core