### PR TITLE
Memory leak fixes

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -87,11 +87,6 @@ static void shutdown_common(void)
 
 	git__free(git__user_agent);
 	git__free(git__ssl_ciphers);
-
-#if defined(GIT_MSVC_CRTDBG)
-	git_win32__crtdbg_stacktrace_cleanup();
-	git_win32__stack_cleanup();
-#endif
 }
 
 /**
@@ -183,6 +178,11 @@ int git_libgit2_shutdown(void)
 
 		TlsFree(_tls_index);
 		git_mutex_free(&git__mwindow_mutex);
+
+#if defined(GIT_MSVC_CRTDBG)
+		git_win32__crtdbg_stacktrace_cleanup();
+		git_win32__stack_cleanup();
+#endif
 	}
 
 	/* Exit the lock */

--- a/tests/checkout/typechange.c
+++ b/tests/checkout/typechange.c
@@ -240,8 +240,7 @@ static int make_submodule_dirty(git_submodule *sm, const char *name, void *paylo
 	));
 	git_futils_rmdir_r(git_buf_cstr(&submodulepath), NULL, GIT_RMDIR_REMOVE_FILES);
 
-	/* initialize submodule and its repository */
-	cl_git_pass(git_submodule_init(sm, 1));
+	/* initialize submodule's repository */
 	cl_git_pass(git_submodule_repo_init(&submodule_repo, sm, 0));
 
 	/* create a file in the submodule workdir to make it dirty */
@@ -251,6 +250,7 @@ static int make_submodule_dirty(git_submodule *sm, const char *name, void *paylo
 
 	git_buf_free(&dirtypath);
 	git_buf_free(&submodulepath);
+	git_repository_free(submodule_repo);
 
 	return 0;
 }


### PR DESCRIPTION
This fixes all memory leaks displayed by AppVeyor's debug CRT. The winhttp-related plug is the only actual fix for memory leaks inside of libgit2 and not its tests.