### PR TITLE
checkout: use empty baseline when no index file exists

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2430,8 +2430,13 @@ static int checkout_data_init(
 
 	if (!data->opts.baseline && !data->opts.baseline_index) {
 		data->opts_free_baseline = true;
+		error = 0;
 
-		error = checkout_lookup_head_tree(&data->opts.baseline, repo);
+		/* if we don't have an index, this is an initial checkout and
+		 * should be against an empty baseline
+		 */
+		if (data->index->on_disk)
+			error = checkout_lookup_head_tree(&data->opts.baseline, repo);
 
 		if (error == GIT_EUNBORNBRANCH) {
 			error = 0;


### PR DESCRIPTION
When no index file exists and a baseline is not explicitly provided, use an empty baseline instead of trying to use `HEAD` as the baseline.

This is for compatibility with git:

```
% git status
On branch master
nothing to commit, working directory clean
% rm .git/index
% git status
On branch master
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

	deleted:    README
	deleted:    branch_file.txt
	deleted:    link_to_new.txt
	deleted:    new.txt

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	README
	branch_file.txt
	link_to_new.txt
	new.txt
% git checkout HEAD
error: The following untracked working tree files would be overwritten by checkout:
	README
	branch_file.txt
	link_to_new.txt
	new.txt
Please move or remove them before you can switch branches.
Aborting
% git checkout --force HEAD
% git status
On branch master
nothing to commit, working directory clean
```

Our previous behavior was to try to load `HEAD` when the index does not exist, which would simply do a diff between the baseline (`HEAD`) and the target (again, `HEAD`), which would be a noop.

Fixes #3811 