### PR TITLE
Rebase improvements with IDs

### DIFF
--- a/tests/rebase/abort.c
+++ b/tests/rebase/abort.c
@@ -19,16 +19,14 @@ void test_rebase_abort__cleanup(void)
 	cl_git_sandbox_cleanup();
 }
 
-static void test_abort(git_annotated_commit *branch, git_annotated_commit *onto)
+static void ensure_aborted(
+	git_annotated_commit *branch,
+	git_annotated_commit *onto)
 {
-	git_rebase *rebase;
 	git_reference *head_ref, *branch_ref = NULL;
 	git_status_list *statuslist;
 	git_reflog *reflog;
 	const git_reflog_entry *reflog_entry;
-
-	cl_git_pass(git_rebase_open(&rebase, repo, NULL));
-	cl_git_pass(git_rebase_abort(rebase));
 
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
@@ -58,6 +56,18 @@ static void test_abort(git_annotated_commit *branch, git_annotated_commit *onto)
 	git_reflog_free(reflog);
 	git_reference_free(head_ref);
 	git_reference_free(branch_ref);
+}
+
+static void test_abort(
+	git_annotated_commit *branch, git_annotated_commit *onto)
+{
+	git_rebase *rebase;
+
+	cl_git_pass(git_rebase_open(&rebase, repo, NULL));
+	cl_git_pass(git_rebase_abort(rebase));
+
+	ensure_aborted(branch, onto);
+
 	git_rebase_free(rebase);
 }
 
@@ -86,6 +96,32 @@ void test_rebase_abort__merge(void)
 	git_rebase_free(rebase);
 }
 
+void test_rebase_abort__merge_immediately_after_init(void)
+{
+	git_rebase *rebase;
+	git_reference *branch_ref, *onto_ref;
+	git_annotated_commit *branch_head, *onto_head;
+
+	cl_git_pass(git_reference_lookup(&branch_ref, repo, "refs/heads/beef"));
+	cl_git_pass(git_reference_lookup(&onto_ref, repo, "refs/heads/master"));
+
+	cl_git_pass(git_annotated_commit_from_ref(&branch_head, repo, branch_ref));
+	cl_git_pass(git_annotated_commit_from_ref(&onto_head, repo, onto_ref));
+
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
+	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
+
+	cl_git_pass(git_rebase_abort(rebase));
+	ensure_aborted(branch_head, onto_head);
+
+	git_annotated_commit_free(branch_head);
+	git_annotated_commit_free(onto_head);
+
+	git_reference_free(branch_ref);
+	git_reference_free(onto_ref);
+	git_rebase_free(rebase);
+}
+
 void test_rebase_abort__merge_by_id(void)
 {
 	git_rebase *rebase;
@@ -102,6 +138,30 @@ void test_rebase_abort__merge_by_id(void)
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
 
 	test_abort(branch_head, onto_head);
+
+	git_annotated_commit_free(branch_head);
+	git_annotated_commit_free(onto_head);
+
+	git_rebase_free(rebase);
+}
+
+void test_rebase_abort__merge_by_id_immediately_after_init(void)
+{
+	git_rebase *rebase;
+	git_oid branch_id, onto_id;
+	git_annotated_commit *branch_head, *onto_head;
+
+	cl_git_pass(git_oid_fromstr(&branch_id, "b146bd7608eac53d9bf9e1a6963543588b555c64"));
+	cl_git_pass(git_oid_fromstr(&onto_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00"));
+
+	cl_git_pass(git_annotated_commit_lookup(&branch_head, repo, &branch_id));
+	cl_git_pass(git_annotated_commit_lookup(&onto_head, repo, &onto_id));
+
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, NULL, onto_head, NULL));
+	cl_assert_equal_i(GIT_REPOSITORY_STATE_REBASE_MERGE, git_repository_state(repo));
+
+	cl_git_pass(git_rebase_abort(rebase));
+	ensure_aborted(branch_head, onto_head);
 
 	git_annotated_commit_free(branch_head);
 	git_annotated_commit_free(onto_head);

--- a/tests/rebase/merge.c
+++ b/tests/rebase/merge.c
@@ -475,6 +475,56 @@ void test_rebase_merge__finish(void)
 	git_rebase_free(rebase);
 }
 
+void test_rebase_merge__finish_with_ids(void)
+{
+	git_rebase *rebase;
+	git_reference *head_ref;
+	git_oid branch_id, upstream_id;
+	git_annotated_commit *branch_head, *upstream_head;
+	git_rebase_operation *rebase_operation;
+	git_oid commit_id;
+	git_reflog *reflog;
+	const git_reflog_entry *reflog_entry;
+	int error;
+
+	cl_git_pass(git_oid_fromstr(&branch_id, "d616d97082eb7bb2dc6f180a7cca940993b7a56f"));
+	cl_git_pass(git_oid_fromstr(&upstream_id, "f87d14a4a236582a0278a916340a793714256864"));
+
+	cl_git_pass(git_annotated_commit_lookup(&branch_head, repo, &branch_id));
+	cl_git_pass(git_annotated_commit_lookup(&upstream_head, repo, &upstream_id));
+
+	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
+
+	cl_git_pass(git_rebase_next(&rebase_operation, rebase));
+	cl_git_pass(git_rebase_commit(&commit_id, rebase, NULL, signature,
+		NULL, NULL));
+
+	cl_git_fail(error = git_rebase_next(&rebase_operation, rebase));
+	cl_assert_equal_i(GIT_ITEROVER, error);
+
+	cl_git_pass(git_rebase_finish(rebase, signature));
+
+	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
+
+	cl_git_pass(git_reference_lookup(&head_ref, repo, "HEAD"));
+	cl_assert_equal_i(GIT_REF_OID, git_reference_type(head_ref));
+	cl_assert_equal_oid(&commit_id, git_reference_target(head_ref));
+
+	/* reflogs are not updated as if we were operating on proper
+	 * branches.  check that the last reflog entry is the rebase.
+	 */
+	cl_git_pass(git_reflog_read(&reflog, repo, "HEAD"));
+	cl_assert(reflog_entry = git_reflog_entry_byindex(reflog, 0));
+	cl_assert_equal_oid(&commit_id, git_reflog_entry_id_new(reflog_entry));
+	cl_assert_equal_s("rebase: Modification 3 to gravy", git_reflog_entry_message(reflog_entry));
+	git_reflog_free(reflog);
+
+	git_annotated_commit_free(branch_head);
+	git_annotated_commit_free(upstream_head);
+	git_reference_free(head_ref);
+	git_rebase_free(rebase);
+}
+
 static void test_copy_note(
 	const git_rebase_options *opts,
 	bool should_exist)


### PR DESCRIPTION
When rebasing with IDs, ensure that we can correctly abort and finish.