### PR TITLE
Fix truncation of SHA in error message for git_odb_read

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1362,8 +1362,8 @@ int git_odb__error_notfound(
 {
 	if (oid != NULL) {
 		size_t buf_len = oid_len;
-		if (oid_len == GIT_OID_HEXSZ) buf_len++;
 		char oid_str[GIT_OID_HEXSZ + 1];
+		if (oid_len == GIT_OID_HEXSZ) buf_len++;
 		git_oid_tostr(oid_str, buf_len, oid);
 		giterr_set(GITERR_ODB, "Object not found - %s (%.*s)",
 			message, oid_len, oid_str);

--- a/src/odb.c
+++ b/src/odb.c
@@ -1361,10 +1361,8 @@ int git_odb__error_notfound(
 	const char *message, const git_oid *oid, size_t oid_len)
 {
 	if (oid != NULL) {
-		size_t buf_len = oid_len;
 		char oid_str[GIT_OID_HEXSZ + 1];
-		if (oid_len == GIT_OID_HEXSZ) buf_len++;
-		git_oid_tostr(oid_str, buf_len, oid);
+		git_oid_tostr(oid_str, oid_len+1, oid);
 		giterr_set(GITERR_ODB, "Object not found - %s (%.*s)",
 			message, oid_len, oid_str);
 	} else

--- a/src/odb.c
+++ b/src/odb.c
@@ -1361,8 +1361,10 @@ int git_odb__error_notfound(
 	const char *message, const git_oid *oid, size_t oid_len)
 {
 	if (oid != NULL) {
+		size_t buf_len = oid_len;
+		if (oid_len == GIT_OID_HEXSZ) buf_len++;
 		char oid_str[GIT_OID_HEXSZ + 1];
-		git_oid_tostr(oid_str, oid_len, oid);
+		git_oid_tostr(oid_str, buf_len, oid);
 		giterr_set(GITERR_ODB, "Object not found - %s (%.*s)",
 			message, oid_len, oid_str);
 	} else


### PR DESCRIPTION
This is an attempt to fix #3753. The bug appears to only occur when the `oid_len` parameter passed to `git_odb__error_notfound()` is the maximum length of GIT_OID_HEXSZ. This PR fixes it by passing the actual buffer length to `git_oid_tostr()`.