### PR TITLE
Fix off-by-one problems in git_signature__parse

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -251,7 +251,7 @@ int git_signature__parse(git_signature *sig, const char **buffer_out,
 			 * only store timezone if it's not overflowing;
 			 * see http://www.worldtimezone.com/faq.html
 			 */
-			if (hours < 14 && mins < 59) {
+			if (hours <= 14 && mins <= 59) {
 				sig->when.offset = (hours * 60) + mins;
 				if (tz_start[0] == '-')
 					sig->when.offset = -sig->when.offset;


### PR DESCRIPTION
Etc/GMT-14 aka UTC+14:00 is a thing....
https://en.wikipedia.org/wiki/UTC%2B14:00

Also allow offsets on the last minute (59).

Addresses: https://bugs.debian.org/841532
Fixes: #3970