### PR TITLE
Return `HEAD` itself for `git_repository_head` when unborn

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1747,10 +1747,16 @@ int git_repository_head(git_reference **head_out, git_repository *repo)
 		return 0;
 	}
 
-	error = git_reference_lookup_resolved(head_out, repo, git_reference_symbolic_target(head), -1);
-	git_reference_free(head);
+	error = git_reference_lookup_resolved(head_out,
+		repo, git_reference_symbolic_target(head), -1);
 
-	return error == GIT_ENOTFOUND ? GIT_EUNBORNBRANCH : error;
+	if (error == GIT_ENOTFOUND) {
+		*head_out = head;
+		return GIT_EUNBORNBRANCH;
+	}
+
+	git_reference_free(head);
+	return error;
 }
 
 int git_repository_head_unborn(git_repository *repo)

--- a/tests/repo/head.c
+++ b/tests/repo/head.c
@@ -79,6 +79,11 @@ void test_repo_head__set_head_Attaches_HEAD_to_un_unborn_branch_when_the_branch_
 	cl_assert_equal_i(false, git_repository_head_detached(repo));
 
 	cl_assert_equal_i(GIT_EUNBORNBRANCH, git_repository_head(&head, repo));
+
+	cl_assert(head);
+	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
+	cl_assert_equal_s("HEAD", git_reference_name(head));
+	cl_assert_equal_s("refs/heads/doesnt/exist/yet", git_reference_symbolic_target(head));
 }
 
 void test_repo_head__set_head_Returns_ENOTFOUND_when_the_reference_doesnt_exist(void)


### PR DESCRIPTION
When consulting `git_repository_head` for an unborn branch, set the out pointer to the current `HEAD` as well as returning `GIT_EUNBORNBRANCH`.  This allows callers to determine what the unborn branch _is_.