### PR TITLE
Allow NULL refspec in git_remote_push

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -2412,7 +2412,7 @@ int git_remote_push(git_remote *remote, const git_strarray *refspecs, const git_
 		proxy = &opts->proxy_opts;
 	}
 
-	assert(remote && refspecs);
+	assert(remote);
 
 	if ((error = git_remote_connect(remote, GIT_DIRECTION_PUSH, cbs, proxy, custom_headers)) < 0)
 		return error;


### PR DESCRIPTION
We've been (incorrectly) using this in julia and see no errors in release builds. Given that `refspec` is only passed to `git_remote_upload` which allows a `NULL` `refspec` I think this assertion can be relaxed.

Ref https://github.com/JuliaLang/julia/issues/21639
