### PR TITLE
Fix some race conditions in concurrent initialization

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -89,7 +89,7 @@ static void filter_registry_shutdown(void)
 static int filter_registry_initialize(void)
 {
 	int error = 0;
-	struct filter_registry *reg;
+	struct filter_registry *reg, *found;
 
 	if (git__filter_registry)
 		return 0;
@@ -101,8 +101,8 @@ static int filter_registry_initialize(void)
 			&reg->filters, 2, filter_def_priority_cmp)) < 0)
 		goto cleanup;
 
-	reg = git__compare_and_swap(&git__filter_registry, NULL, reg);
-	if (reg != NULL)
+	found = git__compare_and_swap(&git__filter_registry, NULL, reg);
+	if (found != NULL)
 		goto cleanup;
 
 	git__on_shutdown(filter_registry_shutdown);


### PR DESCRIPTION
Some of the travis tests I have for the [git2-rs](https://github.com/alexcrichton/git2-rs) Rust library for libgit2 have been failing a lot recently with the error:

```
src/global.c:38: git__on_shutdown: Assertion `count <= 8 && count > 0' failed.
```

Curious as to why this was happening, I scrutinized some of the calls to `git__on_shutdown`, and I think the latter of these two commits may be the cause of this. Unfortunately I wasn't ever able to reproduce locally, so I'm not *sure* that this fixes the bug I'm seeing, but it seems like these may want to be fixed regardless!