### PR TITLE
fix examples/network/clone.c: heap-buffer-overflow

### DIFF
--- a/examples/network/clone.c
+++ b/examples/network/clone.c
@@ -50,7 +50,7 @@ static int sideband_progress(const char *str, int len, void *payload)
 {
 	(void)payload; // unused
 
-	printf("remote: %*s", len, str);
+	printf("remote: %.*s", len, str);
 	fflush(stdout);
 	return 0;
 }


### PR DESCRIPTION
Format of a length of string to the correct format is:%.*s

How to reproduce? Used when compiling libgit2 AddressSanitizer flag
`-fsanitize=address -fno-omit-frame-pointer`,
 then under the example program gives you.