### PR TITLE
xdiff: fix memleak on error case

### DIFF
--- a/src/xdiff/xmerge.c
+++ b/src/xdiff/xmerge.c
@@ -633,8 +633,11 @@ int xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
 	result->ptr = NULL;
 	result->size = 0;
 
-	if (xdl_do_diff(orig, mf1, xpp, &xe1) < 0 ||
-			xdl_do_diff(orig, mf2, xpp, &xe2) < 0) {
+	if (xdl_do_diff(orig, mf1, xpp, &xe1) < 0) {
+		return -1;
+	}
+	if (xdl_do_diff(orig, mf2, xpp, &xe2) < 0) {
+		xdl_free_env(&xe1);
 		return -1;
 	}
 	if (xdl_change_compact(&xe1.xdf1, &xe1.xdf2, xpp->flags) < 0 ||


### PR DESCRIPTION
Commit 3d1abc5afce fixes a memory leak in the xdiff code. In the
process of upstreaming the fix it was pointed out by Johannes
Schindelin that there is another memory leak present (see [1]).

Fix the second memory leak by applying the upstream fix to our
code base.

[1]: http://thread.gmane.org/gmane.comp.version-control.git/287034