### PR TITLE
FETCH_HEAD and multiple refspecs

### DIFF
--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -118,7 +118,7 @@ int git_fetchhead_write(git_repository *repo, git_vector *fetchhead_refs)
 	if (git_buf_joinpath(&path, repo->gitdir, GIT_FETCH_HEAD_FILE) < 0)
 		return -1;
 
-	if (git_filebuf_open(&file, path.ptr, GIT_FILEBUF_FORCE, GIT_REFS_FILE_MODE) < 0) {
+	if (git_filebuf_open(&file, path.ptr, GIT_FILEBUF_APPEND, GIT_REFS_FILE_MODE) < 0) {
 		git_buf_free(&path);
 		return -1;
 	}

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -102,6 +102,16 @@ int git_futils_open_ro(const char *path)
 	return fd;
 }
 
+int git_futils_truncate(const char *path, int mode)
+{
+	int fd = p_open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, mode);
+	if (fd < 0)
+		return git_path_set_error(errno, path, "open");
+
+	close(fd);
+	return 0;
+}
+
 git_off_t git_futils_filesize(git_file fd)
 {
 	struct stat sb;

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -248,6 +248,11 @@ extern int git_futils_cp_r(
 extern int git_futils_open_ro(const char *path);
 
 /**
+ * Truncate a file, creating it if it doesn't exist.
+ */
+extern int git_futils_truncate(const char *path, int mode);
+
+/**
  * Get the filesize in bytes of a file
  */
 extern git_off_t git_futils_filesize(git_file fd);

--- a/src/remote.c
+++ b/src/remote.c
@@ -1541,6 +1541,20 @@ cleanup:
 	return error;
 }
 
+static int truncate_fetch_head(const char *gitdir)
+{
+	git_buf path = GIT_BUF_INIT;
+	int error;
+
+	if ((error = git_buf_joinpath(&path, gitdir, GIT_FETCH_HEAD_FILE)) < 0)
+		return error;
+
+	error = git_futils_truncate(path.ptr, GIT_REFS_FILE_MODE);
+	git_buf_free(&path);
+
+	return error;
+}
+
 int git_remote_update_tips(
 		git_remote *remote,
 		const git_remote_callbacks *callbacks,
@@ -1570,6 +1584,9 @@ int git_remote_update_tips(
 		tagopt = remote->download_tags;
 	else
 		tagopt = download_tags;
+
+	if ((error = truncate_fetch_head(git_repository_path(remote->repo))) < 0)
+		goto out;
 
 	if (tagopt == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {
 		if ((error = update_tips_for_spec(remote, callbacks, update_fetchhead, tagopt, &tagspec, &refs, reflog_message)) < 0)


### PR DESCRIPTION
The functions that write to FETCH_HEAD assume we only handle a single refspec at a time, which means we might fail to write part of the data that should be there, or we'll overwrite one refspec's information with another's.