### PR TITLE
checkout: don't try to calculate oid for directories

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -212,6 +212,10 @@ static bool checkout_is_workdir_modified(
 	if (baseitem->size && wditem->file_size != baseitem->size)
 		return true;
 
+	/* if the workdir item is a directory, it cannot be a modified file */
+	if (S_ISDIR(wditem->mode))
+		return false;
+
 	if (git_diff__oid_for_entry(&oid, data->diff, wditem, wditem->mode, NULL) < 0)
 		return false;
 


### PR DESCRIPTION
When trying to determine if we can safely overwrite an existing workdir item, we may need to calculate the oid for the workdir item to determine if its identical to the old side (and eligible for removal).

We previously did this regardless of the type of entry in the workdir; if it was a directory, we would open(2) it and then try to read(2).  The read(2) of a directory fails on many platforms, so we would treat it as if it were unmodified and continue to perform the checkout.

On FreeBSD, you _can_ read(2) a directory, so this pattern failed.  We would calculate an oid from the data read and determine that the directory was modified and would therefore generate a checkout conflict.

This reliance on read(2) is silly (and was most likely accidentally giving us the behavior we wanted), we should be explicit about the directory test.

Fixes #3911 