### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -401,7 +401,7 @@ done:
 static int submodules_from_head(git_strmap *map, git_tree *head, git_config *cfg)
 {
 	int error;
-	git_iterator *i;
+	git_iterator *i = NULL;
 	const git_index_entry *entry;
 	git_strmap *names = 0;
 	git_strmap_alloc(&names);


### PR DESCRIPTION
Fix the following warning emitted by clang:

```
[ 16%] Building C object CMakeFiles/libgit2_clar.dir/src/submodule.c.o
/Users/mplough/devel/external/libgit2/src/submodule.c:408:6: warning: variable 'i' is used uninitialized whenever 'if' condition is true
      [-Wsometimes-uninitialized]
        if ((error = load_submodule_names(names, cfg)))
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mplough/devel/external/libgit2/src/submodule.c:448:20: note: uninitialized use occurs here
        git_iterator_free(i);
                          ^
/Users/mplough/devel/external/libgit2/src/submodule.c:408:2: note: remove the 'if' if its condition is always false
        if ((error = load_submodule_names(names, cfg)))
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mplough/devel/external/libgit2/src/submodule.c:404:17: note: initialize the variable 'i' to silence this warning
        git_iterator *i;
                       ^
                        = NULL
1 warning generated.
```