### PR TITLE
Clang analyzer run

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -278,7 +278,7 @@ int git_ignore__for_path(
 	int error = 0;
 	const char *workdir = git_repository_workdir(repo);
 
-	assert(ignores && path);
+	assert(repo && ignores && path);
 
 	memset(ignores, 0, sizeof(*ignores));
 	ignores->repo = repo;
@@ -503,9 +503,9 @@ int git_ignore_path_is_ignored(
 	unsigned int i;
 	git_attr_file *file;
 
-	assert(ignored && pathname);
+	assert(repo && ignored && pathname);
 
-	workdir = repo ? git_repository_workdir(repo) : NULL;
+	workdir = git_repository_workdir(repo);
 
 	memset(&path, 0, sizeof(path));
 	memset(&ignores, 0, sizeof(ignores));

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1738,7 +1738,7 @@ int git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk)
 	if (error == GIT_ITEROVER)
 		error = 0;
 
-	return 0;
+	return error;
 }
 
 int git_packbuilder_set_callbacks(git_packbuilder *pb, git_packbuilder_progress progress_cb, void *progress_cb_payload)

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -451,8 +451,10 @@ int git_diff_foreach(
 
 		if (binary_cb || hunk_cb || data_cb) {
 			if ((error = patch_generated_init(&patch, diff, idx)) != 0 ||
-				(error = patch_generated_load(&patch, &xo.output)) != 0)
+				(error = patch_generated_load(&patch, &xo.output)) != 0) {
+				git_patch_free(&patch.base);
 				return error;
+			}
 		}
 
 		if ((error = patch_generated_invoke_file_callback(&patch, &xo.output)) == 0) {


### PR DESCRIPTION
This is a few low-hanging fruits from using Xcode "Analyze" against libgit2.

Current `master` has 85 of those, this one is 81, and I managed to get it down to 64 by having more fine-grained control over `GITERR_CHECK_ALLOC` helps. If you feel that's a worthy goal, I can make another PR with those changes.

There are a few harder things which I can't tell if they're false-positives or not.