### PR TITLE
tests: fix core/stream test when built with openssl off

### DIFF
--- a/tests/core/stream.c
+++ b/tests/core/stream.c
@@ -33,8 +33,12 @@ void test_core_stream__register_tls(void)
 	cl_git_pass(git_stream_register_tls(NULL));
 	error = git_tls_stream_new(&stream, "localhost", "443");
 
-	/* We don't have arbitrary TLS stream support on Windows */
-#if GIT_WIN32
+	/* We don't have arbitrary TLS stream support on Windows
+	 * or when openssl support is disabled (except on OSX
+	 * with Security framework).
+	 */
+#if defined(GIT_WIN32) || \
+	(!defined(GIT_SECURE_TRANSPORT) && !defined(GIT_OPENSSL))
 	cl_git_fail_with(-1, error);
 #else
 	cl_git_pass(error);


### PR DESCRIPTION
When passing -DUSE_OPENSSL:BOOL=OFF to cmake the testsuite will
fail with the following error:

core::stream::register_tls [/tmp/libgit2/tests/core/stream.c:40]
  Function call failed: (error)
  error -1 - <no message>

Fix test to assume failure for tls when built without openssl.
While at it also fix GIT_WIN32 cpp to check if it's defined
or not.