### PR TITLE
fsync all the things

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -179,7 +179,7 @@ typedef enum {
 	GIT_OPT_SET_SSL_CIPHERS,
 	GIT_OPT_GET_USER_AGENT,
 	GIT_OPT_ENABLE_OFS_DELTA,
-	GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION,
+	GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION,
 } git_libgit2_opt_t;
 
 /**
@@ -317,7 +317,7 @@ typedef enum {
  *		> Packfiles containing offset deltas can still be read.
  *		> This defaults to enabled.
  *
- *	* opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, int enabled)
+ *	* opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, int enabled)
  *
  *		> Enable synchronized writes of new objects using `fsync`
  *		> (or the platform equivalent) to ensure that new object data

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -179,6 +179,7 @@ typedef enum {
 	GIT_OPT_SET_SSL_CIPHERS,
 	GIT_OPT_GET_USER_AGENT,
 	GIT_OPT_ENABLE_OFS_DELTA,
+	GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION,
 } git_libgit2_opt_t;
 
 /**
@@ -315,6 +316,13 @@ typedef enum {
  *		> and thus smaller resultant packfiles.
  *		> Packfiles containing offset deltas can still be read.
  *		> This defaults to enabled.
+ *
+ *	* opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, int enabled)
+ *
+ *		> Enable synchronized writes of new objects using `fsync`
+ *		> (or the platform equivalent) to ensure that new object data
+ *		> is written to permanent storage, not simply cached.  This
+ *		> defaults to disabled.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -39,7 +39,7 @@ GIT_EXTERN(int) git_odb_backend_pack(git_odb_backend **out, const char *objects_
  * @param out location to store the odb backend pointer
  * @param objects_dir the Git repository's objects directory
  * @param compression_level zlib compression level to use
- * @param do_fsync whether to do an fsync() after writing (currently ignored)
+ * @param do_fsync whether to do an fsync() after writing
  * @param dir_mode permissions to use creating a directory or 0 for defaults
  * @param file_mode permissions to use creating a file or 0 for defaults
  *

--- a/src/config_cache.c
+++ b/src/config_cache.c
@@ -78,6 +78,7 @@ static struct map_data _cvar_maps[] = {
 	{"core.logallrefupdates", NULL, 0, GIT_LOGALLREFUPDATES_DEFAULT },
 	{"core.protecthfs", NULL, 0, GIT_PROTECTHFS_DEFAULT },
 	{"core.protectntfs", NULL, 0, GIT_PROTECTNTFS_DEFAULT },
+	{"core.fsyncobjectfiles", NULL, 0, GIT_FSYNCOBJECTFILES_DEFAULT },
 };
 
 int git_config__cvar(int *out, git_config *config, git_cvar_cached cvar)

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -445,6 +445,9 @@ int git_filebuf_commit(git_filebuf *file)
 		goto on_error;
 	}
 
+	if (file->do_fsync && git_futils_fsync_parent(file->path_original) < 0)
+		goto on_error;
+
 	file->did_rename = true;
 
 	git_filebuf_cleanup(file);

--- a/src/filebuf.h
+++ b/src/filebuf.h
@@ -20,7 +20,8 @@
 #define GIT_FILEBUF_FORCE				(1 << 3)
 #define GIT_FILEBUF_TEMPORARY			(1 << 4)
 #define GIT_FILEBUF_DO_NOT_BUFFER		(1 << 5)
-#define GIT_FILEBUF_DEFLATE_SHIFT		(6)
+#define GIT_FILEBUF_FSYNC				(1 << 6)
+#define GIT_FILEBUF_DEFLATE_SHIFT		(7)
 
 #define GIT_FILELOCK_EXTENSION ".lock\0"
 #define GIT_FILELOCK_EXTLENGTH 6
@@ -47,6 +48,7 @@ struct git_filebuf {
 	bool created_lock;
 	bool did_rename;
 	bool do_not_buffer;
+	bool do_fsync;
 	int last_error;
 };
 

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -1127,6 +1127,10 @@ void git_futils_filestamp_set_from_stat(
 
 int git_futils_fsync_dir(const char *path)
 {
+#ifdef GIT_WIN32
+	GIT_UNUSED(path);
+	return 0;
+#else
 	int fd, error = -1;
 
 	if ((fd = p_open(path, O_RDONLY)) < 0) {
@@ -1139,6 +1143,7 @@ int git_futils_fsync_dir(const char *path)
 
 	p_close(fd);
 	return error;
+#endif
 }
 
 int git_futils_fsync_parent(const char *path)

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -237,13 +237,13 @@ int git_futils_writebuffer(
 {
 	int fd, do_fsync = 0, error = 0;
 
+	if (!flags)
+		flags = O_CREAT | O_TRUNC | O_WRONLY;
+
 	if ((flags & O_FSYNC) != 0)
 		do_fsync = 1;
 
 	flags &= ~O_FSYNC;
-
-	if (flags <= 0)
-		flags = O_CREAT | O_TRUNC | O_WRONLY;
 
 	if (!mode)
 		mode = GIT_FILEMODE_BLOB;

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -363,4 +363,22 @@ extern void git_futils_filestamp_set(
 extern void git_futils_filestamp_set_from_stat(
 	git_futils_filestamp *stamp, struct stat *st);
 
+/**
+ * `fsync` the parent directory of the given path, if `fsync` is
+ * supported for directories on this platform.
+ *
+ * @param path Path of the directory to sync.
+ * @return 0 on success, -1 on error
+ */
+extern int git_futils_fsync_dir(const char *path);
+
+/**
+ * `fsync` the parent directory of the given path, if `fsync` is
+ * supported for directories on this platform.
+ *
+ * @param path Path of the file whose parent directory should be synced.
+ * @return 0 on success, -1 on error
+ */
+extern int git_futils_fsync_parent(const char *path);
+
 #endif /* INCLUDE_fileops_h__ */

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -25,6 +25,13 @@ extern int git_futils_readbuffer_updated(
 	git_buf *obj, const char *path, git_oid *checksum, int *updated);
 extern int git_futils_readbuffer_fd(git_buf *obj, git_file fd, size_t len);
 
+/* Additional constants for `git_futils_writebuffer`'s `open_flags`.  We
+ * support these internally and they will be removed before the `open` call.
+ */
+#ifndef O_FSYNC
+# define O_FSYNC (1 << 31)
+#endif
+
 extern int git_futils_writebuffer(
 	const git_buf *buf, const char *path, int open_flags, mode_t mode);
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -17,6 +17,7 @@
 #include "oid.h"
 #include "oidmap.h"
 #include "zstream.h"
+#include "object.h"
 
 extern git_mutex git__mwindow_mutex;
 
@@ -989,7 +990,9 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 		return -1;
 
 	if (git_filebuf_open(&index_file, filename.ptr,
-		GIT_FILEBUF_HASH_CONTENTS, idx->mode) < 0)
+		GIT_FILEBUF_HASH_CONTENTS |
+		(git_object__synchronized_writing ? GIT_FILEBUF_FSYNC : 0),
+		idx->mode) < 0)
 		goto on_error;
 
 	/* Write out the header */
@@ -1064,6 +1067,11 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	if (p_ftruncate(idx->pack->mwf.fd, idx->pack->mwf.size) < 0) {
 		giterr_set(GITERR_OS, "failed to truncate pack file '%s'", idx->pack->pack_name);
 		return -1;
+	}
+
+	if (git_object__synchronized_writing && p_fsync(idx->pack->mwf.fd) < 0) {
+		giterr_set(GITERR_OS, "failed to fsync packfile");
+		goto on_error;
 	}
 
 	/* We need to close the descriptor here so Windows doesn't choke on commit_at */

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -991,7 +991,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 
 	if (git_filebuf_open(&index_file, filename.ptr,
 		GIT_FILEBUF_HASH_CONTENTS |
-		(git_object__synchronized_writing ? GIT_FILEBUF_FSYNC : 0),
+		(git_object__synchronous_writing ? GIT_FILEBUF_FSYNC : 0),
 		idx->mode) < 0)
 		goto on_error;
 
@@ -1069,7 +1069,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 		return -1;
 	}
 
-	if (git_object__synchronized_writing && p_fsync(idx->pack->mwf.fd) < 0) {
+	if (git_object__synchronous_writing && p_fsync(idx->pack->mwf.fd) < 0) {
 		giterr_set(GITERR_OS, "failed to fsync packfile");
 		goto on_error;
 	}
@@ -1090,7 +1090,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 		goto on_error;
 
 	/* And fsync the parent directory if we're asked to. */
-	if (git_object__synchronized_writing &&
+	if (git_object__synchronous_writing &&
 		git_futils_fsync_parent(git_buf_cstr(&filename)) < 0)
 		goto on_error;
 

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_indexer_h__
+#define INCLUDE_indexer_h__
+
+extern int git_indexer__set_fsync(git_indexer *idx, int do_fsync);
+
+#endif

--- a/src/object.c
+++ b/src/object.c
@@ -16,6 +16,7 @@
 #include "tag.h"
 
 bool git_object__strict_input_validation = true;
+bool git_object__synchronized_writing = false;
 
 typedef struct {
 	const char	*str;	/* type name string */

--- a/src/object.c
+++ b/src/object.c
@@ -16,7 +16,7 @@
 #include "tag.h"
 
 bool git_object__strict_input_validation = true;
-bool git_object__synchronized_writing = false;
+bool git_object__synchronous_writing = false;
 
 typedef struct {
 	const char	*str;	/* type name string */

--- a/src/object.h
+++ b/src/object.h
@@ -10,6 +10,7 @@
 #include "repository.h"
 
 extern bool git_object__strict_input_validation;
+extern bool git_object__synchronized_writing;
 
 /** Base git object for inheritance */
 struct git_object {

--- a/src/object.h
+++ b/src/object.h
@@ -10,7 +10,7 @@
 #include "repository.h"
 
 extern bool git_object__strict_input_validation;
-extern bool git_object__synchronized_writing;
+extern bool git_object__synchronous_writing;
 
 /** Base git object for inheritance */
 struct git_object {

--- a/src/odb.h
+++ b/src/odb.h
@@ -38,7 +38,24 @@ struct git_odb {
 	git_refcount rc;
 	git_vector backends;
 	git_cache own_cache;
+	unsigned int do_fsync :1;
 };
+
+typedef enum {
+	GIT_ODB_CAP_FROM_OWNER = -1,
+} git_odb_cap_t;
+
+/*
+ * Set the capabilities for the object database.
+ */
+int git_odb__set_caps(git_odb *odb, int caps);
+
+/*
+ * Add the default loose and packed backends for a database.
+ */
+int git_odb__add_default_backends(
+	git_odb *db, const char *objects_dir,
+	bool as_alternates, int alternate_depth);
 
 /*
  * Hash a git_rawobj internally.

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -838,6 +838,17 @@ static void loose_backend__stream_free(git_odb_stream *_stream)
 	git__free(stream);
 }
 
+static int filebuf_flags(loose_backend *backend)
+{
+	int flags = GIT_FILEBUF_TEMPORARY |
+		(backend->object_zlib_level << GIT_FILEBUF_DEFLATE_SHIFT);
+
+	if (backend->fsync_object_files)
+		flags |= GIT_FILEBUF_FSYNC;
+
+	return flags;
+}
+
 static int loose_backend__stream(git_odb_stream **stream_out, git_odb_backend *_backend, git_off_t length, git_otype type)
 {
 	loose_backend *backend;
@@ -864,9 +875,7 @@ static int loose_backend__stream(git_odb_stream **stream_out, git_odb_backend *_
 	stream->stream.mode = GIT_STREAM_WRONLY;
 
 	if (git_buf_joinpath(&tmp_path, backend->objects_dir, "tmp_object") < 0 ||
-		git_filebuf_open(&stream->fbuf, tmp_path.ptr,
-			GIT_FILEBUF_TEMPORARY |
-			(backend->object_zlib_level << GIT_FILEBUF_DEFLATE_SHIFT),
+		git_filebuf_open(&stream->fbuf, tmp_path.ptr, filebuf_flags(backend),
 			backend->object_file_mode) < 0 ||
 		stream->stream.write((git_odb_stream *)stream, hdr, hdrlen) < 0)
 	{
@@ -894,9 +903,7 @@ static int loose_backend__write(git_odb_backend *_backend, const git_oid *oid, c
 	header_len = git_odb__format_object_header(header, sizeof(header), len, type);
 
 	if (git_buf_joinpath(&final_path, backend->objects_dir, "tmp_object") < 0 ||
-		git_filebuf_open(&fbuf, final_path.ptr,
-			GIT_FILEBUF_TEMPORARY |
-			(backend->object_zlib_level << GIT_FILEBUF_DEFLATE_SHIFT),
+		git_filebuf_open(&fbuf, final_path.ptr, filebuf_flags(backend),
 			backend->object_file_mode) < 0)
 	{
 		error = -1;

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -14,6 +14,7 @@
 #include "odb.h"
 #include "delta.h"
 #include "filebuf.h"
+#include "object.h"
 
 #include "git2/odb_backend.h"
 #include "git2/types.h"
@@ -843,7 +844,7 @@ static int filebuf_flags(loose_backend *backend)
 	int flags = GIT_FILEBUF_TEMPORARY |
 		(backend->object_zlib_level << GIT_FILEBUF_DEFLATE_SHIFT);
 
-	if (backend->fsync_object_files)
+	if (backend->fsync_object_files || git_object__synchronized_writing)
 		flags |= GIT_FILEBUF_FSYNC;
 
 	return flags;

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -844,7 +844,7 @@ static int filebuf_flags(loose_backend *backend)
 	int flags = GIT_FILEBUF_TEMPORARY |
 		(backend->object_zlib_level << GIT_FILEBUF_DEFLATE_SHIFT);
 
-	if (backend->fsync_object_files || git_object__synchronized_writing)
+	if (backend->fsync_object_files || git_object__synchronous_writing)
 		flags |= GIT_FILEBUF_FSYNC;
 
 	return flags;

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1385,12 +1385,16 @@ int git_packbuilder_write(
 	git_indexer *indexer;
 	git_transfer_progress stats;
 	struct pack_write_context ctx;
+	int t;
 
 	PREPARE_PACK;
 
 	if (git_indexer_new(
 		&indexer, path, mode, pb->odb, progress_cb, progress_cb_payload) < 0)
 		return -1;
+
+	if (!git_repository__cvar(&t, pb->repo, GIT_CVAR_FSYNCOBJECTFILES) && t)
+		git_indexer__set_fsync(indexer, 1);
 
 	ctx.indexer = indexer;
 	ctx.stats = &stats;

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -16,6 +16,7 @@
 #include "netops.h"
 #include "zstream.h"
 #include "pool.h"
+#include "indexer.h"
 
 #include "git2/oid.h"
 #include "git2/pack.h"

--- a/src/posix.c
+++ b/src/posix.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include <ctype.h>
 
+size_t p_fsync__cnt = 0;
+
 #ifndef GIT_WIN32
 
 #ifdef NO_ADDRINFO

--- a/src/posix.h
+++ b/src/posix.h
@@ -111,6 +111,12 @@ extern int p_rename(const char *from, const char *to);
 extern int git__page_size(size_t *page_size);
 extern int git__mmap_alignment(size_t *page_size);
 
+/* The number of times `p_fsync` has been called.  Note that this is for
+ * test code only; it it not necessarily thread-safe and should not be
+ * relied upon in production.
+ */
+extern size_t p_fsync__cnt;
+
 /**
  * Platform-dependent methods
  */

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -447,8 +447,8 @@ static int rebase_setupfiles_merge(git_rebase *rebase)
 	size_t i;
 	int error = 0;
 
-	if ((error = rebase_setupfile(rebase, END_FILE, -1, "%" PRIuZ "\n", git_array_size(rebase->operations))) < 0 ||
-		(error = rebase_setupfile(rebase, ONTO_NAME_FILE, -1, "%s\n", rebase->onto_name)) < 0)
+	if ((error = rebase_setupfile(rebase, END_FILE, 0, "%" PRIuZ "\n", git_array_size(rebase->operations))) < 0 ||
+		(error = rebase_setupfile(rebase, ONTO_NAME_FILE, 0, "%s\n", rebase->onto_name)) < 0)
 		goto done;
 
 	for (i = 0; i < git_array_size(rebase->operations); i++) {
@@ -459,7 +459,7 @@ static int rebase_setupfiles_merge(git_rebase *rebase)
 
 		git_oid_fmt(id_str, &operation->id);
 
-		if ((error = rebase_setupfile(rebase, commit_filename.ptr, -1,
+		if ((error = rebase_setupfile(rebase, commit_filename.ptr, 0,
 				"%.*s\n", GIT_OID_HEXSZ, id_str)) < 0)
 			goto done;
 	}
@@ -486,10 +486,10 @@ static int rebase_setupfiles(git_rebase *rebase)
 		rebase->orig_head_name;
 
 	if (git_repository__set_orig_head(rebase->repo, &rebase->orig_head_id) < 0 ||
-		rebase_setupfile(rebase, HEAD_NAME_FILE, -1, "%s\n", orig_head_name) < 0 ||
-		rebase_setupfile(rebase, ONTO_FILE, -1, "%.*s\n", GIT_OID_HEXSZ, onto) < 0 ||
-		rebase_setupfile(rebase, ORIG_HEAD_FILE, -1, "%.*s\n", GIT_OID_HEXSZ, orig_head) < 0 ||
-		rebase_setupfile(rebase, QUIET_FILE, -1, rebase->quiet ? "t\n" : "\n") < 0)
+		rebase_setupfile(rebase, HEAD_NAME_FILE, 0, "%s\n", orig_head_name) < 0 ||
+		rebase_setupfile(rebase, ONTO_FILE, 0, "%.*s\n", GIT_OID_HEXSZ, onto) < 0 ||
+		rebase_setupfile(rebase, ORIG_HEAD_FILE, 0, "%.*s\n", GIT_OID_HEXSZ, orig_head) < 0 ||
+		rebase_setupfile(rebase, QUIET_FILE, 0, rebase->quiet ? "t\n" : "\n") < 0)
 		return -1;
 
 	return rebase_setupfiles_merge(rebase);
@@ -821,8 +821,8 @@ static int rebase_next_merge(
 	normalize_checkout_options_for_apply(&checkout_opts, rebase, current_commit);
 
 	if ((error = git_indexwriter_init_for_operation(&indexwriter, rebase->repo, &checkout_opts.checkout_strategy)) < 0 ||
-		(error = rebase_setupfile(rebase, MSGNUM_FILE, -1, "%" PRIuZ "\n", rebase->current+1)) < 0 ||
-		(error = rebase_setupfile(rebase, CURRENT_FILE, -1, "%.*s\n", GIT_OID_HEXSZ, current_idstr)) < 0 ||
+		(error = rebase_setupfile(rebase, MSGNUM_FILE, 0, "%" PRIuZ "\n", rebase->current+1)) < 0 ||
+		(error = rebase_setupfile(rebase, CURRENT_FILE, 0, "%.*s\n", GIT_OID_HEXSZ, current_idstr)) < 0 ||
 		(error = git_merge_trees(&index, rebase->repo, parent_tree, head_tree, current_tree, &rebase->options.merge_options)) < 0 ||
 		(error = git_merge__check_result(rebase->repo, index)) < 0 ||
 		(error = git_checkout_index(rebase->repo, index, &checkout_opts)) < 0 ||

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -62,6 +62,7 @@ typedef struct refdb_fs_backend {
 	int peeling_mode;
 	git_iterator_flag_t iterator_flags;
 	uint32_t direach_flags;
+	int fsync;
 } refdb_fs_backend;
 
 static int refdb_reflog_fs__delete(git_refdb_backend *_backend, const char *name);
@@ -756,7 +757,7 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 		return -1;
 
 	filebuf_flags = GIT_FILEBUF_FORCE;
-	if (git_object__synchronous_writing)
+	if (backend->fsync)
 		filebuf_flags |= GIT_FILEBUF_FSYNC;
 
 	error = git_filebuf_open(file, ref_path.ptr, filebuf_flags, GIT_REFS_FILE_MODE);
@@ -1001,7 +1002,7 @@ static int packed_write(refdb_fs_backend *backend)
 	if ((error = git_sortedcache_wlock(refcache)) < 0)
 		return error;
 
-	if (git_object__synchronous_writing)
+	if (backend->fsync)
 		open_flags = GIT_FILEBUF_FSYNC;
 
 	/* Open the file! */
@@ -1861,7 +1862,7 @@ static int reflog_append(refdb_fs_backend *backend, const git_reference *ref, co
 
 	open_flags = O_WRONLY | O_CREAT | O_APPEND;
 
-	if (git_object__synchronous_writing)
+	if (backend->fsync)
 		open_flags |= O_FSYNC;
 
 	error = git_futils_writebuffer(&buf, git_buf_cstr(&path), open_flags, GIT_REFLOG_FILE_MODE);
@@ -2014,6 +2015,9 @@ int git_refdb_backend_fs(
 		backend->iterator_flags |= GIT_ITERATOR_PRECOMPOSE_UNICODE;
 		backend->direach_flags  |= GIT_PATH_DIR_PRECOMPOSE_UNICODE;
 	}
+	if ((!git_repository__cvar(&t, backend->repo, GIT_CVAR_FSYNCOBJECTFILES) && t) ||
+		git_object__synchronous_writing)
+		backend->fsync = 1;
 
 	backend->parent.exists = &refdb_fs_backend__exists;
 	backend->parent.lookup = &refdb_fs_backend__lookup;

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -994,15 +994,18 @@ static int packed_write(refdb_fs_backend *backend)
 {
 	git_sortedcache *refcache = backend->refcache;
 	git_filebuf pack_file = GIT_FILEBUF_INIT;
-	int error;
+	int error, open_flags = 0;
 	size_t i;
 
 	/* lock the cache to updates while we do this */
 	if ((error = git_sortedcache_wlock(refcache)) < 0)
 		return error;
 
+	if (git_object__synchronized_writing)
+		open_flags = GIT_FILEBUF_FSYNC;
+
 	/* Open the file! */
-	if ((error = git_filebuf_open(&pack_file, git_sortedcache_path(refcache), 0, GIT_PACKEDREFS_FILE_MODE)) < 0)
+	if ((error = git_filebuf_open(&pack_file, git_sortedcache_path(refcache), open_flags, GIT_PACKEDREFS_FILE_MODE)) < 0)
 		goto fail;
 
 	/* Packfiles have a header... apparently

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -756,7 +756,7 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 		return -1;
 
 	filebuf_flags = GIT_FILEBUF_FORCE;
-	if (git_object__synchronized_writing)
+	if (git_object__synchronous_writing)
 		filebuf_flags |= GIT_FILEBUF_FSYNC;
 
 	error = git_filebuf_open(file, ref_path.ptr, filebuf_flags, GIT_REFS_FILE_MODE);
@@ -1001,7 +1001,7 @@ static int packed_write(refdb_fs_backend *backend)
 	if ((error = git_sortedcache_wlock(refcache)) < 0)
 		return error;
 
-	if (git_object__synchronized_writing)
+	if (git_object__synchronous_writing)
 		open_flags = GIT_FILEBUF_FSYNC;
 
 	/* Open the file! */
@@ -1861,7 +1861,7 @@ static int reflog_append(refdb_fs_backend *backend, const git_reference *ref, co
 
 	open_flags = O_WRONLY | O_CREAT | O_APPEND;
 
-	if (git_object__synchronized_writing)
+	if (git_object__synchronous_writing)
 		open_flags |= O_FSYNC;
 
 	error = git_futils_writebuffer(&buf, git_buf_cstr(&path), open_flags, GIT_REFLOG_FILE_MODE);

--- a/src/repository.h
+++ b/src/repository.h
@@ -46,6 +46,7 @@ typedef enum {
 	GIT_CVAR_LOGALLREFUPDATES, /* core.logallrefupdates */
 	GIT_CVAR_PROTECTHFS,    /* core.protectHFS */
 	GIT_CVAR_PROTECTNTFS,   /* core.protectNTFS */
+	GIT_CVAR_FSYNCOBJECTFILES, /* core.fsyncObjectFiles */
 	GIT_CVAR_CACHE_MAX
 } git_cvar_cached;
 
@@ -106,6 +107,8 @@ typedef enum {
 	GIT_PROTECTHFS_DEFAULT = GIT_CVAR_FALSE,
 	/* core.protectNTFS */
 	GIT_PROTECTNTFS_DEFAULT = GIT_CVAR_FALSE,
+	/* core.fsyncObjectFiles */
+	GIT_FSYNCOBJECTFILES_DEFAULT = GIT_CVAR_FALSE,
 } git_cvar_value;
 
 /* internal repository init flags */

--- a/src/settings.c
+++ b/src/settings.c
@@ -227,8 +227,8 @@ int git_libgit2_opts(int key, ...)
 		git_smart__ofs_delta_enabled = (va_arg(ap, int) != 0);
 		break;
 
-	case GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION:
-		git_object__synchronized_writing = (va_arg(ap, int) != 0);
+	case GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION:
+		git_object__synchronous_writing = (va_arg(ap, int) != 0);
 		break;
 
 	default:

--- a/src/settings.c
+++ b/src/settings.c
@@ -227,6 +227,10 @@ int git_libgit2_opts(int key, ...)
 		git_smart__ofs_delta_enabled = (va_arg(ap, int) != 0);
 		break;
 
+	case GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION:
+		git_object__synchronized_writing = (va_arg(ap, int) != 0);
+		break;
+
 	default:
 		giterr_set(GITERR_INVALID, "invalid option key");
 		error = -1;

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -40,8 +40,13 @@ typedef int GIT_SOCKET;
 #define p_link(o,n) link(o, n)
 #define p_unlink(p) unlink(p)
 #define p_mkdir(p,m) mkdir(p, m)
-#define p_fsync(fd) fsync(fd)
 extern char *p_realpath(const char *, char *);
+
+GIT_INLINE(int) p_fsync(int fd)
+{
+	p_fsync__cnt++;
+	return fsync(fd);
+}
 
 #define p_recv(s,b,l,f) recv(s,b,l,f)
 #define p_send(s,b,l,f) send(s,b,l,f)

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -113,6 +113,8 @@ int p_fsync(int fd)
 {
 	HANDLE fh = (HANDLE)_get_osfhandle(fd);
 
+	p_fsync__cnt++;
+
 	if (fh == INVALID_HANDLE_VALUE) {
 		errno = EBADF;
 		return -1;

--- a/tests/odb/loose.c
+++ b/tests/odb/loose.c
@@ -62,7 +62,7 @@ void test_odb_loose__initialize(void)
 
 void test_odb_loose__cleanup(void)
 {
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 0));
 	cl_fixture_cleanup("test-objects");
 }
 
@@ -180,7 +180,7 @@ void test_odb_loose__fsync_obeys_odb_option(void)
 
 void test_odb_loose__fsync_obeys_global_setting(void)
 {
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
 	write_object_to_loose_odb(0);
 	cl_assert(p_fsync__cnt > 0);
 }

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -31,7 +31,7 @@ void test_pack_packbuilder__cleanup(void)
 	git_oid *o;
 	unsigned int i;
 
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 0));
 
 	if (_commits_is_initialized) {
 		_commits_is_initialized = 0;
@@ -200,7 +200,7 @@ void test_pack_packbuilder__does_not_fsync_by_default(void)
 
 void test_pack_packbuilder__fsync_when_asked(void)
 {
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
 	p_fsync__cnt = 0;
 	seed_packbuilder();
 	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -200,11 +200,20 @@ void test_pack_packbuilder__does_not_fsync_by_default(void)
 
 void test_pack_packbuilder__fsync_when_asked(void)
 {
+	/* We fsync the packfile and index.  On non-Windows, we also fsync
+	 * the parent directories.
+	 */
+#ifdef GIT_WIN32
+	int expected = 2;
+#else
+	int expected = 4;
+#endif
+
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
 	p_fsync__cnt = 0;
 	seed_packbuilder();
 	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);
-	cl_assert_equal_sz(4, p_fsync__cnt);
+	cl_assert_equal_sz(expected, p_fsync__cnt);
 }
 
 static int foreach_cb(void *buf, size_t len, void *payload)

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -204,7 +204,7 @@ void test_pack_packbuilder__fsync_when_asked(void)
 	p_fsync__cnt = 0;
 	seed_packbuilder();
 	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);
-	cl_assert_equal_sz(2, p_fsync__cnt);
+	cl_assert_equal_sz(4, p_fsync__cnt);
 }
 
 static int foreach_cb(void *buf, size_t len, void *payload)

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -22,7 +22,7 @@ void test_refs_create__cleanup(void)
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, 1));
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 0));
 }
 
 void test_refs_create__symbolic(void)
@@ -323,7 +323,7 @@ void test_refs_create__fsyncs_when_requested(void)
 	git_refdb *refdb;
 	git_oid id;
 
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
 	p_fsync__cnt = 0;
 
 	git_oid_fromstr(&id, current_master_tip);

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -329,7 +329,7 @@ void test_refs_create__fsyncs_when_requested(void)
 	git_oid_fromstr(&id, current_master_tip);
 	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/fsync_test", &id, 0, "log message"));
 	git_reference_free(ref);
-	cl_assert_equal_i(2, p_fsync__cnt);
+	cl_assert_equal_i(4, p_fsync__cnt);
 
 	p_fsync__cnt = 0;
 
@@ -337,5 +337,5 @@ void test_refs_create__fsyncs_when_requested(void)
 	cl_git_pass(git_refdb_compress(refdb));
 	git_refdb_free(refdb);
 
-	cl_assert_equal_i(1, p_fsync__cnt);
+	cl_assert_equal_i(2, p_fsync__cnt);
 }


### PR DESCRIPTION
Optionally `fsync` loose objects, packfiles and their indexes, loose references and packed reference files.  This can be enabled by setting the option `GIT_OPT_ENABLE_SYNCHRONIZED_OBJECT_CREATION`, and it is not enabled by default.

Additionally, enable the `do_fsync` option to the loose odb backend to perform similar calls.

At present, we do not honor `core.fsyncObjectFiles`, though this would be a logical next step.