### PR TITLE
Fix the documentation for git_cred_acquire_cb

### DIFF
--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -321,13 +321,13 @@ GIT_EXTERN(void) git_cred_free(git_cred *cred);
 /**
  * Signature of a function which acquires a credential object.
  *
- * - cred: The newly created credential object.
- * - url: The resource for which we are demanding a credential.
- * - username_from_url: The username that was embedded in a "user\@host"
+ * @param cred The newly created credential object.
+ * @param url The resource for which we are demanding a credential.
+ * @param username_from_url The username that was embedded in a "user\@host"
  *                          remote url, or NULL if not included.
- * - allowed_types: A bitmask stating which cred types are OK to return.
- * - payload: The payload provided when specifying this callback.
- * - returns 0 for success, < 0 to indicate an error, > 0 to indicate
+ * @param allowed_types A bitmask stating which cred types are OK to return.
+ * @param payload The payload provided when specifying this callback.
+ * @return 0 for success, < 0 to indicate an error, > 0 to indicate
  *       no credential was acquired
  */
 typedef int (*git_cred_acquire_cb)(


### PR DESCRIPTION
If you look at the documentation for [`git_cred_acquire_cb`](https://libgit2.github.com/libgit2/#v0.25.1/group/callback/git_cred_acquire_cb), you will see that the format is completely off with everything at the bottom with its return value and parameters undocumented. Compare this with [`git_diff_progress_cb`](https://libgit2.github.com/libgit2/#v0.25.1/group/callback/git_diff_progress_cb) where its parameters and return value is correctly documented because of its [proper use of tags](https://github.com/libgit2/libgit2/blob/adedac5aba9e4525475fd59d751cd02c6f2b3a4f/include/git2/diff.h#L359-L373) in the header file.

The documentation for `git_cred_acquire_cb` should be using standard `@param` and `@return` tags so that the documentation will be generated correctly.