### PR TITLE
ssh_stream_read(): fix possible *bytes_read < 0 branch

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -136,9 +136,14 @@ static int ssh_stream_read(
 	 * not-found error, so read from stderr and signal EOF on
 	 * stderr.
 	 */
-	if (rc == 0 && (rc = libssh2_channel_read_stderr(s->channel, buffer, buf_size)) > 0) {
-		giterr_set(GITERR_SSH, "%*s", rc, buffer);
-		return GIT_EEOF;
+	if (rc == 0) {
+		if ((rc = libssh2_channel_read_stderr(s->channel, buffer, buf_size)) > 0) {
+			giterr_set(GITERR_SSH, "%*s", rc, buffer);
+			return GIT_EEOF;
+		} else if (rc < LIBSSH2_ERROR_NONE) {
+			ssh_error(s->session, "SSH could not read stderr");
+			return -1;
+		}
 	}
 
 


### PR DESCRIPTION
Fix the possibility of returning successfully from `ssh_stream_read()` with `*bytes_read` < 0. This would occur if stdout channel read resulted in 0, and stderr channel read failed afterwards.