### PR TITLE
Gift deprecated in favor of SwiftGit2

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Here are the bindings to libgit2 that are currently available:
 * Rust
     * git2-rs <https://github.com/alexcrichton/git2-rs>
 * Swift
-    * Gift <https://github.com/modocache/Gift>
+    * SwiftGit2 <https://github.com/SwiftGit2/SwiftGit2>
 * Vala
     * libgit2.vapi <https://github.com/apmasell/vapis/blob/master/libgit2.vapi>
 


### PR DESCRIPTION
According to the Gift repo it is now deprecated in favor of SwiftGit2.
> This library isn't really maintained anymore. You should use SwiftGit2 instead.

So changing the link for that here.