### PR TITLE
Allow Windows with WinHTTP to use external http-parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,10 +235,21 @@ IF (WIN32 AND EMBED_SSH_PATH)
 	ADD_DEFINITIONS(-DGIT_SSH)
 ENDIF()
 
-IF (WIN32 AND WINHTTP)
-	ADD_DEFINITIONS(-DGIT_WINHTTP)
+
+FIND_PACKAGE(HTTP_Parser)
+IF (HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
+	INCLUDE_DIRECTORIES(${HTTP_PARSER_INCLUDE_DIRS})
+	LINK_LIBRARIES(${HTTP_PARSER_LIBRARIES})
+	LIST(APPEND LIBGIT2_PC_LIBS "-lhttp_parser")
+ELSE()
+	MESSAGE(STATUS "http-parser was not found or is too old; using bundled 3rd-party sources.")
 	INCLUDE_DIRECTORIES(deps/http-parser)
 	FILE(GLOB SRC_HTTP deps/http-parser/*.c deps/http-parser/*.h)
+ENDIF()
+
+
+IF (WIN32 AND WINHTTP)
+	ADD_DEFINITIONS(-DGIT_WINHTTP)
 
 	# Since MinGW does not come with headers or an import library for winhttp,
 	# we have to include a private header and generate our own import library
@@ -290,17 +301,6 @@ ELSE ()
 		LINK_DIRECTORIES(${CURL_LIBRARY_DIRS})
 		LINK_LIBRARIES(${CURL_LIBRARIES})
 		LIST(APPEND LIBGIT2_PC_LIBS ${CURL_LDFLAGS})
-	ENDIF()
-
-	FIND_PACKAGE(HTTP_Parser)
-	IF (HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
-		INCLUDE_DIRECTORIES(${HTTP_PARSER_INCLUDE_DIRS})
-		LINK_LIBRARIES(${HTTP_PARSER_LIBRARIES})
-		LIST(APPEND LIBGIT2_PC_LIBS "-lhttp_parser")
-	ELSE()
-		MESSAGE(STATUS "http-parser was not found or is too old; using bundled 3rd-party sources.")
-		INCLUDE_DIRECTORIES(deps/http-parser)
-		FILE(GLOB SRC_HTTP deps/http-parser/*.c deps/http-parser/*.h)
 	ENDIF()
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,19 +235,6 @@ IF (WIN32 AND EMBED_SSH_PATH)
 	ADD_DEFINITIONS(-DGIT_SSH)
 ENDIF()
 
-
-FIND_PACKAGE(HTTP_Parser)
-IF (HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
-	INCLUDE_DIRECTORIES(${HTTP_PARSER_INCLUDE_DIRS})
-	LINK_LIBRARIES(${HTTP_PARSER_LIBRARIES})
-	LIST(APPEND LIBGIT2_PC_LIBS "-lhttp_parser")
-ELSE()
-	MESSAGE(STATUS "http-parser was not found or is too old; using bundled 3rd-party sources.")
-	INCLUDE_DIRECTORIES(deps/http-parser)
-	FILE(GLOB SRC_HTTP deps/http-parser/*.c deps/http-parser/*.h)
-ENDIF()
-
-
 IF (WIN32 AND WINHTTP)
 	ADD_DEFINITIONS(-DGIT_WINHTTP)
 
@@ -330,6 +317,18 @@ ENDIF()
 IF(WIN32 OR AMIGA OR CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
 	INCLUDE_DIRECTORIES(deps/regex)
 	SET(SRC_REGEX deps/regex/regex.c)
+ENDIF()
+
+# Optional external dependency: http-parser
+FIND_PACKAGE(HTTP_Parser)
+IF (HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
+	INCLUDE_DIRECTORIES(${HTTP_PARSER_INCLUDE_DIRS})
+	LINK_LIBRARIES(${HTTP_PARSER_LIBRARIES})
+	LIST(APPEND LIBGIT2_PC_LIBS "-lhttp_parser")
+ELSE()
+	MESSAGE(STATUS "http-parser version 2 was not found; using bundled 3rd-party sources.")
+	INCLUDE_DIRECTORIES(deps/http-parser)
+	FILE(GLOB SRC_HTTP deps/http-parser/*.c deps/http-parser/*.h)
 ENDIF()
 
 # Optional external dependency: zlib


### PR DESCRIPTION
Currently, when building `libgit2` on windows, if building against WinHTTP, there is no option to use an external `http-parser` library, we are [locked into using the builtin `http-parser` library](https://github.com/libgit2/libgit2/blob/ae5838f118a4819e608990a815bf8fc482be5772/CMakeLists.txt#L238-L241).  I'd guess this was done because there were purportedly some differences between the third-party `http-parser` library on windows and the builtin `http-parser` library.  However, I cannot find any special treatment of the windows build of the internal `http-parser`, so it stands to reason that we should be able to use the same external `http-parser` library on windows as we do on Linux or OSX.

This patch allows searching for `http-parser` libraries on any platform.