### PR TITLE
merge: set default rename threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ v0.25 + 1
 
 ### Changes or improvements
 
+* `GIT_MERGE_OPTIONS_INIT` now includes a setting to perform rename detection.
+  This aligns this structure with the default by `git_merge` and
+  `git_merge_trees` when `NULL` was provided for the options.
+
 ### API additions
 
 ### API removals

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -290,7 +290,8 @@ typedef struct {
 } git_merge_options;
 
 #define GIT_MERGE_OPTIONS_VERSION 1
-#define GIT_MERGE_OPTIONS_INIT {GIT_MERGE_OPTIONS_VERSION}
+#define GIT_MERGE_OPTIONS_INIT { \
+	GIT_MERGE_OPTIONS_VERSION, GIT_MERGE_FIND_RENAMES }
 
 /**
  * Initializes a `git_merge_options` with default values. Equivalent to

--- a/src/merge.c
+++ b/src/merge.c
@@ -1713,15 +1713,15 @@ static int merge_normalize_opts(
 	if ((error = git_repository_config__weakptr(&cfg, repo)) < 0)
 		return error;
 
-	if (given != NULL)
+	if (given != NULL) {
 		memcpy(opts, given, sizeof(git_merge_options));
-	else {
+	} else {
 		git_merge_options init = GIT_MERGE_OPTIONS_INIT;
 		memcpy(opts, &init, sizeof(init));
-
-		opts->flags = GIT_MERGE_FIND_RENAMES;
-		opts->rename_threshold = GIT_MERGE_DEFAULT_RENAME_THRESHOLD;
 	}
+
+	if ((opts->flags & GIT_MERGE_FIND_RENAMES) && !opts->rename_threshold)
+		opts->rename_threshold = GIT_MERGE_DEFAULT_RENAME_THRESHOLD;
 
 	if (given && given->default_driver) {
 		opts->default_driver = git__strdup(given->default_driver);

--- a/tests/merge/trees/renames.c
+++ b/tests/merge/trees/renames.c
@@ -242,6 +242,8 @@ void test_merge_trees_renames__no_rename_index(void)
 		{ 0100644, "b69fe837e4cecfd4c9a40cdca7c138468687df07", 3, "7-both-renamed.txt" },
 	};
 
+	opts.flags &= ~GIT_MERGE_FIND_RENAMES;
+
 	cl_git_pass(merge_trees_from_branches(&index, repo,
 		BRANCH_RENAME_OURS, BRANCH_RENAME_THEIRS,
 		&opts));


### PR DESCRIPTION
When `GIT_MERGE_FIND_RENAMES` is set, provide a default for `rename_threshold` when it is unset.

The merge machinery expects `rename_threshold` to be nonzero if `GIT_MERGE_FIND_RENAMES` is set.  Previously, a consumer could set `GIT_MERGE_FIND_RENAMES` but leave `rename_threshold` unset and merge would get terribly confused.

Fixes #4035 