### PR TITLE
socket_stream: continue to next addrinfo on socket creation failure

### DIFF
--- a/src/socket_stream.c
+++ b/src/socket_stream.c
@@ -106,10 +106,8 @@ int socket_connect(git_stream *stream)
 	for (p = info; p != NULL; p = p->ai_next) {
 		s = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
 
-		if (s == INVALID_SOCKET) {
-			net_set_error("error creating socket");
-			break;
-		}
+		if (s == INVALID_SOCKET)
+			continue;
 
 		if (connect(s, p->ai_addr, (socklen_t)p->ai_addrlen) == 0)
 			break;


### PR DESCRIPTION
When connecting to a remote via socket stream, we first use getaddrinfo
to obtain the possible connection methods followed by creating and
connecting the socket. But when creating the socket, we error out as
soon as we get an invalid socket instead of trying out other address
hints returned by addrinfo.

Fix this by continuing on invalid socket instead of returning an error.
This fixes connection establishment with musl libc.