### PR TITLE
Trivial memory leak fixes in test suite

### DIFF
--- a/tests/core/vector.c
+++ b/tests/core/vector.c
@@ -404,4 +404,6 @@ void test_core_vector__reverse(void)
 
 	for (i = 0; i < 5; i++)
 		cl_assert_equal_p(out2[i], git_vector_get(&v, i));
+
+	git_vector_free(&v);
 }

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -126,6 +126,8 @@ void test_online_fetchhead__explicit_dst_refspec_creates_branch(void)
 
 	cl_git_pass(git_branch_lookup(&ref, g_repo, "explicit-refspec", GIT_BRANCH_ALL));
 	cl_assert_equal_i(refs + 1, count_references());
+
+	git_reference_free(ref);
 }
 
 void test_online_fetchhead__empty_dst_refspec_creates_no_branch(void)


### PR DESCRIPTION
There were two trivial memory leaks in our test suite. This PR fixes both :)