### PR TITLE
Fix GCC warnings

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1002,7 +1002,7 @@ static int odb_read_1(git_odb_object **out, git_odb *db, const git_oid *id,
 	git_odb_object *object;
 	git_oid hashed;
 	bool found = false;
-	int error;
+	int error = 0;
 
 	if (!only_refreshed && odb_read_hardcoded(&raw, id) == 0)
 		found = true;
@@ -1099,7 +1099,7 @@ static int read_prefix_1(git_odb_object **out, git_odb *db,
 		const git_oid *key, size_t len, bool only_refreshed)
 {
 	size_t i;
-	int error;
+	int error = 0;
 	git_oid found_full_oid = {{0}};
 	git_rawobj raw = {0};
 	void *data = NULL;

--- a/src/odb.c
+++ b/src/odb.c
@@ -1326,9 +1326,9 @@ static int git_odb_stream__invalid_length(
 {
 	giterr_set(GITERR_ODB,
 		"cannot %s - "
-		"Invalid length. %"PRIuZ" was expected. The "
-		"total size of the received chunks amounts to %"PRIuZ".",
-		action, stream->declared_size, stream->received_bytes);		
+		"Invalid length. %"PRIdZ" was expected. The "
+		"total size of the received chunks amounts to %"PRIdZ".",
+		action, stream->declared_size, stream->received_bytes);
 
 	return -1;
 }

--- a/tests/clone/local.c
+++ b/tests/clone/local.c
@@ -16,6 +16,7 @@ static int file_url(git_buf *buf, const char *host, const char *path)
 	return git_buf_printf(buf, "file://%s/%s", host, path);
 }
 
+#ifdef GIT_WIN32
 static int git_style_unc_path(git_buf *buf, const char *host, const char *path)
 {
 	git_buf_clear(buf);
@@ -49,6 +50,7 @@ static int unc_path(git_buf *buf, const char *host, const char *path)
 
 	return 0;
 }
+#endif
 
 void test_clone_local__should_clone_local(void)
 {

--- a/tests/threads/basic.c
+++ b/tests/threads/basic.c
@@ -54,12 +54,6 @@ static void *return_normally(void *param)
 {
 	return param;
 }
-
-static void *exit_abruptly(void *param)
-{
-	git_thread_exit(param);
-	return NULL;
-}
 #endif
 
 void test_threads_basic__exit(void)


### PR DESCRIPTION
This is split out from #4211. With this, we're free of compiler warnings on Ubuntu Trusty images, which will allow us to selectively enable "-Werror" in the future.