### PR TITLE
submodule: Try to fetch when update fails to find the target commit.

### DIFF
--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -154,13 +154,19 @@ typedef struct git_submodule_update_options {
 	 * in the working directory for the newly cloned repository.
 	 */
 	unsigned int clone_checkout_strategy;
+
+	/**
+	 * Allow fetching from the submodule's default remote if the target
+	 * commit isn't found. Enabled by default.
+	 */
+	int allow_fetch;
 } git_submodule_update_options;
 
 #define GIT_SUBMODULE_UPDATE_OPTIONS_VERSION 1
 #define GIT_SUBMODULE_UPDATE_OPTIONS_INIT \
-	{ GIT_CHECKOUT_OPTIONS_VERSION, \
+	{ GIT_SUBMODULE_UPDATE_OPTIONS_VERSION, \
 		{ GIT_CHECKOUT_OPTIONS_VERSION, GIT_CHECKOUT_SAFE }, \
-	GIT_FETCH_OPTIONS_INIT, GIT_CHECKOUT_SAFE }
+	GIT_FETCH_OPTIONS_INIT, GIT_CHECKOUT_SAFE, 1 }
 
 /**
  * Initializes a `git_submodule_update_options` with default values.
@@ -176,7 +182,9 @@ GIT_EXTERN(int) git_submodule_update_init_options(
 /**
  * Update a submodule. This will clone a missing submodule and
  * checkout the subrepository to the commit specified in the index of
- * containing repository.
+ * the containing repository. If the submodule repository doesn't contain
+ * the target commit (e.g. because fetchRecurseSubmodules isn't set), then
+ * the submodule is fetched using the fetch options supplied in options.
  *
  * @param submodule Submodule object
  * @param init If the submodule is not initialized, setting this flag to true


### PR DESCRIPTION
This fixes #3783. When submodule update doesn't find the target commit in the submodule, fetch from the default remote and then try to lookup the commit again.