### PR TITLE
transports: smart: abort on early end of stream

### DIFF
--- a/include/git2/proxy.h
+++ b/include/git2/proxy.h
@@ -19,7 +19,7 @@ typedef enum {
 	/**
 	 * Do not attempt to connect through a proxy
 	 *
-	 * If built against lbicurl, it itself may attempt to connect
+	 * If built against libcurl, it itself may attempt to connect
 	 * to a proxy if the environment variables specify it.
 	 */
 	GIT_PROXY_NONE,

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -50,7 +50,7 @@ int git_smart__store_refs(transport_smart *t, int flushes)
 			if ((recvd = gitno_recv(buf)) < 0)
 				return recvd;
 
-			if (recvd == 0 && !flush) {
+			if (recvd == 0) {
 				giterr_set(GITERR_NET, "early EOF");
 				return GIT_EEOF;
 			}

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -222,8 +222,12 @@ static int recv_pkt(git_pkt **out, gitno_buffer *buf)
 		if (error < 0 && error != GIT_EBUFS)
 			return error;
 
-		if ((ret = gitno_recv(buf)) < 0)
+		if ((ret = gitno_recv(buf)) < 0) {
 			return ret;
+		} else if (ret == 0) {
+			giterr_set(GITERR_NET, "early EOF");
+			return GIT_EEOF;
+		}
 	} while (error);
 
 	gitno_consume(buf, line_end);


### PR DESCRIPTION
I've started playing around with mitmproxy to test our online protocol and was able to force libgit2 into an infinite loop on first try. The issue occurs if we fetch from a remote via the smart protocol if the last flush packet from the remote is modified.

This PR fixes the infinite loop. I'm actually not sure why we only returned an EOF before when `flush == 0`, I couldn't find any reason here. One thing I could imagine is that we actually wanted to return `0` if the last received packet was actually a flush packet _and_ the socket returned EOF so that we wouldn't produce an error if we received less flushes than expected. But we actually only use the function once and only check if the return code was an error, so we wouldn't handle positive values (e.g. there are outstanding flushes).

Yeah, so I'm quite clueless here. Anyway, the issue obviously requires a fix as it's remotely exploitable, so I'm putting this up for discussion here.