### PR TITLE
Don't include inttypes if compiling for Mac/iOS

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -24,7 +24,8 @@
  GIT_BEGIN_DECL
 # include "inttypes.h"
  GIT_END_DECL
-#else
+/** This check is needed for importing this file in an iOS/OS X framework throws an error in Xcode otherwise.*/
+#elif !defined(__CLANG_INTTYPES_H)
 # include <inttypes.h>
 #endif
 


### PR DESCRIPTION
In ObjectiveGit have recurring problems (see https://github.com/libgit2/objective-git/issues/436#issuecomment-70563677 and https://github.com/libgit2/objective-git/issues/542) with Xcode complaining with `Include of non-modular header inside framework module 'ObjectiveGit.git2.sys.filter'` this is due to the fact that `libgit2` is including `inttypes.h` in `common.h`. There is no need to import this header on iOS and Mac platforms and thus I excluded it.

This fixes our recurring compilation issues and still works. I am happy to discuss this change as it has some implications. I also find this way of solving the problem pretty naive but after days of trying is the only solution I could come up with.