### PR TITLE
ssh: initialize libssh2

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -12,6 +12,7 @@
 #include "openssl_stream.h"
 #include "thread-utils.h"
 #include "git2/global.h"
+#include "transports/ssh.h"
 
 #if defined(GIT_MSVC_CRTDBG)
 #include "win32/w32_stack.h"
@@ -56,7 +57,8 @@ static int init_common(void)
 	/* Initialize any other subsystems that have global state */
 	if ((ret = git_hash_global_init()) == 0 &&
 		(ret = git_sysdir_global_init()) == 0 &&
-		(ret = git_filter_global_init()) == 0)
+		(ret = git_filter_global_init()) == 0 &&
+		(ret = git_transport_ssh_global_init()) == 0)
 		ret = git_openssl_stream_global_init();
 
 	GIT_MEMORY_BARRIER;

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -15,6 +15,7 @@
 #include "smart.h"
 #include "cred.h"
 #include "socket_stream.h"
+#include "ssh.h"
 
 #ifdef GIT_SSH
 
@@ -874,5 +875,20 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 
 	giterr_set(GITERR_INVALID, "Cannot create SSH transport. Library was built without SSH support");
 	return -1;
+#endif
+}
+
+int git_transport_ssh_global_init(void)
+{
+#ifdef GIT_SSH
+
+	libssh2_init(0);
+	return 0;
+
+#else
+
+	/* Nothing to initialize */
+	return 0;
+
 #endif
 }

--- a/src/transports/ssh.h
+++ b/src/transports/ssh.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_ssh_h__
+#define INCLUDE_ssh_h__
+
+int git_transport_ssh_global_init(void);
+
+#endif


### PR DESCRIPTION
We should have been doing this, but it initializes itself upon first
use, which works as long as nobody's doing concurrent network
operations. Initialize it on our init to make sure it's not getting
initialized concurrently.