### PR TITLE
Better document `git_merge_commits` redux

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -527,10 +527,6 @@ GIT_EXTERN(int) git_merge_trees(
  * or checked out.  If the index is to be converted to a tree, the caller
  * should resolve any conflicts that arose as part of the merge.
  *
- * The merge performed uses the first common ancestor, unlike the
- * `git-merge-recursive` strategy, which may produce an artificial common
- * ancestor tree when there are multiple ancestors.
- *
  * The returned index must be freed explicitly with `git_index_free`.
  *
  * @param out pointer to store the index result in
@@ -552,10 +548,6 @@ GIT_EXTERN(int) git_merge_commits(
  * directory.  Any changes are staged for commit and any conflicts are written
  * to the index.  Callers should inspect the repository's index after this
  * completes, resolve any conflicts and prepare a commit.
- *
- * The merge performed uses the first common ancestor, unlike the
- * `git-merge-recursive` strategy, which may produce an artificial common
- * ancestor tree when there are multiple ancestors.
  *
  * For compatibility with git, the repository is put into a merging
  * state. Once the commit is done (or if the uses wishes to abort),


### PR DESCRIPTION
`git_merge_commits` and `git_merge` now *do* handle recursive base
building for criss-cross merges.  Remove the documentation that says
that they do not.

(Recursion is documented itself in `git_merge_options`).

This reverts commit 5e44d9bcb6d5b20922f49b1913723186f8ced8b5.