### PR TITLE
Thread namespacing

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -45,7 +45,7 @@
 # include "win32/error.h"
 # include "win32/version.h"
 # ifdef GIT_THREADS
-#	include "win32/pthread.h"
+#	include "win32/thread.h"
 # endif
 # if defined(GIT_MSVC_CRTDBG)
 #   include "win32/w32_stack.h"

--- a/src/global.c
+++ b/src/global.c
@@ -134,7 +134,7 @@ static int synchronized_threads_init(void)
 
 	_tls_index = TlsAlloc();
 
-	win32_pthread_initialize();
+	git_threads_init();
 
 	if (git_mutex_init(&git__mwindow_mutex))
 		return -1;

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1186,7 +1186,7 @@ static int ll_find_deltas(git_packbuilder *pb, git_pobject **list,
 		git_mutex_init(&p[i].mutex);
 		git_cond_init(&p[i].cond);
 
-		ret = git_thread_create(&p[i].thread, NULL,
+		ret = git_thread_create(&p[i].thread,
 					threaded_find_deltas, &p[i]);
 		if (ret) {
 			giterr_set(GITERR_THREAD, "unable to create thread");

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -41,16 +41,7 @@ typedef git_atomic git_atomic_ssize;
 #ifdef GIT_THREADS
 
 #if !defined(GIT_WIN32)
-
-typedef struct {
-	pthread_t thread;
-} git_thread;
-
-#define git_thread_create(git_thread_ptr, attr, start_routine, arg) \
-	pthread_create(&(git_thread_ptr)->thread, attr, start_routine, arg)
-#define git_thread_join(git_thread_ptr, status) \
-	pthread_join((git_thread_ptr)->thread, status)
-
+#   include "unix/pthread.h"
 #endif
 
 /* Pthreads Mutex */
@@ -178,7 +169,7 @@ GIT_INLINE(int64_t) git_atomic64_add(git_atomic64 *a, int64_t addend)
 #else
 
 #define git_thread unsigned int
-#define git_thread_create(thread, attr, start_routine, arg) 0
+#define git_thread_create(thread, start_routine, arg) 0
 #define git_thread_join(id, status) (void)0
 
 /* Pthreads Mutex */

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -52,7 +52,6 @@ typedef git_atomic git_atomic_ssize;
 #define git_cond_free(c) 	pthread_cond_destroy(c)
 #define git_cond_wait(c, l)	pthread_cond_wait(c, l)
 #define git_cond_signal(c)	pthread_cond_signal(c)
-#define git_cond_broadcast(c)	pthread_cond_broadcast(c)
 
 /* Pthread (-ish) rwlock
  *

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -46,13 +46,6 @@ typedef git_atomic git_atomic_ssize;
 #   include "unix/pthread.h"
 #endif
 
-/* Pthreads condition vars */
-#define git_cond pthread_cond_t
-#define git_cond_init(c)	pthread_cond_init(c, NULL)
-#define git_cond_free(c) 	pthread_cond_destroy(c)
-#define git_cond_wait(c, l)	pthread_cond_wait(c, l)
-#define git_cond_signal(c)	pthread_cond_signal(c)
-
 /* Pthread (-ish) rwlock
  *
  * This differs from normal pthreads rwlocks in two ways:

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -40,16 +40,11 @@ typedef git_atomic git_atomic_ssize;
 
 #ifdef GIT_THREADS
 
-#if !defined(GIT_WIN32)
+#ifdef GIT_WIN32
+#   include "win32/pthread.h"
+#else
 #   include "unix/pthread.h"
 #endif
-
-/* Pthreads Mutex */
-#define git_mutex pthread_mutex_t
-#define git_mutex_init(a)	pthread_mutex_init(a, NULL)
-#define git_mutex_lock(a)	pthread_mutex_lock(a)
-#define git_mutex_unlock(a) pthread_mutex_unlock(a)
-#define git_mutex_free(a)	pthread_mutex_destroy(a)
 
 /* Pthreads condition vars */
 #define git_cond pthread_cond_t

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -46,30 +46,6 @@ typedef git_atomic git_atomic_ssize;
 #   include "unix/pthread.h"
 #endif
 
-/* Pthread (-ish) rwlock
- *
- * This differs from normal pthreads rwlocks in two ways:
- * 1. Separate APIs for releasing read locks and write locks (as
- *    opposed to the pure POSIX API which only has one unlock fn)
- * 2. You should not use recursive read locks (i.e. grabbing a read
- *    lock in a thread that already holds a read lock) because the
- *    Windows implementation doesn't support it
- */
-#define git_rwlock pthread_rwlock_t
-#define git_rwlock_init(a)		pthread_rwlock_init(a, NULL)
-#define git_rwlock_rdlock(a)	pthread_rwlock_rdlock(a)
-#define git_rwlock_rdunlock(a)	pthread_rwlock_rdunlock(a)
-#define git_rwlock_wrlock(a)	pthread_rwlock_wrlock(a)
-#define git_rwlock_wrunlock(a)	pthread_rwlock_wrunlock(a)
-#define git_rwlock_free(a)		pthread_rwlock_destroy(a)
-#define GIT_RWLOCK_STATIC_INIT	PTHREAD_RWLOCK_INITIALIZER
-
-#ifndef GIT_WIN32
-#define pthread_rwlock_rdunlock pthread_rwlock_unlock
-#define pthread_rwlock_wrunlock pthread_rwlock_unlock
-#endif
-
-
 GIT_INLINE(void) git_atomic_set(git_atomic *a, int val)
 {
 #if defined(GIT_WIN32)

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -41,7 +41,7 @@ typedef git_atomic git_atomic_ssize;
 #ifdef GIT_THREADS
 
 #ifdef GIT_WIN32
-#   include "win32/pthread.h"
+#   include "win32/thread.h"
 #else
 #   include "unix/pthread.h"
 #endif

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -24,4 +24,12 @@ typedef struct {
 #define git_mutex_unlock(a)     pthread_mutex_unlock(a)
 #define git_mutex_free(a)	pthread_mutex_destroy(a)
 
+/* Git condition vars */
+#define git_cond pthread_cond_t
+#define git_cond_init(c)	pthread_cond_init(c, NULL)
+#define git_cond_free(c) 	pthread_cond_destroy(c)
+#define git_cond_wait(c, l)	pthread_cond_wait(c, l)
+#define git_cond_signal(c)	pthread_cond_signal(c)
+#define git_cond_broadcast(c)	pthread_cond_broadcast(c)
+
 #endif /* INCLUDE_unix_pthread_h__ */

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -12,6 +12,7 @@ typedef struct {
 	pthread_t thread;
 } git_thread;
 
+#define git_threads_init() (void)0
 #define git_thread_create(git_thread_ptr, start_routine, arg) \
 	pthread_create(&(git_thread_ptr)->thread, NULL, start_routine, arg)
 #define git_thread_join(git_thread_ptr, status) \

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_unix_pthread_h__
+#define INCLUDE_unix_pthread_h__
+
+typedef struct {
+	pthread_t thread;
+} git_thread;
+
+#define git_thread_create(git_thread_ptr, start_routine, arg) \
+	pthread_create(&(git_thread_ptr)->thread, NULL, start_routine, arg)
+#define git_thread_join(git_thread_ptr, status) \
+	pthread_join((git_thread_ptr)->thread, status)
+
+#endif /* INCLUDE_unix_pthread_h__ */

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -17,4 +17,11 @@ typedef struct {
 #define git_thread_join(git_thread_ptr, status) \
 	pthread_join((git_thread_ptr)->thread, status)
 
+/* Git Mutex */
+#define git_mutex pthread_mutex_t
+#define git_mutex_init(a)	pthread_mutex_init(a, NULL)
+#define git_mutex_lock(a)	pthread_mutex_lock(a)
+#define git_mutex_unlock(a)     pthread_mutex_unlock(a)
+#define git_mutex_free(a)	pthread_mutex_destroy(a)
+
 #endif /* INCLUDE_unix_pthread_h__ */

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -32,4 +32,22 @@ typedef struct {
 #define git_cond_signal(c)	pthread_cond_signal(c)
 #define git_cond_broadcast(c)	pthread_cond_broadcast(c)
 
+/* Pthread (-ish) rwlock
+ *
+ * This differs from normal pthreads rwlocks in two ways:
+ * 1. Separate APIs for releasing read locks and write locks (as
+ *    opposed to the pure POSIX API which only has one unlock fn)
+ * 2. You should not use recursive read locks (i.e. grabbing a read
+ *    lock in a thread that already holds a read lock) because the
+ *    Windows implementation doesn't support it
+ */
+#define git_rwlock              pthread_rwlock_t
+#define git_rwlock_init(a)	pthread_rwlock_init(a, NULL)
+#define git_rwlock_rdlock(a)	pthread_rwlock_rdlock(a)
+#define git_rwlock_rdunlock(a)	pthread_rwlock_unlock(a)
+#define git_rwlock_wrlock(a)	pthread_rwlock_wrlock(a)
+#define git_rwlock_wrunlock(a)	pthread_rwlock_unlock(a)
+#define git_rwlock_free(a)	pthread_rwlock_destroy(a)
+#define GIT_RWLOCK_STATIC_INIT	PTHREAD_RWLOCK_INITIALIZER
+
 #endif /* INCLUDE_unix_pthread_h__ */

--- a/src/win32/precompiled.h
+++ b/src/win32/precompiled.h
@@ -16,7 +16,7 @@
 #include <io.h>
 #include <direct.h>
 #ifdef GIT_THREADS
- #include "win32/pthread.h"
+ #include "win32/thread.h"
 #endif
 
 #include "git2.h"

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -156,10 +156,6 @@ int pthread_cond_signal(pthread_cond_t *cond)
 	return 0;
 }
 
-/* pthread_cond_broadcast is not implemented because doing so with just
- * Win32 events is quite complicated, and no caller in libgit2 uses it
- * yet.
- */
 int pthread_num_processors_np(void)
 {
 	DWORD_PTR p, s;

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -91,12 +91,8 @@ int git_mutex_unlock(git_mutex *mutex)
 	return 0;
 }
 
-int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
+int git_cond_init(git_cond *cond)
 {
-	/* We don't support non-default attributes. */
-	if (attr)
-		return EINVAL;
-
 	/* This is an auto-reset event. */
 	*cond = CreateEventW(NULL, FALSE, FALSE, NULL);
 	assert(*cond);
@@ -106,7 +102,7 @@ int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
 	return *cond ? 0 : ENOMEM;
 }
 
-int pthread_cond_destroy(pthread_cond_t *cond)
+int git_cond_free(git_cond *cond)
 {
 	BOOL closed;
 
@@ -121,7 +117,7 @@ int pthread_cond_destroy(pthread_cond_t *cond)
 	return 0;
 }
 
-int pthread_cond_wait(pthread_cond_t *cond, git_mutex *mutex)
+int git_cond_wait(git_cond *cond, git_mutex *mutex)
 {
 	int error;
 	DWORD wait_result;
@@ -142,7 +138,7 @@ int pthread_cond_wait(pthread_cond_t *cond, git_mutex *mutex)
 	return git_mutex_lock(mutex);
 }
 
-int pthread_cond_signal(pthread_cond_t *cond)
+int git_cond_signal(git_cond *cond)
 {
 	BOOL signaled;
 

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -67,28 +67,25 @@ int git_thread_join(
 	return 0;
 }
 
-int pthread_mutex_init(
-	pthread_mutex_t *GIT_RESTRICT mutex,
-	const pthread_mutexattr_t *GIT_RESTRICT mutexattr)
+int git_mutex_init(git_mutex *GIT_RESTRICT mutex)
 {
-	GIT_UNUSED(mutexattr);
 	InitializeCriticalSection(mutex);
 	return 0;
 }
 
-int pthread_mutex_destroy(pthread_mutex_t *mutex)
+int git_mutex_free(git_mutex *mutex)
 {
 	DeleteCriticalSection(mutex);
 	return 0;
 }
 
-int pthread_mutex_lock(pthread_mutex_t *mutex)
+int git_mutex_lock(git_mutex *mutex)
 {
 	EnterCriticalSection(mutex);
 	return 0;
 }
 
-int pthread_mutex_unlock(pthread_mutex_t *mutex)
+int git_mutex_unlock(git_mutex *mutex)
 {
 	LeaveCriticalSection(mutex);
 	return 0;
@@ -124,7 +121,7 @@ int pthread_cond_destroy(pthread_cond_t *cond)
 	return 0;
 }
 
-int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+int pthread_cond_wait(pthread_cond_t *cond, git_mutex *mutex)
 {
 	int error;
 	DWORD wait_result;
@@ -133,7 +130,7 @@ int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
 		return EINVAL;
 
 	/* The caller must be holding the mutex. */
-	error = pthread_mutex_unlock(mutex);
+	error = git_mutex_unlock(mutex);
 
 	if (error)
 		return error;
@@ -142,7 +139,7 @@ int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
 	assert(WAIT_OBJECT_0 == wait_result);
 	GIT_UNUSED(wait_result);
 
-	return pthread_mutex_lock(mutex);
+	return git_mutex_lock(mutex);
 }
 
 int pthread_cond_signal(pthread_cond_t *cond)

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -16,7 +16,7 @@
  * void pointer. This requires the indirection. */
 static DWORD WINAPI git_win32__threadproc(LPVOID lpParameter)
 {
-	git_win32_thread *thread = lpParameter;
+	git_thread *thread = lpParameter;
 
 	thread->result = thread->proc(thread->param);
 
@@ -25,14 +25,11 @@ static DWORD WINAPI git_win32__threadproc(LPVOID lpParameter)
 	return CLEAN_THREAD_EXIT;
 }
 
-int git_win32__thread_create(
-	git_win32_thread *GIT_RESTRICT thread,
-	const pthread_attr_t *GIT_RESTRICT attr,
+int git_thread_create(
+	git_thread *GIT_RESTRICT thread,
 	void *(*start_routine)(void*),
 	void *GIT_RESTRICT arg)
 {
-	GIT_UNUSED(attr);
-
 	thread->result = NULL;
 	thread->param = arg;
 	thread->proc = start_routine;
@@ -42,8 +39,8 @@ int git_win32__thread_create(
 	return thread->thread ? 0 : -1;
 }
 
-int git_win32__thread_join(
-	git_win32_thread *thread,
+int git_thread_join(
+	git_thread *thread,
 	void **value_ptr)
 {
 	DWORD exit;

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -152,17 +152,6 @@ int git_cond_signal(git_cond *cond)
 	return 0;
 }
 
-int pthread_num_processors_np(void)
-{
-	DWORD_PTR p, s;
-	int n = 0;
-
-	if (GetProcessAffinityMask(GetCurrentProcess(), &p, &s))
-		for (; p; p >>= 1)
-			n += p&1;
-
-	return n ? n : 1;
-}
 
 typedef void (WINAPI *win32_srwlock_fn)(GIT_SRWLOCK *);
 

--- a/src/win32/pthread.c
+++ b/src/win32/pthread.c
@@ -172,12 +172,8 @@ static win32_srwlock_fn win32_srwlock_release_shared;
 static win32_srwlock_fn win32_srwlock_acquire_exclusive;
 static win32_srwlock_fn win32_srwlock_release_exclusive;
 
-int pthread_rwlock_init(
-	pthread_rwlock_t *GIT_RESTRICT lock,
-	const pthread_rwlockattr_t *GIT_RESTRICT attr)
+int git_rwlock_init(git_rwlock *GIT_RESTRICT lock)
 {
-	GIT_UNUSED(attr);
-
 	if (win32_srwlock_initialize)
 		win32_srwlock_initialize(&lock->native.srwl);
 	else
@@ -186,7 +182,7 @@ int pthread_rwlock_init(
 	return 0;
 }
 
-int pthread_rwlock_rdlock(pthread_rwlock_t *lock)
+int git_rwlock_rdlock(git_rwlock *lock)
 {
 	if (win32_srwlock_acquire_shared)
 		win32_srwlock_acquire_shared(&lock->native.srwl);
@@ -196,7 +192,7 @@ int pthread_rwlock_rdlock(pthread_rwlock_t *lock)
 	return 0;
 }
 
-int pthread_rwlock_rdunlock(pthread_rwlock_t *lock)
+int git_rwlock_rdunlock(git_rwlock *lock)
 {
 	if (win32_srwlock_release_shared)
 		win32_srwlock_release_shared(&lock->native.srwl);
@@ -206,7 +202,7 @@ int pthread_rwlock_rdunlock(pthread_rwlock_t *lock)
 	return 0;
 }
 
-int pthread_rwlock_wrlock(pthread_rwlock_t *lock)
+int git_rwlock_wrlock(git_rwlock *lock)
 {
 	if (win32_srwlock_acquire_exclusive)
 		win32_srwlock_acquire_exclusive(&lock->native.srwl);
@@ -216,7 +212,7 @@ int pthread_rwlock_wrlock(pthread_rwlock_t *lock)
 	return 0;
 }
 
-int pthread_rwlock_wrunlock(pthread_rwlock_t *lock)
+int git_rwlock_wrunlock(git_rwlock *lock)
 {
 	if (win32_srwlock_release_exclusive)
 		win32_srwlock_release_exclusive(&lock->native.srwl);
@@ -226,7 +222,7 @@ int pthread_rwlock_wrunlock(pthread_rwlock_t *lock)
 	return 0;
 }
 
-int pthread_rwlock_destroy(pthread_rwlock_t *lock)
+int git_rwlock_free(git_rwlock *lock)
 {
 	if (!win32_srwlock_initialize)
 		DeleteCriticalSection(&lock->native.csec);

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -23,11 +23,6 @@ typedef struct {
 	void *result;
 } git_thread;
 
-typedef int pthread_mutexattr_t;
-typedef int pthread_condattr_t;
-typedef int pthread_attr_t;
-typedef int pthread_rwlockattr_t;
-
 typedef CRITICAL_SECTION git_mutex;
 typedef HANDLE git_cond;
 
@@ -39,8 +34,6 @@ typedef struct {
 		CRITICAL_SECTION csec;
 	} native;
 } git_rwlock;
-
-#define PTHREAD_MUTEX_INITIALIZER  {(void*)-1}
 
 int git_thread_create(git_thread *GIT_RESTRICT,
 	void *(*) (void *),

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -56,7 +56,6 @@ int pthread_cond_init(pthread_cond_t *, const pthread_condattr_t *);
 int pthread_cond_destroy(pthread_cond_t *);
 int pthread_cond_wait(pthread_cond_t *, git_mutex *);
 int pthread_cond_signal(pthread_cond_t *);
-/* pthread_cond_broadcast is not supported on Win32 yet. */
 
 int pthread_num_processors_np(void);
 

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -29,7 +29,7 @@ typedef int pthread_attr_t;
 typedef int pthread_rwlockattr_t;
 
 typedef CRITICAL_SECTION git_mutex;
-typedef HANDLE pthread_cond_t;
+typedef HANDLE git_cond;
 
 typedef struct { void *Ptr; } GIT_SRWLOCK;
 
@@ -52,10 +52,10 @@ int git_mutex_free(git_mutex *);
 int git_mutex_lock(git_mutex *);
 int git_mutex_unlock(git_mutex *);
 
-int pthread_cond_init(pthread_cond_t *, const pthread_condattr_t *);
-int pthread_cond_destroy(pthread_cond_t *);
-int pthread_cond_wait(pthread_cond_t *, git_mutex *);
-int pthread_cond_signal(pthread_cond_t *);
+int git_cond_init(git_cond *);
+int git_cond_free(git_cond *);
+int git_cond_wait(git_cond *, git_mutex *);
+int git_cond_signal(git_cond *);
 
 int pthread_num_processors_np(void);
 

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -28,7 +28,7 @@ typedef int pthread_condattr_t;
 typedef int pthread_attr_t;
 typedef int pthread_rwlockattr_t;
 
-typedef CRITICAL_SECTION pthread_mutex_t;
+typedef CRITICAL_SECTION git_mutex;
 typedef HANDLE pthread_cond_t;
 
 typedef struct { void *Ptr; } GIT_SRWLOCK;
@@ -47,16 +47,14 @@ int git_thread_create(git_thread *GIT_RESTRICT,
 	void *GIT_RESTRICT);
 int git_thread_join(git_thread *, void **);
 
-int pthread_mutex_init(
-	pthread_mutex_t *GIT_RESTRICT mutex,
-	const pthread_mutexattr_t *GIT_RESTRICT mutexattr);
-int pthread_mutex_destroy(pthread_mutex_t *);
-int pthread_mutex_lock(pthread_mutex_t *);
-int pthread_mutex_unlock(pthread_mutex_t *);
+int git_mutex_init(git_mutex *GIT_RESTRICT mutex);
+int git_mutex_free(git_mutex *);
+int git_mutex_lock(git_mutex *);
+int git_mutex_unlock(git_mutex *);
 
 int pthread_cond_init(pthread_cond_t *, const pthread_condattr_t *);
 int pthread_cond_destroy(pthread_cond_t *);
-int pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *);
+int pthread_cond_wait(pthread_cond_t *, git_mutex *);
 int pthread_cond_signal(pthread_cond_t *);
 /* pthread_cond_broadcast is not supported on Win32 yet. */
 

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -38,7 +38,7 @@ typedef struct {
 		GIT_SRWLOCK srwl;
 		CRITICAL_SECTION csec;
 	} native;
-} pthread_rwlock_t;
+} git_rwlock;
 
 #define PTHREAD_MUTEX_INITIALIZER  {(void*)-1}
 
@@ -59,14 +59,12 @@ int git_cond_signal(git_cond *);
 
 int pthread_num_processors_np(void);
 
-int pthread_rwlock_init(
-	pthread_rwlock_t *GIT_RESTRICT lock,
-	const pthread_rwlockattr_t *GIT_RESTRICT attr);
-int pthread_rwlock_rdlock(pthread_rwlock_t *);
-int pthread_rwlock_rdunlock(pthread_rwlock_t *);
-int pthread_rwlock_wrlock(pthread_rwlock_t *);
-int pthread_rwlock_wrunlock(pthread_rwlock_t *);
-int pthread_rwlock_destroy(pthread_rwlock_t *);
+int git_rwlock_init(git_rwlock *GIT_RESTRICT lock);
+int git_rwlock_rdlock(git_rwlock *);
+int git_rwlock_rdunlock(git_rwlock *);
+int git_rwlock_wrlock(git_rwlock *);
+int git_rwlock_wrunlock(git_rwlock *);
+int git_rwlock_free(git_rwlock *);
 
 extern int win32_pthread_initialize(void);
 

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -57,8 +57,6 @@ int git_cond_free(git_cond *);
 int git_cond_wait(git_cond *, git_mutex *);
 int git_cond_signal(git_cond *);
 
-int pthread_num_processors_np(void);
-
 int git_rwlock_init(git_rwlock *GIT_RESTRICT lock);
 int git_rwlock_rdlock(git_rwlock *);
 int git_rwlock_rdunlock(git_rwlock *);

--- a/src/win32/pthread.h
+++ b/src/win32/pthread.h
@@ -21,7 +21,7 @@ typedef struct {
 	void *(*proc)(void *);
 	void *param;
 	void *result;
-} git_win32_thread;
+} git_thread;
 
 typedef int pthread_mutexattr_t;
 typedef int pthread_condattr_t;
@@ -42,26 +42,10 @@ typedef struct {
 
 #define PTHREAD_MUTEX_INITIALIZER  {(void*)-1}
 
-int git_win32__thread_create(
-	git_win32_thread *GIT_RESTRICT,
-	const pthread_attr_t *GIT_RESTRICT,
+int git_thread_create(git_thread *GIT_RESTRICT,
 	void *(*) (void *),
 	void *GIT_RESTRICT);
-
-int git_win32__thread_join(
-	git_win32_thread *,
-	void **);
-
-#ifdef GIT_THREADS
-
-typedef git_win32_thread git_thread;
-
-#define git_thread_create(git_thread_ptr, attr, start_routine, arg) \
-	git_win32__thread_create(git_thread_ptr, attr, start_routine, arg)
-#define git_thread_join(git_thread_ptr, status) \
-	git_win32__thread_join(git_thread_ptr, status)
-
-#endif
+int git_thread_join(git_thread *, void **);
 
 int pthread_mutex_init(
 	pthread_mutex_t *GIT_RESTRICT mutex,

--- a/src/win32/thread.c
+++ b/src/win32/thread.c
@@ -5,7 +5,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "pthread.h"
+#include "thread.h"
 #include "../global.h"
 
 #define CLEAN_THREAD_EXIT 0x6F012842

--- a/src/win32/thread.h
+++ b/src/win32/thread.h
@@ -35,6 +35,8 @@ typedef struct {
 	} native;
 } git_rwlock;
 
+int git_threads_init(void);
+
 int git_thread_create(git_thread *GIT_RESTRICT,
 	void *(*) (void *),
 	void *GIT_RESTRICT);
@@ -56,7 +58,5 @@ int git_rwlock_rdunlock(git_rwlock *);
 int git_rwlock_wrlock(git_rwlock *);
 int git_rwlock_wrunlock(git_rwlock *);
 int git_rwlock_free(git_rwlock *);
-
-extern int win32_pthread_initialize(void);
 
 #endif /* INCLUDE_win32_thread_h__ */

--- a/src/win32/thread.h
+++ b/src/win32/thread.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef GIT_PTHREAD_H
-#define GIT_PTHREAD_H
+#ifndef INCLUDE_win32_thread_h__
+#define INCLUDE_win32_thread_h__
 
 #include "../common.h"
 
@@ -59,4 +59,4 @@ int git_rwlock_free(git_rwlock *);
 
 extern int win32_pthread_initialize(void);
 
-#endif
+#endif /* INCLUDE_win32_thread_h__ */

--- a/tests/object/cache.c
+++ b/tests/object/cache.c
@@ -220,7 +220,7 @@ void test_object_cache__threadmania(void)
 			fn = (th & 1) ? cache_parsed : cache_raw;
 
 #ifdef GIT_THREADS
-			cl_git_pass(git_thread_create(&t[th], NULL, fn, data));
+			cl_git_pass(git_thread_create(&t[th], fn, data));
 #else
 			cl_assert(fn(data) == data);
 			git__free(data);
@@ -267,7 +267,7 @@ void test_object_cache__fast_thread_rush(void)
 			data[th] = th;
 #ifdef GIT_THREADS
 			cl_git_pass(
-				git_thread_create(&t[th], NULL, cache_quick, &data[th]));
+				git_thread_create(&t[th], cache_quick, &data[th]));
 #else
 			cl_assert(cache_quick(&data[th]) == &data[th]);
 #endif

--- a/tests/threads/refdb.c
+++ b/tests/threads/refdb.c
@@ -75,7 +75,7 @@ void test_threads_refdb__iterator(void)
 		for (t = 0; t < THREADS; ++t) {
 			id[t] = t;
 #ifdef GIT_THREADS
-			cl_git_pass(git_thread_create(&th[t], NULL, iterate_refs, &id[t]));
+			cl_git_pass(git_thread_create(&th[t], iterate_refs, &id[t]));
 #else
 			th[t] = t;
 			iterate_refs(&id[t]);
@@ -196,7 +196,7 @@ void test_threads_refdb__edit_while_iterate(void)
 		 * for now by just running on a single thread...
 		 */
 /* #ifdef GIT_THREADS */
-/*		cl_git_pass(git_thread_create(&th[t], NULL, fn, &id[t])); */
+/*		cl_git_pass(git_thread_create(&th[t], fn, &id[t])); */
 /* #else */
 		fn(&id[t]);
 /* #endif */
@@ -211,7 +211,7 @@ void test_threads_refdb__edit_while_iterate(void)
 
 	for (t = 0; t < THREADS; ++t) {
 		id[t] = t;
-		cl_git_pass(git_thread_create(&th[t], NULL, iterate_refs, &id[t]));
+		cl_git_pass(git_thread_create(&th[t], iterate_refs, &id[t]));
 	}
 
 	for (t = 0; t < THREADS; ++t) {

--- a/tests/threads/thread_helpers.c
+++ b/tests/threads/thread_helpers.c
@@ -24,7 +24,7 @@ void run_in_parallel(
 		for (t = 0; t < threads; ++t) {
 			id[t] = t;
 #ifdef GIT_THREADS
-			cl_git_pass(git_thread_create(&th[t], NULL, func, &id[t]));
+			cl_git_pass(git_thread_create(&th[t], func, &id[t]));
 #else
 			cl_assert(func(&id[t]) == &id[t]);
 #endif


### PR DESCRIPTION
This PR aims to fix the namespacing-issue in issue #3825. The Windows-specific pthreads.c source file tries to re-implement the API exposed by pthreads by implementing many of the pthread-symbols with Windows-specific threading code. This unfortunately results in runtime errors when a user links his application to both libgit2 and winpthreads, causing one of both libraries to override symbols of the other library, causing inconsistencies.

Fix the issue by introducing proper namespacing to our threading API. Instead of trying to re-implement all functions, implement functions inside the `git_` namespace and adjust the `#define`s in Unix-specific code.

This solves the part where linking against both libraries causes runtime errors. What is still missing is to allow Windows-users to link libgit2 not against the internal thread API but against winpthread provided by MinGW/MSYS2. This will follow later either by updating this PR or creating a new one if this one got merged already.