### PR TITLE
Do not free config when creating remote

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -260,7 +260,6 @@ on_error:
 	if (error)
 		git_remote_free(remote);
 
-	git_config_free(config);
 	git_buf_free(&canonical_url);
 	git_buf_free(&var);
 	return error;


### PR DESCRIPTION
The regression was introduced in 22261344de18b3cc60ee6937468d66a6a6a28875