### PR TITLE
Add a no-op size_t typedef for the doc parser

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -29,6 +29,14 @@
 # include <inttypes.h>
 #endif
 
+#ifdef DOCURIUM
+/*
+ * This is so clang's doc parser acknowledges comments on functions
+ * with size_t parameters.
+ */
+typedef size_t size_t;
+#endif
+
 /** Declare a public function exported for application use. */
 #if __GNUC__ >= 4
 # define GIT_EXTERN(type) extern \


### PR DESCRIPTION
Clang's documentation parser, which we use in our documentation system
does not report any comments for functions which use size_t as a type.

The root cause is buried somewhere in libclang but we can work around it
by defining the type ourselves. This typedef makes sure that libclang
sees it and that we do not change its size.

---

I'm not particularly happy with this, but I've already burnt a lot of time tracking down the root cause and a work-around would still be needed for released versions anyhow.