### PR TITLE
Few p_getaddrinfo fixes

### DIFF
--- a/src/posix.c
+++ b/src/posix.c
@@ -62,7 +62,10 @@ int p_getaddrinfo(
 	ai = ainfo;
 
 	for (p = 1; ainfo->ai_hostent->h_addr_list[p] != NULL; p++) {
-		ai->ai_next = malloc(sizeof(struct addrinfo));
+		if (!(ai->ai_next = malloc(sizeof(struct addrinfo)))) {
+			p_freeaddrinfo(ainfo);
+			return -1;
+		}
 		memcpy(&ai->ai_next, ainfo, sizeof(struct addrinfo));
 		memcpy(&ai->ai_next->ai_addr_in.sin_addr,
 			ainfo->ai_hostent->h_addr_list[p],

--- a/src/posix.c
+++ b/src/posix.c
@@ -66,7 +66,7 @@ int p_getaddrinfo(
 			p_freeaddrinfo(ainfo);
 			return -1;
 		}
-		memcpy(&ai->ai_next, ainfo, sizeof(struct addrinfo));
+		memcpy(ai->ai_next, ainfo, sizeof(struct addrinfo));
 		memcpy(&ai->ai_next->ai_addr_in.sin_addr,
 			ainfo->ai_hostent->h_addr_list[p],
 			ainfo->ai_hostent->h_length);


### PR DESCRIPTION
These are some (hopefully correct) fixes for the p_getaddrinfo() function.

If you prefer to use GITERR_CHECK_ALLOC() in commit ea5942b I can also do it of course.