### PR TITLE
filter: only close filter if it's been initialized correctly

### DIFF
--- a/tests/filter/custom.c
+++ b/tests/filter/custom.c
@@ -55,6 +55,7 @@ void test_filter_custom__initialize(void)
 		"hero* bitflip reverse\n"
 		"herofile text\n"
 		"heroflip -reverse binary\n"
+		"villain erroneous\n"
 		"*.bin binary\n");
 }
 
@@ -80,6 +81,11 @@ static void register_custom_filters(void)
 		cl_git_pass(git_filter_register(
 			"pre-reverse",
 			create_reverse_filter("+prereverse"),
+			GIT_FILTER_DRIVER_PRIORITY));
+
+		cl_git_pass(git_filter_register(
+			"erroneous",
+			create_erroneous_filter("+erroneous"),
 			GIT_FILTER_DRIVER_PRIORITY));
 
 		filters_registered = 1;
@@ -234,4 +240,19 @@ void test_filter_custom__filter_registry_failure_cases(void)
 	cl_git_fail(git_filter_unregister(GIT_FILTER_CRLF));
 	cl_git_fail(git_filter_unregister(GIT_FILTER_IDENT));
 	cl_assert_equal_i(GIT_ENOTFOUND, git_filter_unregister("not-a-filter"));
+}
+
+void test_filter_custom__erroneous_filter_fails(void)
+{
+	git_filter_list *filters;
+	git_buf out = GIT_BUF_INIT;
+	git_buf in = GIT_BUF_INIT_CONST(workdir_data, strlen(workdir_data));
+
+	cl_git_pass(git_filter_list_load(
+		&filters, g_repo, NULL, "villain", GIT_FILTER_TO_WORKTREE, 0));
+
+	cl_git_fail(git_filter_list_apply_to_data(&out, filters, &in));
+
+	git_filter_list_free(filters);
+	git_buf_free(&out);
 }

--- a/tests/filter/custom_helpers.c
+++ b/tests/filter/custom_helpers.c
@@ -106,3 +106,36 @@ git_filter *create_reverse_filter(const char *attrs)
 
 	return filter;
 }
+
+int erroneous_filter_stream(
+	git_writestream **out,
+	git_filter *self,
+	void **payload,
+	const git_filter_source *src,
+	git_writestream *next)
+{
+	GIT_UNUSED(out);
+	GIT_UNUSED(self);
+	GIT_UNUSED(payload);
+	GIT_UNUSED(src);
+	GIT_UNUSED(next);
+	return -1;
+}
+
+static void erroneous_filter_free(git_filter *f)
+{
+	git__free(f);
+}
+
+git_filter *create_erroneous_filter(const char *attrs)
+{
+	git_filter *filter = git__calloc(1, sizeof(git_filter));
+	cl_assert(filter);
+
+	filter->version = GIT_FILTER_VERSION;
+	filter->attributes = attrs;
+	filter->stream = erroneous_filter_stream;
+	filter->shutdown = erroneous_filter_free;
+
+	return filter;
+}

--- a/tests/filter/custom_helpers.h
+++ b/tests/filter/custom_helpers.h
@@ -2,6 +2,7 @@
 
 extern git_filter *create_bitflip_filter(void);
 extern git_filter *create_reverse_filter(const char *attr);
+extern git_filter *create_erroneous_filter(const char *attr);
 
 extern int bitflip_filter_apply(
 	git_filter     *self,


### PR DESCRIPTION
In the function `git_filter_list_stream_data`, we initialize, write and
subesquently close the stream which should receive content processed by
the filter. While we skip writing to the stream if its initialization
failed, we still try to close it unconditionally -- even if the
initialization failed, where the stream might not be set at all, leading
us to segfault.

Semantics in this code is not really clear. The function handling the
same logic for files instead of data seems to do the right thing here in
only closing the stream when initialization succeeded. When stepping
back a bit, this is only reasonable: if a stream cannot be initialized,
the caller would not expect it to be closed again. So actually, both
callers of `stream_list_init` fail to do so. The data streaming function
will always close the stream and the file streaming function will not
close the stream if writing to it has failed.

The fix is thus two-fold:

- callers of `stream_list_init` now close the stream iff it has been
  initialized
- `stream_list_init` now closes the lastly initialized stream if
  the current stream in the chain failed to initialize

Add a test which segfaulted previous to these changes.