### PR TITLE
Detail exactly which objects can no longer be used after repository free'd

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -160,11 +160,13 @@ GIT_EXTERN(int) git_repository_open_bare(git_repository **out, const char *bare_
 /**
  * Free a previously allocated repository
  *
- * Note that after a repository is free'd, all the objects it has spawned
- * will still exist until they are manually closed by the user
- * with `git_object_free`, but accessing any of the attributes of
- * an object without a backing repository will result in undefined
- * behavior
+ * Note that after a repository is free'd, all objects it has spawned will still
+ * exist until they are manually closed by the user (e.g. with
+ * `git_object_free`), but using the object in any other manner without a
+ * backing repository will result in undefined behavior. The exceptions to this
+ * rule are `git_config`, `git_config_entry`, `git_index`, `git_index_entry`,
+ * `git_odb`, `gt_reflog_entry`, `git_tree_entry`, `git_signature` and
+ * `git_note` objects.
  *
  * @param repo repository handle to close. If NULL nothing occurs.
  */


### PR DESCRIPTION
The background is in [this StackOverflow question](http://stackoverflow.com/q/41408798/392585).

Based on my reading of the source, the following ticked exported opaque objects keep pointers to a `git_repository` object (possibly via some intermediate other object):

- [ ] `git_odb`
- [ ] `git_odb_backend`
- [ ] `git_odb_object`
- [ ] `git_odb_stream`
- [ ] `git_odb_writepack`
- [x] `git_refdb`
- [ ] `git_refdb_backend`
- [x] `git_object`
- [x] `git_revwalk`
- [x] `git_tag`
- [x] `git_blob`
- [x] `git_commit`
- [ ] `git_tree_entry`
- [x] `git_tree`
- [x] `git_treebuilder`
- [ ] `git_index`
- [ ] `git_index_conflict_iterator`
- [ ] `git_config`
- [ ] `git_config_backend`
- [ ] `git_reflog_entry`
- [x] `git_reflog`
- [ ] `git_note`
- [x] `git_packbuilder`
- [x] `git_reference`
- [x] `git_reference_iterator`
- [x] `git_transaction`
- [x] `git_annotated_commit`
- [ ] `git_merge_result` (does not appear to be defined/used)
- [x] `git_status_list`
- [x] `git_rebase`
- [ ] `git_refspec`
- [x] `git_remote`
- [ ] `git_transport`
- [x] `git_push`
- [ ] `git_remote_head`
- [ ] `git_remote_callbacks`
- [x] `git_submodule`
- [ ] `git_writestream`

If there are any errors or omissions, please let me know and I can update the PR. I'm not 100% sure about `git_index`, as it's quite a complicated object: could someone confirm this for me?