### PR TITLE
Support using notes via a commit rather than a ref

### DIFF
--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -223,6 +223,32 @@ GIT_EXTERN(int) git_note_remove(
 	const git_oid *oid);
 
 /**
+ * Remove the note for an object
+ *
+ * @param notes_commit_out pointer to store the new notes commit (optional);
+ *					NULL in case of error.
+ *					When removing a note a new tree containing all notes
+ *					sans the note to be removed is created and a new commit
+ *					pointing to that tree is also created.
+ *					In the case where the resulting tree is an empty tree
+ *					a new commit pointing to this empty tree will be returned.
+ * @param repo repository where the note lives
+ * @param notes_commit a pointer to the notes commit object
+ * @param author signature of the notes commit author
+ * @param committer signature of the notes commit committer
+ * @param oid OID of the git object to remove the note from
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_note_commit_remove(
+		git_oid *notes_commit_out,
+		git_repository *repo,
+		git_commit *notes_commit,
+		const git_signature *author,
+		const git_signature *committer,
+		const git_oid *oid);
+
+/**
  * Free a git_note object
  *
  * @param note git_note object

--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -153,6 +153,36 @@ GIT_EXTERN(int) git_note_create(
 	const char *note,
 	int force);
 
+/**
+ * Add a note for an object from a commit
+ *
+ * This function will create a notes commit for a given object,
+ * the commit is a dangling commit, no reference is created.
+ *
+ * @param notes_commit_out pointer to store the commit (optional);
+ *					NULL in case of error
+ * @param notes_blob_out a point to the id of a note blob (optional)
+ * @param repo repository where the note will live
+ * @param parent Pointer to parent note
+ *					or NULL if this shall start a new notes tree
+ * @param author signature of the notes commit author
+ * @param committer signature of the notes commit committer
+ * @param oid OID of the git object to decorate
+ * @param note Content of the note to add for object oid
+ * @param allow_note_overwrite Overwrite existing note
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_note_commit_create(
+	git_oid *notes_commit_out,
+	git_oid *notes_blob_out,
+	git_repository *repo,
+	git_commit *parent,
+	const git_signature *author,
+	const git_signature *committer,
+	const git_oid *oid,
+	const char *note,
+	int allow_note_overwrite);
 
 /**
  * Remove the note for an object

--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -52,6 +52,20 @@ GIT_EXTERN(int) git_note_iterator_new(
 	const char *notes_ref);
 
 /**
+ * Creates a new iterator for notes from a commit
+ *
+ * The iterator must be freed manually by the user.
+ *
+ * @param out pointer to the iterator
+ * @param notes_commit a pointer to the notes commit object
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_note_commit_iterator_new(
+	git_note_iterator **out,
+	git_commit *notes_commit);
+
+/**
  * Frees an git_note_iterator
  *
  * @param it pointer to the iterator

--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -94,6 +94,25 @@ GIT_EXTERN(int) git_note_read(
 	const char *notes_ref,
 	const git_oid *oid);
 
+
+/**
+ * Read the note for an object from a note commit
+ *
+ * The note must be freed manually by the user.
+ *
+ * @param out pointer to the read note; NULL in case of error
+ * @param repo repository where to look up the note
+ * @param notes_commit a pointer to the notes commit object
+ * @param oid OID of the git object to read the note from
+ *
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_note_commit_read(
+	git_note **out,
+	git_repository *repo,
+	git_commit *notes_commit,
+	const git_oid *oid);
+
 /**
  * Get the note author
  *

--- a/src/notes.c
+++ b/src/notes.c
@@ -497,6 +497,37 @@ cleanup:
 	return error;
 }
 
+int git_note_commit_create(
+	git_oid *notes_commit_out,
+	git_oid *notes_blob_out,
+	git_repository *repo,
+	git_commit *parent,
+	const git_signature *author,
+	const git_signature *committer,
+	const git_oid *oid,
+	const char *note,
+	int allow_note_overwrite)
+{
+	int error;
+	git_tree *tree = NULL;
+	char target[GIT_OID_HEXSZ + 1];
+
+	git_oid_tostr(target, sizeof(target), oid);
+
+	if (parent != NULL && (error = git_commit_tree(&tree, parent)) < 0)
+		goto cleanup;
+
+	error = note_write(notes_commit_out, notes_blob_out, repo, author,
+			committer, NULL, note, tree, target, &parent, allow_note_overwrite);
+
+	if (error < 0)
+		goto cleanup;
+
+cleanup:
+	git_tree_free(tree);
+	return error;
+}
+
 int git_note_remove(git_repository *repo, const char *notes_ref_in,
 		const git_signature *author, const git_signature *committer,
 		const git_oid *oid)

--- a/src/notes.c
+++ b/src/notes.c
@@ -463,6 +463,28 @@ int git_note_read(git_note **out, git_repository *repo,
 	return error;
 }
 
+int git_note_commit_read(
+	git_note **out,
+	git_repository *repo,
+	git_commit *notes_commit,
+	const git_oid *oid)
+{
+	int error;
+	git_tree *tree = NULL;
+	char target[GIT_OID_HEXSZ + 1];
+
+	git_oid_tostr(target, sizeof(target), oid);
+
+	if ((error = git_commit_tree(&tree, notes_commit)) < 0)
+		goto cleanup;
+
+	error = note_lookup(out, repo, notes_commit, tree, target);
+
+cleanup:
+	git_tree_free(tree);
+	return error;
+}
+
 int git_note_create(
 	git_oid *out,
 	git_repository *repo,

--- a/src/notes.c
+++ b/src/notes.c
@@ -268,7 +268,9 @@ static int insert_note_in_tree_enotfound_cb(git_tree **out,
 		GIT_FILEMODE_BLOB);
 }
 
-static int note_write(git_oid *out,
+static int note_write(
+	git_oid *notes_commit_out,
+	git_oid *notes_blob_out,
 	git_repository *repo,
 	const git_signature *author,
 	const git_signature *committer,
@@ -294,12 +296,16 @@ static int note_write(git_oid *out,
 		insert_note_in_tree_enotfound_cb)) < 0)
 		goto cleanup;
 
-	if (out)
-		git_oid_cpy(out, &oid);
+	if (notes_blob_out)
+		git_oid_cpy(notes_blob_out, &oid);
+
 
 	error = git_commit_create(&oid, repo, notes_ref, author, committer,
 				  NULL, GIT_NOTES_DEFAULT_MSG_ADD,
 				  tree, *parents == NULL ? 0 : 1, (const git_commit **) parents);
+
+	if (notes_commit_out)
+		git_oid_cpy(notes_commit_out, &oid);
 
 cleanup:
 	git_tree_free(tree);
@@ -480,7 +486,7 @@ int git_note_create(
 	if (error < 0 && error != GIT_ENOTFOUND)
 		goto cleanup;
 
-	error = note_write(out, repo, author, committer, notes_ref,
+	error = note_write(NULL, out, repo, author, committer, notes_ref,
 			note, tree, target, &commit, allow_note_overwrite);
 
 cleanup:

--- a/src/notes.c
+++ b/src/notes.c
@@ -766,6 +766,25 @@ cleanup:
 	return error;
 }
 
+int git_note_commit_iterator_new(
+	git_note_iterator **it,
+	git_commit *notes_commit)
+{
+	int error;
+	git_tree *tree;
+
+	if ((error = git_commit_tree(&tree, notes_commit)) < 0)
+		goto cleanup;
+
+	if ((error = git_iterator_for_tree(it, tree, NULL)) < 0)
+		git_iterator_free(*it);
+
+cleanup:
+	git_tree_free(tree);
+
+	return error;
+}
+
 int git_note_next(
 	git_oid* note_id,
 	git_oid* annotated_id,

--- a/src/notes.c
+++ b/src/notes.c
@@ -369,7 +369,9 @@ cleanup:
 	return error;
 }
 
-static int note_remove(git_repository *repo,
+static int note_remove(
+		git_oid *notes_commit_out,
+		git_repository *repo,
 		const git_signature *author, const git_signature *committer,
 		const char *notes_ref, git_tree *tree,
 		const char *target, git_commit **parents)
@@ -388,6 +390,12 @@ static int note_remove(git_repository *repo,
 	  tree_after_removal,
 	  *parents == NULL ? 0 : 1,
 	  (const git_commit **) parents);
+
+	if (error < 0)
+		goto cleanup;
+
+	if (notes_commit_out)
+		git_oid_cpy(notes_commit_out, &oid);
 
 cleanup:
 	git_tree_free(tree_after_removal);
@@ -564,12 +572,37 @@ int git_note_remove(git_repository *repo, const char *notes_ref_in,
 
 	if (!(error = retrieve_note_tree_and_commit(
 		      &tree, &commit, &notes_ref, repo, notes_ref_in)))
-		error = note_remove(
+		error = note_remove(NULL,
 			repo, author, committer, notes_ref, tree, target, &commit);
 
 	git__free(notes_ref);
 	git__free(target);
 	git_commit_free(commit);
+	git_tree_free(tree);
+	return error;
+}
+
+int git_note_commit_remove(
+		git_oid *notes_commit_out,
+		git_repository *repo,
+		git_commit *notes_commit,
+		const git_signature *author,
+		const git_signature *committer,
+		const git_oid *oid)
+{
+	int error;
+	git_tree *tree = NULL;
+	char target[GIT_OID_HEXSZ + 1];
+
+	git_oid_tostr(target, sizeof(target), oid);
+
+	if ((error = git_commit_tree(&tree, notes_commit)) < 0)
+		goto cleanup;
+
+	error = note_remove(notes_commit_out,
+		repo, author, committer, NULL, tree, target, &notes_commit);
+
+cleanup:
 	git_tree_free(tree);
 	return error;
 }

--- a/tests/notes/notes.c
+++ b/tests/notes/notes.c
@@ -415,6 +415,31 @@ void test_notes_notes__can_read_a_note_from_a_commit(void)
 	git_note_free(note);
 }
 
+/* Test that we can read a commit with no note fails */
+void test_notes_notes__attempt_to_read_a_note_from_a_commit_with_no_note_fails(void)
+{
+	git_oid oid, notes_commit_oid;
+	git_commit *notes_commit;
+	git_note *note;
+
+	cl_git_pass(git_oid_fromstr(&oid, "4a202b346bb0fb0db7eff3cffeb3c70babbd2045"));
+
+	cl_git_pass(git_note_commit_create(&notes_commit_oid, NULL, _repo, NULL, _sig, _sig, &oid, "I decorate 4a20\n", 1));
+
+	git_commit_lookup(&notes_commit, _repo, &notes_commit_oid);
+
+	cl_git_pass(git_note_commit_remove(&notes_commit_oid, _repo, notes_commit, _sig, _sig, &oid));
+	git_commit_free(notes_commit);
+
+	git_commit_lookup(&notes_commit, _repo, &notes_commit_oid);
+
+	cl_assert(notes_commit);
+
+	cl_git_fail_with(GIT_ENOTFOUND, git_note_commit_read(&note, _repo, notes_commit, &oid));
+
+	git_commit_free(notes_commit);
+}
+
 /*
  * $ git ls-tree refs/notes/fanout
  * 040000 tree 4b22b35d44b5a4f589edf3dc89196399771796ea    84

--- a/tests/notes/notes.c
+++ b/tests/notes/notes.c
@@ -73,6 +73,128 @@ static int note_list_cb(
 	return 0;
 }
 
+struct note_create_payload {
+	const char *note_oid;
+	const char *object_oid;
+	unsigned seen;
+};
+
+static int note_list_create_cb(
+	const git_oid *blob_oid, const git_oid *annotated_obj_id, void *payload)
+{
+	git_oid expected_note_oid, expected_target_oid;
+	struct note_create_payload *notes = payload;
+	size_t i;
+
+	for (i = 0; notes[i].note_oid != NULL; i++) {
+		cl_git_pass(git_oid_fromstr(&expected_note_oid, notes[i].note_oid));
+
+		if (git_oid_cmp(&expected_note_oid, blob_oid) != 0)
+			continue;
+
+		cl_git_pass(git_oid_fromstr(&expected_target_oid, notes[i].object_oid));
+
+		if (git_oid_cmp(&expected_target_oid, annotated_obj_id) != 0)
+			continue;
+
+		notes[i].seen = 1;
+		return 0;
+	}
+
+	cl_fail("Did not see expected note");
+	return 0;
+}
+
+void assert_notes_seen(struct note_create_payload payload[], size_t n)
+{
+	size_t seen = 0, i;
+
+	for (i = 0; payload[i].note_oid != NULL; i++) {
+		if (payload[i].seen)
+			seen++;
+	}
+
+	cl_assert_equal_i(seen, n);
+}
+
+void test_notes_notes__can_create_a_note(void)
+{
+	git_oid note_oid;
+	static struct note_create_payload can_create_a_note[] = {
+		{ "1c9b1bc36730582a42d56eeee0dc58673d7ae869", "4a202b346bb0fb0db7eff3cffeb3c70babbd2045", 0 },
+		{ NULL, NULL, 0 }
+	};
+
+	create_note(&note_oid, "refs/notes/i-can-see-dead-notes", can_create_a_note[0].object_oid, "I decorate 4a20\n");
+
+	cl_git_pass(git_note_foreach(_repo, "refs/notes/i-can-see-dead-notes", note_list_create_cb, &can_create_a_note));
+
+	assert_notes_seen(can_create_a_note, 1);
+}
+
+void test_notes_notes__can_create_a_note_from_commit(void)
+{
+	git_oid oid;
+	git_oid notes_commit_out;
+	git_reference *ref;
+	static struct note_create_payload can_create_a_note_from_commit[] = {
+		{ "1c9b1bc36730582a42d56eeee0dc58673d7ae869", "4a202b346bb0fb0db7eff3cffeb3c70babbd2045", 0 },
+		{ NULL, NULL, 0 }
+	};
+
+	cl_git_pass(git_oid_fromstr(&oid, can_create_a_note_from_commit[0].object_oid));
+
+	cl_git_pass(git_note_commit_create(&notes_commit_out, NULL, _repo, NULL, _sig, _sig, &oid, "I decorate 4a20\n", 1));
+
+	/* create_from_commit will not update any ref,
+	 * so we must manually create the ref, that points to the commit */
+	cl_git_pass(git_reference_create(&ref, _repo, "refs/notes/i-can-see-dead-notes", &notes_commit_out, 0, NULL));
+
+	cl_git_pass(git_note_foreach(_repo, "refs/notes/i-can-see-dead-notes", note_list_create_cb, &can_create_a_note_from_commit));
+
+	assert_notes_seen(can_create_a_note_from_commit, 1);
+
+	git_reference_free(ref);
+}
+
+
+/* Test that we can create a note from a commit, given an existing commit */
+void test_notes_notes__can_create_a_note_from_commit_given_an_existing_commit(void)
+{
+	git_oid oid;
+	git_oid notes_commit_out;
+	git_commit *existing_notes_commit = NULL;
+	git_reference *ref;
+	static struct note_create_payload can_create_a_note_from_commit_given_an_existing_commit[] = {
+		{ "1c9b1bc36730582a42d56eeee0dc58673d7ae869", "4a202b346bb0fb0db7eff3cffeb3c70babbd2045", 0 },
+		{ "1aaf94147c21f981e0a20bf57b89137c5a6aae52", "9fd738e8f7967c078dceed8190330fc8648ee56a", 0 },
+		{ NULL, NULL, 0 }
+	};
+
+	cl_git_pass(git_oid_fromstr(&oid, "4a202b346bb0fb0db7eff3cffeb3c70babbd2045"));
+
+	cl_git_pass(git_note_commit_create(&notes_commit_out, NULL, _repo, NULL, _sig, _sig, &oid, "I decorate 4a20\n", 0));
+
+	cl_git_pass(git_oid_fromstr(&oid, "9fd738e8f7967c078dceed8190330fc8648ee56a"));
+
+	git_commit_lookup(&existing_notes_commit, _repo, &notes_commit_out);
+
+	cl_assert(existing_notes_commit);
+
+	cl_git_pass(git_note_commit_create(&notes_commit_out, NULL, _repo, existing_notes_commit, _sig, _sig, &oid, "I decorate 9fd7\n", 0));
+
+	/* create_from_commit will not update any ref,
+	 * so we must manually create the ref, that points to the commit */
+	cl_git_pass(git_reference_create(&ref, _repo, "refs/notes/i-can-see-dead-notes", &notes_commit_out, 0, NULL));
+
+	cl_git_pass(git_note_foreach(_repo, "refs/notes/i-can-see-dead-notes", note_list_create_cb, &can_create_a_note_from_commit_given_an_existing_commit));
+
+	assert_notes_seen(can_create_a_note_from_commit_given_an_existing_commit, 2);
+
+	git_commit_free(existing_notes_commit);
+	git_reference_free(ref);
+}
+
 /*
  * $ git notes --ref i-can-see-dead-notes add -m "I decorate a65f" a65fedf39aefe402d3bb6e24df4d4f5fe4547750
  * $ git notes --ref i-can-see-dead-notes add -m "I decorate c478" c47800c7266a2be04c571c04d5a6614691ea99bd

--- a/tests/notes/notes.c
+++ b/tests/notes/notes.c
@@ -375,6 +375,46 @@ static char *messages[] = {
 
 #define MESSAGES_COUNT (sizeof(messages)/sizeof(messages[0])) - 1
 
+/* Test that we can read a note */
+void test_notes_notes__can_read_a_note(void)
+{
+	git_oid note_oid, target_oid;
+	git_note *note;
+
+	create_note(&note_oid, "refs/notes/i-can-see-dead-notes", "4a202b346bb0fb0db7eff3cffeb3c70babbd2045", "I decorate 4a20\n");
+
+	cl_git_pass(git_oid_fromstr(&target_oid, "4a202b346bb0fb0db7eff3cffeb3c70babbd2045"));
+
+	cl_git_pass(git_note_read(&note, _repo, "refs/notes/i-can-see-dead-notes", &target_oid));
+
+	cl_assert_equal_s(git_note_message(note), "I decorate 4a20\n");
+
+	git_note_free(note);
+}
+
+/* Test that we can read a note with from commit api */
+void test_notes_notes__can_read_a_note_from_a_commit(void)
+{
+	git_oid oid, notes_commit_oid;
+	git_commit *notes_commit;
+	git_note *note;
+
+	cl_git_pass(git_oid_fromstr(&oid, "4a202b346bb0fb0db7eff3cffeb3c70babbd2045"));
+
+	cl_git_pass(git_note_commit_create(&notes_commit_oid, NULL, _repo, NULL, _sig, _sig, &oid, "I decorate 4a20\n", 1));
+
+	git_commit_lookup(&notes_commit, _repo, &notes_commit_oid);
+
+	cl_assert(notes_commit);
+
+	cl_git_pass(git_note_commit_read(&note, _repo, notes_commit, &oid));
+
+	cl_assert_equal_s(git_note_message(note), "I decorate 4a20\n");
+
+	git_commit_free(notes_commit);
+	git_note_free(note);
+}
+
 /*
  * $ git ls-tree refs/notes/fanout
  * 040000 tree 4b22b35d44b5a4f589edf3dc89196399771796ea    84

--- a/tests/notes/notes.c
+++ b/tests/notes/notes.c
@@ -594,3 +594,46 @@ void test_notes_notes__empty_iterate(void)
 
 	cl_git_fail(git_note_iterator_new(&iter, _repo, "refs/notes/commits"));
 }
+
+void test_notes_notes__iterate_from_commit(void)
+{
+	git_note_iterator *iter;
+	git_note *note;
+	git_oid note_id, annotated_id;
+	git_oid oids[2];
+	git_oid notes_commit_oids[2];
+	git_commit *notes_commits[2];
+	const char* note_message[] = {
+		"I decorate a65f\n",
+		"I decorate c478\n"
+	};
+	int i, err;
+
+	cl_git_pass(git_oid_fromstr(&(oids[0]), "a65fedf39aefe402d3bb6e24df4d4f5fe4547750"));
+	cl_git_pass(git_oid_fromstr(&(oids[1]), "c47800c7266a2be04c571c04d5a6614691ea99bd"));
+
+	cl_git_pass(git_note_commit_create(&notes_commit_oids[0], NULL, _repo, NULL, _sig, _sig, &(oids[0]), note_message[0], 0));
+
+	git_commit_lookup(&notes_commits[0], _repo, &notes_commit_oids[0]);
+	cl_assert(notes_commits[0]);
+
+	cl_git_pass(git_note_commit_create(&notes_commit_oids[1], NULL, _repo, notes_commits[0], _sig, _sig, &(oids[1]), note_message[1], 0));
+
+	git_commit_lookup(&notes_commits[1], _repo, &notes_commit_oids[1]);
+	cl_assert(notes_commits[1]);
+
+	cl_git_pass(git_note_commit_iterator_new(&iter, notes_commits[1]));
+
+	for (i = 0; (err = git_note_next(&note_id, &annotated_id, iter)) >= 0; ++i) {
+		cl_git_pass(git_note_commit_read(&note, _repo, notes_commits[1], &annotated_id));
+		cl_assert_equal_s(git_note_message(note), note_message[i]);
+		git_note_free(note);
+	}
+
+	cl_assert_equal_i(GIT_ITEROVER, err);
+	cl_assert_equal_i(2, i);
+
+	git_note_iterator_free(iter);
+	git_commit_free(notes_commits[0]);
+	git_commit_free(notes_commits[1]);
+}


### PR DESCRIPTION
Hi!

This is a work in progress implementation to solve issue #3782 
each new function will be added in a separate commit.

Finally existing notes functions will be reimplemented in terms of the new functions.

I'm opening this now in case anyone has any suggestions in the early stages
that will allow me to avoid rework later on.

Thanks,
Richard Ipsum