### PR TITLE
Fix UTF-16 to UTF-8 issue in Windows XP

### DIFF
--- a/src/win32/utf-conv.c
+++ b/src/win32/utf-conv.c
@@ -25,14 +25,14 @@ GIT_INLINE(void) git__set_errno(void)
 */
 DWORD git__get_utf6_to_8_flags()
 {
-    DWORD flags = 0;
-    
-    /* The WC_ERR_INVALID_CHARS flag is only usable on Windows Vista or later. On Windows XP, using this
-     * flag when calling WideStringToMultiByte causes the function to fail with ERROR_INVALID_FLAGS */
-    if (IsWindowsVistaOrGreater())
-        flags = WC_ERR_INVALID_CHARS;
+	DWORD flags = 0;
+	
+	/* The WC_ERR_INVALID_CHARS flag is only usable on Windows Vista or later. On Windows XP, using this
+	 * flag when calling WideStringToMultiByte causes the function to fail with ERROR_INVALID_FLAGS */
+	if (IsWindowsVistaOrGreater())
+		flags = WC_ERR_INVALID_CHARS;
 
-    return flags;
+	return flags;
 }
 
 /**
@@ -71,8 +71,8 @@ int git__utf16_to_8(char *dest, size_t dest_size, const wchar_t *src)
 	/* Length of -1 indicates NULL termination of the input string. Subtract 1 from the result to
 	 * turn 0 into -1 (an error code) and to not count the NULL terminator as part of the string's
 	 * length. WideCharToMultiByte never returns int's minvalue, so underflow is not possible */
-    DWORD flags = git__get_utf6_to_8_flags();
-    if ((len = WideCharToMultiByte(CP_UTF8, flags, src, -1, dest, (int)dest_size, NULL, NULL) - 1) < 0)
+	DWORD flags = git__get_utf6_to_8_flags();
+	if ((len = WideCharToMultiByte(CP_UTF8, flags, src, -1, dest, (int)dest_size, NULL, NULL) - 1) < 0)
 		git__set_errno();
 
 	return len;
@@ -133,12 +133,12 @@ int git__utf8_to_16_alloc(wchar_t **dest, const char *src)
 int git__utf16_to_8_alloc(char **dest, const wchar_t *src)
 {
 	int utf8_size;
-    DWORD flags = git__get_utf6_to_8_flags();
+	DWORD flags = git__get_utf6_to_8_flags();
 
 	*dest = NULL;
 
 	/* Length of -1 indicates NULL termination of the input string */
-    utf8_size = WideCharToMultiByte(CP_UTF8, flags, src, -1, NULL, 0, NULL, NULL);
+	utf8_size = WideCharToMultiByte(CP_UTF8, flags, src, -1, NULL, 0, NULL, NULL);
 
 	if (!utf8_size) {
 		git__set_errno();
@@ -152,7 +152,7 @@ int git__utf16_to_8_alloc(char **dest, const wchar_t *src)
 		return -1;
 	}
 
-    utf8_size = WideCharToMultiByte(CP_UTF8, flags, src, -1, *dest, utf8_size, NULL, NULL);
+	utf8_size = WideCharToMultiByte(CP_UTF8, flags, src, -1, *dest, utf8_size, NULL, NULL);
 
 	if (!utf8_size) {
 		git__set_errno();

--- a/src/win32/utf-conv.c
+++ b/src/win32/utf-conv.c
@@ -8,12 +8,31 @@
 #include "common.h"
 #include "utf-conv.h"
 
+#include "VersionHelpers.h"
+
 GIT_INLINE(void) git__set_errno(void)
 {
 	if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
 		errno = ENAMETOOLONG;
 	else
 		errno = EINVAL;
+}
+
+/**
+* Gets the conversion flags to convert a wide string to UTF-8.
+*
+* @return The dwFlags argument that should be used when calling WideStringToMultiByte.
+*/
+DWORD git__get_utf6_to_8_flags()
+{
+    DWORD flags = 0;
+    
+    /* The WC_ERR_INVALID_CHARS flag is only usable on Windows Vista or later. On Windows XP, using this
+     * flag when calling WideStringToMultiByte causes the function to fail with ERROR_INVALID_FLAGS */
+    if (IsWindowsVistaOrGreater())
+        flags = WC_ERR_INVALID_CHARS;
+
+    return flags;
 }
 
 /**
@@ -52,7 +71,8 @@ int git__utf16_to_8(char *dest, size_t dest_size, const wchar_t *src)
 	/* Length of -1 indicates NULL termination of the input string. Subtract 1 from the result to
 	 * turn 0 into -1 (an error code) and to not count the NULL terminator as part of the string's
 	 * length. WideCharToMultiByte never returns int's minvalue, so underflow is not possible */
-	if ((len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, src, -1, dest, (int)dest_size, NULL, NULL) - 1) < 0)
+    DWORD flags = git__get_utf6_to_8_flags();
+    if ((len = WideCharToMultiByte(CP_UTF8, flags, src, -1, dest, (int)dest_size, NULL, NULL) - 1) < 0)
 		git__set_errno();
 
 	return len;
@@ -113,11 +133,12 @@ int git__utf8_to_16_alloc(wchar_t **dest, const char *src)
 int git__utf16_to_8_alloc(char **dest, const wchar_t *src)
 {
 	int utf8_size;
+    DWORD flags = git__get_utf6_to_8_flags();
 
 	*dest = NULL;
 
 	/* Length of -1 indicates NULL termination of the input string */
-	utf8_size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, src, -1, NULL, 0, NULL, NULL);
+    utf8_size = WideCharToMultiByte(CP_UTF8, flags, src, -1, NULL, 0, NULL, NULL);
 
 	if (!utf8_size) {
 		git__set_errno();
@@ -131,7 +152,7 @@ int git__utf16_to_8_alloc(char **dest, const wchar_t *src)
 		return -1;
 	}
 
-	utf8_size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, src, -1, *dest, utf8_size, NULL, NULL);
+    utf8_size = WideCharToMultiByte(CP_UTF8, flags, src, -1, *dest, utf8_size, NULL, NULL);
 
 	if (!utf8_size) {
 		git__set_errno();

--- a/src/win32/utf-conv.h
+++ b/src/win32/utf-conv.h
@@ -15,6 +15,13 @@
 #endif
 
 /**
+ * Gets the conversion flags to convert a wide string to UTF-8.
+ * 
+ * @return The dwFlags argument that should be used when calling WideStringToMultiByte.
+ */
+DWORD git__get_utf6_to_8_flags();
+
+/**
  * Converts a UTF-8 string to wide characters.
  *
  * @param dest The buffer to receive the wide string.

--- a/src/win32/w32_buffer.c
+++ b/src/win32/w32_buffer.c
@@ -26,7 +26,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 {
 	int utf8_len, utf8_write_len;
 	size_t new_size;
-    DWORD flags = git__get_utf6_to_8_flags();
+	DWORD flags = git__get_utf6_to_8_flags();
 
 	if (!len_w)
 		return 0;
@@ -34,7 +34,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 	assert(string_w);
 
 	/* Measure the string necessary for conversion */
-    if ((utf8_len = WideCharToMultiByte(CP_UTF8, flags, string_w, len_w, NULL, 0, NULL, NULL)) == 0)
+	if ((utf8_len = WideCharToMultiByte(CP_UTF8, flags, string_w, len_w, NULL, 0, NULL, NULL)) == 0)
 		return 0;
 
 	assert(utf8_len > 0);
@@ -46,7 +46,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 		return -1;
 
 	if ((utf8_write_len = WideCharToMultiByte(
-        CP_UTF8, flags, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
+		CP_UTF8, flags, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
 		return handle_wc_error();
 
 	assert(utf8_write_len == utf8_len);

--- a/src/win32/w32_buffer.c
+++ b/src/win32/w32_buffer.c
@@ -46,7 +46,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 		return -1;
 
 	if ((utf8_write_len = WideCharToMultiByte(
-		CP_UTF8, flags, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
+			CP_UTF8, flags, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
 		return handle_wc_error();
 
 	assert(utf8_write_len == utf8_len);

--- a/src/win32/w32_buffer.c
+++ b/src/win32/w32_buffer.c
@@ -10,6 +10,8 @@
 #include "../buffer.h"
 #include "utf-conv.h"
 
+#include "VersionHelpers.h"
+
 GIT_INLINE(int) handle_wc_error(void)
 {
 	if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
@@ -24,6 +26,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 {
 	int utf8_len, utf8_write_len;
 	size_t new_size;
+    DWORD flags = git__get_utf6_to_8_flags();
 
 	if (!len_w)
 		return 0;
@@ -31,7 +34,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 	assert(string_w);
 
 	/* Measure the string necessary for conversion */
-	if ((utf8_len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, string_w, len_w, NULL, 0, NULL, NULL)) == 0)
+    if ((utf8_len = WideCharToMultiByte(CP_UTF8, flags, string_w, len_w, NULL, 0, NULL, NULL)) == 0)
 		return 0;
 
 	assert(utf8_len > 0);
@@ -43,7 +46,7 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 		return -1;
 
 	if ((utf8_write_len = WideCharToMultiByte(
-			CP_UTF8, WC_ERR_INVALID_CHARS, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
+        CP_UTF8, flags, string_w, len_w, &buf->ptr[buf->size], utf8_len, NULL, NULL)) == 0)
 		return handle_wc_error();
 
 	assert(utf8_write_len == utf8_len);


### PR DESCRIPTION
When on Windows XP, the Windows function WideCharToMultiByte cases an "ERROR_INVALID_FLAGS" error. According to [the documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/dd374130(v=vs.85).aspx), the WC_ERR_INVALID_CHARS flag only works starting from Windows Vista.

Using the VersionHelpers file, we can easily check if we should use the WC_ERR_INVALID_CHARS. I added a git__get_utf16_to_8_flags() function to return the correct flag (0 or WC_ERR_INVALIR_CHARS). 

Since it looks like all conversions to UTF-8 come from strings that were converted from UTF-8 in the first place, another solution would be to remove the version check and always provide 0 as the dwFlags parameter.