### PR TITLE
refdb: bubble up recursive rm when locking a ref

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -729,8 +729,8 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 	/* Remove a possibly existing empty directory hierarchy
 	 * which name would collide with the reference name
 	 */
-	if (git_futils_rmdir_r(name, backend->path, GIT_RMDIR_SKIP_NONEMPTY) < 0)
-		return -1;
+	if ((error = git_futils_rmdir_r(name, backend->path, GIT_RMDIR_SKIP_NONEMPTY)) < 0)
+		return error;
 
 	if (git_buf_joinpath(&ref_path, backend->path, name) < 0)
 		return -1;


### PR DESCRIPTION
Failure to bubble up this error means some locking errors do not get reported as
such on Windows.

There's another issue around repacking references where some seem to go missing when all the threads start compressing at the same time, but this eliminates one of the common causes of CI failing (and of course actually helps with reporting the actual error).