### PR TITLE
pack: dereference cached pack entry on error

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -757,8 +757,11 @@ int git_packfile_unpack(
 	}
 
 cleanup:
-	if (error < 0)
+	if (error < 0) {
 		git__free(obj->data);
+		if (cached)
+			git_atomic_dec(&cached->refcount);
+	}
 
 	if (elem)
 		*obj_offset = curpos;


### PR DESCRIPTION
When trying to uncompress deltas in a packfile's delta chain, we try to
add object bases to the packfile cache, subsequently decrementing its
reference count if it has been added successfully. This may lead to a
mismatched reference count in the case where we exit the loop early due
to an encountered error.

Fix the issue by decrementing the reference count in error cleanup.