### PR TITLE
config: don't special-case multivars that don't exist yet

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -561,30 +561,14 @@ static int config_set_multivar(
 	git_config_backend *cfg, const char *name, const char *regexp, const char *value)
 {
 	diskfile_backend *b = (diskfile_backend *)cfg;
-	refcounted_strmap *map;
-	git_strmap *values;
 	char *key;
 	regex_t preg;
 	int result;
-	khiter_t pos;
 
 	assert(regexp);
 
 	if ((result = git_config__normalize_name(name, &key)) < 0)
 		return result;
-
-	if ((map = refcounted_strmap_take(&b->header)) == NULL)
-		return -1;
-	values = b->header.values->values;
-
-	pos = git_strmap_lookup_index(values, key);
-	if (!git_strmap_valid_index(values, pos)) {
-		/* If we don't have it, behave like a normal set */
-		result = config_set(cfg, name, value);
-		refcounted_strmap_free(map);
-		git__free(key);
-		return result;
-	}
 
 	result = regcomp(&preg, regexp, REG_EXTENDED);
 	if (result != 0) {
@@ -600,7 +584,6 @@ static int config_set_multivar(
 	result = config_refresh(cfg);
 
 out:
-	refcounted_strmap_free(map);
 	git__free(key);
 	regfree(&preg);
 

--- a/tests/config/multivar.c
+++ b/tests/config/multivar.c
@@ -163,7 +163,7 @@ void test_config_multivar__add_new(void)
 
 	cl_git_pass(git_config_open_ondisk(&cfg, "config/config11"));
 
-	cl_git_pass(git_config_set_multivar(cfg, var, "", "variable"));
+	cl_git_pass(git_config_set_multivar(cfg, var, "$^", "variable"));
 	n = 0;
 	cl_git_pass(git_config_get_multivar_foreach(cfg, var, NULL, cb, &n));
 	cl_assert_equal_i(n, 1);


### PR DESCRIPTION
This special-casing ignores that we might have a locked file, so the
hashtable does not represent the contents of the file we want to
write. This causes multivar writes to overwrite entries instead of add
to them when under lock.

There is no need for this as the normal code-path will write to the file
just fine, so simply get rid of it.