### PR TITLE
time: Export `git_time_monotonic`

### DIFF
--- a/include/git2/sys/time.h
+++ b/include/git2/sys/time.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_time_h__
+#define INCLUDE_git_time_h__
+
+#include "git2/common.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * Return a monotonic time value, useful for measuring running time
+ * and setting up timeouts.
+ *
+ * The returned value is an arbitrary point in time -- it can only be
+ * used when comparing it to another `git_time_monotonic` call.
+ *
+ * The time is returned in seconds, with a decimal fraction that differs
+ * on accuracy based on the underlying system, but should be least
+ * accurate to Nanoseconds.
+ *
+ * This function cannot fail.
+ */
+GIT_EXTERN(double) git_time_monotonic(void);
+
+GIT_END_DECL
+#endif
+

--- a/src/util.c
+++ b/src/util.c
@@ -783,6 +783,11 @@ int git__utf8_iterate(const uint8_t *str, int str_len, int32_t *dst)
 	return length;
 }
 
+double git_time_monotonic(void)
+{
+	return git__timer();
+}
+
 #ifdef GIT_WIN32
 int git__getenv(git_buf *out, const char *name)
 {


### PR DESCRIPTION
This will allow libgit2 wrappers like Rugged to implement their own custom timeout logic while reusing the work we've already done in libgit2 to provide cross-platform, accurate monotonic timers.

See: https://github.com/libgit2/rugged/pull/631

cc @brianmario @mclark @ethomson @carlosmn 