### PR TITLE
git_commit_create: freshen tree objects in commit

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -159,6 +159,9 @@ static int git_commit__create_internal(
 	if (git_repository_odb__weakptr(&odb, repo) < 0)
 		goto cleanup;
 
+	if (git_odb__freshen(odb, tree) < 0)
+		goto cleanup;
+
 	if (git_odb_write(id, odb, buf.ptr, buf.size, GIT_OBJ_COMMIT) < 0)
 		goto cleanup;
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -695,7 +695,7 @@ static int odb_freshen_1(
 	return (int)found;
 }
 
-static int odb_freshen(git_odb *db, const git_oid *id)
+int git_odb__freshen(git_odb *db, const git_oid *id)
 {
 	assert(db && id);
 
@@ -1167,7 +1167,7 @@ int git_odb_write(
 	assert(oid && db);
 
 	git_odb_hash(oid, data, len, type);
-	if (odb_freshen(db, oid))
+	if (git_odb__freshen(db, oid))
 		return 0;
 
 	for (i = 0; i < db->backends.length && error < 0; ++i) {
@@ -1293,7 +1293,7 @@ int git_odb_stream_finalize_write(git_oid *out, git_odb_stream *stream)
 
 	git_hash_final(out, stream->hash_ctx);
 
-	if (odb_freshen(stream->backend->odb, out))
+	if (git_odb__freshen(stream->backend->odb, out))
 		return 0;
 
 	return stream->finalize_write(stream, out);

--- a/src/odb.h
+++ b/src/odb.h
@@ -98,6 +98,9 @@ int git_odb__read_header_or_object(
 	git_odb_object **out, size_t *len_p, git_otype *type_p,
 	git_odb *db, const git_oid *id);
 
+/* freshen an entry in the object database */
+int git_odb__freshen(git_odb *db, const git_oid *id);
+
 /* fully free the object; internal method, DO NOT EXPORT */
 void git_odb_object__free(void *object);
 

--- a/tests/odb/freshen.c
+++ b/tests/odb/freshen.c
@@ -17,34 +17,99 @@ void test_odb_freshen__cleanup(void)
 	cl_git_sandbox_cleanup();
 }
 
-#define LOOSE_STR "hey\n"
-#define LOOSE_ID  "1385f264afb75a56a5bec74243be9b367ba4ca08"
-#define LOOSE_FN  "13/85f264afb75a56a5bec74243be9b367ba4ca08"
+static void set_time_wayback(struct stat *out, const char *fn)
+{
+	git_buf fullpath = GIT_BUF_INIT;
+	struct p_timeval old[2];
 
-void test_odb_freshen__loose_object(void)
+	old[0].tv_sec = 1234567890;
+	old[0].tv_usec = 0;
+	old[1].tv_sec = 1234567890;
+	old[1].tv_usec = 0;
+
+	git_buf_joinpath(&fullpath, "testrepo.git/objects", fn);
+
+	cl_must_pass(p_utimes(git_buf_cstr(&fullpath), old));
+	cl_must_pass(p_lstat(git_buf_cstr(&fullpath), out));
+	git_buf_free(&fullpath);
+}
+
+#define LOOSE_STR     "my new file\n"
+#define LOOSE_BLOB_ID "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd"
+#define LOOSE_BLOB_FN "a7/1586c1dfe8a71c6cbf6c129f404c5642ff31bd"
+
+void test_odb_freshen__loose_blob(void)
 {
 	git_oid expected_id, id;
 	struct stat before, after;
-	struct p_timeval old_times[2];
 
-	cl_git_pass(git_oid_fromstr(&expected_id, LOOSE_ID));
+	cl_git_pass(git_oid_fromstr(&expected_id, LOOSE_BLOB_ID));
+	set_time_wayback(&before, LOOSE_BLOB_FN);
 
-	old_times[0].tv_sec = 1234567890;
-	old_times[0].tv_usec = 0;
-	old_times[1].tv_sec = 1234567890;
-	old_times[1].tv_usec = 0;
-
-	/* set time to way back */
-	cl_must_pass(p_utimes("testrepo.git/objects/" LOOSE_FN, old_times));
-	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_FN, &before));
-
-	cl_git_pass(git_odb_write(&id, odb, LOOSE_STR, CONST_STRLEN(LOOSE_STR),
-		GIT_OBJ_BLOB));
+	/* make sure we freshen a blob */
+	cl_git_pass(git_blob_create_frombuffer(&id, repo, LOOSE_STR, CONST_STRLEN(LOOSE_STR)));
 	cl_assert_equal_oid(&expected_id, &id);
-	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_FN, &after));
+	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_BLOB_FN, &after));
 
 	cl_assert(before.st_atime < after.st_atime);
 	cl_assert(before.st_mtime < after.st_mtime);
+}
+
+#define LOOSE_TREE_ID "944c0f6e4dfa41595e6eb3ceecdb14f50fe18162"
+#define LOOSE_TREE_FN "94/4c0f6e4dfa41595e6eb3ceecdb14f50fe18162"
+
+void test_odb_freshen__loose_tree(void)
+{
+	git_oid expected_id, id;
+	git_tree *tree;
+	struct stat before, after;
+
+	cl_git_pass(git_oid_fromstr(&expected_id, LOOSE_TREE_ID));
+	set_time_wayback(&before, LOOSE_TREE_FN);
+
+	cl_git_pass(git_tree_lookup(&tree, repo, &expected_id));
+	cl_git_pass(git_tree_create_updated(&id, repo, tree, 0, NULL));
+
+	/* make sure we freshen a tree */
+	cl_assert_equal_oid(&expected_id, &id);
+	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_TREE_FN, &after));
+
+	cl_assert(before.st_atime < after.st_atime);
+	cl_assert(before.st_mtime < after.st_mtime);
+
+	git_tree_free(tree);
+}
+
+void test_odb_freshen__tree_during_commit(void)
+{
+	git_oid tree_id, parent_id, commit_id;
+	git_tree *tree;
+	git_commit *parent;
+	git_signature *signature;
+	struct stat before, after;
+
+	cl_git_pass(git_oid_fromstr(&tree_id, LOOSE_TREE_ID));
+	cl_git_pass(git_tree_lookup(&tree, repo, &tree_id));
+	set_time_wayback(&before, LOOSE_TREE_FN);
+
+	cl_git_pass(git_oid_fromstr(&parent_id, "a65fedf39aefe402d3bb6e24df4d4f5fe4547750"));
+	cl_git_pass(git_commit_lookup(&parent, repo, &parent_id));
+
+	cl_git_pass(git_signature_new(&signature,
+		"Refresher", "refresher@example.com", 1488547083, 0));
+
+	cl_git_pass(git_commit_create(&commit_id, repo, NULL,
+		signature, signature, NULL, "New commit pointing to old tree",
+		tree, 1, (const git_commit **)&parent));
+
+	/* make sure we freshen the tree the commit points to */
+	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_TREE_FN, &after));
+	cl_assert(before.st_atime < after.st_atime);
+	cl_assert(before.st_mtime < after.st_mtime);
+
+	git_signature_free(signature);
+	git_commit_free(parent);
+	git_tree_free(tree);
 }
 
 #define PACKED_STR "Testing a readme.txt\n"


### PR DESCRIPTION
Freshen the tree object that a commit points to during commit time.  This can help to freshen trees when a new commit is written that points to an old tree (but that tree id was recorded, instead of being newly computed with `git_odb_write`, which would have done the tree freshening itself.)

/cc @carlosmn 