### PR TITLE
Introduce some clar helpers for child threads

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -16,6 +16,12 @@ typedef struct {
 	git_error error_t;
 	git_buf error_buf;
 	char oid_fmt[GIT_OID_HEXSZ+1];
+
+	/* On Windows, this is the current child thread that was started by
+	 * `git_thread_create`.  This is used to set the thread's exit code
+	 * when terminated by `git_thread_exit`.  It is unused on POSIX.
+	 */
+	git_thread *current_thread;
 } git_global_st;
 
 #ifdef GIT_OPENSSL

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -17,6 +17,8 @@ typedef struct {
 	pthread_create(&(git_thread_ptr)->thread, NULL, start_routine, arg)
 #define git_thread_join(git_thread_ptr, status) \
 	pthread_join((git_thread_ptr)->thread, status)
+#define git_thread_currentid() ((size_t)(pthread_self()))
+#define git_thread_exit(retval) pthread_exit(retval)
 
 /* Git Mutex */
 #define git_mutex pthread_mutex_t

--- a/src/win32/thread.h
+++ b/src/win32/thread.h
@@ -41,6 +41,8 @@ int git_thread_create(git_thread *GIT_RESTRICT,
 	void *(*) (void *),
 	void *GIT_RESTRICT);
 int git_thread_join(git_thread *, void **);
+size_t git_thread_currentid(void);
+void git_thread_exit(void *);
 
 int git_mutex_init(git_mutex *GIT_RESTRICT mutex);
 int git_mutex_free(git_mutex *);

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -41,6 +41,47 @@
 	} \
 	} while(0)
 
+/**
+ * Thread safe assertions; you cannot use `cl_git_report_failure` from a
+ * child thread since it will try to `longjmp` to abort and "the effect of
+ * a call to longjmp() where initialization of the jmp_buf structure was
+ * not performed in the calling thread is undefined."
+ *
+ * Instead, callers can provide a clar thread error context to a thread,
+ * which will populate and return it on failure.  Callers can check the
+ * status with `cl_git_thread_check`.
+ */
+typedef struct {
+	int error;
+	const char *file;
+	int line;
+	const char *expr;
+	char error_msg[4096];
+} cl_git_thread_err;
+
+#define cl_git_thread_pass(threaderr, expr) cl_git_thread_pass_(threaderr, (expr), __FILE__, __LINE__)
+
+#define cl_git_thread_pass_(__threaderr, __expr, __file, __line) do { \
+	giterr_clear(); \
+	if ((((cl_git_thread_err *)__threaderr)->error = (__expr)) != 0) { \
+		const git_error *_last = giterr_last(); \
+		((cl_git_thread_err *)__threaderr)->file = __file; \
+		((cl_git_thread_err *)__threaderr)->line = __line; \
+		((cl_git_thread_err *)__threaderr)->expr = "Function call failed: " #__expr; \
+		p_snprintf(((cl_git_thread_err *)__threaderr)->error_msg, 4096, "thread 0x%" PRIxZ " - error %d - %s", \
+			git_thread_currentid(), ((cl_git_thread_err *)__threaderr)->error, \
+			_last ? _last->message : "<no message>"); \
+		git_thread_exit(__threaderr); \
+	} \
+	} while (0)
+
+static void cl_git_thread_check(void *data)
+{
+	cl_git_thread_err *threaderr = (cl_git_thread_err *)data;
+	if (threaderr->error != 0)
+		clar__assert(0, threaderr->file, threaderr->line, threaderr->expr, threaderr->error_msg, 1);
+}
+
 void cl_git_report_failure(int, const char *, int, const char *);
 
 #define cl_assert_at_line(expr,file,line) \

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -59,7 +59,11 @@ typedef struct {
 	char error_msg[4096];
 } cl_git_thread_err;
 
-#define cl_git_thread_pass(threaderr, expr) cl_git_thread_pass_(threaderr, (expr), __FILE__, __LINE__)
+#ifdef GIT_THREADS
+# define cl_git_thread_pass(threaderr, expr) cl_git_thread_pass_(threaderr, (expr), __FILE__, __LINE__)
+#else
+# define cl_git_thread_pass(threaderr, expr) cl_git_pass(expr)
+#endif
 
 #define cl_git_thread_pass_(__threaderr, __expr, __file, __line) do { \
 	giterr_clear(); \

--- a/tests/core/init.c
+++ b/tests/core/init.c
@@ -39,14 +39,14 @@ void test_core_init__concurrent_init_succeeds(void)
 	git_thread threads[10];
 	unsigned i;
 
-	cl_assert_equal_i(0, git_libgit2_shutdown());
+	cl_assert_equal_i(2, git_libgit2_init());
 
 	for (i = 0; i < ARRAY_SIZE(threads); i++)
 		git_thread_create(&threads[i], reinit, NULL);
 	for (i = 0; i < ARRAY_SIZE(threads); i++)
 		git_thread_join(&threads[i], NULL);
 
-	cl_assert_equal_i(1, git_libgit2_init());
+	cl_assert_equal_i(1, git_libgit2_shutdown());
 	cl_sandbox_set_search_path_defaults();
 #else
 	cl_skip();

--- a/tests/threads/basic.c
+++ b/tests/threads/basic.c
@@ -49,6 +49,7 @@ void test_threads_basic__set_error(void)
 	run_in_parallel(1, 4, set_error, NULL, NULL);
 }
 
+#ifdef GIT_THREADS
 static void *return_normally(void *param)
 {
 	return param;
@@ -59,9 +60,13 @@ static void *exit_abruptly(void *param)
 	git_thread_exit(param);
 	return NULL;
 }
+#endif
 
 void test_threads_basic__exit(void)
 {
+#ifndef GIT_THREADS
+	clar__skip();
+#else
 	git_thread thread;
 	void *result;
 
@@ -74,4 +79,5 @@ void test_threads_basic__exit(void)
 	cl_git_pass(git_thread_create(&thread, return_normally, (void *)232323));
 	cl_git_pass(git_thread_join(&thread, &result));
 	cl_assert_equal_sz(232323, (size_t)result);
+#endif
 }

--- a/tests/threads/basic.c
+++ b/tests/threads/basic.c
@@ -48,3 +48,30 @@ void test_threads_basic__set_error(void)
 {
 	run_in_parallel(1, 4, set_error, NULL, NULL);
 }
+
+static void *return_normally(void *param)
+{
+	return param;
+}
+
+static void *exit_abruptly(void *param)
+{
+	git_thread_exit(param);
+	return NULL;
+}
+
+void test_threads_basic__exit(void)
+{
+	git_thread thread;
+	void *result;
+
+	/* Ensure that the return value of the threadproc is returned. */
+	cl_git_pass(git_thread_create(&thread, return_normally, (void *)424242));
+	cl_git_pass(git_thread_join(&thread, &result));
+	cl_assert_equal_sz(424242, (size_t)result);
+
+	/* Ensure that the return value of `git_thread_exit` is returned. */
+	cl_git_pass(git_thread_create(&thread, return_normally, (void *)232323));
+	cl_git_pass(git_thread_join(&thread, &result));
+	cl_assert_equal_sz(232323, (size_t)result);
+}


### PR DESCRIPTION
When running in a child thread, we cannot `clar_git_pass` (or anything that will cause clar to `longjmp` to its error handler):

> The effect of a call to `longjmp()` where initialization of the `jmp_buf` structure was not performed in the calling thread is undefined.

Instead, provide some helpers to set up an error context in the child thread that the clar execution thread can then restore and abort when safe.  Use this for the `threads::refdb` test so that it errors gracefully, instead of crashing.

Obviously this does not fix the underlying problem in the`threads::refdb` test, but it does make it easier to reason about.