### PR TITLE
Flag given_opts in git_revert as optional

### DIFF
--- a/include/git2/revert.h
+++ b/include/git2/revert.h
@@ -75,7 +75,7 @@ GIT_EXTERN(int) git_revert_commit(
  *
  * @param repo the repository to revert
  * @param commit the commit to revert
- * @param given_opts merge flags
+ * @param given_opts the revert options (or null for defaults)
  * @return zero on success, -1 on failure.
  */
 GIT_EXTERN(int) git_revert(


### PR DESCRIPTION
The documentation for `git_revert` as of [v0.24.2](https://libgit2.github.com/libgit2/#v0.24.2/group/revert/git_revert) doesn't state that it can be null. However, if you look at the [code](https://github.com/libgit2/libgit2/blob/909d5494368a00809bc42f4780e86f4dd66e4422/src/revert.c#L81-L86) you will see that libgit2 will actually initialize options for the revert if `NULL` is passed into the function.

The header file should be updated as such to reflect that `given_opts` can actually be `NULL`.