### PR TITLE
Mention field addition in breaking API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,8 @@ v0.25
   If this is `NULL`, then it will not be called and the `exists` function
   will be used instead.
 
-* `git_remote_connect()` now accepts proxy options.
+* `git_remote_connect()` now accepts `git_proxy_options` argument, and
+  `git_fetch_options` and `git_push_options` each have a `proxy_opts` field.
 
 v0.24
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,10 @@ v0.25
 * `git_remote_connect()` now accepts `git_proxy_options` argument, and
   `git_fetch_options` and `git_push_options` each have a `proxy_opts` field.
 
+* `git_merge_options` now provides a `default_driver` that can be used
+  to provide the name of a merge driver to be used to handle files changed
+  during a merge.
+
 v0.24
 -------
 
@@ -227,10 +231,6 @@ v0.24
 * No APIs were removed in this version.
 
 ### Breaking API changes
-
-* `git_merge_options` now provides a `default_driver` that can be used
-  to provide the name of a merge driver to be used to handle files changed
-  during a merge.
 
 * The `git_merge_tree_flag_t` is now `git_merge_flag_t`.  Subsequently,
   its members are no longer prefixed with `GIT_MERGE_TREE_FLAG` but are


### PR DESCRIPTION
`proxy_opts` fields were added to 2 structs, but not mentioned in the CHANGELOG. Cross ref https://github.com/JuliaLang/julia/issues/19793.