### PR TITLE
travis: upgrade container to Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
     - openssh-server
     - valgrind
 
+dist: trusty
 sudo: false
 
 matrix:
@@ -38,13 +39,19 @@ matrix:
      compiler: gcc
  include:
    - compiler: gcc
+     env: PRECISE=1
+     os: linux
+     dist: precise
+   - compiler: gcc
      env: COVERITY=1
      os: linux
+     dist: trusty
    - compiler: gcc
      env:
        - VALGRIND=1
          OPTIONS="-DBUILD_CLAR=ON -DBUILD_EXAMPLES=OFF -DDEBUG_POOL=ON -DCMAKE_BUILD_TYPE=Debug"
      os: linux
+     dist: trusty
  allow_failures:
    - env: COVERITY=1
 

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -547,7 +547,7 @@ void test_online_clone__ssh_cert(void)
 	if (!_remote_ssh_fingerprint)
 		cl_skip();
 
-	cl_git_fail_with(GIT_EUSER, git_clone(&g_repo, "ssh://localhost/foo", "./foo", &g_options));
+	cl_git_fail_with(GIT_EUSER, git_clone(&g_repo, _remote_url, "./foo", &g_options));
 }
 
 static char *read_key_file(const char *path)


### PR DESCRIPTION
Ubuntu 12.04 (Precise Pangolin) reaches end of life on April 28th, 2017.
As such, we should update our build infrastructure to use the next
available LTS release, which is Ubuntu 14.04 LTS (Trusty Tahr). Note
that Trusty is still considered beta quality on Travis. But considering
we are able to correctly build and test libgit2, this seems to be a
non-issue for us.

Switch over our default distribution to Trusty. As Precise still has
extended support for paying customers, add an additional job which
compiles libgit2 on the old release.