### PR TITLE
Make symbolic ref target validation optional

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -157,6 +157,7 @@ typedef enum {
 	GIT_OPT_SET_SSL_CERT_LOCATIONS,
 	GIT_OPT_SET_USER_AGENT,
 	GIT_OPT_ENABLE_STRICT_OBJECT_CREATION,
+	GIT_OPT_ENABLE_SYMBOLIC_REF_TARGET_VALIDATION,
 	GIT_OPT_SET_SSL_CIPHERS,
 	GIT_OPT_GET_USER_AGENT,
 } git_libgit2_opt_t;
@@ -270,6 +271,18 @@ typedef enum {
  *		> example, when this is enabled, the parent(s) and tree inputs
  *		> will be validated when creating a new commit.  This defaults
  *		> to disabled.
+ *
+ *	* opts(GIT_OPT_ENABLE_SYMBOLIC_REF_TARGET_VALIDATION, int enabled)
+ *
+ *		> Validate the target of a symbolic ref when creating it.
+ *		> For example, 'foobar' is not a valid ref,
+ *		> therefore 'foobar' is not a valid target
+ *		> for a symbolic ref by default,
+ *		> where as 'refs/heads/foobar' is.
+ *		> Disabling this bypasses validation so that an arbitrary
+ *		> strings such as 'foobar' can be used for a symbolic ref target.
+ *		> This defaults to enabled.
+ *
  *	* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)
  *
  *		> Set the SSL ciphers use for HTTPS connections.

--- a/src/refs.h
+++ b/src/refs.h
@@ -15,6 +15,8 @@
 #include "buffer.h"
 #include "oid.h"
 
+extern bool git_reference__enable_symbolic_ref_target_validation;
+
 #define GIT_REFS_DIR "refs/"
 #define GIT_REFS_HEADS_DIR GIT_REFS_DIR "heads/"
 #define GIT_REFS_TAGS_DIR GIT_REFS_DIR "tags/"
@@ -53,6 +55,7 @@
 #define GIT_REFS_STASH_FILE GIT_REFS_DIR GIT_STASH_FILE
 
 #define GIT_REF_FORMAT__PRECOMPOSE_UNICODE	(1u << 16)
+#define GIT_REF_VALIDATION_DISABLE	(1u << 15)
 
 #define GIT_REFNAME_MAX 1024
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -15,6 +15,7 @@
 #include "cache.h"
 #include "global.h"
 #include "object.h"
+#include "refs.h"
 
 void git_libgit2_version(int *major, int *minor, int *rev)
 {
@@ -189,6 +190,10 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_ENABLE_STRICT_OBJECT_CREATION:
 		git_object__strict_input_validation = (va_arg(ap, int) != 0);
+		break;
+
+	case GIT_OPT_ENABLE_SYMBOLIC_REF_TARGET_VALIDATION:
+		git_reference__enable_symbolic_ref_target_validation = (va_arg(ap, int) != 0);
 		break;
 
 	case GIT_OPT_SET_SSL_CIPHERS:


### PR DESCRIPTION
Introduce GIT_OPT_ENABLE_SYMBOLIC_REF_TARGET_VALIDATION option.
Setting this option to 0 allows
validation of a symbolic ref's target to be bypassed.
This option is enabled by default.

This mechanism is added primarily to address a discrepancy between git
behaviour and libgit2 behaviour, whereby the former allows the symbolic
ref target to carry an arbitrary string and the latter does not, so:

```
$ git symbolic-ref refs/heads/foo bar
$ cat .git/refs/heads/foo
ref: bar
```

where as attempting the same via libgit2 raises an error:

```
The given reference name 'bar' is not valid
```

this mechanism also allows those that might want to make use of
git's more lenient treatment of symbolic ref targets to do so.
