### PR TITLE
Handle dotfiles as the repo template dir and inside the template dir

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1438,7 +1438,9 @@ static int repo_init_structure(
 		}
 
 		if (tdir) {
-			uint32_t cpflags = GIT_CPDIR_COPY_SYMLINKS | GIT_CPDIR_SIMPLE_TO_MODE;
+			uint32_t cpflags = GIT_CPDIR_COPY_SYMLINKS |
+				GIT_CPDIR_SIMPLE_TO_MODE |
+				GIT_CPDIR_COPY_DOTFILES;
 			if (opts->mode != GIT_REPOSITORY_INIT_SHARED_UMASK)
 					cpflags |= GIT_CPDIR_CHMOD_DIRS;
 			error = git_futils_cp_r(tdir, repo_dir, cpflags, dmode);

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -519,7 +519,8 @@ static void assert_mode_seems_okay(
 
 static const char *template_sandbox(const char *name)
 {
-	git_buf hooks_path = GIT_BUF_INIT, link_path = GIT_BUF_INIT;
+	git_buf hooks_path = GIT_BUF_INIT, link_path = GIT_BUF_INIT,
+		dotfile_path = GIT_BUF_INIT;
 	const char *path = cl_fixture(name);
 
 	cl_fixture_sandbox(name);
@@ -537,6 +538,12 @@ static const char *template_sandbox(const char *name)
 	cl_must_pass(symlink("update.sample", link_path.ptr));
 #endif
 
+	/* create a file starting with a dot */
+	cl_git_pass(git_buf_joinpath(&dotfile_path, hooks_path.ptr, ".dotfile"));
+	cl_git_mkfile(dotfile_path.ptr, "something\n");
+	git_buf_free(&dotfile_path);
+
+	git_buf_free(&dotfile_path);
 	git_buf_free(&link_path);
 	git_buf_free(&hooks_path);
 
@@ -594,6 +601,10 @@ static void validate_templates(git_repository *repo, const char *template_path)
 	assert_hooks_match(
 		template_path, git_repository_path(repo),
 		"hooks/link.sample", filemode);
+
+	assert_hooks_match(
+		template_path, git_repository_path(repo),
+		"hooks/.dotfile", filemode);
 
 	git_buf_free(&expected);
 	git_buf_free(&actual);


### PR DESCRIPTION
Include dotfiles when copying the template directory, which handles both #3459 (that template dirs with a leading dot are not copied) and the additional issue illustrated in #3472 (that dotfiles inside the template dir are not copied).