### PR TITLE
SecureTransport: handle NULL trust on success

### DIFF
--- a/src/stransport_stream.c
+++ b/src/stransport_stream.c
@@ -67,6 +67,9 @@ int stransport_connect(git_stream *stream)
 	if ((ret = SSLCopyPeerTrust(st->ctx, &trust)) != noErr)
 		goto on_error;
 
+	if (!trust)
+		return GIT_ECERTIFICATE;
+
 	if ((ret = SecTrustEvaluate(trust, &sec_res)) != noErr)
 		goto on_error;
 


### PR DESCRIPTION
The `SSLCopyPeerTrust` call can succeed but fail to return a trust
object if it can't load the certificate chain and thus cannot check the
validity of a certificate. This can lead to us calling `CFRelease` on a
`NULL` trust object, causing a crash.

Handle this by returning ECERTIFICATE.

This may or may not solve #3885 /cc @the-kenny