### PR TITLE
commit: split creating the commit and writing it out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ v0.24 + 1
 
 ### API additions
 
+* `git_commit_create_buffer()` creates a commit and writes it into a
+  user-provided buffer instead of writing it into the object db.
+
 ### API removals
 
 ### Breaking API changes

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -394,6 +394,52 @@ GIT_EXTERN(int) git_commit_amend(
 	const char *message,
 	const git_tree *tree);
 
+/**
+ * Create a commit and write it into a buffer
+ *
+ * Create a commit as with `git_commit_create()` but instead of
+ * writing it to the objectdb, write the contents of the object into a
+ * buffer.
+ *
+ * @param out the buffer into which to write the commit object content
+ *
+ * @param repo Repository where the referenced tree and parents live
+ *
+ * @param author Signature with author and author time of commit
+ *
+ * @param committer Signature with committer and * commit time of commit
+ *
+ * @param message_encoding The encoding for the message in the
+ *  commit, represented with a standard encoding name.
+ *  E.g. "UTF-8". If NULL, no encoding header is written and
+ *  UTF-8 is assumed.
+ *
+ * @param message Full message for this commit
+ *
+ * @param tree An instance of a `git_tree` object that will
+ *  be used as the tree for the commit. This tree object must
+ *  also be owned by the given `repo`.
+ *
+ * @param parent_count Number of parents for this commit
+ *
+ * @param parents Array of `parent_count` pointers to `git_commit`
+ *  objects that will be used as the parents for this commit. This
+ *  array may be NULL if `parent_count` is 0 (root commit). All the
+ *  given commits must be owned by the `repo`.
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_commit_create_buffer(
+	git_buf *out,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[]);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -98,6 +98,45 @@ void test_commit_write__from_memory(void)
    cl_assert_equal_s(commit_message, git_commit_message(commit));
 }
 
+void test_commit_write__into_buf(void)
+{
+	git_oid tree_id;
+	git_signature *author, *committer;
+	git_tree *tree;
+	git_commit *parent;
+	git_oid parent_id;
+	git_buf commit = GIT_BUF_INIT;
+
+	git_oid_fromstr(&tree_id, tree_id_str);
+	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
+
+	/* create signatures */
+	cl_git_pass(git_signature_new(&committer, committer_name, committer_email, 123456789, 60));
+	cl_git_pass(git_signature_new(&author, committer_name, committer_email, 987654321, 90));
+
+	git_oid_fromstr(&parent_id, parent_id_str);
+	cl_git_pass(git_commit_lookup(&parent, g_repo, &parent_id));
+
+	cl_git_pass(git_commit_create_buffer(&commit, g_repo, author, committer,
+					     NULL, root_commit_message, tree, 1, (const git_commit **) &parent));
+
+	cl_assert_equal_s(commit.ptr,
+			  "tree 1810dff58d8a660512d4832e740f692884338ccd\n\
+parent 8496071c1b46c854b31185ea97743be6a8774479\n\
+author Vicent Marti <vicent@github.com> 987654321 +0130\n\
+committer Vicent Marti <vicent@github.com> 123456789 +0100\n\
+\n\
+This is a root commit\n\
+   This is a root commit and should be the only one in this branch\n\
+");
+
+	git_buf_free(&commit);
+	git_tree_free(tree);
+	git_commit_free(parent);
+	git_signature_free(author);
+	git_signature_free(committer);
+}
+
 // create a root commit
 void test_commit_write__root(void)
 {


### PR DESCRIPTION
Sometimes you want to create a commit but not write it out to the
objectdb immediately. For these cases, provide a new function to
retrieve the buffer instead of having to go through the db.

---

This is new, so we should wait to merge until after the release.