### PR TITLE
config: don't write duplicate section

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1500,7 +1500,7 @@ static int config_parse(
 	int (*on_section)(struct reader **reader, const char *current_section, const char *line, size_t line_len, void *data),
 	int (*on_variable)(struct reader **reader, const char *current_section, char *var_name, char *var_value, const char *line, size_t line_len, void *data),
 	int (*on_comment)(struct reader **reader, const char *line, size_t line_len, void *data),
-	int (*on_eof)(struct reader **reader, void *data),
+	int (*on_eof)(struct reader **reader, const char *current_section, void *data),
 	void *data)
 {
 	char *current_section = NULL, *var_name, *var_value, *line_start;
@@ -1551,7 +1551,7 @@ static int config_parse(
 	}
 
 	if (on_eof)
-		result = on_eof(&reader, data);
+		result = on_eof(&reader, current_section, data);
 
 	git__free(current_section);
 	return result;
@@ -1867,7 +1867,8 @@ static int write_on_comment(struct reader **reader, const char *line, size_t lin
 	return write_line_to(&write_data->buffered_comment, line, line_len);
 }
 
-static int write_on_eof(struct reader **reader, void *data)
+static int write_on_eof(
+	struct reader **reader, const char *current_section, void *data)
 {
 	struct write_data *write_data = (struct write_data *)data;
 	int result = 0;
@@ -1886,7 +1887,11 @@ static int write_on_eof(struct reader **reader, void *data)
 	 * value.
 	 */
 	if ((!write_data->preg || !write_data->preg_replaced) && write_data->value) {
-		if ((result = write_section(write_data->buf, write_data->section)) == 0)
+		/* write the section header unless we're already in it */
+		if (!current_section || strcmp(current_section, write_data->section))
+			result = write_section(write_data->buf, write_data->section);
+
+		if (!result)
 			result = write_value(write_data);
 	}
 

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -695,3 +695,27 @@ void test_config_write__locking(void)
 
 	git_config_free(cfg);
 }
+
+void test_config_write__repeated(void)
+{
+	const char *filename = "config-repeated";
+	git_config *cfg;
+	git_buf result;
+	const char *expected = "[sample \"prefix\"]\n\
+\tsetting1 = someValue1\n\
+\tsetting2 = someValue2\n\
+\tsetting3 = someValue3\n\
+\tsetting4 = someValue4\n\
+";
+	cl_git_pass(git_config_open_ondisk(&cfg, filename));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting1", "someValue1"));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting2", "someValue2"));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting3", "someValue3"));
+	cl_git_pass(git_config_set_string(cfg, "sample.prefix.setting4", "someValue4"));
+
+	cl_git_pass(git_config_open_ondisk(&cfg, filename));
+
+	cl_git_pass(git_futils_readbuffer(&result, filename));
+	cl_assert_equal_s(expected, result.ptr);
+	git_buf_free(&result);
+}

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -700,7 +700,7 @@ void test_config_write__repeated(void)
 {
 	const char *filename = "config-repeated";
 	git_config *cfg;
-	git_buf result;
+	git_buf result = GIT_BUF_INIT;
 	const char *expected = "[sample \"prefix\"]\n\
 \tsetting1 = someValue1\n\
 \tsetting2 = someValue2\n\


### PR DESCRIPTION
When we're trying to write some configuration value, we parse the existing configuration file.  When we find a section, we see if we were *previously* in the section that we wanted to write to.  If we were, then we write our value (which allows us to append it to the end of the section we were looking for.)

However, we were *not* doing this for EOF.  We assumed that if we hit the EOF that we must not have found the section that we were looking for, and write the new section and the value.  This is quite silly; we could have been in the section we were looking for and still hit the EOF.  In that case, we should just write the value.