### PR TITLE
Initialize `error` variable

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -748,7 +748,7 @@ int git_odb_expand_ids(
 	size_t count)
 {
 	size_t len, i;
-	int error;
+	int error = 0;
 
 	assert(db && ids);
 


### PR DESCRIPTION
If `count` is 0, this might lead to some random error value be returned from `git_odb_expand_ids`.

(From the most recent coverity report.)