### PR TITLE
Minor `giterr` fixups

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -126,11 +126,6 @@ GIT_EXTERN(void) giterr_clear(void);
  * This error message is stored in thread-local storage and only applies
  * to the particular thread that this libgit2 call is made from.
  *
- * NOTE: Passing the `error_class` as GITERR_OS has a special behavior: we
- * attempt to append the system default error message for the last OS error
- * that occurred and then clear the last error.  The specific implementation
- * of looking up and clearing this last OS error will vary by platform.
- *
  * @param error_class One of the `git_error_t` enum above describing the
  *                    general subsystem that is responsible for the error.
  * @param string The formatted error message to keep

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -17,7 +17,7 @@ int git__page_size(size_t *page_size)
 {
 	long sc_page_size = sysconf(_SC_PAGE_SIZE);
 	if (sc_page_size < 0) {
-		giterr_set_str(GITERR_OS, "Can't determine system page size");
+		giterr_set(GITERR_OS, "can't determine system page size");
 		return -1;
 	}
 	*page_size = (size_t) sc_page_size;


### PR DESCRIPTION
Update the documentation to `giterr_set_str` to reflect that it does not actually honor the `GITERR_OS` argument to include the operating system's error message.  Update internal usages of `giterr_set_str` to more accurately use `giterr_set`.
