### PR TITLE
Check for -1 after CURLINFO_LASTSOCKET

### DIFF
--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -121,6 +121,11 @@ static int curls_connect(git_stream *stream)
 		return seterr_curl(s);
 	}
 
+	if (sockextr == -1) {
+		giterr_set(GITERR_NET, "curl socket is no longer valid");
+		return -1;
+	}
+
 	s->socket = sockextr;
 
 	if (s->parent.encrypted && failed_cert)
@@ -198,6 +203,7 @@ static int wait_for(curl_socket_t fd, bool reading)
 	FD_ZERO(&outfd);
 	FD_ZERO(&errfd);
 
+	assert(fd >= 0);
 	FD_SET(fd, &errfd);
 	if (reading)
 		FD_SET(fd, &infd);


### PR DESCRIPTION
We're recently trying to upgrade to the current mater of libgit2 in Cargo but
we're unfortunately hitting a segfault in one of our tests. A particular test is
just a small smoke test that https works (e.g. it's configured in libgit2). This
test attempts to clone from a URL which simply immediately drops connections
after they're accepted (e.g. terminate abnormally). We expect to see a standard
error from libgit2 but unfortunately we're seeing a segfault.

This segfault is happening inside of the `wait_for` function of `curl_stream.c`
at the line `FD_SET(fd, &errfd)` because `fd` is -1. This ends up doing an
out-of-bounds array access that faults the program. I tracked back to where this
-1 came from to the line here (returned by `CURLINFO_LASTSOCKET`) and added a
check to return an error. This may not be the right fix though, so feedback is
appreciated!