### PR TITLE
Fix proxy auto detect not utilizing callbacks

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -575,6 +575,9 @@ static int apply_proxy_config(http_subtransport *t)
 		if ((error = git_remote__get_http_proxy(t->owner->owner, !!t->connection_data.use_ssl, &url)) < 0)
 			return error;
 
+		opts.credentials = t->owner->proxy.credentials;
+		opts.certificate_check = t->owner->proxy.certificate_check;
+		opts.payload = t->owner->proxy.payload;
 		opts.type = GIT_PROXY_SPECIFIED;
 		opts.url = url;
 		error = git_stream_set_proxy(t->io, &opts);


### PR DESCRIPTION
When using an authenticated proxy and setting proxy_options `type` to `GIT_PROXY_AUTO`, the credentials, certificate check, and payload are discarded. The implication is users will not be prompted for credentials when proxy type is set to auto. I've fixed this by transferring the credentials, certificate_check, and payload to the new struct when in apply_proxy_config.