### PR TITLE
Worktree fixes

### DIFF
--- a/include/git2/worktree.h
+++ b/include/git2/worktree.h
@@ -44,6 +44,18 @@ GIT_EXTERN(int) git_worktree_list(git_strarray *out, git_repository *repo);
 GIT_EXTERN(int) git_worktree_lookup(git_worktree **out, git_repository *repo, const char *name);
 
 /**
+ * Open a worktree of a given repository
+ *
+ * If a repository is not the main tree but a worktree, this
+ * function will look up the worktree inside the parent
+ * repository and create a new `git_worktree` structure.
+ *
+ * @param out Out-pointer for the newly allocated worktree
+ * @param repo Repository to look up worktree for
+ */
+GIT_EXTERN(int) git_worktree_open_from_repository(git_worktree **out, git_repository *repo);
+
+/**
  * Free a previously allocated worktree
  *
  * @param wt worktree handle to close. If NULL nothing occurs.

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -738,6 +738,7 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 {
 	int error;
 	git_buf ref_path = GIT_BUF_INIT;
+	const char *basedir;
 
 	assert(file && backend && name);
 
@@ -746,13 +747,18 @@ static int loose_lock(git_filebuf *file, refdb_fs_backend *backend, const char *
 		return GIT_EINVALIDSPEC;
 	}
 
+	if (is_per_worktree_ref(name))
+		basedir = backend->gitpath;
+	else
+		basedir = backend->commonpath;
+
 	/* Remove a possibly existing empty directory hierarchy
 	 * which name would collide with the reference name
 	 */
-	if ((error = git_futils_rmdir_r(name, backend->gitpath, GIT_RMDIR_SKIP_NONEMPTY)) < 0)
+	if ((error = git_futils_rmdir_r(name, basedir, GIT_RMDIR_SKIP_NONEMPTY)) < 0)
 		return error;
 
-	if (git_buf_joinpath(&ref_path, backend->gitpath, name) < 0)
+	if (git_buf_joinpath(&ref_path, basedir, name) < 0)
 		return -1;
 
 	error = git_filebuf_open(file, ref_path.ptr, GIT_FILEBUF_FORCE, GIT_REFS_FILE_MODE);

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -323,7 +323,7 @@ int git_worktree_add(git_worktree **out, git_repository *repo, const char *name,
 		goto out;
 
 	/* Set worktree's HEAD */
-	if ((err = git_repository_create_head(path.ptr, name)) < 0)
+	if ((err = git_repository_create_head(path.ptr, git_reference_name(ref))) < 0)
 		goto out;
 	if ((err = git_repository_open(&wt, worktree)) < 0)
 		goto out;

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -174,7 +174,7 @@ int git_worktree_lookup(git_worktree **out, git_repository *repo, const char *na
 	if ((error = git_buf_printf(&path, "%s/worktrees/%s", repo->commondir, name)) < 0)
 		goto out;
 
-	if ((error = (open_worktree_dir(out, git_repository_path(repo), path.ptr, name))) < 0)
+	if ((error = (open_worktree_dir(out, git_repository_workdir(repo), path.ptr, name))) < 0)
 		goto out;
 
 out:
@@ -202,7 +202,7 @@ int git_worktree_open_from_repository(git_worktree **out, git_repository *repo)
 	gitdir = git_repository_path(repo);
 	commondir = git_repository_commondir(repo);
 
-	if ((error = git_path_prettify_dir(&parent, commondir, NULL)) < 0)
+	if ((error = git_path_prettify_dir(&parent, "..", commondir)) < 0)
 		goto out;
 
 	/* The name is defined by the last component in '.git/worktree/%s' */
@@ -457,7 +457,7 @@ int git_worktree_prune(git_worktree *wt, unsigned flags)
 	}
 
 	/* Delete gitdir in parent repository */
-	if ((err = git_buf_printf(&path, "%s/worktrees/%s", wt->parent_path, wt->name)) < 0)
+	if ((err = git_buf_printf(&path, "%s/worktrees/%s", wt->commondir_path, wt->name)) < 0)
 		goto out;
 	if (!git_path_exists(path.ptr))
 	{

--- a/src/worktree.h
+++ b/src/worktree.h
@@ -24,7 +24,7 @@ struct git_worktree {
 	/* Path to the common directory contained in the parent
 	 * repository */
 	char *commondir_path;
-	/* Path to the parent's .git directory */
+	/* Path to the parent's working directory */
 	char *parent_path;
 
 	int locked:1;

--- a/tests/resources/submodules/testrepo/.gitted/config
+++ b/tests/resources/submodules/testrepo/.gitted/config
@@ -4,9 +4,6 @@
 	bare = false
 	logallrefupdates = true
 	ignorecase = true
-[remote "origin"]
-	fetch = +refs/heads/*:refs/remotes/origin/*
-	url = /Users/rb/src/libgit2/tests/resources/testrepo.git
 [branch "master"]
 	remote = origin
 	merge = refs/heads/master

--- a/tests/worktree/open.c
+++ b/tests/worktree/open.c
@@ -1,5 +1,6 @@
 #include "clar_libgit2.h"
 #include "repository.h"
+#include "worktree.h"
 #include "worktree_helpers.h"
 
 #define COMMON_REPO "testrepo"
@@ -114,4 +115,29 @@ void test_worktree_open__repository_with_nonexistent_parent(void)
 	cl_git_fail(git_repository_open(&repo, WORKTREE_REPO));
 
 	cl_fixture_cleanup(WORKTREE_REPO);
+}
+
+void test_worktree_open__open_from_repository(void)
+{
+	git_worktree *opened, *lookedup;
+
+	cl_git_pass(git_worktree_open_from_repository(&opened, fixture.worktree));
+	cl_git_pass(git_worktree_lookup(&lookedup, fixture.repo, WORKTREE_REPO));
+
+	cl_assert_equal_s(opened->name, lookedup->name);
+	cl_assert_equal_s(opened->gitdir_path, lookedup->gitdir_path);
+	cl_assert_equal_s(opened->gitlink_path, lookedup->gitlink_path);
+	cl_assert_equal_s(opened->parent_path, lookedup->parent_path);
+	cl_assert_equal_s(opened->commondir_path, lookedup->commondir_path);
+	cl_assert_equal_i(opened->locked, lookedup->locked);
+
+	git_worktree_free(opened);
+	git_worktree_free(lookedup);
+}
+
+void test_worktree_open__open_from_nonworktree_fails(void)
+{
+	git_worktree *wt;
+
+	cl_git_fail(git_worktree_open_from_repository(&wt, fixture.repo));
 }

--- a/tests/worktree/open.c
+++ b/tests/worktree/open.c
@@ -5,6 +5,9 @@
 #define COMMON_REPO "testrepo"
 #define WORKTREE_REPO "testrepo-worktree"
 
+static worktree_fixture fixture =
+	WORKTREE_FIXTURE_INIT(COMMON_REPO, WORKTREE_REPO);
+
 static void assert_worktree_valid(git_repository *wt, const char *parentdir, const char *wtdir)
 {
 	git_buf path = GIT_BUF_INIT;
@@ -31,55 +34,45 @@ static void assert_worktree_valid(git_repository *wt, const char *parentdir, con
 	git_buf_free(&path);
 }
 
+void test_worktree_open__initialize(void)
+{
+	setup_fixture_worktree(&fixture);
+}
+
+void test_worktree_open__cleanup(void)
+{
+	cleanup_fixture_worktree(&fixture);
+}
+
 void test_worktree_open__repository(void)
 {
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT(COMMON_REPO, WORKTREE_REPO);
-	setup_fixture_worktree(&fixture);
-
 	assert_worktree_valid(fixture.worktree, COMMON_REPO, WORKTREE_REPO);
-
-	cleanup_fixture_worktree(&fixture);
 }
 
 void test_worktree_open__repository_through_workdir(void)
 {
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT(COMMON_REPO, WORKTREE_REPO);
 	git_repository *wt;
-
-	setup_fixture_worktree(&fixture);
 
 	cl_git_pass(git_repository_open(&wt, WORKTREE_REPO));
 	assert_worktree_valid(wt, COMMON_REPO, WORKTREE_REPO);
 
 	git_repository_free(wt);
-	cleanup_fixture_worktree(&fixture);
 }
 
 void test_worktree_open__repository_through_gitlink(void)
 {
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT(COMMON_REPO, WORKTREE_REPO);
 	git_repository *wt;
-
-	setup_fixture_worktree(&fixture);
 
 	cl_git_pass(git_repository_open(&wt, WORKTREE_REPO "/.git"));
 	assert_worktree_valid(wt, COMMON_REPO, WORKTREE_REPO);
 
 	git_repository_free(wt);
-	cleanup_fixture_worktree(&fixture);
 }
 
 void test_worktree_open__repository_through_gitdir(void)
 {
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT(COMMON_REPO, WORKTREE_REPO);
 	git_buf gitdir_path = GIT_BUF_INIT;
 	git_repository *wt;
-
-	setup_fixture_worktree(&fixture);
 
 	cl_git_pass(git_buf_joinpath(&gitdir_path, COMMON_REPO, ".git"));
 	cl_git_pass(git_buf_joinpath(&gitdir_path, gitdir_path.ptr, "worktrees"));
@@ -90,17 +83,12 @@ void test_worktree_open__repository_through_gitdir(void)
 
 	git_buf_free(&gitdir_path);
 	git_repository_free(wt);
-	cleanup_fixture_worktree(&fixture);
 }
 
 void test_worktree_open__open_discovered_worktree(void)
 {
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT(COMMON_REPO, WORKTREE_REPO);
 	git_buf path = GIT_BUF_INIT;
 	git_repository *repo;
-
-	setup_fixture_worktree(&fixture);
 
 	cl_git_pass(git_repository_discover(&path,
 		git_repository_workdir(fixture.worktree), false, NULL));
@@ -110,12 +98,13 @@ void test_worktree_open__open_discovered_worktree(void)
 
 	git_buf_free(&path);
 	git_repository_free(repo);
-	cleanup_fixture_worktree(&fixture);
 }
 
 void test_worktree_open__repository_with_nonexistent_parent(void)
 {
 	git_repository *repo;
+
+	cleanup_fixture_worktree(&fixture);
 
 	cl_fixture_sandbox(WORKTREE_REPO);
 	cl_git_pass(p_chdir(WORKTREE_REPO));
@@ -126,4 +115,3 @@ void test_worktree_open__repository_with_nonexistent_parent(void)
 
 	cl_fixture_cleanup(WORKTREE_REPO);
 }
-

--- a/tests/worktree/open.c
+++ b/tests/worktree/open.c
@@ -2,9 +2,6 @@
 #include "repository.h"
 #include "worktree_helpers.h"
 
-#define WORKTREE_PARENT "submodules-worktree-parent"
-#define WORKTREE_CHILD "submodules-worktree-child"
-
 #define COMMON_REPO "testrepo"
 #define WORKTREE_REPO "testrepo-worktree"
 
@@ -130,65 +127,3 @@ void test_worktree_open__repository_with_nonexistent_parent(void)
 	cl_fixture_cleanup(WORKTREE_REPO);
 }
 
-void test_worktree_open__submodule_worktree_parent(void)
-{
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
-	setup_fixture_worktree(&fixture);
-
-	cl_assert(git_repository_path(fixture.worktree) != NULL);
-	cl_assert(git_repository_workdir(fixture.worktree) != NULL);
-
-	cl_assert(!fixture.repo->is_worktree);
-	cl_assert(fixture.worktree->is_worktree);
-
-	cleanup_fixture_worktree(&fixture);
-}
-
-void test_worktree_open__submodule_worktree_child(void)
-{
-	worktree_fixture parent_fixture =
-		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
-	worktree_fixture child_fixture =
-		WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
-
-	setup_fixture_worktree(&parent_fixture);
-	cl_git_pass(p_rename(
-		"submodules/testrepo/.gitted",
-		"submodules/testrepo/.git"));
-	setup_fixture_worktree(&child_fixture);
-
-	cl_assert(!parent_fixture.repo->is_worktree);
-	cl_assert(parent_fixture.worktree->is_worktree);
-	cl_assert(child_fixture.worktree->is_worktree);
-
-	cleanup_fixture_worktree(&child_fixture);
-	cleanup_fixture_worktree(&parent_fixture);
-}
-
-void test_worktree_open__open_discovered_submodule_worktree(void)
-{
-	worktree_fixture parent_fixture =
-		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
-	worktree_fixture child_fixture =
-		WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
-	git_buf path = GIT_BUF_INIT;
-	git_repository *repo;
-
-	setup_fixture_worktree(&parent_fixture);
-	cl_git_pass(p_rename(
-		"submodules/testrepo/.gitted",
-		"submodules/testrepo/.git"));
-	setup_fixture_worktree(&child_fixture);
-
-	cl_git_pass(git_repository_discover(&path,
-		git_repository_workdir(child_fixture.worktree), false, NULL));
-	cl_git_pass(git_repository_open(&repo, path.ptr));
-	cl_assert_equal_s(git_repository_workdir(child_fixture.worktree),
-		git_repository_workdir(repo));
-
-	git_buf_free(&path);
-	git_repository_free(repo);
-	cleanup_fixture_worktree(&child_fixture);
-	cleanup_fixture_worktree(&parent_fixture);
-}

--- a/tests/worktree/submodule.c
+++ b/tests/worktree/submodule.c
@@ -1,0 +1,69 @@
+#include "clar_libgit2.h"
+#include "repository.h"
+#include "worktree_helpers.h"
+
+#define WORKTREE_PARENT "submodules-worktree-parent"
+#define WORKTREE_CHILD "submodules-worktree-child"
+
+void test_worktree_submodule__submodule_worktree_parent(void)
+{
+	worktree_fixture fixture =
+		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
+	setup_fixture_worktree(&fixture);
+
+	cl_assert(git_repository_path(fixture.worktree) != NULL);
+	cl_assert(git_repository_workdir(fixture.worktree) != NULL);
+
+	cl_assert(!fixture.repo->is_worktree);
+	cl_assert(fixture.worktree->is_worktree);
+
+	cleanup_fixture_worktree(&fixture);
+}
+
+void test_worktree_submodule__submodule_worktree_child(void)
+{
+	worktree_fixture parent_fixture =
+		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
+	worktree_fixture child_fixture =
+		WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
+
+	setup_fixture_worktree(&parent_fixture);
+	cl_git_pass(p_rename(
+		"submodules/testrepo/.gitted",
+		"submodules/testrepo/.git"));
+	setup_fixture_worktree(&child_fixture);
+
+	cl_assert(!parent_fixture.repo->is_worktree);
+	cl_assert(parent_fixture.worktree->is_worktree);
+	cl_assert(child_fixture.worktree->is_worktree);
+
+	cleanup_fixture_worktree(&child_fixture);
+	cleanup_fixture_worktree(&parent_fixture);
+}
+
+void test_worktree_submodule__open_discovered_submodule_worktree(void)
+{
+	worktree_fixture parent_fixture =
+		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
+	worktree_fixture child_fixture =
+		WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
+	git_buf path = GIT_BUF_INIT;
+	git_repository *repo;
+
+	setup_fixture_worktree(&parent_fixture);
+	cl_git_pass(p_rename(
+		"submodules/testrepo/.gitted",
+		"submodules/testrepo/.git"));
+	setup_fixture_worktree(&child_fixture);
+
+	cl_git_pass(git_repository_discover(&path,
+		git_repository_workdir(child_fixture.worktree), false, NULL));
+	cl_git_pass(git_repository_open(&repo, path.ptr));
+	cl_assert_equal_s(git_repository_workdir(child_fixture.worktree),
+		git_repository_workdir(repo));
+
+	git_buf_free(&path);
+	git_repository_free(repo);
+	cleanup_fixture_worktree(&child_fixture);
+	cleanup_fixture_worktree(&parent_fixture);
+}

--- a/tests/worktree/submodule.c
+++ b/tests/worktree/submodule.c
@@ -5,65 +5,55 @@
 #define WORKTREE_PARENT "submodules-worktree-parent"
 #define WORKTREE_CHILD "submodules-worktree-child"
 
+static worktree_fixture parent
+    = WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
+static worktree_fixture child
+    = WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
+
+void test_worktree_submodule__initialize(void)
+{
+	setup_fixture_worktree(&parent);
+
+	cl_git_pass(p_rename(
+		"submodules/testrepo/.gitted",
+		"submodules/testrepo/.git"));
+
+	setup_fixture_worktree(&child);
+}
+
+void test_worktree_submodule__cleanup(void)
+{
+	cleanup_fixture_worktree(&child);
+	cleanup_fixture_worktree(&parent);
+}
+
 void test_worktree_submodule__submodule_worktree_parent(void)
 {
-	worktree_fixture fixture =
-		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
-	setup_fixture_worktree(&fixture);
+	cl_assert(git_repository_path(parent.worktree) != NULL);
+	cl_assert(git_repository_workdir(parent.worktree) != NULL);
 
-	cl_assert(git_repository_path(fixture.worktree) != NULL);
-	cl_assert(git_repository_workdir(fixture.worktree) != NULL);
-
-	cl_assert(!fixture.repo->is_worktree);
-	cl_assert(fixture.worktree->is_worktree);
-
-	cleanup_fixture_worktree(&fixture);
+	cl_assert(!parent.repo->is_worktree);
+	cl_assert(parent.worktree->is_worktree);
 }
 
 void test_worktree_submodule__submodule_worktree_child(void)
 {
-	worktree_fixture parent_fixture =
-		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
-	worktree_fixture child_fixture =
-		WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
-
-	setup_fixture_worktree(&parent_fixture);
-	cl_git_pass(p_rename(
-		"submodules/testrepo/.gitted",
-		"submodules/testrepo/.git"));
-	setup_fixture_worktree(&child_fixture);
-
-	cl_assert(!parent_fixture.repo->is_worktree);
-	cl_assert(parent_fixture.worktree->is_worktree);
-	cl_assert(child_fixture.worktree->is_worktree);
-
-	cleanup_fixture_worktree(&child_fixture);
-	cleanup_fixture_worktree(&parent_fixture);
+	cl_assert(!parent.repo->is_worktree);
+	cl_assert(parent.worktree->is_worktree);
+	cl_assert(child.worktree->is_worktree);
 }
 
 void test_worktree_submodule__open_discovered_submodule_worktree(void)
 {
-	worktree_fixture parent_fixture =
-		WORKTREE_FIXTURE_INIT("submodules", WORKTREE_PARENT);
-	worktree_fixture child_fixture =
-		WORKTREE_FIXTURE_INIT(NULL, WORKTREE_CHILD);
 	git_buf path = GIT_BUF_INIT;
 	git_repository *repo;
 
-	setup_fixture_worktree(&parent_fixture);
-	cl_git_pass(p_rename(
-		"submodules/testrepo/.gitted",
-		"submodules/testrepo/.git"));
-	setup_fixture_worktree(&child_fixture);
-
 	cl_git_pass(git_repository_discover(&path,
-		git_repository_workdir(child_fixture.worktree), false, NULL));
+		git_repository_workdir(child.worktree), false, NULL));
 	cl_git_pass(git_repository_open(&repo, path.ptr));
-	cl_assert_equal_s(git_repository_workdir(child_fixture.worktree),
+	cl_assert_equal_s(git_repository_workdir(child.worktree),
 		git_repository_workdir(repo));
 
 	git_buf_free(&path);
 	git_repository_free(repo);
-	cleanup_fixture_worktree(&child_fixture);
-	cleanup_fixture_worktree(&parent_fixture);
 }

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -118,8 +118,9 @@ void test_worktree_worktree__lookup(void)
 	cl_git_pass(git_buf_joinpath(&gitdir_path, fixture.repo->commondir, "worktrees/testrepo-worktree/"));
 
 	cl_assert_equal_s(wt->gitdir_path, gitdir_path.ptr);
-	cl_assert_equal_s(wt->parent_path, fixture.repo->gitdir);
+	cl_assert_equal_s(wt->parent_path, fixture.repo->workdir);
 	cl_assert_equal_s(wt->gitlink_path, fixture.worktree->gitlink);
+	cl_assert_equal_s(wt->commondir_path, fixture.repo->gitdir);
 	cl_assert_equal_s(wt->commondir_path, fixture.repo->commondir);
 
 	git_buf_free(&gitdir_path);

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -115,7 +115,7 @@ void test_worktree_worktree__lookup(void)
 
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 
-	git_buf_printf(&gitdir_path, "%s/worktrees/%s", fixture.repo->commondir, "testrepo-worktree");
+	cl_git_pass(git_buf_joinpath(&gitdir_path, fixture.repo->commondir, "worktrees/testrepo-worktree/"));
 
 	cl_assert_equal_s(wt->gitdir_path, gitdir_path.ptr);
 	cl_assert_equal_s(wt->parent_path, fixture.repo->gitdir);

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -306,7 +306,9 @@ void test_worktree_worktree__init_submodule(void)
 	cl_git_pass(git_worktree_add(&worktree, sm, "repo-worktree", path.ptr));
 	cl_git_pass(git_repository_open_from_worktree(&wt, worktree));
 
+	cl_git_pass(git_path_prettify_dir(&path, path.ptr, NULL));
 	cl_assert_equal_s(path.ptr, wt->workdir);
+	cl_git_pass(git_path_prettify_dir(&path, sm->commondir, NULL));
 	cl_assert_equal_s(sm->commondir, wt->commondir);
 
 	cl_git_pass(git_buf_joinpath(&path, sm->gitdir, "worktrees/repo-worktree/"));


### PR DESCRIPTION
So this is the first batch of fixes for the worktree implementation. Fixes:

- the parent path inside of the `git_worktree` path now correctly points to the parent repository, that is it will usually point to the parent working directory
- resolving relative URLs for a working tree of a submodule now correctly resolves the URL relative to the working tree's parent working directory
- a new function `git_worktree_open_from_repository` has been added to retrieve the worktree structure from a repository, if it actually is a working tree
- non-per-worktree file references are now actually created in the common directory instead of the gitdir. This was a major oversight
- worktree link files are now resolved so that we write absolute paths instead of relative paths
- the HEAD reference for newly created worktrees now contains the fully qualified reference