### PR TITLE
git_futils: don't O_EXCL and O_TRUNC

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -66,8 +66,8 @@ int git_futils_creat_withpath(const char *path, const mode_t dirmode, const mode
 
 int git_futils_creat_locked(const char *path, const mode_t mode)
 {
-	int fd = p_open(path, O_WRONLY | O_CREAT | O_TRUNC |
-		O_EXCL | O_BINARY | O_CLOEXEC, mode);
+	int fd = p_open(path, O_WRONLY | O_CREAT | O_EXCL | O_BINARY | O_CLOEXEC,
+		mode);
 
 	if (fd < 0) {
 		int error = errno;


### PR DESCRIPTION
`O_EXCL` and `O_TRUNC` are mutually exclusive flags to open(2); you can't truncate a file if you're asserting that it can't exist in the first place.  Drop `O_TRUNC`.

Fixes #4017 