### PR TITLE
Use a shared buffer in calls of git_treebuilder_write to avoid heap contention

### DIFF
--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -375,6 +375,19 @@ GIT_EXTERN(void) git_treebuilder_filter(
 GIT_EXTERN(int) git_treebuilder_write(
 	git_oid *id, git_treebuilder *bld);
 
+/**
+ * Write the contents of the tree builder as a tree object
+ * using a shared git_buf.
+ *
+ * @see git_treebuilder_write
+ *
+ * @param id Pointer to store the OID of the newly written tree
+ * @param bld Tree builder to write
+ * @param tree Shared buffer for writing the tree. Will be grown as necessary.
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_treebuilder_write_with_buffer(
+	git_oid *oid, git_treebuilder *bld, git_buf *tree);
 
 /** Callback for the tree traversal method */
 typedef int (*git_treewalk_cb)(


### PR DESCRIPTION
When doing many merges in parallel in a large repository, we saw performance degrade rapidly due to memory allocations in git_treebuilder_write. This change uses a shared buffer created in git_tree__write_index to avoid the small allocation per tree in git_treebuilder_write.

In our tests against that repository we saw improvements of ~50% in merges under heavy load.
