### PR TITLE
win32: open read-only files with read sharing

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -104,10 +104,10 @@ int git_futils_open_ro(const char *path)
 	 */
 	h = CreateFileW(buf,
 		GENERIC_READ,
-		FILE_SHARE_READ | FILE_SHARE_DELETE,
+		FILE_SHARE_READ,
 		NULL,
 		OPEN_EXISTING,
-		FILE_FLAG_BACKUP_SEMANTICS,
+		FILE_ATTRIBUTE_NORMAL,
 		NULL);
 	
 	if (h == INVALID_HANDLE_VALUE) {


### PR DESCRIPTION
By default Windows does not let two processes read the same file
concurrently even if both want read-only access.

Make the fileops function through which reference and config reading go
call CreateFile directly so we can tell Windows it's ok for multiple
processes to read from these files.

---

The flags I took from the Win32 `p_mmap()` so I'd appreciate someone seeing if they make sense.