### PR TITLE
Coverity user model

### DIFF
--- a/script/user_model.c
+++ b/script/user_model.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+void *realloc(void *ptr, size_t size);
+size_t strlen(const char *s);
+
+typedef struct git_vector {
+	void **contents;
+	size_t length;
+} git_vector;
+
+typedef struct git_buf {
+	char *ptr;
+	size_t asize, size;
+} git_buf;
+
+int git_vector_insert(git_vector *v, void *element)
+{
+	if (!v)
+		__coverity_panic__();
+
+	v->contents = realloc(v->contents, ++v->length);
+	if (!v->contents)
+		__coverity_panic__();
+	v->contents[v->length] = element;
+
+	return 0;
+}
+
+int git_buf_len(const struct git_buf *buf)
+{
+	return strlen(buf->ptr);
+}

--- a/script/user_model.c
+++ b/script/user_model.c
@@ -6,7 +6,10 @@
  */
 
 void *realloc(void *ptr, size_t size);
+void *memmove(void *dest, const void *src, size_t n);
 size_t strlen(const char *s);
+
+typedef struct va_list_str *va_list;
 
 typedef struct git_vector {
 	void **contents;
@@ -34,4 +37,39 @@ int git_vector_insert(git_vector *v, void *element)
 int git_buf_len(const struct git_buf *buf)
 {
 	return strlen(buf->ptr);
+}
+
+int git_buf_vprintf(git_buf *buf, const char *format, va_list ap)
+{
+    char ch, *s;
+    size_t len;
+
+    __coverity_string_null_sink__(format);
+    __coverity_string_size_sink__(format);
+
+    ch = *format;
+    ch = *(char *)ap;
+
+    buf->ptr = __coverity_alloc__(len);
+    __coverity_writeall__(buf->ptr);
+    buf->size = len;
+
+    return 0;
+}
+
+int git_buf_put(git_buf *buf, const char *data, size_t len)
+{
+    buf->ptr = __coverity_alloc__(buf->size + len + 1);
+    memmove(buf->ptr + buf->size, data, len);
+    buf->size += len;
+    buf->ptr[buf->size + len] = 0;
+    return 0;
+}
+
+int git_buf_set(git_buf *buf, const void *data, size_t len)
+{
+    buf->ptr = __coverity_alloc__(len + 1);
+    memmove(buf->ptr, data, len);
+    buf->size = len + 1;
+    return 0;
 }


### PR DESCRIPTION
So by now more than half of the issues reported by Coverity can be labeled as false positives as the number of issues went down. I've written a user model that I am using to fix most of these false positives in my own fork, which brings down the number of issues from 37 to 14. Most of these issues are related to either git_vector or git_buf, which seem to be too complex to handle for Coverity.

I've split up this PR into two commits. The first commit includes the user model I am actually using right now. Due to an expired license (dunno why, I've contacted Coverity support but got no feedback until now) I am not able to update the user model, though, so I cannot test changes made in the second commit.

I'd be glad if this got accepted. Accepting alone won't help, though, as there seems to be no simple way of using the model when executing Coverity's tooling. Instead, someone needs to update the user model online. To do so, you'll have to go to scan.coverity.com, select the libgit2 project and then select the tab "Analysis Settings". There is a section "Modeling File" at the bottom where the file can be uploaded.