### PR TITLE
tests: skip the unreadable file tests as root

### DIFF
--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -673,6 +673,11 @@ void test_iterator_workdir__skips_unreadable_dirs(void)
 	if (!cl_is_chmod_supported())
 		return;
 
+#ifndef GIT_WIN32
+	if (geteuid() == 0)
+		cl_skip();
+#endif
+
 	g_repo = cl_git_sandbox_init("empty_standard_repo");
 
 	cl_must_pass(p_mkdir("empty_standard_repo/r", 0777));

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -1048,6 +1048,9 @@ void test_status_worktree__unreadable(void)
 	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
 	status_entry_counts counts = {0};
 
+	if (geteuid() == 0)
+		cl_skip();
+
 	/* Create directory with no read permission */
 	cl_git_pass(git_futils_mkdir_r("empty_standard_repo/no_permission", 0777));
 	cl_git_mkfile("empty_standard_repo/no_permission/foo", "dummy");


### PR DESCRIPTION
When running as root, skip the unreadable file tests, because, well,
they're probably _not_ unreadable to root unless you've got some
crazy NSA clearance-level honoring operating system shit going on.

I suspect this is the root cause of #3731 