### PR TITLE
giterr format

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -173,7 +173,7 @@ static int apply_hunk(
 		git_diff_line *line = git_array_get(patch->lines, linenum);
 
 		if (!line) {
-			error = apply_err("Preimage does not contain line %d", linenum);
+			error = apply_err("Preimage does not contain line %"PRIuZ, linenum);
 			goto done;
 		}
 

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1966,7 +1966,7 @@ static int checkout_path_suffixed(git_buf *path, const char *suffix)
 	if (i == INT_MAX) {
 		git_buf_truncate(path, path_len);
 
-		giterr_set(GITERR_CHECKOUT, "Could not write '%s': working directory file exists", path);
+		giterr_set(GITERR_CHECKOUT, "Could not write '%s': working directory file exists", path->ptr);
 		return GIT_EEXISTS;
 	}
 
@@ -2469,7 +2469,7 @@ static int checkout_data_init(
 			data->opts.checkout_strategy |= GIT_CHECKOUT_CONFLICT_STYLE_DIFF3;
 		else {
 			giterr_set(GITERR_CHECKOUT, "unknown style '%s' given for 'merge.conflictstyle'",
-				conflict_style);
+				conflict_style->value);
 			error = -1;
 			git_config_entry_free(conflict_style);
 			goto cleanup;

--- a/src/common.h
+++ b/src/common.h
@@ -103,7 +103,8 @@
 /**
  * Set the error message for this thread, formatting as needed.
  */
-void giterr_set(int error_class, const char *string, ...);
+
+void giterr_set(int error_class, const char *string, ...) GIT_FORMAT_PRINTF(2, 3);
 
 /**
  * Set the error message for a regex failure, using the internal regex

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -149,7 +149,7 @@ static int fetchhead_ref_parse(
 
 	if (!*line) {
 		giterr_set(GITERR_FETCHHEAD,
-			"Empty line in FETCH_HEAD line %d", line_num);
+			"Empty line in FETCH_HEAD line %"PRIuZ, line_num);
 		return -1;
 	}
 
@@ -163,7 +163,7 @@ static int fetchhead_ref_parse(
 
 	if (strlen(oid_str) != GIT_OID_HEXSZ) {
 		giterr_set(GITERR_FETCHHEAD,
-			"Invalid object ID in FETCH_HEAD line %d", line_num);
+			"Invalid object ID in FETCH_HEAD line %"PRIuZ, line_num);
 		return -1;
 	}
 
@@ -171,7 +171,7 @@ static int fetchhead_ref_parse(
 		const git_error *oid_err = giterr_last();
 		const char *err_msg = oid_err ? oid_err->message : "Invalid object ID";
 
-		giterr_set(GITERR_FETCHHEAD, "%s in FETCH_HEAD line %d",
+		giterr_set(GITERR_FETCHHEAD, "%s in FETCH_HEAD line %"PRIuZ,
 			err_msg, line_num);
 		return -1;
 	}
@@ -180,7 +180,7 @@ static int fetchhead_ref_parse(
 	if (*line) {
 		if ((is_merge_str = git__strsep(&line, "\t")) == NULL) {
 			giterr_set(GITERR_FETCHHEAD,
-				"Invalid description data in FETCH_HEAD line %d", line_num);
+				"Invalid description data in FETCH_HEAD line %"PRIuZ, line_num);
 			return -1;
 		}
 
@@ -190,13 +190,13 @@ static int fetchhead_ref_parse(
 			*is_merge = 0;
 		else {
 			giterr_set(GITERR_FETCHHEAD,
-				"Invalid for-merge entry in FETCH_HEAD line %d", line_num);
+				"Invalid for-merge entry in FETCH_HEAD line %"PRIuZ, line_num);
 			return -1;
 		}
 
 		if ((desc = line) == NULL) {
 			giterr_set(GITERR_FETCHHEAD,
-				"Invalid description in FETCH_HEAD line %d", line_num);
+				"Invalid description in FETCH_HEAD line %"PRIuZ, line_num);
 			return -1;
 		}
 
@@ -213,7 +213,7 @@ static int fetchhead_ref_parse(
 			if ((desc = strstr(name, "' ")) == NULL ||
 				git__prefixcmp(desc, "' of ") != 0) {
 				giterr_set(GITERR_FETCHHEAD,
-					"Invalid description in FETCH_HEAD line %d", line_num);
+					"Invalid description in FETCH_HEAD line %"PRIuZ, line_num);
 				return -1;
 			}
 
@@ -277,7 +277,7 @@ int git_repository_fetchhead_foreach(git_repository *repo,
 	}
 
 	if (*buffer) {
-		giterr_set(GITERR_FETCHHEAD, "No EOL at line %d", line_num+1);
+		giterr_set(GITERR_FETCHHEAD, "No EOL at line %"PRIuZ, line_num+1);
 		error = -1;
 		goto done;
 	}

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1311,7 +1311,7 @@ static int filesystem_iterator_frame_push(
 
 	if (iter->frames.size == FILESYSTEM_MAX_DEPTH) {
 		giterr_set(GITERR_REPOSITORY,
-			"directory nesting too deep (%d)", iter->frames.size);
+			"directory nesting too deep (%"PRIuZ")", iter->frames.size);
 		return -1;
 	}
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -591,7 +591,7 @@ int git_repository_mergehead_foreach(
 	}
 
 	if (*buffer) {
-		giterr_set(GITERR_MERGE, "No EOL at line %d", line_num);
+		giterr_set(GITERR_MERGE, "No EOL at line %"PRIuZ, line_num);
 		error = -1;
 		goto cleanup;
 	}

--- a/src/odb.c
+++ b/src/odb.c
@@ -1400,7 +1400,7 @@ int git_odb__error_notfound(
 		char oid_str[GIT_OID_HEXSZ + 1];
 		git_oid_tostr(oid_str, oid_len+1, oid);
 		giterr_set(GITERR_ODB, "Object not found - %s (%.*s)",
-			message, oid_len, oid_str);
+			message, (int) oid_len, oid_str);
 	} else
 		giterr_set(GITERR_ODB, "Object not found - %s", message);
 

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -176,7 +176,7 @@ static int parse_header_mode(uint16_t *mode, git_patch_parse_ctx *ctx)
 	int ret;
 
 	if (ctx->line_len < 1 || !git__isdigit(ctx->line[0]))
-		return parse_err("invalid file mode at line %d", ctx->line_num);
+		return parse_err("invalid file mode at line %"PRIuZ, ctx->line_num);
 
 	if ((ret = git__strntol32(&m, ctx->line, ctx->line_len, &end, 8)) < 0)
 		return ret;
@@ -205,7 +205,7 @@ static int parse_header_oid(
 
 	if (len < GIT_OID_MINPREFIXLEN || len > GIT_OID_HEXSZ ||
 		git_oid_fromstrn(oid, ctx->line, len) < 0)
-		return parse_err("invalid hex formatted object id at line %d",
+		return parse_err("invalid hex formatted object id at line %"PRIuZ,
 			ctx->line_num);
 
 	parse_advance_chars(ctx, len);
@@ -350,7 +350,7 @@ static int parse_header_similarity(
 	git_patch_parsed *patch, git_patch_parse_ctx *ctx)
 {
 	if (parse_header_percent(&patch->base.delta->similarity, ctx) < 0)
-		return parse_err("invalid similarity percentage at line %d",
+		return parse_err("invalid similarity percentage at line %"PRIuZ,
 			ctx->line_num);
 
 	return 0;
@@ -362,7 +362,7 @@ static int parse_header_dissimilarity(
 	uint16_t dissimilarity;
 
 	if (parse_header_percent(&dissimilarity, ctx) < 0)
-		return parse_err("invalid similarity percentage at line %d",
+		return parse_err("invalid similarity percentage at line %"PRIuZ,
 			ctx->line_num);
 
 	patch->base.delta->similarity = 100 - dissimilarity;
@@ -406,15 +406,15 @@ static int parse_header_git(
 
 	/* Parse the diff --git line */
 	if (parse_advance_expected_str(ctx, "diff --git ") < 0)
-		return parse_err("corrupt git diff header at line %d", ctx->line_num);
+		return parse_err("corrupt git diff header at line %"PRIuZ, ctx->line_num);
 
 	if (parse_header_path(&patch->header_old_path, ctx) < 0)
-		return parse_err("corrupt old path in git diff header at line %d",
+		return parse_err("corrupt old path in git diff header at line %"PRIuZ,
 			ctx->line_num);
 
 	if (parse_advance_ws(ctx) < 0 ||
 		parse_header_path(&patch->header_new_path, ctx) < 0)
-		return parse_err("corrupt new path in git diff header at line %d",
+		return parse_err("corrupt new path in git diff header at line %"PRIuZ,
 			ctx->line_num);
 
 	/* Parse remaining header lines */
@@ -447,7 +447,7 @@ static int parse_header_git(
 			parse_advance_expected_str(ctx, "\n");
 
 			if (ctx->line_len > 0) {
-				error = parse_err("trailing data at line %d", ctx->line_num);
+				error = parse_err("trailing data at line %"PRIuZ, ctx->line_num);
 				goto done;
 			}
 
@@ -456,7 +456,7 @@ static int parse_header_git(
 		}
 		
 		if (!found) {
-			error = parse_err("invalid patch header at line %d",
+			error = parse_err("invalid patch header at line %"PRIuZ,
 				ctx->line_num);
 			goto done;
 		}
@@ -536,7 +536,7 @@ static int parse_hunk_header(
 
 	hunk->hunk.header_len = ctx->line - header_start;
 	if (hunk->hunk.header_len > (GIT_DIFF_HUNK_HEADER_SIZE - 1))
-		return parse_err("oversized patch hunk header at line %d",
+		return parse_err("oversized patch hunk header at line %"PRIuZ,
 			ctx->line_num);
 
 	memcpy(hunk->hunk.header, header_start, hunk->hunk.header_len);
@@ -545,7 +545,7 @@ static int parse_hunk_header(
 	return 0;
 
 fail:
-	giterr_set(GITERR_PATCH, "invalid patch hunk header at line %d",
+	giterr_set(GITERR_PATCH, "invalid patch hunk header at line %"PRIuZ,
 		ctx->line_num);
 	return -1;
 }
@@ -570,7 +570,7 @@ static int parse_hunk_body(
 		int prefix = 1;
 
 		if (ctx->line_len == 0 || ctx->line[ctx->line_len - 1] != '\n') {
-			error = parse_err("invalid patch instruction at line %d",
+			error = parse_err("invalid patch instruction at line %"PRIuZ,
 				ctx->line_num);
 			goto done;
 		}
@@ -596,7 +596,7 @@ static int parse_hunk_body(
 			break;
 
 		default:
-			error = parse_err("invalid patch hunk at line %d", ctx->line_num);
+			error = parse_err("invalid patch hunk at line %"PRIuZ, ctx->line_num);
 			goto done;
 		}
 
@@ -672,7 +672,7 @@ static int parse_patch_header(
 				continue;
 			}
 
-			error = parse_err("invalid hunk header outside patch at line %d",
+			error = parse_err("invalid hunk header outside patch at line %"PRIuZ,
 				line_num);
 			goto done;
 		}
@@ -715,12 +715,12 @@ static int parse_patch_binary_side(
 		parse_advance_chars(ctx, 6);
 	} else {
 		error = parse_err(
-			"unknown binary delta type at line %d", ctx->line_num);
+			"unknown binary delta type at line %"PRIuZ, ctx->line_num);
 		goto done;
 	}
 
 	if (parse_number(&len, ctx) < 0 || parse_advance_nl(ctx) < 0 || len < 0) {
-		error = parse_err("invalid binary size at line %d", ctx->line_num);
+		error = parse_err("invalid binary size at line %"PRIuZ, ctx->line_num);
 		goto done;
 	}
 
@@ -736,7 +736,7 @@ static int parse_patch_binary_side(
 			decoded_len = c - 'a' + (('z' - 'a') + 1) + 1;
 
 		if (!decoded_len) {
-			error = parse_err("invalid binary length at line %d", ctx->line_num);
+			error = parse_err("invalid binary length at line %"PRIuZ, ctx->line_num);
 			goto done;
 		}
 
@@ -745,7 +745,7 @@ static int parse_patch_binary_side(
 		encoded_len = ((decoded_len / 4) + !!(decoded_len % 4)) * 5;
 
 		if (encoded_len > ctx->line_len - 1) {
-			error = parse_err("truncated binary data at line %d", ctx->line_num);
+			error = parse_err("truncated binary data at line %"PRIuZ, ctx->line_num);
 			goto done;
 		}
 
@@ -754,14 +754,14 @@ static int parse_patch_binary_side(
 			goto done;
 
 		if (decoded.size - decoded_orig != decoded_len) {
-			error = parse_err("truncated binary data at line %d", ctx->line_num);
+			error = parse_err("truncated binary data at line %"PRIuZ, ctx->line_num);
 			goto done;
 		}
 
 		parse_advance_chars(ctx, encoded_len);
 
 		if (parse_advance_nl(ctx) < 0) {
-			error = parse_err("trailing data at line %d", ctx->line_num);
+			error = parse_err("trailing data at line %"PRIuZ, ctx->line_num);
 			goto done;
 		}
 	}
@@ -785,7 +785,7 @@ static int parse_patch_binary(
 
 	if (parse_advance_expected_str(ctx, "GIT binary patch") < 0 ||
 		parse_advance_nl(ctx) < 0)
-		return parse_err("corrupt git binary header at line %d", ctx->line_num);
+		return parse_err("corrupt git binary header at line %"PRIuZ, ctx->line_num);
 
 	/* parse old->new binary diff */
 	if ((error = parse_patch_binary_side(
@@ -793,7 +793,7 @@ static int parse_patch_binary(
 		return error;
 
 	if (parse_advance_nl(ctx) < 0)
-		return parse_err("corrupt git binary separator at line %d",
+		return parse_err("corrupt git binary separator at line %"PRIuZ,
 			ctx->line_num);
 
 	/* parse new->old binary diff */
@@ -802,7 +802,7 @@ static int parse_patch_binary(
 		return error;
 
 	if (parse_advance_nl(ctx) < 0)
-		return parse_err("corrupt git binary patch separator at line %d",
+		return parse_err("corrupt git binary patch separator at line %"PRIuZ,
 			ctx->line_num);
 
 	patch->base.binary.contains_data = 1;
@@ -820,7 +820,7 @@ static int parse_patch_binary_nodata(
 		parse_advance_expected_str(ctx, patch->header_new_path) < 0 ||
 		parse_advance_expected_str(ctx, " differ") < 0 ||
 		parse_advance_nl(ctx) < 0)
-		return parse_err("corrupt git binary header at line %d", ctx->line_num);
+		return parse_err("corrupt git binary header at line %"PRIuZ, ctx->line_num);
 
 	patch->base.binary.contains_data = 0;
 	patch->base.delta->flags |= GIT_DIFF_FLAG_BINARY;
@@ -912,7 +912,7 @@ static int check_prefix(
 
 	if (remain_len || !*path)
 		return parse_err(
-			"header filename does not contain %d path components",
+			"header filename does not contain %"PRIuZ" path components",
 			prefix_len);
 
 done:

--- a/src/path.c
+++ b/src/path.c
@@ -1347,7 +1347,7 @@ int git_path_diriter_next(git_path_diriter *diriter)
 				return GIT_ITEROVER;
 
 			giterr_set(GITERR_OS,
-				"Could not read directory '%s'", diriter->path);
+				"Could not read directory '%s'", diriter->path.ptr);
 			return -1;
 		}
 	} while (skip_dot && git_path_is_dot_or_dotdot(de->d_name));

--- a/src/tree.c
+++ b/src/tree.c
@@ -917,7 +917,7 @@ int git_tree_entry_bypath(
 
 	if (entry == NULL) {
 		giterr_set(GITERR_TREE,
-			   "the path '%.*s' does not exist in the given tree", filename_len, path);
+			   "the path '%.*s' does not exist in the given tree", (int) filename_len, path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -927,7 +927,7 @@ int git_tree_entry_bypath(
 		 * then this entry *must* be a tree */
 		if (!git_tree_entry__is_tree(entry)) {
 			giterr_set(GITERR_TREE,
-				   "the path '%.*s' exists but is not a tree", filename_len, path);
+				   "the path '%.*s' exists but is not a tree", (int) filename_len, path);
 			return GIT_ENOTFOUND;
 		}
 


### PR DESCRIPTION
While inspecting #4000, I've been very surprised to find out that we were passing a `git_buf` pointer to `giterr_set` without any warning of the compiler. Seems we didn't put a printf-attribute hint at the declaration, causing the compiler to accept whatever we put there.

Next to the many cases of `"%d"` instead of `"%"PRIuZ` which can cause us to overflow in the output, there were also three real errors where we passed a structure pointer to "%s" instead of the real value.