### PR TITLE
Fixed bug while parsing INT64_MIN

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -128,8 +128,8 @@ int git__strntol64(int64_t *result, const char *nptr, size_t nptr_len, const cha
 			v = c - 'A' + 10;
 		if (v >= base)
 			break;
-		nn = n*base + v;
-		if (nn < n)
+		nn = n * base + (neg ? -v : v);
+		if ((!neg && nn < n) || (neg && nn > n))
 			ovfl = 1;
 		n = nn;
 	}
@@ -148,7 +148,7 @@ Return:
 		return -1;
 	}
 
-	*result = neg ? -n : n;
+	*result = n;
 	return 0;
 }
 

--- a/tests/core/strtol.c
+++ b/tests/core/strtol.c
@@ -33,5 +33,13 @@ void test_core_strtol__int64(void)
 	cl_assert(i == 2147483657LL);
 	cl_git_pass(git__strtol64(&i, "  -2147483657 ", NULL, 10));
 	cl_assert(i == -2147483657LL);
+	cl_git_pass(git__strtol64(&i, " 9223372036854775807  ", NULL, 10));
+	cl_assert(i == INT64_MAX);
+	cl_git_pass(git__strtol64(&i, "   -9223372036854775808  ", NULL, 10));
+	cl_assert(i == INT64_MIN);
+	cl_git_pass(git__strtol64(&i, "   0x7fffffffffffffff  ", NULL, 16));
+	cl_assert(i == INT64_MAX);
+	cl_git_pass(git__strtol64(&i, "   -0x8000000000000000   ", NULL, 16));
+	cl_assert(i == INT64_MIN);
 }
 


### PR DESCRIPTION
Fixed the bug which caused `strtol()` to fail parsing `INT64_MIN`. Addressed in #3817.

Added test cases in `tests/core/strtol.c` to check for the boundary values. 