### PR TITLE
fetch: Fixed spurious update callback for existing tags.

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -1423,7 +1423,11 @@ static int update_tips_for_spec(
 		/* In autotag mode, don't overwrite any locally-existing tags */
 		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, !autotag, 
 				log_message);
-		if (error < 0 && error != GIT_EEXISTS)
+
+		if (error == GIT_EEXISTS)
+			continue;
+
+		if (error < 0)
 			goto on_error;
 
 		git_reference_free(ref);


### PR DESCRIPTION
When an existing tag is changed on the remote, the default (autotag) behavior is to not overwrite the local tag, but the update callback is still called as if the tag had been updated. This commit fixes that.