### PR TITLE
git_libgit2_opts: minor documentation & usage fixes

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -245,6 +245,12 @@ typedef enum {
  *
  *	* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)
  *
+ *		> Set the value of the User-Agent header.  This value will be
+ *		> appended to "git/1.0", for compatibility with other git clients.
+ *		>
+ *		> - `user_agent` is the value that will be delivered as the
+ *		>   User-Agent header on HTTP requests.
+ *
  * @param option Option key
  * @param ... value to set the option
  * @return 0 on success, <0 on failure

--- a/src/settings.c
+++ b/src/settings.c
@@ -181,6 +181,9 @@ int git_libgit2_opts(int key, ...)
 		}
 
 		break;
+	default:
+		giterr_set(GITERR_INVALID, "invalid option key");
+		error = -1;
 	}
 
 	va_end(ap);

--- a/tests/core/opts.c
+++ b/tests/core/opts.c
@@ -17,3 +17,9 @@ void test_core_opts__readwrite(void)
 
 	cl_assert(new_val == old_val);
 }
+
+void test_core_opts__invalid_option(void)
+{
+	cl_git_fail(git_libgit2_opts(-1, "foobar"));
+}
+


### PR DESCRIPTION
For git_libgit2_opts: first, document the GIT_OPT_SET_USER_AGENT option. Second, provide some validation on invalid keys.