### PR TITLE
merge_driver: fix missing `goto done;`

### DIFF
--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -178,6 +178,7 @@ int git_merge_driver_global_init(void)
 			merge_driver_name__union, &git_merge_driver__union.base)) < 0 ||
 		(error = merge_driver_registry_insert(
 			merge_driver_name__binary, &git_merge_driver__binary)) < 0)
+		goto done;
 
 	git__on_shutdown(git_merge_driver_global_shutdown);
 


### PR DESCRIPTION
The code initializing the merge driver registry accidentally
forgot a `goto done` in case of an error. Because of this the
next line, which registers the global shutdown callback for the
merge drivers, is only called when an error occured.

Fix this by adding the missing `goto done`. This fixes some
memory leaks when the global state is shut down.