### PR TITLE
rebase: persist a single in-memory index

### DIFF
--- a/include/git2/rebase.h
+++ b/include/git2/rebase.h
@@ -142,12 +142,6 @@ typedef struct {
 	 * be populated for operations of type `GIT_REBASE_OPERATION_EXEC`.
 	 */
 	const char *exec;
-
-	/**
-	 * The index that is the result of an operation.
-	 * This is set only for in-memory rebases.
-	 */
-	git_index *index;
 } git_rebase_operation;
 
 /**
@@ -245,6 +239,21 @@ GIT_EXTERN(git_rebase_operation *) git_rebase_operation_byindex(
  */
 GIT_EXTERN(int) git_rebase_next(
 	git_rebase_operation **operation,
+	git_rebase *rebase);
+
+/**
+ * Gets the index produced by the last operation, which is the result
+ * of `git_rebase_next` and which will be committed by the next
+ * invocation of `git_rebase_commit`.  This is useful for resolving
+ * conflicts in an in-memory rebase before committing them.  You must
+ * call `git_index_free` when you are finished with this.
+ *
+ * This is only applicable for in-memory rebases; for rebases within
+ * a working directory, the changes were applied to the repository's
+ * index.
+ */
+GIT_EXTERN(int) git_rebase_inmemory_index(
+	git_index **index,
 	git_rebase *rebase);
 
 /**

--- a/tests/rebase/iterator.c
+++ b/tests/rebase/iterator.c
@@ -13,7 +13,8 @@ void test_rebase_iterator__initialize(void)
 {
 	repo = cl_git_sandbox_init("rebase");
 	cl_git_pass(git_repository_index(&_index, repo));
-	cl_git_pass(git_signature_now(&signature, "Rebaser", "rebaser@rebaser.rb"));
+	cl_git_pass(git_signature_new(&signature, "Rebaser",
+		"rebaser@rebaser.rb", 1405694510, 0));
 }
 
 void test_rebase_iterator__cleanup(void)
@@ -53,7 +54,7 @@ void test_iterator(bool inmemory)
 	git_reference *branch_ref, *upstream_ref;
 	git_annotated_commit *branch_head, *upstream_head;
 	git_rebase_operation *rebase_operation;
-	git_oid commit_id;
+	git_oid commit_id, expected_id;
 	int error;
 
 	opts.inmemory = inmemory;
@@ -77,15 +78,24 @@ void test_iterator(bool inmemory)
 		NULL, NULL));
 	test_operations(rebase, 0);
 
+	git_oid_fromstr(&expected_id, "776e4c48922799f903f03f5f6e51da8b01e4cce0");
+	cl_assert_equal_oid(&expected_id, &commit_id);
+
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
 		NULL, NULL));
 	test_operations(rebase, 1);
 
+	git_oid_fromstr(&expected_id, "ba1f9b4fd5cf8151f7818be2111cc0869f1eb95a");
+	cl_assert_equal_oid(&expected_id, &commit_id);
+
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
 		NULL, NULL));
 	test_operations(rebase, 2);
+
+	git_oid_fromstr(&expected_id, "948b12fe18b84f756223a61bece4c307787cd5d4");
+	cl_assert_equal_oid(&expected_id, &commit_id);
 
 	if (!inmemory) {
 		git_rebase_free(rebase);
@@ -97,10 +107,16 @@ void test_iterator(bool inmemory)
 		NULL, NULL));
 	test_operations(rebase, 3);
 
+	git_oid_fromstr(&expected_id, "d9d5d59d72c9968687f9462578d79878cd80e781");
+	cl_assert_equal_oid(&expected_id, &commit_id);
+
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase));
 	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
 		NULL, NULL));
 	test_operations(rebase, 4);
+
+	git_oid_fromstr(&expected_id, "9cf383c0a125d89e742c5dec58ed277dd07588b3");
+	cl_assert_equal_oid(&expected_id, &commit_id);
 
 	cl_git_fail(error = git_rebase_next(&rebase_operation, rebase));
 	cl_assert_equal_i(GIT_ITEROVER, error);


### PR DESCRIPTION
When performing an in-memory rebase, keep a single index for the
duration, so that callers have the expected index lifecycle and
do not hold on to an index that is free'd out from under them.