### PR TITLE
Fix BIO_* functions method linking when compiled with libressl (OpenBSD).

### DIFF
--- a/src/openssl_stream.h
+++ b/src/openssl_stream.h
@@ -27,7 +27,7 @@ extern int git_openssl_stream_new(git_stream **out, const char *host, const char
 
 
 
-# if OPENSSL_VERSION_NUMBER < 0x10100000L
+# if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 GIT_INLINE(BIO_METHOD*) BIO_meth_new(int type, const char *name)
 {


### PR DESCRIPTION
Hello,

I tried to build libgit2 in OpenBSD (as dependencies of rust's cargo) and found that it can't find BIO_* functions defined in openssl_stream.h. Obviously because it was guarded with openssl version check. I found a reference (below) that we can use libressl as we check openssl for version < 1.1.0. This patch does just that.

Thanks.

ref:
https://github.com/gentoo/libressl/blob/672ac74ce7b7cb2e4799b2d66bc0b1b1efa3454e/media-video/ffmpeg/files/ffmpeg-3.2-libressl.patch