### PR TITLE
Ensure packfiles with different contents have different names

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -931,7 +931,6 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	git_buf filename = GIT_BUF_INIT;
 	struct entry *entry;
 	git_oid trailer_hash, file_hash;
-	git_hash_ctx ctx;
 	git_filebuf index_file = {0};
 	void *packfile_trailer;
 
@@ -939,9 +938,6 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 		giterr_set(GITERR_INDEXER, "incomplete pack header");
 		return -1;
 	}
-
-	if (git_hash_ctx_init(&ctx) < 0)
-		return -1;
 
 	/* Test for this before resolve_deltas(), as it plays with idx->off */
 	if (idx->off + 20 < idx->pack->mwf.size) {
@@ -986,6 +982,10 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 
 	git_vector_sort(&idx->objects);
 
+	/* Use the trailer hash as the pack file name to ensure
+	 * files with different contents have different names */
+	git_oid_cpy(&idx->hash, &trailer_hash);
+
 	git_buf_sets(&filename, idx->pack->pack_name);
 	git_buf_shorten(&filename, strlen("pack"));
 	git_buf_puts(&filename, "idx");
@@ -1010,9 +1010,7 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	/* Write out the object names (SHA-1 hashes) */
 	git_vector_foreach(&idx->objects, i, entry) {
 		git_filebuf_write(&index_file, &entry->oid, sizeof(git_oid));
-		git_hash_update(&ctx, &entry->oid, GIT_OID_RAWSZ);
 	}
-	git_hash_final(&idx->hash, &ctx);
 
 	/* Write out the CRC32 values */
 	git_vector_foreach(&idx->objects, i, entry) {
@@ -1086,14 +1084,12 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 	idx->pack_committed = 1;
 
 	git_buf_free(&filename);
-	git_hash_ctx_cleanup(&ctx);
 	return 0;
 
 on_error:
 	git_mwindow_free_all(&idx->pack->mwf);
 	git_filebuf_cleanup(&index_file);
 	git_buf_free(&filename);
-	git_hash_ctx_cleanup(&ctx);
 	return -1;
 }
 

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -85,7 +85,7 @@ void test_pack_indexer__fix_thin(void)
 	cl_assert_equal_i(stats.indexed_objects, 2);
 	cl_assert_equal_i(stats.local_objects, 1);
 
-	git_oid_fromstr(&should_id, "11f0f69b334728fdd8bc86b80499f22f29d85b15");
+	git_oid_fromstr(&should_id, "fefdb2d740a3a6b6c03a0c7d6ce431c6d5810e13");
 	cl_assert_equal_oid(&should_id, git_indexer_hash(idx));
 
 	git_indexer_free(idx);
@@ -102,7 +102,7 @@ void test_pack_indexer__fix_thin(void)
 		int fd;
 		ssize_t read;
 		struct stat st;
-		const char *name = "pack-11f0f69b334728fdd8bc86b80499f22f29d85b15.pack";
+		const char *name = "pack-fefdb2d740a3a6b6c03a0c7d6ce431c6d5810e13.pack";
 
 		fd = p_open(name, O_RDONLY);
 		cl_assert(fd != -1);

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -113,7 +113,7 @@ void test_pack_packbuilder__create_pack(void)
 	 * $ cd tests/resources/testrepo.git
 	 * $ git rev-list --objects HEAD | \
 	 * 	git pack-objects -q --no-reuse-delta --threads=1 pack
-	 * $ sha1sum git-80e61eb315239ef3c53033e37fee43b744d57122.pack
+	 * $ sha1sum pack-7f5fa362c664d68ba7221259be1cbd187434b2f0.pack
 	 * 5d410bdf97cf896f9007681b92868471d636954b
 	 *
 	 */
@@ -142,7 +142,7 @@ void test_pack_packbuilder__get_hash(void)
 	git_packbuilder_write(_packbuilder, ".", 0, NULL, NULL);
 	git_oid_fmt(hex, git_packbuilder_hash(_packbuilder));
 
-	cl_assert_equal_s(hex, "80e61eb315239ef3c53033e37fee43b744d57122");
+	cl_assert_equal_s(hex, "7f5fa362c664d68ba7221259be1cbd187434b2f0");
 }
 
 static void test_write_pack_permission(mode_t given, mode_t expected)
@@ -166,10 +166,10 @@ static void test_write_pack_permission(mode_t given, mode_t expected)
 	mask = p_umask(0);
 	p_umask(mask);
 
-	cl_git_pass(p_stat("pack-80e61eb315239ef3c53033e37fee43b744d57122.idx", &statbuf));
+	cl_git_pass(p_stat("pack-7f5fa362c664d68ba7221259be1cbd187434b2f0.idx", &statbuf));
 	cl_assert_equal_i(statbuf.st_mode & os_mask, (expected & ~mask) & os_mask);
 
-	cl_git_pass(p_stat("pack-80e61eb315239ef3c53033e37fee43b744d57122.pack", &statbuf));
+	cl_git_pass(p_stat("pack-7f5fa362c664d68ba7221259be1cbd187434b2f0.pack", &statbuf));
 	cl_assert_equal_i(statbuf.st_mode & os_mask, (expected & ~mask) & os_mask);
 }
 


### PR DESCRIPTION
Use the hash of the complete packfile as the filename instead of the hash of just the OIDs.  This matches the behavior of core git, which changed in 2013 in [commit 1190a1a](https://github.com/git/git/commit/1190a1acf800acdcfd7569f87ac1560e2d077414).  The message for that commit includes the reasoning behind the change.  

I ran into a problem with the current naming in an application that occasionally performs two fetches of the same remote at the same time.  The objects in the resulting packfiles are the same, so they get the same filename, but the contents are sometimes different, likely because pack building is multi-threaded.  The second fetch to complete will overwrite the `.idx` file from the first fetch, but fail to rename the `.pack` file, so the `.idx` and `.pack` files don't match.  Reading a branch that was just fetched will then fail with "Target OID for the reference doesn't exist on the repository".  

The second commit adds error handling to the rename call so that this situation would also report an error to the client.  
