### PR TITLE
Add a method specifically for modifying trees

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -418,6 +418,52 @@ GIT_EXTERN(int) git_tree_walk(
  */
 GIT_EXTERN(int) git_tree_dup(git_tree **out, git_tree *source);
 
+/**
+ * The kind of update to perform
+ */
+typedef enum {
+	/** Update or insert an entry at the specified path */
+	GIT_TREE_UPDATE_UPSERT,
+	/** Remove an entry from the specified path */
+	GIT_TREE_UPDATE_REMOVE,
+} git_tree_update_t;
+
+/**
+ * An action to perform during the update of a tree
+ */
+typedef struct {
+	/** Update action. If it's an removal, only the path is looked at */
+	git_tree_update_t action;
+	/** The entry's id */
+	git_oid id;
+	/** The filemode/kind of object */
+	git_filemode_t filemode;
+	/** The full path from the root tree */
+	const char *path;
+} git_tree_update;
+
+/**
+ * Create a tree based on another one with the specified modifications
+ *
+ * Given the `baseline` perform the changes described in the list of
+ * `updates` and create a new tree.
+ *
+ * This function is optimized for common file/directory addition, removal and
+ * replacement in trees. It is much more efficient than reading the tree into a
+ * `git_index` and modifying that, but in exchange it is not as flexible.
+ *
+ * Deleting and adding the same entry is undefined behaviour, changing
+ * a tree to a blob or viceversa is not supported.
+ *
+ * @param out id of the new tree
+ * @param repo the repository in which to create the tree, must be the
+ * same as for `baseline`
+ * @param baseline the tree to base these changes on
+ * @param nupdates the number of elements in the update list
+ * @param updates the list of updates to perform
+ */
+GIT_EXTERN(int) git_tree_create_updated(git_oid *out, git_repository *repo, git_tree *baseline, size_t nupdates, const git_tree_update *updates);
+
 /** @} */
 
 GIT_END_DECL

--- a/tests/object/tree/update.c
+++ b/tests/object/tree/update.c
@@ -1,0 +1,167 @@
+#include "clar_libgit2.h"
+#include "tree.h"
+
+static git_repository *g_repo;
+
+void test_object_tree_update__initialize(void)
+{
+	g_repo = cl_git_sandbox_init("testrepo");
+}
+
+void test_object_tree_update__cleanup(void)
+{
+   cl_git_sandbox_cleanup();
+}
+
+void test_object_tree_update__remove_blob(void)
+{
+	git_oid tree_index_id, tree_updater_id, base_id;
+	git_tree *base_tree;
+	git_index *idx;
+	const char *path = "README";
+
+	git_tree_update updates[] = {
+		{ GIT_TREE_UPDATE_REMOVE, {{0}}, GIT_FILEMODE_BLOB /* ignored */, path},
+	};
+
+	cl_git_pass(git_oid_fromstr(&base_id, "45dd856fdd4d89b884c340ba0e047752d9b085d6"));
+	cl_git_pass(git_tree_lookup(&base_tree, g_repo, &base_id));
+
+	/* Create it with an index */
+	cl_git_pass(git_index_new(&idx));
+	cl_git_pass(git_index_read_tree(idx, base_tree));
+	cl_git_pass(git_index_remove(idx, path, 0));
+	cl_git_pass(git_index_write_tree_to(&tree_index_id, idx, g_repo));
+	git_index_free(idx);
+
+	/* Perform the same operation via the tree updater */
+	cl_git_pass(git_tree_create_updated(&tree_updater_id, g_repo, base_tree, 1, updates));
+
+	cl_assert_equal_oid(&tree_index_id, &tree_updater_id);
+
+	git_tree_free(base_tree);
+}
+
+void test_object_tree_update__replace_blob(void)
+{
+	git_oid tree_index_id, tree_updater_id, base_id;
+	git_tree *base_tree;
+	git_index *idx;
+	const char *path = "README";
+	git_index_entry entry = { {0} };
+
+	git_tree_update updates[] = {
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, path},
+	};
+
+	cl_git_pass(git_oid_fromstr(&base_id, "45dd856fdd4d89b884c340ba0e047752d9b085d6"));
+	cl_git_pass(git_tree_lookup(&base_tree, g_repo, &base_id));
+
+	/* Create it with an index */
+	cl_git_pass(git_index_new(&idx));
+	cl_git_pass(git_index_read_tree(idx, base_tree));
+
+	entry.path = path;
+	cl_git_pass(git_oid_fromstr(&entry.id, "3697d64be941a53d4ae8f6a271e4e3fa56b022cc"));
+	entry.mode = GIT_FILEMODE_BLOB;
+	cl_git_pass(git_index_add(idx, &entry));
+
+	cl_git_pass(git_index_write_tree_to(&tree_index_id, idx, g_repo));
+	git_index_free(idx);
+
+	/* Perform the same operation via the tree updater */
+	cl_git_pass(git_oid_fromstr(&updates[0].id, "3697d64be941a53d4ae8f6a271e4e3fa56b022cc"));
+	cl_git_pass(git_tree_create_updated(&tree_updater_id, g_repo, base_tree, 1, updates));
+
+	cl_assert_equal_oid(&tree_index_id, &tree_updater_id);
+
+	git_tree_free(base_tree);
+}
+
+void test_object_tree_update__add_blobs(void)
+{
+	git_oid tree_index_id, tree_updater_id, base_id;
+	git_tree *base_tree;
+	git_index *idx;
+	git_index_entry entry = { {0} };
+	int i;
+	const char *paths[] = {
+		"some/deep/path",
+		"some/other/path",
+		"a/path/elsewhere",
+	};
+
+	git_tree_update updates[] = {
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, paths[0]},
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, paths[1]},
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, paths[2]},
+	};
+
+	cl_git_pass(git_oid_fromstr(&base_id, "45dd856fdd4d89b884c340ba0e047752d9b085d6"));
+	cl_git_pass(git_tree_lookup(&base_tree, g_repo, &base_id));
+
+	entry.mode = GIT_FILEMODE_BLOB;
+	cl_git_pass(git_oid_fromstr(&entry.id, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd"));
+
+	for (i = 0; i < 3; i++) {
+		cl_git_pass(git_oid_fromstr(&updates[i].id, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd"));
+	}
+
+	for (i = 0; i < 2; i++) {
+		int j;
+
+		/* Create it with an index */
+		cl_git_pass(git_index_new(&idx));
+
+		base_tree = NULL;
+		if (i == 1) {
+			cl_git_pass(git_tree_lookup(&base_tree, g_repo, &base_id));
+			cl_git_pass(git_index_read_tree(idx, base_tree));
+		}
+
+		for (j = 0; j < 3; j++) {
+			entry.path = paths[j];
+			cl_git_pass(git_index_add(idx, &entry));
+		}
+
+		cl_git_pass(git_index_write_tree_to(&tree_index_id, idx, g_repo));
+		git_index_free(idx);
+
+		/* Perform the same operations via the tree updater */
+		cl_git_pass(git_tree_create_updated(&tree_updater_id, g_repo, base_tree, 3, updates));
+
+		cl_assert_equal_oid(&tree_index_id, &tree_updater_id);
+	}
+}
+
+void test_object_tree_update__add_conflict(void)
+{
+	int i;
+	git_oid tree_updater_id;
+	git_tree_update updates[] = {
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, "a/dir/blob"},
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, "a/dir"},
+	};
+
+	for (i = 0; i < 2; i++) {
+		cl_git_pass(git_oid_fromstr(&updates[i].id, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd"));
+	}
+
+	cl_git_fail(git_tree_create_updated(&tree_updater_id, g_repo, NULL, 2, updates));
+}
+
+void test_object_tree_update__add_conflict2(void)
+{
+	int i;
+	git_oid tree_updater_id;
+	git_tree_update updates[] = {
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_BLOB, "a/dir/blob"},
+		{ GIT_TREE_UPDATE_UPSERT, {{0}}, GIT_FILEMODE_TREE, "a/dir/blob"},
+	};
+
+	for (i = 0; i < 2; i++) {
+		cl_git_pass(git_oid_fromstr(&updates[i].id, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd"));
+	}
+
+	cl_git_fail(git_tree_create_updated(&tree_updater_id, g_repo, NULL, 2, updates));
+}


### PR DESCRIPTION
The way we currently recommend modifying trees is via an index. This method has a couple of advantages: it's what any tool would do on their `git-commit` equivalent, and it's code that we already have and use. It does however mean doing a recursive read of the root tree, and that can get big. Modifying a file becomes more expensive as files are added to the tree regardless of where the updated file lives.

On a workdir, it's not so bad because the index is kept across operations but when doing this without the advantage of a user-provided workdir, the recursive read can become the primary cost of the update operation.

This PR adds a function which, given a baseline tree and a list of updates, reads just enough trees to perform the necessary updates.

---

This needs better history and some tests to make sure that performing modifications via the index and this new function has the same result, but I think the design of the function seems reasonable.