### PR TITLE
Handle `USE_NSECS` 

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -62,6 +62,12 @@
 # endif
 #define GIT_STDLIB_CALL
 
+#ifdef GIT_USE_STAT_ATIMESPEC
+# define st_atim st_atimespec
+# define st_ctim st_ctimespec
+# define st_mtim st_mtimespec
+#endif
+
 # include <arpa/inet.h>
 
 #endif

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -13,12 +13,6 @@
 #include "win32/findfile.h"
 #endif
 
-#ifdef GIT_USE_STAT_ATIMESPEC
-#define st_atim st_atimespec
-#define st_ctim st_ctimespec
-#define st_mtim st_mtimespec
-#endif
-
 GIT__USE_STRMAP
 
 int git_futils_mkpath2file(const char *file_path, const mode_t mode)

--- a/src/index.h
+++ b/src/index.h
@@ -92,7 +92,7 @@ GIT_INLINE(bool) git_index_entry_newer_than_index(
 
 	/* If the timestamp is the same or newer than the index, it's racy */
 #if defined(GIT_USE_NSEC)
-	if ((int32_t)index->stamp.tv_sec < entry->mtime.seconds)
+	if ((int32_t)index->stamp.mtime.tv_sec < entry->mtime.seconds)
 		return true;
 	else if ((int32_t)index->stamp.mtime.tv_sec > entry->mtime.seconds)
 		return false;


### PR DESCRIPTION
Include @Therzok 's fix from #3586 which was missed after some index timestamp refactoring.

Also increase the scope of `st_mtim` -> `st_mtimespec` so that it affects all the files.