### PR TITLE
treebuilder: don't try to verify submodules exist in the odb

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -757,7 +757,8 @@ int git_treebuilder_insert(
 	if (!valid_entry_name(bld->repo, filename))
 		return tree_error("Failed to insert entry. Invalid name for a tree entry", filename);
 
-	if (!git_object__is_valid(bld->repo, id, otype_from_mode(filemode)))
+	if (filemode != GIT_FILEMODE_COMMIT &&
+	    !git_object__is_valid(bld->repo, id, otype_from_mode(filemode)))
 		return tree_error("Failed to insert entry; invalid object specified", filename);
 
 	pos = git_strmap_lookup_index(bld->map, filename);

--- a/tests/object/tree/write.c
+++ b/tests/object/tree/write.c
@@ -490,13 +490,25 @@ static void test_invalid_objects(bool should_allow_invalid)
 	git_treebuilder_free(builder);
 }
 
+static void test_inserting_submodule(void)
+{
+	git_treebuilder *bld;
+	git_oid sm_id;
+
+	cl_git_pass(git_treebuilder_new(&bld, g_repo, NULL));
+	cl_git_pass(git_treebuilder_insert(NULL, bld, "sm", &sm_id, GIT_FILEMODE_COMMIT));
+	git_treebuilder_free(bld);
+}
+
 void test_object_tree_write__object_validity(void)
 {
 	/* Ensure that we cannot add invalid objects by default */
 	test_invalid_objects(false);
+	test_inserting_submodule();
 
 	/* Ensure that we can turn off validation */
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 0));
 	test_invalid_objects(true);
+	test_inserting_submodule();
 }
 


### PR DESCRIPTION
Submodules don't exist in the objectdb and the code is making us try to
look for a blob with its commit id, which is obviously not going to
work.

Skip the test if the user wants to insert a submodule.
