### PR TITLE
Setup better defaults for OpenSSL ciphers

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -149,6 +149,7 @@ typedef enum {
 	GIT_OPT_SET_SSL_CERT_LOCATIONS,
 	GIT_OPT_SET_USER_AGENT,
 	GIT_OPT_ENABLE_STRICT_OBJECT_CREATION,
+	GIT_OPT_SET_SSL_CIPHERS,
 } git_libgit2_opt_t;
 
 /**
@@ -260,6 +261,11 @@ typedef enum {
  *		> example, when this is enabled, the parent(s) and tree inputs
  *		> will be validated when creating a new commit.  This defaults
  *		> to disabled.
+ *	* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)
+ *
+ *		> Set the SSL ciphers use for HTTPS connections.
+ *		>
+ *		> - `ciphers` is the list of ciphers that are eanbled.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/src/global.c
+++ b/src/global.c
@@ -27,6 +27,7 @@ static git_global_shutdown_fn git__shutdown_callbacks[MAX_SHUTDOWN_CB];
 static git_atomic git__n_shutdown_callbacks;
 static git_atomic git__n_inits;
 char *git__user_agent;
+char *git__ssl_ciphers;
 
 void git__on_shutdown(git_global_shutdown_fn callback)
 {
@@ -83,6 +84,7 @@ static void shutdown_common(void)
 	}
 
 	git__free(git__user_agent);
+	git__free(git__ssl_ciphers);
 
 #if defined(GIT_MSVC_CRTDBG)
 	git_win32__crtdbg_stacktrace_cleanup();

--- a/src/global.h
+++ b/src/global.h
@@ -36,5 +36,6 @@ extern void git__on_shutdown(git_global_shutdown_fn callback);
 extern void git__free_tls_data(void);
 
 extern const char *git_libgit2__user_agent(void);
+extern const char *git_libgit2__ssl_ciphers(void);
 
 #endif

--- a/src/settings.c
+++ b/src/settings.c
@@ -71,10 +71,16 @@ static int config_level_to_sysdir(int config_level)
 }
 
 extern char *git__user_agent;
+extern char *git__ssl_ciphers;
 
 const char *git_libgit2__user_agent()
 {
 	return git__user_agent;
+}
+
+const char *git_libgit2__ssl_ciphers()
+{
+	return git__ssl_ciphers;
 }
 
 int git_libgit2_opts(int key, ...)
@@ -185,6 +191,22 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_ENABLE_STRICT_OBJECT_CREATION:
 		git_object__strict_input_validation = (va_arg(ap, int) != 0);
+		break;
+
+	case GIT_OPT_SET_SSL_CIPHERS:
+#ifdef GIT_OPENSSL
+		{
+			git__free(git__ssl_ciphers);
+			git__ssl_ciphers = git__strdup(va_arg(ap, const char *));
+			if (!git__ssl_ciphers) {
+				giterr_set_oom();
+				error = -1;
+			}
+		}
+#else
+		giterr_set(GITERR_NET, "Cannot set custom ciphers: OpenSSL is not enabled");
+		error = -1;
+#endif
 		break;
 
 	default:

--- a/src/settings.c
+++ b/src/settings.c
@@ -175,7 +175,7 @@ int git_libgit2_opts(int key, ...)
 			}
 		}
 #else
-		giterr_set(GITERR_NET, "Cannot set certificate locations: OpenSSL is not enabled");
+		giterr_set(GITERR_NET, "cannot set certificate locations: OpenSSL is not enabled");
 		error = -1;
 #endif
 		break;
@@ -204,7 +204,7 @@ int git_libgit2_opts(int key, ...)
 			}
 		}
 #else
-		giterr_set(GITERR_NET, "Cannot set custom ciphers: OpenSSL is not enabled");
+		giterr_set(GITERR_NET, "cannot set custom ciphers: OpenSSL is not enabled");
 		error = -1;
 #endif
 		break;

--- a/tests/online/badssl.c
+++ b/tests/online/badssl.c
@@ -42,6 +42,5 @@ void test_online_badssl__old_cipher(void)
 	if (!g_has_ssl)
 		cl_skip();
 
-	cl_git_fail_with(GIT_ERROR,
-			 git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
+	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
 }

--- a/tests/online/badssl.c
+++ b/tests/online/badssl.c
@@ -36,3 +36,12 @@ void test_online_badssl__self_signed(void)
 	cl_git_fail_with(GIT_ECERTIFICATE,
 			 git_clone(&g_repo, "https://self-signed.badssl.com/fake.git", "./fake", NULL));
 }
+
+void test_online_badssl__old_cipher(void)
+{
+	if (!g_has_ssl)
+		cl_skip();
+
+	cl_git_fail_with(GIT_ERROR,
+			 git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
+}


### PR DESCRIPTION
This ensures that when using OpenSSL a safe default set of ciphers
is selected. This is done so that the client communicates securely
and we don't accidentally enable unsafe ciphers like RC4, or even
worse some old export ciphers.

Implements the first part of https://github.com/libgit2/libgit2/issues/3682

cc @carlosmn 