### PR TITLE
git_treebuilder_write_with_buffer refactorings

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -841,7 +841,7 @@ int git_treebuilder_write_with_buffer(git_oid *oid, git_treebuilder *bld, git_bu
 	git_vector_sort(&entries);
 
 	for (i = 0; i < entries.length && !error; ++i) {
-		git_tree_entry *entry = git_vector_get(&entries, i);
+		entry = git_vector_get(&entries, i);
 
 		git_buf_printf(tree, "%o ", entry->attr);
 		git_buf_put(tree, entry->filename, entry->filename_len + 1);

--- a/src/tree.c
+++ b/src/tree.c
@@ -847,12 +847,13 @@ int git_treebuilder_write_with_buffer(git_oid *oid, git_treebuilder *bld, git_bu
 		git_buf_put(tree, entry->filename, entry->filename_len + 1);
 		git_buf_put(tree, (char *)entry->oid->id, GIT_OID_RAWSZ);
 
-		if (git_buf_oom(tree))
+		if (git_buf_oom(tree)) {
 			error = -1;
+			goto out;
+		}
 	}
 
-	if (!error &&
-		!(error = git_repository_odb__weakptr(&odb, bld->repo)))
+	if ((error = git_repository_odb__weakptr(&odb, bld->repo)) == 0)
 		error = git_odb_write(oid, odb, tree->ptr, tree->size, GIT_OBJ_TREE);
 
 out:


### PR DESCRIPTION
Some small refactorings and memory leak fixes for the git_treebuilder_write_with_buffer function. This was triggered by #4181, but does not actually fix the issue.