### PR TITLE
Validate pointer before access the member.

### DIFF
--- a/src/iterator.c
+++ b/src/iterator.c
@@ -558,7 +558,7 @@ static bool tree_iterator__pop_frame(tree_iterator *ti, bool final)
 {
 	tree_iterator_frame *tf = ti->head;
 
-	if (!tf->up)
+	if (!tf || !tf->up)
 		return false;
 
 	ti->head = tf->up;
@@ -581,7 +581,8 @@ static void tree_iterator__pop_all(tree_iterator *ti, bool to_end, bool final)
 	while (tree_iterator__pop_frame(ti, final)) /* pop to root */;
 
 	if (!final) {
-		ti->head->current = to_end ? ti->head->n_entries : 0;
+		if(ti->head)
+			ti->head->current = to_end ? ti->head->n_entries : 0;
 		ti->path_ambiguities = 0;
 		git_buf_clear(&ti->path);
 	}
@@ -775,7 +776,8 @@ static void tree_iterator__free(git_iterator *self)
 
 	tree_iterator__pop_all(ti, true, false);
 
-	git_tree_free(ti->head->entries[0]->tree);
+	if(ti->head)
+		git_tree_free(ti->head->entries[0]->tree);
 	git__free(ti->head);
 	git_pool_clear(&ti->pool);
 	git_buf_free(&ti->path);


### PR DESCRIPTION
When Git repository at network locations, sometimes git_iterator_for_tree fails at iterator__update_ignore_case so it goes to git_iterator_free. Null pointer will crash the process if not check. One example is loading file (the parent path of the file contains a git repository) from remote network locations in atom.

Call stack:

```
git.node!tree_iterator__pop_frame(tree_iterator * ti, unsigned char final) Line 562 C
git.node!tree_iterator__pop_all(tree_iterator * ti, unsigned char to_end, unsigned char final) Line 582 C
git.node!tree_iterator__free(git_iterator * self) Line 778 C
git.node!git_iterator_free(git_iterator * iter) Line 1872 C
git.node!git_iterator_for_tree(git_iterator * * iter, git_tree * tree, git_iterator_options * options) Line 838 C
git.node!submodules_from_head(kh_str_s * map, git_tree * head, git_config * cfg) Line 373 C
git.node!all_submodules(git_repository * repo, kh_str_s * map) Line 477 C
git.node!git_submodule_foreach(git_repository * repo, int (git_submodule *, const char *, void *) * callback, void * payload) Line 510 C
git.node!Repository::GetSubmodulePaths(const Nan::FunctionCallbackInfov8::Value & info) Line 182 C++
git.node!Nan::imp::FunctionCallbackWrapper(const v8::FunctionCallbackInfov8::Value & info) Line 174 C++
node.dll!0f3cf9be() Unknown
[Frames below may be incorrect and/or missing, no symbols loaded for node.dll]

node.dll!0f3be311() Unknown
node.dll!0f3bfe7d() Unknown
[External Code] 
node.dll!0f3dc4f3() Unknown
node.dll!0f3dba0b() Unknown
node.dll!0f510b7d() Unknown
[External Code]
```

Expect call sequence should be:
git_iterator_for_tree
->iterator__update_ignore_case

But iterator__update_ignore_case fails so it goto git_iterator_free, then hit the issue.