### PR TITLE
Fix - Negation of rules

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -170,10 +170,6 @@ static int parse_ignore_file(
 
 			scan = git__next_line(scan);
 
-			/* if a negative match doesn't actually do anything, throw it away */
-			if (match->flags & GIT_ATTR_FNMATCH_NEGATIVE)
-				error = does_negate_rule(&valid_rule, &attrs->rules, match);
-
 			if (!error && valid_rule)
 				error = git_vector_insert(&attrs->rules, match);
 		}
@@ -580,4 +576,3 @@ int git_ignore__check_pathspec_for_exact_ignores(
 
 	return error;
 }
-

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -291,3 +291,24 @@ void test_attr_ignore__symlink_to_outside(void)
 	assert_is_ignored(true, "symlink");
 	assert_is_ignored(true, "lala/../symlink");
 }
+
+void test_attr_ignore__dont_ignore_not_path(void)
+{
+    /* Create gitignore */
+    cl_git_rmfile("attr/.gitignore");
+  	cl_git_mkfile("attr/.gitignore", "test\n!dir1/test\n");
+
+    /* Create directory structure */
+    cl_must_pass(p_mkdir("attr/dir1", 0777));
+    cl_must_pass(p_mkdir("attr/dir2", 0777));
+
+    /* Add files */
+    cl_git_mkfile("attr/dir1/test", "test/\n");
+    cl_git_mkfile("attr/test", "test/\n");
+    cl_git_mkfile("attr/dir2/test", "test/\n");
+
+    /* Check test file is ignored depending on parent directory */
+    assert_is_ignored(true, "test");
+    assert_is_ignored(false, "dir1/test");
+    assert_is_ignored(true, "dir2/test");
+}


### PR DESCRIPTION
Currently, negative rules are thrown away if they do not affect a rule before.
This change adds a test which failed before but works now that we no longer
throw away negative rules.

I have tried to prove this with tests but I think more are required to cover this.