### PR TITLE
fileops: fix leaking fd in `mmap_ro_file`

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -304,15 +304,19 @@ int git_futils_mmap_ro_file(git_map *out, const char *path)
 	if (fd < 0)
 		return fd;
 
-	if ((len = git_futils_filesize(fd)) < 0)
-		return -1;
+	if ((len = git_futils_filesize(fd)) < 0) {
+		result = -1;
+		goto out;
+	}
 
 	if (!git__is_sizet(len)) {
 		giterr_set(GITERR_OS, "file `%s` too large to mmap", path);
-		return -1;
+		result = -1;
+		goto out;
 	}
 
 	result = git_futils_mmap_ro(out, fd, 0, (size_t)len);
+out:
 	p_close(fd);
 	return result;
 }


### PR DESCRIPTION
When the `git_futils_mmap_ro_file` function encounters an error after
the file has been opened, it will do a simple returns. Instead, we
should close the opened file descriptor to avoid a leak. This commit
fixes the issue.