### PR TITLE
Use a temporary variable for that test

### DIFF
--- a/tests/refs/iterator.c
+++ b/tests/refs/iterator.c
@@ -192,12 +192,12 @@ void test_refs_iterator__concurrent_delete(void)
 	git_reference_iterator *iter;
 	size_t full_count = 0, concurrent_count = 0;
 	const char *name;
+	git_repository *tmp_repo;
 	int error;
 
-	git_repository_free(repo);
-	repo = cl_git_sandbox_init("testrepo");
+	tmp_repo = cl_git_sandbox_init("testrepo");
 
-	cl_git_pass(git_reference_iterator_new(&iter, repo));
+	cl_git_pass(git_reference_iterator_new(&iter, tmp_repo));
 	while ((error = git_reference_next_name(&name, iter)) == 0) {
 		full_count++;
 	}
@@ -205,9 +205,9 @@ void test_refs_iterator__concurrent_delete(void)
 	git_reference_iterator_free(iter);
 	cl_assert_equal_i(GIT_ITEROVER, error);
 
-	cl_git_pass(git_reference_iterator_new(&iter, repo));
+	cl_git_pass(git_reference_iterator_new(&iter, tmp_repo));
 	while ((error = git_reference_next_name(&name, iter)) == 0) {
-		cl_git_pass(git_reference_remove(repo, name));
+		cl_git_pass(git_reference_remove(tmp_repo, name));
 		concurrent_count++;
 	}
 
@@ -217,5 +217,4 @@ void test_refs_iterator__concurrent_delete(void)
 	cl_assert_equal_i(full_count, concurrent_count);
 
 	cl_git_sandbox_cleanup();
-	repo = NULL;
 }


### PR DESCRIPTION
I'll let ASAN speak for me here. That fix might be completely wrong, and it's expected to be able to run with both instances at the same time, but here I consistently get a failure when running the full test suite.

```
==25948==ERROR: AddressSanitizer: heap-use-after-free on address 0x614000003260 at pc 0x0001000520c5 bp 0x7fff5fbff4a0 sp 0x7fff5fbff498
READ of size 8 at 0x614000003260 thread T0
    #0 0x1000520c4 in clear_cache cache.c:84
    #1 0x10005205f in git_cache_clear cache.c:101
    #2 0x1002527b0 in git_repository__cleanup repository.c:112
    #3 0x100252bb7 in git_repository_free repository.c:128
    #4 0x1005c72ef in test_refs_iterator__cleanup iterator.c:14
    #5 0x10037f14f in clar_run_test clar.c:232
    #6 0x10037abf1 in clar_run_suite clar.c:286
    #7 0x100379f97 in clar_test_run clar.c:420
    #8 0x1004f37a8 in main main.c:19
    #9 0x7fff956995ac in start (libdyld.dylib+0x35ac)
    #10 0x0  (+0x0)

0x614000003260 is located 32 bytes inside of 448-byte region [0x614000003240,0x614000003400)
freed by thread T0 here:
    #0 0x100e96b89 in wrap_free (libclang_rt.asan_osx_dynamic.dylib+0x48b89)
    #1 0x100253074 in git__free util.h:246
    #2 0x10025304f in git_repository_free repository.c:147
    #3 0x1005c8b59 in test_refs_iterator__concurrent_delete iterator.c:197
    #4 0x10037f074 in clar_run_test clar.c:222
    #5 0x10037abf1 in clar_run_suite clar.c:286
    #6 0x100379f97 in clar_test_run clar.c:420
    #7 0x1004f37a8 in main main.c:19
    #8 0x7fff956995ac in start (libdyld.dylib+0x35ac)
    #9 0x0  (+0x0)

previously allocated by thread T0 here:
    #0 0x100e96f27 in wrap_calloc (libclang_rt.asan_osx_dynamic.dylib+0x48f27)
    #1 0x100262ffc in git__calloc util.h:169
    #2 0x10025321a in repository_alloc repository.c:173
    #3 0x100253b8f in git_repository_open_ext repository.c:692
    #4 0x100256ab5 in git_repository_open repository.c:739
    #5 0x1005c72a7 in test_refs_iterator__initialize iterator.c:9
    #6 0x10037f001 in clar_run_test clar.c:219
    #7 0x10037abf1 in clar_run_suite clar.c:286
    #8 0x100379f97 in clar_test_run clar.c:420
    #9 0x1004f37a8 in main main.c:19
    #10 0x7fff956995ac in start (libdyld.dylib+0x35ac)
    #11 0x0  (+0x0)

SUMMARY: AddressSanitizer: heap-use-after-free cache.c:84 in clear_cache
Shadow bytes around the buggy address:
  0x1c28000005f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa
  0x1c2800000600: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x1c2800000610: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2800000620: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2800000630: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x1c2800000640: fa fa fa fa fa fa fa fa fd fd fd fd[fd]fd fd fd
  0x1c2800000650: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2800000660: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2800000670: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c2800000680: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x1c2800000690: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==25948==ABORTING
```