### PR TITLE
Teach `git_patch_from_diff` about parsed diffs

### DIFF
--- a/src/diff.h
+++ b/src/diff.h
@@ -8,6 +8,7 @@
 #define INCLUDE_diff_h__
 
 #include "git2/diff.h"
+#include "git2/patch.h"
 #include "git2/sys/diff.h"
 #include "git2/oid.h"
 
@@ -44,6 +45,7 @@ struct git_diff {
 	int (*pfxcomp)(const char *str, const char *pfx);
 	int (*entrycomp)(const void *a, const void *b);
 
+	int (*patch_fn)(git_patch **out, git_diff *diff, size_t idx);
 	void (*free_fn)(git_diff *diff);
 };
 

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "diff.h"
 #include "diff_generate.h"
+#include "patch_generate.h"
 #include "fileops.h"
 #include "config.h"
 #include "attr_file.h"
@@ -414,6 +415,7 @@ static git_diff_generated *diff_generated_alloc(
 	diff->base.repo = repo;
 	diff->base.old_src = old_iter->type;
 	diff->base.new_src = new_iter->type;
+	diff->base.patch_fn = git_patch_generated_from_diff;
 	diff->base.free_fn = diff_generated_free;
 	memcpy(&diff->base.opts, &dflt, sizeof(git_diff_options));
 

--- a/src/diff_parse.c
+++ b/src/diff_parse.c
@@ -6,14 +6,9 @@
  */
 #include "common.h"
 #include "diff.h"
+#include "diff_parse.h"
 #include "patch.h"
 #include "patch_parse.h"
-
-typedef struct {
-	struct git_diff base;
-
-	git_vector patches;
-} git_diff_parsed;
 
 static void diff_parsed_free(git_diff *d)
 {
@@ -47,6 +42,7 @@ static git_diff_parsed *diff_parsed_alloc(void)
 	diff->base.strncomp = git__strncmp;
 	diff->base.pfxcomp = git__prefixcmp;
 	diff->base.entrycomp = git_diff__entry_cmp;
+	diff->base.patch_fn = git_patch_parsed_from_diff;
 	diff->base.free_fn = diff_parsed_free;
 
 	git_pool_init(&diff->base.pool, 1);

--- a/src/diff_parse.h
+++ b/src/diff_parse.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_diff_parse_h__
+#define INCLUDE_diff_parse_h__
+
+#include "diff.h"
+
+typedef struct {
+	struct git_diff base;
+
+	git_vector patches;
+} git_diff_parsed;
+
+#endif

--- a/src/patch.c
+++ b/src/patch.c
@@ -194,6 +194,12 @@ int git_patch_get_line_in_hunk(
 	return 0;
 }
 
+int git_patch_from_diff(git_patch **out, git_diff *diff, size_t idx)
+{
+	assert(out && diff && diff->patch_fn);
+	return diff->patch_fn(out, diff, idx);
+}
+
 static void git_patch__free(git_patch *patch)
 {
 	if (patch->free_fn)

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -746,7 +746,7 @@ int git_patch_from_buffers(
 	return patch_from_sources(out, &osrc, &nsrc, opts);
 }
 
-int git_patch_from_diff(
+int git_patch_generated_from_diff(
 	git_patch **patch_ptr, git_diff *diff, size_t idx)
 {
 	int error = 0;

--- a/src/patch_generate.h
+++ b/src/patch_generate.h
@@ -42,6 +42,8 @@ extern void git_patch_generated_old_data(
 	char **, size_t *, git_patch_generated *);
 extern void git_patch_generated_new_data(
 	char **, size_t *, git_patch_generated *);
+extern int git_patch_generated_from_diff(
+	git_patch **, git_diff *, size_t);
 
 typedef struct git_patch_generated_output git_patch_generated_output;
 

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -7,6 +7,7 @@
 #include "git2/patch.h"
 #include "patch.h"
 #include "patch_parse.h"
+#include "diff_parse.h"
 #include "path.h"
 
 #define parse_err(...) \
@@ -1023,6 +1024,20 @@ static void patch_parse_ctx_free(git_patch_parse_ctx *ctx)
 void git_patch_parse_ctx_free(git_patch_parse_ctx *ctx)
 {
 	GIT_REFCOUNT_DEC(ctx, patch_parse_ctx_free);
+}
+
+int git_patch_parsed_from_diff(git_patch **out, git_diff *d, size_t idx)
+{
+	git_diff_parsed *diff = (git_diff_parsed *)d;
+	git_patch *p;
+
+	if ((p = git_vector_get(&diff->patches, idx)) == NULL)
+		return -1;
+
+	GIT_REFCOUNT_INC(p);
+	*out = p;
+
+	return 0;
 }
 
 static void patch_parsed__free(git_patch *p)

--- a/src/patch_parse.h
+++ b/src/patch_parse.h
@@ -51,4 +51,6 @@ extern int git_patch_parse(
 	git_patch **out,
 	git_patch_parse_ctx *ctx);
 
+extern int git_patch_parsed_from_diff(git_patch **, git_diff *, size_t);
+
 #endif


### PR DESCRIPTION
Ensure that `git_patch_from_diff` can return the patch for parsed diffs,
not just generate a patch for a generated diff.