### PR TITLE
[RFC] Overflow macros

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -101,7 +101,8 @@ typedef enum {
 	GITERR_FILESYSTEM,
 	GITERR_PATCH,
 	GITERR_WORKTREE,
-	GITERR_SHA1
+	GITERR_SHA1,
+	GITERR_OVERFLOW
 } git_error_t;
 
 /**
@@ -145,6 +146,17 @@ GIT_EXTERN(void) giterr_set_str(int error_class, const char *string);
  * internal value.
  */
 GIT_EXTERN(void) giterr_set_oom(void);
+
+/**
+ * Set the error message to a special value for integer overflows.
+ *
+ * The normal `giterr_set_str()` function attempts to `strdup()` the string
+ * that is passed in.  This is not a good idea when the error in question
+ * is a memory allocation failure.  That circumstance has a special setter
+ * function that sets the error string to a known and statically allocated
+ * internal value.
+ */
+GIT_EXTERN(void) giterr_set_overflow(void);
 
 /** @} */
 GIT_END_DECL

--- a/script/user_nodefs.h
+++ b/script/user_nodefs.h
@@ -20,7 +20,7 @@
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), three) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), four)) { __coverity_panic__(); }
 
-#nodef GITERR_CHECK_ALLOC_MULTIPLY(out, nelem, elsize) \
+#nodef GITERR_CHECK_MULTIPLY(out, nelem, elsize) \
 	if (GIT_MULTIPLY_SIZET_OVERFLOW(out, nelem, elsize)) { __coverity_panic__(); }
 
 #nodef GITERR_CHECK_VERSION(S,V,N) if (giterr__check_version(S,V,N) < 0)  { __coverity_panic__(); }

--- a/script/user_nodefs.h
+++ b/script/user_nodefs.h
@@ -8,14 +8,14 @@
 #nodef GITERR_CHECK_ALLOC(ptr) if (ptr == NULL) { __coverity_panic__(); }
 #nodef GITERR_CHECK_ALLOC_BUF(buf) if (buf == NULL || git_buf_oom(buf)) { __coverity_panic__(); }
 
-#nodef GITERR_CHECK_ALLOC_ADD(out, one, two) \
+#nodef GITERR_CHECK_ADD(out, one, two) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two)) { __coverity_panic__(); }
 
-#nodef GITERR_CHECK_ALLOC_ADD3(out, one, two, three) \
+#nodef GITERR_CHECK_ADD3(out, one, two, three) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), three)) { __coverity_panic__(); }
 
-#nodef GITERR_CHECK_ALLOC_ADD4(out, one, two, three, four) \
+#nodef GITERR_CHECK_ADD4(out, one, two, three, four) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), three) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), four)) { __coverity_panic__(); }

--- a/src/blame_git.c
+++ b/src/blame_git.c
@@ -45,8 +45,8 @@ static int make_origin(git_blame__origin **out, git_commit *commit, const char *
 			path, GIT_OBJ_BLOB)) < 0)
 		return error;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, sizeof(*o), path_len);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 1);
+	GITERR_CHECK_ADD(&alloc_len, sizeof(*o), path_len);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 1);
 	o = git__calloc(1, alloc_len);
 	GITERR_CHECK_ALLOC(o);
 

--- a/src/buf_text.c
+++ b/src/buf_text.c
@@ -29,7 +29,7 @@ int git_buf_text_puts_escaped(
 		scan += count;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, total, 1);
+	GITERR_CHECK_ADD(&alloclen, total, 1);
 	if (git_buf_grow_by(buf, alloclen) < 0)
 		return -1;
 
@@ -75,7 +75,7 @@ int git_buf_text_crlf_to_lf(git_buf *tgt, const git_buf *src)
 		return git_buf_set(tgt, src->ptr, src->size);
 
 	/* reduce reallocs while in the loop */
-	GITERR_CHECK_ALLOC_ADD(&new_size, src->size, 1);
+	GITERR_CHECK_ADD(&new_size, src->size, 1);
 	if (git_buf_grow(tgt, new_size) < 0)
 		return -1;
 
@@ -122,8 +122,8 @@ int git_buf_text_lf_to_crlf(git_buf *tgt, const git_buf *src)
 		return git_buf_set(tgt, src->ptr, src->size);
 
 	/* attempt to reduce reallocs while in the loop */
-	GITERR_CHECK_ALLOC_ADD(&alloclen, src->size, src->size >> 4);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, src->size, src->size >> 4);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 	if (git_buf_grow(tgt, alloclen) < 0)
 		return -1;
 	tgt->size = 0;
@@ -135,7 +135,7 @@ int git_buf_text_lf_to_crlf(git_buf *tgt, const git_buf *src)
 		if (copylen && next[-1] == '\r')
 			copylen--;
 
-		GITERR_CHECK_ALLOC_ADD(&alloclen, copylen, 3);
+		GITERR_CHECK_ADD(&alloclen, copylen, 3);
 		if (git_buf_grow_by(tgt, alloclen) < 0)
 			return -1;
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -239,7 +239,7 @@ int git_buf_encode_base64(git_buf *buf, const char *data, size_t len)
 	size_t blocks = (len / 3) + !!extra, alloclen;
 
 	GITERR_CHECK_ALLOC_ADD(&blocks, blocks, 1);
-	GITERR_CHECK_ALLOC_MULTIPLY(&alloclen, blocks, 4);
+	GITERR_CHECK_MULTIPLY(&alloclen, blocks, 4);
 	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, buf->size);
 
 	ENSURE_SIZE(buf, alloclen);
@@ -337,7 +337,7 @@ int git_buf_encode_base85(git_buf *buf, const char *data, size_t len)
 {
 	size_t blocks = (len / 4) + !!(len % 4), alloclen;
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&alloclen, blocks, 5);
+	GITERR_CHECK_MULTIPLY(&alloclen, blocks, 5);
 	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, buf->size);
 	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
 
@@ -459,7 +459,7 @@ int git_buf_vprintf(git_buf *buf, const char *format, va_list ap)
 	size_t expected_size, new_size;
 	int len;
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&expected_size, strlen(format), 2);
+	GITERR_CHECK_MULTIPLY(&expected_size, strlen(format), 2);
 	GITERR_CHECK_ALLOC_ADD(&expected_size, expected_size, buf->size);
 	ENSURE_SIZE(buf, expected_size);
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -155,7 +155,7 @@ int git_buf_set(git_buf *buf, const void *data, size_t len)
 		git_buf_clear(buf);
 	} else {
 		if (data != buf->ptr) {
-			GITERR_CHECK_ALLOC_ADD(&alloclen, len, 1);
+			GITERR_CHECK_ADD(&alloclen, len, 1);
 			ENSURE_SIZE(buf, alloclen);
 			memmove(buf->ptr, data, len);
 		}
@@ -186,7 +186,7 @@ int git_buf_sets(git_buf *buf, const char *string)
 int git_buf_putc(git_buf *buf, char c)
 {
 	size_t new_size;
-	GITERR_CHECK_ALLOC_ADD(&new_size, buf->size, 2);
+	GITERR_CHECK_ADD(&new_size, buf->size, 2);
 	ENSURE_SIZE(buf, new_size);
 	buf->ptr[buf->size++] = c;
 	buf->ptr[buf->size] = '\0';
@@ -196,8 +196,8 @@ int git_buf_putc(git_buf *buf, char c)
 int git_buf_putcn(git_buf *buf, char c, size_t len)
 {
 	size_t new_size;
-	GITERR_CHECK_ALLOC_ADD(&new_size, buf->size, len);
-	GITERR_CHECK_ALLOC_ADD(&new_size, new_size, 1);
+	GITERR_CHECK_ADD(&new_size, buf->size, len);
+	GITERR_CHECK_ADD(&new_size, new_size, 1);
 	ENSURE_SIZE(buf, new_size);
 	memset(buf->ptr + buf->size, c, len);
 	buf->size += len;
@@ -212,8 +212,8 @@ int git_buf_put(git_buf *buf, const char *data, size_t len)
 
 		assert(data);
 		
-		GITERR_CHECK_ALLOC_ADD(&new_size, buf->size, len);
-		GITERR_CHECK_ALLOC_ADD(&new_size, new_size, 1);
+		GITERR_CHECK_ADD(&new_size, buf->size, len);
+		GITERR_CHECK_ADD(&new_size, new_size, 1);
 		ENSURE_SIZE(buf, new_size);
 		memmove(buf->ptr + buf->size, data, len);
 		buf->size += len;
@@ -238,9 +238,9 @@ int git_buf_encode_base64(git_buf *buf, const char *data, size_t len)
 	const uint8_t *read = (const uint8_t *)data;
 	size_t blocks = (len / 3) + !!extra, alloclen;
 
-	GITERR_CHECK_ALLOC_ADD(&blocks, blocks, 1);
+	GITERR_CHECK_ADD(&blocks, blocks, 1);
 	GITERR_CHECK_MULTIPLY(&alloclen, blocks, 4);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, buf->size);
+	GITERR_CHECK_ADD(&alloclen, alloclen, buf->size);
 
 	ENSURE_SIZE(buf, alloclen);
 	write = (uint8_t *)&buf->ptr[buf->size];
@@ -305,8 +305,8 @@ int git_buf_decode_base64(git_buf *buf, const char *base64, size_t len)
 	}
 
 	assert(len % 4 == 0);
-	GITERR_CHECK_ALLOC_ADD(&new_size, (len / 4 * 3), buf->size);
-	GITERR_CHECK_ALLOC_ADD(&new_size, new_size, 1);
+	GITERR_CHECK_ADD(&new_size, (len / 4 * 3), buf->size);
+	GITERR_CHECK_ADD(&new_size, new_size, 1);
 	ENSURE_SIZE(buf, new_size);
 
 	for (i = 0; i < len; i += 4) {
@@ -338,8 +338,8 @@ int git_buf_encode_base85(git_buf *buf, const char *data, size_t len)
 	size_t blocks = (len / 4) + !!(len % 4), alloclen;
 
 	GITERR_CHECK_MULTIPLY(&alloclen, blocks, 5);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, buf->size);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, alloclen, buf->size);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 
 	ENSURE_SIZE(buf, alloclen);
 
@@ -406,8 +406,8 @@ int git_buf_decode_base85(
 		return -1;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&new_size, output_len, buf->size);
-	GITERR_CHECK_ALLOC_ADD(&new_size, new_size, 1);
+	GITERR_CHECK_ADD(&new_size, output_len, buf->size);
+	GITERR_CHECK_ADD(&new_size, new_size, 1);
 	ENSURE_SIZE(buf, new_size);
 
 	while (output_len) {
@@ -460,7 +460,7 @@ int git_buf_vprintf(git_buf *buf, const char *format, va_list ap)
 	int len;
 
 	GITERR_CHECK_MULTIPLY(&expected_size, strlen(format), 2);
-	GITERR_CHECK_ALLOC_ADD(&expected_size, expected_size, buf->size);
+	GITERR_CHECK_ADD(&expected_size, expected_size, buf->size);
 	ENSURE_SIZE(buf, expected_size);
 
 	while (1) {
@@ -486,8 +486,8 @@ int git_buf_vprintf(git_buf *buf, const char *format, va_list ap)
 			break;
 		}
 
-		GITERR_CHECK_ALLOC_ADD(&new_size, buf->size, len);
-		GITERR_CHECK_ALLOC_ADD(&new_size, new_size, 1);
+		GITERR_CHECK_ADD(&new_size, buf->size, len);
+		GITERR_CHECK_ADD(&new_size, new_size, 1);
 		ENSURE_SIZE(buf, new_size);
 	}
 
@@ -630,10 +630,10 @@ int git_buf_join_n(git_buf *buf, char separator, int nbuf, ...)
 
 		segment_len = strlen(segment);
 
-		GITERR_CHECK_ALLOC_ADD(&total_size, total_size, segment_len);
+		GITERR_CHECK_ADD(&total_size, total_size, segment_len);
 
 		if (segment_len == 0 || segment[segment_len - 1] != separator)
-			GITERR_CHECK_ALLOC_ADD(&total_size, total_size, 1);
+			GITERR_CHECK_ADD(&total_size, total_size, 1);
 	}
 	va_end(ap);
 
@@ -641,7 +641,7 @@ int git_buf_join_n(git_buf *buf, char separator, int nbuf, ...)
 	if (total_size == 0)
 		return 0;
 
-	GITERR_CHECK_ALLOC_ADD(&total_size, total_size, 1);
+	GITERR_CHECK_ADD(&total_size, total_size, 1);
 	if (git_buf_grow_by(buf, total_size) < 0)
 		return -1;
 
@@ -721,9 +721,9 @@ int git_buf_join(
 	if (str_a >= buf->ptr && str_a < buf->ptr + buf->size)
 		offset_a = str_a - buf->ptr;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, strlen_a, strlen_b);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, need_sep);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 1);
+	GITERR_CHECK_ADD(&alloc_len, strlen_a, strlen_b);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, need_sep);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 1);
 	if (git_buf_grow(buf, alloc_len) < 0)
 		return -1;
 	assert(buf->ptr);
@@ -775,11 +775,11 @@ int git_buf_join3(
 			sep_b = (str_b[len_b - 1] != separator);
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&len_total, len_a, sep_a);
-	GITERR_CHECK_ALLOC_ADD(&len_total, len_total, len_b);
-	GITERR_CHECK_ALLOC_ADD(&len_total, len_total, sep_b);
-	GITERR_CHECK_ALLOC_ADD(&len_total, len_total, len_c);
-	GITERR_CHECK_ALLOC_ADD(&len_total, len_total, 1);
+	GITERR_CHECK_ADD(&len_total, len_a, sep_a);
+	GITERR_CHECK_ADD(&len_total, len_total, len_b);
+	GITERR_CHECK_ADD(&len_total, len_total, sep_b);
+	GITERR_CHECK_ADD(&len_total, len_total, len_c);
+	GITERR_CHECK_ADD(&len_total, len_total, 1);
 	if (git_buf_grow(buf, len_total) < 0)
 		return -1;
 
@@ -843,8 +843,8 @@ int git_buf_splice(
 	/* Ported from git.git
 	 * https://github.com/git/git/blob/16eed7c/strbuf.c#L159-176
 	 */
-	GITERR_CHECK_ALLOC_ADD(&new_size, (buf->size - nb_to_remove), nb_to_insert);
-	GITERR_CHECK_ALLOC_ADD(&alloc_size, new_size, 1);
+	GITERR_CHECK_ADD(&new_size, (buf->size - nb_to_remove), nb_to_insert);
+	GITERR_CHECK_ADD(&alloc_size, new_size, 1);
 	ENSURE_SIZE(buf, alloc_size);
 
 	memmove(splice_loc + nb_to_insert,

--- a/src/common.h
+++ b/src/common.h
@@ -231,7 +231,7 @@ GIT_INLINE(void) git__init_structure(void *structure, size_t len, unsigned int v
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), four)) { return -1; }
 
 /** Check for multiplicative overflow, failing if it would occur. */
-#define GITERR_CHECK_ALLOC_MULTIPLY(out, nelem, elsize) \
+#define GITERR_CHECK_MULTIPLY(out, nelem, elsize) \
 	if (GIT_MULTIPLY_SIZET_OVERFLOW(out, nelem, elsize)) { return -1; }
 
 /* NOTE: other giterr functions are in the public errors.h header file */

--- a/src/common.h
+++ b/src/common.h
@@ -218,14 +218,14 @@ GIT_INLINE(void) git__init_structure(void *structure, size_t len, unsigned int v
 	(git__multiply_sizet_overflow(out, nelem, elsize) ? (giterr_set_oom(), 1) : 0)
 
 /** Check for additive overflow, failing if it would occur. */
-#define GITERR_CHECK_ALLOC_ADD(out, one, two) \
+#define GITERR_CHECK_ADD(out, one, two) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two)) { return -1; }
 
-#define GITERR_CHECK_ALLOC_ADD3(out, one, two, three) \
+#define GITERR_CHECK_ADD3(out, one, two, three) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), three)) { return -1; }
 
-#define GITERR_CHECK_ALLOC_ADD4(out, one, two, three, four) \
+#define GITERR_CHECK_ADD4(out, one, two, three, four) \
 	if (GIT_ADD_SIZET_OVERFLOW(out, one, two) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), three) || \
 		GIT_ADD_SIZET_OVERFLOW(out, *(out), four)) { return -1; }

--- a/src/common.h
+++ b/src/common.h
@@ -211,11 +211,11 @@ GIT_INLINE(void) git__init_structure(void *structure, size_t len, unsigned int v
 
 /** Check for additive overflow, setting an error if would occur. */
 #define GIT_ADD_SIZET_OVERFLOW(out, one, two) \
-	(git__add_sizet_overflow(out, one, two) ? (giterr_set_oom(), 1) : 0)
+	(git__add_sizet_overflow(out, one, two) ? (giterr_set_overflow(), 1) : 0)
 
 /** Check for additive overflow, setting an error if would occur. */
 #define GIT_MULTIPLY_SIZET_OVERFLOW(out, nelem, elsize) \
-	(git__multiply_sizet_overflow(out, nelem, elsize) ? (giterr_set_oom(), 1) : 0)
+	(git__multiply_sizet_overflow(out, nelem, elsize) ? (giterr_set_overflow(), 1) : 0)
 
 /** Check for additive overflow, failing if it would occur. */
 #define GITERR_CHECK_ADD(out, one, two) \

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1038,8 +1038,8 @@ static int parse_section_header_ext(struct reader *reader, const char *line, con
 		return -1;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, base_name_len, quoted_len);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 2);
+	GITERR_CHECK_ADD(&alloc_len, base_name_len, quoted_len);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 2);
 
 	git_buf_grow(&buf, alloc_len);
 	git_buf_printf(&buf, "%s.", base_name);
@@ -1112,7 +1112,7 @@ static int parse_section_header(struct reader *reader, char **section_out)
 		return -1;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&line_len, (size_t)(name_end - line), 1);
+	GITERR_CHECK_ADD(&line_len, (size_t)(name_end - line), 1);
 	name = git__malloc(line_len);
 	GITERR_CHECK_ALLOC(name);
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -127,8 +127,8 @@ static int lookup_index_alloc(
 	GITERR_CHECK_MULTIPLY(&entries_len, entries, sizeof(struct index_entry));
 	GITERR_CHECK_MULTIPLY(&hash_len, hash_count, sizeof(struct index_entry *));
 
-	GITERR_CHECK_ALLOC_ADD(&index_len, sizeof(struct git_delta_index), entries_len);
-	GITERR_CHECK_ALLOC_ADD(&index_len, index_len, hash_len);
+	GITERR_CHECK_ADD(&index_len, sizeof(struct git_delta_index), entries_len);
+	GITERR_CHECK_ADD(&index_len, index_len, hash_len);
 
 	if (!git__is_ulong(index_len)) {
 		giterr_set(GITERR_NOMEMORY, "overly large delta");
@@ -553,7 +553,7 @@ int git_delta_apply(
 		return -1;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_sz, res_sz, 1);
+	GITERR_CHECK_ADD(&alloc_sz, res_sz, 1);
 	res_dp = git__malloc(alloc_sz);
 	GITERR_CHECK_ALLOC(res_dp);
 

--- a/src/delta.c
+++ b/src/delta.c
@@ -124,8 +124,8 @@ static int lookup_index_alloc(
 {
 	size_t entries_len, hash_len, index_len;
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&entries_len, entries, sizeof(struct index_entry));
-	GITERR_CHECK_ALLOC_MULTIPLY(&hash_len, hash_count, sizeof(struct index_entry *));
+	GITERR_CHECK_MULTIPLY(&entries_len, entries, sizeof(struct index_entry));
+	GITERR_CHECK_MULTIPLY(&hash_len, hash_count, sizeof(struct index_entry *));
 
 	GITERR_CHECK_ALLOC_ADD(&index_len, sizeof(struct git_delta_index), entries_len);
 	GITERR_CHECK_ALLOC_ADD(&index_len, index_len, hash_len);

--- a/src/diff.c
+++ b/src/diff.c
@@ -250,7 +250,7 @@ int git_diff_format_email(
 			goto on_error;
 		}
 
-		GITERR_CHECK_ALLOC_ADD(&allocsize, offset, 1);
+		GITERR_CHECK_ADD(&allocsize, offset, 1);
 		summary = git__calloc(allocsize, sizeof(char));
 		GITERR_CHECK_ALLOC(summary);
 

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -162,8 +162,8 @@ static int diff_driver_alloc(
 		namelen = strlen(name),
 		alloclen;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, driverlen, namelen);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, driverlen, namelen);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 
 	driver = git__calloc(1, alloclen);
 	GITERR_CHECK_ALLOC(driver);

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -826,7 +826,7 @@ int git_diff_find_similar(
 	if ((opts.flags & GIT_DIFF_FIND_ALL) == 0)
 		goto cleanup;
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&sigcache_size, num_deltas, 2);
+	GITERR_CHECK_MULTIPLY(&sigcache_size, num_deltas, 2);
 	sigcache = git__calloc(sigcache_size, sizeof(void *));
 	GITERR_CHECK_ALLOC(sigcache);
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -18,6 +18,11 @@ static git_error g_git_oom_error = {
 	GITERR_NOMEMORY
 };
 
+static git_error g_git_overflow_error = {
+	"Integer overflow",
+	GITERR_OVERFLOW
+};
+
 static void set_error_from_buffer(int error_class)
 {
 	git_error *error = &GIT_GLOBAL->error_t;
@@ -45,6 +50,11 @@ static void set_error(int error_class, char *string)
 void giterr_set_oom(void)
 {
 	GIT_GLOBAL->last_error = &g_git_oom_error;
+}
+
+void giterr_set_overflow(void)
+{
+	GIT_GLOBAL->last_error = &g_git_overflow_error;
 }
 
 void giterr_set(int error_class, const char *string, ...)

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -360,7 +360,7 @@ int git_filebuf_open_withsize(git_filebuf *file, const char *path, int flags, mo
 		file->path_original = git_buf_detach(&resolved_path);
 
 		/* create the locking path by appending ".lock" to the original */
-		GITERR_CHECK_ALLOC_ADD(&alloc_len, path_len, GIT_FILELOCK_EXTLENGTH);
+		GITERR_CHECK_ADD(&alloc_len, path_len, GIT_FILELOCK_EXTLENGTH);
 		file->path_lock = git__malloc(alloc_len);
 		GITERR_CHECK_ALLOC(file->path_lock);
 

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -139,7 +139,7 @@ int git_futils_readbuffer_fd(git_buf *buf, git_file fd, size_t len)
 		return -1;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, len, 1);
+	GITERR_CHECK_ADD(&alloc_len, len, 1);
 	if (git_buf_grow(buf, alloc_len) < 0)
 		return -1;
 
@@ -598,7 +598,7 @@ retry_lstat:
 			char *cache_path;
 			size_t alloc_size;
 
-			GITERR_CHECK_ALLOC_ADD(&alloc_size, make_path.size, 1);
+			GITERR_CHECK_ADD(&alloc_size, make_path.size, 1);
 			if (!git__is_uint32(alloc_size))
 				return -1;
 			cache_path = git_pool_malloc(opts->pool, (uint32_t)alloc_size);
@@ -864,7 +864,7 @@ static int cp_link(const char *from, const char *to, size_t link_size)
 	char *link_data;
 	size_t alloc_size;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_size, link_size, 1);
+	GITERR_CHECK_ADD(&alloc_size, link_size, 1);
 	link_data = git__malloc(alloc_size);
 	GITERR_CHECK_ALLOC(link_data);
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -156,8 +156,8 @@ static int filter_registry_insert(
 	if (filter_def_scan_attrs(&attrs, &nattr, &nmatch, filter->attributes) < 0)
 		return -1;
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&alloc_len, nattr, 2);
-	GITERR_CHECK_ALLOC_MULTIPLY(&alloc_len, alloc_len, sizeof(char *));
+	GITERR_CHECK_MULTIPLY(&alloc_len, nattr, 2);
+	GITERR_CHECK_MULTIPLY(&alloc_len, alloc_len, sizeof(char *));
 	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, sizeof(git_filter_def));
 
 	fdef = git__calloc(1, alloc_len);

--- a/src/filter.c
+++ b/src/filter.c
@@ -158,7 +158,7 @@ static int filter_registry_insert(
 
 	GITERR_CHECK_MULTIPLY(&alloc_len, nattr, 2);
 	GITERR_CHECK_MULTIPLY(&alloc_len, alloc_len, sizeof(char *));
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, sizeof(git_filter_def));
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, sizeof(git_filter_def));
 
 	fdef = git__calloc(1, alloc_len);
 	GITERR_CHECK_ALLOC(fdef);
@@ -403,8 +403,8 @@ static int filter_list_new(
 	git_filter_list *fl = NULL;
 	size_t pathlen = src->path ? strlen(src->path) : 0, alloclen;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(git_filter_list), pathlen);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, sizeof(git_filter_list), pathlen);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 
 	fl = git__calloc(1, alloclen);
 	GITERR_CHECK_ALLOC(fl);

--- a/src/index.c
+++ b/src/index.c
@@ -906,8 +906,8 @@ static int index_entry_create(
 		return -1;
 	}
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(struct entry_internal), pathlen);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, sizeof(struct entry_internal), pathlen);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 	entry = git__calloc(1, alloclen);
 	GITERR_CHECK_ALLOC(entry);
 
@@ -2364,7 +2364,7 @@ static size_t read_entry(
 		if (varint_len == 0)
 			return index_error_invalid("incorrect prefix length");
 
-		GITERR_CHECK_ALLOC_ADD(&tmp_path_len, shared, len + 1);
+		GITERR_CHECK_ADD(&tmp_path_len, shared, len + 1);
 		tmp_path = git__malloc(tmp_path_len);
 		GITERR_CHECK_ALLOC(tmp_path);
 		memcpy(tmp_path, last, last_len);

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -631,7 +631,7 @@ GIT_INLINE(int) tree_iterator_frame_push_neighbors(
 		if ((error = tree_iterator_compute_path(path, entry)) < 0)
 			break;
 
-		GITERR_CHECK_ALLOC_ADD(&new_size,
+		GITERR_CHECK_ADD(&new_size,
 			frame->entries.length, tree->entries.size);
 		git_vector_size_hint(&frame->entries, new_size);
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -2660,7 +2660,7 @@ static int merge_ancestor_head(
 
 	assert(repo && our_head && their_heads);
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, their_heads_len, 1);
+	GITERR_CHECK_ADD(&alloc_len, their_heads_len, 1);
 	oids = git__calloc(alloc_len, sizeof(git_oid));
 	GITERR_CHECK_ALLOC(oids);
 

--- a/src/merge.c
+++ b/src/merge.c
@@ -1401,7 +1401,7 @@ int git_merge_diff_list__find_renames(
 		goto done;
 
 	if (diff_list->conflicts.length <= opts->target_limit) {
-		GITERR_CHECK_ALLOC_MULTIPLY(&cache_size, diff_list->conflicts.length, 3);
+		GITERR_CHECK_MULTIPLY(&cache_size, diff_list->conflicts.length, 3);
 		cache = git__calloc(cache_size, sizeof(void *));
 		GITERR_CHECK_ALLOC(cache);
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -262,7 +262,7 @@ int git_odb__hashlink(git_oid *out, const char *path)
 		int read_len;
 		size_t alloc_size;
 
-		GITERR_CHECK_ALLOC_ADD(&alloc_size, size, 1);
+		GITERR_CHECK_ADD(&alloc_size, size, 1);
 		link_data = git__malloc(alloc_size);
 		GITERR_CHECK_ALLOC(link_data);
 

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -66,8 +66,8 @@ static int object_file_name(
 	size_t alloclen;
 
 	/* expand length for object root + 40 hex sha1 chars + 2 * '/' + '\0' */
-	GITERR_CHECK_ALLOC_ADD(&alloclen, be->objects_dirlen, GIT_OID_HEXSZ);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 3);
+	GITERR_CHECK_ADD(&alloclen, be->objects_dirlen, GIT_OID_HEXSZ);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 3);
 	if (git_buf_grow(name, alloclen) < 0)
 		return -1;
 
@@ -326,7 +326,7 @@ static int inflate_packlike_loose_disk_obj(git_rawobj *out, git_buf *obj)
 	/*
 	 * allocate a buffer and inflate the data into it
 	 */
-	GITERR_CHECK_ALLOC_ADD(&alloclen, hdr.size, 1);
+	GITERR_CHECK_ADD(&alloclen, hdr.size, 1);
 	buf = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(buf);
 
@@ -526,8 +526,8 @@ static int locate_object_short_oid(
 	int error;
 
 	/* prealloc memory for OBJ_DIR/xx/xx..38x..xx */
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, dir_len, GIT_OID_HEXSZ);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 3);
+	GITERR_CHECK_ADD(&alloc_len, dir_len, GIT_OID_HEXSZ);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 3);
 	if (git_buf_grow(object_location, alloc_len) < 0)
 		return -1;
 
@@ -573,8 +573,8 @@ static int locate_object_short_oid(
 		return error;
 
 	/* Update the location according to the oid obtained */
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, dir_len, GIT_OID_HEXSZ);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 2);
+	GITERR_CHECK_ADD(&alloc_len, dir_len, GIT_OID_HEXSZ);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 2);
 
 	git_buf_truncate(object_location, dir_len);
 	if (git_buf_grow(object_location, alloc_len) < 0)
@@ -959,8 +959,8 @@ int git_odb_backend_loose(
 
 	objects_dirlen = strlen(objects_dir);
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(loose_backend), objects_dirlen);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 2);
+	GITERR_CHECK_ADD(&alloclen, sizeof(loose_backend), objects_dirlen);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 2);
 	backend = git__calloc(1, alloclen);
 	GITERR_CHECK_ALLOC(backend);
 

--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -46,7 +46,7 @@ static int impl__write(git_odb_backend *_backend, const git_oid *oid, const void
 	if (rval == 0)
 		return 0;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, sizeof(struct memobject), len);
+	GITERR_CHECK_ADD(&alloc_len, sizeof(struct memobject), len);
 	obj = git__malloc(alloc_len);
 	GITERR_CHECK_ALLOC(obj);
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -219,7 +219,7 @@ int git_packbuilder_insert(git_packbuilder *pb, const git_oid *oid,
 
 	if (pb->nr_objects >= pb->nr_alloc) {
 		GITERR_CHECK_ALLOC_ADD(&newsize, pb->nr_alloc, 1024);
-		GITERR_CHECK_ALLOC_MULTIPLY(&newsize, newsize, 3 / 2);
+		GITERR_CHECK_MULTIPLY(&newsize, newsize, 3 / 2);
 
 		if (!git__is_uint32(newsize)) {
 			giterr_set(GITERR_NOMEMORY, "packfile too large to fit in memory.");

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -218,7 +218,7 @@ int git_packbuilder_insert(git_packbuilder *pb, const git_oid *oid,
 		return 0;
 
 	if (pb->nr_objects >= pb->nr_alloc) {
-		GITERR_CHECK_ALLOC_ADD(&newsize, pb->nr_alloc, 1024);
+		GITERR_CHECK_ADD(&newsize, pb->nr_alloc, 1024);
 		GITERR_CHECK_MULTIPLY(&newsize, newsize, 3 / 2);
 
 		if (!git__is_uint32(newsize)) {

--- a/src/pack.c
+++ b/src/pack.c
@@ -689,7 +689,7 @@ int git_packfile_unpack(
 	if (cached && stack_size == 1) {
 		void *data = obj->data;
 
-		GITERR_CHECK_ALLOC_ADD(&alloclen, obj->len, 1);
+		GITERR_CHECK_ADD(&alloclen, obj->len, 1);
 		obj->data = git__malloc(alloclen);
 		GITERR_CHECK_ALLOC(obj->data);
 
@@ -853,7 +853,7 @@ static int packfile_unpack_compressed(
 	z_stream stream;
 	unsigned char *buffer, *in;
 
-	GITERR_CHECK_ALLOC_ADD(&buf_size, size, 1);
+	GITERR_CHECK_ADD(&buf_size, size, 1);
 	buffer = git__calloc(1, buf_size);
 	GITERR_CHECK_ALLOC(buffer);
 
@@ -1121,8 +1121,8 @@ int git_packfile_alloc(struct git_pack_file **pack_out, const char *path)
 	if (path_len < strlen(".idx"))
 		return git_odb__error_notfound("invalid packfile path", NULL, 0);
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, sizeof(*p), path_len);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 2);
+	GITERR_CHECK_ADD(&alloc_len, sizeof(*p), path_len);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 2);
 
 	p = git__calloc(1, alloc_len);
 	GITERR_CHECK_ALLOC(p);

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -571,9 +571,9 @@ static int patch_generated_with_delta_alloc(
 	size_t new_len = *new_path ? strlen(*new_path) : 0;
 	size_t alloc_len;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, sizeof(*pd), old_len);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, new_len);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 2);
+	GITERR_CHECK_ADD(&alloc_len, sizeof(*pd), old_len);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, new_len);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 2);
 
 	*out = pd = git__calloc(1, alloc_len);
 	GITERR_CHECK_ALLOC(pd);

--- a/src/path.c
+++ b/src/path.c
@@ -910,9 +910,9 @@ int git_path_make_relative(git_buf *path, const char *parent)
 		depth++;
 
 	GITERR_CHECK_MULTIPLY(&newlen, depth, 3);
-	GITERR_CHECK_ALLOC_ADD(&newlen, newlen, plen);
+	GITERR_CHECK_ADD(&newlen, newlen, plen);
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, newlen, 1);
+	GITERR_CHECK_ADD(&alloclen, newlen, 1);
 
 	/* save the offset as we might realllocate the pointer */
 	offset = p - path->ptr;
@@ -971,7 +971,7 @@ int git_path_iconv(git_path_iconv_t *ic, const char **in, size_t *inlen)
 	git_buf_clear(&ic->buf);
 
 	while (1) {
-		GITERR_CHECK_ALLOC_ADD(&alloclen, wantlen, 1);
+		GITERR_CHECK_ADD(&alloclen, wantlen, 1);
 		if (git_buf_grow(&ic->buf, alloclen) < 0)
 			return -1;
 

--- a/src/path.c
+++ b/src/path.c
@@ -909,7 +909,7 @@ int git_path_make_relative(git_buf *path, const char *parent)
 	for (; (q = strchr(q, '/')) && *(q + 1); q++)
 		depth++;
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&newlen, depth, 3);
+	GITERR_CHECK_MULTIPLY(&newlen, depth, 3);
 	GITERR_CHECK_ALLOC_ADD(&newlen, newlen, plen);
 
 	GITERR_CHECK_ALLOC_ADD(&alloclen, newlen, 1);

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -13,8 +13,8 @@ int git_sortedcache_new(
 
 	pathlen = path ? strlen(path) : 0;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(git_sortedcache), pathlen);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, sizeof(git_sortedcache), pathlen);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 	sc = git__calloc(1, alloclen);
 	GITERR_CHECK_ALLOC(sc);
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -117,7 +117,7 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 
 	text_len = search - buffer;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, text_len, 1);
+	GITERR_CHECK_ADD(&alloc_len, text_len, 1);
 	tag->tag_name = git__malloc(alloc_len);
 	GITERR_CHECK_ALLOC(tag->tag_name);
 
@@ -148,7 +148,7 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 
 		text_len = buffer_end - ++buffer;
 
-		GITERR_CHECK_ALLOC_ADD(&alloc_len, text_len, 1);
+		GITERR_CHECK_ADD(&alloc_len, text_len, 1);
 		tag->message = git__malloc(alloc_len);
 		GITERR_CHECK_ALLOC(tag->message);
 

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -366,8 +366,8 @@ int git_cred_username_new(git_cred **cred, const char *username)
 
 	len = strlen(username);
 
-	GITERR_CHECK_ALLOC_ADD(&allocsize, sizeof(git_cred_username), len);
-	GITERR_CHECK_ALLOC_ADD(&allocsize, allocsize, 1);
+	GITERR_CHECK_ADD(&allocsize, sizeof(git_cred_username), len);
+	GITERR_CHECK_ADD(&allocsize, allocsize, 1);
 	c = git__malloc(allocsize);
 	GITERR_CHECK_ALLOC(c);
 

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -104,8 +104,8 @@ static int comment_pkt(git_pkt **out, const char *line, size_t len)
 	git_pkt_comment *pkt;
 	size_t alloclen;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(git_pkt_comment), len);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, sizeof(git_pkt_comment), len);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 	pkt = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt);
 
@@ -127,8 +127,8 @@ static int err_pkt(git_pkt **out, const char *line, size_t len)
 	line += 4;
 	len -= 4;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(git_pkt_progress), len);
-	GITERR_CHECK_ALLOC_ADD(&alloclen, alloclen, 1);
+	GITERR_CHECK_ADD(&alloclen, sizeof(git_pkt_progress), len);
+	GITERR_CHECK_ADD(&alloclen, alloclen, 1);
 	pkt = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt);
 
@@ -150,7 +150,7 @@ static int data_pkt(git_pkt **out, const char *line, size_t len)
 	line++;
 	len--;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(git_pkt_progress), len);
+	GITERR_CHECK_ADD(&alloclen, sizeof(git_pkt_progress), len);
 	pkt = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt);
 
@@ -171,7 +171,7 @@ static int sideband_progress_pkt(git_pkt **out, const char *line, size_t len)
 	line++;
 	len--;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, sizeof(git_pkt_progress), len);
+	GITERR_CHECK_ADD(&alloclen, sizeof(git_pkt_progress), len);
 	pkt = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt);
 
@@ -192,8 +192,8 @@ static int sideband_error_pkt(git_pkt **out, const char *line, size_t len)
 	line++;
 	len--;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, sizeof(git_pkt_err), len);
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, alloc_len, 1);
+	GITERR_CHECK_ADD(&alloc_len, sizeof(git_pkt_err), len);
+	GITERR_CHECK_ADD(&alloc_len, alloc_len, 1);
 	pkt = git__malloc(alloc_len);
 	GITERR_CHECK_ALLOC(pkt);
 
@@ -238,7 +238,7 @@ static int ref_pkt(git_pkt **out, const char *line, size_t len)
 	if (line[len - 1] == '\n')
 		--len;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, len, 1);
+	GITERR_CHECK_ADD(&alloclen, len, 1);
 	pkt->head.name = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt->head.name);
 
@@ -276,7 +276,7 @@ static int ok_pkt(git_pkt **out, const char *line, size_t len)
 	}
 	len = ptr - line;
 
-	GITERR_CHECK_ALLOC_ADD(&alloc_len, len, 1);
+	GITERR_CHECK_ADD(&alloc_len, len, 1);
 	pkt->ref = git__malloc(alloc_len);
 	GITERR_CHECK_ALLOC(pkt->ref);
 
@@ -304,7 +304,7 @@ static int ng_pkt(git_pkt **out, const char *line, size_t len)
 		goto out_err;
 	len = ptr - line;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, len, 1);
+	GITERR_CHECK_ADD(&alloclen, len, 1);
 	pkt->ref = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt->ref);
 
@@ -316,7 +316,7 @@ static int ng_pkt(git_pkt **out, const char *line, size_t len)
 		goto out_err;
 	len = ptr - line;
 
-	GITERR_CHECK_ALLOC_ADD(&alloclen, len, 1);
+	GITERR_CHECK_ADD(&alloclen, len, 1);
 	pkt->msg = git__malloc(alloclen);
 	GITERR_CHECK_ALLOC(pkt->msg);
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -54,7 +54,7 @@ int git_vector_dup(git_vector *v, const git_vector *src, git_vector_cmp cmp)
 
 	assert(v && src);
 
-	GITERR_CHECK_ALLOC_MULTIPLY(&bytes, src->length, sizeof(void *));
+	GITERR_CHECK_MULTIPLY(&bytes, src->length, sizeof(void *));
 
 	v->_alloc_size = src->length;
 	v->_cmp = cmp ? cmp : src->_cmp;

--- a/src/vector.c
+++ b/src/vector.c
@@ -337,7 +337,7 @@ int git_vector_insert_null(git_vector *v, size_t idx, size_t insert_len)
 
 	assert(insert_len > 0 && idx <= v->length);
 
-	GITERR_CHECK_ALLOC_ADD(&new_length, v->length, insert_len);
+	GITERR_CHECK_ADD(&new_length, v->length, insert_len);
 
 	if (new_length > v->_alloc_size && resize_vector(v, new_length) < 0)
 		return -1;

--- a/src/win32/w32_buffer.c
+++ b/src/win32/w32_buffer.c
@@ -36,8 +36,8 @@ int git_buf_put_w(git_buf *buf, const wchar_t *string_w, size_t len_w)
 
 	assert(utf8_len > 0);
 
-	GITERR_CHECK_ALLOC_ADD(&new_size, buf->size, (size_t)utf8_len);
-	GITERR_CHECK_ALLOC_ADD(&new_size, new_size, 1);
+	GITERR_CHECK_ADD(&new_size, buf->size, (size_t)utf8_len);
+	GITERR_CHECK_ADD(&new_size, new_size, 1);
 
 	if (git_buf_grow(buf, new_size) < 0)
 		return -1;

--- a/src/xdiff/xdiffi.c
+++ b/src/xdiff/xdiffi.c
@@ -345,9 +345,9 @@ int xdl_do_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	 * One is to store the forward path and one to store the backward path.
 	 */
 	GITERR_CHECK_ALLOC_ADD3(&ndiags, xe->xdf1.nreff, xe->xdf2.nreff, 3);
-	GITERR_CHECK_ALLOC_MULTIPLY(&allocsize, ndiags, 2);
+	GITERR_CHECK_MULTIPLY(&allocsize, ndiags, 2);
 	GITERR_CHECK_ALLOC_ADD(&allocsize, allocsize, 2);
-	GITERR_CHECK_ALLOC_MULTIPLY(&allocsize, allocsize, sizeof(long));
+	GITERR_CHECK_MULTIPLY(&allocsize, allocsize, sizeof(long));
 
 	if (!(kvd = (long *) xdl_malloc(allocsize))) {
 		xdl_free_env(xe);

--- a/src/xdiff/xdiffi.c
+++ b/src/xdiff/xdiffi.c
@@ -344,9 +344,9 @@ int xdl_do_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	 * Allocate and setup K vectors to be used by the differential algorithm.
 	 * One is to store the forward path and one to store the backward path.
 	 */
-	GITERR_CHECK_ALLOC_ADD3(&ndiags, xe->xdf1.nreff, xe->xdf2.nreff, 3);
+	GITERR_CHECK_ADD3(&ndiags, xe->xdf1.nreff, xe->xdf2.nreff, 3);
 	GITERR_CHECK_MULTIPLY(&allocsize, ndiags, 2);
-	GITERR_CHECK_ALLOC_ADD(&allocsize, allocsize, 2);
+	GITERR_CHECK_ADD(&allocsize, allocsize, 2);
 	GITERR_CHECK_MULTIPLY(&allocsize, allocsize, sizeof(long));
 
 	if (!(kvd = (long *) xdl_malloc(allocsize))) {

--- a/src/xdiff/xhistogram.c
+++ b/src/xdiff/xhistogram.c
@@ -303,7 +303,7 @@ static int histogram_diff(
 
 	index.table_bits = xdl_hashbits(count1);
 	sz = index.records_size = 1 << index.table_bits;
-	GITERR_CHECK_ALLOC_MULTIPLY(&sz, sz, sizeof(struct record *));
+	GITERR_CHECK_MULTIPLY(&sz, sz, sizeof(struct record *));
 
 	if (!(index.records = (struct record **) xdl_malloc(sz)))
 		goto cleanup;

--- a/src/xdiff/xmerge.c
+++ b/src/xdiff/xmerge.c
@@ -126,7 +126,7 @@ static int xdl_recs_copy_0(size_t *out, int use_orig, xdfenv_t *xe, int i, int c
 		if (dest)
 			memcpy(dest + size, recs[i]->ptr, recs[i]->size);
 
-		GITERR_CHECK_ALLOC_ADD(&size, size, recs[i++]->size);
+		GITERR_CHECK_ADD(&size, size, recs[i++]->size);
 	}
 
 	if (add_nl) {
@@ -135,7 +135,7 @@ static int xdl_recs_copy_0(size_t *out, int use_orig, xdfenv_t *xe, int i, int c
 			if (dest)
 				dest[size] = '\n';
 
-			GITERR_CHECK_ALLOC_ADD(&size, size, 1);
+			GITERR_CHECK_ADD(&size, size, 1);
 		}
 	}
 
@@ -174,10 +174,10 @@ static int fill_conflict_hunk(size_t *out, xdfenv_t *xe1, const char *name1,
 			      dest ? dest + size : NULL) < 0)
 		return -1;
 
-	GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+	GITERR_CHECK_ADD(&size, size, copied);
 
 	if (!dest) {
-		GITERR_CHECK_ALLOC_ADD4(&size, size, marker_size, 1, marker1_size);
+		GITERR_CHECK_ADD4(&size, size, marker_size, 1, marker1_size);
 	} else {
 		memset(dest + size, '<', marker_size);
 		size += marker_size;
@@ -194,12 +194,12 @@ static int fill_conflict_hunk(size_t *out, xdfenv_t *xe1, const char *name1,
 			      dest ? dest + size : NULL) < 0)
 		return -1;
 
-	GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+	GITERR_CHECK_ADD(&size, size, copied);
 
 	if (style == XDL_MERGE_DIFF3) {
 		/* Shared preimage */
 		if (!dest) {
-			GITERR_CHECK_ALLOC_ADD4(&size, size, marker_size, 1, marker3_size);
+			GITERR_CHECK_ADD4(&size, size, marker_size, 1, marker3_size);
 		} else {
 			memset(dest + size, '|', marker_size);
 			size += marker_size;
@@ -214,11 +214,11 @@ static int fill_conflict_hunk(size_t *out, xdfenv_t *xe1, const char *name1,
 		if (xdl_orig_copy(&copied, xe1, m->i0, m->chg0, 1,
 				      dest ? dest + size : NULL) < 0)
 			return -1;
-		GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+		GITERR_CHECK_ADD(&size, size, copied);
 	}
 
 	if (!dest) {
-		GITERR_CHECK_ALLOC_ADD3(&size, size, marker_size, 1);
+		GITERR_CHECK_ADD3(&size, size, marker_size, 1);
 	} else {
 		memset(dest + size, '=', marker_size);
 		size += marker_size;
@@ -230,10 +230,10 @@ static int fill_conflict_hunk(size_t *out, xdfenv_t *xe1, const char *name1,
 	if (xdl_recs_copy(&copied, xe2, m->i2, m->chg2, 1,
 			      dest ? dest + size : NULL) < 0)
 		return -1;
-	GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+	GITERR_CHECK_ADD(&size, size, copied);
 
 	if (!dest) {
-		GITERR_CHECK_ALLOC_ADD4(&size, size, marker_size, 1, marker2_size);
+		GITERR_CHECK_ADD4(&size, size, marker_size, 1, marker2_size);
 	} else {
 		memset(dest + size, '>', marker_size);
 		size += marker_size;
@@ -278,14 +278,14 @@ static int xdl_fill_merge_buffer(size_t *out,
 			if (xdl_recs_copy(&copied, xe1, i, m->i1 - i, 0,
 					      dest ? dest + size : NULL) < 0)
 				return -1;
-			GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+			GITERR_CHECK_ADD(&size, size, copied);
 
 			/* Postimage from side #1 */
 			if (m->mode & 1) {
 				if (xdl_recs_copy(&copied, xe1, m->i1, m->chg1, (m->mode & 2),
 						      dest ? dest + size : NULL) < 0)
 					return -1;
-				GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+				GITERR_CHECK_ADD(&size, size, copied);
 			}
 
 			/* Postimage from side #2 */
@@ -293,7 +293,7 @@ static int xdl_fill_merge_buffer(size_t *out,
 				if (xdl_recs_copy(&copied, xe2, m->i2, m->chg2, 0,
 						      dest ? dest + size : NULL) < 0)
 					return -1;
-				GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+				GITERR_CHECK_ADD(&size, size, copied);
 			}
 		} else
 			continue;
@@ -303,7 +303,7 @@ static int xdl_fill_merge_buffer(size_t *out,
 	if (xdl_recs_copy(&copied, xe1, i, xe1->xdf2.nrec - i, 0,
 			      dest ? dest + size : NULL) < 0)
 		return -1;
-	GITERR_CHECK_ALLOC_ADD(&size, size, copied);
+	GITERR_CHECK_ADD(&size, size, copied);
 
 	*out = size;
 	return 0;

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -159,7 +159,7 @@ void test_core_errors__restore_oom(void)
 static int test_arraysize_multiply(size_t nelem, size_t size)
 {
 	size_t out;
-	GITERR_CHECK_ALLOC_MULTIPLY(&out, nelem, size);
+	GITERR_CHECK_MULTIPLY(&out, nelem, size);
 	return 0;
 }
 

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -174,8 +174,8 @@ void test_core_errors__integer_overflow_alloc_multiply(void)
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX-1, sizeof(void *)));
 	cl_git_fail(test_arraysize_multiply((SIZE_MAX/sizeof(void *))+1, sizeof(void *)));
 
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_i(GITERR_OVERFLOW, giterr_last()->klass);
+	cl_assert_equal_s("Integer overflow", giterr_last()->message);
 }
 
 static int test_arraysize_add(size_t one, size_t two)
@@ -194,8 +194,8 @@ void test_core_errors__integer_overflow_alloc_add(void)
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX-1, 2));
 	cl_git_fail(test_arraysize_multiply(SIZE_MAX, SIZE_MAX));
 
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_i(GITERR_OVERFLOW, giterr_last()->klass);
+	cl_assert_equal_s("Integer overflow", giterr_last()->message);
 }
 
 void test_core_errors__integer_overflow_sets_oom(void)
@@ -212,11 +212,11 @@ void test_core_errors__integer_overflow_sets_oom(void)
 
 	giterr_clear();
 	cl_assert(GIT_ADD_SIZET_OVERFLOW(&out, SIZE_MAX, SIZE_MAX));
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_i(GITERR_OVERFLOW, giterr_last()->klass);
+	cl_assert_equal_s("Integer overflow", giterr_last()->message);
 
 	giterr_clear();
 	cl_assert(GIT_ADD_SIZET_OVERFLOW(&out, SIZE_MAX, SIZE_MAX));
-	cl_assert_equal_i(GITERR_NOMEMORY, giterr_last()->klass);
-	cl_assert_equal_s("Out of memory", giterr_last()->message);
+	cl_assert_equal_i(GITERR_OVERFLOW, giterr_last()->klass);
+	cl_assert_equal_s("Integer overflow", giterr_last()->message);
 }

--- a/tests/core/errors.c
+++ b/tests/core/errors.c
@@ -181,7 +181,7 @@ void test_core_errors__integer_overflow_alloc_multiply(void)
 static int test_arraysize_add(size_t one, size_t two)
 {
 	size_t out;
-	GITERR_CHECK_ALLOC_ADD(&out, one, two);
+	GITERR_CHECK_ADD(&out, one, two);
 	return 0;
 }
 


### PR DESCRIPTION
So I'm quite regularly confused by the `GIT_CHECK_ALLOC_ADD` kind of macros. While these are used in the context of memory allocations, they are in fact quite generic in their possible use in that these macros simply add/multiplicate integers with each other and check for an overflow.

So I've renamed these macros to remove the `ALLOC` part and switched their error class to a new class `GITERR_OVERFLOW`. I'm not too sure about it, though: while it improves readability for me, these macros are only used in the context of memory allocations. So I'm putting this up as an RFC.