### PR TITLE
Coverity fixes round 7

### DIFF
--- a/src/blame_git.c
+++ b/src/blame_git.c
@@ -525,7 +525,8 @@ static int pass_blame(git_blame *blame, git_blame__origin *origin, uint32_t opt)
 		if (sg_origin[i])
 			continue;
 
-		git_commit_parent(&p, origin->commit, i);
+		if ((error = git_commit_parent(&p, origin->commit, i)) < 0)
+			goto finish;
 		porigin = find_origin(blame, p, origin);
 
 		if (!porigin)

--- a/src/config_cache.c
+++ b/src/config_cache.c
@@ -86,7 +86,8 @@ int git_config__cvar(int *out, git_config *config, git_cvar_cached cvar)
 	struct map_data *data = &_cvar_maps[(int)cvar];
 	git_config_entry *entry;
 
-	git_config__lookup_entry(&entry, config, data->cvar_name, false);
+	if ((error = git_config__lookup_entry(&entry, config, data->cvar_name, false)) < 0)
+		return error;
 
 	if (!entry)
 		*out = data->default_value;

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -70,6 +70,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		git_file source;
 		char buffer[FILEIO_BUFSIZE];
 		ssize_t read_bytes;
+		int error;
 
 		source = p_open(file->path_original, O_RDONLY);
 		if (source < 0) {
@@ -80,7 +81,8 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		}
 
 		while ((read_bytes = p_read(source, buffer, sizeof(buffer))) > 0) {
-			p_write(file->fd, buffer, read_bytes);
+			if ((error = p_write(file->fd, buffer, read_bytes)) < 0)
+				break;
 			if (file->compute_digest)
 				git_hash_update(&file->digest, buffer, read_bytes);
 		}
@@ -89,6 +91,9 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 
 		if (read_bytes < 0) {
 			giterr_set(GITERR_OS, "Failed to read file '%s'", file->path_original);
+			return -1;
+		} else if (error < 0) {
+			giterr_set(GITERR_OS, "Failed to write file '%s'", file->path_lock);
 			return -1;
 		}
 	}

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -962,6 +962,7 @@ static int packed_write(refdb_fs_backend *backend)
 
 	for (i = 0; i < git_sortedcache_entrycount(refcache); ++i) {
 		struct packref *ref = git_sortedcache_entry(refcache, i);
+		assert(ref);
 
 		if (packed_find_peel(backend, ref) < 0)
 			goto fail;


### PR DESCRIPTION
Mostly fixes involving ignored return codes. Down to a defect density of 0.25 and 29 defects outstanding in my fork.

While we're at it: I've got a custom user model that fixes how Coverity models vectors (see [user_model.c](https://github.com/pks-t/libgit2/blob/f943300f1001e146445802df3ee3cbefd6bf352e/script/user_model.c)). It fixes some issues but requires us to manually upload the file into Coverity. Do we want this added?