### PR TITLE
xdiff/xprepare: fixup memory leak fix

### DIFF
--- a/src/xdiff/xprepare.c
+++ b/src/xdiff/xprepare.c
@@ -305,7 +305,7 @@ int xdl_prepare_env(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 		return -1;
 	}
 
-	if (XDF_DIFF_ALG((xpp->flags) & XDF_HISTOGRAM_DIFF))
+	if (XDF_DIFF_ALG(xpp->flags) != XDF_HISTOGRAM_DIFF)
 		xdl_free_classifier(&cf);
 
 	return 0;


### PR DESCRIPTION
Commit 1bce148 tried to cherry-pick a fix from upstream git.git
to the xprepare code. The patch was not applied correctly,
though.

Fix up by correctly applying the upstream fix.