### PR TITLE
giterr_set: consistent error messages

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -173,7 +173,7 @@ static int apply_hunk(
 		git_diff_line *line = git_array_get(patch->lines, linenum);
 
 		if (!line) {
-			error = apply_err("Preimage does not contain line %"PRIuZ, linenum);
+			error = apply_err("preimage does not contain line %"PRIuZ, linenum);
 			goto done;
 		}
 
@@ -193,7 +193,7 @@ static int apply_hunk(
 	line_num = hunk->hunk.new_start ? hunk->hunk.new_start - 1 : 0;
 
 	if (!find_hunk_linenum(&line_num, image, &preimage, line_num)) {
-		error = apply_err("Hunk at line %d did not apply",
+		error = apply_err("hunk at line %d did not apply",
 			hunk->hunk.new_start);
 		goto done;
 	}

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -30,7 +30,7 @@ int git_attr_file__new(
 	GITERR_CHECK_ALLOC(attrs);
 
 	if (git_mutex_init(&attrs->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to initialize lock");
+		giterr_set(GITERR_OS, "failed to initialize lock");
 		git__free(attrs);
 		return -1;
 	}
@@ -49,7 +49,7 @@ int git_attr_file__clear_rules(git_attr_file *file, bool need_lock)
 	git_attr_rule *rule;
 
 	if (need_lock && git_mutex_lock(&file->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock attribute file");
+		giterr_set(GITERR_OS, "failed to lock attribute file");
 		return -1;
 	}
 
@@ -140,7 +140,7 @@ int git_attr_file__load(
 		break;
 	}
 	default:
-		giterr_set(GITERR_INVALID, "Unknown file source %d", source);
+		giterr_set(GITERR_INVALID, "unknown file source %d", source);
 		return -1;
 	}
 
@@ -212,7 +212,7 @@ int git_attr_file__out_of_date(
 	}
 
 	default:
-		giterr_set(GITERR_INVALID, "Invalid file type %d", file->source);
+		giterr_set(GITERR_INVALID, "invalid file type %d", file->source);
 		return -1;
 	}
 }
@@ -238,7 +238,7 @@ int git_attr_file__parse_buffer(
 		context = attrs->entry->path;
 
 	if (git_mutex_lock(&attrs->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock attribute file");
+		giterr_set(GITERR_OS, "failed to lock attribute file");
 		return -1;
 	}
 

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -12,7 +12,7 @@ GIT_INLINE(int) attr_cache_lock(git_attr_cache *cache)
 	GIT_UNUSED(cache); /* avoid warning if threading is off */
 
 	if (git_mutex_lock(&cache->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to get attr cache lock");
+		giterr_set(GITERR_OS, "unable to get attr cache lock");
 		return -1;
 	}
 	return 0;
@@ -365,7 +365,7 @@ int git_attr_cache__do_init(git_repository *repo)
 
 	/* set up lock */
 	if (git_mutex_init(&cache->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to initialize lock for attr cache");
+		giterr_set(GITERR_OS, "unable to initialize lock for attr cache");
 		git__free(cache);
 		return -1;
 	}
@@ -430,7 +430,7 @@ int git_attr_cache__insert_macro(git_repository *repo, git_attr_rule *macro)
 		return 0;
 
 	if (git_mutex_lock(&cache->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to get attr cache lock");
+		giterr_set(GITERR_OS, "unable to get attr cache lock");
 		error = -1;
 	} else {
 		git_strmap_insert(macros, macro->match.pattern, macro, error);

--- a/src/blob.c
+++ b/src/blob.c
@@ -96,7 +96,7 @@ static int write_file_stream(
 	p_close(fd);
 
 	if (written != file_size || read_len < 0) {
-		giterr_set(GITERR_OS, "Failed to read file into stream");
+		giterr_set(GITERR_OS, "failed to read file into stream");
 		error = -1;
 	}
 
@@ -142,7 +142,7 @@ static int write_symlink(
 
 	read_len = p_readlink(path, link_data, link_size);
 	if (read_len != (ssize_t)link_size) {
-		giterr_set(GITERR_OS, "Failed to create blob.  Can't read symlink '%s'", path);
+		giterr_set(GITERR_OS, "failed to create blob: cannot read symlink '%s'", path);
 		git__free(link_data);
 		return -1;
 	}
@@ -186,7 +186,7 @@ int git_blob__create_from_paths(
 		goto done;
 
 	if (S_ISDIR(st.st_mode)) {
-		giterr_set(GITERR_ODB, "cannot create blob from '%s'; it is a directory", content_path);
+		giterr_set(GITERR_ODB, "cannot create blob from '%s': it is a directory", content_path);
 		error = GIT_EDIRECTORY;
 		goto done;
 	}

--- a/src/branch.c
+++ b/src/branch.c
@@ -33,7 +33,7 @@ static int retrieve_branch_reference(
 		/* OOM */;
 	else if ((error = git_reference_lookup(&branch, repo, ref_name.ptr)) < 0)
 		giterr_set(
-			GITERR_REFERENCE, "Cannot locate %s branch '%s'",
+			GITERR_REFERENCE, "cannot locate %s branch '%s'",
 			is_remote ? "remote-tracking" : "local", branch_name);
 
 	*branch_reference_out = branch; /* will be NULL on error */
@@ -46,7 +46,7 @@ static int not_a_local_branch(const char *reference_name)
 {
 	giterr_set(
 		GITERR_INVALID,
-		"Reference '%s' is not a local branch.", reference_name);
+		"reference '%s' is not a local branch.", reference_name);
 	return -1;
 }
 
@@ -80,7 +80,7 @@ static int create_branch(
 	}
 
 	if (is_unmovable_head && force) {
-		giterr_set(GITERR_REFERENCE, "Cannot force update branch '%s' as it is "
+		giterr_set(GITERR_REFERENCE, "cannot force update branch '%s' as it is "
 			"the current HEAD of the repository.", branch_name);
 		error = -1;
 		goto cleanup;
@@ -135,7 +135,7 @@ int git_branch_delete(git_reference *branch)
 	assert(branch);
 
 	if (!git_reference_is_branch(branch) && !git_reference_is_remote(branch)) {
-		giterr_set(GITERR_INVALID, "Reference '%s' is not a valid branch.",
+		giterr_set(GITERR_INVALID, "reference '%s' is not a valid branch.",
 			git_reference_name(branch));
 		return GIT_ENOTFOUND;
 	}
@@ -144,7 +144,7 @@ int git_branch_delete(git_reference *branch)
 		return is_head;
 
 	if (is_head) {
-		giterr_set(GITERR_REFERENCE, "Cannot delete branch '%s' as it is "
+		giterr_set(GITERR_REFERENCE, "cannot delete branch '%s' as it is "
 			"the current HEAD of the repository.", git_reference_name(branch));
 		return -1;
 	}
@@ -306,7 +306,7 @@ int git_branch_name(
 		branch_name += strlen(GIT_REFS_REMOTES_DIR);
 	} else {
 		giterr_set(GITERR_INVALID,
-				"Reference '%s' is neither a local nor a remote branch.", ref->name);
+				"reference '%s' is neither a local nor a remote branch.", ref->name);
 		return -1;
 	}
 	*out = branch_name;
@@ -436,7 +436,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 
 	/* Verify that this is a remote branch */
 	if (!git_reference__is_remote(refname)) {
-		giterr_set(GITERR_INVALID, "Reference '%s' is not a remote branch.",
+		giterr_set(GITERR_INVALID, "reference '%s' is not a remote branch.",
 			refname);
 		error = GIT_ERROR;
 		goto cleanup;
@@ -463,7 +463,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 				git_remote_free(remote);
 
 				giterr_set(GITERR_REFERENCE,
-					"Reference '%s' is ambiguous", refname);
+					"reference '%s' is ambiguous", refname);
 				error = GIT_EAMBIGUOUS;
 				goto cleanup;
 			}
@@ -477,7 +477,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 		error = git_buf_puts(buf, remote_name);
 	} else {
 		giterr_set(GITERR_REFERENCE,
-			"Could not determine remote for '%s'", refname);
+			"could not determine remote for '%s'", refname);
 		error = GIT_ENOTFOUND;
 	}
 
@@ -566,7 +566,7 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 		local = 0;
 	else {
 		giterr_set(GITERR_REFERENCE,
-			"Cannot set upstream for branch '%s'", shortname);
+			"cannot set upstream for branch '%s'", shortname);
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -962,14 +962,14 @@ int git_buf_unquote(git_buf *buf)
 			case '0': case '1': case '2': case '3':
 				if (j == buf->size-3) {
 					giterr_set(GITERR_INVALID,
-						"Truncated quoted character \\%c", ch);
+						"truncated quoted character \\%c", ch);
 					return -1;
 				}
 
 				if (buf->ptr[j+1] < '0' || buf->ptr[j+1] > '7' ||
 					buf->ptr[j+2] < '0' || buf->ptr[j+2] > '7') {
 					giterr_set(GITERR_INVALID,
-						"Truncated quoted character \\%c%c%c",
+						"truncated quoted character \\%c%c%c",
 						buf->ptr[j], buf->ptr[j+1], buf->ptr[j+2]);
 					return -1;
 				}
@@ -981,7 +981,7 @@ int git_buf_unquote(git_buf *buf)
 				break;
 
 			default:
-				giterr_set(GITERR_INVALID, "Invalid quoted character \\%c", ch);
+				giterr_set(GITERR_INVALID, "invalid quoted character \\%c", ch);
 				return -1;
 			}
 		}
@@ -995,6 +995,6 @@ int git_buf_unquote(git_buf *buf)
 	return 0;
 
 invalid:
-	giterr_set(GITERR_INVALID, "Invalid quoted line");
+	giterr_set(GITERR_INVALID, "invalid quoted line");
 	return -1;
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -70,7 +70,7 @@ int git_cache_init(git_cache *cache)
 	cache->map = git_oidmap_alloc();
 	GITERR_CHECK_ALLOC(cache->map);
 	if (git_rwlock_init(&cache->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize cache rwlock");
+		giterr_set(GITERR_OS, "failed to initialize cache rwlock");
 		return -1;
 	}
 	return 0;

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1021,13 +1021,13 @@ static int checkout_conflicts_load_byname_entry(
 	*theirs_out = NULL;
 
 	if (!name_entry->ancestor) {
-		giterr_set(GITERR_INDEX, "A NAME entry exists without an ancestor");
+		giterr_set(GITERR_INDEX, "a NAME entry exists without an ancestor");
 		error = -1;
 		goto done;
 	}
 
 	if (!name_entry->ours && !name_entry->theirs) {
-		giterr_set(GITERR_INDEX, "A NAME entry exists without an ours or theirs");
+		giterr_set(GITERR_INDEX, "a NAME entry exists without an ours or theirs");
 		error = -1;
 		goto done;
 	}
@@ -1035,7 +1035,7 @@ static int checkout_conflicts_load_byname_entry(
 	if ((ancestor = checkout_conflicts_search_ancestor(data,
 		name_entry->ancestor)) == NULL) {
 		giterr_set(GITERR_INDEX,
-			"A NAME entry referenced ancestor entry '%s' which does not exist in the main index",
+			"a NAME entry referenced ancestor entry '%s' which does not exist in the main index",
 			name_entry->ancestor);
 		error = -1;
 		goto done;
@@ -1047,7 +1047,7 @@ static int checkout_conflicts_load_byname_entry(
 		else if ((ours = checkout_conflicts_search_branch(data, name_entry->ours)) == NULL ||
 			ours->ours == NULL) {
 			giterr_set(GITERR_INDEX,
-				"A NAME entry referenced our entry '%s' which does not exist in the main index",
+				"a NAME entry referenced our entry '%s' which does not exist in the main index",
 				name_entry->ours);
 			error = -1;
 			goto done;
@@ -1062,7 +1062,7 @@ static int checkout_conflicts_load_byname_entry(
 		else if ((theirs = checkout_conflicts_search_branch(data, name_entry->theirs)) == NULL ||
 			theirs->theirs == NULL) {
 			giterr_set(GITERR_INDEX,
-				"A NAME entry referenced their entry '%s' which does not exist in the main index",
+				"a NAME entry referenced their entry '%s' which does not exist in the main index",
 				name_entry->theirs);
 			error = -1;
 			goto done;
@@ -1161,7 +1161,7 @@ static int checkout_conflicts_mark_directoryfile(
 		if ((error = git_index_find(&j, index, path)) < 0) {
 			if (error == GIT_ENOTFOUND)
 				giterr_set(GITERR_INDEX,
-					"Index inconsistency, could not find entry for expected conflict '%s'", path);
+					"index inconsistency, could not find entry for expected conflict '%s'", path);
 
 			goto done;
 		}
@@ -1169,7 +1169,7 @@ static int checkout_conflicts_mark_directoryfile(
 		for (; j < len; j++) {
 			if ((entry = git_index_get_byindex(index, j)) == NULL) {
 				giterr_set(GITERR_INDEX,
-					"Index inconsistency, truncated index while loading expected conflict '%s'", path);
+					"index inconsistency, truncated index while loading expected conflict '%s'", path);
 				error = -1;
 				goto done;
 			}
@@ -1254,14 +1254,14 @@ static int checkout_verify_paths(
 
 	if (action & CHECKOUT_ACTION__REMOVE) {
 		if (!git_path_isvalid(repo, delta->old_file.path, flags)) {
-			giterr_set(GITERR_CHECKOUT, "Cannot remove invalid path '%s'", delta->old_file.path);
+			giterr_set(GITERR_CHECKOUT, "cannot remove invalid path '%s'", delta->old_file.path);
 			return -1;
 		}
 	}
 
 	if (action & ~CHECKOUT_ACTION__REMOVE) {
 		if (!git_path_isvalid(repo, delta->new_file.path, flags)) {
-			giterr_set(GITERR_CHECKOUT, "Cannot checkout to invalid path '%s'", delta->new_file.path);
+			giterr_set(GITERR_CHECKOUT, "cannot checkout to invalid path '%s'", delta->new_file.path);
 			return -1;
 		}
 	}
@@ -1430,7 +1430,7 @@ static int mkpath2file(
 			 */
 			error = git_futils_rmdir_r(path, NULL, GIT_RMDIR_REMOVE_FILES);
 		} else if (errno != ENOENT) {
-			giterr_set(GITERR_OS, "Failed to stat file '%s'", path);
+			giterr_set(GITERR_OS, "failed to stat '%s'", path);
 			return GIT_EEXISTS;
 		} else {
 			giterr_clear();
@@ -1454,7 +1454,7 @@ static int checkout_stream_write(
 	int ret;
 
 	if ((ret = p_write(stream->fd, buffer, len)) < 0)
-		giterr_set(GITERR_OS, "Could not write to '%s'", stream->path);
+		giterr_set(GITERR_OS, "could not write to '%s'", stream->path);
 
 	return ret;
 }
@@ -1503,7 +1503,7 @@ static int blob_content_to_file(
 		mode = GIT_FILEMODE_BLOB;
 
 	if ((fd = p_open(path, flags, mode)) < 0) {
-		giterr_set(GITERR_OS, "Could not open '%s' for writing", path);
+		giterr_set(GITERR_OS, "could not open '%s' for writing", path);
 		return fd;
 	}
 
@@ -1540,7 +1540,7 @@ static int blob_content_to_file(
 		data->perfdata.stat_calls++;
 
 		if ((error = p_stat(path, st)) < 0) {
-			giterr_set(GITERR_OS, "Error statting '%s'", path);
+			giterr_set(GITERR_OS, "failed to stat '%s'", path);
 			return error;
 		}
 
@@ -1567,7 +1567,7 @@ static int blob_content_to_link(
 
 	if (data->can_symlink) {
 		if ((error = p_symlink(git_buf_cstr(&linktarget), path)) < 0)
-			giterr_set(GITERR_OS, "Could not create symlink %s", path);
+			giterr_set(GITERR_OS, "could not create symlink %s", path);
 	} else {
 		error = git_futils_fake_symlink(git_buf_cstr(&linktarget), path);
 	}
@@ -1576,7 +1576,7 @@ static int blob_content_to_link(
 		data->perfdata.stat_calls++;
 
 		if ((error = p_lstat(path, st)) < 0)
-			giterr_set(GITERR_CHECKOUT, "Could not stat symlink %s", path);
+			giterr_set(GITERR_CHECKOUT, "could not stat symlink %s", path);
 
 		st->st_mode = GIT_FILEMODE_LINK;
 	}
@@ -1621,7 +1621,7 @@ static int checkout_submodule_update_index(
 	data->perfdata.stat_calls++;
 	if (p_stat(fullpath->ptr, &st) < 0) {
 		giterr_set(
-			GITERR_CHECKOUT, "Could not stat submodule %s\n", file->path);
+			GITERR_CHECKOUT, "could not stat submodule %s\n", file->path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1694,7 +1694,7 @@ static int checkout_safe_for_update_only(
 			return 0;
 
 		/* otherwise, stat error and no update */
-		giterr_set(GITERR_OS, "Failed to stat file '%s'", path);
+		giterr_set(GITERR_OS, "failed to stat '%s'", path);
 		return -1;
 	}
 
@@ -1966,7 +1966,7 @@ static int checkout_path_suffixed(git_buf *path, const char *suffix)
 	if (i == INT_MAX) {
 		git_buf_truncate(path, path_len);
 
-		giterr_set(GITERR_CHECKOUT, "Could not write '%s': working directory file exists", path->ptr);
+		giterr_set(GITERR_CHECKOUT, "could not write '%s': working directory file exists", path->ptr);
 		return GIT_EEXISTS;
 	}
 
@@ -2097,7 +2097,7 @@ static int checkout_write_merge(
 		goto done;
 
 	if (result.path == NULL || result.mode == 0) {
-		giterr_set(GITERR_CHECKOUT, "Could not merge contents of file");
+		giterr_set(GITERR_CHECKOUT, "could not merge contents of file");
 		error = GIT_ECONFLICT;
 		goto done;
 	}
@@ -2345,7 +2345,7 @@ static int checkout_data_init(
 	memset(data, 0, sizeof(*data));
 
 	if (!repo) {
-		giterr_set(GITERR_CHECKOUT, "Cannot checkout nothing");
+		giterr_set(GITERR_CHECKOUT, "cannot checkout nothing");
 		return -1;
 	}
 
@@ -2647,7 +2647,7 @@ int git_checkout_index(
 
 	if (!index && !repo) {
 		giterr_set(GITERR_CHECKOUT,
-			"Must provide either repository or index to checkout");
+			"must provide either repository or index to checkout");
 		return -1;
 	}
 
@@ -2655,7 +2655,7 @@ int git_checkout_index(
 		git_index_owner(index) &&
 		git_index_owner(index) != repo) {
 		giterr_set(GITERR_CHECKOUT,
-			"Index to checkout does not match repository");
+			"index to checkout does not match repository");
 		return -1;
 	} else if(index && repo && !git_index_owner(index)) {
 		GIT_REFCOUNT_OWN(index, repo);
@@ -2694,12 +2694,12 @@ int git_checkout_tree(
 
 	if (!treeish && !repo) {
 		giterr_set(GITERR_CHECKOUT,
-			"Must provide either repository or tree to checkout");
+			"must provide either repository or tree to checkout");
 		return -1;
 	}
 	if (treeish && repo && git_object_owner(treeish) != repo) {
 		giterr_set(GITERR_CHECKOUT,
-			"Object to checkout does not match repository");
+			"object to checkout does not match repository");
 		return -1;
 	}
 
@@ -2709,7 +2709,7 @@ int git_checkout_tree(
 	if (treeish) {
 		if (git_object_peel((git_object **)&tree, treeish, GIT_OBJ_TREE) < 0) {
 			giterr_set(
-				GITERR_CHECKOUT, "Provided object cannot be peeled to a tree");
+				GITERR_CHECKOUT, "provided object cannot be peeled to a tree");
 			return -1;
 		}
 	}

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -130,13 +130,13 @@ int git_cherrypick_commit(
 	if (git_commit_parentcount(cherrypick_commit) > 1) {
 		if (!mainline)
 			return cherrypick_seterr(cherrypick_commit,
-				"Mainline branch is not specified but %s is a merge commit");
+				"mainline branch is not specified but %s is a merge commit");
 
 		parent = mainline;
 	} else {
 		if (mainline)
 			return cherrypick_seterr(cherrypick_commit,
-				"Mainline branch specified but %s is not a merge commit");
+				"mainline branch specified but %s is not a merge commit");
 
 		parent = git_commit_parentcount(cherrypick_commit);
 	}

--- a/src/commit.c
+++ b/src/commit.c
@@ -468,7 +468,7 @@ int git_commit__parse(void *_commit, git_odb_object *odb_obj)
 	return 0;
 
 bad_buffer:
-	giterr_set(GITERR_OBJECT, "Failed to parse bad commit object");
+	giterr_set(GITERR_OBJECT, "failed to parse bad commit object");
 	return -1;
 }
 
@@ -598,7 +598,7 @@ int git_commit_parent(
 
 	parent_id = git_commit_parent_id(commit, n);
 	if (parent_id == NULL) {
-		giterr_set(GITERR_INVALID, "Parent %u does not exist", n);
+		giterr_set(GITERR_INVALID, "parent %u does not exist", n);
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -61,7 +61,7 @@ static int commit_error(git_commit_list_node *commit, const char *msg)
 	git_oid_fmt(commit_oid, &commit->oid);
 	commit_oid[GIT_OID_HEXSZ] = '\0';
 
-	giterr_set(GITERR_ODB, "Failed to parse commit %s - %s", commit_oid, msg);
+	giterr_set(GITERR_ODB, "failed to parse commit %s - %s", commit_oid, msg);
 
 	return -1;
 }
@@ -191,7 +191,7 @@ int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit)
 		return error;
 
 	if (obj->cached.type != GIT_OBJ_COMMIT) {
-		giterr_set(GITERR_INVALID, "Object is no commit object");
+		giterr_set(GITERR_INVALID, "object is no commit object");
 		error = -1;
 	} else
 		error = commit_quick_parse(

--- a/src/common.h
+++ b/src/common.h
@@ -188,7 +188,7 @@ GIT_INLINE(int) giterr__check_version(const void *structure, unsigned int expect
 	if (actual > 0 && actual <= expected_max)
 		return 0;
 
-	giterr_set(GITERR_INVALID, "Invalid version %d on %s", actual, name);
+	giterr_set(GITERR_INVALID, "invalid version %d on %s", actual, name);
 	return -1;
 }
 #define GITERR_CHECK_VERSION(S,V,N) if (giterr__check_version(S,V,N) < 0) return -1

--- a/src/config.c
+++ b/src/config.c
@@ -109,7 +109,7 @@ int git_config_add_file_ondisk(
 
 	res = p_stat(path, &st);
 	if (res < 0 && errno != ENOENT) {
-		giterr_set(GITERR_CONFIG, "Error stat'ing config file '%s'", path);
+		giterr_set(GITERR_CONFIG, "failed to stat '%s'", path);
 		return -1;
 	}
 
@@ -203,7 +203,7 @@ static int find_internal_file_by_level(
 
 	if (pos == -1) {
 		giterr_set(GITERR_CONFIG,
-			"No config file exists for the given level '%i'", (int)level);
+			"no config file exists for the given level '%i'", (int)level);
 		return GIT_ENOTFOUND;
 	}
 
@@ -218,7 +218,7 @@ static int duplicate_level(void **old_raw, void *new_raw)
 
 	GIT_UNUSED(new_raw);
 
-	giterr_set(GITERR_CONFIG, "A file with the same level (%i) has already been added to the config", (int)(*old)->level);
+	giterr_set(GITERR_CONFIG, "a file with the same level (%i) has already been added to the config", (int)(*old)->level);
 	return GIT_EEXISTS;
 }
 
@@ -579,7 +579,7 @@ int git_config_foreach_match(
 static int config_error_nofiles(const char *name)
 {
 	giterr_set(GITERR_CONFIG,
-		"Cannot set value for '%s' when no config files exist", name);
+		"cannot set value for '%s' when no config files exist", name);
 	return GIT_ENOTFOUND;
 }
 
@@ -620,7 +620,7 @@ int git_config_set_string(git_config *cfg, const char *name, const char *value)
 	file_internal *internal;
 
 	if (!value) {
-		giterr_set(GITERR_CONFIG, "The value to set cannot be NULL");
+		giterr_set(GITERR_CONFIG, "the value to set cannot be NULL");
 		return -1;
 	}
 
@@ -674,7 +674,7 @@ int git_config__update_entry(
 
 static int config_error_notfound(const char *name)
 {
-	giterr_set(GITERR_CONFIG, "Config value '%s' was not found", name);
+	giterr_set(GITERR_CONFIG, "config value '%s' was not found", name);
 	return GIT_ENOTFOUND;
 }
 
@@ -1236,7 +1236,7 @@ int git_config_lookup_map_value(
 	}
 
 fail_parse:
-	giterr_set(GITERR_CONFIG, "Failed to map '%s'", value);
+	giterr_set(GITERR_CONFIG, "failed to map '%s'", value);
 	return -1;
 }
 
@@ -1270,7 +1270,7 @@ int git_config_parse_bool(int *out, const char *value)
 		return 0;
 	}
 
-	giterr_set(GITERR_CONFIG, "Failed to parse '%s' as a boolean value", value);
+	giterr_set(GITERR_CONFIG, "failed to parse '%s' as a boolean value", value);
 	return -1;
 }
 
@@ -1313,7 +1313,7 @@ int git_config_parse_int64(int64_t *out, const char *value)
 	}
 
 fail_parse:
-	giterr_set(GITERR_CONFIG, "Failed to parse '%s' as an integer", value ? value : "(null)");
+	giterr_set(GITERR_CONFIG, "failed to parse '%s' as an integer", value ? value : "(null)");
 	return -1;
 }
 
@@ -1333,7 +1333,7 @@ int git_config_parse_int32(int32_t *out, const char *value)
 	return 0;
 
 fail_parse:
-	giterr_set(GITERR_CONFIG, "Failed to parse '%s' as a 32-bit integer", value ? value : "(null)");
+	giterr_set(GITERR_CONFIG, "failed to parse '%s' as a 32-bit integer", value ? value : "(null)");
 	return -1;
 }
 
@@ -1398,7 +1398,7 @@ int git_config__normalize_name(const char *in, char **out)
 
 invalid:
 	git__free(name);
-	giterr_set(GITERR_CONFIG, "Invalid config item name '%s'", in);
+	giterr_set(GITERR_CONFIG, "invalid config item name '%s'", in);
 	return GIT_EINVALIDSPEC;
 }
 
@@ -1461,7 +1461,7 @@ int git_config_rename_section(
 			replace.ptr, strchr(replace.ptr, '.'))) < 0)
 	{
 		giterr_set(
-			GITERR_CONFIG, "Invalid config section '%s'", new_section_name);
+			GITERR_CONFIG, "invalid config section '%s'", new_section_name);
 		goto cleanup;
 	}
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -126,7 +126,7 @@ static int config_snapshot(git_config_backend **out, git_config_backend *in);
 
 static void set_parse_error(struct reader *reader, int col, const char *error_str)
 {
-	giterr_set(GITERR_CONFIG, "Failed to parse config file: %s (in %s:%d, column %d)",
+	giterr_set(GITERR_CONFIG, "failed to parse config file: %s (in %s:%d, column %d)",
 		error_str, reader->file_path, reader->line_number, col);
 }
 
@@ -233,7 +233,7 @@ static refcounted_strmap *refcounted_strmap_take(diskfile_header *h)
 	refcounted_strmap *map;
 
 	if (git_mutex_lock(&h->values_mutex) < 0) {
-	    giterr_set(GITERR_OS, "Failed to lock config backend");
+	    giterr_set(GITERR_OS, "failed to lock config backend");
 	    return NULL;
 	}
 
@@ -322,7 +322,7 @@ static int config__refresh(git_config_backend *cfg)
 		goto out;
 
 	if ((error = git_mutex_lock(&b->header.values_mutex)) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock config backend");
+		giterr_set(GITERR_OS, "failed to lock config backend");
 		goto out;
 	}
 
@@ -479,7 +479,7 @@ static int config_set(git_config_backend *cfg, const char *name, const char *val
 		cvar_t *existing = git_strmap_value_at(values, pos);
 
 		if (existing->next != NULL) {
-			giterr_set(GITERR_CONFIG, "Multivar incompatible with simple set");
+			giterr_set(GITERR_CONFIG, "multivar incompatible with simple set");
 			ret = -1;
 			goto out;
 		}
@@ -611,7 +611,7 @@ static int config_delete(git_config_backend *cfg, const char *name)
 
 	if (!git_strmap_valid_index(values, pos)) {
 		refcounted_strmap_free(map);
-		giterr_set(GITERR_CONFIG, "Could not find key '%s' to delete", name);
+		giterr_set(GITERR_CONFIG, "could not find key '%s' to delete", name);
 		return GIT_ENOTFOUND;
 	}
 
@@ -619,7 +619,7 @@ static int config_delete(git_config_backend *cfg, const char *name)
 	refcounted_strmap_free(map);
 
 	if (var->next != NULL) {
-		giterr_set(GITERR_CONFIG, "Cannot delete multivar with a single delete");
+		giterr_set(GITERR_CONFIG, "cannot delete multivar with a single delete");
 		return -1;
 	}
 
@@ -651,7 +651,7 @@ static int config_delete_multivar(git_config_backend *cfg, const char *name, con
 	if (!git_strmap_valid_index(values, pos)) {
 		refcounted_strmap_free(map);
 		git__free(key);
-		giterr_set(GITERR_CONFIG, "Could not find key '%s' to delete", name);
+		giterr_set(GITERR_CONFIG, "could not find key '%s' to delete", name);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1325,7 +1325,7 @@ static int unescape_line(
 				*fixed++ = escaped[esc - escapes];
 			} else {
 				git__free(str);
-				giterr_set(GITERR_CONFIG, "Invalid escape at %s", ptr);
+				giterr_set(GITERR_CONFIG, "invalid escape at %s", ptr);
 				return -1;
 			}
 		}
@@ -1639,7 +1639,7 @@ static int config_read(git_strmap *values, diskfile_backend *cfg_file, struct re
 	struct parse_data parse_data;
 
 	if (depth >= MAX_INCLUDE_DEPTH) {
-		giterr_set(GITERR_CONFIG, "Maximum config include depth reached");
+		giterr_set(GITERR_CONFIG, "maximum config include depth reached");
 		return -1;
 	}
 

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -218,7 +218,7 @@ static const char *line_ending(struct crlf_attrs *ca)
 		return "\r\n";
 
 line_ending_error:
-	giterr_set(GITERR_INVALID, "Invalid input to line ending filter");
+	giterr_set(GITERR_INVALID, "invalid input to line ending filter");
 	return NULL;
 }
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -131,7 +131,7 @@ static int lookup_index_alloc(
 	GITERR_CHECK_ALLOC_ADD(&index_len, index_len, hash_len);
 
 	if (!git__is_ulong(index_len)) {
-		giterr_set(GITERR_NOMEMORY, "Overly large delta");
+		giterr_set(GITERR_NOMEMORY, "overly large delta");
 		return -1;
 	}
 
@@ -544,12 +544,12 @@ int git_delta_apply(
 	* base object, resulting in data corruption or segfault.
 	*/
 	if ((hdr_sz(&base_sz, &delta, delta_end) < 0) || (base_sz != base_len)) {
-		giterr_set(GITERR_INVALID, "Failed to apply delta. Base size does not match given data");
+		giterr_set(GITERR_INVALID, "failed to apply delta: base size does not match given data");
 		return -1;
 	}
 
 	if (hdr_sz(&res_sz, &delta, delta_end) < 0) {
-		giterr_set(GITERR_INVALID, "Failed to apply delta. Base size does not match given data");
+		giterr_set(GITERR_INVALID, "failed to apply delta: base size does not match given data");
 		return -1;
 	}
 
@@ -614,6 +614,6 @@ fail:
 	*out = NULL;
 	*out_len = 0;
 
-	giterr_set(GITERR_INVALID, "Failed to apply delta");
+	giterr_set(GITERR_INVALID, "failed to apply delta");
 	return -1;
 }

--- a/src/describe.c
+++ b/src/describe.c
@@ -335,14 +335,14 @@ static int display_name(git_buf *buf, git_repository *repo, struct commit_name *
 {
 	if (n->prio == 2 && !n->tag) {
 		if (git_tag_lookup(&n->tag, repo, &n->sha1) < 0) {
-			giterr_set(GITERR_TAG, "Annotated tag '%s' not available", n->path);
+			giterr_set(GITERR_TAG, "annotated tag '%s' not available", n->path);
 			return -1;
 		}
 	}
 
 	if (n->tag && !n->name_checked) {
 		if (!git_tag_name(n->tag)) {
-			giterr_set(GITERR_TAG, "Annotated tag '%s' has no embedded name", n->path);
+			giterr_set(GITERR_TAG, "annotated tag '%s' has no embedded name", n->path);
 			return -1;
 		}
 
@@ -471,7 +471,7 @@ static int describe(
 	if (!data->opts->max_candidates_tags) {
 		error = describe_not_found(
 			git_commit_id(commit),
-			"Cannot describe - no tag exactly matches '%s'");
+			"cannot describe - no tag exactly matches '%s'");
 
 		goto cleanup;
 	}
@@ -564,15 +564,15 @@ static int describe(
 		}
 		if (unannotated_cnt) {
 			error = describe_not_found(git_commit_id(commit), 
-				"Cannot describe - "
-				"No annotated tags can describe '%s'."
-			    "However, there were unannotated tags.");
+				"cannot describe - "
+				"no annotated tags can describe '%s'; "
+			    "however, there were unannotated tags.");
 			goto cleanup;
 		}
 		else {
 			error = describe_not_found(git_commit_id(commit), 
-				"Cannot describe - "
-				"No tags can describe '%s'.");
+				"cannot describe - "
+				"no tags can describe '%s'.");
 			goto cleanup;
 		}
 	}
@@ -695,8 +695,8 @@ int git_describe_commit(
 				goto cleanup;
 
 	if (git_oidmap_size(data.names) == 0 && !opts->show_commit_oid_as_fallback) {
-		giterr_set(GITERR_DESCRIBE, "Cannot describe - "
-			"No reference found, cannot describe anything.");
+		giterr_set(GITERR_DESCRIBE, "cannot describe - "
+			"no reference found, cannot describe anything.");
 		error = -1;
 		goto cleanup;
 	}
@@ -793,7 +793,7 @@ int git_describe_format(git_buf *out, const git_describe_result *result, const g
 
 
 	if (opts.always_use_long_format && opts.abbreviated_size == 0) {
-		giterr_set(GITERR_DESCRIBE, "Cannot describe - "
+		giterr_set(GITERR_DESCRIBE, "cannot describe - "
 			"'always_use_long_format' is incompatible with a zero"
 			"'abbreviated_size'");
 		return -1;

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -151,7 +151,7 @@ static git_diff_driver_registry *git_repository_driver_registry(
 	}
 
 	if (!repo->diff_drivers)
-		giterr_set(GITERR_REPOSITORY, "Unable to create diff driver registry");
+		giterr_set(GITERR_REPOSITORY, "unable to create diff driver registry");
 
 	return repo->diff_drivers;
 }

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -304,7 +304,7 @@ static int diff_file_content_load_workdir_symlink(
 
 	read_len = p_readlink(git_buf_cstr(path), fc->map.data, alloc_len);
 	if (read_len < 0) {
-		giterr_set(GITERR_OS, "Failed to read symlink '%s'", fc->file->path);
+		giterr_set(GITERR_OS, "failed to read symlink '%s'", fc->file->path);
 		return -1;
 	}
 

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -624,7 +624,7 @@ int git_diff__oid_for_entry(
 		error = git_odb__hashlink(out, full_path.ptr);
 		diff->base.perf.oid_calculations++;
 	} else if (!git__is_sizet(entry.file_size)) {
-		giterr_set(GITERR_OS, "File size overflow (for 32-bits) on '%s'",
+		giterr_set(GITERR_OS, "file size overflow (for 32-bits) on '%s'",
 			entry.path);
 		error = -1;
 	} else if (!(error = git_filter_list_load(&fl,
@@ -1587,7 +1587,7 @@ int git_diff__commit(
 		char commit_oidstr[GIT_OID_HEXSZ + 1];
 
 		error = -1;
-		giterr_set(GITERR_INVALID, "Commit %s is a merge commit",
+		giterr_set(GITERR_INVALID, "commit %s is a merge commit",
 			git_oid_tostr(commit_oidstr, GIT_OID_HEXSZ + 1, git_commit_id(commit)));
 		goto on_error;
 	}

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -222,7 +222,7 @@ static int diff_print_one_raw(
 
 	if (pi->id_strlen > id_abbrev) {
 		giterr_set(GITERR_PATCH,
-			"The patch input contains %d id characters (cannot print %d)",
+			"the patch input contains %d id characters (cannot print %d)",
 			id_abbrev, pi->id_strlen);
 		return -1;
 	}
@@ -273,7 +273,7 @@ static int diff_print_oid_range(
 	if (delta->old_file.mode &&
 			id_strlen > delta->old_file.id_abbrev) {
 		giterr_set(GITERR_PATCH,
-			"The patch input contains %d id characters (cannot print %d)",
+			"the patch input contains %d id characters (cannot print %d)",
 			delta->old_file.id_abbrev, id_strlen);
 		return -1;
 	}
@@ -281,7 +281,7 @@ static int diff_print_oid_range(
 	if ((delta->new_file.mode &&
 			id_strlen > delta->new_file.id_abbrev)) {
 		giterr_set(GITERR_PATCH,
-			"The patch input contains %d id characters (cannot print %d)",
+			"the patch input contains %d id characters (cannot print %d)",
 			delta->new_file.id_abbrev, id_strlen);
 		return -1;
 	}
@@ -680,7 +680,7 @@ int git_diff_print(
 		print_file = diff_print_one_name_status;
 		break;
 	default:
-		giterr_set(GITERR_INVALID, "Unknown diff output format (%d)", format);
+		giterr_set(GITERR_INVALID, "unknown diff output format (%d)", format);
 		return -1;
 	}
 
@@ -708,7 +708,7 @@ int git_diff_print_callback__to_buf(
 	GIT_UNUSED(delta); GIT_UNUSED(hunk);
 
 	if (!output) {
-		giterr_set(GITERR_INVALID, "Buffer pointer must be provided");
+		giterr_set(GITERR_INVALID, "buffer pointer must be provided");
 		return -1;
 	}
 

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -131,7 +131,7 @@ int git_diff__merge(
 	if (ignore_case != ((from->opts.flags & GIT_DIFF_IGNORE_CASE) != 0) ||
 		reversed    != ((from->opts.flags & GIT_DIFF_REVERSE) != 0)) {
 		giterr_set(GITERR_INVALID,
-			"Attempt to merge diffs created with conflicting options");
+			"attempt to merge diffs created with conflicting options");
 		return -1;
 	}
 

--- a/src/diff_xdiff.c
+++ b/src/diff_xdiff.c
@@ -50,7 +50,7 @@ static int git_xdiff_parse_hunk(git_diff_hunk *hunk, const char *header)
 	return 0;
 
 fail:
-	giterr_set(GITERR_INVALID, "Malformed hunk header from xdiff");
+	giterr_set(GITERR_INVALID, "malformed hunk header from xdiff");
 	return -1;
 }
 
@@ -99,7 +99,7 @@ static int diff_update_lines(
 		info->new_lineno += (int)line->num_lines;
 		break;
 	default:
-		giterr_set(GITERR_INVALID, "Unknown diff line origin %02x",
+		giterr_set(GITERR_INVALID, "unknown diff line origin %02x",
 			(unsigned int)line->origin);
 		return -1;
 	}

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -113,7 +113,7 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 	remote->need_pack = 0;
 
 	if (filter_wants(remote, opts) < 0) {
-		giterr_set(GITERR_NET, "Failed to filter the reference list for wants");
+		giterr_set(GITERR_NET, "failed to filter the reference list for wants");
 		return -1;
 	}
 

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -149,7 +149,7 @@ static int fetchhead_ref_parse(
 
 	if (!*line) {
 		giterr_set(GITERR_FETCHHEAD,
-			"Empty line in FETCH_HEAD line %"PRIuZ, line_num);
+			"empty line in FETCH_HEAD line %"PRIuZ, line_num);
 		return -1;
 	}
 
@@ -163,13 +163,13 @@ static int fetchhead_ref_parse(
 
 	if (strlen(oid_str) != GIT_OID_HEXSZ) {
 		giterr_set(GITERR_FETCHHEAD,
-			"Invalid object ID in FETCH_HEAD line %"PRIuZ, line_num);
+			"invalid object ID in FETCH_HEAD line %"PRIuZ, line_num);
 		return -1;
 	}
 
 	if (git_oid_fromstr(oid, oid_str) < 0) {
 		const git_error *oid_err = giterr_last();
-		const char *err_msg = oid_err ? oid_err->message : "Invalid object ID";
+		const char *err_msg = oid_err ? oid_err->message : "invalid object ID";
 
 		giterr_set(GITERR_FETCHHEAD, "%s in FETCH_HEAD line %"PRIuZ,
 			err_msg, line_num);
@@ -180,7 +180,7 @@ static int fetchhead_ref_parse(
 	if (*line) {
 		if ((is_merge_str = git__strsep(&line, "\t")) == NULL) {
 			giterr_set(GITERR_FETCHHEAD,
-				"Invalid description data in FETCH_HEAD line %"PRIuZ, line_num);
+				"invalid description data in FETCH_HEAD line %"PRIuZ, line_num);
 			return -1;
 		}
 
@@ -190,13 +190,13 @@ static int fetchhead_ref_parse(
 			*is_merge = 0;
 		else {
 			giterr_set(GITERR_FETCHHEAD,
-				"Invalid for-merge entry in FETCH_HEAD line %"PRIuZ, line_num);
+				"invalid for-merge entry in FETCH_HEAD line %"PRIuZ, line_num);
 			return -1;
 		}
 
 		if ((desc = line) == NULL) {
 			giterr_set(GITERR_FETCHHEAD,
-				"Invalid description in FETCH_HEAD line %"PRIuZ, line_num);
+				"invalid description in FETCH_HEAD line %"PRIuZ, line_num);
 			return -1;
 		}
 
@@ -213,7 +213,7 @@ static int fetchhead_ref_parse(
 			if ((desc = strstr(name, "' ")) == NULL ||
 				git__prefixcmp(desc, "' of ") != 0) {
 				giterr_set(GITERR_FETCHHEAD,
-					"Invalid description in FETCH_HEAD line %"PRIuZ, line_num);
+					"invalid description in FETCH_HEAD line %"PRIuZ, line_num);
 				return -1;
 			}
 
@@ -277,7 +277,7 @@ int git_repository_fetchhead_foreach(git_repository *repo,
 	}
 
 	if (*buffer) {
-		giterr_set(GITERR_FETCHHEAD, "No EOL at line %"PRIuZ, line_num+1);
+		giterr_set(GITERR_FETCHHEAD, "no EOL at line %"PRIuZ, line_num+1);
 		error = -1;
 		goto done;
 	}

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -23,7 +23,7 @@ static int verify_last_error(git_filebuf *file)
 {
 	switch (file->last_error) {
 	case BUFERR_WRITE:
-		giterr_set(GITERR_OS, "Failed to write out file");
+		giterr_set(GITERR_OS, "failed to write out file");
 		return -1;
 
 	case BUFERR_MEM:
@@ -48,7 +48,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		else {
 			giterr_clear(); /* actual OS error code just confuses */
 			giterr_set(GITERR_OS,
-				"Failed to lock file '%s' for writing", file->path_lock);
+				"failed to lock file '%s' for writing", file->path_lock);
 			return GIT_ELOCKED;
 		}
 	}
@@ -75,7 +75,7 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		source = p_open(file->path_original, O_RDONLY);
 		if (source < 0) {
 			giterr_set(GITERR_OS,
-				"Failed to open file '%s' for reading",
+				"failed to open file '%s' for reading",
 				file->path_original);
 			return -1;
 		}
@@ -90,10 +90,10 @@ static int lock_file(git_filebuf *file, int flags, mode_t mode)
 		p_close(source);
 
 		if (read_bytes < 0) {
-			giterr_set(GITERR_OS, "Failed to read file '%s'", file->path_original);
+			giterr_set(GITERR_OS, "failed to read file '%s'", file->path_original);
 			return -1;
 		} else if (error < 0) {
-			giterr_set(GITERR_OS, "Failed to write file '%s'", file->path_lock);
+			giterr_set(GITERR_OS, "failed to write file '%s'", file->path_lock);
 			return -1;
 		}
 	}
@@ -316,7 +316,7 @@ int git_filebuf_open_withsize(git_filebuf *file, const char *path, int flags, mo
 	if (compression != 0) {
 		/* Initialize the ZLib stream */
 		if (deflateInit(&file->zs, compression) != Z_OK) {
-			giterr_set(GITERR_ZLIB, "Failed to initialize zlib");
+			giterr_set(GITERR_ZLIB, "failed to initialize zlib");
 			goto cleanup;
 		}
 
@@ -426,14 +426,14 @@ int git_filebuf_commit(git_filebuf *file)
 	file->fd_is_open = false;
 
 	if (p_close(file->fd) < 0) {
-		giterr_set(GITERR_OS, "Failed to close file at '%s'", file->path_lock);
+		giterr_set(GITERR_OS, "failed to close file at '%s'", file->path_lock);
 		goto on_error;
 	}
 
 	file->fd = -1;
 
 	if (p_rename(file->path_lock, file->path_original) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename lockfile to '%s'", file->path_original);
+		giterr_set(GITERR_OS, "failed to rename lockfile to '%s'", file->path_original);
 		goto on_error;
 	}
 
@@ -571,7 +571,7 @@ int git_filebuf_stats(time_t *mtime, size_t *size, git_filebuf *file)
 		res = p_stat(file->path_original, &st);
 
 	if (res < 0) {
-		giterr_set(GITERR_OS, "Could not get stat info for '%s'",
+		giterr_set(GITERR_OS, "could not get stat info for '%s'",
 			file->path_original);
 		return res;
 	}

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -37,13 +37,13 @@ int git_futils_mktmp(git_buf *path_out, const char *filename, mode_t mode)
 
 	if ((fd = p_mkstemp(path_out->ptr)) < 0) {
 		giterr_set(GITERR_OS,
-			"Failed to create temporary file '%s'", path_out->ptr);
+			"failed to create temporary file '%s'", path_out->ptr);
 		return -1;
 	}
 
 	if (p_chmod(path_out->ptr, (mode & ~mask))) {
 		giterr_set(GITERR_OS,
-			"Failed to set permissions on file '%s'", path_out->ptr);
+			"failed to set permissions on file '%s'", path_out->ptr);
 		return -1;
 	}
 
@@ -59,7 +59,7 @@ int git_futils_creat_withpath(const char *path, const mode_t dirmode, const mode
 
 	fd = p_creat(path, mode);
 	if (fd < 0) {
-		giterr_set(GITERR_OS, "Failed to create file '%s'", path);
+		giterr_set(GITERR_OS, "failed to create file '%s'", path);
 		return -1;
 	}
 
@@ -73,7 +73,7 @@ int git_futils_creat_locked(const char *path, const mode_t mode)
 
 	if (fd < 0) {
 		int error = errno;
-		giterr_set(GITERR_OS, "Failed to create locked file '%s'", path);
+		giterr_set(GITERR_OS, "failed to create locked file '%s'", path);
 		switch (error) {
 		case EEXIST:
 			return GIT_ELOCKED;
@@ -108,7 +108,7 @@ git_off_t git_futils_filesize(git_file fd)
 	struct stat sb;
 
 	if (p_fstat(fd, &sb)) {
-		giterr_set(GITERR_OS, "Failed to stat file descriptor");
+		giterr_set(GITERR_OS, "failed to stat file descriptor");
 		return -1;
 	}
 
@@ -137,7 +137,7 @@ int git_futils_readbuffer_fd(git_buf *buf, git_file fd, size_t len)
 	git_buf_clear(buf);
 
 	if (!git__is_ssizet(len)) {
-		giterr_set(GITERR_INVALID, "Read too large.");
+		giterr_set(GITERR_INVALID, "read too large");
 		return -1;
 	}
 
@@ -149,7 +149,7 @@ int git_futils_readbuffer_fd(git_buf *buf, git_file fd, size_t len)
 	read_size = p_read(fd, buf->ptr, len);
 
 	if (read_size != (ssize_t)len) {
-		giterr_set(GITERR_OS, "Failed to read descriptor");
+		giterr_set(GITERR_OS, "failed to read descriptor");
 		git_buf_free(buf);
 		return -1;
 	}
@@ -184,7 +184,7 @@ int git_futils_readbuffer_updated(
 	}
 
 	if (!git__is_sizet(st.st_size+1)) {
-		giterr_set(GITERR_OS, "Invalid regular file stat for '%s'", path);
+		giterr_set(GITERR_OS, "invalid regular file stat for '%s'", path);
 		return -1;
 	}
 
@@ -245,18 +245,18 @@ int git_futils_writebuffer(
 		mode = GIT_FILEMODE_BLOB;
 
 	if ((fd = p_open(path, flags, mode)) < 0) {
-		giterr_set(GITERR_OS, "Could not open '%s' for writing", path);
+		giterr_set(GITERR_OS, "could not open '%s' for writing", path);
 		return fd;
 	}
 
 	if ((error = p_write(fd, git_buf_cstr(buf), git_buf_len(buf))) < 0) {
-		giterr_set(GITERR_OS, "Could not write to '%s'", path);
+		giterr_set(GITERR_OS, "could not write to '%s'", path);
 		(void)p_close(fd);
 		return error;
 	}
 
 	if ((error = p_close(fd)) < 0)
-		giterr_set(GITERR_OS, "Error while closing '%s'", path);
+		giterr_set(GITERR_OS, "error while closing '%s'", path);
 
 	return error;
 }
@@ -267,7 +267,7 @@ int git_futils_mv_withpath(const char *from, const char *to, const mode_t dirmod
 		return -1;
 
 	if (p_rename(from, to) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename '%s' to '%s'", from, to);
+		giterr_set(GITERR_OS, "failed to rename '%s' to '%s'", from, to);
 		return -1;
 	}
 
@@ -290,7 +290,7 @@ int git_futils_mmap_ro_file(git_map *out, const char *path)
 
 	len = git_futils_filesize(fd);
 	if (!git__is_sizet(len)) {
-		giterr_set(GITERR_OS, "File `%s` too large to mmap", path);
+		giterr_set(GITERR_OS, "file `%s` too large to mmap", path);
 		return -1;
 	}
 
@@ -314,14 +314,14 @@ GIT_INLINE(int) mkdir_validate_dir(
 	/* with exclusive create, existing dir is an error */
 	if ((flags & GIT_MKDIR_EXCL) != 0) {
 		giterr_set(GITERR_FILESYSTEM,
-			"Failed to make directory '%s': directory exists", path);
+			"failed to make directory '%s': directory exists", path);
 		return GIT_EEXISTS;
 	}
 
 	if ((S_ISREG(st->st_mode) && (flags & GIT_MKDIR_REMOVE_FILES)) ||
 		(S_ISLNK(st->st_mode) && (flags & GIT_MKDIR_REMOVE_SYMLINKS))) {
 		if (p_unlink(path) < 0) {
-			giterr_set(GITERR_OS, "Failed to remove %s '%s'",
+			giterr_set(GITERR_OS, "failed to remove %s '%s'",
 				S_ISLNK(st->st_mode) ? "symlink" : "file", path);
 			return GIT_EEXISTS;
 		}
@@ -329,7 +329,7 @@ GIT_INLINE(int) mkdir_validate_dir(
 		opts->perfdata.mkdir_calls++;
 
 		if (p_mkdir(path, mode) < 0) {
-			giterr_set(GITERR_OS, "Failed to make directory '%s'", path);
+			giterr_set(GITERR_OS, "failed to make directory '%s'", path);
 			return GIT_EEXISTS;
 		}
 	}
@@ -339,14 +339,14 @@ GIT_INLINE(int) mkdir_validate_dir(
 		opts->perfdata.stat_calls++;
 
 		if (p_stat(path, st) < 0) {
-			giterr_set(GITERR_OS, "Failed to make directory '%s'", path);
+			giterr_set(GITERR_OS, "failed to make directory '%s'", path);
 			return GIT_EEXISTS;
 		}
 	}
 
 	else if (!S_ISDIR(st->st_mode)) {
 		giterr_set(GITERR_FILESYSTEM,
-			"Failed to make directory '%s': directory exists", path);
+			"failed to make directory '%s': directory exists", path);
 		return GIT_EEXISTS;
 	}
 
@@ -569,7 +569,7 @@ int git_futils_mkdir_relative(
 retry_lstat:
 		if (p_lstat(make_path.ptr, &st) < 0) {
 			if (mkdir_attempted || errno != ENOENT) {
-				giterr_set(GITERR_OS, "Cannot access component in path '%s'", make_path.ptr);
+				giterr_set(GITERR_OS, "cannot access component in path '%s'", make_path.ptr);
 				error = -1;
 				goto done;
 			}
@@ -580,7 +580,7 @@ retry_lstat:
 			if (p_mkdir(make_path.ptr, mode) < 0) {
 				if (errno == EEXIST)
 					goto retry_lstat;
-				giterr_set(GITERR_OS, "Failed to make directory '%s'", make_path.ptr);
+				giterr_set(GITERR_OS, "failed to make directory '%s'", make_path.ptr);
 				error = -1;
 				goto done;
 			}
@@ -621,7 +621,7 @@ retry_lstat:
 		opts->perfdata.stat_calls++;
 
 		if (p_stat(make_path.ptr, &st) < 0 || !S_ISDIR(st.st_mode)) {
-			giterr_set(GITERR_OS, "Path is not a directory '%s'",
+			giterr_set(GITERR_OS, "path is not a directory '%s'",
 				make_path.ptr);
 			error = GIT_ENOTFOUND;
 		}
@@ -644,10 +644,10 @@ typedef struct {
 static int futils__error_cannot_rmdir(const char *path, const char *filemsg)
 {
 	if (filemsg)
-		giterr_set(GITERR_OS, "Could not remove directory. File '%s' %s",
+		giterr_set(GITERR_OS, "could not remove directory '%s': %s",
 				   path, filemsg);
 	else
-		giterr_set(GITERR_OS, "Could not remove directory '%s'", path);
+		giterr_set(GITERR_OS, "could not remove directory '%s'", path);
 
 	return -1;
 }
@@ -815,7 +815,7 @@ static int cp_by_fd(int ifd, int ofd, bool close_fd_when_done)
 		error = p_write(ofd, buffer, len);
 
 	if (len < 0) {
-		giterr_set(GITERR_OS, "Read error while copying file");
+		giterr_set(GITERR_OS, "read error while copying file");
 		error = (int)len;
 	}
 
@@ -871,14 +871,14 @@ static int cp_link(const char *from, const char *to, size_t link_size)
 
 	read_len = p_readlink(from, link_data, link_size);
 	if (read_len != (ssize_t)link_size) {
-		giterr_set(GITERR_OS, "Failed to read symlink data for '%s'", from);
+		giterr_set(GITERR_OS, "failed to read symlink data for '%s'", from);
 		error = -1;
 	}
 	else {
 		link_data[read_len] = '\0';
 
 		if (p_symlink(link_data, to) < 0) {
-			giterr_set(GITERR_OS, "Could not symlink '%s' as '%s'",
+			giterr_set(GITERR_OS, "could not symlink '%s' as '%s'",
 				link_data, to);
 			error = -1;
 		}
@@ -974,7 +974,7 @@ static int _cp_r_callback(void *ref, git_buf *from)
 			return 0;
 
 		if (p_unlink(info->to.ptr) < 0) {
-			giterr_set(GITERR_OS, "Cannot overwrite existing file '%s'",
+			giterr_set(GITERR_OS, "cannot overwrite existing file '%s'",
 				info->to.ptr);
 			return GIT_EEXISTS;
 		}

--- a/src/filter.c
+++ b/src/filter.c
@@ -296,7 +296,7 @@ int git_filter_unregister(const char *name)
 
 	/* cannot unregister default filters */
 	if (!strcmp(GIT_FILTER_CRLF, name) || !strcmp(GIT_FILTER_IDENT, name)) {
-		giterr_set(GITERR_FILTER, "Cannot unregister filter '%s'", name);
+		giterr_set(GITERR_FILTER, "cannot unregister filter '%s'", name);
 		return -1;
 	}
 
@@ -306,7 +306,7 @@ int git_filter_unregister(const char *name)
 	}
 
 	if ((fdef = filter_registry_lookup(&pos, name)) == NULL) {
-		giterr_set(GITERR_FILTER, "Cannot find filter '%s' to unregister", name);
+		giterr_set(GITERR_FILTER, "cannot find filter '%s' to unregister", name);
 		error = GIT_ENOTFOUND;
 		goto done;
 	}
@@ -645,7 +645,7 @@ int git_filter_list_push(
 	git_rwlock_rdunlock(&filter_registry.lock);
 
 	if (fdef == NULL) {
-		giterr_set(GITERR_FILTER, "Cannot use an unregistered filter");
+		giterr_set(GITERR_FILTER, "cannot use an unregistered filter");
 		return -1;
 	}
 
@@ -758,7 +758,7 @@ static int buf_from_blob(git_buf *out, git_blob *blob)
 	git_off_t rawsize = git_blob_rawsize(blob);
 
 	if (!git__is_sizet(rawsize)) {
-		giterr_set(GITERR_OS, "Blob is too large to filter");
+		giterr_set(GITERR_OS, "blob is too large to filter");
 		return -1;
 	}
 

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -214,7 +214,7 @@ static int hashsig_finalize_hashes(git_hashsig *sig)
 	if (sig->mins.size < HASHSIG_HEAP_MIN_SIZE &&
 		!(sig->opt & GIT_HASHSIG_ALLOW_SMALL_FILES)) {
 		giterr_set(GITERR_INVALID,
-			"File too small for similarity signature calculation");
+			"file too small for similarity signature calculation");
 		return GIT_EBUFS;
 	}
 
@@ -286,7 +286,7 @@ int git_hashsig_create_fromfile(
 		if ((buflen = p_read(fd, buf, sizeof(buf))) <= 0) {
 			if ((error = (int)buflen) < 0)
 				giterr_set(GITERR_OS,
-					"Read error on '%s' calculating similarity hashes", path);
+					"read error on '%s' calculating similarity hashes", path);
 			break;
 		}
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -175,7 +175,7 @@ static int parse_ignore_file(
 		context = attrs->entry->path;
 
 	if (git_mutex_lock(&attrs->lock) < 0) {
-		giterr_set(GITERR_OS, "Failed to lock ignore file");
+		giterr_set(GITERR_OS, "failed to lock ignore file");
 		return -1;
 	}
 

--- a/src/index.c
+++ b/src/index.c
@@ -570,7 +570,7 @@ int git_index_set_caps(git_index *index, int caps)
 
 		if (!repo)
 			return create_index_error(
-				-1, "Cannot access repository to set index caps");
+				-1, "cannot access repository to set index caps");
 
 		if (!git_repository__cvar(&val, repo, GIT_CVAR_IGNORECASE))
 			index->ignore_case = (val != 0);
@@ -639,7 +639,7 @@ int git_index_read(git_index *index, int force)
 
 	if (!index->index_file_path)
 		return create_index_error(-1,
-			"Failed to read index: The index is in-memory only");
+			"failed to read index: The index is in-memory only");
 
 	index->on_disk = git_path_exists(index->index_file_path);
 
@@ -653,7 +653,7 @@ int git_index_read(git_index *index, int force)
 	    ((updated = compare_checksum(index)) < 0)) {
 		giterr_set(
 			GITERR_INDEX,
-			"Failed to read index: '%s' no longer exists",
+			"failed to read index: '%s' no longer exists",
 			index->index_file_path);
 		return updated;
 	}
@@ -765,7 +765,7 @@ int git_index_set_version(git_index *index, unsigned int version)
 
 	if (version < INDEX_VERSION_NUMBER_LB ||
 	    version > INDEX_VERSION_NUMBER_UB) {
-		giterr_set(GITERR_INDEX, "Invalid version number");
+		giterr_set(GITERR_INDEX, "invalid version number");
 		return -1;
 	}
 
@@ -805,7 +805,7 @@ int git_index_write_tree(git_oid *oid, git_index *index)
 
 	if (repo == NULL)
 		return create_index_error(-1, "Failed to write tree. "
-		  "The index file is not backed up by an existing repository");
+		  "the index file is not backed up by an existing repository");
 
 	return git_tree__write_index(oid, index, repo);
 }
@@ -847,7 +847,7 @@ const git_index_entry *git_index_get_bypath(
 	if (git_idxmap_valid_index(index->entries_map, pos))
 		return git_idxmap_value_at(index->entries_map, pos);
 
-	giterr_set(GITERR_INDEX, "Index does not contain %s", path);
+	giterr_set(GITERR_INDEX, "index does not contain '%s'", path);
 	return NULL;
 }
 
@@ -934,7 +934,7 @@ static int index_entry_init(
 
 	if (INDEX_OWNER(index) == NULL)
 		return create_index_error(-1,
-			"Could not initialize index entry. "
+			"could not initialize index entry. "
 			"Index is not backed up by an existing repository.");
 
 	if (index_entry_create(&entry, INDEX_OWNER(index), rel_path, true) < 0)
@@ -1423,7 +1423,7 @@ int git_index_add_frombuffer(
 
 	if (INDEX_OWNER(index) == NULL)
 		return create_index_error(-1,
-			"Could not initialize index entry. "
+			"could not initialize index entry. "
 			"Index is not backed up by an existing repository.");
 
 	if (!valid_filemode(source_entry->mode)) {
@@ -1637,7 +1637,7 @@ int git_index_remove(git_index *index, const char *path, int stage)
 
 	if (index_find(&position, index, path, 0, stage) < 0) {
 		giterr_set(
-			GITERR_INDEX, "Index does not contain %s at stage %d", path, stage);
+			GITERR_INDEX, "index does not contain %s at stage %d", path, stage);
 		error = GIT_ENOTFOUND;
 	} else {
 		error = index_remove_entry(index, position);
@@ -1709,7 +1709,7 @@ int git_index_find(size_t *at_pos, git_index *index, const char *path)
 
 	if (git_vector_bsearch2(
 			&pos, &index->entries, index->entries_search_path, path) < 0) {
-		giterr_set(GITERR_INDEX, "Index does not contain %s", path);
+		giterr_set(GITERR_INDEX, "index does not contain %s", path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -2153,7 +2153,7 @@ void git_index_reuc_clear(git_index *index)
 
 static int index_error_invalid(const char *message)
 {
-	giterr_set(GITERR_INDEX, "Invalid data in index - %s", message);
+	giterr_set(GITERR_INDEX, "invalid data in index - %s", message);
 	return -1;
 }
 
@@ -3390,7 +3390,7 @@ static int index_apply_to_all(
 				i--; /* back up foreach if we removed this */
 			break;
 		default:
-			giterr_set(GITERR_INVALID, "Unknown index action %d", action);
+			giterr_set(GITERR_INVALID, "unknown index action %d", action);
 			error = -1;
 			break;
 		}
@@ -3475,13 +3475,13 @@ int git_indexwriter_init(
 
 	if (!index->index_file_path)
 		return create_index_error(-1,
-			"Failed to write index: The index is in-memory only");
+			"failed to write index: The index is in-memory only");
 
 	if ((error = git_filebuf_open(
 		&writer->file, index->index_file_path, GIT_FILEBUF_HASH_CONTENTS, GIT_INDEX_FILE_MODE)) < 0) {
 
 		if (error == GIT_ELOCKED)
-			giterr_set(GITERR_INDEX, "The index is locked. This might be due to a concurrent or crashed process");
+			giterr_set(GITERR_INDEX, "the index is locked; this might be due to a concurrent or crashed process");
 
 		return error;
 	}
@@ -3530,7 +3530,7 @@ int git_indexwriter_commit(git_indexwriter *writer)
 
 	if ((error = git_futils_filestamp_check(
 		&writer->index->stamp, writer->index->index_file_path)) < 0) {
-		giterr_set(GITERR_OS, "Could not read index timestamp");
+		giterr_set(GITERR_OS, "could not read index timestamp");
 		return -1;
 	}
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -83,12 +83,12 @@ static int parse_header(struct git_pack_header *hdr, struct git_pack_file *pack)
 
 	/* Verify we recognize this pack file format. */
 	if (hdr->hdr_signature != ntohl(PACK_SIGNATURE)) {
-		giterr_set(GITERR_INDEXER, "Wrong pack signature");
+		giterr_set(GITERR_INDEXER, "wrong pack signature");
 		return -1;
 	}
 
 	if (!pack_version_ok(hdr->hdr_version)) {
-		giterr_set(GITERR_INDEXER, "Wrong pack version");
+		giterr_set(GITERR_INDEXER, "wrong pack version");
 		return -1;
 	}
 
@@ -376,7 +376,7 @@ static int hash_and_save(git_indexer *idx, git_rawobj *obj, git_off_t entry_star
 	GITERR_CHECK_ALLOC(entry);
 
 	if (git_odb__hashobj(&oid, obj) < 0) {
-		giterr_set(GITERR_INDEXER, "Failed to hash object");
+		giterr_set(GITERR_INDEXER, "failed to hash object");
 		goto on_error;
 	}
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -78,7 +78,7 @@ int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_reposito
 	unsigned int i;
 
 	if (length < 2) {
-		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %" PRIuZ ".", length);
+		giterr_set(GITERR_INVALID, "at least two commits are required to find an ancestor");
 		return -1;
 	}
 
@@ -104,7 +104,7 @@ int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_reposito
 		goto on_error;
 
 	if (!result) {
-		giterr_set(GITERR_MERGE, "No merge base found");
+		giterr_set(GITERR_MERGE, "no merge base found");
 		error = GIT_ENOTFOUND;
 		goto on_error;
 	}
@@ -184,7 +184,7 @@ int git_merge_base_octopus(git_oid *out, git_repository *repo, size_t length, co
 	assert(out && repo && input_array);
 
 	if (length < 2) {
-		giterr_set(GITERR_INVALID, "At least two commits are required to find an ancestor. Provided 'length' was %" PRIuZ ".", length);
+		giterr_set(GITERR_INVALID, "at least two commits are required to find an ancestor");
 		return -1;
 	}
 
@@ -230,7 +230,7 @@ static int merge_bases(git_commit_list **out, git_revwalk **walk_out, git_reposi
 
 	if (!result) {
 		git_revwalk_free(walk);
-		giterr_set(GITERR_MERGE, "No merge base found");
+		giterr_set(GITERR_MERGE, "no merge base found");
 		return GIT_ENOTFOUND;
 	}
 
@@ -574,7 +574,7 @@ int git_repository_mergehead_foreach(
 
 	while ((line = git__strsep(&buffer, "\n")) != NULL) {
 		if (strlen(line) != GIT_OID_HEXSZ) {
-			giterr_set(GITERR_INVALID, "Unable to parse OID - invalid length");
+			giterr_set(GITERR_INVALID, "unable to parse OID - invalid length");
 			error = -1;
 			goto cleanup;
 		}
@@ -591,7 +591,7 @@ int git_repository_mergehead_foreach(
 	}
 
 	if (*buffer) {
-		giterr_set(GITERR_MERGE, "No EOL at line %"PRIuZ, line_num);
+		giterr_set(GITERR_MERGE, "no EOL at line %"PRIuZ, line_num);
 		error = -1;
 		goto cleanup;
 	}
@@ -3043,7 +3043,7 @@ int git_merge_analysis(
 	assert(analysis_out && preference_out && repo && their_heads);
 
 	if (their_heads_len != 1) {
-		giterr_set(GITERR_MERGE, "Can only merge a single branch");
+		giterr_set(GITERR_MERGE, "can only merge a single branch");
 		error = -1;
 		goto done;
 	}
@@ -3099,7 +3099,7 @@ int git_merge(
 	assert(repo && their_heads);
 
 	if (their_heads_len != 1) {
-		giterr_set(GITERR_MERGE, "Can only merge a single branch");
+		giterr_set(GITERR_MERGE, "can only merge a single branch");
 		return -1;
 	}
 

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -127,7 +127,7 @@ static int merge_file__xdiff(
 
 	if ((xdl_result = xdl_merge(&ancestor_mmfile, &our_mmfile,
 		&their_mmfile, &xmparam, &mmbuffer)) < 0) {
-		giterr_set(GITERR_MERGE, "Failed to merge files.");
+		giterr_set(GITERR_MERGE, "failed to merge files");
 		error = -1;
 		goto done;
 	}

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -231,7 +231,7 @@ static int git_mwindow_close_lru(git_mwindow_file *mwf)
 	}
 
 	if (!lru_w) {
-		giterr_set(GITERR_OS, "Failed to close memory window. Couldn't find LRU");
+		giterr_set(GITERR_OS, "failed to close memory window; couldn't find LRU");
 		return -1;
 	}
 

--- a/src/netops.c
+++ b/src/netops.c
@@ -144,7 +144,7 @@ int gitno_connection_data_from_url(
 		default_port = "80";
 
 		if (data->use_ssl) {
-			giterr_set(GITERR_NET, "Redirect from HTTPS to HTTP is not allowed");
+			giterr_set(GITERR_NET, "redirect from HTTPS to HTTP is not allowed");
 			goto cleanup;
 		}
 	} else if (!git__prefixcmp(url, prefix_https)) {
@@ -155,7 +155,7 @@ int gitno_connection_data_from_url(
 		default_port = data->use_ssl ? "443" : "80";
 
 	if (!default_port) {
-		giterr_set(GITERR_NET, "Unrecognized URL prefix");
+		giterr_set(GITERR_NET, "unrecognized URL prefix");
 		goto cleanup;
 	}
 
@@ -187,7 +187,7 @@ int gitno_connection_data_from_url(
 
 		/* Check for errors in the resulting data */
 		if (original_host && url[0] != '/' && strcmp(original_host, data->host)) {
-			giterr_set(GITERR_NET, "Cross host redirect not allowed");
+			giterr_set(GITERR_NET, "cross host redirect not allowed");
 			error = -1;
 		}
 	}
@@ -237,7 +237,7 @@ int gitno_extract_url_parts(
 	const char *_host, *_port, *_path, *_userinfo;
 
 	if (http_parser_parse_url(url, strlen(url), false, &u)) {
-		giterr_set(GITERR_NET, "Malformed URL '%s'", url);
+		giterr_set(GITERR_NET, "malformed URL '%s'", url);
 		return GIT_EINVALIDSPEC;
 	}
 

--- a/src/notes.c
+++ b/src/notes.c
@@ -15,7 +15,7 @@
 
 static int note_error_notfound(void)
 {
-	giterr_set(GITERR_INVALID, "Note could not be found");
+	giterr_set(GITERR_INVALID, "note could not be found");
 	return GIT_ENOTFOUND;
 }
 
@@ -226,7 +226,7 @@ static int remove_note_in_tree_enotfound_cb(
 	GIT_UNUSED(note_oid);
 	GIT_UNUSED(fanout);
 
-	giterr_set(GITERR_REPOSITORY, "Object '%s' has no note", annotated_object_sha);
+	giterr_set(GITERR_REPOSITORY, "object '%s' has no note", annotated_object_sha);
 	return current_error;
 }
 
@@ -244,7 +244,7 @@ static int insert_note_in_tree_eexists_cb(git_tree **out,
 	GIT_UNUSED(note_oid);
 	GIT_UNUSED(fanout);
 
-	giterr_set(GITERR_REPOSITORY, "Note for '%s' exists already", annotated_object_sha);
+	giterr_set(GITERR_REPOSITORY, "note for '%s' exists already", annotated_object_sha);
 	return current_error;
 }
 

--- a/src/object.c
+++ b/src/object.c
@@ -66,12 +66,12 @@ int git_object__from_odb_object(
 	/* Validate type match */
 	if (type != GIT_OBJ_ANY && type != odb_obj->cached.type) {
 		giterr_set(GITERR_INVALID,
-			"The requested type does not match the type in the ODB");
+			"the requested type does not match the type in the ODB");
 		return GIT_ENOTFOUND;
 	}
 
 	if ((object_size = git_object__size(odb_obj->cached.type)) == 0) {
-		giterr_set(GITERR_INVALID, "The requested type is invalid");
+		giterr_set(GITERR_INVALID, "the requested type is invalid");
 		return GIT_ENOTFOUND;
 	}
 
@@ -122,7 +122,7 @@ int git_object_lookup_prefix(
 	assert(repo && object_out && id);
 
 	if (len < GIT_OID_MINPREFIXLEN) {
-		giterr_set(GITERR_OBJECT, "Ambiguous lookup - OID prefix is too short");
+		giterr_set(GITERR_OBJECT, "ambiguous lookup - OID prefix is too short");
 		return GIT_EAMBIGUOUS;
 	}
 
@@ -147,7 +147,7 @@ int git_object_lookup_prefix(
 				if (type != GIT_OBJ_ANY && type != object->cached.type) {
 					git_object_free(object);
 					giterr_set(GITERR_INVALID,
-						"The requested type does not match the type in ODB");
+						"the requested type does not match the type in ODB");
 					return GIT_ENOTFOUND;
 				}
 
@@ -292,7 +292,7 @@ static int peel_error(int error, const git_oid *oid, git_otype type)
 	git_oid_fmt(hex_oid, oid);
 	hex_oid[GIT_OID_HEXSZ] = '\0';
 
-	giterr_set(GITERR_OBJECT, "The git_object of id '%s' can not be "
+	giterr_set(GITERR_OBJECT, "the git_object of id '%s' can not be "
 		"successfully peeled into a %s (git_otype=%i).", hex_oid, type_name, type);
 
 	return error;

--- a/src/odb.c
+++ b/src/odb.c
@@ -176,7 +176,7 @@ int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 	int error = 0;
 
 	if (!git_object_typeisloose(type)) {
-		giterr_set(GITERR_INVALID, "Invalid object type for hash");
+		giterr_set(GITERR_INVALID, "invalid object type for hash");
 		return -1;
 	}
 
@@ -199,7 +199,7 @@ int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 	 * If size is not zero, the file was truncated after we originally
 	 * stat'd it, so we consider this a read failure too */
 	if (read_len < 0 || size > 0) {
-		giterr_set(GITERR_OS, "Error reading file for hashing");
+		giterr_set(GITERR_OS, "error reading file for hashing");
 		error = -1;
 
 		goto done;
@@ -251,7 +251,7 @@ int git_odb__hashlink(git_oid *out, const char *path)
 		return -1;
 
 	if (!git__is_int(st.st_size) || (int)st.st_size < 0) {
-		giterr_set(GITERR_FILESYSTEM, "File size overflow for 32-bit systems");
+		giterr_set(GITERR_FILESYSTEM, "file size overflow for 32-bit systems");
 		return -1;
 	}
 
@@ -269,7 +269,7 @@ int git_odb__hashlink(git_oid *out, const char *path)
 		read_len = p_readlink(path, link_data, size);
 		link_data[size] = '\0';
 		if (read_len != size) {
-			giterr_set(GITERR_OS, "Failed to read symlink data for '%s'", path);
+			giterr_set(GITERR_OS, "failed to read symlink data for '%s'", path);
 			git__free(link_data);
 			return -1;
 		}
@@ -295,7 +295,7 @@ int git_odb_hashfile(git_oid *out, const char *path, git_otype type)
 		return fd;
 
 	if ((size = git_futils_filesize(fd)) < 0 || !git__is_sizet(size)) {
-		giterr_set(GITERR_OS, "File size overflow for 32-bit systems");
+		giterr_set(GITERR_OS, "file size overflow for 32-bit systems");
 		p_close(fd);
 		return -1;
 	}
@@ -475,7 +475,7 @@ size_t git_odb_num_backends(git_odb *odb)
 static int git_odb__error_unsupported_in_backend(const char *action)
 {
 	giterr_set(GITERR_ODB,
-		"Cannot %s - unsupported in the loaded odb backends", action);
+		"cannot %s - unsupported in the loaded odb backends", action);
 	return -1;
 }
 
@@ -492,7 +492,7 @@ int git_odb_get_backend(git_odb_backend **out, git_odb *odb, size_t pos)
 		return 0;
 	}
 
-	giterr_set(GITERR_ODB, "No ODB backend loaded at index %" PRIuZ, pos);
+	giterr_set(GITERR_ODB, "no ODB backend loaded at index %" PRIuZ, pos);
 	return GIT_ENOTFOUND;
 }
 
@@ -517,7 +517,7 @@ static int add_default_backends(
 		if (as_alternates)
 			return 0;
 
-		giterr_set(GITERR_ODB, "Failed to load object database in '%s'", objects_dir);
+		giterr_set(GITERR_ODB, "failed to load object database in '%s'", objects_dir);
 		return -1;
 	}
 
@@ -1264,7 +1264,7 @@ static int git_odb_stream__invalid_length(
 	const char *action)
 {
 	giterr_set(GITERR_ODB,
-		"Cannot %s - "
+		"cannot %s - "
 		"Invalid length. %"PRIuZ" was expected. The "
 		"total size of the received chunks amounts to %"PRIuZ".",
 		action, stream->declared_size, stream->received_bytes);		
@@ -1399,17 +1399,17 @@ int git_odb__error_notfound(
 	if (oid != NULL) {
 		char oid_str[GIT_OID_HEXSZ + 1];
 		git_oid_tostr(oid_str, oid_len+1, oid);
-		giterr_set(GITERR_ODB, "Object not found - %s (%.*s)",
+		giterr_set(GITERR_ODB, "object not found - %s (%.*s)",
 			message, (int) oid_len, oid_str);
 	} else
-		giterr_set(GITERR_ODB, "Object not found - %s", message);
+		giterr_set(GITERR_ODB, "object not found - %s", message);
 
 	return GIT_ENOTFOUND;
 }
 
 int git_odb__error_ambiguous(const char *message)
 {
-	giterr_set(GITERR_ODB, "Ambiguous SHA1 prefix - %s", message);
+	giterr_set(GITERR_ODB, "ambiguous SHA1 prefix - %s", message);
 	return GIT_EAMBIGUOUS;
 }
 

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -214,7 +214,7 @@ static int finish_inflate(z_stream *s)
 	inflateEnd(s);
 
 	if ((status != Z_STREAM_END) || (s->avail_in != 0)) {
-		giterr_set(GITERR_ZLIB, "Failed to finish ZLib inflation. Stream aborted prematurely");
+		giterr_set(GITERR_ZLIB, "failed to finish zlib inflation; stream aborted prematurely");
 		return -1;
 	}
 
@@ -243,7 +243,7 @@ static int inflate_buffer(void *in, size_t inlen, void *out, size_t outlen)
 	zs.avail_in = (uInt)inlen;
 
 	if (inflateInit(&zs) < Z_OK) {
-		giterr_set(GITERR_ZLIB, "Failed to inflate buffer");
+		giterr_set(GITERR_ZLIB, "failed to inflate buffer");
 		return -1;
 	}
 
@@ -255,7 +255,7 @@ static int inflate_buffer(void *in, size_t inlen, void *out, size_t outlen)
 	if (status != Z_STREAM_END /* || zs.avail_in != 0 */ ||
 		zs.total_out != outlen)
 	{
-		giterr_set(GITERR_ZLIB, "Failed to inflate buffer. Stream aborted prematurely");
+		giterr_set(GITERR_ZLIB, "failed to inflate buffer; stream aborted prematurely");
 		return -1;
 	}
 
@@ -319,7 +319,7 @@ static int inflate_packlike_loose_disk_obj(git_rawobj *out, git_buf *obj)
 	 */
 	if ((used = get_binary_object_header(&hdr, obj)) == 0 ||
 		!git_object_typeisloose(hdr.type)) {
-		giterr_set(GITERR_ODB, "Failed to inflate loose object.");
+		giterr_set(GITERR_ODB, "failed to inflate loose object");
 		return -1;
 	}
 
@@ -366,7 +366,7 @@ static int inflate_disk_obj(git_rawobj *out, git_buf *obj)
 		(used = get_object_header(&hdr, head)) == 0 ||
 		!git_object_typeisloose(hdr.type))
 	{
-		giterr_set(GITERR_ODB, "Failed to inflate disk object.");
+		giterr_set(GITERR_ODB, "failed to inflate disk object");
 		return -1;
 	}
 
@@ -455,7 +455,7 @@ static int read_header_loose(git_rawobj *out, git_buf *loc)
 		|| get_object_header(&header_obj, inflated_buffer) == 0
 		|| git_object_typeisloose(header_obj.type) == 0)
 	{
-		giterr_set(GITERR_ZLIB, "Failed to read loose object header");
+		giterr_set(GITERR_ZLIB, "failed to read loose object header");
 		error = -1;
 	} else {
 		out->len = header_obj.size;

--- a/src/oid.c
+++ b/src/oid.c
@@ -16,7 +16,7 @@ static char to_hex[] = "0123456789abcdef";
 
 static int oid_error_invalid(const char *msg)
 {
-	giterr_set(GITERR_INVALID, "Unable to parse OID - %s", msg);
+	giterr_set(GITERR_INVALID, "unable to parse OID - %s", msg);
 	return -1;
 }
 
@@ -380,7 +380,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 	node_index idx;
 
 	if (os->full) {
-		giterr_set(GITERR_INVALID, "Unable to shorten OID - OID set full");
+		giterr_set(GITERR_INVALID, "unable to shorten OID - OID set full");
 		return -1;
 	}
 
@@ -395,7 +395,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 		trie_node *node;
 
 		if (c == -1) {
-			giterr_set(GITERR_INVALID, "Unable to shorten OID - invalid hex value");
+			giterr_set(GITERR_INVALID, "unable to shorten OID - invalid hex value");
 			return -1;
 		}
 
@@ -410,7 +410,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 			node = push_leaf(os, idx, git__fromhex(tail[0]), &tail[1]);
 			if (node == NULL) {
 				if (os->full)
-					giterr_set(GITERR_INVALID, "Unable to shorten OID - OID set full");
+					giterr_set(GITERR_INVALID, "unable to shorten OID - OID set full");
 				return -1;
 			}
 		}
@@ -418,7 +418,7 @@ int git_oid_shorten_add(git_oid_shorten *os, const char *text_oid)
 		if (node->children[c] == 0) {
 			if (push_leaf(os, idx, c, &text_oid[i + 1]) == NULL) {
 				if (os->full)
-					giterr_set(GITERR_INVALID, "Unable to shorten OID - OID set full");
+					giterr_set(GITERR_INVALID, "unable to shorten OID - OID set full");
 				return -1;
 			}
 			break;

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -257,10 +257,10 @@ static int ssl_set_error(SSL *ssl, int error)
 	switch (err) {
 	case SSL_ERROR_WANT_CONNECT:
 	case SSL_ERROR_WANT_ACCEPT:
-		giterr_set(GITERR_NET, "SSL error: connection failure\n");
+		giterr_set(GITERR_NET, "SSL error: connection failure");
 		break;
 	case SSL_ERROR_WANT_X509_LOOKUP:
-		giterr_set(GITERR_NET, "SSL error: x509 error\n");
+		giterr_set(GITERR_NET, "SSL error: x509 error");
 		break;
 	case SSL_ERROR_SYSCALL:
 		e = ERR_get_error();
@@ -327,7 +327,7 @@ static int verify_server_cert(SSL *ssl, const char *host)
 	int i = -1,j;
 
 	if (SSL_get_verify_result(ssl) != X509_V_OK) {
-		giterr_set(GITERR_SSL, "The SSL certificate is invalid");
+		giterr_set(GITERR_SSL, "the SSL certificate is invalid");
 		return GIT_ECERTIFICATE;
 	}
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -162,7 +162,7 @@ int git_packbuilder_new(git_packbuilder **out, git_repository *repo)
 		git_mutex_init(&pb->progress_mutex) ||
 		git_cond_init(&pb->progress_cond))
 	{
-		giterr_set(GITERR_OS, "Failed to initialize packbuilder mutex");
+		giterr_set(GITERR_OS, "failed to initialize packbuilder mutex");
 		goto on_error;
 	}
 
@@ -225,7 +225,7 @@ int git_packbuilder_insert(git_packbuilder *pb, const git_oid *oid,
 		GITERR_CHECK_ALLOC_MULTIPLY(&newsize, newsize, 3 / 2);
 
 		if (!git__is_uint32(newsize)) {
-			giterr_set(GITERR_NOMEMORY, "Packfile too large to fit in memory.");
+			giterr_set(GITERR_NOMEMORY, "packfile too large to fit in memory.");
 			return -1;
 		}
 
@@ -298,7 +298,7 @@ static int get_delta(void **out, git_odb *odb, git_pobject *po)
 		goto on_error;
 
 	if (error == GIT_EBUFS || delta_size != po->delta_size) {
-		giterr_set(GITERR_INVALID, "Delta size changed");
+		giterr_set(GITERR_INVALID, "delta size changed");
 		goto on_error;
 	}
 
@@ -808,7 +808,7 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 
 		if (sz != trg_size) {
 			giterr_set(GITERR_INVALID,
-				   "Inconsistent target object length");
+				   "inconsistent target object length");
 			return -1;
 		}
 
@@ -830,7 +830,7 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 
 		if (sz != src_size) {
 			giterr_set(GITERR_INVALID,
-				   "Inconsistent source object length");
+				   "inconsistent source object length");
 			return -1;
 		}
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -45,7 +45,7 @@ static int pack_entry_find_offset(
 
 static int packfile_error(const char *message)
 {
-	giterr_set(GITERR_ODB, "Invalid pack file - %s", message);
+	giterr_set(GITERR_ODB, "invalid pack file - %s", message);
 	return -1;
 }
 
@@ -99,7 +99,7 @@ static int cache_init(git_pack_cache *cache)
 	cache->memory_limit = GIT_PACK_CACHE_MEMORY_LIMIT;
 
 	if (git_mutex_init(&cache->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize pack cache mutex");
+		giterr_set(GITERR_OS, "failed to initialize pack cache mutex");
 
 		git__free(cache->entries);
 		cache->entries = NULL;
@@ -226,7 +226,7 @@ static int pack_index_check(const char *path, struct git_pack_file *p)
 
 	if (p_fstat(fd, &st) < 0) {
 		p_close(fd);
-		giterr_set(GITERR_OS, "Unable to stat pack index '%s'", path);
+		giterr_set(GITERR_OS, "unable to stat pack index '%s'", path);
 		return -1;
 	}
 
@@ -235,7 +235,7 @@ static int pack_index_check(const char *path, struct git_pack_file *p)
 		(idx_size = (size_t)st.st_size) < 4 * 256 + 20 + 20)
 	{
 		p_close(fd);
-		giterr_set(GITERR_ODB, "Invalid pack index '%s'", path);
+		giterr_set(GITERR_ODB, "invalid pack index '%s'", path);
 		return -1;
 	}
 
@@ -1082,7 +1082,7 @@ static int packfile_open(struct git_pack_file *p)
 	return 0;
 
 cleanup:
-	giterr_set(GITERR_OS, "Invalid packfile '%s'", p->pack_name);
+	giterr_set(GITERR_OS, "invalid packfile '%s'", p->pack_name);
 
 	if (p->mwf.fd >= 0)
 		p_close(p->mwf.fd);
@@ -1158,7 +1158,7 @@ int git_packfile_alloc(struct git_pack_file **pack_out, const char *path)
 	p->index_version = -1;
 
 	if (git_mutex_init(&p->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize packfile mutex");
+		giterr_set(GITERR_OS, "failed to initialize packfile mutex");
 		git__free(p);
 		return -1;
 	}

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -417,7 +417,7 @@ static int diff_required(git_diff *diff, const char *action)
 {
 	if (diff)
 		return 0;
-	giterr_set(GITERR_INVALID, "Must provide valid diff to %s", action);
+	giterr_set(GITERR_INVALID, "must provide valid diff to %s", action);
 	return -1;
 }
 
@@ -776,7 +776,7 @@ int git_patch_generated_from_diff(
 
 	delta = git_vector_get(&diff->deltas, idx);
 	if (!delta) {
-		giterr_set(GITERR_INVALID, "Index out of range for delta in diff");
+		giterr_set(GITERR_INVALID, "index out of range for delta in diff");
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/path.c
+++ b/src/path.c
@@ -341,7 +341,7 @@ int git_path_prettify(git_buf *path_out, const char *path, const char *base)
 	if (p_realpath(path, buf) == NULL) {
 		/* giterr_set resets the errno when dealing with a GITERR_OS kind of error */
 		int error = (errno == ENOENT || errno == ENOTDIR) ? GIT_ENOTFOUND : -1;
-		giterr_set(GITERR_OS, "Failed to resolve path '%s'", path);
+		giterr_set(GITERR_OS, "failed to resolve path '%s'", path);
 
 		git_buf_clear(path_out);
 
@@ -632,24 +632,24 @@ int git_path_set_error(int errno_value, const char *path, const char *action)
 	switch (errno_value) {
 	case ENOENT:
 	case ENOTDIR:
-		giterr_set(GITERR_OS, "Could not find '%s' to %s", path, action);
+		giterr_set(GITERR_OS, "could not find '%s' to %s", path, action);
 		return GIT_ENOTFOUND;
 
 	case EINVAL:
 	case ENAMETOOLONG:
-		giterr_set(GITERR_OS, "Invalid path for filesystem '%s'", path);
+		giterr_set(GITERR_OS, "invalid path for filesystem '%s'", path);
 		return GIT_EINVALIDSPEC;
 
 	case EEXIST:
-		giterr_set(GITERR_OS, "Failed %s - '%s' already exists", action, path);
+		giterr_set(GITERR_OS, "failed %s - '%s' already exists", action, path);
 		return GIT_EEXISTS;
 
 	case EACCES:
-		giterr_set(GITERR_OS, "Failed %s - '%s' is locked", action, path);
+		giterr_set(GITERR_OS, "failed %s - '%s' is locked", action, path);
 		return GIT_ELOCKED;
 
 	default:
-		giterr_set(GITERR_OS, "Could not %s '%s'", action, path);
+		giterr_set(GITERR_OS, "could not %s '%s'", action, path);
 		return -1;
 	}
 }
@@ -758,7 +758,7 @@ int git_path_resolve_relative(git_buf *path, size_t ceiling)
 			/* error out if trying to up one from a hard base */
 			if (to == base && ceiling != 0) {
 				giterr_set(GITERR_INVALID,
-					"Cannot strip root component off url");
+					"cannot strip root component off url");
 				return -1;
 			}
 
@@ -987,7 +987,7 @@ int git_path_iconv(git_path_iconv_t *ic, const char **in, size_t *inlen)
 	return 0;
 
 fail:
-	giterr_set(GITERR_OS, "Unable to convert unicode path data");
+	giterr_set(GITERR_OS, "unable to convert unicode path data");
 	return -1;
 }
 
@@ -1080,7 +1080,7 @@ int git_path_direach(
 	wd_len = git_buf_len(path);
 
 	if ((dir = opendir(path->ptr)) == NULL) {
-		giterr_set(GITERR_OS, "Failed to open directory '%s'", path->ptr);
+		giterr_set(GITERR_OS, "failed to open directory '%s'", path->ptr);
 		if (errno == ENOENT)
 			return GIT_ENOTFOUND;
 
@@ -1161,13 +1161,13 @@ int git_path_diriter_init(
 	git_path_trim_slashes(&diriter->path_utf8);
 
 	if (diriter->path_utf8.size == 0) {
-		giterr_set(GITERR_FILESYSTEM, "Could not open directory '%s'", path);
+		giterr_set(GITERR_FILESYSTEM, "could not open directory '%s'", path);
 		return -1;
 	}
 
 	if ((diriter->parent_len = git_win32_path_from_utf8(diriter->path, diriter->path_utf8.ptr)) < 0 ||
 			!git_win32__findfirstfile_filter(path_filter, diriter->path_utf8.ptr)) {
-		giterr_set(GITERR_OS, "Could not parse the directory path '%s'", path);
+		giterr_set(GITERR_OS, "could not parse the directory path '%s'", path);
 		return -1;
 	}
 
@@ -1180,7 +1180,7 @@ int git_path_diriter_init(
 		is_win7_or_later ? FIND_FIRST_EX_LARGE_FETCH : 0);
 
 	if (diriter->handle == INVALID_HANDLE_VALUE) {
-		giterr_set(GITERR_OS, "Could not open directory '%s'", path);
+		giterr_set(GITERR_OS, "could not open directory '%s'", path);
 		return -1;
 	}
 
@@ -1310,14 +1310,14 @@ int git_path_diriter_init(
 	git_path_trim_slashes(&diriter->path);
 
 	if (diriter->path.size == 0) {
-		giterr_set(GITERR_FILESYSTEM, "Could not open directory '%s'", path);
+		giterr_set(GITERR_FILESYSTEM, "could not open directory '%s'", path);
 		return -1;
 	}
 
 	if ((diriter->dir = opendir(diriter->path.ptr)) == NULL) {
 		git_buf_free(&diriter->path);
 
-		giterr_set(GITERR_OS, "Failed to open directory '%s'", path);
+		giterr_set(GITERR_OS, "failed to open directory '%s'", path);
 		return -1;
 	}
 
@@ -1350,7 +1350,7 @@ int git_path_diriter_next(git_path_diriter *diriter)
 				return GIT_ITEROVER;
 
 			giterr_set(GITERR_OS,
-				"Could not read directory '%s'", diriter->path.ptr);
+				"could not read directory '%s'", diriter->path.ptr);
 			return -1;
 		}
 	} while (skip_dot && git_path_is_dot_or_dotdot(de->d_name));

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -487,7 +487,7 @@ static int pathspec_match_from_iterator(
 
 	/* if every pattern failed to match, then we have failed */
 	if ((flags & GIT_PATHSPEC_NO_MATCH_ERROR) != 0 && !found_files) {
-		giterr_set(GITERR_INVALID, "No matching files were found");
+		giterr_set(GITERR_INVALID, "no matching files were found");
 		error = GIT_ENOTFOUND;
 	}
 
@@ -658,7 +658,7 @@ int git_pathspec_match_diff(
 
 	/* if every pattern failed to match, then we have failed */
 	if ((flags & GIT_PATHSPEC_NO_MATCH_ERROR) != 0 && !found_deltas) {
-		giterr_set(GITERR_INVALID, "No matching deltas were found");
+		giterr_set(GITERR_INVALID, "no matching deltas were found");
 		error = GIT_ENOTFOUND;
 	}
 

--- a/src/posix.c
+++ b/src/posix.c
@@ -240,7 +240,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	out->len = 0;
 
 	if ((prot & GIT_PROT_WRITE) && ((flags & GIT_MAP_TYPE) == GIT_MAP_SHARED)) {
-		giterr_set(GITERR_OS, "Trying to map shared-writeable");
+		giterr_set(GITERR_OS, "trying to map shared-writeable");
 		return -1;
 	}
 

--- a/src/push.c
+++ b/src/push.c
@@ -90,7 +90,7 @@ static void free_refspec(push_spec *spec)
 static int check_rref(char *ref)
 {
 	if (git__prefixcmp(ref, "refs/")) {
-		giterr_set(GITERR_INVALID, "Not a valid reference '%s'", ref);
+		giterr_set(GITERR_INVALID, "not a valid reference '%s'", ref);
 		return -1;
 	}
 
@@ -111,7 +111,7 @@ static int check_lref(git_push *push, char *ref)
 		giterr_set(GITERR_REFERENCE,
 			"src refspec '%s' does not match any existing object", ref);
 	else
-		giterr_set(GITERR_INVALID, "Not a valid reference '%s'", ref);
+		giterr_set(GITERR_INVALID, "not a valid reference '%s'", ref);
 	return -1;
 }
 
@@ -321,7 +321,7 @@ static int revwalk(git_vector *commits, git_push *push)
 
 			if (!git_odb_exists(push->repo->_odb, &spec->roid)) {
 				giterr_set(GITERR_REFERENCE, 
-					"Cannot push because a reference that you are trying to update on the remote contains commits that are not present locally.");
+					"cannot push because a reference that you are trying to update on the remote contains commits that are not present locally.");
 				error = GIT_ENONFASTFORWARD;
 				goto on_error;
 			}
@@ -332,7 +332,7 @@ static int revwalk(git_vector *commits, git_push *push)
 			if (error == GIT_ENOTFOUND ||
 				(!error && !git_oid_equal(&base, &spec->roid))) {
 				giterr_set(GITERR_REFERENCE,
-					"Cannot push non-fastforwardable reference");
+					"cannot push non-fastforwardable reference");
 				error = GIT_ENONFASTFORWARD;
 				goto on_error;
 			}
@@ -553,7 +553,7 @@ static int calculate_work(git_push *push)
 			/* This is a create or update.  Local ref must exist. */
 			if (git_reference_name_to_id(
 					&spec->loid, push->repo, spec->refspec.src) < 0) {
-				giterr_set(GITERR_REFERENCE, "No such reference '%s'", spec->refspec.src);
+				giterr_set(GITERR_REFERENCE, "no such reference '%s'", spec->refspec.src);
 				return -1;
 			}
 		}
@@ -579,7 +579,7 @@ static int do_push(git_push *push, const git_remote_callbacks *callbacks)
 	git_transport *transport = push->remote->transport;
 
 	if (!transport->push) {
-		giterr_set(GITERR_NET, "Remote transport doesn't support push");
+		giterr_set(GITERR_NET, "remote transport doesn't support push");
 		error = -1;
 		goto on_error;
 	}

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -152,7 +152,7 @@ GIT_INLINE(int) rebase_readint(
 		return error;
 
 	if (git__strtol32(&num, asc_out->ptr, &eol, 10) < 0 || num < 0 || *eol) {
-		giterr_set(GITERR_REBASE, "The file '%s' contains an invalid numeric value", filename);
+		giterr_set(GITERR_REBASE, "the file '%s' contains an invalid numeric value", filename);
 		return -1;
 	}
 
@@ -170,7 +170,7 @@ GIT_INLINE(int) rebase_readoid(
 		return error;
 
 	if (str_out->size != GIT_OID_HEXSZ || git_oid_fromstr(out, str_out->ptr) < 0) {
-		giterr_set(GITERR_REBASE, "The file '%s' contains an invalid object ID", filename);
+		giterr_set(GITERR_REBASE, "the file '%s' contains an invalid object ID", filename);
 		return -1;
 	}
 
@@ -316,7 +316,7 @@ int git_rebase_open(
 		goto done;
 
 	if (rebase->type == GIT_REBASE_TYPE_NONE) {
-		giterr_set(GITERR_REBASE, "There is no rebase in progress");
+		giterr_set(GITERR_REBASE, "there is no rebase in progress");
 		error = GIT_ENOTFOUND;
 		goto done;
 	}
@@ -372,14 +372,14 @@ int git_rebase_open(
 
 	switch (rebase->type) {
 	case GIT_REBASE_TYPE_INTERACTIVE:
-		giterr_set(GITERR_REBASE, "Interactive rebase is not supported");
+		giterr_set(GITERR_REBASE, "interactive rebase is not supported");
 		error = -1;
 		break;
 	case GIT_REBASE_TYPE_MERGE:
 		error = rebase_open_merge(rebase);
 		break;
 	case GIT_REBASE_TYPE_APPLY:
-		giterr_set(GITERR_REBASE, "Patch application rebase is not supported");
+		giterr_set(GITERR_REBASE, "patch application rebase is not supported");
 		error = -1;
 		break;
 	default:
@@ -478,7 +478,7 @@ static int rebase_setupfiles(git_rebase *rebase)
 	git_oid_fmt(orig_head, &rebase->orig_head_id);
 
 	if (p_mkdir(rebase->state_path, REBASE_DIR_MODE) < 0) {
-		giterr_set(GITERR_OS, "Failed to create rebase directory '%s'", rebase->state_path);
+		giterr_set(GITERR_OS, "failed to create rebase directory '%s'", rebase->state_path);
 		return -1;
 	}
 
@@ -511,7 +511,7 @@ static int rebase_ensure_not_in_progress(git_repository *repo)
 		return error;
 
 	if (type != GIT_REBASE_TYPE_NONE) {
-		giterr_set(GITERR_REBASE, "There is an existing rebase in progress");
+		giterr_set(GITERR_REBASE, "there is an existing rebase in progress");
 		return -1;
 	}
 
@@ -536,7 +536,7 @@ static int rebase_ensure_not_dirty(
 			goto done;
 
 		if (git_diff_num_deltas(diff) > 0) {
-			giterr_set(GITERR_REBASE, "Uncommitted changes exist in index");
+			giterr_set(GITERR_REBASE, "uncommitted changes exist in index");
 			error = fail_with;
 			goto done;
 		}
@@ -550,7 +550,7 @@ static int rebase_ensure_not_dirty(
 			goto done;
 
 		if (git_diff_num_deltas(diff) > 0) {
-			giterr_set(GITERR_REBASE, "Unstaged changes exist in workdir");
+			giterr_set(GITERR_REBASE, "unstaged changes exist in workdir");
 			error = fail_with;
 			goto done;
 		}
@@ -807,7 +807,7 @@ static int rebase_next_merge(
 		goto done;
 
 	if ((parent_count = git_commit_parentcount(current_commit)) > 1) {
-		giterr_set(GITERR_REBASE, "Cannot rebase a merge commit");
+		giterr_set(GITERR_REBASE, "cannot rebase a merge commit");
 		error = -1;
 		goto done;
 	} else if (parent_count) {
@@ -864,7 +864,7 @@ static int rebase_next_inmemory(
 		goto done;
 
 	if ((parent_count = git_commit_parentcount(current_commit)) > 1) {
-		giterr_set(GITERR_REBASE, "Cannot rebase a merge commit");
+		giterr_set(GITERR_REBASE, "cannot rebase a merge commit");
 		error = -1;
 		goto done;
 	} else if (parent_count) {
@@ -1259,7 +1259,7 @@ static int rebase_copy_notes(
 	goto done;
 
 on_error:
-	giterr_set(GITERR_REBASE, "Invalid rewritten file at line %d", linenum);
+	giterr_set(GITERR_REBASE, "invalid rewritten file at line %d", linenum);
 	error = -1;
 
 done:

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -128,7 +128,7 @@ int git_refdb_iterator(git_reference_iterator **out, git_refdb *db, const char *
 	int error;
 
 	if (!db->backend || !db->backend->iterator) {
-		giterr_set(GITERR_REFERENCE, "This backend doesn't support iterators");
+		giterr_set(GITERR_REFERENCE, "this backend doesn't support iterators");
 		return -1;
 	}
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -185,7 +185,7 @@ static int packed_reload(refdb_fs_backend *backend)
 	return 0;
 
 parse_failed:
-	giterr_set(GITERR_REFERENCE, "Corrupted packed references file");
+	giterr_set(GITERR_REFERENCE, "corrupted packed references file");
 
 	git_sortedcache_clear(backend->refcache, false);
 	git_sortedcache_wunlock(backend->refcache);
@@ -212,7 +212,7 @@ static int loose_parse_oid(
 		return 0;
 
 corrupted:
-	giterr_set(GITERR_REFERENCE, "Corrupted loose reference file: %s", filename);
+	giterr_set(GITERR_REFERENCE, "corrupted loose reference file: %s", filename);
 	return -1;
 }
 
@@ -349,7 +349,7 @@ static const char *loose_parse_symbolic(git_buf *file_content)
 	refname_start = (const char *)file_content->ptr;
 
 	if (git_buf_len(file_content) < header_len + 1) {
-		giterr_set(GITERR_REFERENCE, "Corrupted loose reference file");
+		giterr_set(GITERR_REFERENCE, "corrupted loose reference file");
 		return NULL;
 	}
 
@@ -398,7 +398,7 @@ static int loose_lookup(
 
 static int ref_error_notfound(const char *name)
 {
-	giterr_set(GITERR_REFERENCE, "Reference '%s' not found", name);
+	giterr_set(GITERR_REFERENCE, "reference '%s' not found", name);
 	return GIT_ENOTFOUND;
 }
 
@@ -691,7 +691,7 @@ static int reference_path_available(
 
 		if (exists) {
 			giterr_set(GITERR_REFERENCE,
-				"Failed to write reference '%s': a reference with "
+				"failed to write reference '%s': a reference with "
 				"that name already exists.", new_ref);
 			return GIT_EEXISTS;
 		}
@@ -705,7 +705,7 @@ static int reference_path_available(
 		if (ref && !ref_is_available(old_ref, new_ref, ref->name)) {
 			git_sortedcache_runlock(backend->refcache);
 			giterr_set(GITERR_REFERENCE,
-				"Path to reference '%s' collides with existing one", new_ref);
+				"path to reference '%s' collides with existing one", new_ref);
 			return -1;
 		}
 	}
@@ -722,7 +722,7 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 	assert(file && backend && name);
 
 	if (!git_path_isvalid(backend->repo, name, GIT_PATH_REJECT_FILESYSTEM_DEFAULTS)) {
-		giterr_set(GITERR_INVALID, "Invalid reference name '%s'.", name);
+		giterr_set(GITERR_INVALID, "invalid reference name '%s'", name);
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -1484,7 +1484,7 @@ static int reflog_parse(git_reflog *log, const char *buf, size_t buf_size)
 
 #define seek_forward(_increase) do { \
 	if (_increase >= buf_size) { \
-		giterr_set(GITERR_INVALID, "Ran out of data while parsing reflog"); \
+		giterr_set(GITERR_INVALID, "ran out of data while parsing reflog"); \
 		goto fail; \
 	} \
 	buf += _increase; \
@@ -1700,7 +1700,7 @@ static int lock_reflog(git_filebuf *file, refdb_fs_backend *backend, const char 
 	repo = backend->repo;
 
 	if (!git_path_isvalid(backend->repo, refname, GIT_PATH_REJECT_FILESYSTEM_DEFAULTS)) {
-		giterr_set(GITERR_INVALID, "Invalid reference name '%s'.", refname);
+		giterr_set(GITERR_INVALID, "invalid reference name '%s'", refname);
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -1709,7 +1709,7 @@ static int lock_reflog(git_filebuf *file, refdb_fs_backend *backend, const char 
 
 	if (!git_path_isfile(git_buf_cstr(&log_path))) {
 		giterr_set(GITERR_INVALID,
-			"Log file for reference '%s' doesn't exist.", refname);
+			"log file for reference '%s' doesn't exist", refname);
 		error = -1;
 		goto cleanup;
 	}
@@ -1889,7 +1889,7 @@ static int refdb_reflog_fs__rename(git_refdb_backend *_backend, const char *old_
 	p_close(fd);
 
 	if (p_rename(git_buf_cstr(&old_path), git_buf_cstr(&temp_path)) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename reflog for %s", new_name);
+		giterr_set(GITERR_OS, "failed to rename reflog for %s", new_name);
 		error = -1;
 		goto cleanup;
 	}
@@ -1906,7 +1906,7 @@ static int refdb_reflog_fs__rename(git_refdb_backend *_backend, const char *old_
 	}
 
 	if (p_rename(git_buf_cstr(&temp_path), git_buf_cstr(&new_path)) < 0) {
-		giterr_set(GITERR_OS, "Failed to rename reflog for %s", new_name);
+		giterr_set(GITERR_OS, "failed to rename reflog for %s", new_name);
 		error = -1;
 	}
 

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -93,7 +93,7 @@ int git_reflog_append(git_reflog *reflog, const git_oid *new_oid, const git_sign
 
 		if (newline) {
 			if (newline[1] != '\0') {
-				giterr_set(GITERR_INVALID, "Reflog message cannot contain newline");
+				giterr_set(GITERR_INVALID, "reflog message cannot contain newline");
 				goto cleanup;
 			}
 
@@ -193,7 +193,7 @@ int git_reflog_drop(git_reflog *reflog, size_t idx, int rewrite_previous_entry)
 	entry = (git_reflog_entry *)git_reflog_entry_byindex(reflog, idx);
 
 	if (entry == NULL) {
-		giterr_set(GITERR_REFERENCE, "No reflog entry at index %"PRIuZ, idx);
+		giterr_set(GITERR_REFERENCE, "no reflog entry at index %"PRIuZ, idx);
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -236,7 +236,7 @@ int git_reference_lookup_resolved(
 
 	if (scan_type != GIT_REF_OID && max_nesting != 0) {
 		giterr_set(GITERR_REFERENCE,
-			"Cannot resolve reference (>%u levels deep)", max_nesting);
+			"cannot resolve reference (>%u levels deep)", max_nesting);
 		git_reference_free(ref);
 		return -1;
 	}
@@ -298,7 +298,7 @@ cleanup:
 	if (error && !foundvalid) {
 		/* never found a valid reference name */
 		giterr_set(GITERR_REFERENCE,
-			"Could not use '%s' as valid reference name", git_buf_cstr(&name));
+			"could not use '%s' as valid reference name", git_buf_cstr(&name));
 	}
 
 	if (error == GIT_ENOTFOUND)
@@ -396,7 +396,7 @@ static int reference__create(
 
 		if (!git_object__is_valid(repo, oid, GIT_OBJ_ANY)) {
 			giterr_set(GITERR_REFERENCE,
-				"Target OID for the reference doesn't exist on the repository");
+				"target OID for the reference doesn't exist on the repository");
 			return -1;
 		}
 
@@ -524,7 +524,7 @@ static int ensure_is_an_updatable_direct_reference(git_reference *ref)
 	if (ref->type == GIT_REF_OID)
 		return 0;
 
-	giterr_set(GITERR_REFERENCE, "Cannot set OID on symbolic reference");
+	giterr_set(GITERR_REFERENCE, "cannot set OID on symbolic reference");
 	return -1;
 }
 
@@ -552,7 +552,7 @@ static int ensure_is_an_updatable_symbolic_reference(git_reference *ref)
 	if (ref->type == GIT_REF_SYMBOLIC)
 		return 0;
 
-	giterr_set(GITERR_REFERENCE, "Cannot set symbolic target on a direct reference");
+	giterr_set(GITERR_REFERENCE, "cannot set symbolic target on a direct reference");
 	return -1;
 }
 
@@ -599,7 +599,7 @@ static int reference__rename(git_reference **out, git_reference *ref, const char
 	/* Update HEAD it was pointing to the reference being renamed */
 	if (should_head_be_updated &&
 		(error = git_repository_set_head(ref->db->repo, normalized)) < 0) {
-		giterr_set(GITERR_REFERENCE, "Failed to update HEAD after renaming reference");
+		giterr_set(GITERR_REFERENCE, "failed to update HEAD after renaming reference");
 		return error;
 	}
 
@@ -636,7 +636,7 @@ int git_reference_resolve(git_reference **ref_out, const git_reference *ref)
 		return git_reference_lookup_resolved(ref_out, ref->db->repo, ref->target.symbolic, -1);
 
 	default:
-		giterr_set(GITERR_REFERENCE, "Invalid reference");
+		giterr_set(GITERR_REFERENCE, "invalid reference");
 		return -1;
 	}
 }
@@ -973,7 +973,7 @@ cleanup:
 	if (error == GIT_EINVALIDSPEC)
 		giterr_set(
 			GITERR_REFERENCE,
-			"The given reference name '%s' is not valid", name);
+			"the given reference name '%s' is not valid", name);
 
 	if (error && normalize)
 		git_buf_free(buf);
@@ -1000,7 +1000,7 @@ int git_reference_normalize_name(
 	if (git_buf_len(&buf) > buffer_size - 1) {
 		giterr_set(
 		GITERR_REFERENCE,
-		"The provided buffer is too short to hold the normalization of '%s'", name);
+		"the provided buffer is too short to hold the normalization of '%s'", name);
 		error = GIT_EBUFS;
 		goto cleanup;
 	}
@@ -1046,7 +1046,7 @@ static int get_terminal(git_reference **out, git_repository *repo, const char *r
 	int error = 0;
 
 	if (nesting > MAX_NESTING_LEVEL) {
-		giterr_set(GITERR_REFERENCE, "Reference chain too deep (%d)", nesting);
+		giterr_set(GITERR_REFERENCE, "reference chain too deep (%d)", nesting);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1229,7 +1229,7 @@ static int peel_error(int error, git_reference *ref, const char* msg)
 {
 	giterr_set(
 		GITERR_INVALID,
-		"The reference '%s' cannot be peeled - %s", git_reference_name(ref), msg);
+		"the reference '%s' cannot be peeled - %s", git_reference_name(ref), msg);
 	return error;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -283,7 +283,7 @@ static int ensure_remote_doesnot_exist(git_repository *repo, const char *name)
 
 	giterr_set(
 		GITERR_CONFIG,
-		"Remote '%s' already exists.", name);
+		"remote '%s' already exists", name);
 
 	return GIT_EEXISTS;
 }
@@ -476,7 +476,7 @@ int git_remote_lookup(git_remote **out, git_repository *repo, const char *name)
 
 	if (!optional_setting_found) {
 		error = GIT_ENOTFOUND;
-		giterr_set(GITERR_CONFIG, "Remote '%s' does not exist.", name);
+		giterr_set(GITERR_CONFIG, "remote '%s' does not exist", name);
 		goto cleanup;
 	}
 
@@ -1718,7 +1718,7 @@ int git_remote_set_autotag(git_repository *repo, const char *remote, git_remote_
 			error = 0;
 		break;
 	default:
-		giterr_set(GITERR_INVALID, "Invalid value for the tagopt setting");
+		giterr_set(GITERR_INVALID, "invalid value for the tagopt setting");
 		error = -1;
 	}
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -332,7 +332,7 @@ static int read_gitfile(git_buf *path_out, const char *file_path)
 		memcmp(git_buf_cstr(&file), GIT_FILE_CONTENT_PREFIX, prefix_len) != 0)
 	{
 		giterr_set(GITERR_REPOSITORY,
-			"The `.git` file at '%s' is malformed", file_path);
+			"the `.git` file at '%s' is malformed", file_path);
 		error = -1;
 	}
 	else if ((error = git_path_dirname_r(path_out, file_path)) >= 0) {
@@ -459,7 +459,7 @@ static int find_repo(
 	 * to report, report that. */
 	if (!git_buf_len(repo_path) && !error) {
 		giterr_set(GITERR_REPOSITORY,
-			"Could not find repository from '%s'", start_path);
+			"could not find repository from '%s'", start_path);
 		error = GIT_ENOTFOUND;
 	}
 
@@ -481,7 +481,7 @@ int git_repository_open_bare(
 
 	if (!valid_repository_path(&path)) {
 		git_buf_free(&path);
-		giterr_set(GITERR_REPOSITORY, "Path is not a repository: %s", bare_path);
+		giterr_set(GITERR_REPOSITORY, "path is not a repository: %s", bare_path);
 		return GIT_ENOTFOUND;
 	}
 
@@ -1180,7 +1180,7 @@ static int check_repositoryformatversion(git_config *config)
 
 	if (GIT_REPO_VERSION < version) {
 		giterr_set(GITERR_REPOSITORY,
-			"Unsupported repository version %d. Only versions up to %d are supported.",
+			"unsupported repository version %d. Only versions up to %d are supported.",
 			version, GIT_REPO_VERSION);
 		return -1;
 	}
@@ -1274,12 +1274,12 @@ static int create_empty_file(const char *path, mode_t mode)
 	int fd;
 
 	if ((fd = p_creat(path, mode)) < 0) {
-		giterr_set(GITERR_OS, "Error while creating '%s'", path);
+		giterr_set(GITERR_OS, "error while creating '%s'", path);
 		return -1;
 	}
 
 	if (p_close(fd) < 0) {
-		giterr_set(GITERR_OS, "Error while closing '%s'", path);
+		giterr_set(GITERR_OS, "error while closing '%s'", path);
 		return -1;
 	}
 
@@ -1508,7 +1508,7 @@ static int repo_write_template(
 
 	if (error)
 		giterr_set(GITERR_OS,
-			"Failed to initialize repository with template '%s'", file);
+			"failed to initialize repository with template '%s'", file);
 
 	return error;
 }
@@ -1539,7 +1539,7 @@ static int repo_write_gitlink(
 
 	if (!p_stat(buf.ptr, &st) && !S_ISREG(st.st_mode)) {
 		giterr_set(GITERR_REPOSITORY,
-			"Cannot overwrite gitlink file into path '%s'", in_dir);
+			"cannot overwrite gitlink file into path '%s'", in_dir);
 		error = GIT_EEXISTS;
 		goto cleanup;
 	}
@@ -1593,7 +1593,7 @@ static int repo_init_structure(
 	if ((opts->flags & GIT_REPOSITORY_INIT__HAS_DOTGIT) != 0) {
 		if (git_win32__set_hidden(repo_dir, true) < 0) {
 			giterr_set(GITERR_OS,
-				"Failed to mark Git repository folder as hidden");
+				"failed to mark Git repository folder as hidden");
 			return -1;
 		}
 	}
@@ -1747,7 +1747,7 @@ static int repo_init_directories(
 			if (git_path_dirname_r(wd_path, repo_path->ptr) < 0)
 				return -1;
 		} else {
-			giterr_set(GITERR_REPOSITORY, "Cannot pick working directory"
+			giterr_set(GITERR_REPOSITORY, "cannot pick working directory"
 				" for non-bare repository that isn't a '.git' directory");
 			return -1;
 		}
@@ -1867,7 +1867,7 @@ int git_repository_init_ext(
 
 		if ((opts->flags & GIT_REPOSITORY_INIT_NO_REINIT) != 0) {
 			giterr_set(GITERR_REPOSITORY,
-				"Attempt to reinitialize '%s'", given_repo);
+				"attempt to reinitialize '%s'", given_repo);
 			error = GIT_EEXISTS;
 			goto cleanup;
 		}
@@ -2149,7 +2149,7 @@ int git_repository_message(git_buf *out, git_repository *repo)
 	if ((error = p_stat(git_buf_cstr(&path), &st)) < 0) {
 		if (errno == ENOENT)
 			error = GIT_ENOTFOUND;
-		giterr_set(GITERR_OS, "Could not access message file");
+		giterr_set(GITERR_OS, "could not access message file");
 	} else {
 		error = git_futils_readbuffer(out, git_buf_cstr(&path));
 	}
@@ -2227,7 +2227,7 @@ int git_repository_hashfile(
 	}
 
 	if (!git__is_sizet(len)) {
-		giterr_set(GITERR_OS, "File size overflow for 32-bit systems");
+		giterr_set(GITERR_OS, "file size overflow for 32-bit systems");
 		error = -1;
 		goto cleanup;
 	}

--- a/src/repository.h
+++ b/src/repository.h
@@ -182,7 +182,7 @@ GIT_INLINE(int) git_repository__ensure_not_bare(
 
 	giterr_set(
 		GITERR_REPOSITORY,
-		"Cannot %s. This operation is not allowed against bare repositories.",
+		"cannot %s. This operation is not allowed against bare repositories.",
 		operation_name);
 
 	return GIT_EBAREREPO;

--- a/src/reset.c
+++ b/src/reset.c
@@ -137,7 +137,7 @@ static int reset(
 		(git_repository_state(repo) == GIT_REPOSITORY_STATE_MERGE ||
 		 git_index_has_conflicts(index)))
 	{
-		giterr_set(GITERR_OBJECT, "%s (soft) in the middle of a merge.", ERROR_MSG);
+		giterr_set(GITERR_OBJECT, "%s (soft) in the middle of a merge", ERROR_MSG);
 		error = GIT_EUNMERGED;
 		goto cleanup;
 	}

--- a/src/revert.c
+++ b/src/revert.c
@@ -133,13 +133,13 @@ int git_revert_commit(
 	if (git_commit_parentcount(revert_commit) > 1) {
 		if (!mainline)
 			return revert_seterr(revert_commit,
-				"Mainline branch is not specified but %s is a merge commit");
+				"mainline branch is not specified but %s is a merge commit");
 
 		parent = mainline;
 	} else {
 		if (mainline)
 			return revert_seterr(revert_commit,
-				"Mainline branch specified but %s is not a merge commit");
+				"mainline branch specified but %s is not a merge commit");
 
 		parent = git_commit_parentcount(revert_commit);
 	}

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -46,7 +46,7 @@ static int build_regex(regex_t *regex, const char *pattern)
 	int error;
 
 	if (*pattern == '\0') {
-		giterr_set(GITERR_REGEX, "Empty pattern");
+		giterr_set(GITERR_REGEX, "empty pattern");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -118,7 +118,7 @@ static int revparse_lookup_object(
 	if ((error = maybe_describe(object_out, repo, spec)) != GIT_ENOTFOUND)
 		return error;
 
-	giterr_set(GITERR_REFERENCE, "Revspec '%s' not found.", spec);
+	giterr_set(GITERR_REFERENCE, "revspec '%s' not found", spec);
 	return GIT_ENOTFOUND;
 }
 
@@ -245,7 +245,7 @@ static int retrieve_oid_from_reflog(git_oid *oid, git_reference *ref, size_t ide
 notfound:
 	giterr_set(
 		GITERR_REFERENCE,
-		"Reflog for '%s' has only %"PRIuZ" entries, asked for %"PRIuZ,
+		"reflog for '%s' has only %"PRIuZ" entries, asked for %"PRIuZ,
 		git_reference_name(ref), numentries, identifier);
 
 	git_reflog_free(reflog);
@@ -757,7 +757,7 @@ int revparse__ext(
 					 * TODO: support merge-stage path lookup (":2:Makefile")
 					 * and plain index blob lookup (:i-am/a/blob)
 					 */
-					giterr_set(GITERR_INVALID, "Unimplemented");
+					giterr_set(GITERR_INVALID, "unimplemented");
 					error = GIT_ERROR;
 					goto cleanup;
 				}
@@ -816,7 +816,7 @@ cleanup:
 	if (error) {
 		if (error == GIT_EINVALIDSPEC)
 			giterr_set(GITERR_INVALID,
-				"Failed to parse revision specifier - Invalid pattern '%s'", spec);
+				"failed to parse revision specifier - Invalid pattern '%s'", spec);
 
 		git_object_free(base_rev);
 		git_reference_free(reference);

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -61,7 +61,7 @@ static int push_commit(git_revwalk *walk, const git_oid *oid, int uninteresting,
 		if (from_glob)
 			return 0;
 
-		giterr_set(GITERR_INVALID, "Object is not a committish");
+		giterr_set(GITERR_INVALID, "object is not a committish");
 		return -1;
 	}
 	if (error < 0)
@@ -198,7 +198,7 @@ int git_revwalk_push_range(git_revwalk *walk, const char *range)
 
 	if (revspec.flags & GIT_REVPARSE_MERGE_BASE) {
 		/* TODO: support "<commit>...<commit>" */
-		giterr_set(GITERR_INVALID, "Symmetric differences not implemented in revwalk");
+		giterr_set(GITERR_INVALID, "symmetric differences not implemented in revwalk");
 		return GIT_EINVALIDSPEC;
 	}
 
@@ -733,7 +733,7 @@ int git_revwalk_add_hide_cb(
 
 	if (walk->hide_cb) {
 		/* There is already a callback added */
-		giterr_set(GITERR_INVALID, "There is already a callback added to hide commits in revision walker.");
+		giterr_set(GITERR_INVALID, "there is already a callback added to hide commits in revwalk");
 		return -1;
 	}
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -64,7 +64,7 @@ static int config_level_to_sysdir(int config_level)
 		break;
 	default:
 		giterr_set(
-			GITERR_INVALID, "Invalid config path selector %d", config_level);
+			GITERR_INVALID, "invalid config path selector %d", config_level);
 	}
 
 	return val;

--- a/src/sha1_lookup.c
+++ b/src/sha1_lookup.c
@@ -206,7 +206,7 @@ int sha1_entry_pos(const void *table,
 #endif
 
 		if (!(lo <= mi && mi < hi)) {
-			giterr_set(GITERR_INVALID, "Assertion failure. Binary search invariant is false");
+			giterr_set(GITERR_INVALID, "assertion failure: binary search invariant is false");
 			return -1;
 		}
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -25,7 +25,7 @@ void git_signature_free(git_signature *sig)
 
 static int signature_error(const char *msg)
 {
-	giterr_set(GITERR_INVALID, "Failed to parse signature - %s", msg);
+	giterr_set(GITERR_INVALID, "failed to parse signature - %s", msg);
 	return -1;
 }
 

--- a/src/socket_stream.c
+++ b/src/socket_stream.c
@@ -57,7 +57,7 @@ static int close_socket(GIT_SOCKET s)
 		return -1;
 
 	if (0 != WSACleanup()) {
-		giterr_set(GITERR_OS, "Winsock cleanup failed");
+		giterr_set(GITERR_OS, "winsock cleanup failed");
 		return -1;
 	}
 
@@ -82,13 +82,13 @@ int socket_connect(git_stream *stream)
 	WSADATA wsd;
 
 	if (WSAStartup(MAKEWORD(2,2), &wsd) != 0) {
-		giterr_set(GITERR_OS, "Winsock init failed");
+		giterr_set(GITERR_OS, "winsock init failed");
 		return -1;
 	}
 
 	if (LOBYTE(wsd.wVersion) != 2 || HIBYTE(wsd.wVersion) != 2) {
 		WSACleanup();
-		giterr_set(GITERR_OS, "Winsock init failed");
+		giterr_set(GITERR_OS, "winsock init failed");
 		return -1;
 	}
 #endif
@@ -99,7 +99,7 @@ int socket_connect(git_stream *stream)
 
 	if ((ret = p_getaddrinfo(st->host, st->port, &hints, &info)) != 0) {
 		giterr_set(GITERR_NET,
-			   "Failed to resolve address for %s: %s", st->host, p_gai_strerror(ret));
+			   "failed to resolve address for %s: %s", st->host, p_gai_strerror(ret));
 		return -1;
 	}
 
@@ -121,7 +121,7 @@ int socket_connect(git_stream *stream)
 
 	/* Oops, we couldn't connect to any address */
 	if (s == INVALID_SOCKET && p == NULL) {
-		giterr_set(GITERR_OS, "Failed to connect to %s", st->host);
+		giterr_set(GITERR_OS, "failed to connect to %s", st->host);
 		p_freeaddrinfo(info);
 		return -1;
 	}

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -27,7 +27,7 @@ int git_sortedcache_new(
 		goto fail;
 
 	if (git_rwlock_init(&sc->lock)) {
-		giterr_set(GITERR_OS, "Failed to initialize lock");
+		giterr_set(GITERR_OS, "failed to initialize lock");
 		goto fail;
 	}
 
@@ -162,7 +162,7 @@ int git_sortedcache_wlock(git_sortedcache *sc)
 	GIT_UNUSED(sc); /* prevent warning when compiled w/o threads */
 
 	if (git_rwlock_wrlock(&sc->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to acquire write lock on cache");
+		giterr_set(GITERR_OS, "unable to acquire write lock on cache");
 		return -1;
 	}
 	return 0;
@@ -181,7 +181,7 @@ int git_sortedcache_rlock(git_sortedcache *sc)
 	GIT_UNUSED(sc); /* prevent warning when compiled w/o threads */
 
 	if (git_rwlock_rdlock(&sc->lock) < 0) {
-		giterr_set(GITERR_OS, "Unable to acquire read lock on cache");
+		giterr_set(GITERR_OS, "unable to acquire read lock on cache");
 		return -1;
 	}
 	return 0;
@@ -221,7 +221,7 @@ int git_sortedcache_lockandload(git_sortedcache *sc, git_buf *buf)
 	}
 
 	if (!git__is_sizet(st.st_size)) {
-		giterr_set(GITERR_INVALID, "Unable to load file larger than size_t");
+		giterr_set(GITERR_INVALID, "unable to load file larger than size_t");
 		error = -1;
 		(void)p_close(fd);
 		goto unlock;
@@ -373,7 +373,7 @@ int git_sortedcache_remove(git_sortedcache *sc, size_t pos)
 	 */
 
 	if ((item = git_vector_get(&sc->items, pos)) == NULL) {
-		giterr_set(GITERR_INVALID, "Removing item out of range");
+		giterr_set(GITERR_INVALID, "removing item out of range");
 		return GIT_ENOTFOUND;
 	}
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -27,7 +27,7 @@
 
 static int create_error(int error, const char *msg)
 {
-	giterr_set(GITERR_STASH, "Cannot stash changes - %s", msg);
+	giterr_set(GITERR_STASH, "cannot stash changes - %s", msg);
 	return error;
 }
 
@@ -36,7 +36,7 @@ static int retrieve_head(git_reference **out, git_repository *repo)
 	int error = git_repository_head(out, repo);
 
 	if (error == GIT_EUNBORNBRANCH)
-		return create_error(error, "You do not have the initial commit yet.");
+		return create_error(error, "you do not have the initial commit yet.");
 
 	return error;
 }
@@ -198,7 +198,7 @@ static int stash_update_index_from_diff(
 			/* Unimplemented */
 			giterr_set(
 				GITERR_INVALID,
-				"Cannot update index. Unimplemented status (%d)",
+				"cannot update index. Unimplemented status (%d)",
 				delta->status);
 			return -1;
 		}
@@ -479,7 +479,7 @@ static int ensure_there_are_changes_to_stash(
 		return 0;
 
 	if (!error)
-		return create_error(GIT_ENOTFOUND, "There is nothing to stash.");
+		return create_error(GIT_ENOTFOUND, "there is nothing to stash.");
 
 	return error;
 }
@@ -593,7 +593,7 @@ static int retrieve_stash_commit(
 	max = git_reflog_entrycount(reflog);
 	if (!max || index > max - 1) {
 		error = GIT_ENOTFOUND;
-		giterr_set(GITERR_STASH, "No stashed state at position %" PRIuZ, index);
+		giterr_set(GITERR_STASH, "no stashed state at position %" PRIuZ, index);
 		goto cleanup;
 	}
 
@@ -1036,7 +1036,7 @@ int git_stash_drop(
 
 	if (!max || index > max - 1) {
 		error = GIT_ENOTFOUND;
-		giterr_set(GITERR_STASH, "No stashed state at position %" PRIuZ, index);
+		giterr_set(GITERR_STASH, "no stashed state at position %" PRIuZ, index);
 		goto cleanup;
 	}
 

--- a/src/status.c
+++ b/src/status.c
@@ -243,13 +243,13 @@ static int status_validate_options(const git_status_options *opts)
 	GITERR_CHECK_VERSION(opts, GIT_STATUS_OPTIONS_VERSION, "git_status_options");
 
 	if (opts->show > GIT_STATUS_SHOW_WORKDIR_ONLY) {
-		giterr_set(GITERR_INVALID, "Unknown status 'show' option");
+		giterr_set(GITERR_INVALID, "unknown status 'show' option");
 		return -1;
 	}
 
 	if ((opts->flags & GIT_STATUS_OPT_NO_REFRESH) != 0 &&
 		(opts->flags & GIT_STATUS_OPT_UPDATE_INDEX) != 0) {
-		giterr_set(GITERR_INVALID, "Updating index from status "
+		giterr_set(GITERR_INVALID, "updating index from status "
 			"is not allowed when index refresh is disabled");
 		return -1;
 	}
@@ -510,13 +510,13 @@ int git_status_file(
 
 	if (error < 0 && sfi.ambiguous) {
 		giterr_set(GITERR_INVALID,
-			"Ambiguous path '%s' given to git_status_file", sfi.expected);
+			"ambiguous path '%s' given to git_status_file", sfi.expected);
 		error = GIT_EAMBIGUOUS;
 	}
 
 	if (!error && !sfi.count) {
 		giterr_set(GITERR_INVALID,
-			"Attempt to get status of nonexistent file '%s'", path);
+			"attempt to get status of nonexistent file '%s'", path);
 		error = GIT_ENOTFOUND;
 	}
 

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -124,8 +124,8 @@ static void submodule_set_lookup_error(int error, const char *name)
 		return;
 
 	giterr_set(GITERR_SUBMODULE, (error == GIT_ENOTFOUND) ?
-		"No submodule named '%s'" :
-		"Submodule '%s' has not been added yet", name);
+		"no submodule named '%s'" :
+		"submodule '%s' has not been added yet", name);
 }
 
 typedef struct {
@@ -618,7 +618,7 @@ int git_submodule_add_setup(
 		giterr_clear();
 	else {
 		giterr_set(GITERR_SUBMODULE,
-			"Attempt to add submodule '%s' that already exists", path);
+			"attempt to add submodule '%s' that already exists", path);
 		return GIT_EEXISTS;
 	}
 
@@ -628,7 +628,7 @@ int git_submodule_add_setup(
 		path += strlen(git_repository_workdir(repo));
 
 	if (git_path_root(path) >= 0) {
-		giterr_set(GITERR_SUBMODULE, "Submodule path must be a relative path");
+		giterr_set(GITERR_SUBMODULE, "submodule path must be a relative path");
 		error = -1;
 		goto cleanup;
 	}
@@ -637,7 +637,7 @@ int git_submodule_add_setup(
 
 	if (!(mods = open_gitmodules(repo, GITMODULES_CREATE))) {
 		giterr_set(GITERR_SUBMODULE,
-			"Adding submodules to a bare repository is not supported");
+			"adding submodules to a bare repository is not supported");
 		return -1;
 	}
 
@@ -758,7 +758,7 @@ int git_submodule_add_to_index(git_submodule *sm, int write_index)
 	/* read stat information for submodule working directory */
 	if (p_stat(path.ptr, &st) < 0) {
 		giterr_set(GITERR_SUBMODULE,
-			"Cannot add submodule without working directory");
+			"cannot add submodule without working directory");
 		error = -1;
 		goto cleanup;
 	}
@@ -771,7 +771,7 @@ int git_submodule_add_to_index(git_submodule *sm, int write_index)
 	/* calling git_submodule_open will have set sm->wd_oid if possible */
 	if ((sm->flags & GIT_SUBMODULE_STATUS__WD_OID_VALID) == 0) {
 		giterr_set(GITERR_SUBMODULE,
-			"Cannot add submodule without HEAD to index");
+			"cannot add submodule without HEAD to index");
 		error = -1;
 		goto cleanup;
 	}
@@ -861,7 +861,7 @@ int git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *ur
 	} else if (strchr(url, ':') != NULL || url[0] == '/') {
 		error = git_buf_sets(out, url);
 	} else {
-		giterr_set(GITERR_SUBMODULE, "Invalid format for submodule URL");
+		giterr_set(GITERR_SUBMODULE, "invalid format for submodule URL");
 		error = -1;
 	}
 
@@ -1133,7 +1133,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 				goto done;
 
 			if (!init) {
-				giterr_set(GITERR_SUBMODULE, "Submodule is not initialized.");
+				giterr_set(GITERR_SUBMODULE, "submodule is not initialized");
 				error = GIT_ERROR;
 				goto done;
 			}
@@ -1215,7 +1215,7 @@ int git_submodule_init(git_submodule *sm, int overwrite)
 
 	if (!sm->url) {
 		giterr_set(GITERR_SUBMODULE,
-			"No URL configured for submodule '%s'", sm->name);
+			"no URL configured for submodule '%s'", sm->name);
 		return -1;
 	}
 
@@ -1259,7 +1259,7 @@ int git_submodule_sync(git_submodule *sm)
 
 	if (!sm->url) {
 		giterr_set(GITERR_SUBMODULE,
-			"No URL configured for submodule '%s'", sm->name);
+			"no URL configured for submodule '%s'", sm->name);
 		return -1;
 	}
 
@@ -1578,7 +1578,7 @@ static int submodule_alloc(
 	git_submodule *sm;
 
 	if (!name || !(namelen = strlen(name))) {
-		giterr_set(GITERR_SUBMODULE, "Invalid submodule name");
+		giterr_set(GITERR_SUBMODULE, "invalid submodule name");
 		return -1;
 	}
 
@@ -1630,7 +1630,7 @@ void git_submodule_free(git_submodule *sm)
 static int submodule_config_error(const char *property, const char *value)
 {
 	giterr_set(GITERR_INVALID,
-		"Invalid value for submodule '%s' property: '%s'", property, value);
+		"invalid value for submodule '%s' property: '%s'", property, value);
 	return -1;
 }
 
@@ -1968,7 +1968,7 @@ static int lookup_default_remote(git_remote **remote, git_repository *repo)
 	if (error == GIT_ENOTFOUND)
 		giterr_set(
 			GITERR_SUBMODULE,
-			"Cannot get default remote for submodule - no local tracking "
+			"cannot get default remote for submodule - no local tracking "
 			"branch for HEAD and origin does not exist");
 
 	return error;

--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -150,7 +150,7 @@ int git_sysdir_get_str(
 	GITERR_CHECK_ERROR(git_sysdir_get(&path, which));
 
 	if (!out || path->size >= outlen) {
-		giterr_set(GITERR_NOMEMORY, "Buffer is too short for the path");
+		giterr_set(GITERR_NOMEMORY, "buffer is too short for the path");
 		return GIT_EBUFS;
 	}
 
@@ -241,7 +241,7 @@ static int git_sysdir_find_in_dirlist(
 
 done:
 	git_buf_free(path);
-	giterr_set(GITERR_OS, "The %s file '%s' doesn't exist", label, name);
+	giterr_set(GITERR_OS, "the %s file '%s' doesn't exist", label, name);
 	return GIT_ENOTFOUND;
 }
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -61,7 +61,7 @@ const char *git_tag_message(const git_tag *t)
 
 static int tag_error(const char *str)
 {
-	giterr_set(GITERR_TAG, "Failed to parse tag. %s", str);
+	giterr_set(GITERR_TAG, "failed to parse tag: %s", str);
 	return -1;
 }
 
@@ -76,13 +76,13 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 	char *search;
 
 	if (git_oid__parse(&tag->target, &buffer, buffer_end, "object ") < 0)
-		return tag_error("Object field invalid");
+		return tag_error("object field invalid");
 
 	if (buffer + 5 >= buffer_end)
-		return tag_error("Object too short");
+		return tag_error("object too short");
 
 	if (memcmp(buffer, "type ", 5) != 0)
-		return tag_error("Type field not found");
+		return tag_error("type field not found");
 	buffer += 5;
 
 	tag->type = GIT_OBJ_BAD;
@@ -91,7 +91,7 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 		size_t type_length = strlen(tag_types[i]);
 
 		if (buffer + type_length >= buffer_end)
-			return tag_error("Object too short");
+			return tag_error("object too short");
 
 		if (memcmp(buffer, tag_types[i], type_length) == 0) {
 			tag->type = i;
@@ -101,19 +101,19 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 	}
 
 	if (tag->type == GIT_OBJ_BAD)
-		return tag_error("Invalid object type");
+		return tag_error("invalid object type");
 
 	if (buffer + 4 >= buffer_end)
-		return tag_error("Object too short");
+		return tag_error("object too short");
 
 	if (memcmp(buffer, "tag ", 4) != 0)
-		return tag_error("Tag field not found");
+		return tag_error("tag field not found");
 
 	buffer += 4;
 
 	search = memchr(buffer, '\n', buffer_end - buffer);
 	if (search == NULL)
-		return tag_error("Object too short");
+		return tag_error("object too short");
 
 	text_len = search - buffer;
 
@@ -234,7 +234,7 @@ static int write_tag_annotation(
 
 on_error:
 	git_buf_free(&tag);
-	giterr_set(GITERR_OBJECT, "Failed to create tag annotation.");
+	giterr_set(GITERR_OBJECT, "failed to create tag annotation");
 	return -1;
 }
 
@@ -257,7 +257,7 @@ static int git_tag_create__internal(
 	assert(!create_tag_annotation || (tagger && message));
 
 	if (git_object_owner(target) != repo) {
-		giterr_set(GITERR_INVALID, "The given target does not belong to this repository");
+		giterr_set(GITERR_INVALID, "the given target does not belong to this repository");
 		return -1;
 	}
 
@@ -269,7 +269,7 @@ static int git_tag_create__internal(
 	 *	reference unless overwriting has explicitly been requested **/
 	if (error == 0 && !allow_ref_overwrite) {
 		git_buf_free(&ref_name);
-		giterr_set(GITERR_TAG, "Tag already exists");
+		giterr_set(GITERR_TAG, "tag already exists");
 		return GIT_EEXISTS;
 	}
 
@@ -349,7 +349,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 		goto on_error;
 
 	if (tag.type != target_obj->cached.type) {
-		giterr_set(GITERR_TAG, "The type for the given target is invalid");
+		giterr_set(GITERR_TAG, "the type for the given target is invalid");
 		goto on_error;
 	}
 
@@ -366,7 +366,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 	/** Ensure the tag name doesn't conflict with an already existing
 	 *	reference unless overwriting has explicitly been requested **/
 	if (error == 0 && !allow_ref_overwrite) {
-		giterr_set(GITERR_TAG, "Tag already exists");
+		giterr_set(GITERR_TAG, "tag already exists");
 		return GIT_EEXISTS;
 	}
 

--- a/src/trace.c
+++ b/src/trace.c
@@ -32,7 +32,7 @@ int git_trace_set(git_trace_level_t level, git_trace_callback callback)
 	GIT_UNUSED(callback);
 
 	giterr_set(GITERR_INVALID,
-		"This version of libgit2 was not built with tracing.");
+		"this version of libgit2 was not built with tracing.");
 	return -1;
 #endif
 }

--- a/src/transport.c
+++ b/src/transport.c
@@ -121,7 +121,7 @@ int git_transport_new(git_transport **out, git_remote *owner, const char *url)
 	int error;
 
 	if ((error = transport_find_fn(&fn, url, &param)) == GIT_ENOTFOUND) {
-		giterr_set(GITERR_NET, "Unsupported URL protocol");
+		giterr_set(GITERR_NET, "unsupported URL protocol");
 		return -1;
 	} else if (error < 0)
 		return error;

--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -107,13 +107,13 @@ static int negotiate_next_token(
 	challenge_len = ctx->challenge ? strlen(ctx->challenge) : 0;
 
 	if (challenge_len < 9) {
-		giterr_set(GITERR_NET, "No negotiate challenge sent from server");
+		giterr_set(GITERR_NET, "no negotiate challenge sent from server");
 		error = -1;
 		goto done;
 	} else if (challenge_len > 9) {
 		if (git_buf_decode_base64(&input_buf,
 				ctx->challenge + 10, challenge_len - 10) < 0) {
-			giterr_set(GITERR_NET, "Invalid negotiate challenge from server");
+			giterr_set(GITERR_NET, "invalid negotiate challenge from server");
 			error = -1;
 			goto done;
 		}
@@ -122,7 +122,7 @@ static int negotiate_next_token(
 		input_token.length = input_buf.size;
 		input_token_ptr = &input_token;
 	} else if (ctx->gss_context != GSS_C_NO_CONTEXT) {
-		giterr_set(GITERR_NET, "Could not restart authentication");
+		giterr_set(GITERR_NET, "could not restart authentication");
 		error = -1;
 		goto done;
 	}
@@ -228,7 +228,7 @@ static int negotiate_init_context(
 	gss_release_oid_set(&status_minor, &mechanism_list);
 
 	if (!ctx->oid) {
-		giterr_set(GITERR_NET, "Negotiate authentication is not supported");
+		giterr_set(GITERR_NET, "negotiate authentication is not supported");
 		return -1;
 	}
 

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -216,7 +216,7 @@ int git_cred_ssh_key_memory_new(
 	GIT_UNUSED(passphrase);
 
 	giterr_set(GITERR_INVALID,
-		"This version of libgit2 was not built with ssh memory credentials.");
+		"this version of libgit2 was not built with ssh memory credentials.");
 	return -1;
 #endif
 }

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -45,7 +45,7 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 
 	delim = strchr(url, '/');
 	if (delim == NULL) {
-		giterr_set(GITERR_NET, "Malformed URL");
+		giterr_set(GITERR_NET, "malformed URL");
 		return -1;
 	}
 
@@ -240,7 +240,7 @@ static int _git_uploadpack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK");
+	giterr_set(GITERR_NET, "must call UPLOADPACK_LS before UPLOADPACK");
 	return -1;
 }
 
@@ -296,7 +296,7 @@ static int _git_receivepack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK");
+	giterr_set(GITERR_NET, "must call RECEIVEPACK_LS before RECEIVEPACK");
 	return -1;
 }
 

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -403,7 +403,7 @@ static int on_headers_complete(http_parser *parser)
 	    t->location) {
 
 		if (s->redirect_count >= 7) {
-			giterr_set(GITERR_NET, "Too many redirects");
+			giterr_set(GITERR_NET, "too many redirects");
 			return t->parse_error = PARSE_ERROR_GENERIC;
 		}
 
@@ -428,14 +428,14 @@ static int on_headers_complete(http_parser *parser)
 	/* Check for a 200 HTTP status code. */
 	if (parser->status_code != 200) {
 		giterr_set(GITERR_NET,
-			"Unexpected HTTP status code: %d",
+			"unexpected HTTP status code: %d",
 			parser->status_code);
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
 
 	/* The response must contain a Content-Type header. */
 	if (!t->content_type) {
-		giterr_set(GITERR_NET, "No Content-Type header in response");
+		giterr_set(GITERR_NET, "no Content-Type header in response");
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
 
@@ -455,7 +455,7 @@ static int on_headers_complete(http_parser *parser)
 	if (strcmp(t->content_type, git_buf_cstr(&buf))) {
 		git_buf_free(&buf);
 		giterr_set(GITERR_NET,
-			"Invalid Content-Type: %s",
+			"invalid Content-Type: %s",
 			t->content_type);
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
@@ -488,7 +488,7 @@ static int on_body_fill_buffer(http_parser *parser, const char *str, size_t len)
 		return 0;
 
 	if (ctx->buf_size < len) {
-		giterr_set(GITERR_NET, "Can't fit data in the buffer");
+		giterr_set(GITERR_NET, "can't fit data in the buffer");
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
 
@@ -857,7 +857,7 @@ static int http_stream_write_single(
 	assert(t->connected);
 
 	if (s->sent_request) {
-		giterr_set(GITERR_NET, "Subtransport configured for only one write");
+		giterr_set(GITERR_NET, "subtransport configured for only one write");
 		return -1;
 	}
 

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -252,7 +252,7 @@ static int local_ls(const git_remote_head ***out, size_t *size, git_transport *t
 	transport_local *t = (transport_local *)transport;
 
 	if (!t->have_refs) {
-		giterr_set(GITERR_NET, "The transport has not yet loaded the refs");
+		giterr_set(GITERR_NET, "the transport has not yet loaded the refs");
 		return -1;
 	}
 
@@ -371,7 +371,7 @@ static int local_push(
 	   but we forbid all pushes just in case */
 	if (!remote_repo->is_bare) {
 		error = GIT_EBAREREPO;
-		giterr_set(GITERR_INVALID, "Local push doesn't (yet) support pushing to non-bare repos.");
+		giterr_set(GITERR_INVALID, "local push doesn't (yet) support pushing to non-bare repos.");
 		goto on_error;
 	}
 

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -231,7 +231,7 @@ static int git_smart__connect(
 	else if (GIT_DIRECTION_PUSH == t->direction)
 		service = GIT_SERVICE_RECEIVEPACK_LS;
 	else {
-		giterr_set(GITERR_NET, "Invalid direction");
+		giterr_set(GITERR_NET, "invalid direction");
 		return -1;
 	}
 
@@ -252,7 +252,7 @@ static int git_smart__connect(
 		pkt = (git_pkt *)git_vector_get(&t->refs, 0);
 
 		if (!pkt || GIT_PKT_COMMENT != pkt->type) {
-			giterr_set(GITERR_NET, "Invalid response");
+			giterr_set(GITERR_NET, "invalid response");
 			return -1;
 		} else {
 			/* Remove the comment pkt from the list */
@@ -299,7 +299,7 @@ static int git_smart__ls(const git_remote_head ***out, size_t *size, git_transpo
 	transport_smart *t = (transport_smart *)transport;
 
 	if (!t->have_refs) {
-		giterr_set(GITERR_NET, "The transport has not yet loaded the refs");
+		giterr_set(GITERR_NET, "the transport has not yet loaded the refs");
 		return -1;
 	}
 
@@ -319,7 +319,7 @@ int git_smart__negotiation_step(git_transport *transport, void *data, size_t len
 		return -1;
 
 	if (GIT_DIRECTION_FETCH != t->direction) {
-		giterr_set(GITERR_NET, "This operation is only valid for fetch");
+		giterr_set(GITERR_NET, "this operation is only valid for fetch");
 		return -1;
 	}
 
@@ -348,7 +348,7 @@ int git_smart__get_push_stream(transport_smart *t, git_smart_subtransport_stream
 		return -1;
 
 	if (GIT_DIRECTION_PUSH != t->direction) {
-		giterr_set(GITERR_NET, "This operation is only valid for push");
+		giterr_set(GITERR_NET, "this operation is only valid for push");
 		return -1;
 	}
 

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -226,7 +226,7 @@ static int ref_pkt(git_pkt **out, const char *line, size_t len)
 
 	/* Check for a bit of consistency */
 	if (line[GIT_OID_HEXSZ] != ' ') {
-		giterr_set(GITERR_NET, "Error parsing pkt-line");
+		giterr_set(GITERR_NET, "error parsing pkt-line");
 		error = -1;
 		goto error_out;
 	}
@@ -270,7 +270,7 @@ static int ok_pkt(git_pkt **out, const char *line, size_t len)
 
 	line += 3; /* skip "ok " */
 	if (!(ptr = strchr(line, '\n'))) {
-		giterr_set(GITERR_NET, "Invalid packet line");
+		giterr_set(GITERR_NET, "invalid packet line");
 		git__free(pkt);
 		return -1;
 	}
@@ -327,7 +327,7 @@ static int ng_pkt(git_pkt **out, const char *line, size_t len)
 	return 0;
 
 out_err:
-	giterr_set(GITERR_NET, "Invalid packet line");
+	giterr_set(GITERR_NET, "invalid packet line");
 	git__free(pkt->ref);
 	git__free(pkt);
 	return -1;
@@ -535,7 +535,7 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
 
 	if (len > 0xffff) {
 		giterr_set(GITERR_NET,
-			"Tried to produce packet with invalid length %" PRIuZ, len);
+			"tried to produce packet with invalid length %" PRIuZ, len);
 		return -1;
 	}
 

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -60,7 +60,7 @@ int git_smart__store_refs(transport_smart *t, int flushes)
 
 		gitno_consume(buf, line_end);
 		if (pkt->type == GIT_PKT_ERR) {
-			giterr_set(GITERR_NET, "Remote error: %s", ((git_pkt_err *)pkt)->error);
+			giterr_set(GITERR_NET, "remote error: %s", ((git_pkt_err *)pkt)->error);
 			git__free(pkt);
 			return -1;
 		}

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -83,7 +83,7 @@ static int gen_proto(git_buf *request, const char *cmd, const char *url)
 
 done:
 	if (!repo) {
-		giterr_set(GITERR_NET, "Malformed git protocol URL");
+		giterr_set(GITERR_NET, "malformed git protocol URL");
 		return -1;
 	}
 
@@ -274,7 +274,7 @@ static int git_ssh_extract_url_parts(
 	}
 
 	if (colon == NULL || (colon < start)) {
-		giterr_set(GITERR_NET, "Malformed URL");
+		giterr_set(GITERR_NET, "malformed URL");
 		return -1;
 	}
 
@@ -445,7 +445,7 @@ static int request_creds(git_cred **out, ssh_subtransport *t, const char *user, 
 		else if (error < 0)
 			return error;
 		else if (!cred) {
-			giterr_set(GITERR_SSH, "Callback failed to initialize SSH credentials");
+			giterr_set(GITERR_SSH, "callback failed to initialize SSH credentials");
 			return -1;
 		}
 	}
@@ -478,7 +478,7 @@ static int _git_ssh_session_create(
 
 	s = libssh2_session_init();
 	if (!s) {
-		giterr_set(GITERR_NET, "Failed to initialize SSH session");
+		giterr_set(GITERR_NET, "failed to initialize SSH session");
 		return -1;
 	}
 
@@ -487,7 +487,7 @@ static int _git_ssh_session_create(
 	} while (LIBSSH2_ERROR_EAGAIN == rc || LIBSSH2_ERROR_TIMEOUT == rc);
 
 	if (rc != LIBSSH2_ERROR_NONE) {
-		ssh_error(s, "Failed to start SSH session");
+		ssh_error(s, "failed to start SSH session");
 		libssh2_session_free(s);
 		return -1;
 	}
@@ -685,7 +685,7 @@ static int ssh_uploadpack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call UPLOADPACK_LS before UPLOADPACK");
+	giterr_set(GITERR_NET, "must call UPLOADPACK_LS before UPLOADPACK");
 	return -1;
 }
 
@@ -712,7 +712,7 @@ static int ssh_receivepack(
 		return 0;
 	}
 
-	giterr_set(GITERR_NET, "Must call RECEIVEPACK_LS before RECEIVEPACK");
+	giterr_set(GITERR_NET, "must call RECEIVEPACK_LS before RECEIVEPACK");
 	return -1;
 }
 
@@ -844,7 +844,7 @@ int git_smart_subtransport_ssh(
 	assert(out);
 	*out = NULL;
 
-	giterr_set(GITERR_INVALID, "Cannot create SSH transport. Library was built without SSH support");
+	giterr_set(GITERR_INVALID, "cannot create SSH transport. Library was built without SSH support");
 	return -1;
 #endif
 }
@@ -888,7 +888,7 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 	assert(out);
 	*out = NULL;
 
-	giterr_set(GITERR_INVALID, "Cannot create SSH transport. Library was built without SSH support");
+	giterr_set(GITERR_INVALID, "cannot create SSH transport. Library was built without SSH support");
 	return -1;
 #endif
 }

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -139,12 +139,12 @@ static int apply_basic_credential(HINTERNET request, git_cred *cred)
 		goto on_error;
 
 	if ((wide_len = git__utf8_to_16_alloc(&wide, git_buf_cstr(&buf))) < 0) {
-		giterr_set(GITERR_OS, "Failed to convert string to wide form");
+		giterr_set(GITERR_OS, "failed to convert string to wide form");
 		goto on_error;
 	}
 
 	if (!WinHttpAddRequestHeaders(request, wide, (ULONG) -1L, WINHTTP_ADDREQ_FLAG_ADD)) {
-		giterr_set(GITERR_OS, "Failed to add a header to the request");
+		giterr_set(GITERR_OS, "failed to add a header to the request");
 		goto on_error;
 	}
 
@@ -202,7 +202,7 @@ static int fallback_cred_acquire_cb(
 
 		/* Convert URL to wide characters */
 		if (git__utf8_to_16_alloc(&wide_url, url) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert string to wide form");
+			giterr_set(GITERR_OS, "failed to convert string to wide form");
 			return -1;
 		}
 
@@ -351,7 +351,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 
 	/* Convert URL to wide characters */
 	if (git__utf8_to_16_alloc(&s->request_uri, git_buf_cstr(&buf)) < 0) {
-		giterr_set(GITERR_OS, "Failed to convert string to wide form");
+		giterr_set(GITERR_OS, "failed to convert string to wide form");
 		goto on_error;
 	}
 
@@ -366,12 +366,12 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			t->connection_data.use_ssl ? WINHTTP_FLAG_SECURE : 0);
 
 	if (!s->request) {
-		giterr_set(GITERR_OS, "Failed to open request");
+		giterr_set(GITERR_OS, "failed to open request");
 		goto on_error;
 	}
 
 	if (!WinHttpSetTimeouts(s->request, default_timeout, default_connect_timeout, default_timeout, default_timeout)) {
-		giterr_set(GITERR_OS, "Failed to set timeouts for WinHTTP");
+		giterr_set(GITERR_OS, "failed to set timeouts for WinHTTP");
 		goto on_error;
 	}
 
@@ -444,7 +444,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			WINHTTP_OPTION_PROXY,
 			&proxy_info,
 			sizeof(WINHTTP_PROXY_INFO))) {
-			giterr_set(GITERR_OS, "Failed to set proxy");
+			giterr_set(GITERR_OS, "failed to set proxy");
 			git__free(proxy_wide);
 			goto on_error;
 		}
@@ -467,7 +467,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 		WINHTTP_OPTION_DISABLE_FEATURE,
 		&disable_redirects,
 		sizeof(disable_redirects))) {
-			giterr_set(GITERR_OS, "Failed to disable redirects");
+			giterr_set(GITERR_OS, "failed to disable redirects");
 			goto on_error;
 	}
 
@@ -481,7 +481,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 
 	/* Send Pragma: no-cache header */
 	if (!WinHttpAddRequestHeaders(s->request, pragma_nocache, (ULONG) -1L, WINHTTP_ADDREQ_FLAG_ADD)) {
-		giterr_set(GITERR_OS, "Failed to add a header to the request");
+		giterr_set(GITERR_OS, "failed to add a header to the request");
 		goto on_error;
 	}
 
@@ -494,13 +494,13 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			goto on_error;
 
 		if (git__utf8_to_16(ct, MAX_CONTENT_TYPE_LEN, git_buf_cstr(&buf)) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert content-type to wide characters");
+			giterr_set(GITERR_OS, "failed to convert content-type to wide characters");
 			goto on_error;
 		}
 
 		if (!WinHttpAddRequestHeaders(s->request, ct, (ULONG)-1L,
 			WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE)) {
-			giterr_set(GITERR_OS, "Failed to add a header to the request");
+			giterr_set(GITERR_OS, "failed to add a header to the request");
 			goto on_error;
 		}
 
@@ -511,13 +511,13 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			goto on_error;
 
 		if (git__utf8_to_16(ct, MAX_CONTENT_TYPE_LEN, git_buf_cstr(&buf)) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert accept header to wide characters");
+			giterr_set(GITERR_OS, "failed to convert accept header to wide characters");
 			goto on_error;
 		}
 
 		if (!WinHttpAddRequestHeaders(s->request, ct, (ULONG)-1L,
 			WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE)) {
-			giterr_set(GITERR_OS, "Failed to add a header to the request");
+			giterr_set(GITERR_OS, "failed to add a header to the request");
 			goto on_error;
 		}
 	}
@@ -527,13 +527,13 @@ static int winhttp_stream_connect(winhttp_stream *s)
 			git_buf_clear(&buf);
 			git_buf_puts(&buf, t->owner->custom_headers.strings[i]);
 			if (git__utf8_to_16(ct, MAX_CONTENT_TYPE_LEN, git_buf_cstr(&buf)) < 0) {
-				giterr_set(GITERR_OS, "Failed to convert custom header to wide characters");
+				giterr_set(GITERR_OS, "failed to convert custom header to wide characters");
 				goto on_error;
 			}
 
 			if (!WinHttpAddRequestHeaders(s->request, ct, (ULONG)-1L,
 				WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE)) {
-				giterr_set(GITERR_OS, "Failed to add a header to the request");
+				giterr_set(GITERR_OS, "failed to add a header to the request");
 				goto on_error;
 			}
 		}
@@ -596,7 +596,7 @@ static int parse_unauthorized_response(
 	 * We can assume this was already done, since we know we are unauthorized. 
 	 */
 	if (!WinHttpQueryAuthSchemes(request, &supported, &first, &target)) {
-		giterr_set(GITERR_OS, "Failed to parse supported auth schemes"); 
+		giterr_set(GITERR_OS, "failed to parse supported auth schemes"); 
 		return -1;
 	}
 
@@ -629,7 +629,7 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 		git_buf_cstr(&buf),	(DWORD)git_buf_len(&buf),
 		&bytes_written)) {
 		git_buf_free(&buf);
-		giterr_set(GITERR_OS, "Failed to write chunk header");
+		giterr_set(GITERR_OS, "failed to write chunk header");
 		return -1;
 	}
 
@@ -639,7 +639,7 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 	if (!WinHttpWriteData(request,
 		buffer, (DWORD)len,
 		&bytes_written)) {
-		giterr_set(GITERR_OS, "Failed to write chunk");
+		giterr_set(GITERR_OS, "failed to write chunk");
 		return -1;
 	}
 
@@ -647,7 +647,7 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 	if (!WinHttpWriteData(request,
 		"\r\n", 2,
 		&bytes_written)) {
-		giterr_set(GITERR_OS, "Failed to write chunk footer");
+		giterr_set(GITERR_OS, "failed to write chunk footer");
 		return -1;
 	}
 
@@ -660,7 +660,7 @@ static int winhttp_close_connection(winhttp_subtransport *t)
 
 	if (t->connection) {
 		if (!WinHttpCloseHandle(t->connection)) {
-			giterr_set(GITERR_OS, "Unable to close connection");
+			giterr_set(GITERR_OS, "unable to close connection");
 			ret = -1;
 		}
 
@@ -669,7 +669,7 @@ static int winhttp_close_connection(winhttp_subtransport *t)
 
 	if (t->session) {
 		if (!WinHttpCloseHandle(t->session)) {
-			giterr_set(GITERR_OS, "Unable to close session");
+			giterr_set(GITERR_OS, "unable to close session");
 			ret = -1;
 		}
 
@@ -714,7 +714,7 @@ static int winhttp_connect(
 
 	/* Prepare host */
 	if (git__utf8_to_16_alloc(&wide_host, t->connection_data.host) < 0) {
-		giterr_set(GITERR_OS, "Unable to convert host to wide characters");
+		giterr_set(GITERR_OS, "unable to convert host to wide characters");
 		return -1;
 	}
 
@@ -724,7 +724,7 @@ static int winhttp_connect(
 	}
 
 	if (git__utf8_to_16_alloc(&wide_ua, git_buf_cstr(&ua)) < 0) {
-		giterr_set(GITERR_OS, "Unable to convert host to wide characters");
+		giterr_set(GITERR_OS, "unable to convert host to wide characters");
 		git__free(wide_host);
 		git_buf_free(&ua);
 		return -1;
@@ -741,12 +741,12 @@ static int winhttp_connect(
 		0);
 
 	if (!t->session) {
-		giterr_set(GITERR_OS, "Failed to init WinHTTP");
+		giterr_set(GITERR_OS, "failed to init WinHTTP");
 		goto on_error;
 	}
 
 	if (!WinHttpSetTimeouts(t->session, default_timeout, default_connect_timeout, default_timeout, default_timeout)) {
-		giterr_set(GITERR_OS, "Failed to set timeouts for WinHTTP");
+		giterr_set(GITERR_OS, "failed to set timeouts for WinHTTP");
 		goto on_error;
 	}
 
@@ -759,7 +759,7 @@ static int winhttp_connect(
 		0);
 
 	if (!t->connection) {
-		giterr_set(GITERR_OS, "Failed to connect to host");
+		giterr_set(GITERR_OS, "failed to connect to host");
 		goto on_error;
 	}
 
@@ -853,7 +853,7 @@ static int winhttp_stream_read(
 replay:
 	/* Enforce a reasonable cap on the number of replays */
 	if (++replay_count >= 7) {
-		giterr_set(GITERR_NET, "Too many redirects or authentication replays");
+		giterr_set(GITERR_NET, "too many redirects or authentication replays");
 		return -1;
 	}
 
@@ -888,7 +888,7 @@ replay:
 			if (!WinHttpWriteData(s->request,
 				"0\r\n\r\n", 5,
 				&bytes_written)) {
-				giterr_set(GITERR_OS, "Failed to write final chunk");
+				giterr_set(GITERR_OS, "failed to write final chunk");
 				return -1;
 			}
 		}
@@ -899,7 +899,7 @@ replay:
 			if (INVALID_SET_FILE_POINTER == SetFilePointer(s->post_body,
 					0, 0, FILE_BEGIN) &&
 				NO_ERROR != GetLastError()) {
-				giterr_set(GITERR_OS, "Failed to reset file pointer");
+				giterr_set(GITERR_OS, "failed to reset file pointer");
 				return -1;
 			}
 
@@ -913,14 +913,14 @@ replay:
 					&bytes_read, NULL) ||
 					!bytes_read) {
 					git__free(buffer);
-					giterr_set(GITERR_OS, "Failed to read from temp file");
+					giterr_set(GITERR_OS, "failed to read from temp file");
 					return -1;
 				}
 
 				if (!WinHttpWriteData(s->request, buffer,
 					bytes_read, &bytes_written)) {
 					git__free(buffer);
-					giterr_set(GITERR_OS, "Failed to write data");
+					giterr_set(GITERR_OS, "failed to write data");
 					return -1;
 				}
 
@@ -936,7 +936,7 @@ replay:
 		}
 
 		if (!WinHttpReceiveResponse(s->request, 0)) {
-			giterr_set(GITERR_OS, "Failed to receive response");
+			giterr_set(GITERR_OS, "failed to receive response");
 			return -1;
 		}
 
@@ -948,7 +948,7 @@ replay:
 			WINHTTP_HEADER_NAME_BY_INDEX,
 			&status_code, &status_code_length,
 			WINHTTP_NO_HEADER_INDEX)) {
-				giterr_set(GITERR_OS, "Failed to retrieve status code");
+				giterr_set(GITERR_OS, "failed to retrieve status code");
 				return -1;
 		}
 
@@ -978,7 +978,7 @@ replay:
 				&location_length,
 				WINHTTP_NO_HEADER_INDEX) ||
 				GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-				giterr_set(GITERR_OS, "Failed to read Location header");
+				giterr_set(GITERR_OS, "failed to read Location header");
 				return -1;
 			}
 
@@ -991,14 +991,14 @@ replay:
 				location,
 				&location_length,
 				WINHTTP_NO_HEADER_INDEX)) {
-				giterr_set(GITERR_OS, "Failed to read Location header");
+				giterr_set(GITERR_OS, "failed to read Location header");
 				git__free(location);
 				return -1;
 			}
 
 			/* Convert the Location header to UTF-8 */
 			if (git__utf16_to_8_alloc(&location8, location) < 0) {
-				giterr_set(GITERR_OS, "Failed to convert Location header to UTF-8");
+				giterr_set(GITERR_OS, "failed to convert Location header to UTF-8");
 				git__free(location);
 				return -1;
 			}
@@ -1090,7 +1090,7 @@ replay:
 		}
 
 		if (HTTP_STATUS_OK != status_code) {
-			giterr_set(GITERR_NET, "Request failed with status code: %d", status_code);
+			giterr_set(GITERR_NET, "request failed with status code: %d", status_code);
 			return -1;
 		}
 
@@ -1101,7 +1101,7 @@ replay:
 			p_snprintf(expected_content_type_8, MAX_CONTENT_TYPE_LEN, "application/x-git-%s-advertisement", s->service);
 
 		if (git__utf8_to_16(expected_content_type, MAX_CONTENT_TYPE_LEN, expected_content_type_8) < 0) {
-			giterr_set(GITERR_OS, "Failed to convert expected content-type to wide characters");
+			giterr_set(GITERR_OS, "failed to convert expected content-type to wide characters");
 			return -1;
 		}
 
@@ -1112,12 +1112,12 @@ replay:
 			WINHTTP_HEADER_NAME_BY_INDEX,
 			&content_type, &content_type_length,
 			WINHTTP_NO_HEADER_INDEX)) {
-				giterr_set(GITERR_OS, "Failed to retrieve response content-type");
+				giterr_set(GITERR_OS, "failed to retrieve response content-type");
 				return -1;
 		}
 
 		if (wcscmp(expected_content_type, content_type)) {
-			giterr_set(GITERR_NET, "Received unexpected content-type");
+			giterr_set(GITERR_NET, "received unexpected content-type");
 			return -1;
 		}
 
@@ -1129,7 +1129,7 @@ replay:
 		(DWORD)buf_size,
 		&dw_bytes_read))
 	{
-		giterr_set(GITERR_OS, "Failed to read data");
+		giterr_set(GITERR_OS, "failed to read data");
 		return -1;
 	}
 
@@ -1152,7 +1152,7 @@ static int winhttp_stream_write_single(
 
 	/* This implementation of write permits only a single call. */
 	if (s->sent_request) {
-		giterr_set(GITERR_NET, "Subtransport configured for only one write");
+		giterr_set(GITERR_NET, "subtransport configured for only one write");
 		return -1;
 	}
 
@@ -1165,7 +1165,7 @@ static int winhttp_stream_write_single(
 			(LPCVOID)buffer,
 			(DWORD)len,
 			&bytes_written)) {
-		giterr_set(GITERR_OS, "Failed to write data");
+		giterr_set(GITERR_OS, "failed to write data");
 		return -1;
 	}
 
@@ -1183,12 +1183,12 @@ static int put_uuid_string(LPWSTR buffer, size_t buffer_len_cch)
 	if (RPC_S_OK != status &&
 		RPC_S_UUID_LOCAL_ONLY != status &&
 		RPC_S_UUID_NO_ADDRESS != status) {
-		giterr_set(GITERR_NET, "Unable to generate name for temp file");
+		giterr_set(GITERR_NET, "unable to generate name for temp file");
 		return -1;
 	}
 
 	if (buffer_len_cch < UUID_LENGTH_CCH + 1) {
-		giterr_set(GITERR_NET, "Buffer too small for name of temp file");
+		giterr_set(GITERR_NET, "buffer too small for name of temp file");
 		return -1;
 	}
 
@@ -1203,7 +1203,7 @@ static int put_uuid_string(LPWSTR buffer, size_t buffer_len_cch)
 		uuid.Data4[4], uuid.Data4[5], uuid.Data4[6], uuid.Data4[7]);
 
 	if (result < UUID_LENGTH_CCH) {
-		giterr_set(GITERR_OS, "Unable to generate name for temp file");
+		giterr_set(GITERR_OS, "unable to generate name for temp file");
 		return -1;
 	}
 
@@ -1215,7 +1215,7 @@ static int get_temp_file(LPWSTR buffer, DWORD buffer_len_cch)
 	size_t len;
 
 	if (!GetTempPathW(buffer_len_cch, buffer)) {
-		giterr_set(GITERR_OS, "Failed to get temp path");
+		giterr_set(GITERR_OS, "failed to get temp path");
 		return -1;
 	}
 
@@ -1258,13 +1258,13 @@ static int winhttp_stream_write_buffered(
 
 		if (INVALID_HANDLE_VALUE == s->post_body) {
 			s->post_body = NULL;
-			giterr_set(GITERR_OS, "Failed to create temporary file");
+			giterr_set(GITERR_OS, "failed to create temporary file");
 			return -1;
 		}
 	}
 
 	if (!WriteFile(s->post_body, buffer, (DWORD)len, &bytes_written, NULL)) {
-		giterr_set(GITERR_OS, "Failed to write to temporary file");
+		giterr_set(GITERR_OS, "failed to write to temporary file");
 		return -1;
 	}
 
@@ -1291,7 +1291,7 @@ static int winhttp_stream_write_chunked(
 		if (!WinHttpAddRequestHeaders(s->request,
 			transfer_encoding, (ULONG) -1L,
 			WINHTTP_ADDREQ_FLAG_ADD)) {
-			giterr_set(GITERR_OS, "Failed to add a header to the request");
+			giterr_set(GITERR_OS, "failed to add a header to the request");
 			return -1;
 		}
 

--- a/src/tree-cache.c
+++ b/src/tree-cache.c
@@ -137,7 +137,7 @@ static int read_tree_internal(git_tree_cache **out,
 	return 0;
 
  corrupted:
-	giterr_set(GITERR_INDEX, "Corrupted TREE extension in index");
+	giterr_set(GITERR_INDEX, "corrupted TREE extension in index");
 	return -1;
 }
 
@@ -149,7 +149,7 @@ int git_tree_cache_read(git_tree_cache **tree, const char *buffer, size_t buffer
 		return -1;
 
 	if (buffer < buffer_end) {
-		giterr_set(GITERR_INDEX, "Corrupted TREE extension in index (unexpected trailing data)");
+		giterr_set(GITERR_INDEX, "corrupted TREE extension in index (unexpected trailing data)");
 		return -1;
 	}
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -627,7 +627,7 @@ int git_tree__write_index(
 
 	if (git_index_has_conflicts(index)) {
 		giterr_set(GITERR_INDEX,
-			"Cannot create a tree from a not fully merged index.");
+			"cannot create a tree from a not fully merged index.");
 		return GIT_EUNMERGED;
 	}
 
@@ -909,7 +909,7 @@ int git_tree_entry_bypath(
 	filename_len = subpath_len(path);
 
 	if (filename_len == 0) {
-		giterr_set(GITERR_TREE, "Invalid tree path given");
+		giterr_set(GITERR_TREE, "invalid tree path given");
 		return GIT_ENOTFOUND;
 	}
 
@@ -1027,7 +1027,7 @@ int git_tree_walk(
 	git_buf root_path = GIT_BUF_INIT;
 
 	if (mode != GIT_TREEWALK_POST && mode != GIT_TREEWALK_PRE) {
-		giterr_set(GITERR_INVALID, "Invalid walking mode for tree walk");
+		giterr_set(GITERR_INVALID, "invalid walking mode for tree walk");
 		return -1;
 	}
 
@@ -1237,7 +1237,7 @@ int git_tree_create_updated(git_oid *out, git_repository *repo, git_tree *baseli
 				const git_tree_entry *e = git_treebuilder_get(last->bld, basename);
 				if (e && git_tree_entry_type(e) != git_object__type_from_filemode(update->filemode)) {
 					git__free(basename);
-					giterr_set(GITERR_TREE, "Cannot replace '%s' with '%s' at '%s'",
+					giterr_set(GITERR_TREE, "cannot replace '%s' with '%s' at '%s'",
 						   git_object_type2string(git_tree_entry_type(e)),
 						   git_object_type2string(git_object__type_from_filemode(update->filemode)),
 						   update->path);
@@ -1257,7 +1257,7 @@ int git_tree_create_updated(git_oid *out, git_repository *repo, git_tree *baseli
 				break;
 			}
 			default:
-				giterr_set(GITERR_TREE, "unkown action for update");
+				giterr_set(GITERR_TREE, "unknown action for update");
 				error = -1;
 				goto cleanup;
 		}

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -52,7 +52,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	out->data = mmap(NULL, len, mprot, mflag, fd, offset);
 
 	if (!out->data || out->data == MAP_FAILED) {
-		giterr_set(GITERR_OS, "Failed to mmap. Could not write data");
+		giterr_set(GITERR_OS, "failed to mmap. Could not write data");
 		return -1;
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -136,7 +136,7 @@ int git__strntol64(int64_t *result, const char *nptr, size_t nptr_len, const cha
 
 Return:
 	if (ndig == 0) {
-		giterr_set(GITERR_INVALID, "Failed to convert string to long. Not a number");
+		giterr_set(GITERR_INVALID, "failed to convert string to long: not a number");
 		return -1;
 	}
 
@@ -144,7 +144,7 @@ Return:
 		*endptr = p;
 
 	if (ovfl) {
-		giterr_set(GITERR_INVALID, "Failed to convert string to long. Overflow error");
+		giterr_set(GITERR_INVALID, "failed to convert string to long: overflow error");
 		return -1;
 	}
 
@@ -169,7 +169,7 @@ int git__strntol32(int32_t *result, const char *nptr, size_t nptr_len, const cha
 
 	tmp_int = tmp_long & 0xFFFFFFFF;
 	if (tmp_int != tmp_long) {
-		giterr_set(GITERR_INVALID, "Failed to convert. '%s' is too large", nptr);
+		giterr_set(GITERR_INVALID, "failed to convert: '%s' is too large", nptr);
 		return -1;
 	}
 

--- a/src/win32/dir.c
+++ b/src/win32/dir.c
@@ -28,7 +28,7 @@ git__DIR *git__opendir(const char *dir)
 	new->h = FindFirstFileW(filter_w, &new->f);
 
 	if (new->h == INVALID_HANDLE_VALUE) {
-		giterr_set(GITERR_OS, "Could not open directory '%s'", dir);
+		giterr_set(GITERR_OS, "could not open directory '%s'", dir);
 		git__free(new);
 		return NULL;
 	}
@@ -53,7 +53,7 @@ int git__readdir_ext(
 	else if (!FindNextFileW(d->h, &d->f)) {
 		if (GetLastError() == ERROR_NO_MORE_FILES)
 			return 0;
-		giterr_set(GITERR_OS, "Could not read from directory '%s'", d->dir);
+		giterr_set(GITERR_OS, "could not read from directory '%s'", d->dir);
 		return -1;
 	}
 
@@ -98,7 +98,7 @@ void git__rewinddir(git__DIR *d)
 	d->h = FindFirstFileW(filter_w, &d->f);
 
 	if (d->h == INVALID_HANDLE_VALUE)
-		giterr_set(GITERR_OS, "Could not open directory '%s'", d->dir);
+		giterr_set(GITERR_OS, "could not open directory '%s'", d->dir);
 	else
 		d->first = 1;
 }

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -38,7 +38,7 @@ static int win32_path_to_8(git_buf *dest, const wchar_t *src)
 	git_win32_utf8_path utf8_path;
 
 	if (git_win32_path_to_utf8(utf8_path, src) < 0) {
-		giterr_set(GITERR_OS, "Unable to convert path to UTF-8");
+		giterr_set(GITERR_OS, "unable to convert path to UTF-8");
 		return -1;
 	}
 

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -67,7 +67,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 
 	if (fh == INVALID_HANDLE_VALUE) {
 		errno = EBADF;
-		giterr_set(GITERR_OS, "Failed to mmap. Invalid handle value");
+		giterr_set(GITERR_OS, "failed to mmap. Invalid handle value");
 		return -1;
 	}
 
@@ -86,13 +86,13 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 
 	if (page_offset != 0) { /* offset must be multiple of the allocation granularity */
 		errno = EINVAL;
-		giterr_set(GITERR_OS, "Failed to mmap. Offset must be multiple of allocation granularity");
+		giterr_set(GITERR_OS, "failed to mmap. Offset must be multiple of allocation granularity");
 		return -1;
 	}
 
 	out->fmh = CreateFileMapping(fh, NULL, fmap_prot, 0, 0, NULL);
 	if (!out->fmh || out->fmh == INVALID_HANDLE_VALUE) {
-		giterr_set(GITERR_OS, "Failed to mmap. Invalid handle value");
+		giterr_set(GITERR_OS, "failed to mmap. Invalid handle value");
 		out->fmh = NULL;
 		return -1;
 	}
@@ -103,7 +103,7 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	off_hi = (DWORD)(page_start >> 32);
 	out->data = MapViewOfFile(out->fmh, view_prot, off_hi, off_low, len);
 	if (!out->data) {
-		giterr_set(GITERR_OS, "Failed to mmap. No data written");
+		giterr_set(GITERR_OS, "failed to mmap. No data written");
 		CloseHandle(out->fmh);
 		out->fmh = NULL;
 		return -1;
@@ -121,7 +121,7 @@ int p_munmap(git_map *map)
 
 	if (map->data) {
 		if (!UnmapViewOfFile(map->data)) {
-			giterr_set(GITERR_OS, "Failed to munmap. Could not unmap view of file");
+			giterr_set(GITERR_OS, "failed to munmap. Could not unmap view of file");
 			error = -1;
 		}
 		map->data = NULL;
@@ -129,7 +129,7 @@ int p_munmap(git_map *map)
 
 	if (map->fmh) {
 		if (!CloseHandle(map->fmh)) {
-			giterr_set(GITERR_OS, "Failed to munmap. Could not close handle");
+			giterr_set(GITERR_OS, "failed to munmap. Could not close handle");
 			error = -1;
 		}
 		map->fmh = NULL;

--- a/src/win32/w32_crtdbg_stacktrace.c
+++ b/src/win32/w32_crtdbg_stacktrace.c
@@ -253,11 +253,11 @@ int git_win32__crtdbg_stacktrace__dump(
 	bool b_quiet            = IS_BIT_SET(opt, GIT_WIN32__CRTDBG_STACKTRACE__QUIET);
 
 	if (b_leaks_since_mark && b_leaks_total) {
-		giterr_set(GITERR_INVALID, "Cannot combine LEAKS_SINCE_MARK and LEAKS_TOTAL.");
+		giterr_set(GITERR_INVALID, "cannot combine LEAKS_SINCE_MARK and LEAKS_TOTAL.");
 		return GIT_ERROR;
 	}
 	if (!b_set_mark && !b_leaks_since_mark && !b_leaks_total) {
-		giterr_set(GITERR_INVALID, "Nothing to do.");
+		giterr_set(GITERR_INVALID, "nothing to do.");
 		return GIT_ERROR;
 	}
 

--- a/src/win32/w32_util.c
+++ b/src/win32/w32_util.c
@@ -68,7 +68,7 @@ int git_win32__set_hidden(const char *path, bool hidden)
 		newattrs = attrs & ~FILE_ATTRIBUTE_HIDDEN;
 
 	if (attrs != newattrs && !SetFileAttributesW(buf, newattrs)) {
-		giterr_set(GITERR_OS, "Failed to %s hidden bit for '%s'",
+		giterr_set(GITERR_OS, "failed to %s hidden bit for '%s'",
 			hidden ? "set" : "unset", path);
 		return -1;
 	}

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -174,7 +174,7 @@ GIT_INLINE(int) git_win32__file_attribute_to_stat(
 			/* st_size gets the UTF-8 length of the target name, in bytes,
 			 * not counting the NULL terminator */
 			if ((st->st_size = git__utf16_to_8(NULL, 0, target)) < 0) {
-				giterr_set(GITERR_OS, "Could not convert reparse point name for '%ls'", path);
+				giterr_set(GITERR_OS, "could not convert reparse point name for '%ls'", path);
 				return -1;
 			}
 		}

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -23,7 +23,7 @@ static int zstream_seterr(git_zstream *zs)
 	else if (zs->z.msg)
 		giterr_set_str(GITERR_ZLIB, zs->z.msg);
 	else
-		giterr_set(GITERR_ZLIB, "Unknown compression error");
+		giterr_set(GITERR_ZLIB, "unknown compression error");
 
 	return -1;
 }

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -293,7 +293,7 @@ void test_fetchhead_nonetwork__invalid_for_merge(void)
 	cl_git_rewritefile("./test1/.git/FETCH_HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0\tinvalid-merge\t\n");
 	cl_git_fail(git_repository_fetchhead_foreach(g_repo, read_noop, NULL));
 
-	cl_assert(git__prefixcmp(giterr_last()->message, "Invalid for-merge") == 0);
+	cl_assert(git__prefixcmp(giterr_last()->message, "invalid for-merge") == 0);
 }
 
 void test_fetchhead_nonetwork__invalid_description(void)
@@ -304,7 +304,7 @@ void test_fetchhead_nonetwork__invalid_description(void)
 	cl_git_rewritefile("./test1/.git/FETCH_HEAD", "49322bb17d3acc9146f98c97d078513228bbf3c0\tnot-for-merge\n");
 	cl_git_fail(git_repository_fetchhead_foreach(g_repo, read_noop, NULL));
 
-	cl_assert(git__prefixcmp(giterr_last()->message, "Invalid description") == 0);
+	cl_assert(git__prefixcmp(giterr_last()->message, "invalid description") == 0);
 }
 
 static int assert_master_for_merge(const char *ref, const char *url, const git_oid *id, unsigned int is_merge, void *data)

--- a/tests/odb/backend/nobackend.c
+++ b/tests/odb/backend/nobackend.c
@@ -40,7 +40,7 @@ void test_odb_backend_nobackend__write_fails_gracefully(void)
 	cl_git_fail(git_odb_write(&id, odb, "Hello world!\n", 13, GIT_OBJ_BLOB));
 
 	err = giterr_last();
-	cl_assert_equal_s(err->message, "Cannot write object - unsupported in the loaded odb backends");
+	cl_assert_equal_s(err->message, "cannot write object - unsupported in the loaded odb backends");
 
 	git_odb_free(odb);
 }

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -175,7 +175,7 @@ void test_refs_branches_upstream__no_fetch_refspec(void)
 	cl_git_pass(git_reference_lookup(&branch, repo, "refs/heads/test"));
 	cl_git_pass(git_reference_create(&ref, repo, "refs/remotes/matching/master", git_reference_target(branch), 1, "fetch"));
 	cl_git_fail(git_branch_set_upstream(branch, "matching/master"));
-	cl_assert_equal_s("Could not determine remote for 'refs/remotes/matching/master'",
+	cl_assert_equal_s("could not determine remote for 'refs/remotes/matching/master'",
 			  giterr_last()->message);
 
 	/* we can't set it automatically, so let's test the user setting it by hand */

--- a/tests/refs/reflog/reflog.c
+++ b/tests/refs/reflog/reflog.c
@@ -261,7 +261,7 @@ void test_refs_reflog_reflog__reading_a_reflog_with_invalid_format_returns_error
 	error = giterr_last();
 
 	cl_assert(error != NULL);
-	cl_assert_equal_s("Unable to parse OID - contains invalid characters", error->message);
+	cl_assert_equal_s("unable to parse OID - contains invalid characters", error->message);
 
 	git_reference_free(ref);
 	git_buf_free(&logpath);


### PR DESCRIPTION
Error messages should be sentence fragments, and therefore:

1. Should not begin with a capital letter,
2. Should not conclude with punctuation, and
3. Should not end a sentence and begin a new one