### PR TITLE
[WIP] config: show we write a spurious duplicated section header

### DIFF
--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -695,3 +695,27 @@ void test_config_write__locking(void)
 
 	git_config_free(cfg);
 }
+
+void test_config_write__repeated(void)
+{
+	const char *filename = "config-repeated";
+	git_config *cfg;
+	git_buf result;
+	const char *expected = "[sample \"prefix\"]\n\
+\tsetting1 = someValue1\n\
+\tsetting2 = someValue2\n\
+\tsetting3 = someValue3\n\
+\tsetting4 = someValue4\n\
+";
+	cl_git_pass(git_config_open_ondisk(&cfg, filename));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting1", "someValue1"));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting2", "someValue2"));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting3", "someValue3"));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting4", "someValue4"));
+
+	cl_git_pass(git_config_open_ondisk(&cfg, filename));
+
+	cl_git_pass(git_futils_readbuffer(&result, filename));
+	cl_assert_equal_s(expected, result.ptr);
+	git_buf_free(&result);
+}


### PR DESCRIPTION
We should notice that we are in the correct section to add. This is a
cosmetic bug, since replacing any of these settings does work.