### PR TITLE
Properly pass `wchar *` type to giterr_set

### DIFF
--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -174,7 +174,7 @@ GIT_INLINE(int) git_win32__file_attribute_to_stat(
 			/* st_size gets the UTF-8 length of the target name, in bytes,
 			 * not counting the NULL terminator */
 			if ((st->st_size = git__utf16_to_8(NULL, 0, target)) < 0) {
-				giterr_set(GITERR_OS, "Could not convert reparse point name for '%S'", path);
+				giterr_set(GITERR_OS, "Could not convert reparse point name for '%ls'", path);
 				return -1;
 			}
 		}

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -174,7 +174,7 @@ GIT_INLINE(int) git_win32__file_attribute_to_stat(
 			/* st_size gets the UTF-8 length of the target name, in bytes,
 			 * not counting the NULL terminator */
 			if ((st->st_size = git__utf16_to_8(NULL, 0, target)) < 0) {
-				giterr_set(GITERR_OS, "Could not convert reparse point name for '%s'", path);
+				giterr_set(GITERR_OS, "Could not convert reparse point name for '%S'", path);
 				return -1;
 			}
 		}


### PR DESCRIPTION
Ensure correct type is passed, no garbage text is sent, and mute compiler warning.