### PR TITLE
Shallow roots

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -11,6 +11,7 @@
 #include "types.h"
 #include "oid.h"
 #include "buffer.h"
+#include "oidarray.h"
 
 /**
  * @file git2/repository.h
@@ -744,6 +745,15 @@ GIT_EXTERN(const char *) git_repository_get_namespace(git_repository *repo);
  * @return 1 if shallow, zero if not
  */
 GIT_EXTERN(int) git_repository_is_shallow(git_repository *repo);
+
+/**
+ * Determine the shallow roots of the repository
+ *
+ * @param out An array of shallow oids. Can be NULL.
+ * @param repo The repository
+ * @return 1 if shallow, zero if not
+ */
+GIT_EXTERN(int) git_repository_shallow_roots(git_oidarray *out, git_repository *repo);
 
 /**
  * Retrieve the configured identity to use for reflogs

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -749,9 +749,9 @@ GIT_EXTERN(int) git_repository_is_shallow(git_repository *repo);
 /**
  * Determine the shallow roots of the repository
  *
- * @param out An array of shallow oids. Can be NULL.
+ * @param out An array of shallow oids.
  * @param repo The repository
- * @return 1 if shallow, zero if not
+ * @return 0 on success, an error otherwise.
  */
 GIT_EXTERN(int) git_repository_shallow_roots(git_oidarray *out, git_repository *repo);
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -2524,11 +2524,12 @@ unchanged:
 
 int git_repository_shallow_roots(git_oidarray *out, git_repository *repo)
 {
+	int ret;
 	git_array_oid_t array;
 
 	assert(out);
 
-	int ret = git_repository__shallow_roots(&array, repo);
+	ret = git_repository__shallow_roots(&array, repo);
 
 	git_oidarray__from_array(out, &array);
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -2477,7 +2477,7 @@ int git_repository_state_cleanup(git_repository *repo)
 	return git_repository__cleanup_files(repo, state_files, ARRAY_SIZE(state_files));
 }
 
-int git_repository_shallow_roots(git_oidarray *out, git_repository *repo)
+int git_repository__shallow_roots(git_array_oid_t *out, git_repository *repo)
 {
 	git_buf path = GIT_BUF_INIT;
 	git_buf contents = GIT_BUF_INIT;
@@ -2525,9 +2525,21 @@ int git_repository_shallow_roots(git_oidarray *out, git_repository *repo)
 		end++;
 	}
 
-	git_oidarray__from_array(out, &array);
+	*out = array;
 
-	return (out->count > 0 ? 0 : 1);
+	return (git_array_size(array) > 0 ? 0 : 1);
+}
+
+int git_repository_shallow_roots(git_oidarray *out, git_repository *repo)
+{
+	git_array_oid_t array;
+
+	int ret = git_repository__shallow_roots((out ? &array : NULL), repo);
+
+	if (out)
+		git_oidarray__from_array(out, &array);
+
+	return ret;
 }
 
 int git_repository_is_shallow(git_repository *repo)

--- a/src/repository.c
+++ b/src/repository.c
@@ -2506,10 +2506,10 @@ int git_repository__shallow_roots(git_array_oid_t *out, git_repository *repo)
 		if (contents.ptr[end] == '\n' || end == contents.size) {
 			if (end - start == GIT_OID_HEXSZ) {
 				git_oid *oid = git_array_alloc(repo->shallow_oids);
+
 				error = git_oid_fromstrn(oid, contents.ptr + start, GIT_OID_HEXSZ);
-				if (error < 0) {
-					/* TODO: Warn ? */
-				}
+				if (error < 0)
+					return error;
 			}
 			start = end + 1;
 		}

--- a/src/repository.c
+++ b/src/repository.c
@@ -2511,7 +2511,7 @@ int git_repository__shallow_roots(git_array_oid_t *out, git_repository *repo)
 		goto unchanged;
 	}
 
-	git_array_init(repo->shallow_oids);
+	git_array_clear(repo->shallow_oids);
 
 	start = end = 0;
 	while (end < contents.size) {

--- a/src/repository.h
+++ b/src/repository.h
@@ -22,6 +22,7 @@
 #include "attrcache.h"
 #include "submodule.h"
 #include "diff_driver.h"
+#include "oidarray.h"
 
 #define DOT_GIT ".git"
 #define GIT_DIR DOT_GIT "/"
@@ -211,5 +212,7 @@ extern size_t git_repository__reserved_names_posix_len;
  */
 bool git_repository__reserved_names(
 	git_buf **out, size_t *outlen, git_repository *repo, bool include_ntfs);
+
+int git_repository__shallow_roots(git_array_oid_t *out, git_repository *repo);
 
 #endif

--- a/src/repository.h
+++ b/src/repository.h
@@ -141,6 +141,9 @@ struct git_repository {
 
 	unsigned int lru_counter;
 
+	git_oid shallow_checksum;
+	git_array_oid_t shallow_oids;
+
 	git_atomic attr_session_key;
 
 	git_cvar_value cvar_cache[GIT_CVAR_CACHE_MAX];

--- a/tests/repo/shallow.c
+++ b/tests/repo/shallow.c
@@ -37,3 +37,15 @@ void test_repo_shallow__clears_errors(void)
 	cl_assert_equal_i(0, git_repository_is_shallow(g_repo));
 	cl_assert_equal_p(NULL, giterr_last());
 }
+
+void test_repo_shallow__shallow_oids(void)
+{
+	git_oidarray oids;
+	git_oid oid0;
+	g_repo = cl_git_sandbox_init("shallow.git");
+	cl_git_pass(git_oid_fromstr(&oid0, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
+
+	cl_git_pass(git_repository_shallow_roots(&oids, g_repo));
+	cl_assert_equal_i(1, oids.count);
+	cl_assert_equal_oid(&oid0, &oids.ids[0]);
+}

--- a/tests/repo/shallow.c
+++ b/tests/repo/shallow.c
@@ -52,3 +52,26 @@ void test_repo_shallow__shallow_oids(void)
 	cl_git_pass(git_repository_shallow_roots(&oids2, g_repo));
 	cl_assert_equal_p(oids.ids, oids2.ids);
 }
+
+void test_repo_shallow__cache_clearing(void)
+{
+	git_oidarray oids, oids2;
+	git_oid tmp_oid;
+
+	git_oid_fromstr(&tmp_oid, "0000000000000000000000000000000000000000");
+	g_repo = cl_git_sandbox_init("shallow.git");
+
+	cl_git_pass(git_repository_shallow_roots(&oids, g_repo));
+	cl_assert_equal_i(1, oids.count);
+	cl_assert_equal_oid(&g_shallow_oid, &oids.ids[0]);
+
+	cl_git_mkfile("shallow.git/shallow",
+		"be3563ae3f795b2b4353bcce3a527ad0a4f7f644\n"
+		"0000000000000000000000000000000000000000\n"
+	);
+
+	cl_git_pass(git_repository_shallow_roots(&oids2, g_repo));
+	cl_assert_equal_i(2, oids2.count);
+	cl_assert_equal_oid(&g_shallow_oid, &oids2.ids[0]);
+	cl_assert_equal_oid(&tmp_oid, &oids2.ids[1]);
+}

--- a/tests/repo/shallow.c
+++ b/tests/repo/shallow.c
@@ -75,3 +75,18 @@ void test_repo_shallow__cache_clearing(void)
 	cl_assert_equal_oid(&g_shallow_oid, &oids2.ids[0]);
 	cl_assert_equal_oid(&tmp_oid, &oids2.ids[1]);
 }
+
+void test_repo_shallow__errors_on_borked(void)
+{
+	git_oidarray oids;
+
+	g_repo = cl_git_sandbox_init("shallow.git");
+
+	cl_git_mkfile("shallow.git/shallow", "lolno");
+
+	cl_git_fail_with(git_repository_shallow_roots(&oids, g_repo), -1);
+
+	cl_git_mkfile("shallow.git/shallow", "lolno\n");
+
+	cl_git_fail_with(git_repository_shallow_roots(&oids, g_repo), -1);
+}

--- a/tests/repo/shallow.c
+++ b/tests/repo/shallow.c
@@ -2,9 +2,11 @@
 #include "fileops.h"
 
 static git_repository *g_repo;
+static git_oid g_shallow_oid;
 
 void test_repo_shallow__initialize(void)
 {
+	cl_git_pass(git_oid_fromstr(&g_shallow_oid, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
 }
 
 void test_repo_shallow__cleanup(void)
@@ -41,13 +43,11 @@ void test_repo_shallow__clears_errors(void)
 void test_repo_shallow__shallow_oids(void)
 {
 	git_oidarray oids, oids2;
-	git_oid oid0;
 	g_repo = cl_git_sandbox_init("shallow.git");
-	cl_git_pass(git_oid_fromstr(&oid0, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
 
 	cl_git_pass(git_repository_shallow_roots(&oids, g_repo));
 	cl_assert_equal_i(1, oids.count);
-	cl_assert_equal_oid(&oid0, &oids.ids[0]);
+	cl_assert_equal_oid(&g_shallow_oid, &oids.ids[0]);
 
 	cl_git_pass(git_repository_shallow_roots(&oids2, g_repo));
 	cl_assert_equal_p(oids.ids, oids2.ids);

--- a/tests/repo/shallow.c
+++ b/tests/repo/shallow.c
@@ -40,7 +40,7 @@ void test_repo_shallow__clears_errors(void)
 
 void test_repo_shallow__shallow_oids(void)
 {
-	git_oidarray oids;
+	git_oidarray oids, oids2;
 	git_oid oid0;
 	g_repo = cl_git_sandbox_init("shallow.git");
 	cl_git_pass(git_oid_fromstr(&oid0, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
@@ -48,4 +48,7 @@ void test_repo_shallow__shallow_oids(void)
 	cl_git_pass(git_repository_shallow_roots(&oids, g_repo));
 	cl_assert_equal_i(1, oids.count);
 	cl_assert_equal_oid(&oid0, &oids.ids[0]);
+
+	cl_git_pass(git_repository_shallow_roots(&oids2, g_repo));
+	cl_assert_equal_p(oids.ids, oids2.ids);
 }


### PR DESCRIPTION
This adds a helper function to grab the shallow OIDs, as right now there's only a yes/no check available.

I figured a way to get that info (even though our behavior might not be optimal) is a first step toward support.
