### PR TITLE
Documentation fixes

### DIFF
--- a/include/git2/describe.h
+++ b/include/git2/describe.h
@@ -44,8 +44,8 @@ typedef enum {
 typedef struct git_describe_options {
 	unsigned int version;
 
-	unsigned int max_candidates_tags; /** default: 10 */
-	unsigned int describe_strategy; /** default: GIT_DESCRIBE_DEFAULT */
+	unsigned int max_candidates_tags; /**< default: 10 */
+	unsigned int describe_strategy; /**< default: GIT_DESCRIBE_DEFAULT */
 	const char *pattern;
 	/**
 	 * When calculating the distance from the matching tag or
@@ -105,6 +105,9 @@ typedef struct {
 
 GIT_EXTERN(int) git_describe_init_format_options(git_describe_format_options *opts, unsigned int version);
 
+/**
+ * A struct that stores the result of a describe operation.
+ */
 typedef struct git_describe_result git_describe_result;
 
 /**

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -26,8 +26,6 @@
  */
 GIT_BEGIN_DECL
 
-typedef int (*git_remote_rename_problem_cb)(const char *problematic_refspec, void *payload);
-
 /**
  * Add a remote with the default fetch refspec to the repository's configuration.
  *

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -358,6 +358,8 @@ typedef struct {
 } git_push_update;
 
 /**
+ * Callback used to inform of upcoming updates.
+ *
  * @param updates an array containing the updates which will be sent
  * as commands to the destination.
  * @param len number of elements in `updates`
@@ -401,7 +403,7 @@ struct git_remote_callbacks {
 	 * connection to proceed. Returns 1 to allow the connection, 0
 	 * to disallow it or a negative value to indicate an error.
 	 */
-        git_transport_certificate_check_cb certificate_check;
+	git_transport_certificate_check_cb certificate_check;
 
 	/**
 	 * During the download of new data, this will be regularly

--- a/include/git2/transaction.h
+++ b/include/git2/transaction.h
@@ -8,6 +8,14 @@
 #define INCLUDE_git_transaction_h__
 
 #include "common.h"
+
+/**
+ * @file git2/transaction.h
+ * @brief Git transactional reference routines
+ * @defgroup git_transaction Git transactional reference routines
+ * @ingroup Git
+ * @{
+ */
 GIT_BEGIN_DECL
 
 /**
@@ -107,5 +115,6 @@ GIT_EXTERN(int) git_transaction_commit(git_transaction *tx);
  */
 GIT_EXTERN(void) git_transaction_free(git_transaction *tx);
 
+/** @} */
 GIT_END_DECL
 #endif


### PR DESCRIPTION
Note: 8149b17 removes git_remote_rename_problem_cb. Not sure when it stopped being used though.