### PR TITLE
checkout.h: fix warning when compiling with -Wpedantic

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -112,7 +112,6 @@ typedef enum {
 	/** Allow all updates to force working directory to look like index */
 	GIT_CHECKOUT_FORCE = (1u << 1),
 
-
 	/** Allow checkout to recreate missing files */
 	GIT_CHECKOUT_RECREATE_MISSING = (1u << 2),
 
@@ -295,7 +294,7 @@ typedef struct git_checkout_options {
 } git_checkout_options;
 
 #define GIT_CHECKOUT_OPTIONS_VERSION 1
-#define GIT_CHECKOUT_OPTIONS_INIT {GIT_CHECKOUT_OPTIONS_VERSION}
+#define GIT_CHECKOUT_OPTIONS_INIT {.version = GIT_CHECKOUT_OPTIONS_VERSION}
 
 /**
 * Initializes a `git_checkout_options` with default values. Equivalent to


### PR DESCRIPTION
This fixes compiler warnings when compiling with `-Wpedantic` with gcc-6.3.0

Test case that demonstrates this concept:
https://gist.github.com/anonymous/7723e6bb90b6721e1b5013c20febf310

I applied this patch against master, but also applied it to version 0.25.1

