### PR TITLE
Flag checkout_opts in git_reset as optional

### DIFF
--- a/include/git2/reset.h
+++ b/include/git2/reset.h
@@ -53,7 +53,7 @@ typedef enum {
  *
  * @param reset_type Kind of reset operation to perform.
  *
- * @param checkout_opts Checkout options to be used for a HARD reset.
+ * @param checkout_opts Optional checkout options to be used for a HARD reset.
  * The checkout_strategy field will be overridden (based on reset_type).
  * This parameter can be used to propagate notify and progress callbacks.
  *


### PR DESCRIPTION
The documentation for `git_reset` doesn't state that `check-out_opts` can be optional in its documentation. However, if you look at a [test file](https://github.com/libgit2/libgit2/blob/9bc8c80ffa3d20e958406a104c521e2aae0f1255/tests/reset/hard.c#L74) you will see that `NULL` is used everywhere.

The header file should be updated to reflect that `check_opts` is actually an optional argument.