### PR TITLE
git_rebase_init: correctly handle detached HEAD

### DIFF
--- a/src/rebase.c
+++ b/src/rebase.c
@@ -630,7 +630,7 @@ static int rebase_init_merge(
 	rebase->state_path = git_buf_detach(&state_path);
 	GITERR_CHECK_ALLOC(rebase->state_path);
 
-	if (branch->ref_name) {
+	if (branch->ref_name && strcmp(branch->ref_name, "HEAD")) {
 		rebase->orig_head_name = git__strdup(branch->ref_name);
 		GITERR_CHECK_ALLOC(rebase->orig_head_name);
 	} else {


### PR DESCRIPTION
git_rebase_finish relies on head_detached being set, but rebase_init_merge was only setting it when branch->ref_name was unset. But branch->ref_name would be set to "HEAD" in the case of detached
HEAD being either implicitly (NULL) or explicitly passed to git_rebase_init.
