### PR TITLE
Coverity fixes round 6

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1032,6 +1032,11 @@ static int parse_section_header_ext(struct reader *reader, const char *line, con
 	 */
 
 	first_quote = strchr(line, '"');
+	if (first_quote == NULL) {
+		set_parse_error(reader, 0, "Missing quotation marks in section header");
+		return -1;
+	}
+
 	last_quote = strrchr(line, '"');
 	quoted_len = last_quote - first_quote;
 

--- a/src/describe.c
+++ b/src/describe.c
@@ -582,7 +582,8 @@ static int describe(
 	best = (struct possible_tag *)git_vector_get(&all_matches, 0);
 
 	if (gave_up_on) {
-		git_pqueue_insert(&list, gave_up_on);
+		if ((error = git_pqueue_insert(&list, gave_up_on)) < 0)
+			goto cleanup;
 		seen_commits--;
 	}
 	if ((error = finish_depth_computation(

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -261,7 +261,7 @@ static int normalize_find_opts(
 	if (!given ||
 		 (given->flags & GIT_DIFF_FIND_ALL) == GIT_DIFF_FIND_BY_CONFIG)
 	{
-		if (diff->repo) {
+		if (cfg) {
 			char *rule =
 				git_config__get_string_force(cfg, "diff.renames", "true");
 			int boolval;
@@ -318,8 +318,10 @@ static int normalize_find_opts(
 #undef USE_DEFAULT
 
 	if (!opts->rename_limit) {
-		opts->rename_limit = git_config__get_int_force(
-			cfg, "diff.renamelimit", DEFAULT_RENAME_LIMIT);
+		if (cfg) {
+			opts->rename_limit = git_config__get_int_force(
+				cfg, "diff.renamelimit", DEFAULT_RENAME_LIMIT);
+		}
 
 		if (opts->rename_limit <= 0)
 			opts->rename_limit = DEFAULT_RENAME_LIMIT;

--- a/src/index.c
+++ b/src/index.c
@@ -963,14 +963,20 @@ static int index_entry_reuc_init(git_index_reuc_entry **reuc_out,
 	*reuc_out = reuc = reuc_entry_alloc(path);
 	GITERR_CHECK_ALLOC(reuc);
 
-	if ((reuc->mode[0] = ancestor_mode) > 0)
+	if ((reuc->mode[0] = ancestor_mode) > 0) {
+		assert(ancestor_oid);
 		git_oid_cpy(&reuc->oid[0], ancestor_oid);
+	}
 
-	if ((reuc->mode[1] = our_mode) > 0)
+	if ((reuc->mode[1] = our_mode) > 0) {
+		assert(our_oid);
 		git_oid_cpy(&reuc->oid[1], our_oid);
+	}
 
-	if ((reuc->mode[2] = their_mode) > 0)
+	if ((reuc->mode[2] = their_mode) > 0) {
+		assert(their_oid);
 		git_oid_cpy(&reuc->oid[2], their_oid);
+	}
 
 	return 0;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -12,6 +12,7 @@
 #include "commit.h"
 #include "tree.h"
 #include "blob.h"
+#include "oid.h"
 #include "tag.h"
 
 bool git_object__strict_input_validation = true;
@@ -166,13 +167,9 @@ int git_object_lookup_prefix(
 			error = git_odb_read(&odb_obj, odb, id);
 		}
 	} else {
-		git_oid short_oid;
+		git_oid short_oid = {{ 0 }};
 
-		/* We copy the first len*4 bits from id and fill the remaining with 0s */
-		memcpy(short_oid.id, id->id, (len + 1) / 2);
-		if (len % 2)
-			short_oid.id[len / 2] &= 0xF0;
-		memset(short_oid.id + (len + 1) / 2, 0, (GIT_OID_HEXSZ - len) / 2);
+		git_oid__cpy_prefix(&short_oid, id, len);
 
 		/* If len < GIT_OID_HEXSZ (a strict short oid was given), we have
 		 * 2 options :

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -848,8 +848,10 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 
 		git_packbuilder__cache_unlock(pb);
 
-		if (overflow)
+		if (overflow) {
+			git__free(delta_buf);
 			return -1;
+		}
 
 		trg_object->delta_data = git__realloc(delta_buf, delta_size);
 		GITERR_CHECK_ALLOC(trg_object->delta_data);

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -80,7 +80,8 @@ static kh_inline int str_equal_no_trailing_slash(const char *a, const char *b)
 	if (blen > 0 && b[blen - 1] == '/')
 		blen--;
 
-	return (alen == blen && strncmp(a, b, alen) == 0);
+	return (alen == 0 && blen == 0) ||
+		(alen == blen && strncmp(a, b, alen) == 0);
 }
 
 __KHASH_IMPL(


### PR DESCRIPTION
Another week, another round of Coverity fixes. This brings Coverity down by another ten issues. By now fixes are not that obvious anymore and require a bit more knowledge about surrounding code, so the pace is going a bit slower by now.

On top of the bug fixing commits is another fix improving interoperation between Coverity and Travis. Curl does not report any errors when receiving error status codes and thus Travis happily pretends the submission of the tarball was successful when it indeed failed. The most common case of failing (at least for me) is the rate limit hitting.

I've improved this by instructing curl to output the HTTP code and then manually parsing the whole output to not lose any information. Unfortunately curl has no easier way of accomplishing this - we want both the returned body as it contains why the build actually failed and the status code. When using `curl --fail` we get the code but output is suppressed. When using `curl --write-out %{html_code}` we have to manually parse body and status code. Whatever, at least it works now, but I'd be glad if somebody pointed out a prettier solution than this.