### PR TITLE
Warnings API redux

### DIFF
--- a/include/git2.h
+++ b/include/git2.h
@@ -61,5 +61,6 @@
 #include "git2/tree.h"
 #include "git2/types.h"
 #include "git2/version.h"
+#include "git2/warning.h"
 
 #endif

--- a/include/git2/warning.h
+++ b/include/git2/warning.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_warning_h__
+#define INCLUDE_git_warning_h__
+
+#include "common.h"
+#include "types.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * The kind of warning that was generated.
+ */
+typedef enum {
+	/**
+	 * Sentinel value. Should never be used.
+	 */
+	GIT_GENERIC_NONE = 0,
+
+	/**
+	 * Generic warning. There is no extended information
+	 * available.
+	 */
+	GIT_WARNING_GENERIC,
+} git_warning_t;
+
+/**
+ * Base struct for warnings.
+
+ * These fields are always available for warnings.
+ */
+typedef struct {
+	/**
+	 * The kind of warning.
+	 */
+	git_warning_t type;
+
+	/**
+	 * The text for this warning
+	 */
+	const char *str;
+} git_warning;
+
+/**
+ * User-specified callback for warnings
+ *
+ * The warning object is owned by the library and may be deallocated
+ * on function return. Make a copy if you want to store the data for
+ * later processing. Do not attempt to free it.
+ *
+ * Note that this may be called concurrently from multiple threads.
+ *
+ * @param warning the current warning
+ * @param payload user-provided payload when registering
+ * @return 0 to continue, a negative number to stop processing
+ */
+typedef int (*git_warning_cb)(git_warning *warning, void *payload);
+
+/**
+ * Set the warning callback
+ *
+ * This sets the global warning callback which be called in places
+ * where issues were found which might be of interest to a user but
+ * would not cause an error to be returned.
+ *
+ * This function does not perform locking. Do not call it
+ * concurrently.
+ *
+ * @param callback the function to call; pass `NULL` to unregister
+ * @param payload user-specified data to be passed to the callback
+ */
+GIT_EXTERN(int) git_warning_set_callback(git_warning_cb callback, void *payload);
+
+GIT_END_DECL
+
+#endif

--- a/include/git2/warning.h
+++ b/include/git2/warning.h
@@ -26,6 +26,11 @@ typedef enum {
 	 * available.
 	 */
 	GIT_WARNING_GENERIC,
+
+	/**
+	 * Warning related to line ending conversion.
+	 */
+	GIT_WARNING_CRLF,
 } git_warning_t;
 
 /**
@@ -44,6 +49,14 @@ typedef struct {
 	 */
 	const char *str;
 } git_warning;
+
+typedef struct {
+	/** The base struct */
+	git_warning parent;
+
+	/** The file this warning refers to */
+	const char *path;
+} git_warning_crlf;
 
 /**
  * User-specified callback for warnings

--- a/src/warning.c
+++ b/src/warning.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "warning.h"
+
+static void *warning_payload;
+static git_warning_cb warning_callback;
+
+int git_warning_set_callback(git_warning_cb callback, void *payload)
+{
+	warning_callback = callback;
+	warning_payload = callback ? payload : NULL;
+
+	return 0;
+}
+
+int git_warning__raise(git_warning *warning)
+{
+	if (!warning_callback)
+		return 0;
+
+	return warning_callback(warning, warning_payload);
+}

--- a/src/warning.h
+++ b/src/warning.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_warning_h__
+#define INCLUDE_warning_h__
+
+#include "common.h"
+#include "git2/warning.h"
+
+/**
+ * Raise a warning.
+ *
+ * It returns the return value from the user-specified callback. If no
+ * callback is set, it returns 0.
+ */
+extern int git_warning__raise(git_warning *warning);
+
+#endif

--- a/tests/core/warning.c
+++ b/tests/core/warning.c
@@ -1,0 +1,49 @@
+#include "clar_libgit2.h"
+#include "warning.h"
+
+static git_warning g_warning = { GIT_WARNING_GENERIC, "Not really an error" };
+static int g_dummy_payload;
+
+void test_core_warning__cleanup(void)
+{
+	git_warning_set_callback(NULL, NULL);
+}
+
+void test_core_warning__zero_on_unset(void)
+{
+	cl_git_pass(git_warning__raise(&g_warning));
+}
+
+static int values_callback(git_warning *warning, void *payload)
+{
+	cl_assert_equal_p(&g_warning, warning);
+	cl_assert_equal_p(&g_dummy_payload, payload);
+
+	return 0;
+}
+
+void test_core_warning__raises_values(void)
+{
+	cl_git_pass(git_warning_set_callback(values_callback, &g_dummy_payload));
+	cl_git_pass(git_warning__raise(&g_warning));
+}
+
+static int should_be_called;
+static int can_unset_callback(git_warning *warning, void *payload)
+{
+	GIT_UNUSED(warning); GIT_UNUSED(payload);
+
+	cl_assert(should_be_called);
+
+	return 0;
+}
+
+void test_core_warning__can_unset(void)
+{
+	should_be_called = 1;
+	cl_git_pass(git_warning_set_callback(can_unset_callback, &g_dummy_payload));
+	cl_git_pass(git_warning__raise(&g_warning));
+	should_be_called = 0;
+	cl_git_pass(git_warning_set_callback(NULL, NULL));
+	cl_git_pass(git_warning__raise(&g_warning));
+}


### PR DESCRIPTION
This is another attempt at #2101 which incorporates the subclassing described in the comments. An application may choose to print to stdout/stderr or it may look into the subclass to show the warnings in a GUI or to provide its own format.

The commit signature parsing code has changed quite a bit since the original PR, so I've used CRLF as an example of how we'd use it.