### PR TITLE
Delete temporary packfile in indexer

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -1091,6 +1091,12 @@ void git_indexer_free(git_indexer *idx)
 	git_vector_free_deep(&idx->deltas);
 
 	/* Try to delete the temporary file in case it was not committed. */
+	git_mwindow_free_all(&idx->pack->mwf);
+	/* We need to close the descriptor here so Windows doesn't choke on unlink */
+	if (idx->pack->mwf.fd != -1) {
+		(void)p_close(idx->pack->mwf.fd);
+		idx->pack->mwf.fd = -1;
+	}
 	(void)p_unlink(idx->pack->pack_name);
 
 	if (!git_mutex_lock(&git__mwindow_mutex)) {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -151,11 +151,11 @@ cleanup:
 	if (fd != -1)
 		p_close(fd);
 
-	if (git_buf_is_allocated(&tmp_path))
-		(void)p_unlink(git_buf_cstr(&tmp_path));
+	if (git_buf_len(&tmp_path) > 0)
+		p_unlink(git_buf_cstr(&tmp_path));
 
 	if (idx->pack != NULL)
-		(void)p_unlink(idx->pack->pack_name);
+		p_unlink(idx->pack->pack_name);
 
 	git_buf_free(&path);
 	git_buf_free(&tmp_path);
@@ -1094,10 +1094,10 @@ void git_indexer_free(git_indexer *idx)
 	git_mwindow_free_all(&idx->pack->mwf);
 	/* We need to close the descriptor here so Windows doesn't choke on unlink */
 	if (idx->pack->mwf.fd != -1) {
-		(void)p_close(idx->pack->mwf.fd);
+		p_close(idx->pack->mwf.fd);
 		idx->pack->mwf.fd = -1;
 	}
-	(void)p_unlink(idx->pack->pack_name);
+	p_unlink(idx->pack->pack_name);
 
 	if (!git_mutex_lock(&git__mwindow_mutex)) {
 		git_packfile_free(idx->pack);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -151,6 +151,12 @@ cleanup:
 	if (fd != -1)
 		p_close(fd);
 
+	if (git_buf_is_allocated(&tmp_path))
+		(void)p_unlink(git_buf_cstr(&tmp_path));
+
+	if (idx->pack != NULL)
+		(void)p_unlink(idx->pack->pack_name);
+
 	git_buf_free(&path);
 	git_buf_free(&tmp_path);
 	git__free(idx);
@@ -1083,6 +1089,9 @@ void git_indexer_free(git_indexer *idx)
 	}
 
 	git_vector_free_deep(&idx->deltas);
+
+	/* Try to delete the temporary file in case it was not committed. */
+	(void)p_unlink(idx->pack->pack_name);
 
 	if (!git_mutex_lock(&git__mwindow_mutex)) {
 		git_packfile_free(idx->pack);

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -155,11 +155,7 @@ void test_pack_indexer__no_tmp_files(void)
 	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
 	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
 	git_buf_free(&path);
-	if (git_buf_is_allocated(&first_tmp_file)) {
-		git_buf_free(&first_tmp_file);
-		cl_warning("Found a temporary file before running the test");
-		cl_skip();
-	}
+	cl_assert(git_buf_len(&first_tmp_file) == 0);
 
 	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
 	git_indexer_free(idx);
@@ -167,9 +163,6 @@ void test_pack_indexer__no_tmp_files(void)
 	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
 	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
 	git_buf_free(&path);
-	if (git_buf_is_allocated(&first_tmp_file)) {
-		cl_warning(git_buf_cstr(&first_tmp_file));
-		git_buf_free(&first_tmp_file);
-		cl_fail("Found a temporary file");
-	}
+	cl_assert(git_buf_len(&first_tmp_file) == 0);
+	git_buf_free(&first_tmp_file);
 }

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -125,3 +125,43 @@ void test_pack_indexer__fix_thin(void)
 		git_indexer_free(idx);
 	}
 }
+
+static int find_tmp_file_recurs(void *opaque, git_buf *path)
+{
+	int error = 0;
+	git_buf *first_tmp_file = opaque;
+	struct stat st;
+
+	if ((error = p_lstat_posixly(path->ptr, &st)) < 0)
+		return error;
+
+	if (S_ISDIR(st.st_mode))
+		return git_path_direach(path, 0, find_tmp_file_recurs, opaque);
+
+	/* This is the template that's used in git_futils_mktmp. */
+	if (strstr(git_buf_cstr(path), "_git2_") != NULL)
+		return git_buf_sets(first_tmp_file, git_buf_cstr(path));
+
+	return 0;
+}
+
+void test_pack_indexer__no_tmp_files(void)
+{
+	git_indexer *idx = NULL;
+	git_buf path = GIT_BUF_INIT;
+	git_buf first_tmp_file = GIT_BUF_INIT;
+
+	/* Precondition: there are no temporary files. */
+	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
+	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
+	if (git_buf_is_allocated(&first_tmp_file)) {
+		cl_warning("Found a temporary file before running the test");
+		cl_skip();
+	}
+
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	git_indexer_free(idx);
+
+	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
+	cl_check(!git_buf_is_allocated(&first_tmp_file));
+}

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -154,7 +154,9 @@ void test_pack_indexer__no_tmp_files(void)
 	/* Precondition: there are no temporary files. */
 	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
 	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
+	git_buf_free(&path);
 	if (git_buf_is_allocated(&first_tmp_file)) {
+		git_buf_free(&first_tmp_file);
 		cl_warning("Found a temporary file before running the test");
 		cl_skip();
 	}
@@ -162,6 +164,12 @@ void test_pack_indexer__no_tmp_files(void)
 	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
 	git_indexer_free(idx);
 
+	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
 	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
-	cl_check(!git_buf_is_allocated(&first_tmp_file));
+	git_buf_free(&path);
+	if (git_buf_is_allocated(&first_tmp_file)) {
+		cl_warning(git_buf_cstr(&first_tmp_file));
+		git_buf_free(&first_tmp_file);
+		cl_fail("Found a temporary file");
+	}
 }


### PR DESCRIPTION
This change deletes the temporary packfile that the indexer creates to
avoid littering the pack/ directory with garbage.