### PR TITLE
Forced checkout

### DIFF
--- a/tests/checkout/head.c
+++ b/tests/checkout/head.c
@@ -60,3 +60,79 @@ void test_checkout_head__with_index_only_tree(void)
 
 	git_index_free(index);
 }
+
+void test_checkout_head__do_not_remove_untracked_file(void)
+{
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_index *index;
+
+	cl_git_pass(p_mkdir("testrepo/tracked", 0755));
+	cl_git_mkfile("testrepo/tracked/tracked", "tracked\n");
+	cl_git_mkfile("testrepo/tracked/untracked", "untracked\n");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "tracked/tracked"));
+	cl_git_pass(git_index_write(index));
+
+	git_index_free(index);
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+	cl_git_pass(git_checkout_head(g_repo, &opts));
+
+	cl_assert(!git_path_isfile("testrepo/tracked/tracked"));
+	cl_assert(git_path_isfile("testrepo/tracked/untracked"));
+}
+
+void test_checkout_head__do_not_remove_untracked_file_in_subdir(void)
+{
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_index *index;
+
+	cl_git_pass(p_mkdir("testrepo/tracked", 0755));
+	cl_git_pass(p_mkdir("testrepo/tracked/subdir", 0755));
+	cl_git_mkfile("testrepo/tracked/tracked", "tracked\n");
+	cl_git_mkfile("testrepo/tracked/subdir/tracked", "tracked\n");
+	cl_git_mkfile("testrepo/tracked/subdir/untracked", "untracked\n");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "tracked/tracked"));
+	cl_git_pass(git_index_add_bypath(index, "tracked/subdir/tracked"));
+	cl_git_pass(git_index_write(index));
+
+	git_index_free(index);
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+	cl_git_pass(git_checkout_head(g_repo, &opts));
+
+	cl_assert(!git_path_isfile("testrepo/tracked/tracked"));
+	cl_assert(!git_path_isfile("testrepo/tracked/subdir/tracked"));
+	cl_assert(git_path_isfile("testrepo/tracked/subdir/untracked"));
+}
+
+void test_checkout_head__do_remove_tracked_subdir(void)
+{
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_index *index;
+
+	cl_git_pass(p_mkdir("testrepo/subdir", 0755));
+	cl_git_pass(p_mkdir("testrepo/subdir/tracked", 0755));
+	cl_git_mkfile("testrepo/subdir/tracked-file", "tracked\n");
+	cl_git_mkfile("testrepo/subdir/untracked-file", "untracked\n");
+	cl_git_mkfile("testrepo/subdir/tracked/tracked1", "tracked\n");
+	cl_git_mkfile("testrepo/subdir/tracked/tracked2", "tracked\n");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "subdir/tracked-file"));
+	cl_git_pass(git_index_add_bypath(index, "subdir/tracked/tracked1"));
+	cl_git_pass(git_index_add_bypath(index, "subdir/tracked/tracked2"));
+	cl_git_pass(git_index_write(index));
+
+	git_index_free(index);
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+	cl_git_pass(git_checkout_head(g_repo, &opts));
+
+	cl_assert(!git_path_isdir("testrepo/subdir/tracked"));
+	cl_assert(!git_path_isfile("testrepo/subdir/tracked-file"));
+	cl_assert(git_path_isfile("testrepo/subdir/untracked-file"));
+}

--- a/tests/checkout/head.c
+++ b/tests/checkout/head.c
@@ -38,7 +38,7 @@ void test_checkout_head__with_index_only_tree(void)
 	cl_git_pass(git_repository_index(&index, g_repo));
 
 	p_mkdir("testrepo/newdir", 0777);
-    cl_git_mkfile("testrepo/newdir/newfile.txt", "new file\n");
+	cl_git_mkfile("testrepo/newdir/newfile.txt", "new file\n");
 
 	cl_git_pass(git_index_add_bypath(index, "newdir/newfile.txt"));
 	cl_git_pass(git_index_write(index));


### PR DESCRIPTION
A failing test for #4125.

The issue is that we delete untracked files in directories which contain newly created tracked files. E.g. a directory `dir/` contains a newly added and staged `dir/tracked` and an untracked `dir/untracked`. `git reset --hard` will delete `dir/tracked` only when doing a `git reset --hard HEAD -- dir` and not touch `dir/untracked`.

The issue resised in `checkout_action_wd_only`. The function is responsible for handling items which are present only in the working directory and not in the current commit. The interesting call path is the following:

1. call `checkout_action_wd_only` on `dir/`
2. is it tracked? -> yes
3. is it a tree? -> yes
4. is the index entry following the tree tracked as well? -> yes, we have `dir/tracked`

If this criteria matches, we decide that we can simply delete the complete directory (if `GIT_CHECKOUT_FORCE` is given). We obviously miss the step to see if there are any _untracked_ files inside of the directory - in which case we cannot just delete it. This check is missing [here](https://github.com/libgit2/libgit2/blob/master/src/checkout.c#L373).

So I actually couldn't think of an efficient thing yet to fix the issue, so for now I'm just leaving the test and my observations here.