### PR TITLE
refs: provide a more general error message for dwim

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -289,6 +289,9 @@ cleanup:
 			"Could not use '%s' as valid reference name", git_buf_cstr(&name));
 	}
 
+	if (error == GIT_ENOTFOUND)
+		giterr_set(GITERR_REFERENCE, "no reference found for shorthand '%s'", refname);
+
 	git_buf_free(&name);
 	git_buf_free(&refnamebuf);
 	return error;

--- a/tests/refs/lookup.c
+++ b/tests/refs/lookup.c
@@ -58,3 +58,11 @@ void test_refs_lookup__namespace(void)
 	error = git_reference_lookup(&ref, g_repo, "refs/heads/");
 	cl_assert_equal_i(error, GIT_EINVALIDSPEC);
 }
+
+void test_refs_lookup__dwim_notfound(void)
+{
+	git_reference *ref;
+
+	cl_git_fail_with(GIT_ENOTFOUND, git_reference_dwim(&ref, g_repo, "idontexist"));
+	cl_assert_equal_s("no reference found for shorthand 'idontexist'", giterr_last()->message);
+}


### PR DESCRIPTION
If we cannot dwim the input, set the error message to be explicit about
that. Otherwise we leave the error for the last failed lookup, which
can be rather unexpected as it mentions a remote when the user thought
they were trying to look up a branch.