### PR TITLE
less vague uploadpack and receivepack error messages

### DIFF
--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -240,7 +240,7 @@ static int _git_uploadpack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK");
+	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK (git)");
 	return -1;
 }
 
@@ -296,7 +296,7 @@ static int _git_receivepack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK");
+	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK (git)");
 	return -1;
 }
 

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -669,7 +669,7 @@ static int ssh_uploadpack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK");
+	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK (ssh)");
 	return -1;
 }
 
@@ -696,7 +696,7 @@ static int ssh_receivepack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK");
+	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK (ssh)");
 	return -1;
 }
 


### PR DESCRIPTION
Trying to identify an error as an end user is difficult when you get the error message
`Must call UPLOADPACK_LS before UPLOADPACK`
since this error message is the same for a git or ssh error.

Added `(git)` and `(ssh)` to the end of the error messages for easier identification.