### PR TITLE
Fix `git_commit_create` for an initial commit

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -104,7 +104,7 @@ static int validate_tree_and_parents(git_array_oid_t *parents, git_repository *r
 		i++;
 	}
 
-	if (current_id && git_oid_cmp(current_id, git_array_get(*parents, 0))) {
+	if (current_id && (parents->size == 0 || git_oid_cmp(current_id, git_array_get(*parents, 0)))) {
 		giterr_set(GITERR_OBJECT, "failed to create commit: current tip is not the first parent");
 		error = GIT_EMODIFIED;
 		goto on_error;

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -84,13 +84,10 @@ void test_commit_commit__create_initial_commit(void)
 void test_commit_commit__create_initial_commit_parent_not_current(void)
 {
 	git_oid oid;
+	git_oid original_oid;
 	git_tree *tree;
 	git_commit *commit;
 	git_signature *s;
-	git_reference *origRef;
-	git_reference *origRefTarget;
-	git_reference *ref;
-	git_reference *refTarget;
 
 	git_oid_fromstr(&oid, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	cl_git_pass(git_commit_lookup(&commit, _repo, &oid));
@@ -100,40 +97,18 @@ void test_commit_commit__create_initial_commit_parent_not_current(void)
 
 	cl_git_pass(git_signature_now(&s, "alice", "alice@example.com"));
 
-	cl_git_pass(git_reference_lookup(&origRef, _repo, "HEAD"));
+	cl_git_pass(git_reference_name_to_id(&original_oid, _repo, "HEAD"));
 
 	cl_git_fail(git_commit_create(&oid, _repo, "HEAD", s, s,
 				      NULL, "initial commit", tree, 0, NULL));
 
-	cl_git_pass(git_reference_lookup(&ref, _repo, "HEAD"));
+	cl_git_pass(git_reference_name_to_id(&oid, _repo, "HEAD"));
 
-	cl_git_pass(
-		git_reference_lookup(
-			&origRefTarget,
-			_repo,
-			git_reference_symbolic_target(origRef)
-		)
-	);
-	cl_git_pass(
-		git_reference_lookup(
-			&refTarget,
-			_repo,
-			git_reference_symbolic_target(ref)
-		)
-	);
-
-	cl_assert_equal_oid(
-		git_reference_target(origRefTarget),
-		git_reference_target(refTarget)
-	);
+	cl_assert_equal_oid(&oid, &original_oid);
 
 	git_tree_free(tree);
 	git_commit_free(commit);
 	git_signature_free(s);
-	git_reference_free(origRef);
-	git_reference_free(origRefTarget);
-	git_reference_free(ref);
-	git_reference_free(refTarget);
 }
 
 void assert_commit_summary(const char *expected, const char *given)


### PR DESCRIPTION
When calling `git_commit_create` with an empty array of `parents` and `parent_count == 0` 
the call will segfault at https://github.com/libgit2/libgit2/blob/master/src/commit.c#L107 
when it's trying to compare `current_id` to a null parent oid. 

This just puts in a check to stop that segfault.