### PR TITLE
remote: Handle missing config values when deleting a remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ v0.24 + 1
   directory matching the starting directory will not prevent git from
   finding a repository in the starting directory or a parent directory.
 
+* Do not fail when deleting remotes in the presence of broken
+  global configs which contain branches.
+
 ### API additions
 
 * You can now get the user-agent used by libgit2 using the

--- a/src/remote.c
+++ b/src/remote.c
@@ -2162,15 +2162,21 @@ static int remove_branch_config_related_entries(
 		if (git_buf_printf(&buf, "branch.%.*s.merge", (int)branch_len, branch) < 0)
 			break;
 
-		if ((error = git_config_delete_entry(config, git_buf_cstr(&buf))) < 0)
-			break;
+		if ((error = git_config_delete_entry(config, git_buf_cstr(&buf))) < 0) {
+			if (error != GIT_ENOTFOUND)
+				break;
+			giterr_clear();
+		}
 
 		git_buf_clear(&buf);
 		if (git_buf_printf(&buf, "branch.%.*s.remote", (int)branch_len, branch) < 0)
 			break;
 
-		if ((error = git_config_delete_entry(config, git_buf_cstr(&buf))) < 0)
-			break;
+		if ((error = git_config_delete_entry(config, git_buf_cstr(&buf))) < 0) {
+			if (error != GIT_ENOTFOUND)
+				break;
+			giterr_clear();
+		}
 	}
 
 	if (error == GIT_ITEROVER)


### PR DESCRIPTION
Somehow I ended up with the following in my ~/.gitconfig:
[branch "master"]
remote = origin
merge = master
rebase = true

I assume something went crazy while I was running the git.git tests
some time ago, and that I never noticed until now.

This is not a good configuration, but it shouldn't cause problems. But
it does. Specifically, if you have this in your config, and you
perform the following set of actions:

create a remote
fetch from that remote
create a branch off of the remote master branch called "master"
delete the branch
delete the remote

The remote delete fails with the message "Could not find key
'branch.master.rebase' to delete". This is because it's iterating over
the config entries (including the ones in the global config) and
believes that there is a master branch which must therefore have these
config keys.

https://github.com/libgit2/libgit2/issues/3856