### PR TITLE
Don't reuse the old index.

### DIFF
--- a/src/rebase.c
+++ b/src/rebase.c
@@ -881,8 +881,11 @@ static int rebase_next_inmemory(
 		rebase->index = index;
 		index = NULL;
 	} else {
-		if ((error = git_index_read_index(rebase->index, index)) < 0)
-			goto done;
+		git_index *tmp = NULL;
+
+		tmp = rebase->index;
+		rebase->index = index;
+		index = tmp;
 	}
 
 	*out = operation;


### PR DESCRIPTION
`rebase_next_inmemory` was reusing the same index throughout all rebase operations. This was causing entries to get lost sporadically and would lead to incorrect rebase results.

Instead of reusing the index, always switch to the index created by the latest merge operation.

This fixes the issue demonstrated in https://github.com/libgit2/rugged/pull/609.
