### PR TITLE
pkgconfig: fix handling of prefixes containing whitespaces

### DIFF
--- a/libgit2.pc.in
+++ b/libgit2.pc.in
@@ -1,4 +1,4 @@
-prefix=@PKGCONFIG_PREFIX@
+prefix="@PKGCONFIG_PREFIX@"
 libdir=@PKGCONFIG_LIBDIR@
 includedir=@PKGCONFIG_INCLUDEDIR@
 
@@ -6,7 +6,7 @@ Name: libgit2
 Description: The git library, take 2
 Version: @LIBGIT2_VERSION_STRING@
 
-Libs: -L"${libdir}" -lgit2
+Libs: -L${libdir} -lgit2
 Libs.private: @LIBGIT2_PC_LIBS@
 Requires.private: @LIBGIT2_PC_REQUIRES@
 


### PR DESCRIPTION
Our libgit2.pc.in file is quoting the `libdir` variable in our declared
"Libs:" line. The intention is to handle whitespaces here, but pkgconfig
already does so by automatically escaping whitespace with backslashes.
The correct thing to do is to instead quote the prefix, as this is the
one which is being substituted by CMake upon installation. As both
libdir and includedir will be expanded to "${prefix}/lib" and
"${prefix}/include", respectively, pkgconfig will also correctly escape
whitespaces.

Note that this will actually break when a user manually wants to
override libdir and includedir with a path containing whitespace. But
actually, this cannot be helped, as always quoting these variables will
actuall break the common case of being prefixed with "${prefix}". So we
just bail out here and declare this as unsupported out of the box.