### PR TITLE
Coverity improvements for GITERR_CHECK_ALLOC

### DIFF
--- a/script/coverity.sh
+++ b/script/coverity.sh
@@ -50,10 +50,9 @@ COVERITY_UNSUPPORTED=1 \
 tar czf libgit2.tgz cov-int
 SHA=$(git rev-parse --short HEAD)
 curl \
-	--form project=libgit2 \
 	--form token="$COVERITY_TOKEN" \
 	--form email=bs@github.com \
 	--form file=@libgit2.tgz \
 	--form version="$SHA" \
 	--form description="Travis build" \
-	http://scan5.coverity.com/cgi-bin/upload.py
+	https://scan.coverity.com/builds?project=libgit2

--- a/script/coverity.sh
+++ b/script/coverity.sh
@@ -33,6 +33,8 @@ if [ ! -d "$TOOL_BASE" ]; then
 	ln -s "$TOOL_DIR" "$TOOL_BASE"/cov-analysis
 fi
 
+cp script/user_nodefs.h "$TOOL_BASE"/cov-analysis/config/user_nodefs.h
+
 COV_BUILD="$TOOL_BASE/cov-analysis/bin/cov-build"
 
 # Configure and build

--- a/script/user_nodefs.h
+++ b/script/user_nodefs.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#nodef GITERR_CHECK_ALLOC(ptr) if (ptr == NULL) { __coverity_panic__(); }


### PR DESCRIPTION
Two small improvements to Coverity. The first commit tries to mitigate the issue with `GITERR_CHECK_ALLOC` by providing a `user_nodefs.h` file which overrides the macro. The second is a security enhancement stopping us from sending over the Coverity authorization token in plain text.

This is a follow-up for libgit2/libgit2#3603. I was not able to verify that the `user_nodefs.h` thing suppresses the resource leak errors as I cannot get Coverity to provide the analysis results to me. It builds, but after submitting the instrumentalized archive I get no results back.