### PR TITLE
Respect negation rules where pattern length is greater than negated rule

### DIFF
--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -164,6 +164,19 @@ void test_attr_ignore__subdirectory_gitignore(void)
 	assert_is_ignored(false, "dir/file3");
 }
 
+void test_attr_ignore__negated_patterns(void)
+{
+	cl_git_rewritefile(
+		"attr/.gitignore",
+		"dir\n"
+		"!/foo/dir\n");
+
+	assert_is_ignored(true, "dir");
+	assert_is_ignored(true, "dir/file1");
+	assert_is_ignored(false, "foo/dir");
+	assert_is_ignored(false, "foo/dir/file1");
+}
+
 void test_attr_ignore__expand_tilde_to_homedir(void)
 {
 	git_config *cfg;


### PR DESCRIPTION
In git core, the following .gitignore rules
```
dir
!foo/dir
```
would leave a file `foo/dir/file1` unignored. But in libgit2  `foo/dir/file1` is still ignored.

As far as I can tell this is caused by the validation done before an ignore rule is added. If the negation rule is longer the rule it is checked against the rule is considered not to match so the rule is thrown out.

Not sure if this is the right spot to tweak but `does_negate_pattern` now returns true if the rule and negation pattern's tails match one another.