### PR TITLE
Introduce `git_signature_from_buffer`

### DIFF
--- a/include/git2/signature.h
+++ b/include/git2/signature.h
@@ -63,6 +63,19 @@ GIT_EXTERN(int) git_signature_now(git_signature **out, const char *name, const c
 GIT_EXTERN(int) git_signature_default(git_signature **out, git_repository *repo);
 
 /**
+ * Create a new signature by parsing the given buffer, which is
+ * expected to be in the format "Real Name <email> timestamp tzoffset",
+ * where `timestamp` is the number of seconds since the Unix epoch and
+ * `tzoffset` is the timezone offset in `hhmm` format (note the lack
+ * of a colon separator).
+ *
+ * @param out new signature
+ * @param buf signature string
+ * @return 0 on success, or an error code
+ */
+GIT_EXTERN(int) git_signature_from_buffer(git_signature **out, const char *buf);
+
+/**
  * Create a copy of an existing signature.  All internal strings are also
  * duplicated.
  *

--- a/src/signature.c
+++ b/src/signature.c
@@ -200,7 +200,8 @@ int git_signature__parse(git_signature *sig, const char **buffer_out,
 
 	memset(sig, 0, sizeof(git_signature));
 
-	if ((buffer_end = memchr(buffer, ender, buffer_end - buffer)) == NULL)
+	if (ender &&
+		(buffer_end = memchr(buffer, ender, buffer_end - buffer)) == NULL)
 		return signature_error("no newline given");
 
 	if (header) {
@@ -260,6 +261,30 @@ int git_signature__parse(git_signature *sig, const char **buffer_out,
 
 	*buffer_out = buffer_end + 1;
 	return 0;
+}
+
+int git_signature_from_buffer(git_signature **out, const char *buf)
+{
+	git_signature *sig;
+	const char *buf_end;
+	int error;
+
+	assert(out && buf);
+
+	*out = NULL;
+
+	sig = git__calloc(1, sizeof(git_signature));
+	GITERR_CHECK_ALLOC(sig);
+
+	buf_end = buf + strlen(buf);
+	error = git_signature__parse(sig, &buf, buf_end, NULL, '\0');
+
+	if (error)
+		git__free(sig);
+	else
+		*out = sig;
+
+	return error;
 }
 
 void git_signature__writebuf(git_buf *buf, const char *header, const git_signature *sig)

--- a/tests/commit/signature.c
+++ b/tests/commit/signature.c
@@ -86,3 +86,16 @@ void test_commit_signature__create_zero_char(void)
 	cl_git_fail(git_signature_new(&sign, "", "x@y.z", 1234567890, 60));
 	cl_assert(sign == NULL);
 }
+
+void test_commit_signature__from_buf(void)
+{
+	git_signature *sign;
+
+	cl_git_pass(git_signature_from_buffer(&sign, "Test User <test@test.tt> 1461698487 +0200"));
+	cl_assert_equal_s("Test User", sign->name);
+	cl_assert_equal_s("test@test.tt", sign->email);
+	cl_assert_equal_i(1461698487, sign->when.time);
+	cl_assert_equal_i(120, sign->when.offset);
+	git_signature_free(sign);
+}
+


### PR DESCRIPTION
Allow users to construct a signature from the type of signature lines that actually appear in commits.  It may be natural for users to serialize author/committer information into this type of format, a helper method will provide some assistance for that.