### PR TITLE
Remove `map_free` macros

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2319,8 +2319,6 @@ static void checkout_data_clear(checkout_data *data)
 	git__free(data->pfx);
 	data->pfx = NULL;
 
-	git_strmap_free(data->mkdir_map);
-
 	git_buf_free(&data->target_path);
 	git_buf_free(&data->tmp);
 
@@ -2328,6 +2326,7 @@ static void checkout_data_clear(checkout_data *data)
 	data->index = NULL;
 
 	git_strmap_free(data->mkdir_map);
+	data->mkdir_map = NULL;
 
 	git_attr_session__free(&data->attr_session);
 }

--- a/src/idxmap.c
+++ b/src/idxmap.c
@@ -99,7 +99,7 @@ void git_idxmap_icase_resize(git_idxmap_icase *map, size_t size)
 	kh_resize(idxicase, map, size);
 }
 
-void git_idxmap__free(git_idxmap *map)
+void git_idxmap_free(git_idxmap *map)
 {
 	kh_destroy(idx, map);
 }

--- a/src/idxmap.h
+++ b/src/idxmap.h
@@ -39,8 +39,7 @@ int git_idxmap_has_data(git_idxmap *map, size_t idx);
 
 void git_idxmap_resize(git_idxmap *map, size_t size);
 void git_idxmap_icase_resize(git_idxmap_icase *map, size_t size);
-#define git_idxmap_free(h) git_idxmap__free(h); (h) = NULL
-void git_idxmap__free(git_idxmap *map);
+void git_idxmap_free(git_idxmap *map);
 void git_idxmap_clear(git_idxmap *map);
 
 void git_idxmap_delete_at(git_idxmap *map, size_t idx);

--- a/src/offmap.c
+++ b/src/offmap.c
@@ -14,7 +14,7 @@ git_offmap *git_offmap_alloc(void)
 	return kh_init(off);
 }
 
-void git_offmap__free(git_offmap *map)
+void git_offmap_free(git_offmap *map)
 {
 	kh_destroy(off, map);
 }

--- a/src/offmap.h
+++ b/src/offmap.h
@@ -21,8 +21,7 @@ __KHASH_TYPE(off, git_off_t, void *)
 typedef khash_t(off) git_offmap;
 
 git_offmap *git_offmap_alloc(void);
-#define git_offmap_free(h) git_offmap__free(h); (h) = NULL
-void git_offmap__free(git_offmap *map);
+void git_offmap_free(git_offmap *map);
 void git_offmap_clear(git_offmap *map);
 
 size_t git_offmap_num_entries(git_offmap *map);

--- a/src/oidmap.c
+++ b/src/oidmap.c
@@ -21,7 +21,7 @@ git_oidmap *git_oidmap_alloc()
 	return kh_init(oid);
 }
 
-void git_oidmap__free(git_oidmap *map)
+void git_oidmap_free(git_oidmap *map)
 {
 	kh_destroy(oid, map);
 }

--- a/src/oidmap.h
+++ b/src/oidmap.h
@@ -21,8 +21,7 @@ __KHASH_TYPE(oid, const git_oid *, void *)
 typedef khash_t(oid) git_oidmap;
 
 git_oidmap *git_oidmap_alloc(void);
-#define git_oidmap_free(h) git_oidmap__free(h); (h) = NULL
-void git_oidmap__free(git_oidmap *map);
+void git_oidmap_free(git_oidmap *map);
 void git_oidmap_clear(git_oidmap *map);
 
 size_t git_oidmap_size(git_oidmap *map);

--- a/src/strmap.c
+++ b/src/strmap.c
@@ -19,7 +19,7 @@ int git_strmap_alloc(git_strmap **map)
 	return 0;
 }
 
-void git_strmap__free(git_strmap *map)
+void git_strmap_free(git_strmap *map)
 {
 	kh_destroy(str, map);
 }

--- a/src/strmap.h
+++ b/src/strmap.h
@@ -21,9 +21,7 @@ typedef khash_t(str) git_strmap;
 typedef khiter_t git_strmap_iter;
 
 int git_strmap_alloc(git_strmap **map);
-
-#define git_strmap_free(h) git_strmap__free(h); (h) = NULL
-void git_strmap__free(git_strmap *map);
+void git_strmap_free(git_strmap *map);
 void git_strmap_clear(git_strmap *map);
 
 size_t git_strmap_num_entries(git_strmap *map);


### PR DESCRIPTION
I just noticed a subtle bug via Coverity which I introduced in my recent refactoring of the map interfaces. The `git_map_free` functions were implemented as macros, but in fact in a subtly wrong way where the statements were not grouped together by a `do { ... } while (0)` block. I think no real issues were introduced by this, but I took it as a hint to remove the macro altogether. One caller needed to be fixed, but this was a double-free anyway and as such wrong.