### PR TITLE
Add missing ')' to callbacks documentation

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -376,7 +376,7 @@ struct git_remote_callbacks {
 	/**
 	 * Textual progress from the remote. Text send over the
 	 * progress side-band will be passed to this function (this is
-	 * the 'counting objects' output.
+	 * the 'counting objects' output).
 	 */
 	git_transport_message_cb sideband_progress;
 


### PR DESCRIPTION
Super minor, but it was bugging me.

There was a missing closing paren in the docs.