### PR TITLE
Fix the build when defining USE_NSEC

### DIFF
--- a/src/index.h
+++ b/src/index.h
@@ -92,7 +92,7 @@ GIT_INLINE(bool) git_index_entry_newer_than_index(
 
 	/* If the timestamp is the same or newer than the index, it's racy */
 #if defined(GIT_USE_NSEC)
-	if ((int32_t)index->stamp.tv_sec < entry->mtime.seconds)
+	if ((int32_t)index->stamp.mtime.tv_sec < entry->mtime.seconds)
 		return true;
 	else if ((int32_t)index->stamp.mtime.tv_sec > entry->mtime.seconds)
 		return false;


### PR DESCRIPTION
This fixes the build on Windows machines, I'm not sure about other kinds of machines.

One other issue I have observed on OS X:
https://github.com/libgit2/libgit2/blob/master/src/index.c#L831-L834

They're typo'd, they should be st_mtime, st_ctime, but on Darwin, they should be st_mtimespec, st_ctimespec.