### PR TITLE
Allow creation of a configuration object in an in-memory repository

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -433,12 +433,12 @@ typedef enum {
  * item. It will thereby honor things like the repository's
  * common directory, gitdir, etc. In case a file path cannot
  * exist for a given item (e.g. the working directory of a bare
- * repository), an error is returned.
+ * repository), GIT_ENOTFOUND is returned.
  *
  * @param out Buffer to store the path at
  * @param repo Repository to get path for
  * @param item The repository item for which to retrieve the path
- * @return 0 on success, otherwise a negative value
+ * @return 0, GIT_ENOTFOUND if the path cannot exist or an error code
  */
 GIT_EXTERN(int) git_repository_item_path(git_buf *out, git_repository *repo, git_repository_item_t item);
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -943,13 +943,10 @@ static int load_config(
 	if ((error = git_config_new(&cfg)) < 0)
 		return error;
 
-	error = git_repository_item_path(&config_path, repo, GIT_REPOSITORY_ITEM_CONFIG);
-	if (error < 0)
-		goto on_error;
+	if ((error = git_repository_item_path(&config_path, repo, GIT_REPOSITORY_ITEM_CONFIG)) == 0)
+		error = git_config_add_file_ondisk(cfg, config_path.ptr, GIT_CONFIG_LEVEL_LOCAL, 0);
 
-	if ((error = git_config_add_file_ondisk(
-			cfg, config_path.ptr, GIT_CONFIG_LEVEL_LOCAL, 0)) < 0 &&
-		error != GIT_ENOTFOUND)
+	if (error && error != GIT_ENOTFOUND)
 		goto on_error;
 
 	git_buf_free(&config_path);

--- a/src/repository.c
+++ b/src/repository.c
@@ -2266,12 +2266,12 @@ int git_repository_item_path(git_buf *out, git_repository *repo, git_repository_
 			parent = git_repository_commondir(repo);
 			break;
 		default:
-			giterr_set(GITERR_INVALID, "Invalid item directory");
+			giterr_set(GITERR_INVALID, "invalid item directory");
 			return -1;
 	}
 
 	if (parent == NULL) {
-		giterr_set(GITERR_INVALID, "Path cannot exist in repository");
+		giterr_set(GITERR_INVALID, "path cannot exist in repository");
 		return -1;
 	}
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -2272,7 +2272,7 @@ int git_repository_item_path(git_buf *out, git_repository *repo, git_repository_
 
 	if (parent == NULL) {
 		giterr_set(GITERR_INVALID, "path cannot exist in repository");
-		return -1;
+		return GIT_ENOTFOUND;
 	}
 
 	if (git_buf_sets(out, parent) < 0)

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -465,3 +465,19 @@ void test_network_remote_local__push_delete(void)
 	cl_fixture_cleanup("target.git");
 	cl_git_sandbox_cleanup();
 }
+
+void test_network_remote_local__anonymous_remote_inmemory_repo(void)
+{
+	git_repository *inmemory;
+	git_remote *remote;
+
+	git_buf_sets(&file_path_buf, cl_git_path_url(cl_fixture("testrepo.git")));
+
+	cl_git_pass(git_repository_new(&inmemory));
+	cl_git_pass(git_remote_create_anonymous(&remote, inmemory, git_buf_cstr(&file_path_buf)));
+	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH, NULL, NULL, NULL));
+	cl_assert(git_remote_connected(remote));
+	git_remote_disconnect(remote);
+	git_remote_free(remote);
+	git_repository_free(inmemory);
+}


### PR DESCRIPTION
Regression:  we cannot create a configuration object against an in-memory remote, since the path to the repository configuration cannot be created.

Change `git_repository_item_path` to return `GIT_ENOTFOUND` when the path could not be constructed because the underlying directory does not exist.  (For example, when requesting the `config` file on an in-memory repository.

Add a unit test for a concrete scenario: create an anonymous remote on an in-memory repository (to allow for emulating `git ls-remote`).