### PR TITLE
Remove most of the silly warnings

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -826,8 +826,8 @@ const git_index_entry *git_index_get_bypath(
 void git_index_entry__init_from_stat(
 	git_index_entry *entry, struct stat *st, bool trust_mode)
 {
-	entry->ctime.seconds = (git_time_t)st->st_ctime;
-	entry->mtime.seconds = (git_time_t)st->st_mtime;
+	entry->ctime.seconds = (int32_t)st->st_ctime;
+	entry->mtime.seconds = (int32_t)st->st_mtime;
 #if defined(GIT_USE_NSEC)
 	entry->mtime.nanoseconds = st->st_mtim.tv_nsec;
 	entry->ctime.nanoseconds = st->st_ctim.tv_nsec;
@@ -838,7 +838,7 @@ void git_index_entry__init_from_stat(
 		git_index__create_mode(0666) : git_index__create_mode(st->st_mode);
 	entry->uid  = st->st_uid;
 	entry->gid  = st->st_gid;
-	entry->file_size = st->st_size;
+	entry->file_size = (uint32_t)st->st_size;
 }
 
 static void index_entry_adjust_namemask(

--- a/src/index.c
+++ b/src/index.c
@@ -603,14 +603,14 @@ const git_oid *git_index_checksum(git_index *index)
  */
 static int compare_checksum(git_index *index)
 {
-	int fd, error;
+	int fd;
 	ssize_t bytes_read;
 	git_oid checksum = {{ 0 }};
 
 	if ((fd = p_open(index->index_file_path, O_RDONLY)) < 0)
 		return fd;
 
-	if ((error = p_lseek(fd, -20, SEEK_END)) < 0) {
+	if (p_lseek(fd, -20, SEEK_END) < 0) {
 		p_close(fd);
 		giterr_set(GITERR_OS, "failed to seek to end of file");
 		return -1;

--- a/src/index.c
+++ b/src/index.c
@@ -1515,7 +1515,7 @@ int git_index__fill(git_index *index, const git_vector *source_entries)
 		return 0;
 
 	git_vector_size_hint(&index->entries, source_entries->length);
-	git_idxmap_resize(index->entries_map, source_entries->length * 1.3);
+	git_idxmap_resize(index->entries_map, (khint_t)(source_entries->length * 1.3));
 
 	git_vector_foreach(source_entries, i, source_entry) {
 		git_index_entry *entry = NULL;

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -778,9 +778,9 @@ int git_submodule_add_to_index(git_submodule *sm, int write_index)
 	if ((error = git_commit_lookup(&head, sm_repo, &sm->wd_oid)) < 0)
 		goto cleanup;
 
-	entry.ctime.seconds = git_commit_time(head);
+	entry.ctime.seconds = (int32_t)git_commit_time(head);
 	entry.ctime.nanoseconds = 0;
-	entry.mtime.seconds = git_commit_time(head);
+	entry.mtime.seconds = (int32_t)git_commit_time(head);
 	entry.mtime.nanoseconds = 0;
 
 	git_commit_free(head);

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -283,7 +283,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 	unsigned long disable_redirects = WINHTTP_DISABLE_REDIRECTS;
 	int default_timeout = TIMEOUT_INFINITE;
 	int default_connect_timeout = DEFAULT_CONNECT_TIMEOUT;
-	int i;
+	size_t i;
 
 	/* Prepare URL */
 	git_buf_printf(&buf, "%s%s", t->connection_data.path, s->service_url);

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -52,8 +52,10 @@ extern char *p_realpath(const char *, char *);
 #define p_localtime_r(c, r) localtime_r(c, r)
 #define p_gmtime_r(c, r) gmtime_r(c, r)
 
+#define p_timeval timeval
+
 #ifdef HAVE_FUTIMENS
-GIT_INLINE(int) p_futimes(int f, const struct timeval t[2])
+GIT_INLINE(int) p_futimes(int f, const struct p_timeval t[2])
 {
 	struct timespec s[2];
 	s[0].tv_sec = t[0].tv_sec;

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -9,6 +9,7 @@
 
 #include "common.h"
 #include "../posix.h"
+#include "win32-compat.h"
 #include "path_w32.h"
 #include "utf-conv.h"
 #include "dir.h"
@@ -20,8 +21,8 @@ typedef SOCKET GIT_SOCKET;
 extern int p_lstat(const char *file_name, struct stat *buf);
 extern int p_stat(const char* path, struct stat* buf);
 
-extern int p_utimes(const char *filename, const struct timeval times[2]);
-extern int p_futimes(int fd, const struct timeval times[2]);
+extern int p_utimes(const char *filename, const struct p_timeval times[2]);
+extern int p_futimes(int fd, const struct p_timeval times[2]);
 
 extern int p_readlink(const char *path, char *buf, size_t bufsiz);
 extern int p_symlink(const char *old, const char *new);

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -17,9 +17,10 @@
 typedef SOCKET GIT_SOCKET;
 
 #define p_lseek(f,n,w) _lseeki64(f, n, w)
-#define p_fstat(f,b) _fstat64(f, b)
+
+extern int p_fstat(int fd, struct stat *buf);
 extern int p_lstat(const char *file_name, struct stat *buf);
-extern int p_stat(const char* path, struct stat* buf);
+extern int p_stat(const char* path, struct stat *buf);
 
 extern int p_utimes(const char *filename, const struct p_timeval times[2]);
 extern int p_futimes(int fd, const struct p_timeval times[2]);

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -210,7 +210,7 @@ int p_lstat_posixly(const char *filename, struct stat *buf)
 	return do_lstat(filename, buf, true);
 }
 
-int p_utimes(const char *filename, const struct timeval times[2])
+int p_utimes(const char *filename, const struct p_timeval times[2])
 {
 	int fd, error;
 
@@ -223,7 +223,7 @@ int p_utimes(const char *filename, const struct timeval times[2])
 	return error;
 }
 
-int p_futimes(int fd, const struct timeval times[2])
+int p_futimes(int fd, const struct p_timeval times[2])
 {
 	HANDLE handle;
 	FILETIME atime = {0}, mtime = {0};

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -398,6 +398,22 @@ static int follow_and_lstat_link(git_win32_path path, struct stat* buf)
 	return lstat_w(target_w, buf, false);
 }
 
+int p_fstat(int fd, struct stat *buf)
+{
+	BY_HANDLE_FILE_INFORMATION fhInfo;
+
+	HANDLE fh = (HANDLE)_get_osfhandle(fd);
+
+	if (fh == INVALID_HANDLE_VALUE ||
+		!GetFileInformationByHandle(fh, &fhInfo)) {
+		errno = EBADF;
+		return -1;
+	}
+
+	git_win32__file_information_to_stat(buf, &fhInfo);
+	return 0;
+}
+
 int p_stat(const char* path, struct stat* buf)
 {
 	git_win32_path path_w;

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -105,19 +105,25 @@ GIT_INLINE(void) git_win32__timeval_to_filetime(
 	ft->dwLowDateTime = (ticks & 0xffffffffLL);
 }
 
-GIT_INLINE(int) git_win32__file_attribute_to_stat(
+GIT_INLINE(void) git_win32__stat_init(
 	struct stat *st,
-	const WIN32_FILE_ATTRIBUTE_DATA *attrdata,
-	const wchar_t *path)
+	DWORD dwFileAttributes,
+	DWORD nFileSizeHigh,
+	DWORD nFileSizeLow,
+	FILETIME ftCreationTime,
+	FILETIME ftLastAccessTime,
+	FILETIME ftLastWriteTime)
 {
 	mode_t mode = S_IREAD;
 
-	if (attrdata->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	memset(st, 0, sizeof(struct stat));
+
+	if (dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		mode |= S_IFDIR;
 	else
 		mode |= S_IFREG;
 
-	if ((attrdata->dwFileAttributes & FILE_ATTRIBUTE_READONLY) == 0)
+	if ((dwFileAttributes & FILE_ATTRIBUTE_READONLY) == 0)
 		mode |= S_IWRITE;
 
 	st->st_ino = 0;
@@ -125,12 +131,39 @@ GIT_INLINE(int) git_win32__file_attribute_to_stat(
 	st->st_uid = 0;
 	st->st_nlink = 1;
 	st->st_mode = mode;
-	st->st_size = ((git_off_t)attrdata->nFileSizeHigh << 32) + attrdata->nFileSizeLow;
+	st->st_size = ((git_off_t)nFileSizeHigh << 32) + nFileSizeLow;
 	st->st_dev = _getdrive() - 1;
 	st->st_rdev = st->st_dev;
-	git_win32__filetime_to_timespec(&(attrdata->ftLastAccessTime), &(st->st_atim));
-	git_win32__filetime_to_timespec(&(attrdata->ftLastWriteTime), &(st->st_mtim));
-	git_win32__filetime_to_timespec(&(attrdata->ftCreationTime), &(st->st_ctim));
+	git_win32__filetime_to_timespec(&ftLastAccessTime, &(st->st_atim));
+	git_win32__filetime_to_timespec(&ftLastWriteTime, &(st->st_mtim));
+	git_win32__filetime_to_timespec(&ftCreationTime, &(st->st_ctim));
+}
+
+GIT_INLINE(void) git_win32__file_information_to_stat(
+	struct stat *st,
+	const BY_HANDLE_FILE_INFORMATION *fileinfo)
+{
+	git_win32__stat_init(st,
+		fileinfo->dwFileAttributes,
+		fileinfo->nFileSizeHigh,
+		fileinfo->nFileSizeLow,
+		fileinfo->ftCreationTime,
+		fileinfo->ftLastAccessTime,
+		fileinfo->ftLastWriteTime);
+}
+
+GIT_INLINE(int) git_win32__file_attribute_to_stat(
+	struct stat *st,
+	const WIN32_FILE_ATTRIBUTE_DATA *attrdata,
+	const wchar_t *path)
+{
+	git_win32__stat_init(st,
+		attrdata->dwFileAttributes,
+		attrdata->nFileSizeHigh,
+		attrdata->nFileSizeLow,
+		attrdata->ftCreationTime,
+		attrdata->ftLastAccessTime,
+		attrdata->ftLastWriteTime);
 
 	if (attrdata->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT && path) {
 		git_win32_path target;
@@ -139,7 +172,7 @@ GIT_INLINE(int) git_win32__file_attribute_to_stat(
 			st->st_mode = (st->st_mode & ~S_IFMT) | S_IFLNK;
 
 			/* st_size gets the UTF-8 length of the target name, in bytes,
-				* not counting the NULL terminator */
+			 * not counting the NULL terminator */
 			if ((st->st_size = git__utf16_to_8(NULL, 0, target)) < 0) {
 				giterr_set(GITERR_OS, "Could not convert reparse point name for '%s'", path);
 				return -1;

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -96,7 +96,7 @@ GIT_INLINE(void) git_win32__filetime_to_timespec(
 }
 
 GIT_INLINE(void) git_win32__timeval_to_filetime(
-	FILETIME *ft, const struct timeval tv)
+	FILETIME *ft, const struct p_timeval tv)
 {
 	long long ticks = (tv.tv_sec * 10000000LL) +
 		(tv.tv_usec * 10LL) + 116444736000000000LL;

--- a/src/win32/win32-compat.h
+++ b/src/win32/win32-compat.h
@@ -13,6 +13,13 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+typedef long suseconds_t;
+
+struct p_timeval {
+	time_t tv_sec;
+	suseconds_t tv_usec;
+};
+
 struct p_timespec {
 	time_t tv_sec;
 	long tv_nsec;

--- a/tests/checkout/checkout_helpers.c
+++ b/tests/checkout/checkout_helpers.c
@@ -133,7 +133,7 @@ int checkout_count_callback(
 void tick_index(git_index *index)
 {
 	struct timespec ts;
-	struct timeval times[2];
+	struct p_timeval times[2];
 
 	cl_assert(index->on_disk);
 	cl_assert(git_index_path(index));

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -100,7 +100,7 @@ void test_core_posix__inet_pton(void)
 
 void test_core_posix__utimes(void)
 {
-	struct timeval times[2];
+	struct p_timeval times[2];
 	struct stat st;
 	time_t curtime;
 	int fd;

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -1755,7 +1755,7 @@ void test_diff_workdir__with_stale_index(void)
 static int touch_file(void *payload, git_buf *path)
 {
 	struct stat st;
-	struct timeval times[2];
+	struct p_timeval times[2];
 
 	GIT_UNUSED(payload);
 	if (git_path_isdir(path->ptr))
@@ -2006,7 +2006,7 @@ void test_diff_workdir__only_writes_index_when_necessary(void)
 	git_oid initial, first, second;
 	git_buf path = GIT_BUF_INIT;
 	struct stat st;
-	struct timeval times[2];
+	struct p_timeval times[2];
 
 	opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED | GIT_DIFF_UPDATE_INDEX;
 

--- a/tests/index/racy.c
+++ b/tests/index/racy.c
@@ -54,7 +54,7 @@ void test_index_racy__write_index_just_after_file(void)
 	git_index *index;
 	git_diff *diff;
 	git_buf path = GIT_BUF_INIT;
-	struct timeval times[2];
+	struct p_timeval times[2];
 
 	/* Make sure we do have a timestamp */
 	cl_git_pass(git_repository_index(&index, g_repo));

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -162,8 +162,8 @@ static void hack_index(char *files[])
 		cl_git_pass(p_utimes(path.ptr, times));
 		cl_git_pass(p_stat(path.ptr, &statbuf));
 
-		entry->ctime.seconds = (git_time_t)statbuf.st_ctime;
-		entry->mtime.seconds = (git_time_t)statbuf.st_mtime;
+		entry->ctime.seconds = (int32_t)statbuf.st_ctime;
+		entry->mtime.seconds = (int32_t)statbuf.st_mtime;
 #if defined(GIT_USE_NSEC)
 		entry->ctime.nanoseconds = statbuf.st_ctim.tv_nsec;
 		entry->mtime.nanoseconds = statbuf.st_mtim.tv_nsec;
@@ -175,7 +175,7 @@ static void hack_index(char *files[])
 		entry->ino = statbuf.st_ino;
 		entry->uid  = statbuf.st_uid;
 		entry->gid  = statbuf.st_gid;
-		entry->file_size = statbuf.st_size;
+		entry->file_size = (uint32_t)statbuf.st_size;
 	}
 
 	git_buf_free(&path);

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -133,7 +133,7 @@ static void hack_index(char *files[])
 	struct stat statbuf;
 	git_buf path = GIT_BUF_INIT;
 	git_index_entry *entry;
-	struct timeval times[2];
+	struct p_timeval times[2];
 	time_t now;
 	size_t i;
 

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -238,7 +238,7 @@ void test_reset_hard__reflog_is_correct(void)
 
 void test_reset_hard__switch_file_to_dir(void)
 {
-	git_index_entry entry = { 0 };
+	git_index_entry entry = {{ 0 }};
 	git_index *idx;
 	git_object *commit;
 	git_tree *tree;

--- a/tests/win32/longpath.c
+++ b/tests/win32/longpath.c
@@ -36,7 +36,7 @@ void assert_name_too_long(void)
 {
 	const git_error *err;
 	size_t expected_len, actual_len;
-	const char *expected_msg;
+	char *expected_msg;
 
 	err = giterr_last();
 	actual_len = strlen(err->message);


### PR DESCRIPTION
Fix up some of the silly warning:  correct casts, constness, etc.  This doesn't get us to zero warnings on all platforms, but it gets us closer.
