### PR TITLE
Coverity fixes

### DIFF
--- a/src/diff_parse.c
+++ b/src/diff_parse.c
@@ -44,7 +44,11 @@ static git_diff_parsed *diff_parsed_alloc(void)
 	diff->base.patch_fn = git_patch_parsed_from_diff;
 	diff->base.free_fn = diff_parsed_free;
 
-	git_diff_init_options(&diff->base.opts, GIT_DIFF_OPTIONS_VERSION);
+	if (git_diff_init_options(&diff->base.opts, GIT_DIFF_OPTIONS_VERSION) < 0) {
+		git__free(&diff);
+		return NULL;
+	}
+
 	diff->base.opts.flags &= ~GIT_DIFF_IGNORE_CASE;
 
 	git_pool_init(&diff->base.pool, 1);

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -428,7 +428,7 @@ static int pack_backend__read_prefix(
 			git_oid_cpy(out_oid, short_oid);
 	} else {
 		struct git_pack_entry e;
-		git_rawobj raw;
+		git_rawobj raw = {NULL};
 
 		if ((error = pack_entry_find_prefix(
 				&e, (struct pack_backend *)backend, short_oid, len)) == 0 &&

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -66,7 +66,7 @@ static void shutdown_ssl_locking(void)
 	CRYPTO_set_locking_callback(NULL);
 
 	for (i = 0; i < num_locks; ++i)
-		git_mutex_free(openssl_locks);
+		git_mutex_free(&openssl_locks[i]);
 	git__free(openssl_locks);
 }
 

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -444,9 +444,9 @@ static int parse_header_git(
 				goto done;
 
 			parse_advance_ws(ctx);
-			parse_advance_expected_str(ctx, "\n");
 
-			if (ctx->line_len > 0) {
+			if (parse_advance_expected_str(ctx, "\n") < 0 ||
+			    ctx->line_len > 0) {
 				error = parse_err("trailing data at line %"PRIuZ, ctx->line_num);
 				goto done;
 			}


### PR DESCRIPTION
Some Coverity fixes. The most important one is the `openssl_stream` commit, which fixes an actual use after free/segfault when we shut down OpenSSL's mutexes.