### PR TITLE
Backport the object parsing fixes

### DIFF
--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -44,8 +44,13 @@ ssh-keygen -t rsa -f ~/.ssh/id_rsa -N "" -q
 cat ~/.ssh/id_rsa.pub >>~/.ssh/authorized_keys
 ssh-keyscan -t rsa localhost >>~/.ssh/known_hosts
 
-# Get the fingerprint for localhost and remove the colons so we can parse it as a hex number
-export GITTEST_REMOTE_SSH_FINGERPRINT=$(ssh-keygen -F localhost -l | tail -n 1 | cut -d ' ' -f 2 | tr -d ':')
+# Get the fingerprint for localhost and remove the colons so we can parse it as
+# a hex number. The Mac version is newer so it has a different output format.
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    export GITTEST_REMOTE_SSH_FINGERPRINT=$(ssh-keygen -E md5 -F localhost -l | tail -n 1 | cut -d ' ' -f 3 | cut -d : -f2- | tr -d :)
+else
+    export GITTEST_REMOTE_SSH_FINGERPRINT=$(ssh-keygen -F localhost -l | tail -n 1 | cut -d ' ' -f 2 | tr -d ':')
+fi
 
 export GITTEST_REMOTE_URL="ssh://localhost/$HOME/_temp/test.git"
 export GITTEST_REMOTE_USER=$USER

--- a/src/commit.c
+++ b/src/commit.c
@@ -410,10 +410,11 @@ int git_commit__parse(void *_commit, git_odb_object *odb_obj)
 	buffer = buffer_start + header_len + 1;
 
 	/* extract commit message */
-	if (buffer <= buffer_end) {
+	if (buffer <= buffer_end)
 		commit->raw_message = git__strndup(buffer, buffer_end - buffer);
-		GITERR_CHECK_ALLOC(commit->raw_message);
-	}
+	else
+		commit->raw_message = git__strdup("");
+	GITERR_CHECK_ALLOC(commit->raw_message);
 
 	return 0;
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -447,7 +447,12 @@ int git_tree__parse(void *_tree, git_odb_object *odb_obj)
 		if ((nul = memchr(buffer, 0, buffer_end - buffer)) == NULL)
 			return tree_error("Failed to parse tree. Object is corrupted", NULL);
 
-		filename_len = nul - buffer;
+		if ((filename_len = nul - buffer) == 0)
+			return tree_error("Failed to parse tree. Can't parse filename", NULL);
+
+		if ((buffer_end - (nul + 1)) < GIT_OID_RAWSZ)
+			return tree_error("Failed to parse tree. Can't parse OID", NULL);
+
 		/* Allocate the entry */
 		{
 			entry = git_array_alloc(tree->entries);


### PR DESCRIPTION
These issues, though hard to trigger on someone else's machine, were assigned CVEs (CVE-2016-8568 and CVE-2016-8569) and Fedora even had an update to address these. So let's do a release with these security updates.