### PR TITLE
MinGW m32 vsnprintf compatibility

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -524,7 +524,7 @@ char *p_realpath(const char *orig_path, char *buffer)
 
 int p_vsnprintf(char *buffer, size_t count, const char *format, va_list argptr)
 {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || !_WIN64
 	int len;
 
 	if (count == 0)


### PR DESCRIPTION
https://ffmpeg.org/pipermail/ffmpeg-cvslog/2012-September/054932.html

MinGW m32 environment has broken vsnprintf. It needs same work around with MSVC.
