### PR TITLE
Introduce home directory expansion function for config files, attribute files

### DIFF
--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -290,14 +290,16 @@ static int attr_cache__lookup_path(
 		const char *cfgval = entry->value;
 
 		/* expand leading ~/ as needed */
-		if (cfgval && cfgval[0] == '~' && cfgval[1] == '/' &&
-			!git_sysdir_find_global_file(&buf, &cfgval[2]))
-			*out = git_buf_detach(&buf);
-		else if (cfgval)
+		if (cfgval && cfgval[0] == '~' && cfgval[1] == '/') {
+			if (! (error = git_sysdir_expand_global_file(&buf, &cfgval[2])))
+				*out = git_buf_detach(&buf);
+		} else if (cfgval) {
 			*out = git__strdup(cfgval);
+		}
 	}
-	else if (!git_sysdir_find_xdg_file(&buf, fallback))
+	else if (!git_sysdir_find_xdg_file(&buf, fallback)) {
 		*out = git_buf_detach(&buf);
+	}
 
 	git_config_entry_free(entry);
 	git_buf_free(&buf);

--- a/src/config.c
+++ b/src/config.c
@@ -1339,9 +1339,6 @@ fail_parse:
 
 int git_config_parse_path(git_buf *out, const char *value)
 {
-	int error = 0;
-	const git_buf *home;
-
 	assert(out && value);
 
 	git_buf_sanitize(out);
@@ -1352,16 +1349,7 @@ int git_config_parse_path(git_buf *out, const char *value)
 			return -1;
 		}
 
-		if ((error = git_sysdir_get(&home, GIT_SYSDIR_GLOBAL)) < 0)
-			return error;
-
-		git_buf_sets(out, home->ptr);
-		git_buf_puts(out, value + 1);
-
-		if (git_buf_oom(out))
-			return -1;
-
-		return 0;
+		return git_sysdir_expand_global_file(out, value[1] ? &value[2] : NULL);
 	}
 
 	return git_buf_sets(out, value);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1254,8 +1254,16 @@ static int strip_comments(char *line, int in_quotes)
 static int included_path(git_buf *out, const char *dir, const char *path)
 {
 	/* From the user's home */
-	if (path[0] == '~' && path[1] == '/')
-		return git_sysdir_find_global_file(out, &path[1]);
+	int result;
+	if (path[0] == '~' && path[1] == '/') {
+		result = git_sysdir_find_global_file(out, &path[1]);
+		if (result == GIT_ENOTFOUND) {
+			git_buf_sets(out, &path[1]);
+			return 0;
+		}
+
+		return result;
+	}
 
 	return git_path_join_unrooted(out, path, dir, NULL);
 }

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -1254,16 +1254,8 @@ static int strip_comments(char *line, int in_quotes)
 static int included_path(git_buf *out, const char *dir, const char *path)
 {
 	/* From the user's home */
-	int result;
-	if (path[0] == '~' && path[1] == '/') {
-		result = git_sysdir_find_global_file(out, &path[1]);
-		if (result == GIT_ENOTFOUND) {
-			git_buf_sets(out, &path[1]);
-			return 0;
-		}
-
-		return result;
-	}
+	if (path[0] == '~' && path[1] == '/')
+		return git_sysdir_expand_global_file(out, &path[1]);
 
 	return git_path_join_unrooted(out, path, dir, NULL);
 }

--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -275,3 +275,14 @@ int git_sysdir_find_template_dir(git_buf *path)
 		path, NULL, GIT_SYSDIR_TEMPLATE, "template");
 }
 
+int git_sysdir_expand_global_file(git_buf *path, const char *filename)
+{
+	int error;
+
+	if ((error = git_sysdir_find_global_file(path, NULL)) == 0) {
+		if (filename)
+			error = git_buf_joinpath(path, path->ptr, filename);
+	}
+
+	return error;
+}

--- a/src/sysdir.h
+++ b/src/sysdir.h
@@ -55,6 +55,18 @@ extern int git_sysdir_find_programdata_file(git_buf *path, const char *filename)
  */
 extern int git_sysdir_find_template_dir(git_buf *path);
 
+/**
+ * Expand the name of a "global" file (i.e. one in a user's home
+ * directory).  Unlike `find_global_file` (above), this makes no
+ * attempt to check for the existence of the file, and is useful if
+ * you want the full path regardless of existence.
+ *
+ * @param path buffer to write the full path into
+ * @param filename name of file in the home directory
+ * @return 0 on success or -1 on error
+ */
+extern int git_sysdir_expand_global_file(git_buf *path, const char *filename);
+
 typedef enum {
 	GIT_SYSDIR_SYSTEM = 0,
 	GIT_SYSDIR_GLOBAL = 1,

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -113,6 +113,7 @@ void test_config_include__missing_homedir(void)
 	git_config *cfg;
 	git_buf buf = GIT_BUF_INIT;
 
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, cl_fixture("config")));
 	cl_git_mkfile("including", "[include]\npath = ~/.nonexistentfile\n[foo]\nbar = baz");
 
 	giterr_clear();
@@ -123,6 +124,8 @@ void test_config_include__missing_homedir(void)
 
 	git_buf_free(&buf);
 	git_config_free(cfg);
+
+	cl_sandbox_set_search_path_defaults();
 }
 
 #define replicate10(s) s s s s s s s s s s

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -108,6 +108,23 @@ void test_config_include__missing(void)
 	git_config_free(cfg);
 }
 
+void test_config_include__missing_homedir(void)
+{
+	git_config *cfg;
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_mkfile("including", "[include]\npath = ~/.nonexistentfile\n[foo]\nbar = baz");
+
+	giterr_clear();
+	cl_git_pass(git_config_open_ondisk(&cfg, "including"));
+	cl_assert(giterr_last() == NULL);
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar"));
+	cl_assert_equal_s("baz", git_buf_cstr(&buf));
+
+	git_buf_free(&buf);
+	git_config_free(cfg);
+}
+
 #define replicate10(s) s s s s s s s s s s
 void test_config_include__depth2(void)
 {


### PR DESCRIPTION
When we need to expand a tilde-prefixed path to the home directory (eg `~/file.txt` -> `/home/ethomson/file.txt`) we currently use `git_sysdir_find_global_file`.  Unfortunately, this function will return `GIT_ENOTFOUND` if the file does not exist in the home directory, which can make the error handling odd.

As a result, we currently if a nonexistent config file is included with a `~` path, and if a non-existent attribute file is loaded by a `~`, we will (incorrectly) fall back to looking for a file with a literal `~`.

This introduces `git_sysdir_expand_global_file` so that callers can simply expand the filename and then use it in their normal error handling logic if it is ultimately not found.

This builds on the fixes in #3828, which this obsoletes.

Fixes #3681.