### PR TITLE
Fix .gitignore pattern matching with globs and path delimiters

### DIFF
--- a/src/fnmatch.c
+++ b/src/fnmatch.c
@@ -88,6 +88,7 @@ p_fnmatchx(const char *pattern, const char *string, int flags, size_t recurs)
 						break;
 				case '*':
 						c = *pattern;
+						bool pattern_path_delimiter_start = false;
 
 						/* Let '**' override PATHNAME match for this segment.
 						 * It will be restored if/when we recurse below.
@@ -96,8 +97,10 @@ p_fnmatchx(const char *pattern, const char *string, int flags, size_t recurs)
 							flags &= ~FNM_PATHNAME;
 							while (c == '*')
 								c = *++pattern;
-							if (c == '/')
+							if (c == '/') {
 								c = *++pattern;
+								pattern_path_delimiter_start = true;
+							}
 						}
 
 						if (*string == '.' && (flags & FNM_PERIOD) &&
@@ -119,15 +122,18 @@ p_fnmatchx(const char *pattern, const char *string, int flags, size_t recurs)
 								break;
 						}
 
+						bool string_path_delimiter_start = true;
 						/* General case, use recursion. */
 						while ((test = *string) != EOS) {
 								int e;
 
 								e = p_fnmatchx(pattern, string, recurs_flags, recurs);
-								if (e != FNM_NOMATCH)
-										return e;
-								if (test == '/' && (flags & FNM_PATHNAME))
-										break;
+								if (e != FNM_NOMATCH && !(pattern_path_delimiter_start && !string_path_delimiter_start)) {
+									return e;
+								}
+								string_path_delimiter_start = test == '/';
+								if (string_path_delimiter_start && (flags & FNM_PATHNAME))
+									break;
 								++string;
 						}
 						return (FNM_NOMATCH);

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -134,18 +134,6 @@ void test_attr_ignore__leading_stars(void)
 
 void test_attr_ignore__globs_and_path_delimiters(void)
 {
-	git_futils_mkdir_r("attr/test_folder/", 0777);
-	git_futils_mkdir_r("attr/_test/a/b/c", 0777);
-	git_futils_mkdir_r("attr/_test/foo/bar/qux", 0777);
-	git_futils_mkdir_r("attr/_test/foo/bar/crux", 0777);
-	git_futils_mkdir_r("attr/_test/foo/bar/code", 0777);
-	cl_git_mkfile("attr/test_folder/file", "");
-	cl_git_mkfile("attr/_test/file", "");
-	cl_git_mkfile("attr/_test/a/file", "");
-	cl_git_mkfile("attr/_test/foo/bar/qux/file", "");
-	cl_git_mkfile("attr/_test/foo/bar/crux/file", "");
-	cl_git_mkfile("attr/_test/foo/bar/code/file", "");
-
 	cl_git_rewritefile("attr/.gitignore", "**/_*/");
 	assert_is_ignored(false, "test_folder/file");
 	assert_is_ignored(true, "_test/file");

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -140,7 +140,6 @@ void test_attr_ignore__globs_and_path_delimiters(void)
 	assert_is_ignored(true, "_test/a/file");
 
 	cl_git_rewritefile("attr/.gitignore", "**/_*/foo/bar/*ux");
-
 	assert_is_ignored(true, "_test/foo/bar/qux/file");
 	assert_is_ignored(true, "_test/foo/bar/crux/file");
 	assert_is_ignored(false, "_test/foo/bar/code/file");

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -132,6 +132,32 @@ void test_attr_ignore__leading_stars(void)
 	assert_is_ignored(false, "dir1/kid2/file");
 }
 
+void test_attr_ignore__globs_and_path_delimiters(void)
+{
+	git_futils_mkdir_r("attr/test_folder/", 0777);
+	git_futils_mkdir_r("attr/_test/a/b/c", 0777);
+	git_futils_mkdir_r("attr/_test/foo/bar/qux", 0777);
+	git_futils_mkdir_r("attr/_test/foo/bar/crux", 0777);
+	git_futils_mkdir_r("attr/_test/foo/bar/code", 0777);
+	cl_git_mkfile("attr/test_folder/file", "");
+	cl_git_mkfile("attr/_test/file", "");
+	cl_git_mkfile("attr/_test/a/file", "");
+	cl_git_mkfile("attr/_test/foo/bar/qux/file", "");
+	cl_git_mkfile("attr/_test/foo/bar/crux/file", "");
+	cl_git_mkfile("attr/_test/foo/bar/code/file", "");
+
+	cl_git_rewritefile("attr/.gitignore", "**/_*/");
+	assert_is_ignored(false, "test_folder/file");
+	assert_is_ignored(true, "_test/file");
+	assert_is_ignored(true, "_test/a/file");
+
+	cl_git_rewritefile("attr/.gitignore", "**/_*/foo/bar/*ux");
+
+	assert_is_ignored(true, "_test/foo/bar/qux/file");
+	assert_is_ignored(true, "_test/foo/bar/crux/file");
+	assert_is_ignored(false, "_test/foo/bar/code/file");
+}
+
 void test_attr_ignore__skip_gitignore_directory(void)
 {
 	cl_git_rewritefile("attr/.git/info/exclude", "/NewFolder\n/NewFolder/NewFolder");

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -138,6 +138,8 @@ void test_attr_ignore__globs_and_path_delimiters(void)
 	assert_is_ignored(false, "test_folder/file");
 	assert_is_ignored(true, "_test/file");
 	assert_is_ignored(true, "_test/a/file");
+	assert_is_ignored(true, "foo/bar/qux/_baz/");
+	assert_is_ignored(false, "foo/bar/qux/code_baz");
 
 	cl_git_rewritefile("attr/.gitignore", "**/_*/foo/bar/*ux");
 	assert_is_ignored(true, "_test/foo/bar/qux/file");


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/10689

We are observing a weird behavior in Atom where some folders are being ignored even when `git status` doesn't. It seems like the problem is related to how libgit2 handles `.gitignore` pattern matching, so this PR is an attempt to fix it.

Previously, when encountering a glob pattern, we would skip any character until some of them start to match, in which case we return `0` (i.e. "matched") in `p_fnmatchx`. This seems inconsistent with how `git` handles the same scenario: for example, patterns like `**/_*/` gets interpreted as: "find any folder that starts with `_`"; conversely, libgit2 interprets them as: "find any folder that contains `_`".

This PR changes the way we perform the matching, so that when encountering a glob followed by a path delimiter, we enforce that the string to perform pattern matching against also starts with a path delimiter.

Specs pass locally, but this is my first contribution to libgit2, so I am not totally sure about the consequences of this change. Hopefully, however, this will be a good starting point for discussion and a first step towards the resolution. :sparkles: 

What do you think? Thanks! :bow: