### PR TITLE
commit: fix extraction of single-line signatures

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -726,7 +726,7 @@ int git_commit_extract_signature(git_buf *signature, git_buf *signed_data, git_r
 
 	buf = git_odb_object_data(obj);
 
-	while ((h = strchr(buf, '\n')) && h[1] != '\0' && h[1] != '\n') {
+	while ((h = strchr(buf, '\n')) && h[1] != '\0') {
 		h++;
 		if (git__prefixcmp(buf, field)) {
 			if (git_buf_put(signed_data, buf, h - buf) < 0)

--- a/tests/commit/parse.c
+++ b/tests/commit/parse.c
@@ -498,6 +498,21 @@ committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 \n\
 a simple commit which works\n";
 
+	const char *oneline_signature = "tree 51832e6397b30309c8bcad9c55fa6ae67778f378\n\
+parent a1b6decaaac768b5e01e1b5dbf5b2cc081bed1eb\n\
+author Some User <someuser@gmail.com> 1454537944 -0700\n\
+committer Some User <someuser@gmail.com> 1454537944 -0700\n\
+gpgsig bad\n\
+\n\
+corrupt signature\n";
+
+	const char *oneline_data = "tree 51832e6397b30309c8bcad9c55fa6ae67778f378\n\
+parent a1b6decaaac768b5e01e1b5dbf5b2cc081bed1eb\n\
+author Some User <someuser@gmail.com> 1454537944 -0700\n\
+committer Some User <someuser@gmail.com> 1454537944 -0700\n\
+\n\
+corrupt signature\n";
+
 
 	cl_git_pass(git_repository_odb__weakptr(&odb, g_repo));
 	cl_git_pass(git_odb_write(&commit_id, odb, passing_commit_cases[4], strlen(passing_commit_cases[4]), GIT_OBJ_COMMIT));
@@ -522,6 +537,15 @@ a simple commit which works\n";
 	cl_git_pass(git_odb_write(&commit_id, odb, passing_commit_cases[1], strlen(passing_commit_cases[1]), GIT_OBJ_COMMIT));
 	cl_git_fail_with(GIT_ENOTFOUND, git_commit_extract_signature(&signature, &signed_data, g_repo, &commit_id, NULL));
 	cl_assert_equal_i(GITERR_OBJECT, giterr_last()->klass);
+
+	/* Parse the commit with a single-line signature */
+	git_buf_clear(&signature);
+	git_buf_clear(&signed_data);
+	cl_git_pass(git_odb_write(&commit_id, odb, oneline_signature, strlen(oneline_signature), GIT_OBJ_COMMIT));
+	cl_git_pass(git_commit_extract_signature(&signature, &signed_data, g_repo, &commit_id, NULL));
+	cl_assert_equal_s("bad", signature.ptr);
+	cl_assert_equal_s(oneline_data, signed_data.ptr);
+
 
 	git_buf_free(&signature);
 	git_buf_free(&signed_data);


### PR DESCRIPTION
The function to extract signatures suffers from a similar bug to the
header field finding one by having an unecessary line feed check as a
break condition of its loop.

Fix that and add a test for this single-line signature situation.