### PR TITLE
Allow compile with gcc -Werror=format-security

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -552,7 +552,7 @@ int git_index_clear(git_index *index)
 
 static int create_index_error(int error, const char *msg)
 {
-	giterr_set_str(GITERR_INDEX, msg);
+	giterr_set_str(GITERR_INDEX, "index creation error '%s'", msg);
 	return error;
 }
 

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -21,7 +21,7 @@ static int zstream_seterr(git_zstream *zs)
 	if (zs->zerr == Z_MEM_ERROR)
 		giterr_set_oom();
 	else if (zs->z.msg)
-		giterr_set_str(GITERR_ZLIB, zs->z.msg);
+		giterr_set_str(GITERR_ZLIB, "zlib compression error '%s'", zs->z.msg);
 	else
 		giterr_set(GITERR_ZLIB, "Unknown compression error");
 


### PR DESCRIPTION
When building a v.25-rc1 RPM on Fedora 25, the default compiler flags include -Werror=format-security and a compile of v.25-rc1 fails in two locations with "format not a string literal and no format arguments".

Please merge this PR.