### PR TITLE
mempack: set the odb backend version

### DIFF
--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -177,6 +177,7 @@ int git_mempack_new(git_odb_backend **out)
 
 	db->objects = git_oidmap_alloc();
 
+	db->parent.version = GIT_ODB_BACKEND_VERSION;
 	db->parent.read = &impl__read;
 	db->parent.write = &impl__write;
 	db->parent.read_header = &impl__read_header;


### PR DESCRIPTION
A ```git_mempack``` backend is currently unusable due to the ```git_odb_backend``` version being set to ```0``` instead of ```GIT_ODB_BACKEND_VERSION```