### PR TITLE
Extra checks for packfile indices

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -365,8 +365,13 @@ static unsigned char *pack_window_open(
 	 * pointless to ask for an offset into the middle of that
 	 * hash, and the pack_window_contains function above wouldn't match
 	 * don't allow an offset too close to the end of the file.
+	 *
+	 * Don't allow a negative offset, as that means we've wrapped
+	 * around.
 	 */
 	if (offset > (p->mwf.size - 20))
+		return NULL;
+	if (offset < 0)
 		return NULL;
 
 	return git_mwindow_open(&p->mwf, w_cursor, offset, 20, left);


### PR DESCRIPTION
There's a few things we can do to stop things like #3556 from happening. Here's one, also proposed for git, which checks that we're not getting sent past the end of the index for extended entries. We already check the size upon loading so the initial lookup is still safe.

We're still not checking the hashes to make sure the index corresponds to the packfile, or that the hash matches the data. We should be able to check the packfile's trailer match without too much effort. We might not want to check the hash every time as it could become a bit expensive (though it's a one-time cost (except when we miss and reload))