### PR TITLE
global: synchronize initialization and shutdown with pthreads

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -247,6 +247,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstDll, DWORD fdwReason, LPVOID lpvReserved)
 #elif defined(GIT_THREADS) && defined(_POSIX_THREADS)
 
 static pthread_key_t _tls_key;
+static pthread_mutex_t _init_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_once_t _once_init = PTHREAD_ONCE_INIT;
 int init_error = 0;
 
@@ -268,12 +269,19 @@ static void init_once(void)
 
 int git_libgit2_init(void)
 {
-	int ret;
+	int ret, err;
 
 	ret = git_atomic_inc(&git__n_inits);
-	pthread_once(&_once_init, init_once);
 
-	return init_error ? init_error : ret;
+	if ((err = pthread_mutex_lock(&_init_mutex)) != 0)
+		return err;
+	err = pthread_once(&_once_init, init_once);
+	err |= pthread_mutex_unlock(&_init_mutex);
+
+	if (err || init_error)
+		return err | init_error;
+
+	return ret;
 }
 
 int git_libgit2_shutdown(void)
@@ -283,6 +291,9 @@ int git_libgit2_shutdown(void)
 	int ret;
 
 	if ((ret = git_atomic_dec(&git__n_inits)) != 0)
+		return ret;
+
+	if ((ret = pthread_mutex_lock(&_init_mutex)) != 0)
 		return ret;
 
 	/* Shut down any subsystems that have global state */
@@ -297,6 +308,9 @@ int git_libgit2_shutdown(void)
 	pthread_key_delete(_tls_key);
 	git_mutex_free(&git__mwindow_mutex);
 	_once_init = new_once;
+
+	if ((ret = pthread_mutex_unlock(&_init_mutex)) != 0)
+		return ret;
 
 	return 0;
 }

--- a/src/global.c
+++ b/src/global.c
@@ -341,7 +341,7 @@ int git_libgit2_init(void)
 {
 	int ret;
 
-	/* Only init SSL the first time */
+	/* Only init subsystems the first time */
 	if ((ret = git_atomic_inc(&git__n_inits)) != 1)
 		return ret;
 
@@ -359,6 +359,7 @@ int git_libgit2_shutdown(void)
 	if ((ret = git_atomic_dec(&git__n_inits)) == 0) {
 		shutdown_common();
 		git__global_state_cleanup(&__state);
+		memset(&__state, 0, sizeof(__state));
 	}
 
 	return ret;

--- a/tests/core/init.c
+++ b/tests/core/init.c
@@ -12,3 +12,43 @@ void test_core_init__returns_count(void)
 	cl_assert_equal_i(1, git_libgit2_shutdown());
 }
 
+void test_core_init__reinit_succeeds(void)
+{
+	cl_assert_equal_i(0, git_libgit2_shutdown());
+	cl_assert_equal_i(1, git_libgit2_init());
+	cl_sandbox_set_search_path_defaults();
+}
+
+#ifdef GIT_THREADS
+static void *reinit(void *unused)
+{
+	unsigned i;
+
+	for (i = 0; i < 20; i++) {
+		cl_assert(git_libgit2_init() > 0);
+		cl_assert(git_libgit2_shutdown() >= 0);
+	}
+
+	return unused;
+}
+#endif
+
+void test_core_init__concurrent_init_succeeds(void)
+{
+#ifdef GIT_THREADS
+	git_thread threads[10];
+	unsigned i;
+
+	cl_assert_equal_i(0, git_libgit2_shutdown());
+
+	for (i = 0; i < ARRAY_SIZE(threads); i++)
+		git_thread_create(&threads[i], reinit, NULL);
+	for (i = 0; i < ARRAY_SIZE(threads); i++)
+		git_thread_join(&threads[i], NULL);
+
+	cl_assert_equal_i(1, git_libgit2_init());
+	cl_sandbox_set_search_path_defaults();
+#else
+	cl_skip();
+#endif
+}


### PR DESCRIPTION
When trying to initialize and tear down global data structures
from different threads at once with `git_libgit2_init` and
`git_libgit2_shutdown`, we race around initializing data. While
we use `pthread_once` to assert that we only initilize data a
single time, we actually reset the `pthread_once_t` on the last
call to `git_libgit2_shutdown`. As resetting this variable is not
synchronized with other threads trying to access it, this is
actually racy when one thread tries to do a complete shutdown of
libgit2 while another thread tries to initialize it.

Fix the issue by creating a mutex which synchronizes `init_once`
and the library shutdown.
