### PR TITLE
tests: Add create__symbolic_with_arbitrary_content

### DIFF
--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -12,12 +12,12 @@ static git_repository *g_repo;
 
 void test_refs_create__initialize(void)
 {
-   g_repo = cl_git_sandbox_init("testrepo");
+	g_repo = cl_git_sandbox_init("testrepo");
 }
 
 void test_refs_create__cleanup(void)
 {
-   cl_git_sandbox_cleanup();
+	cl_git_sandbox_cleanup();
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, 1));
@@ -25,7 +25,7 @@ void test_refs_create__cleanup(void)
 
 void test_refs_create__symbolic(void)
 {
-   // create a new symbolic reference
+	/* create a new symbolic reference */
 	git_reference *new_reference, *looked_up_ref, *resolved_ref;
 	git_repository *repo2;
 	git_oid id;
@@ -116,7 +116,7 @@ void test_refs_create__symbolic_with_arbitrary_content(void)
 
 void test_refs_create__deep_symbolic(void)
 {
-   // create a deep symbolic reference
+	/* create a deep symbolic reference */
 	git_reference *new_reference, *looked_up_ref, *resolved_ref;
 	git_oid id;
 
@@ -136,7 +136,7 @@ void test_refs_create__deep_symbolic(void)
 
 void test_refs_create__oid(void)
 {
-   // create a new OID reference
+	/* create a new OID reference */
 	git_reference *new_reference, *looked_up_ref;
 	git_repository *repo2;
 	git_oid id;

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -20,6 +20,7 @@ void test_refs_create__cleanup(void)
    cl_git_sandbox_cleanup();
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, 1));
 }
 
 void test_refs_create__symbolic(void)
@@ -63,6 +64,54 @@ void test_refs_create__symbolic(void)
 	git_reference_free(new_reference);
 	git_reference_free(looked_up_ref);
 	git_reference_free(resolved_ref);
+}
+
+void test_refs_create__symbolic_with_arbitrary_content(void)
+{
+	git_reference *new_reference, *looked_up_ref;
+	git_repository *repo2;
+	git_oid id;
+
+	const char *new_head_tracker = "ANOTHER_HEAD_TRACKER";
+	const char *arbitrary_target = "ARBITRARY DATA";
+
+	git_oid_fromstr(&id, current_master_tip);
+
+	/* Attempt to create symbolic ref with arbitrary data in target
+	 * fails by default
+	 */
+	cl_git_fail(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, arbitrary_target, 0, NULL));
+
+	git_libgit2_opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, 0);
+
+	/* With strict target validation disabled, ref creation succeeds */
+	cl_git_pass(git_reference_symbolic_create(&new_reference, g_repo, new_head_tracker, arbitrary_target, 0, NULL));
+
+	/* Ensure the reference can be looked-up... */
+	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
+	cl_assert(git_reference_type(looked_up_ref) & GIT_REF_SYMBOLIC);
+	cl_assert(reference_is_packed(looked_up_ref) == 0);
+	cl_assert_equal_s(looked_up_ref->name, new_head_tracker);
+
+	/* Ensure the target is what we expect it to be */
+	cl_assert_equal_s(git_reference_symbolic_target(new_reference), arbitrary_target);
+
+	/* Similar test with a fresh new repository object */
+	cl_git_pass(git_repository_open(&repo2, "testrepo"));
+
+	/* Ensure the reference can be looked-up... */
+	cl_git_pass(git_reference_lookup(&looked_up_ref, repo2, new_head_tracker));
+	cl_assert(git_reference_type(looked_up_ref) & GIT_REF_SYMBOLIC);
+	cl_assert(reference_is_packed(looked_up_ref) == 0);
+	cl_assert_equal_s(looked_up_ref->name, new_head_tracker);
+
+	/* Ensure the target is what we expect it to be */
+	cl_assert_equal_s(git_reference_symbolic_target(new_reference), arbitrary_target);
+
+	git_repository_free(repo2);
+	git_reference_free(new_reference);
+	git_reference_free(looked_up_ref);
+
 }
 
 void test_refs_create__deep_symbolic(void)


### PR DESCRIPTION
This test ensures that it's possible to create a symbolic ref that
has arbitrary data as its target. It also ensures it's possible
to obtain the target of that symbolic reference from the git_reference
object.