### PR TITLE
Coverity fixes

### DIFF
--- a/include/git2/sys/index.h
+++ b/include/git2/sys/index.h
@@ -25,7 +25,7 @@ typedef struct git_index_name_entry {
 
 /** Representation of a resolve undo entry in the index. */
 typedef struct git_index_reuc_entry {
-	unsigned int mode[3];
+	uint32_t mode[3];
 	git_oid oid[3];
 	char *path;
 } git_index_reuc_entry;

--- a/script/user_nodefs.h
+++ b/script/user_nodefs.h
@@ -6,6 +6,7 @@
  */
 
 #nodef GITERR_CHECK_ALLOC(ptr) if (ptr == NULL) { __coverity_panic__(); }
+#nodef GITERR_CHECK_ALLOC_BUF(buf) if (buf == NULL || git_buf_oom(buf)) { __coverity_panic__(); }
 
 #nodef GITERR_CHECK_ALLOC_ADD(out, one, two) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two)) { __coverity_panic__(); }

--- a/script/user_nodefs.h
+++ b/script/user_nodefs.h
@@ -25,3 +25,9 @@
 #nodef GITERR_CHECK_VERSION(S,V,N) if (giterr__check_version(S,V,N) < 0)  { __coverity_panic__(); }
 
 #nodef LOOKS_LIKE_DRIVE_PREFIX(S) (strlen(S) >= 2 && git__isalpha((S)[0]) && (S)[1] == ':')
+
+#nodef git_vector_foreach(v, iter, elem)	\
+	for ((iter) = 0; (v)->contents != NULL && (iter) < (v)->length && ((elem) = (v)->contents[(iter)], 1); (iter)++ )
+
+#nodef git_vector_rforeach(v, iter, elem)	\
+	for ((iter) = (v)->length - 1; (v)->contents != NULL && (iter) < SIZE_MAX && ((elem) = (v)->contents[(iter)], 1); (iter)-- )

--- a/src/common.h
+++ b/src/common.h
@@ -90,6 +90,11 @@
 #define GITERR_CHECK_ALLOC(ptr) if (ptr == NULL) { return -1; }
 
 /**
+ * Check a buffer allocation result, returning -1 if it failed.
+ */
+#define GITERR_CHECK_ALLOC_BUF(buf) if ((void *)(buf) == NULL || git_buf_oom(buf)) { return -1; }
+
+/**
  * Check a return value and propagate result if non-zero.
  */
 #define GITERR_CHECK_ERROR(code) \

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -346,7 +346,7 @@ static int crlf_apply(
 	/* initialize payload in case `check` was bypassed */
 	if (!*payload) {
 		int error = crlf_check(self, payload, src, NULL);
-		if (error < 0 && error != GIT_PASSTHROUGH)
+		if (error < 0)
 			return error;
 	}
 

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -92,7 +92,11 @@ static int diff_print_info_init_frompatch(
 	git_diff_line_cb cb,
 	void *payload)
 {
-	git_repository *repo = patch && patch->diff ? patch->diff->repo : NULL;
+	git_repository *repo;
+
+	assert(patch);
+
+	repo = patch->diff ? patch->diff->repo : NULL;
 
 	memset(pi, 0, sizeof(diff_print_info));
 

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -261,18 +261,23 @@ static int normalize_find_opts(
 	if (!given ||
 		 (given->flags & GIT_DIFF_FIND_ALL) == GIT_DIFF_FIND_BY_CONFIG)
 	{
-		char *rule =
-			git_config__get_string_force(cfg, "diff.renames", "true");
-		int boolval;
+		if (diff->repo) {
+			char *rule =
+				git_config__get_string_force(cfg, "diff.renames", "true");
+			int boolval;
 
-		if (!git__parse_bool(&boolval, rule) && !boolval)
-			/* don't set FIND_RENAMES if bool value is false */;
-		else if (!strcasecmp(rule, "copies") || !strcasecmp(rule, "copy"))
-			opts->flags |= GIT_DIFF_FIND_RENAMES | GIT_DIFF_FIND_COPIES;
-		else
+			if (!git__parse_bool(&boolval, rule) && !boolval)
+				/* don't set FIND_RENAMES if bool value is false */;
+			else if (!strcasecmp(rule, "copies") || !strcasecmp(rule, "copy"))
+				opts->flags |= GIT_DIFF_FIND_RENAMES | GIT_DIFF_FIND_COPIES;
+			else
+				opts->flags |= GIT_DIFF_FIND_RENAMES;
+
+			git__free(rule);
+		} else {
+			/* set default flag */
 			opts->flags |= GIT_DIFF_FIND_RENAMES;
-
-		git__free(rule);
+		}
 	}
 
 	/* some flags imply others */

--- a/src/index.c
+++ b/src/index.c
@@ -2135,11 +2135,11 @@ static int read_reuc(git_index *index, const char *buffer, size_t size)
 
 		/* read 3 ASCII octal numbers for stage entries */
 		for (i = 0; i < 3; i++) {
-			int tmp;
+			int64_t tmp;
 
-			if (git__strtol32(&tmp, buffer, &endptr, 8) < 0 ||
+			if (git__strtol64(&tmp, buffer, &endptr, 8) < 0 ||
 				!endptr || endptr == buffer || *endptr ||
-				(unsigned)tmp > UINT_MAX) {
+				tmp < 0) {
 				index_entry_reuc_free(lost);
 				return index_error_invalid("reading reuc entry stage");
 			}

--- a/src/index.c
+++ b/src/index.c
@@ -2193,9 +2193,10 @@ static int read_conflict_names(git_index *index, const char *buffer, size_t size
 
 #define read_conflict_name(ptr) \
 	len = p_strnlen(buffer, size) + 1; \
-	if (size < len) \
-		return index_error_invalid("reading conflict name entries"); \
-	\
+	if (size < len) { \
+		index_error_invalid("reading conflict name entries"); \
+		goto out_err; \
+	} \
 	if (len == 1) \
 		ptr = NULL; \
 	else { \
@@ -2216,7 +2217,16 @@ static int read_conflict_names(git_index *index, const char *buffer, size_t size
 		read_conflict_name(conflict_name->theirs);
 
 		if (git_vector_insert(&index->names, conflict_name) < 0)
-			return -1;
+			goto out_err;
+
+		continue;
+
+out_err:
+		git__free(conflict_name->ancestor);
+		git__free(conflict_name->ours);
+		git__free(conflict_name->theirs);
+		git__free(conflict_name);
+		return -1;
 	}
 
 #undef read_conflict_name

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -383,6 +383,8 @@ static int verify_server_cert(SSL *ssl, const char *host)
 			GITERR_CHECK_ALLOC(peer_cn);
 			memcpy(peer_cn, ASN1_STRING_data(str), size);
 			peer_cn[size] = '\0';
+		} else {
+			goto cert_fail_name;
 		}
 	} else {
 		int size = ASN1_STRING_to_UTF8(&peer_cn, str);

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -850,9 +850,11 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 
 		git_packbuilder__cache_unlock(pb);
 
-		if (overflow ||
-			!(trg_object->delta_data = git__realloc(delta_buf, delta_size)))
+		if (overflow)
 			return -1;
+
+		trg_object->delta_data = git__realloc(delta_buf, delta_size);
+		GITERR_CHECK_ALLOC(trg_object->delta_data);
 	} else {
 		/* create delta when writing the pack */
 		git_packbuilder__cache_unlock(pb);

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -629,10 +629,8 @@ static int write_pack(git_packbuilder *pb,
 	int error = 0;
 
 	write_order = compute_write_order(pb);
-	if (write_order == NULL) {
-		error = -1;
-		goto done;
-	}
+	if (write_order == NULL)
+		return -1;
 
 	/* Write pack header */
 	ph.hdr_signature = htonl(PACK_SIGNATURE);

--- a/src/path.c
+++ b/src/path.c
@@ -705,8 +705,7 @@ int git_path_resolve_relative(git_buf *path, size_t ceiling)
 	char *base, *to, *from, *next;
 	size_t len;
 
-	if (!path || git_buf_oom(path))
-		return -1;
+	GITERR_CHECK_ALLOC_BUF(path);
 
 	if (ceiling > path->size)
 		ceiling = path->size;

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1512,8 +1512,7 @@ static int reflog_parse(git_reflog *log, const char *buf, size_t buf_size)
 #undef seek_forward
 
 fail:
-	if (entry)
-		git_reflog_entry__free(entry);
+	git_reflog_entry__free(entry);
 
 	return -1;
 }

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -323,8 +323,8 @@ int git_refspec__dwim_one(git_vector *out, git_refspec *spec, git_vector *refs)
 	if (git__prefixcmp(spec->src, GIT_REFS_DIR)) {
 		for (j = 0; formatters[j]; j++) {
 			git_buf_clear(&buf);
-			if (git_buf_printf(&buf, formatters[j], spec->src) < 0)
-				return -1;
+			git_buf_printf(&buf, formatters[j], spec->src);
+			GITERR_CHECK_ALLOC_BUF(&buf);
 
 			key.name = (char *) git_buf_cstr(&buf);
 			if (!git_vector_search(&pos, refs, &key)) {
@@ -348,8 +348,8 @@ int git_refspec__dwim_one(git_vector *out, git_refspec *spec, git_vector *refs)
 			git_buf_puts(&buf, GIT_REFS_HEADS_DIR);
 		}
 
-		if (git_buf_puts(&buf, spec->dst) < 0)
-			return -1;
+		git_buf_puts(&buf, spec->dst);
+		GITERR_CHECK_ALLOC_BUF(&buf);
 
 		cur->dst = git_buf_detach(&buf);
 	}

--- a/src/remote.c
+++ b/src/remote.c
@@ -208,8 +208,8 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 
 	remote->repo = repo;
 
-	if (git_vector_init(&remote->refs, 32, NULL) < 0 ||
-		canonicalize_url(&canonical_url, url) < 0)
+	if ((error = git_vector_init(&remote->refs, 32, NULL)) < 0 ||
+		(error = canonicalize_url(&canonical_url, url)) < 0)
 		goto on_error;
 
 	remote->url = apply_insteadof(repo->_config, canonical_url.ptr, GIT_DIRECTION_FETCH);

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -223,8 +223,7 @@ static int push_glob(git_revwalk *walk, const char *glob, int hide)
 		git_buf_joinpath(&buf, GIT_REFS_DIR, glob);
 	else
 		git_buf_puts(&buf, glob);
-	if (git_buf_oom(&buf))
-		return -1;
+	GITERR_CHECK_ALLOC_BUF(&buf);
 
 	/* If no '?', '*' or '[' exist, we append '/ *' to the glob */
 	wildcard = strcspn(glob, "?*[");

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -543,7 +543,9 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
 		"%04xwant %s %s\n", (unsigned int)len, oid, git_buf_cstr(&str));
 	git_buf_free(&str);
 
-	return git_buf_oom(buf);
+	GITERR_CHECK_ALLOC_BUF(buf);
+
+	return 0;
 }
 
 /*

--- a/src/xdiff/xmerge.c
+++ b/src/xdiff/xmerge.c
@@ -646,6 +646,8 @@ int xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
 	if (xdl_change_compact(&xe2.xdf1, &xe2.xdf2, xpp->flags) < 0 ||
 	    xdl_change_compact(&xe2.xdf2, &xe2.xdf1, xpp->flags) < 0 ||
 	    xdl_build_script(&xe2, &xscr2) < 0) {
+		xdl_free_script(xscr1);
+		xdl_free_env(&xe1);
 		xdl_free_env(&xe2);
 		return -1;
 	}


### PR DESCRIPTION
Another round of Coverity fixes. Mostly fixes for memory leaks on error paths and some smallish error value fixes. Otherwise some changes such that Coverity won't complain anymore on wrong positives, especially for `git_vector_foreach`.