### PR TITLE
clar: fix parsing of test suite prefixes

### DIFF
--- a/tests/clar.c
+++ b/tests/clar.c
@@ -340,6 +340,12 @@ clar_parse_args(int argc, char **argv)
 				if (strncmp(argument, _clar_suites[j].name, cmplen) == 0) {
 					int exact = (arglen >= suitelen);
 
+					/* Do we have a real suite prefix separated by a
+					 * trailing '::' or just a matching substring? */
+					if (arglen > suitelen && (argument[suitelen] != ':'
+						    || argument[suitelen + 1] != ':'))
+					    continue;
+
 					++found;
 
 					if (!exact)


### PR DESCRIPTION
When passing in a specific suite which should be executed by clar
via `-stest::suite`, we try to parse this string and then include
all tests contained in this suite. This also includes all tests
in sub-suites, e.g. 'test::suite::foo'.

In the case where multiple suites start with the same _string_,
for example 'test::foo' and 'test::foobar', we fail to
distinguish this correctly. When passing in `-stest::foobar`,
we wrongly determine that 'test::foo' is a prefix and try to
execute all of its matching functions. But as no function
will now match 'test::foobar', we simply execute nothing.

To fix this, we instead have to check if the prefix is an actual
suite prefix as opposed to a simple string prefix. We do so by by
inspecting if the first two characters trailing the prefix are
our suite delimiters '::', and only consider the filter as
matching in this case.