### PR TITLE
rebase: additional setup tests of exotic behavior

### DIFF
--- a/tests/rebase/abort.c
+++ b/tests/rebase/abort.c
@@ -86,19 +86,41 @@ void test_rebase_abort__merge(void)
 	git_rebase_free(rebase);
 }
 
+void test_rebase_abort__merge_by_id(void)
+{
+	git_rebase *rebase;
+	git_oid branch_id, onto_id;
+	git_annotated_commit *branch_head, *onto_head;
+
+	cl_git_pass(git_oid_fromstr(&branch_id, "b146bd7608eac53d9bf9e1a6963543588b555c64"));
+	cl_git_pass(git_oid_fromstr(&onto_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00"));
+
+	cl_git_pass(git_annotated_commit_lookup(&branch_head, repo, &branch_id));
+	cl_git_pass(git_annotated_commit_lookup(&onto_head, repo, &onto_id));
+
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
+	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
+
+	test_abort(branch_head, onto_head);
+
+	git_annotated_commit_free(branch_head);
+	git_annotated_commit_free(onto_head);
+
+	git_rebase_free(rebase);
+}
+
 void test_rebase_abort__detached_head(void)
 {
 	git_rebase *rebase;
-	git_oid branch_id;
-	git_reference *onto_ref;
+	git_oid branch_id, onto_id;
 	git_signature *signature;
 	git_annotated_commit *branch_head, *onto_head;
 
 	git_oid_fromstr(&branch_id, "b146bd7608eac53d9bf9e1a6963543588b555c64");
-	cl_git_pass(git_reference_lookup(&onto_ref, repo, "refs/heads/master"));
+    git_oid_fromstr(&onto_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00");
 
 	cl_git_pass(git_annotated_commit_lookup(&branch_head, repo, &branch_id));
-	cl_git_pass(git_annotated_commit_from_ref(&onto_head, repo, onto_ref));
+	cl_git_pass(git_annotated_commit_lookup(&onto_head, repo, &onto_id));
 
 	cl_git_pass(git_signature_new(&signature, "Rebaser", "rebaser@example.com", 1404157834, -400));
 
@@ -112,7 +134,6 @@ void test_rebase_abort__detached_head(void)
 	git_annotated_commit_free(branch_head);
 	git_annotated_commit_free(onto_head);
 
-	git_reference_free(onto_ref);
 	git_rebase_free(rebase);
 }
 

--- a/tests/rebase/merge.c
+++ b/tests/rebase/merge.c
@@ -252,6 +252,63 @@ void test_rebase_merge__commit(void)
 	git_rebase_free(rebase);
 }
 
+void test_rebase_merge__commit_with_id(void)
+{
+	git_rebase *rebase;
+	git_oid branch_id, upstream_id;
+	git_annotated_commit *branch_head, *upstream_head;
+	git_rebase_operation *rebase_operation;
+	git_oid commit_id, tree_id, parent_id;
+	git_signature *author;
+	git_commit *commit;
+	git_reflog *reflog;
+	const git_reflog_entry *reflog_entry;
+
+	cl_git_pass(git_oid_fromstr(&branch_id, "b146bd7608eac53d9bf9e1a6963543588b555c64"));
+	cl_git_pass(git_oid_fromstr(&upstream_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00"));
+
+	cl_git_pass(git_annotated_commit_lookup(&branch_head, repo, &branch_id));
+	cl_git_pass(git_annotated_commit_lookup(&upstream_head, repo, &upstream_id));
+
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
+
+	cl_git_pass(git_rebase_next(&rebase_operation, rebase));
+	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
+		NULL, NULL));
+
+	cl_git_pass(git_commit_lookup(&commit, repo, &commit_id));
+
+	git_oid_fromstr(&parent_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00");
+	cl_assert_equal_i(1, git_commit_parentcount(commit));
+	cl_assert_equal_oid(&parent_id, git_commit_parent_id(commit, 0));
+
+	git_oid_fromstr(&tree_id, "4461379789c777d2a6c1f2ee0e9d6c86731b9992");
+	cl_assert_equal_oid(&tree_id, git_commit_tree_id(commit));
+
+	cl_assert_equal_s(NULL, git_commit_message_encoding(commit));
+	cl_assert_equal_s("Modification 1 to beef\n", git_commit_message(commit));
+
+	cl_git_pass(git_signature_new(&author,
+		"Edward Thomson", "ethomson@edwardthomson.com", 1405621769, 0-(4*60)));
+	cl_assert(git_signature__equal(author, git_commit_author(commit)));
+
+	cl_assert(git_signature__equal(signature, git_commit_committer(commit)));
+
+	/* Make sure the reflogs are updated appropriately */
+	cl_git_pass(git_reflog_read(&reflog, repo, "HEAD"));
+	cl_assert(reflog_entry = git_reflog_entry_byindex(reflog, 0));
+	cl_assert_equal_oid(&parent_id, git_reflog_entry_id_old(reflog_entry));
+	cl_assert_equal_oid(&commit_id, git_reflog_entry_id_new(reflog_entry));
+	cl_assert_equal_s("rebase: Modification 1 to beef", git_reflog_entry_message(reflog_entry));
+
+	git_reflog_free(reflog);
+	git_signature_free(author);
+	git_commit_free(commit);
+	git_annotated_commit_free(branch_head);
+	git_annotated_commit_free(upstream_head);
+	git_rebase_free(rebase);
+}
+
 void test_rebase_merge__blocked_when_dirty(void)
 {
 	git_rebase *rebase;


### PR DESCRIPTION
Test some additional exotic rebase setup behavior:  that we are
able to set up properly when already in a detached HEAD state,
that the caller specifies all of branch, upstream and onto,
and that the caller specifies branch, upstream and onto by ID.