### PR TITLE
Expand OpenSSL and libssh2 thread safety documentation

### DIFF
--- a/THREADING.md
+++ b/THREADING.md
@@ -72,13 +72,19 @@ which locking function it should use. This means that libgit2 cannot
 know what to set as the user of libgit2 may use OpenSSL independently
 and the locking settings must survive libgit2 shutting down.
 
+Even if libgit2 doesn't use OpenSSL directly, OpenSSL can still be used
+by libssh2 depending on the configuration.  If OpenSSL is used both by
+libgit2 and libssh2, you only need to set up threading for OpenSSL once.
+
 libgit2 does provide a last-resort convenience function
 `git_openssl_set_locking()` (available in `sys/openssl.h`) to use the
 platform-native mutex mechanisms to perform the locking, which you may
 rely on if you do not want to use OpenSSL outside of libgit2, or you
 know that libgit2 will outlive the rest of the operations. It is not
 safe to use OpenSSL multi-threaded after libgit2's shutdown function
-has been called.
+has been called.  Note `git_openssl_set_locking()` only works if
+libgit2 uses OpenSSL directly - if OpenSSL is only used as a dependency
+of libssh2 as described above, `git_openssl_set_locking()` is a no-op.
 
 If your programming language offers a package/bindings for OpenSSL,
 you should very strongly prefer to use that in order to set up
@@ -87,14 +93,14 @@ when using this function.
 
 See the
 [OpenSSL documentation](https://www.openssl.org/docs/crypto/threads.html)
-on threading for more details.
+on threading for more details, and http://trac.libssh2.org/wiki/MultiThreading
+for a specific example of providing the threading callbacks.
 
 Be also aware that libgit2 does not always link against OpenSSL
 if there are alternatives provided by the system.
 
-libssh2 may be linked against OpenSSL or libgcrypt. If it uses
-OpenSSL, you only need to set up threading for OpenSSL once and the
-above paragraphs are enough. If it uses libgcrypt, then you need to
+libssh2 may be linked against OpenSSL or libgcrypt. If it uses OpenSSL,
+see the above paragraphs. If it uses libgcrypt, then you need to
 set up its locking before using it multi-threaded. libgit2 has no
 direct connection to libgcrypt and thus has not convenience functions for
 it (but libgcrypt has macros). Read libgcrypt's


### PR DESCRIPTION
Adds a few useful bits of information that helped in resolving #3624.

For the `libssh2_init` argument, see https://github.com/libssh2/libssh2/blob/d441da3086dcc49989b7c5b9bf3043c4a6a98211/src/global.c#L74-L78 and https://www.libssh2.org/libssh2_init.html
