### PR TITLE
win32: choose the page size as our value for the page size

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -449,7 +449,7 @@ static void hash_partially(git_indexer *idx, const uint8_t *data, size_t size)
 static int write_at(git_indexer *idx, const void *data, git_off_t offset, size_t size)
 {
 	git_file fd = idx->pack->mwf.fd;
-	size_t page_size;
+	size_t mmap_alignment;
 	size_t page_offset;
 	git_off_t page_start;
 	unsigned char *map_data;
@@ -458,11 +458,11 @@ static int write_at(git_indexer *idx, const void *data, git_off_t offset, size_t
 
 	assert(data && size);
 
-	if ((error = git__page_size(&page_size)) < 0)
+	if ((error = git__mmap_alignment(&mmap_alignment)) < 0)
 		return error;
 
-	/* the offset needs to be at the beginning of the a page boundary */
-	page_offset = offset % page_size;
+	/* the offset needs to be at the mmap boundary for the platform */
+	page_offset = offset % mmap_alignment;
 	page_start = offset - page_offset;
 
 	if ((error = p_mmap(&map, page_offset + size, GIT_PROT_WRITE, GIT_MAP_SHARED, fd, page_start)) < 0)

--- a/src/posix.c
+++ b/src/posix.c
@@ -224,6 +224,13 @@ int git__page_size(size_t *page_size)
 	return 0;
 }
 
+int git__mmap_alignment(size_t *alignment)
+{
+	/* dummy; here we don't need any alignment anyway */
+	*alignment = 4096;
+	return 0;
+}
+
 
 int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
 {

--- a/src/posix.h
+++ b/src/posix.h
@@ -109,6 +109,7 @@ extern int p_getcwd(char *buffer_out, size_t size);
 extern int p_rename(const char *from, const char *to);
 
 extern int git__page_size(size_t *page_size);
+extern int git__mmap_alignment(size_t *page_size);
 
 /**
  * Platform-dependent methods

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -24,6 +24,11 @@ int git__page_size(size_t *page_size)
 	return 0;
 }
 
+int git__mmap_alignment(size_t *alignment)
+{
+  return git__page_size(alignment);
+}
+
 int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
 {
 	int mprot = PROT_READ;


### PR DESCRIPTION
We've been using the allocation granularity instead for this value,
but his refers to VirtualAlloc() rather than anything we do. Using this
as a value for the pool means every pool would become at least 64kB with
foreseeable results on memory pressure.

Do use the system's page size as our value for the page size.