### PR TITLE
Fix include.path stopping on non-existent file relative to the home directory

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1250,8 +1250,16 @@ static int strip_comments(char *line, int in_quotes)
 static int included_path(git_buf *out, const char *dir, const char *path)
 {
 	/* From the user's home */
-	if (path[0] == '~' && path[1] == '/')
-		return git_sysdir_find_global_file(out, &path[1]);
+	int result;
+	if (path[0] == '~' && path[1] == '/') {
+		result = git_sysdir_find_global_file(out, &path[1]);
+		if (result == GIT_ENOTFOUND) {
+			git_buf_sets(out, &path[1]);
+			return 0;
+		}
+
+		return result;
+	}
 
 	return git_path_join_unrooted(out, path, dir, NULL);
 }

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -108,6 +108,23 @@ void test_config_include__missing(void)
 	git_config_free(cfg);
 }
 
+void test_config_include__missing_homedir(void)
+{
+	git_config *cfg;
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_mkfile("including", "[include]\npath = ~/.nonexistentfile\n[foo]\nbar = baz");
+
+	giterr_clear();
+	cl_git_pass(git_config_open_ondisk(&cfg, "including"));
+	cl_assert(giterr_last() == NULL);
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar"));
+	cl_assert_equal_s("baz", git_buf_cstr(&buf));
+
+	git_buf_free(&buf);
+	git_config_free(cfg);
+}
+
 #define replicate10(s) s s s s s s s s s s
 void test_config_include__depth2(void)
 {


### PR DESCRIPTION
This is an attempt to fix #3681. While looking at that issue, I was able to determine that parsing a config file stops, when it attempts to include a missing config file relative to the home directory using the following syntax:

```
[include]
path = ~/.nonexistent
```

I was able to demonstrate this by adding a new test that fails when using the above. I therefore committed and push a fix to allow parsing to continue, even if the file referenced does not exist. 

Note that including a non-existent file relative to the search paths or using absolute paths, currently work without any issues. The fix only addresses the case for missing files relatives to the home directory. 
