### PR TITLE
odb_read_prefix: reset error in backends loop

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1116,8 +1116,11 @@ static int read_prefix_1(git_odb_object **out, git_odb *db,
 		if (b->read_prefix != NULL) {
 			git_oid full_oid;
 			error = b->read_prefix(&full_oid, &raw.data, &raw.len, &raw.type, b, key, len);
-			if (error == GIT_ENOTFOUND || error == GIT_PASSTHROUGH)
+
+			if (error == GIT_ENOTFOUND || error == GIT_PASSTHROUGH) {
+				error = 0;
 				continue;
+			}
 
 			if (error)
 				goto out;


### PR DESCRIPTION
When looking for an object by prefix, we query all the backends so that we can ensure that there is no ambiguity.  We need to reset the `error` value between backends; otherwise the first backend may find an object by prefix, but subsequent backends may not.  If we do not reset the `error` value then it will remain at `GIT_ENOTFOUND` and `read_prefix_1` will fail, despite having actually found an object.

LibGit2Sharp creates such a scenario in its tests: it sets up its own custom ODB backend, then adds an object and looks that object up again by a prefix.