### PR TITLE
Improve clar messages

### DIFF
--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -50,7 +50,7 @@ extern char *p_realpath(const char *, char *);
 #define p_strcasecmp(s1, s2) strcasecmp(s1, s2)
 #define p_strncasecmp(s1, s2, c) strncasecmp(s1, s2, c)
 #define p_vsnprintf(b, c, f, a) vsnprintf(b, c, f, a)
-#define p_snprintf(b, c, f, ...) snprintf(b, c, f, __VA_ARGS__)
+#define p_snprintf(b, c, ...) snprintf(b, c, __VA_ARGS__)
 #define p_mkstemp(p) mkstemp(p)
 #define p_chdir(p) chdir(p)
 #define p_chmod(p,m) chmod(p, m)

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -21,7 +21,7 @@ static void assert_is_ignored_(
 {
 	int is_ignored = 0;
 
-	cl_git_exec(
+	cl_git_expect(
 		git_ignore_path_is_ignored(&is_ignored, g_repo, filepath), 0, file, line);
 
 	clar__assert_equal(

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -21,8 +21,8 @@ static void assert_is_ignored_(
 {
 	int is_ignored = 0;
 
-	cl_git_pass_(
-		git_ignore_path_is_ignored(&is_ignored, g_repo, filepath), file, line);
+	cl_git_exec(
+		git_ignore_path_is_ignored(&is_ignored, g_repo, filepath), 0, file, line);
 
 	clar__assert_equal(
 		file, line, "expected != is_ignored", 1, "%d",

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -4,12 +4,20 @@
 #include "git2/sys/repository.h"
 
 void cl_git_report_failure(
-	int error, const char *file, int line, const char *fncall)
+	int error, int expected, const char *file, int line, const char *fncall)
 {
 	char msg[4096];
 	const git_error *last = giterr_last();
-	p_snprintf(msg, 4096, "error %d - %s",
-		error, last ? last->message : "<no message>");
+
+	if (expected)
+		p_snprintf(msg, 4096, "error %d (expected %d) - %s",
+			error, expected, last ? last->message : "<no message>");
+	else if (error || last)
+		p_snprintf(msg, 4096, "error %d - %s",
+			error, last ? last->message : "<no message>");
+	else
+		p_snprintf(msg, 4096, "no error, expected non-zero return");
+
 	clar__assert(0, file, line, fncall, msg, 1);
 }
 

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -12,13 +12,15 @@
  *
  * Use this wrapper around all `git_` library calls that return error codes!
  */
-#define cl_git_pass(expr) cl_git_pass_((expr), __FILE__, __LINE__)
+#define cl_git_pass(expr) cl_git_exec((expr), 0, __FILE__, __LINE__)
 
-#define cl_git_pass_(expr, file, line) do { \
+#define cl_git_fail_with(error, expr) cl_git_exec((expr), error, __FILE__, __LINE__)
+
+#define cl_git_exec(expr, expected, file, line) do { \
 	int _lg2_error; \
 	giterr_clear(); \
-	if ((_lg2_error = (expr)) != 0) \
-		cl_git_report_failure(_lg2_error, file, line, "Function call failed: " #expr); \
+	if ((_lg2_error = (expr)) != expected) \
+		cl_git_report_failure(_lg2_error, expected, file, line, "Function call failed: " #expr); \
 	} while (0)
 
 /**
@@ -26,9 +28,11 @@
  * just for consistency. Use with `git_` library
  * calls that are supposed to fail!
  */
-#define cl_git_fail(expr) cl_must_fail(expr)
-
-#define cl_git_fail_with(expr, error) cl_assert_equal_i(error,expr)
+#define cl_git_fail(expr) do { \
+	giterr_clear(); \
+	if ((expr) == 0) \
+		cl_git_report_failure(0, 0, __FILE__, __LINE__, "Function call succeeded: " #expr); \
+	} while (0)
 
 /**
  * Like cl_git_pass, only for Win32 error code conventions
@@ -37,7 +41,7 @@
 	int _win32_res; \
 	if ((_win32_res = (expr)) == 0) { \
 		giterr_set(GITERR_OS, "Returned: %d, system error code: %d", _win32_res, GetLastError()); \
-		cl_git_report_failure(_win32_res, __FILE__, __LINE__, "System call failed: " #expr); \
+		cl_git_report_failure(_win32_res, 0, __FILE__, __LINE__, "System call failed: " #expr); \
 	} \
 	} while(0)
 
@@ -86,7 +90,7 @@ GIT_INLINE(void) cl_git_thread_check(void *data)
 		clar__assert(0, threaderr->file, threaderr->line, threaderr->expr, threaderr->error_msg, 1);
 }
 
-void cl_git_report_failure(int, const char *, int, const char *);
+void cl_git_report_failure(int, int, const char *, int, const char *);
 
 #define cl_assert_at_line(expr,file,line) \
 	clar__assert((expr) != 0, file, line, "Expression is not true: " #expr, NULL, 1)

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -12,11 +12,11 @@
  *
  * Use this wrapper around all `git_` library calls that return error codes!
  */
-#define cl_git_pass(expr) cl_git_exec((expr), 0, __FILE__, __LINE__)
+#define cl_git_pass(expr) cl_git_expect((expr), 0, __FILE__, __LINE__)
 
-#define cl_git_fail_with(error, expr) cl_git_exec((expr), error, __FILE__, __LINE__)
+#define cl_git_fail_with(error, expr) cl_git_expect((expr), error, __FILE__, __LINE__)
 
-#define cl_git_exec(expr, expected, file, line) do { \
+#define cl_git_expect(expr, expected, file, line) do { \
 	int _lg2_error; \
 	giterr_clear(); \
 	if ((_lg2_error = (expr)) != expected) \

--- a/tests/repo/env.c
+++ b/tests/repo/env.c
@@ -56,8 +56,8 @@ static int GIT_FORMAT_PRINTF(2, 3) cl_setenv_printf(const char *name, const char
 static void env_pass_(const char *path, const char *file, int line)
 {
 	git_repository *repo;
-	cl_git_exec(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
-	cl_git_exec(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
+	cl_git_expect(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
+	cl_git_expect(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
 	cl_assert_at_line(git__suffixcmp(git_repository_path(repo), "attr/.git/") == 0, file, line);
 	cl_assert_at_line(git__suffixcmp(git_repository_workdir(repo), "attr/") == 0, file, line);
 	cl_assert_at_line(!git_repository_is_bare(repo), file, line);
@@ -98,24 +98,24 @@ static void env_check_objects_(bool a, bool t, bool p, const char *file, int lin
 	cl_git_pass(git_oid_fromstr(&oid_a, "45141a79a77842c59a63229403220a4e4be74e3d"));
 	cl_git_pass(git_oid_fromstr(&oid_t, "1385f264afb75a56a5bec74243be9b367ba4ca08"));
 	cl_git_pass(git_oid_fromstr(&oid_p, "0df1a5865c8abfc09f1f2182e6a31be550e99f07"));
-	cl_git_exec(git_repository_open_ext(&repo, "attr", GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
+	cl_git_expect(git_repository_open_ext(&repo, "attr", GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
 
 	if (a) {
-		cl_git_exec(git_object_lookup(&object, repo, &oid_a, GIT_OBJ_BLOB), 0, file, line);
+		cl_git_expect(git_object_lookup(&object, repo, &oid_a, GIT_OBJ_BLOB), 0, file, line);
 		git_object_free(object);
 	} else {
 		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_a, GIT_OBJ_BLOB), file, line);
 	}
 
 	if (t) {
-		cl_git_exec(git_object_lookup(&object, repo, &oid_t, GIT_OBJ_BLOB), 0, file, line);
+		cl_git_expect(git_object_lookup(&object, repo, &oid_t, GIT_OBJ_BLOB), 0, file, line);
 		git_object_free(object);
 	} else {
 		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_t, GIT_OBJ_BLOB), file, line);
 	}
 
 	if (p) {
-		cl_git_exec(git_object_lookup(&object, repo, &oid_p, GIT_OBJ_COMMIT), 0, file, line);
+		cl_git_expect(git_object_lookup(&object, repo, &oid_p, GIT_OBJ_COMMIT), 0, file, line);
 		git_object_free(object);
 	} else {
 		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_p, GIT_OBJ_COMMIT), file, line);

--- a/tests/repo/env.c
+++ b/tests/repo/env.c
@@ -56,8 +56,8 @@ static int GIT_FORMAT_PRINTF(2, 3) cl_setenv_printf(const char *name, const char
 static void env_pass_(const char *path, const char *file, int line)
 {
 	git_repository *repo;
-	cl_git_pass_(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, line);
-	cl_git_pass_(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, line);
+	cl_git_exec(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
+	cl_git_exec(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
 	cl_assert_at_line(git__suffixcmp(git_repository_path(repo), "attr/.git/") == 0, file, line);
 	cl_assert_at_line(git__suffixcmp(git_repository_workdir(repo), "attr/") == 0, file, line);
 	cl_assert_at_line(!git_repository_is_bare(repo), file, line);
@@ -98,24 +98,24 @@ static void env_check_objects_(bool a, bool t, bool p, const char *file, int lin
 	cl_git_pass(git_oid_fromstr(&oid_a, "45141a79a77842c59a63229403220a4e4be74e3d"));
 	cl_git_pass(git_oid_fromstr(&oid_t, "1385f264afb75a56a5bec74243be9b367ba4ca08"));
 	cl_git_pass(git_oid_fromstr(&oid_p, "0df1a5865c8abfc09f1f2182e6a31be550e99f07"));
-	cl_git_pass_(git_repository_open_ext(&repo, "attr", GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, line);
+	cl_git_exec(git_repository_open_ext(&repo, "attr", GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
 
 	if (a) {
-		cl_git_pass_(git_object_lookup(&object, repo, &oid_a, GIT_OBJ_BLOB), file, line);
+		cl_git_exec(git_object_lookup(&object, repo, &oid_a, GIT_OBJ_BLOB), 0, file, line);
 		git_object_free(object);
 	} else {
 		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_a, GIT_OBJ_BLOB), file, line);
 	}
 
 	if (t) {
-		cl_git_pass_(git_object_lookup(&object, repo, &oid_t, GIT_OBJ_BLOB), file, line);
+		cl_git_exec(git_object_lookup(&object, repo, &oid_t, GIT_OBJ_BLOB), 0, file, line);
 		git_object_free(object);
 	} else {
 		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_t, GIT_OBJ_BLOB), file, line);
 	}
 
 	if (p) {
-		cl_git_pass_(git_object_lookup(&object, repo, &oid_p, GIT_OBJ_COMMIT), file, line);
+		cl_git_exec(git_object_lookup(&object, repo, &oid_p, GIT_OBJ_COMMIT), 0, file, line);
 		git_object_free(object);
 	} else {
 		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_p, GIT_OBJ_COMMIT), file, line);

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -20,8 +20,8 @@ static void assert_ignored_(
 	bool expected, const char *filepath, const char *file, int line)
 {
 	int is_ignored = 0;
-	cl_git_pass_(
-		git_status_should_ignore(&is_ignored, g_repo, filepath), file, line);
+	cl_git_exec(
+		git_status_should_ignore(&is_ignored, g_repo, filepath), 0, file, line);
 	clar__assert(
 		(expected != 0) == (is_ignored != 0),
 		file, line, "expected != is_ignored", filepath, 1);

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -20,7 +20,7 @@ static void assert_ignored_(
 	bool expected, const char *filepath, const char *file, int line)
 {
 	int is_ignored = 0;
-	cl_git_exec(
+	cl_git_expect(
 		git_status_should_ignore(&is_ignored, g_repo, filepath), 0, file, line);
 	clar__assert(
 		(expected != 0) == (is_ignored != 0),

--- a/tests/submodule/submodule_helpers.c
+++ b/tests/submodule/submodule_helpers.c
@@ -204,7 +204,7 @@ void assert__submodule_exists(
 	git_submodule *sm;
 	int error = git_submodule_lookup(&sm, repo, name);
 	if (error)
-		cl_git_report_failure(error, file, line, msg);
+		cl_git_report_failure(error, 0, file, line, msg);
 	cl_assert_at_line(sm != NULL, file, line);
 	git_submodule_free(sm);
 }


### PR DESCRIPTION
Provide more detailed messages when conditions pass or fail unexpectedly.  In particular, this provides the error messages when a test fails with a different error code than was expected.

`cl_git_pass` failures look unchanged:
```
  1) Failure:
apply::fromfile::test_name [tests/apply/fromfile.c:42]
  Function call failed: (git_patch_from_buffer(&patch, "", 0, ((void *)0)))
  error -3 - no patch found
```

`cl_git_fail` messages now:
```
  1) Failure:
apply::fromfile::test_name [tests/apply/fromfile.c:42]
  Function call succeeded: git_patch_from_buffer(&patch, patchfile, strlen(patchfile), NULL)
  no error, expected non-zero return
```

`cl_git_fail_with` messages now:
```
  1) Failure:
apply::fromfile::test_name [tests/apply/fromfile.c:42]
  Function call failed: (git_patch_from_buffer(&patch, "", 0, ((void *)0)))
  error -3 (expected -99) - no patch found
```

/cc @pks-t 