### PR TITLE
Don't normalise symbolic ref target

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -402,12 +402,7 @@ static int reference__create(
 
 		ref = git_reference__alloc(normalized, oid, NULL);
 	} else {
-		git_refname_t normalized_target;
-
-		if ((error = reference_normalize_for_repo(normalized_target, repo, symbolic)) < 0)
-			return error;
-
-		ref = git_reference__alloc_symbolic(normalized, normalized_target);
+		ref = git_reference__alloc_symbolic(normalized, symbolic);
 	}
 
 	GITERR_CHECK_ALLOC(ref);


### PR DESCRIPTION
git-symbolic-ref(1) allows creation of symbolic refs whose target is
not a valid ref name.

So
    $ git symbolic-ref refs/heads/foo bar
	$ cat .git/refs/heads/foo
	ref: bar

where as attempting the same via libgit2 raises an error:
`The given reference name 'bar' is not valid`