### PR TITLE
Provide error on gcc < 4.1 when THREADSAFE

### DIFF
--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -7,6 +7,12 @@
 #ifndef INCLUDE_thread_utils_h__
 #define INCLUDE_thread_utils_h__
 
+#if defined(__GNUC__) && defined(GIT_THREADS)
+# if (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 1))
+#  error Atomic primitives do not exist on this version of gcc; configure libgit2 with -DTHREADSAFE=OFF
+# endif
+#endif
+
 /* Common operations even if threading has been disabled */
 typedef struct {
 #if defined(GIT_WIN32)


### PR DESCRIPTION
Provide a descriptive error message when compiling `THREADSAFE` on gcc versions < 4.1.  We require the atomic primitives (eg `__sync_synchronize`) that were introduced in that version.

(Note, clang setes `__GNUC__` but appears to set its version > 4.1.)