### PR TITLE
sysdir: don't assume an empty dir is uninitialized

### DIFF
--- a/src/sysdir.h
+++ b/src/sysdir.h
@@ -103,9 +103,4 @@ extern int git_sysdir_get_str(char *out, size_t outlen, git_sysdir_t which);
  */
 extern int git_sysdir_set(git_sysdir_t which, const char *paths);
 
-/**
- * Free the configuration file search paths.
- */
-extern void git_sysdir_global_shutdown(void);
-
 #endif /* INCLUDE_sysdir_h__ */


### PR DESCRIPTION
Don't assume that an empty system directory buffer is uninitialized.
In fact, there simply may be no appropriate path for that value.
(For example, the Windows-specific programdata directory has no value
on non-Windows machines.)

This prevents us from continually trying to re-lookup these values,
which could get racy if two different threads are each calling
`git_sysdir_get` and trying to lookup / clear the value simultaneously.

Fixes #3871 