### PR TITLE
Fix invalid memory references

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -505,10 +505,11 @@ static int index_remove_entry(git_index *index, size_t pos)
 	int error = 0;
 	git_index_entry *entry = git_vector_get(&index->entries, pos);
 
-	if (entry != NULL)
+	if (entry != NULL) {
 		git_tree_cache_invalidate_path(index->tree, entry->path);
+		DELETE_IN_MAP(index, entry);
+	}
 
-	DELETE_IN_MAP(index, entry);
 	error = git_vector_remove(&index->entries, pos);
 
 	if (!error) {

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -433,6 +433,7 @@ int git_pkt_parse_line(
 	 * line?
 	 */
 	if (len == PKT_LEN_SIZE) {
+		*head = NULL;
 		*out = line;
 		return 0;
 	}

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -759,6 +759,14 @@ static int add_push_report_sideband_pkt(git_push *push, git_pkt_data *data_pkt, 
 		line_len -= (line_end - line);
 		line = line_end;
 
+		/* When a valid packet with no content has been
+		 * read, git_pkt_parse_line does not report an
+		 * error, but the pkt pointer has not been set.
+		 * Handle this by skipping over empty packets.
+		 */
+		if (pkt == NULL)
+			continue;
+
 		error = add_push_report_pkt(push, pkt);
 
 		git_pkt_free(pkt);
@@ -812,6 +820,9 @@ static int parse_report(transport_smart *transport, git_push *push)
 		gitno_consume(buf, line_end);
 
 		error = 0;
+
+		if (pkt == NULL)
+			continue;
 
 		switch (pkt->type) {
 			case GIT_PKT_DATA:


### PR DESCRIPTION
Two small fixes for invalid memory references. As always, some details are included in the commit messages.

I've pushed a fix similar to the smart-transports commit once before, but back then the fix wasn't as obvious and as I wasn't able to recap my own thought process when you asked about the non-obvious fix I simply dropped the commit. But I hope the issue should be clear now.