### PR TITLE
Configuration file fixes with includes

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -490,6 +490,12 @@ static int config_set(git_config_backend *cfg, const char *name, const char *val
 			goto out;
 		}
 
+		if (existing->included) {
+			giterr_set(GITERR_CONFIG, "modifying included variable is not supported");
+			ret = -1;
+			goto out;
+		}
+
 		/* don't update if old and new values already match */
 		if ((!existing->entry->value && !value) ||
 			(existing->entry->value && value &&
@@ -623,6 +629,11 @@ static int config_delete(git_config_backend *cfg, const char *name)
 
 	var = git_strmap_value_at(values, pos);
 	refcounted_strmap_free(map);
+
+	if (var->included) {
+		giterr_set(GITERR_CONFIG, "cannot delete included variable");
+		return -1;
+	}
 
 	if (var->next != NULL) {
 		giterr_set(GITERR_CONFIG, "cannot delete multivar with a single delete");

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -2,25 +2,31 @@
 #include "buffer.h"
 #include "fileops.h"
 
+static git_config *cfg;
+static git_buf buf;
+
+void test_config_include__initialize(void)
+{
+    cfg = NULL;
+    git_buf_init(&buf, 0);
+}
+
+void test_config_include__cleanup(void)
+{
+    git_config_free(cfg);
+    git_buf_free(&buf);
+}
+
 void test_config_include__relative(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
-
 	cl_git_pass(git_config_open_ondisk(&cfg, cl_fixture("config/config-include")));
 
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar.baz"));
 	cl_assert_equal_s("huzzah", git_buf_cstr(&buf));
-
-	git_buf_free(&buf);
-	git_config_free(cfg);
 }
 
 void test_config_include__absolute(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
-
 	cl_git_pass(git_buf_printf(&buf, "[include]\npath = %s/config-included", cl_fixture("config")));
 
 	cl_git_mkfile("config-include-absolute", git_buf_cstr(&buf));
@@ -29,16 +35,10 @@ void test_config_include__absolute(void)
 
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar.baz"));
 	cl_assert_equal_s("huzzah", git_buf_cstr(&buf));
-
-	git_buf_free(&buf);
-	git_config_free(cfg);
 }
 
 void test_config_include__homedir(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
-
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, cl_fixture("config")));
 	cl_git_mkfile("config-include-homedir",  "[include]\npath = ~/config-included");
 
@@ -47,18 +47,12 @@ void test_config_include__homedir(void)
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar.baz"));
 	cl_assert_equal_s("huzzah", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
-	git_config_free(cfg);
-
 	cl_sandbox_set_search_path_defaults();
 }
 
 /* We need to pretend that the variables were defined where the file was included */
 void test_config_include__ordering(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
-
 	cl_git_mkfile("included", "[foo \"bar\"]\nbaz = hurrah\nfrotz = hiya");
 	cl_git_mkfile("including",
 		      "[foo \"bar\"]\nfrotz = hello\n"
@@ -72,16 +66,11 @@ void test_config_include__ordering(void)
 	git_buf_clear(&buf);
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar.baz"));
 	cl_assert_equal_s("huzzah", git_buf_cstr(&buf));
-
-	git_buf_free(&buf);
-	git_config_free(cfg);
 }
 
 /* We need to pretend that the variables were defined where the file was included */
 void test_config_include__depth(void)
 {
-	git_config *cfg;
-
 	cl_git_mkfile("a", "[include]\npath = b");
 	cl_git_mkfile("b", "[include]\npath = a");
 
@@ -93,9 +82,6 @@ void test_config_include__depth(void)
 
 void test_config_include__missing(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
-
 	cl_git_mkfile("including", "[include]\npath = nonexistentfile\n[foo]\nbar = baz");
 
 	giterr_clear();
@@ -103,16 +89,10 @@ void test_config_include__missing(void)
 	cl_assert(giterr_last() == NULL);
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar"));
 	cl_assert_equal_s("baz", git_buf_cstr(&buf));
-
-	git_buf_free(&buf);
-	git_config_free(cfg);
 }
 
 void test_config_include__missing_homedir(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
-
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, cl_fixture("config")));
 	cl_git_mkfile("including", "[include]\npath = ~/.nonexistentfile\n[foo]\nbar = baz");
 
@@ -122,17 +102,12 @@ void test_config_include__missing_homedir(void)
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar"));
 	cl_assert_equal_s("baz", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
-	git_config_free(cfg);
-
 	cl_sandbox_set_search_path_defaults();
 }
 
 #define replicate10(s) s s s s s s s s s s
 void test_config_include__depth2(void)
 {
-	git_config *cfg;
-	git_buf buf = GIT_BUF_INIT;
 	const char *content = "[include]\n" replicate10(replicate10("path=bottom\n"));
 
 	cl_git_mkfile("top-level", "[include]\npath = middle\n[foo]\nbar = baz");
@@ -147,7 +122,4 @@ void test_config_include__depth2(void)
 	git_buf_clear(&buf);
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar2"));
 	cl_assert_equal_s("baz2", git_buf_cstr(&buf));
-
-	git_buf_free(&buf);
-	git_config_free(cfg);
 }

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -133,3 +133,16 @@ void test_config_include__removing_include_removes_values(void)
 	cl_git_mkfile("top-level", "");
 	cl_git_fail(git_config_get_string_buf(&buf, cfg, "foo.bar"));
 }
+
+void test_config_include__rewriting_include_refreshes_values(void)
+{
+	cl_git_mkfile("top-level", "[include]\npath = first\n[include]\npath = second");
+	cl_git_mkfile("first", "[first]\nfoo = bar");
+	cl_git_mkfile("second", "[second]\nfoo = bar");
+
+	cl_git_pass(git_config_open_ondisk(&cfg, "top-level"));
+	cl_git_mkfile("first", "[first]\nother = value");
+	cl_git_fail(git_config_get_string_buf(&buf, cfg, "foo.bar"));
+	cl_git_pass(git_config_get_string_buf(&buf, cfg, "first.other"));
+	cl_assert_equal_s(buf.ptr, "value");
+}

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -123,3 +123,13 @@ void test_config_include__depth2(void)
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar2"));
 	cl_assert_equal_s("baz2", git_buf_cstr(&buf));
 }
+
+void test_config_include__removing_include_removes_values(void)
+{
+	cl_git_mkfile("top-level", "[include]\npath = included");
+	cl_git_mkfile("included", "[foo]\nbar = value");
+
+	cl_git_pass(git_config_open_ondisk(&cfg, "top-level"));
+	cl_git_mkfile("top-level", "");
+	cl_git_fail(git_config_get_string_buf(&buf, cfg, "foo.bar"));
+}

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -146,3 +146,21 @@ void test_config_include__rewriting_include_refreshes_values(void)
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "first.other"));
 	cl_assert_equal_s(buf.ptr, "value");
 }
+
+void test_config_include__included_variables_cannot_be_deleted(void)
+{
+	cl_git_mkfile("top-level", "[include]\npath = included\n");
+	cl_git_mkfile("included", "[foo]\nbar = value");
+
+	cl_git_pass(git_config_open_ondisk(&cfg, "top-level"));
+	cl_git_fail(git_config_delete_entry(cfg, "foo.bar"));
+}
+
+void test_config_include__included_variables_cannot_be_modified(void)
+{
+	cl_git_mkfile("top-level", "[include]\npath = included\n");
+	cl_git_mkfile("included", "[foo]\nbar = value");
+
+	cl_git_pass(git_config_open_ondisk(&cfg, "top-level"));
+	cl_git_fail(git_config_set_string(cfg, "foo.bar", "other-value"));
+}


### PR DESCRIPTION
This fixes the issues causing #4247, but it does not yet fix additional issues with includes. One more issue I found was that upon refreshing a config file, we'll duplicate the includes inside the readers struct, if I'm not mistaken. I'll try to tackle this problem tomorrow, alongside with some tests for the broken behaviour.