### PR TITLE
sysdir: don't re-guess when using variable substitution

### DIFF
--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -171,7 +171,7 @@ int git_sysdir_set(git_sysdir_t which, const char *search_path)
 		expand_path = strstr(search_path, PATH_MAGIC);
 
 	/* reset the default if this path has been cleared */
-	if (!search_path || expand_path)
+	if (!search_path)
 		git_sysdir__dirs[which].guess(&git_sysdir__dirs[which].buf);
 
 	/* if $PATH is not referenced, then just set the path */

--- a/tests/core/env.c
+++ b/tests/core/env.c
@@ -298,3 +298,24 @@ void test_core_env__2(void)
 	git_buf_free(&path);
 	git_buf_free(&found);
 }
+
+void test_core_env__substitution(void)
+{
+  git_buf buf = GIT_BUF_INIT, expected = GIT_BUF_INIT;
+
+  /* Set it to something non-default so we have controllable values */
+  cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, "/tmp/a"));
+  cl_git_pass(git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, &buf));
+  cl_assert_equal_s("/tmp/a", buf.ptr);
+
+  git_buf_clear(&buf);
+  cl_git_pass(git_buf_join(&buf, GIT_PATH_LIST_SEPARATOR, "$PATH", "/tmp/b"));
+  cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, buf.ptr));
+  cl_git_pass(git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, &buf));
+
+  cl_git_pass(git_buf_join(&expected, GIT_PATH_LIST_SEPARATOR, "/tmp/a", "/tmp/b"));
+  cl_assert_equal_s(expected.ptr, buf.ptr);
+
+  git_buf_free(&expected);
+  git_buf_free(&buf);
+}


### PR DESCRIPTION
When a user sets a search path via variable substitution, we should replace the variable with whatever they may have previously set, rather than guess again what we would have chosen.