### PR TITLE
CI Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,6 @@ matrix:
      os: linux
  allow_failures:
    - env: COVERITY=1
-   - env:
-       - VALGRIND=1
-         OPTIONS="-DBUILD_CLAR=ON -DBUILD_EXAMPLES=OFF -DDEBUG_POOL=ON -DCMAKE_BUILD_TYPE=Debug"
 
 install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./script/install-deps-${TRAVIS_OS_NAME}.sh; fi

--- a/script/coverity.sh
+++ b/script/coverity.sh
@@ -12,12 +12,11 @@ then
 	exit 0
 fi
 
-COV_VERSION=6.6.1
 case $(uname -m) in
 	i?86)				BITS=32 ;;
 	amd64|x86_64)	BITS=64 ;;
 esac
-SCAN_TOOL=https://scan.coverity.com/download/linux-${BITS}
+SCAN_TOOL=https://scan.coverity.com/download/cxx/linux${BITS}
 TOOL_BASE=$(pwd)/_coverity-scan
 
 # Install coverity tools

--- a/script/coverity.sh
+++ b/script/coverity.sh
@@ -5,10 +5,10 @@ set -e
 [ -z "$COVERITY_TOKEN" ] && echo "Need to set a coverity token" && exit 1
 
 # Only run this on our branches
-echo "Pull request: $TRAVIS_PULL_REQUEST  |  Slug: $TRAVIS_REPO_SLUG"
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_REPO_SLUG" != "libgit2/libgit2" ];
+echo "Branch: $TRAVIS_BRANCH  |  Pull request: $TRAVIS_PULL_REQUEST  |  Slug: $TRAVIS_REPO_SLUG"
+if [ "$TRAVIS_BRANCH" != "master" -o "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_REPO_SLUG" != "libgit2/libgit2" ];
 then
-	echo "Only analyzing 'development' on the main repo."
+	echo "Only analyzing the 'master' brach of the main repository."
 	exit 0
 fi
 

--- a/script/coverity.sh
+++ b/script/coverity.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Environment check
-[ -z "$COVERITY_TOKEN" ] && echo "Need to set a coverity token" && exit 1
-
 # Only run this on our branches
 echo "Branch: $TRAVIS_BRANCH  |  Pull request: $TRAVIS_PULL_REQUEST  |  Slug: $TRAVIS_REPO_SLUG"
 if [ "$TRAVIS_BRANCH" != "master" -o "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_REPO_SLUG" != "libgit2/libgit2" ];
@@ -11,6 +8,9 @@ then
 	echo "Only analyzing the 'master' brach of the main repository."
 	exit 0
 fi
+
+# Environment check
+[ -z "$COVERITY_TOKEN" ] && echo "Need to set a coverity token" && exit 1
 
 case $(uname -m) in
 	i?86)				BITS=32 ;;


### PR DESCRIPTION
Just realized our Coverity builds were not running for nearly three months. Seems as if Coverity did change the download URLs for their build tools. I've fixed these and re-added a check so that we only let Coverity analyze our master branch.

I also removed valgrind from the allowed failures. I didn't spot any failures from valgrinds in the last builds, so I'd argue its a good thing to do to notice new failures. I'd also like to disallow failures for Coverity, but unfortunately the build is still too unstable due to quotas and occasional problems with downloading their toolset.
