### PR TITLE
 Allow creating a remote without a repository

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Dmitry Kakurin
 Dmitry Kovega
 Emeric Fermas
 Emmanuel Rodriguez
+Eric Myhre
 Florian Forster
 Holger Weiss
 Ingmar Vanhassel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ v0.24 + 1
       `git_repository_open_ext` with this flag will error out if either
       `$GIT_WORK_TREE` or `$GIT_COMMON_DIR` is set.
 
+* `git_remote_create_anonymous2()` creates a remote that is not associated
+  to any repository (and does not apply configuration like 'insteadof' rules).
+  This is mostly useful for e.g. emulating `git ls-remote` behavior.
+
 ### API removals
 
 * `git_blob_create_fromchunks()` has been removed in favour of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ v0.24 + 1
       `git_repository_open_ext` with this flag will error out if either
       `$GIT_WORK_TREE` or `$GIT_COMMON_DIR` is set.
 
-* `git_remote_create_anonymous2()` creates a remote that is not associated
+* `git_remote_create_unattached()` creates a remote that is not associated
   to any repository (and does not apply configuration like 'insteadof' rules).
   This is mostly useful for e.g. emulating `git ls-remote` behavior.
 

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -78,16 +78,20 @@ GIT_EXTERN(int) git_remote_create_anonymous(
 		const char *url);
 
 /**
- * Create an anonymous remote, without a connected local repo
+ * Create a remote without a connected local repo
  *
  * Create a remote with the given url in-memory. You can use this when
  * you have a URL instead of a remote's name.
+ *
+ * Contrasted with git_remote_create_anonymous, an unattached remote
+ * will not consider any repo configuration values (such as insteadof url
+ * substitutions).
  *
  * @param out pointer to the new remote objects
  * @param url the remote repository's URL
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_remote_create_anonymous2(
+GIT_EXTERN(int) git_remote_create_unattached(
 		git_remote **out,
 		const char *url);
 

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -78,6 +78,20 @@ GIT_EXTERN(int) git_remote_create_anonymous(
 		const char *url);
 
 /**
+ * Create an anonymous remote, without a connected local repo
+ *
+ * Create a remote with the given url in-memory. You can use this when
+ * you have a URL instead of a remote's name.
+ *
+ * @param out pointer to the new remote objects
+ * @param url the remote repository's URL
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_remote_create_anonymous2(
+		git_remote **out,
+		const char *url);
+
+/**
  * Get the information for a particular remote
  *
  * The name will be checked for validity.

--- a/src/remote.c
+++ b/src/remote.c
@@ -197,10 +197,10 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 	git_buf var = GIT_BUF_INIT;
 	int error = -1;
 
-	/* name is optional */
-	assert(out && repo && url);
+	/* repo, name, and fetch are optional */
+	assert(out && url);
 
-	if ((error = git_repository_config__weakptr(&config, repo)) < 0)
+	if (repo && (error = git_repository_config__weakptr(&config, repo)) < 0)
 		return error;
 
 	remote = git__calloc(1, sizeof(git_remote));
@@ -212,7 +212,10 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 		(error = canonicalize_url(&canonical_url, url)) < 0)
 		goto on_error;
 
-	remote->url = apply_insteadof(repo->_config, canonical_url.ptr, GIT_DIRECTION_FETCH);
+	if (repo != NULL)
+		remote->url = apply_insteadof(repo->_config, canonical_url.ptr, GIT_DIRECTION_FETCH);
+	else
+		remote->url = git__strdup(canonical_url.ptr);
 
 	if (name != NULL) {
 		remote->name = git__strdup(name);
@@ -331,35 +334,9 @@ int git_remote_create_anonymous(git_remote **out, git_repository *repo, const ch
 	return create_internal(out, repo, NULL, url, NULL);
 }
 
-int git_remote_create_anonymous2(git_remote **out, const char *url)
+int git_remote_create_unattached(git_remote **out, const char *url)
 {
-	git_remote *remote;
-	git_buf canonical_url = GIT_BUF_INIT;
-	int error = -1;
-
-	assert(out && url);
-
-	remote = git__calloc(1, sizeof(git_remote));
-	GITERR_CHECK_ALLOC(remote);
-
-	if ((error = git_vector_init(&remote->refs, 32, NULL)) < 0 ||
-		(error = canonicalize_url(&canonical_url, url)) < 0)
-		goto on_error;
-
-	remote->url = git__strdup(canonical_url.ptr);
-
-	/* A remote without a name doesn't download tags */
-	remote->download_tags = GIT_REMOTE_DOWNLOAD_TAGS_NONE;
-
-	*out = remote;
-	error = 0;
-
-on_error:
-	if (error)
-		git_remote_free(remote);
-
-	git_buf_free(&canonical_url);
-	return error;
+	return create_internal(out, NULL, NULL, url, NULL);
 }
 
 int git_remote_dup(git_remote **dest, git_remote *source)

--- a/src/remote.c
+++ b/src/remote.c
@@ -331,6 +331,37 @@ int git_remote_create_anonymous(git_remote **out, git_repository *repo, const ch
 	return create_internal(out, repo, NULL, url, NULL);
 }
 
+int git_remote_create_anonymous2(git_remote **out, const char *url)
+{
+	git_remote *remote;
+	git_buf canonical_url = GIT_BUF_INIT;
+	int error = -1;
+
+	assert(out && url);
+
+	remote = git__calloc(1, sizeof(git_remote));
+	GITERR_CHECK_ALLOC(remote);
+
+	if ((error = git_vector_init(&remote->refs, 32, NULL)) < 0 ||
+		(error = canonicalize_url(&canonical_url, url)) < 0)
+		goto on_error;
+
+	remote->url = git__strdup(canonical_url.ptr);
+
+	/* A remote without a name doesn't download tags */
+	remote->download_tags = GIT_REMOTE_DOWNLOAD_TAGS_NONE;
+
+	*out = remote;
+	error = 0;
+
+on_error:
+	if (error)
+		git_remote_free(remote);
+
+	git_buf_free(&canonical_url);
+	return error;
+}
+
 int git_remote_dup(git_remote **dest, git_remote *source)
 {
 	size_t i;


### PR DESCRIPTION
This addresses #2923.

A new function `git_remote_create_anonymous2()` creates a remote, given only a url.  It behaves much like `git_remote_create_anonymous()`, but performs much _less_ work: it does not accept a repo param, it thus does not attempt to load any configuration or apply url rewriting rules.

WIP/RFC.  Dunno if this is a great solution; just took stab and this is the first place my code came to rest and, like, compiled.  Not a C expert, so I put on my party hat and figured I'd PR (read: ask for adult supervision) from here :)
