### PR TITLE
test: make sure we retry the auth callback on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,6 +682,10 @@ IF (BUILD_CLAR)
 	ELSE ()
 		ADD_TEST(libgit2_clar libgit2_clar -v)
 	ENDIF ()
+
+	# Add a test target which runs the cred callback tests, to be
+	# called after setting the url and user
+	ADD_TEST(libgit2_clar-cred_callback libgit2_clar -v -sonline::clone::cred_callback)
 ENDIF ()
 
 IF (TAGS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,8 @@ build_script:
 - cmd: |
     if "%GENERATOR%"=="MSYS Makefiles" (C:\MinGW\msys\1.0\bin\sh --login /c/projects/libgit2/script/appveyor-mingw.sh)
 test_script:
-- ps: ctest -V .
+- ps: |
+    ctest -V .
+    $env:GITTEST_REMOTE_URL="https://github.com/libgit2/non-existent"
+    $env:GITTEST_REMOTE_USER="libgit2test"
+    .\Debug\libgit2_clar -sonline::clone::cred_callback

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
     if "%GENERATOR%"=="MSYS Makefiles" (C:\MinGW\msys\1.0\bin\sh --login /c/projects/libgit2/script/appveyor-mingw.sh)
 test_script:
 - ps: |
-    ctest -V .
+    ctest -V -R libgit2_clar
     $env:GITTEST_REMOTE_URL="https://github.com/libgit2/non-existent"
     $env:GITTEST_REMOTE_USER="libgit2test"
-    .\Debug\libgit2_clar -sonline::clone::cred_callback
+    ctest -V -R libgit2_clar-cred_callback

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -25,7 +25,7 @@ git daemon --listen=localhost --export-all --enable=receive-pack --base-path="$H
 export GITTEST_REMOTE_URL="git://localhost/test.git"
 
 # Run the test suite
-ctest -V . || exit $?
+ctest -V -R libgit2_clar || exit $?
 
 # Now that we've tested the raw git protocol, let's set up ssh to we
 # can do the push tests over it
@@ -59,4 +59,4 @@ fi
 
 export GITTEST_REMOTE_URL="https://github.com/libgit2/non-existent"
 export GITTEST_REMOTE_USER="libgit2test"
-./libgit2_clar -sonline::clone::cred_callback || exit $?
+ctest -V -R libgit2_clar-cred_callback

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -56,3 +56,7 @@ if [ -e ./libgit2_clar ]; then
         ./libgit2_clar -sonline::clone::cred_callback || exit $?
     fi
 fi
+
+export GITTEST_REMOTE_URL="https://github.com/libgit2/non-existent"
+export GITTEST_REMOTE_USER="libgit2test"
+./libgit2_clar -sonline::clone::cred_callback || exit $?

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -926,10 +926,11 @@ replay:
 			if (parse_unauthorized_response(s->request, &allowed_types, &t->auth_mechanism) < 0)
 				return -1;
 
-			if (allowed_types &&
-				(!t->cred || 0 == (t->cred->credtype & allowed_types))) {
+			if (allowed_types) {
 				int cred_error = 1;
 
+				git_cred_free(t->cred);
+				t->cred = NULL;
 				/* Start with the user-supplied credential callback, if present */
 				if (t->owner->cred_acquire_cb) {
 					cred_error = t->owner->cred_acquire_cb(&t->cred, t->owner->url,


### PR DESCRIPTION
We were missing this test on Windows, which meant we didn't notice that
we never fixed the single authentication attempt it tries, nor its wrong
return code.

Enable this for the unix platforms as well over HTTP. We previously were
doing it locally but disabled it on OS X due to issues with its sshd not
accepting password authentication.