### PR TITLE
Don't hard-code HTTPS cap & clarify the meanings of the features enum

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -109,9 +109,27 @@ GIT_EXTERN(void) git_libgit2_version(int *major, int *minor, int *rev);
  * was compiled
  */
 typedef enum {
+  /**
+   * If set, libgit2 was built thread-aware and can be safely used from multiple
+   * threads.
+   */
 	GIT_FEATURE_THREADS	= (1 << 0),
+  /**
+   * If set, libgit2 was built with and linked against a TLS implementation.
+   * Custom TLS streams may still be added by the user to support HTTPS
+   * regardless of this.
+   */
 	GIT_FEATURE_HTTPS	= (1 << 1),
+  /**
+   * If set, libgit2 was built with and linked against libssh2. A custom
+   * transport may still be added by the user to support libssh2 regardless of
+   * this.
+   */
 	GIT_FEATURE_SSH		= (1 << 2),
+  /**
+   * If set, libgit2 was built with support for sub-second resolution in file
+   * modification times.
+   */
 	GIT_FEATURE_NSEC	= (1 << 3),
 } git_feature_t;
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -29,7 +29,9 @@ int git_libgit2_features(void)
 #ifdef GIT_THREADS
 		| GIT_FEATURE_THREADS
 #endif
+#if defined(GIT_OPENSSL) || defined(GIT_WINHTTP) || defined(GIT_SECURE_TRANSPORT)
 		| GIT_FEATURE_HTTPS
+#endif
 #if defined(GIT_SSH)
 		| GIT_FEATURE_SSH
 #endif


### PR DESCRIPTION
Most importantly, clarify what we mean by HTTPS and SSH being supported.

/cc @ethomson I think this should go into the next release.