### PR TITLE
Coverity fixes

### DIFF
--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -123,7 +123,7 @@ int git_attr_file__load(
 		break;
 	}
 	case GIT_ATTR_FILE__FROM_FILE: {
-		int fd;
+		int fd = -1;
 
 		/* For open or read errors, pretend that we got ENOTFOUND. */
 		/* TODO: issue warning when warning API is available */
@@ -133,7 +133,8 @@ int git_attr_file__load(
 			(fd = git_futils_open_ro(entry->fullpath)) < 0 ||
 			(error = git_futils_readbuffer_fd(&content, fd, (size_t)st.st_size)) < 0)
 			nonexistent = true;
-		else
+
+		if (fd >= 0)
 			p_close(fd);
 
 		break;

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1487,8 +1487,10 @@ static int blob_content_to_file(
 	if (!data->opts.disable_filters &&
 		(error = git_filter_list__load_ext(
 			&fl, data->repo, blob, hint_path,
-			GIT_FILTER_TO_WORKTREE, &filter_opts)))
+			GIT_FILTER_TO_WORKTREE, &filter_opts))) {
+		p_close(fd);
 		return error;
+	}
 
 	/* setup the writer */
 	memset(&writer, 0, sizeof(struct checkout_stream));

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -605,6 +605,7 @@ static git_pobject **compute_write_order(git_packbuilder *pb)
 	}
 
 	if (wo_end != pb->nr_objects) {
+		git__free(wo);
 		giterr_set(GITERR_INVALID, "invalid write order");
 		return NULL;
 	}

--- a/src/pack.c
+++ b/src/pack.c
@@ -790,7 +790,6 @@ int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, 
 	obj->zstream.next_out = Z_NULL;
 	st = inflateInit(&obj->zstream);
 	if (st != Z_OK) {
-		git__free(obj);
 		giterr_set(GITERR_ZLIB, "failed to init packfile stream");
 		return -1;
 	}


### PR DESCRIPTION
Some more small-ish fixes. I'm still unsure if it's of any benefit to fix memory leaks deep inside the internal APIs, but I guess it can't really hurt to do so.

On another note, I'd like to mark all those errors regarding GITERR_CHECK_ALLOC as false positives or intended in Coverity. Any objections to this?