### PR TITLE
Fix memory leaks

### DIFF
--- a/src/blame_git.c
+++ b/src/blame_git.c
@@ -547,7 +547,6 @@ static int pass_blame(git_blame *blame, git_blame__origin *origin, uint32_t opt)
 		if (porigin->blob && origin->blob &&
 		    !git_oid_cmp(git_blob_id(porigin->blob), git_blob_id(origin->blob))) {
 			error = pass_whole_blame(blame, origin, porigin);
-				goto finish;
 			origin_decref(porigin);
 			goto finish;
 		}

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -212,8 +212,7 @@ int git_worktree_open_from_repository(git_worktree **out, git_repository *repo)
 		goto out;
 
 out:
-	if (error)
-		free(name);
+	free(name);
 	git_buf_free(&parent);
 
 	return error;


### PR DESCRIPTION
The recent addition of an error code to `pass_whole_blame` in ff8d2eb15
(blame_git: check return value of object lookup, 2017-03-20) introduced
a spurious goto. Remove it.

Just noticed a few thousands of new memory leaks in the CI. The error is trivial and kind of embarassing - I'm surprised the compiler didn't throw any warning for unreachable code.