### PR TITLE
Fix reset tests with strict object creation

### DIFF
--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -13,13 +13,14 @@ static git_repository *g_repo;
 void test_refs_create__initialize(void)
 {
    g_repo = cl_git_sandbox_init("testrepo");
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 0));
 }
 
 void test_refs_create__cleanup(void)
 {
    cl_git_sandbox_cleanup();
 
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
 }
 
 void test_refs_create__symbolic(void)

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -122,9 +122,9 @@ static void unmerged_index_init(git_index *index, int entries)
 	int write_theirs = 4;
 	git_oid ancestor, ours, theirs;
 
-	git_oid_fromstr(&ancestor, "6bb0d9f700543ba3d318ba7075fc3bd696b4287b");
-	git_oid_fromstr(&ours, "b19a1e93bec1317dc6097229e12afaffbfa74dc2");
-	git_oid_fromstr(&theirs, "950b81b7eee953d050aa05a641f8e056c85dd1bd");
+	git_oid_fromstr(&ancestor, "452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
+	git_oid_fromstr(&ours, "32504b727382542f9f089e24fddac5e78533e96c");
+	git_oid_fromstr(&theirs, "061d42a44cacde5726057b67558821d95db96f19");
 
 	cl_git_rewritefile("status/conflicting_file", "conflicting file\n");
 


### PR DESCRIPTION
We were leaving strict object creation off after refs tests, so we didn't notice the reset tests used fake ids.

Fixes #3726 