### PR TITLE
inet_pton: don't assume addr families don't exist

### DIFF
--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -94,10 +94,7 @@ void test_core_posix__inet_pton(void)
 	cl_assert(p_inet_pton(AF_INET, "10.foo.bar.1", &addr) == 0);
 
 	/* Test unsupported address families */
-	cl_git_fail(p_inet_pton(12, "52.472", &addr)); /* AF_DECnet */
-	cl_assert_equal_i(EAFNOSUPPORT, errno);
-
-	cl_git_fail(p_inet_pton(5, "315.124", &addr)); /* AF_CHAOS */
+	cl_git_fail(p_inet_pton(INT_MAX-1, "52.472", &addr));
 	cl_assert_equal_i(EAFNOSUPPORT, errno);
 }
 


### PR DESCRIPTION
Address family 5 might exist on some crazy system like Haiku.
Use `INT_MAX-1` as an unsupported address family.

Fixes #3872