### PR TITLE
smart_protocol: fix parsing of server ACK responses

### DIFF
--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -325,7 +325,8 @@ static int wait_while_ack(gitno_buffer *buf)
 
 		if (pkt->type == GIT_PKT_ACK &&
 		    (pkt->status != GIT_ACK_CONTINUE &&
-		     pkt->status != GIT_ACK_COMMON)) {
+		     pkt->status != GIT_ACK_COMMON &&
+		     pkt->status != GIT_ACK_READY)) {
 			git__free(pkt);
 			return 0;
 		}


### PR DESCRIPTION
Fix ACK parsing in `wait_while_ack()` internal function. This patch handles the case where `multi_ack_detailed` mode sends `ready` ACKs. The existing functionality would bail out too early, thus causing the processing of the ensuing packfile to fail if/when `ready` ACKs were sent.

The specification of the git pack-protocol details that for `multi_ack_detailed` mode the server ACKs refs with annotations `common` or `ready` depending on whether the commit was identified as common or if at that point in time the server had already identified a common base commit. In the `git.git` implementation of `git-upload-pack` the process rarely ever sends `ready` ACKs since it seemingly walks the entire DAG and identifies all common commits. However the client could send commits it obtained from another remote or another server implementation could send `ready` on common commits if a previous common commit was identified as a base (i.e. the server is now just blindly ACKing commits).

Since `git2` doesn't seem to really care about what kind of ACK was sent (it seems to just want to read past them to get to the packfile), we need to make sure the `wait_while_ack()` function reads past all of them. It _is_ safe to assume we've reached the end of the ACKs when we find an unannotated ACK since `wait_while_ack()` is only called for `multi_ack` or `multi_ack_detailed` modes and the server _must_ send a final unannotated ACK according to the protocol spec.

I discovered this issue while using GitKraken (which employs `git2`) against a custom git server implementation I've been working on. My implementation issues `ACK ready` once it's identified a common base whereas the core `git-upload-pack` does not. This was causing fetch to fail with the error `wrong pack signature`. Here's a look at the responses:

```
0038ACK 43900234b13264b4040ed05d45cf42cd9e72ff2c common
0037ACK 9ee538319df7f74c4c94fbb54034a7a94a9da4f5 ready
0031ACK 43900234b13264b4040ed05d45cf42cd9e72ff2c
PACK...
```

What `git2` is doing now is keeping the following as the pack file instead of starting at `PACK`:

```
0031ACK 43900234b13264b4040ed05d45cf42cd9e72ff2c
PACK...
```
