### PR TITLE
Strict object creation in `refs::create`

### DIFF
--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -19,7 +19,7 @@ void test_refs_create__cleanup(void)
 {
    cl_git_sandbox_cleanup();
 
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
 }
 
 void test_refs_create__symbolic(void)
@@ -122,7 +122,7 @@ void test_refs_create__oid(void)
 }
 
 /* Can by default create a reference that targets at an unknown id */
-void test_refs_create__oid_unknown_succeeds_by_default(void)
+void test_refs_create__oid_unknown_succeeds_without_strict(void)
 {
 	git_reference *new_reference, *looked_up_ref;
 	git_oid id;
@@ -130,6 +130,8 @@ void test_refs_create__oid_unknown_succeeds_by_default(void)
 	const char *new_head = "refs/heads/new-head";
 
 	git_oid_fromstr(&id, "deadbeef3f795b2b4353bcce3a527ad0a4f7f644");
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 0));
 
 	/* Create and write the new object id reference */
 	cl_git_pass(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL));
@@ -141,7 +143,7 @@ void test_refs_create__oid_unknown_succeeds_by_default(void)
 }
 
 /* Strict object enforcement enforces valid object id */
-void test_refs_create__oid_unknown_fails_strict_mode(void)
+void test_refs_create__oid_unknown_fails_by_default(void)
 {
 	git_reference *new_reference, *looked_up_ref;
 	git_oid id;
@@ -149,8 +151,6 @@ void test_refs_create__oid_unknown_fails_strict_mode(void)
 	const char *new_head = "refs/heads/new-head";
 
 	git_oid_fromstr(&id, "deadbeef3f795b2b4353bcce3a527ad0a4f7f644");
-
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
 
 	/* Create and write the new object id reference */
 	cl_git_fail(git_reference_create(&new_reference, g_repo, new_head, &id, 0, NULL));

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -122,9 +122,9 @@ static void unmerged_index_init(git_index *index, int entries)
 	int write_theirs = 4;
 	git_oid ancestor, ours, theirs;
 
-	git_oid_fromstr(&ancestor, "6bb0d9f700543ba3d318ba7075fc3bd696b4287b");
-	git_oid_fromstr(&ours, "b19a1e93bec1317dc6097229e12afaffbfa74dc2");
-	git_oid_fromstr(&theirs, "950b81b7eee953d050aa05a641f8e056c85dd1bd");
+	git_oid_fromstr(&ancestor, "452e4244b5d083ddf0460acf1ecc74db9dcfa11a");
+	git_oid_fromstr(&ours, "32504b727382542f9f089e24fddac5e78533e96c");
+	git_oid_fromstr(&theirs, "061d42a44cacde5726057b67558821d95db96f19");
 
 	cl_git_rewritefile("status/conflicting_file", "conflicting file\n");
 


### PR DESCRIPTION
When we turned strict object creation validation on by default, we forgot to inform the `refs::create` tests of this.  They, in fact, believed that strict object creation was off by default.  As a result, their cleanup function went and turned strict object creation off for the remaining tests.

Also cherry-picks the `reset` fix from #3735.