### PR TITLE
Add support for lowercase proxy environment variables

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -774,6 +774,18 @@ int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_ur
 	error = git__getenv(&val, use_ssl ? "HTTPS_PROXY" : "HTTP_PROXY");
 
 	if (error < 0) {
+		if (error != GIT_ENOTFOUND) {
+			return error;
+		}
+
+		giterr_clear();
+		error = 0;
+	}
+
+	/* try lowercase environment variables */
+	error = git__getenv(&val, use_ssl ? "https_proxy" : "http_proxy");
+
+	if (error < 0) {
 		if (error == GIT_ENOTFOUND) {
 			giterr_clear();
 			error = 0;

--- a/src/remote.c
+++ b/src/remote.c
@@ -773,10 +773,9 @@ int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_ur
 	/* http_proxy / https_proxy environment variables */
 	error = git__getenv(&val, use_ssl ? "https_proxy" : "http_proxy");
 
-	if (error == GIT_ENOTFOUND) {
-		/* try uppercase environment variables */
+	/* try uppercase environment variables */
+	if (error == GIT_ENOTFOUND)
 		error = git__getenv(&val, use_ssl ? "HTTPS_PROXY" : "HTTP_PROXY");
-	}
 
 	if (error < 0) {
 		if (error == GIT_ENOTFOUND) {

--- a/src/remote.c
+++ b/src/remote.c
@@ -770,20 +770,13 @@ int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_ur
 		goto found;
 	}
 
-	/* HTTP_PROXY / HTTPS_PROXY environment variables */
-	error = git__getenv(&val, use_ssl ? "HTTPS_PROXY" : "HTTP_PROXY");
-
-	if (error < 0) {
-		if (error != GIT_ENOTFOUND) {
-			return error;
-		}
-
-		giterr_clear();
-		error = 0;
-	}
-
-	/* try lowercase environment variables */
+	/* http_proxy / https_proxy environment variables */
 	error = git__getenv(&val, use_ssl ? "https_proxy" : "http_proxy");
+
+	if (error == GIT_ENOTFOUND) {
+		/* try uppercase environment variables */
+		error = git__getenv(&val, use_ssl ? "HTTPS_PROXY" : "HTTP_PROXY");
+	}
 
 	if (error < 0) {
 		if (error == GIT_ENOTFOUND) {


### PR DESCRIPTION
curl supports HTTPS_PROXY in addition to https_proxy (and their http counterparts). This change ensures parity with curl's behavior.