### PR TITLE
Enable https transport for custom TLS streams

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -29,9 +29,7 @@ int git_libgit2_features(void)
 #ifdef GIT_THREADS
 		| GIT_FEATURE_THREADS
 #endif
-#if defined(GIT_OPENSSL) || defined(GIT_WINHTTP) || defined(GIT_SECURE_TRANSPORT)
 		| GIT_FEATURE_HTTPS
-#endif
 #if defined(GIT_SSH)
 		| GIT_FEATURE_SSH
 #endif

--- a/src/transport.c
+++ b/src/transport.c
@@ -29,9 +29,7 @@ static transport_definition local_transport_definition = { "file://", git_transp
 static transport_definition transports[] = {
 	{ "git://",   git_transport_smart, &git_subtransport_definition },
 	{ "http://",  git_transport_smart, &http_subtransport_definition },
-#if defined(GIT_OPENSSL) || defined(GIT_WINHTTP) || defined(GIT_SECURE_TRANSPORT)
 	{ "https://", git_transport_smart, &http_subtransport_definition },
-#endif
 	{ "file://",  git_transport_local, NULL },
 #ifdef GIT_SSH
 	{ "ssh://",   git_transport_smart, &ssh_subtransport_definition },

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -620,7 +620,6 @@ static int http_connect(http_subtransport *t)
 
 	error = git_stream_connect(t->io);
 
-#if defined(GIT_OPENSSL) || defined(GIT_SECURE_TRANSPORT) || defined(GIT_CURL)
 	if ((!error || error == GIT_ECERTIFICATE) && t->owner->certificate_check_cb != NULL &&
 	    git_stream_is_encrypted(t->io)) {
 		git_cert *cert;
@@ -640,7 +639,7 @@ static int http_connect(http_subtransport *t)
 			return error;
 		}
 	}
-#endif
+
 	if (error < 0)
 		return error;
 

--- a/tests/core/features.c
+++ b/tests/core/features.c
@@ -17,11 +17,7 @@ void test_core_features__0(void)
 	cl_assert((caps & GIT_FEATURE_THREADS) == 0);
 #endif
 
-#if defined(GIT_OPENSSL) || defined(GIT_WINHTTP) || defined(GIT_SECURE_TRANSPORT)
 	cl_assert((caps & GIT_FEATURE_HTTPS) != 0);
-#else
-	cl_assert((caps & GIT_FEATURE_HTTPS) == 0);
-#endif
 
 #if defined(GIT_SSH)
 	cl_assert((caps & GIT_FEATURE_SSH) != 0);


### PR DESCRIPTION
Unfortunately, custom TLS stream API is useless because `https` transport become disabled when [any of secure connection frameworks aren't used](https://github.com/libgit2/libgit2/blob/813d73f64d779257fd24cd70bbc281352c34812b/src/transport.c#L32).