### PR TITLE
Flag options in git_stash_apply and git_stash_pop as being optional

### DIFF
--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -173,7 +173,7 @@ GIT_EXTERN(int) git_stash_apply_init_options(
  * @param repo The owning repository.
  * @param index The position within the stash list. 0 points to the
  *              most recent stashed state.
- * @param options Options to control how stashes are applied.
+ * @param options Optional options to control how stashes are applied.
  *
  * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the
  *         given index, GIT_EMERGECONFLICT if changes exist in the working
@@ -242,7 +242,7 @@ GIT_EXTERN(int) git_stash_drop(
  * @param repo The owning repository.
  * @param index The position within the stash list. 0 points to the
  *              most recent stashed state.
- * @param options Options to control how stashes are applied.
+ * @param options Optional options to control how stashes are applied.
  *
  * @return 0 on success, GIT_ENOTFOUND if there's no stashed state for the given
  * index, or error code. (see git_stash_apply() above for details)


### PR DESCRIPTION
The options parameter in both [git_stash_apply](https://github.com/libgit2/libgit2/blob/0175971e91641cd07246f59003930d81019ce40b/tests/stash/apply.c#L105) and [git_stash_pop](https://github.com/libgit2/libgit2/blob/0175971e91641cd07246f59003930d81019ce40b/tests/stash/apply.c#L307) can be `NULL` as can be seen in the linked tests. The documentation in the `stash.h` header file should reflect this.