### PR TITLE
Validate pointer before access.

### DIFF
--- a/src/iterator.c
+++ b/src/iterator.c
@@ -558,7 +558,7 @@ static bool tree_iterator__pop_frame(tree_iterator *ti, bool final)
 {
 	tree_iterator_frame *tf = ti->head;
 
-	if (!tf->up)
+	if (!tf || !tf->up)
 		return false;
 
 	ti->head = tf->up;
@@ -581,7 +581,8 @@ static void tree_iterator__pop_all(tree_iterator *ti, bool to_end, bool final)
 	while (tree_iterator__pop_frame(ti, final)) /* pop to root */;
 
 	if (!final) {
-		ti->head->current = to_end ? ti->head->n_entries : 0;
+		if(ti->head)
+			ti->head->current = to_end ? ti->head->n_entries : 0;
 		ti->path_ambiguities = 0;
 		git_buf_clear(&ti->path);
 	}
@@ -775,7 +776,8 @@ static void tree_iterator__free(git_iterator *self)
 
 	tree_iterator__pop_all(ti, true, false);
 
-	git_tree_free(ti->head->entries[0]->tree);
+	if(ti->head)
+		git_tree_free(ti->head->entries[0]->tree);
 	git__free(ti->head);
 	git_pool_clear(&ti->pool);
 	git_buf_free(&ti->path);


### PR DESCRIPTION
When free the tree iterator, NULL pointer in some circumstance will crash the process. One example is loading file from remote network locations in atom.

Signed-off-by: Colin Xu <colin.xu@gmail.com>