### PR TITLE
Add a new build flag to disable the pool allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ OPTION( USE_SSH				"Link with libssh to enable SSH support" ON )
 OPTION( USE_GSSAPI			"Link with libgssapi for SPNEGO auth"   OFF )
 OPTION( VALGRIND			"Configure build for valgrind"			OFF )
 OPTION( CURL			"User curl for HTTP if available" ON)
+OPTION( DEBUG_POOL			"Enable debug pool allocator"			OFF )
+
+IF(DEBUG_POOL)
+	ADD_DEFINITIONS(-DGIT_DEBUG_POOL)
+ENDIF()
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	SET( USE_ICONV ON )

--- a/src/pool.h
+++ b/src/pool.h
@@ -9,8 +9,13 @@
 
 #include "common.h"
 
+#ifdef GIT_DEBUG_POOL
+#include "vector.h"
+#endif
+
 typedef struct git_pool_page git_pool_page;
 
+#ifndef GIT_DEBUG_POOL
 /**
  * Chunked allocator.
  *
@@ -32,6 +37,30 @@ typedef struct {
 	uint32_t item_size;  /* size of single alloc unit in bytes */
 	uint32_t page_size;  /* size of page in bytes */
 } git_pool;
+
+#else
+
+/**
+ * Debug chunked allocator.
+ *
+ * Acts just like `git_pool` but instead of actually pooling allocations it
+ * passes them through to `git__malloc`. This makes it possible to easily debug
+ * systems that use `git_pool` using valgrind.
+ *
+ * In order to track allocations during the lifetime of the pool we use a
+ * `git_vector`. When the pool is deallocated everything in the vector is
+ * freed.
+ *
+ * `API is exactly the same as the standard `git_pool` with one exception.
+ * Since we aren't allocating pages to hand out in chunks we can't easily
+ * implement `git_pool__open_pages`.
+ */
+typedef struct {
+	git_vector allocations;
+	uint32_t item_size;
+	uint32_t page_size;
+} git_pool;
+#endif
 
 /**
  * Initialize a pool.
@@ -98,7 +127,9 @@ extern char *git_pool_strcat(git_pool *pool, const char *a, const char *b);
 /*
  * Misc utilities
  */
+#ifndef _DEBUG_POOL
 extern uint32_t git_pool__open_pages(git_pool *pool);
+#endif
 extern bool git_pool__ptr_in_pool(git_pool *pool, void *ptr);
 
 #endif

--- a/src/pool.h
+++ b/src/pool.h
@@ -8,10 +8,7 @@
 #define INCLUDE_pool_h__
 
 #include "common.h"
-
-#ifdef GIT_DEBUG_POOL
 #include "vector.h"
-#endif
 
 typedef struct git_pool_page git_pool_page;
 

--- a/src/pool.h
+++ b/src/pool.h
@@ -124,7 +124,7 @@ extern char *git_pool_strcat(git_pool *pool, const char *a, const char *b);
 /*
  * Misc utilities
  */
-#ifndef _DEBUG_POOL
+#ifndef GIT_DEBUG_POOL
 extern uint32_t git_pool__open_pages(git_pool *pool);
 #endif
 extern bool git_pool__ptr_in_pool(git_pool *pool, void *ptr);

--- a/tests/core/pool.c
+++ b/tests/core/pool.c
@@ -31,8 +31,10 @@ void test_core_pool__1(void)
 	for (i = 2010; i > 0; i--)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
+#ifndef GIT_DEBUG_POOL
 	/* with fixed page size, allocation must end up with these values */
 	cl_assert_equal_i(591, git_pool__open_pages(&p));
+#endif
 	git_pool_clear(&p);
 
 	git_pool_init(&p, 1);
@@ -41,8 +43,10 @@ void test_core_pool__1(void)
 	for (i = 2010; i > 0; i--)
 		cl_assert(git_pool_malloc(&p, i) != NULL);
 
+#ifndef GIT_DEBUG_POOL
 	/* with fixed page size, allocation must end up with these values */
 	cl_assert_equal_i(sizeof(void *) == 8 ? 575 : 573, git_pool__open_pages(&p));
+#endif
 	git_pool_clear(&p);
 }
 
@@ -69,8 +73,10 @@ void test_core_pool__2(void)
 		cl_git_pass(git_oid_fromstr(oid, oid_hex));
 	}
 
+#ifndef GIT_DEBUG_POOL
 	/* with fixed page size, allocation must end up with these values */
 	cl_assert_equal_i(sizeof(void *) == 8 ? 55 : 45, git_pool__open_pages(&p));
+#endif
 	git_pool_clear(&p);
 }
 


### PR DESCRIPTION
Calls to git_pool__malloc are proxied directly to git__malloc. Allocations are tracked using a git_vector and freed when git_pool_clear is called. I am currently using ifdef/ifndef to enable and disable the debug code. I also enable/disable a couple of the pool test cases which won't work when debug is turned on.