### PR TITLE
Fix a typo

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -48,7 +48,7 @@ These are good small projects to get started with libgit2.
   a new example that mirrors the behavior.  Examples don't have to be
   perfect emulations, but should demonstrate how to use the libgit2 APIs
   to get results that are similar to Git commands.  This lets you (and us)
-  easily exercise a particular facet of the API and measure compatability
+  easily exercise a particular facet of the API and measure compatibility
   and feature parity with core git.
 * Submit a PR to clarify documentation! While we do try to document all of
   the APIs, your fresh eyes on the documentation will find areas that are


### PR DESCRIPTION
`compatability` → `compatibility`