### PR TITLE
Use the sorted input in the tree updater

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -1200,6 +1200,9 @@ int git_tree_create_updated(git_oid *out, git_repository *repo, git_tree *baseli
 
 			last = git_array_last(stack);
 			entry = last->tree ? git_tree_entry_byname(last->tree, component.ptr) : NULL;
+			if (!entry)
+				entry = treebuilder_get(last->bld, component.ptr);
+
 			if (entry && git_tree_entry_type(entry) != GIT_OBJ_TREE) {
 				giterr_set(GITERR_TREE, "D/F conflict when updating tree");
 				error = -1;

--- a/src/tree.c
+++ b/src/tree.c
@@ -1164,8 +1164,8 @@ int git_tree_create_updated(git_oid *out, git_repository *repo, git_tree *baseli
 		goto cleanup;
 
 	for (i = 0; i < nupdates; i++) {
-		const git_tree_update *last_update = i == 0 ? NULL : &updates[i-1];
-		const git_tree_update *update = &updates[i];
+		const git_tree_update *last_update = i == 0 ? NULL : git_vector_get(&entries, i-1);
+		const git_tree_update *update = git_vector_get(&entries, i);
 		size_t common_prefix = 0, steps_up, j;
 		const char *path;
 


### PR DESCRIPTION
The loop/algo is made to assume that we have sorted inputs. We sort them to make sure but we failed to actually _use_ the sorted list. The tests were inadvertently written with inputs that did not show this bad behaviour.

This fixes #3804 