### PR TITLE
Fix comment for GIT_FILEMODE_LINK

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -45,7 +45,7 @@ GIT_INLINE(git_filemode_t) normalize_filemode(git_filemode_t filemode)
 	if (GIT_MODE_TYPE(filemode) == GIT_FILEMODE_COMMIT)
 		return GIT_FILEMODE_COMMIT;
 
-	/* 12XXXX means commit */
+	/* 12XXXX means symlink */
 	if (GIT_MODE_TYPE(filemode) == GIT_FILEMODE_LINK)
 		return GIT_FILEMODE_LINK;
 


### PR DESCRIPTION
0120000 is symbolic link, not commit.

(No functional change.)