### PR TITLE
Make packfile_unpack_compressed a private API

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -21,7 +21,7 @@ GIT__USE_OIDMAP
 
 static int packfile_open(struct git_pack_file *p);
 static git_off_t nth_packed_object_offset(const struct git_pack_file *p, uint32_t n);
-int packfile_unpack_compressed(
+static int packfile_unpack_compressed(
 		git_rawobj *obj,
 		struct git_pack_file *p,
 		git_mwindow **w_curs,
@@ -843,7 +843,7 @@ void git_packfile_stream_free(git_packfile_stream *obj)
 	inflateEnd(&obj->zstream);
 }
 
-int packfile_unpack_compressed(
+static int packfile_unpack_compressed(
 	git_rawobj *obj,
 	struct git_pack_file *p,
 	git_mwindow **w_curs,

--- a/src/pack.h
+++ b/src/pack.h
@@ -138,13 +138,6 @@ int git_packfile_resolve_header(
 		git_off_t offset);
 
 int git_packfile_unpack(git_rawobj *obj, struct git_pack_file *p, git_off_t *obj_offset);
-int packfile_unpack_compressed(
-	git_rawobj *obj,
-	struct git_pack_file *p,
-	git_mwindow **w_curs,
-	git_off_t *curpos,
-	size_t size,
-	git_otype type);
 
 int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, git_off_t curpos);
 ssize_t git_packfile_stream_read(git_packfile_stream *obj, void *buffer, size_t len);


### PR DESCRIPTION
packfile_unpack_compressed has already been covered in pack.h
