### PR TITLE
ignore: allow unignoring basenames in subdirectories

### DIFF
--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -945,6 +945,44 @@ void test_status_ignore__negative_directory_ignores(void)
 	assert_is_ignored("padded_parent/child8/bar.txt");
 }
 
+void test_status_ignore__unignore_entry_in_ignored_dir(void)
+{
+	static const char *test_files[] = {
+		"empty_standard_repo/bar.txt",
+		"empty_standard_repo/parent/bar.txt",
+		"empty_standard_repo/parent/child/bar.txt",
+		"empty_standard_repo/nested/parent/child/bar.txt",
+		NULL
+	};
+
+	make_test_data("empty_standard_repo", test_files);
+	cl_git_mkfile(
+		"empty_standard_repo/.gitignore",
+		"bar.txt\n"
+		"!parent/child/bar.txt\n");
+
+	assert_is_ignored("bar.txt");
+	assert_is_ignored("parent/bar.txt");
+	refute_is_ignored("parent/child/bar.txt");
+	assert_is_ignored("nested/parent/child/bar.txt");
+}
+
+void test_status_ignore__do_not_unignore_basename_prefix(void)
+{
+	static const char *test_files[] = {
+		"empty_standard_repo/foo_bar.txt",
+		NULL
+	};
+
+	make_test_data("empty_standard_repo", test_files);
+	cl_git_mkfile(
+		"empty_standard_repo/.gitignore",
+		"foo_bar.txt\n"
+		"!bar.txt\n");
+
+	assert_is_ignored("foo_bar.txt");
+}
+
 void test_status_ignore__filename_with_cr(void)
 {
 	int ignored;


### PR DESCRIPTION
The .gitignore file allows for patterns which unignore previous
ignore patterns. When unignoring a previous pattern, there are
basically three cases how this is matched when no globbing is
used:

1. when a previous file has been ignored, it can be unignored by
   using its exact name, e.g.

   foo/bar
   !foo/bar

2. when a file in a subdirectory has been ignored, it can be
   unignored by using its basename, e.g.

   foo/bar
   !bar

3. when all files with a basename are ignored, a specific file
   can be unignored again by specifying its path in a
   subdirectory, e.g.

   bar
   !foo/bar

The first problem in libgit2 is that we did not correctly treat
the second case. While we verified that the negative pattern
matches the tail of the positive one, we did not verify if it
only matches the basename of the positive pattern. So e.g. we
would have also negated a pattern like

    foo/fruz_bar
    !bar

Furthermore, we did not check for the third case, where a
basename is being unignored in a certain subdirectory again.

Both issues are fixed with this commit.