### PR TITLE
refdb: catch additional per-worktree refs

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -365,12 +365,17 @@ static const char *loose_parse_symbolic(git_buf *file_content)
 	return refname_start;
 }
 
+/*
+ * Returns whether a reference is stored per worktree or not.
+ * Per-worktree references are:
+ *
+ * - all pseudorefs, e.g. HEAD and MERGE_HEAD
+ * - all references stored inside of "refs/bisect/"
+ */
 static bool is_per_worktree_ref(const char *ref_name)
 {
-	return strcmp("HEAD", ref_name) == 0 ||
-	    strcmp("FETCH_HEAD", ref_name) == 0 ||
-	    strcmp("MERGE_HEAD", ref_name) == 0 ||
-	    strcmp("ORIG_HEAD", ref_name) == 0;
+	return git__prefixcmp(ref_name, "refs/") != 0 ||
+	    git__prefixcmp(ref_name, "refs/bisect/") == 0;
 }
 
 static int loose_lookup(


### PR DESCRIPTION
The upstream git.git project currently identifies all references inside
of `refs/bisect/` as well as `HEAD` as per-worktree references. This is
already incorrect and is currently being fixed by an in-flight topic
[1]. The new behavior will be to match all pseudo-references outside of
the `refs/` hierarchy as well as `refs/bisect/`.

Our current behavior is to mark a selection of pseudo-references as
per-worktree, only. This matches more pseudo-references than current
git, but forgets about `refs/bisect/`. Adjust behavior to match the
in-flight topic, that is classify the following references as
per-worktree:

- everything outside of `refs/`
- everything inside of `refs/bisect/`

[1]: <20170213152011.12050-1-pclouds@gmail.com>