### PR TITLE
transports: http: set substream as disconnected after closing

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -599,6 +599,7 @@ static int http_connect(http_subtransport *t)
 		git_stream_close(t->io);
 		git_stream_free(t->io);
 		t->io = NULL;
+		t->connected = 0;
 	}
 
 	if (t->connection_data.use_ssl) {

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -1036,6 +1036,8 @@ static int http_close(git_smart_subtransport *subtransport)
 
 	clear_parser_state(t);
 
+	t->connected = 0;
+
 	if (t->io) {
 		git_stream_close(t->io);
 		git_stream_free(t->io);


### PR DESCRIPTION
When calling `http_connect` on a subtransport whose stream is already
connected, we first close the stream in case no keep-alive is in use.
When doing so, we do not reset the transport's connection state,
though. Usually, this will do no harm in case the subsequent connect
will succeed. But when the connection fails we are left with a
substransport which is tagged as connected but which has no valid
stream attached.

Fix the issue by resetting the subtransport's connected-state when
closing its stream in `http_connect`.