### PR TITLE
Changes to provide option to turn off/on ofs_delta

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -178,6 +178,7 @@ typedef enum {
 	GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION,
 	GIT_OPT_SET_SSL_CIPHERS,
 	GIT_OPT_GET_USER_AGENT,
+	GIT_OPT_ENABLE_OFS_DELTA,
 } git_libgit2_opt_t;
 
 /**
@@ -304,6 +305,16 @@ typedef enum {
  *		> Set the SSL ciphers use for HTTPS connections.
  *		>
  *		> - `ciphers` is the list of ciphers that are eanbled.
+ *
+ *	* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)
+ *
+ *		> Enable or disable the use of "offset deltas" when creating packfiles,
+ *		> and the negotiation of them when talking to a remote server.
+ *		> Offset deltas store a delta base location as an offset into the
+ *		> packfile from the current location, which provides a shorter encoding
+ *		> and thus smaller resultant packfiles.
+ *		> Packfiles containing offset deltas can still be read.
+ *		> This defaults to enabled.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/src/settings.c
+++ b/src/settings.c
@@ -16,6 +16,7 @@
 #include "global.h"
 #include "object.h"
 #include "refs.h"
+#include "transports/smart.h"
 
 void git_libgit2_version(int *major, int *minor, int *rev)
 {
@@ -220,6 +221,10 @@ int git_libgit2_opts(int key, ...)
 			git_buf_sanitize(out);
 			error = git_buf_sets(out, git__user_agent);
 		}
+		break;
+
+	case GIT_OPT_ENABLE_OFS_DELTA:
+		git_smart__ofs_delta_enabled = (va_arg(ap, int) != 0);
 		break;
 
 	default:

--- a/src/transports/smart.h
+++ b/src/transports/smart.h
@@ -26,6 +26,8 @@
 #define GIT_CAP_THIN_PACK "thin-pack"
 #define GIT_CAP_SYMREF "symref"
 
+extern bool git_smart__ofs_delta_enabled;
+
 enum git_pkt_type {
 	GIT_PKT_CMD,
 	GIT_PKT_FLUSH,

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -19,6 +19,8 @@
 /* The minimal interval between progress updates (in seconds). */
 #define MIN_PROGRESS_UPDATE_INTERVAL 0.5
 
+bool git_smart__ofs_delta_enabled = true;
+
 int git_smart__store_refs(transport_smart *t, int flushes)
 {
 	gitno_buffer *buf = &t->buffer;
@@ -138,7 +140,7 @@ int git_smart__detect_caps(git_pkt_ref *pkt, transport_smart_caps *caps, git_vec
 		if (*ptr == ' ')
 			ptr++;
 
-		if (!git__prefixcmp(ptr, GIT_CAP_OFS_DELTA)) {
+		if (git_smart__ofs_delta_enabled && !git__prefixcmp(ptr, GIT_CAP_OFS_DELTA)) {
 			caps->common = caps->ofs_delta = 1;
 			ptr += strlen(GIT_CAP_OFS_DELTA);
 			continue;


### PR DESCRIPTION
This change provides an option in git_libgit2_opt_t which can be used in git_libgit2_opts to turn off/on ofs_delta capability in libGit2

This is related to Issue #1414 in libgit2Sharp repository
https://github.com/libgit2/libgit2sharp/issues/1414