### PR TITLE
Fix return value of openssl_read (infinite loop)

### DIFF
--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -522,9 +522,8 @@ ssize_t openssl_read(git_stream *stream, void *data, size_t len)
 	openssl_stream *st = (openssl_stream *) stream;
 	int ret;
 
-	if ((ret = SSL_read(st->ssl, data, len)) <= 0) {
+	if ((ret = SSL_read(st->ssl, data, len)) <= 0)
 		return ssl_set_error(st->ssl, ret);
-	}
 
 	return ret;
 }

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -522,8 +522,9 @@ ssize_t openssl_read(git_stream *stream, void *data, size_t len)
 	openssl_stream *st = (openssl_stream *) stream;
 	int ret;
 
-	if ((ret = SSL_read(st->ssl, data, len)) <= 0)
-		ssl_set_error(st->ssl, ret);
+	if ((ret = SSL_read(st->ssl, data, len)) <= 0) {
+		return ssl_set_error(st->ssl, ret);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
openssl_read should return -1 in case of error.

SSL_read returns values <= 0 in case of error.

A return value of 0 can lead to an infinite loop, so the return value
of ssl_set_error will be returned if SSL_read is not successful (analog
to openssl_write).