### PR TITLE
[WIP] Temporarily disable tree entry pool on Windows

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -466,7 +466,11 @@ int git_tree__parse(void *_tree, git_odb_object *odb_obj)
 		filename_len = nul - buffer;
 		/** Allocate the entry and store it in the entries vector */
 		{
+#ifdef GIT_WIN32
+			entry = alloc_entry(buffer);
+#else
 			entry = alloc_entry_pooled(&tree->pool, buffer, filename_len);
+#endif
 			GITERR_CHECK_ALLOC(entry);
 
 			if (git_vector_insert(&tree->entries, entry) < 0)


### PR DESCRIPTION
Recent tests and benchmarks run by me and @carlosmn have shown that this can have a dramatic adverse effect on memory consumption and fragmentation in high concurrency scenarios. malloc on Windows already has built in support for managing multiple small allocations and the Low-fragmentation Heap is possibly helping here as well but being subverted by the pool.

Note that it's quite likely that we'll end up looking for ways to fix this that doesn't involve disabling it and I don't expect this PR to get merged. This is simply a stopgap measure to be used in GitHub desktop and I'm opening this PR to exploit the CI servers set up here :)

cc @carlosmn @ethomson 