### PR TITLE
curl_stream: use CURLINFO_ACTIVESOCKET if curl is recent enough

### DIFF
--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -15,6 +15,16 @@
 #include "vector.h"
 #include "proxy.h"
 
+/* This is for backwards compatibility with curl<7.45.0. */
+#ifndef CURLINFO_ACTIVESOCKET
+# define CURLINFO_ACTIVESOCKET CURLINFO_LASTSOCKET
+# define GIT_CURL_BADSOCKET -1
+# define git_activesocket_t long
+#else
+# define GIT_CURL_BADSOCKET CURL_SOCKET_BAD
+# define git_activesocket_t curl_socket_t
+#endif
+
 typedef struct {
 	git_stream parent;
 	CURL *handle;
@@ -87,7 +97,8 @@ static int ask_and_apply_proxy_creds(curl_stream *s)
 static int curls_connect(git_stream *stream)
 {
 	curl_stream *s = (curl_stream *) stream;
-	long sockextr, connect_last = 0;
+	git_activesocket_t sockextr;
+	long connect_last = 0;
 	int failed_cert = 0, error;
 	bool retry_connect;
 	CURLcode res;
@@ -117,11 +128,11 @@ static int curls_connect(git_stream *stream)
 	if (res == CURLE_PEER_FAILED_VERIFICATION)
 		failed_cert = 1;
 
-	if ((res = curl_easy_getinfo(s->handle, CURLINFO_LASTSOCKET, &sockextr)) != CURLE_OK) {
+	if ((res = curl_easy_getinfo(s->handle, CURLINFO_ACTIVESOCKET, &sockextr)) != CURLE_OK) {
 		return seterr_curl(s);
 	}
 
-	if (sockextr == -1) {
+	if (sockextr == GIT_CURL_BADSOCKET) {
 		giterr_set(GITERR_NET, "curl socket is no longer valid");
 		return -1;
 	}


### PR DESCRIPTION
The `CURLINFO_LASTSOCKET` information has been deprecated since
curl version 7.45.0 as it may result in an overflow in the
returned socket on certain systems, most importantly on 64 bit
Windows. Instead, a new call `CURLINFO_ACTIVESOCKET` has been
added which instead returns a `curl_socket_t`, which is always
sufficiently long to store a socket.

As the new call has only been introduced with version 7.45.0
which was released in October 2015, we cannot simply remove the
old code but instead are required to conditionally compile based
on libcurl's version.