### PR TITLE
Fix resolving absolute symlinks (on at least Win32)

### DIFF
--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -246,6 +246,7 @@ static int resolve_symlink(git_buf *out, const char *path)
 
 		root = git_path_root(target.ptr);
 		if (root >= 0) {
+			git_buf_clear(&curpath);
 			if ((error = git_buf_puts(&curpath, target.ptr)) < 0)
 				goto cleanup;
 		} else {


### PR DESCRIPTION
The symlink destination is always concatenated to the original path.

See issue #4168.

based on the implementation I assume that this is also broken for *nix symlinks.