### PR TITLE
settings: rename `GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION`

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -179,7 +179,7 @@ typedef enum {
 	GIT_OPT_SET_SSL_CIPHERS,
 	GIT_OPT_GET_USER_AGENT,
 	GIT_OPT_ENABLE_OFS_DELTA,
-	GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION,
+	GIT_OPT_ENABLE_FSYNC_GITDIR,
 	GIT_OPT_GET_WINDOWS_SHAREMODE,
 	GIT_OPT_SET_WINDOWS_SHAREMODE,
 	GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION,
@@ -331,9 +331,9 @@ typedef enum {
  *		> Packfiles containing offset deltas can still be read.
  *		> This defaults to enabled.
  *
- *	* opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, int enabled)
+ *	* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)
  *
- *		> Enable synchronized writes of new objects using `fsync`
+ *		> Enable synchronized writes of files in the gitdir using `fsync`
  *		> (or the platform equivalent) to ensure that new object data
  *		> is written to permanent storage, not simply cached.  This
  *		> defaults to disabled.

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -125,7 +125,7 @@ int git_indexer_new(
 	git_hash_ctx_init(&idx->hash_ctx);
 	git_hash_ctx_init(&idx->trailer);
 
-	if (git_object__synchronous_writing)
+	if (git_repository__fsync_gitdir)
 		idx->do_fsync = 1;
 
 	error = git_buf_joinpath(&path, prefix, suff);

--- a/src/object.c
+++ b/src/object.c
@@ -16,7 +16,6 @@
 #include "tag.h"
 
 bool git_object__strict_input_validation = true;
-bool git_object__synchronous_writing = false;
 
 typedef struct {
 	const char	*str;	/* type name string */

--- a/src/object.h
+++ b/src/object.h
@@ -10,7 +10,6 @@
 #include "repository.h"
 
 extern bool git_object__strict_input_validation;
-extern bool git_object__synchronous_writing;
 
 /** Base git object for inheritance */
 struct git_object {

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -850,7 +850,7 @@ static int filebuf_flags(loose_backend *backend)
 	int flags = GIT_FILEBUF_TEMPORARY |
 		(backend->object_zlib_level << GIT_FILEBUF_DEFLATE_SHIFT);
 
-	if (backend->fsync_object_files || git_object__synchronous_writing)
+	if (backend->fsync_object_files || git_repository__fsync_gitdir)
 		flags |= GIT_FILEBUF_FSYNC;
 
 	return flags;

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -2032,7 +2032,7 @@ int git_refdb_backend_fs(
 		backend->direach_flags  |= GIT_PATH_DIR_PRECOMPOSE_UNICODE;
 	}
 	if ((!git_repository__cvar(&t, backend->repo, GIT_CVAR_FSYNCOBJECTFILES) && t) ||
-		git_object__synchronous_writing)
+		git_repository__fsync_gitdir)
 		backend->fsync = 1;
 
 	backend->parent.exists = &refdb_fs_backend__exists;

--- a/src/repository.c
+++ b/src/repository.c
@@ -36,6 +36,8 @@
 # include "win32/w32_util.h"
 #endif
 
+bool git_repository__fsync_gitdir = false;
+
 static const struct {
     git_repository_item_t parent;
     const char *name;

--- a/src/repository.h
+++ b/src/repository.h
@@ -31,6 +31,8 @@
 /* Default DOS-compatible 8.3 "short name" for a git repository, "GIT~1" */
 #define GIT_DIR_SHORTNAME "GIT~1"
 
+extern bool git_repository__fsync_gitdir;
+
 /** Cvar cache identifiers */
 typedef enum {
 	GIT_CVAR_AUTO_CRLF = 0, /* core.autocrlf */

--- a/src/settings.c
+++ b/src/settings.c
@@ -228,8 +228,8 @@ int git_libgit2_opts(int key, ...)
 		git_smart__ofs_delta_enabled = (va_arg(ap, int) != 0);
 		break;
 
-	case GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION:
-		git_object__synchronous_writing = (va_arg(ap, int) != 0);
+	case GIT_OPT_ENABLE_FSYNC_GITDIR:
+		git_repository__fsync_gitdir = (va_arg(ap, int) != 0);
 		break;
 
 	case GIT_OPT_GET_WINDOWS_SHAREMODE:

--- a/tests/odb/loose.c
+++ b/tests/odb/loose.c
@@ -63,7 +63,7 @@ void test_odb_loose__initialize(void)
 
 void test_odb_loose__cleanup(void)
 {
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 0));
 	cl_fixture_cleanup("test-objects");
 }
 
@@ -181,7 +181,7 @@ void test_odb_loose__fsync_obeys_odb_option(void)
 
 void test_odb_loose__fsync_obeys_global_setting(void)
 {
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 1));
 	write_object_to_loose_odb(0);
 	cl_assert(p_fsync__cnt > 0);
 }

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -31,7 +31,7 @@ void test_pack_packbuilder__cleanup(void)
 	git_oid *o;
 	unsigned int i;
 
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 0));
 
 	if (_commits_is_initialized) {
 		_commits_is_initialized = 0;
@@ -209,7 +209,7 @@ static int expected_fsyncs = 4;
 
 void test_pack_packbuilder__fsync_global_setting(void)
 {
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 1));
 	p_fsync__cnt = 0;
 	seed_packbuilder();
 	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -22,7 +22,7 @@ void test_refs_create__cleanup(void)
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, 1));
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 0));
 }
 
 void test_refs_create__symbolic(void)
@@ -347,7 +347,7 @@ void test_refs_create__fsyncs_when_global_opt_set(void)
 {
 	size_t create_count, compress_count;
 
-	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_SYNCHRONOUS_OBJECT_CREATION, 1));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 1));
 	count_fsyncs(&create_count, &compress_count);
 
 	cl_assert_equal_i(expected_fsyncs_create, create_count);


### PR DESCRIPTION
Initially, the setting has been solely used to enable the use of
`fsync()` when creating objects. Since then, the use has been extended
to also cover references and index files. As the option is not yet part
of any release, we can still correct this by renaming the option to
something more sensible, indicating not only correlation to objects.

This commit renames the option to `GIT_OPT_ENABLE_FSYNC_GITDIR`. We also
move the variable from the object to repository source code.