### PR TITLE
git_diff_file: move `id_abbrev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ v0.24 + 1
 * `git_blob_create_fromchunks()` has been removed in favour of
   `git_blob_create_fromstream()`.
 
-
 ### Breaking API changes
 
 * `git_packbuilder_object_count` and `git_packbuilder_written` now
@@ -60,6 +59,9 @@ v0.24 + 1
 
 * `git_packbuiler_progress` now provides explicitly sized `uint32_t`
   values instead of `unsigned int`.
+
+* `git_diff_file` now includes an `id_abbrev` field that reflects the
+  number of nibbles set in the `id` field.
 
 v0.24
 -------

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -268,11 +268,6 @@ typedef enum {
  * absent side of a diff (e.g. the `old_file` of a `GIT_DELTA_ADDED` delta),
  * then the oid will be zeroes.
  *
- * The `id_abbrev` represents the known length of the `id` field, when
- * converted to a hex string.  It is generally `GIT_OID_HEXSZ`, unless this
- * delta was created from reading a patch file, in which case it may be
- * abbreviated to something reasonable, like 7 characters.
- *
  * `path` is the NUL-terminated path to the entry relative to the working
  * directory of the repository.
  *
@@ -282,14 +277,19 @@ typedef enum {
  *
  * `mode` is, roughly, the stat() `st_mode` value for the item.  This will
  * be restricted to one of the `git_filemode_t` values.
+ *
+ * The `id_abbrev` represents the known length of the `id` field, when
+ * converted to a hex string.  It is generally `GIT_OID_HEXSZ`, unless this
+ * delta was created from reading a patch file, in which case it may be
+ * abbreviated to something reasonable, like 7 characters.
  */
 typedef struct {
 	git_oid     id;
-	int         id_abbrev;
 	const char *path;
 	git_off_t   size;
 	uint32_t    flags;
 	uint16_t    mode;
+	uint16_t    id_abbrev;
 } git_diff_file;
 
 /**

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -192,7 +192,7 @@ static int parse_header_mode(uint16_t *mode, git_patch_parse_ctx *ctx)
 
 static int parse_header_oid(
 	git_oid *oid,
-	int *oid_len,
+	uint16_t *oid_len,
 	git_patch_parse_ctx *ctx)
 {
 	size_t len;
@@ -202,14 +202,14 @@ static int parse_header_oid(
 			break;
 	}
 
-	if (len < GIT_OID_MINPREFIXLEN ||
+	if (len < GIT_OID_MINPREFIXLEN || len > GIT_OID_HEXSZ ||
 		git_oid_fromstrn(oid, ctx->line, len) < 0)
 		return parse_err("invalid hex formatted object id at line %d",
 			ctx->line_num);
 
 	parse_advance_chars(ctx, len);
 
-	*oid_len = (int)len;
+	*oid_len = (uint16_t)len;
 
 	return 0;
 }


### PR DESCRIPTION
Move `id_abbrev` to a more reasonable place where it packs more nicely, and it matches the size of `id_abbrev` in `git_diff_options`.  Do this before the next release before anybody starts using it.