### PR TITLE
use `giterr_set_str()` wherever possible

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -552,7 +552,7 @@ int git_index_clear(git_index *index)
 
 static int create_index_error(int error, const char *msg)
 {
-	giterr_set(GITERR_INDEX, msg);
+	giterr_set_str(GITERR_INDEX, msg);
 	return error;
 }
 

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -21,7 +21,7 @@ static int zstream_seterr(git_zstream *zs)
 	if (zs->zerr == Z_MEM_ERROR)
 		giterr_set_oom();
 	else if (zs->z.msg)
-		giterr_set(GITERR_ZLIB, zs->z.msg);
+		giterr_set_str(GITERR_ZLIB, zs->z.msg);
 	else
 		giterr_set(GITERR_ZLIB, "Unknown compression error");
 


### PR DESCRIPTION
`giterr_set()` is used when it is required to format a string, and since
we don't really require it for this case, it is better to stick to
`giterr_set_str()`.

This also suppresses a warning(-Wformat-security) raised by the compiler.