### PR TITLE
http: bump the pretend git version in the User-Agent

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -208,7 +208,7 @@ static int gen_request(
 
 	git_buf_printf(buf, "%s %s%s HTTP/1.1\r\n", s->verb, path, s->service_url);
 
-	git_buf_printf(buf, "User-Agent: git/1.0 (%s)\r\n", user_agent());
+	git_buf_printf(buf, "User-Agent: git/2.0 (%s)\r\n", user_agent());
 	git_buf_printf(buf, "Host: %s\r\n", t->connection_data.host);
 
 	if (s->chunked || content_length > 0) {


### PR DESCRIPTION
We want to keep the git UA in order for services to recognise that we're
a Git client and not a browser. But in order to stop dumb HTTP some
services have blocked UAs that claim to be pre-1.6.6 git.

Thread these needles by using the "git/2.0" prefix which is still close
enough to git's yet distinct enough that you can tell it's us.

---

It was reported that at least the GNOME host blocks us due to the UA claiming to be pre-1.6.6 git. While a bit ham-fisted it sure would block clients which don't speak the smart protocol. Chances are they're not the only ones who have taken these steps so let's bump it up to 2.0 since it's made up anyway.
