### PR TITLE
iterator/diff: allow trailing `/` on start/end paths to match submodules

### DIFF
--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -1197,8 +1197,11 @@ void test_iterator_workdir__bounded_submodules(void)
 		git_iterator_free(i);
 	}
 
-	/* Test that a submodule never matches when suffixed with a '/' */
+	/* Test that a submodule still matches when suffixed with a '/' */
 	{
+		const char *expected[] = { "sm_changed_head" };
+		size_t expected_len = 1;
+
 		git_vector_clear(&filelist);
 		cl_git_pass(git_vector_insert(&filelist, "sm_changed_head/"));
 
@@ -1207,7 +1210,7 @@ void test_iterator_workdir__bounded_submodules(void)
 		i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
 
 		cl_git_pass(git_iterator_for_workdir(&i, g_repo, index, head, &i_opts));
-		cl_git_fail_with(GIT_ITEROVER, git_iterator_advance(NULL, i));
+		expect_iterator_items(i, expected_len, expected, expected_len, expected);
 		git_iterator_free(i);
 	}
 
@@ -1227,16 +1230,19 @@ void test_iterator_workdir__bounded_submodules(void)
 		git_iterator_free(i);
 	}
 
-	/* Test that start and end do not allow '/' suffixes of submodules */
+	/* Test that start and end allow '/' suffixes of submodules */
 	{
-		i_opts.start = "sm_changed_head/";
-		i_opts.end = "sm_changed_head/";
+		const char *expected[] = { "sm_changed_head", "sm_changed_index" };
+		size_t expected_len = 2;
+
+		i_opts.start = "sm_changed_head";
+		i_opts.end = "sm_changed_index";
 		i_opts.pathlist.strings = NULL;
 		i_opts.pathlist.count = 0;
 		i_opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
 
 		cl_git_pass(git_iterator_for_workdir(&i, g_repo, index, head, &i_opts));
-		cl_git_fail_with(GIT_ITEROVER, git_iterator_advance(NULL, i));
+		expect_iterator_items(i, expected_len, expected, expected_len, expected);
 		git_iterator_free(i);
 	}
 


### PR DESCRIPTION
In the great iterator refactor of 2016, we made clear that submodules should not have trailing slashes for the `start` and `end` paths.  This regressed some expected behavior.

Unfortunately, this does not quite jive with diff's pathspec matching, which will happily accept `foo/` if `foo` is a submodule.  This is problematic because diff will set the iterator's `start` and `end` paths to the longest common substring of the pathspecs.  (Which may be nothing, but it may be something, and if it is that would speed up the diff.)

Therefore, if you are asking about a bunch of paths, and you've foolishly added a trailing slash to a submodule, the behavior is different than if you ask about just that one path:

If you diff with `pathspecs = { "a", "b", "submod/", "z" }`, then there is no common substring and so the diff cannot provide a start and end prefix to the iterator.  Thus, diff looks at all the paths coming back from the iterator and so *its* logic about whether `submod/` should match a submodule named `submod` is used.  (And that *does* match, according to diff.)

However, if you diff the same entries with `pathspecs = { "submod/" }` then now diff notices that it can use a start and end prefix - and it does, of `submod/`.  So now, the iterators _must_ treat this the same way that diff did for consistency.  So `submod/` must match a submodule named `submod` in iterator, so that diff can do *its* thing.

This change is really quite minor, but it's a bit annoying, since I was very careful to treat submodules _differently_ than directories and thought I was actually righting the behavior here.  :)