### PR TITLE
Bug on WindowsXP

### DIFF
--- a/src/win32/utf-conv.c
+++ b/src/win32/utf-conv.c
@@ -8,7 +8,7 @@
 #include "common.h"
 #include "utf-conv.h"
 
-GIT_INLINE(DWORD) get_wc_flags(void)
+DWORD get_wc_flags(void)
 {
 	static char inited = 0;
 	static DWORD flags;

--- a/src/win32/utf-conv.h
+++ b/src/win32/utf-conv.h
@@ -15,6 +15,11 @@
 #endif
 
 /**
+ * As windowsXP does not support WC_ERR_INVALID_CHARS we need to use this function in w32_buffer.c
+ */
+DWORD get_wc_flags(void);
+
+/**
  * Converts a UTF-8 string to wide characters.
  *
  * @param dest The buffer to receive the wide string.

--- a/src/win32/w32_buffer.c
+++ b/src/win32/w32_buffer.c
@@ -31,7 +31,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 	assert(string_w);
 
 	/* Measure the string necessary for conversion */
-	if ((utf8_len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, string_w, len_w, NULL, 0, NULL, NULL)) == 0)
+	if ((utf8_len = WideCharToMultiByte(CP_UTF8, get_wc_flags(), string_w, len_w, NULL, 0, NULL, NULL)) == 0)
 		return 0;
 
 	assert(utf8_len > 0);
@@ -43,7 +43,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 		return -1;
 
 	if ((utf8_write_len = WideCharToMultiByte(
-			CP_UTF8, WC_ERR_INVALID_CHARS, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
+			CP_UTF8, get_wc_flags(), string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
 		return handle_wc_error();
 
 	assert(utf8_write_len == utf8_len);


### PR DESCRIPTION
WideCharToMultiByte does not support WC_ERR_INVALID_CHARS flag on WindowsXp, so we need to fix w32_buffer.c not to use this flag straightforward but with the help of get_wc_flags() function. This function(get_wc_flags) is in src/win32/utf-conv.c but it is not exposed by header, so I decided to expose it.