### PR TITLE
libssh2 shutdown

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -22,7 +22,7 @@
 
 git_mutex git__mwindow_mutex;
 
-#define MAX_SHUTDOWN_CB 8
+#define MAX_SHUTDOWN_CB 9
 
 static git_global_shutdown_fn git__shutdown_callbacks[MAX_SHUTDOWN_CB];
 static git_atomic git__n_shutdown_callbacks;

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -896,8 +896,11 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 int git_transport_ssh_global_init(void)
 {
 #ifdef GIT_SSH
+	if (libssh2_init(0) < 0) {
+		giterr_set(GITERR_SSH, "unable to initialize libssh2");
+		return -1;
+	}
 
-	libssh2_init(0);
 	return 0;
 
 #else

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -9,6 +9,7 @@
 #include <libssh2.h>
 #endif
 
+#include "global.h"
 #include "git2.h"
 #include "buffer.h"
 #include "netops.h"
@@ -893,6 +894,13 @@ int git_transport_ssh_with_paths(git_transport **out, git_remote *owner, void *p
 #endif
 }
 
+#ifdef GIT_SSH
+static void shutdown_ssh(void)
+{
+    libssh2_exit();
+}
+#endif
+
 int git_transport_ssh_global_init(void)
 {
 #ifdef GIT_SSH
@@ -901,6 +909,7 @@ int git_transport_ssh_global_init(void)
 		return -1;
 	}
 
+	git__on_shutdown(shutdown_ssh);
 	return 0;
 
 #else


### PR DESCRIPTION
A few small cleanups regarding libssh2 and git_buf_clear/git_buf_free confusion.

The libssh2 code did not call libssh2_exit on shutdown, which I've fixed. This still leaves us with memory leaks in libssh2/libgcrypt, though, which I cannot track down with the CI only. I'll try to fire up a VM to hunt down the remaining issues, as my host system is incompatible with valgrind due to musl libc. :/