### PR TITLE
global: clarify correct usage of `git_libgit2_init` with threads

### DIFF
--- a/include/git2/global.h
+++ b/include/git2/global.h
@@ -15,7 +15,8 @@ GIT_BEGIN_DECL
  * Init the global state
  *
  * This function must the called before any other libgit2 function in
- * order to set up global state and threading.
+ * order to set up global state. As the function also sets up threading for
+ * libgit2, it needs to be called in a single-threaded context.
  *
  * This function may be called multiple times - it will return the number
  * of times the initialization has been called (including this one) that have


### PR DESCRIPTION
`git_libgit2_init` needs to be called is a single-threaded
context first, as it also sets up threading-related data
structures. While the fact that it does so is mentioned in the
function's documentation, we do not mention the consequences.

Improve the documentation so that we explicitly note that
`git_libgit2_init` shall be called before making use of threads.

Refs #3969 
