### PR TITLE
docs: GIT_OPT_ENABLE_STRICT_OBJECT_CREATION is enabled

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -269,7 +269,8 @@ typedef enum {
  *		> to ensure that all inputs to the new objects are valid.  For
  *		> example, when this is enabled, the parent(s) and tree inputs
  *		> will be validated when creating a new commit.  This defaults
- *		> to disabled.
+ *		> to enabled.
+ *
  *	* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)
  *
  *		> Set the SSL ciphers use for HTTPS connections.


### PR DESCRIPTION
We changed the defaults on strict object creation - it is enabled by default.  Update the documentation to reflect that.