### PR TITLE
diff_parse: free object instead of its pointer

### DIFF
--- a/src/diff_parse.c
+++ b/src/diff_parse.c
@@ -45,7 +45,7 @@ static git_diff_parsed *diff_parsed_alloc(void)
 	diff->base.free_fn = diff_parsed_free;
 
 	if (git_diff_init_options(&diff->base.opts, GIT_DIFF_OPTIONS_VERSION) < 0) {
-		git__free(&diff);
+		git__free(diff);
 		return NULL;
 	}
 


### PR DESCRIPTION
In e7330016a (diff_parse: check return value of `git_diff_init_options`,
2017-03-20), we've introduced an error check whether we're able to
correctly initialize the diff options. This simple commit actually
introduced a segfault in that we now try to free the pointer to the
allocated diff in an error case, instead of the allocated diff itself.
This commit fixes the issue.

Kind of embarrassing... :sweat_drops: 