### PR TITLE
adding GIT_FILTER_VERSION to GIT_FILTER_INIT as part of convention

### DIFF
--- a/include/git2/sys/filter.h
+++ b/include/git2/sys/filter.h
@@ -272,6 +272,17 @@ struct git_filter {
 
 #define GIT_FILTER_VERSION 1
 #define GIT_FILTER_INIT {GIT_FILTER_VERSION}
+
+/**
+ * Initializes a `git_filter` with default values. Equivalent to
+ * creating an instance with GIT_FILTER_INIT.
+ *
+ * @param filter the `git_filter` struct to initialize.
+ * @param version Version the struct; pass `GIT_FILTER_VERSION`
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_filter_init(git_filter *filter, unsigned int version);
+
 /**
  * Register a filter under a given name with a given priority.
  *

--- a/include/git2/sys/filter.h
+++ b/include/git2/sys/filter.h
@@ -271,7 +271,7 @@ struct git_filter {
 };
 
 #define GIT_FILTER_VERSION 1
-
+#define GIT_FILTER_INIT {GIT_FILTER_VERSION}
 /**
  * Register a filter under a given name with a given priority.
  *

--- a/src/filter.c
+++ b/src/filter.c
@@ -895,7 +895,7 @@ static int stream_list_init(
 			git_array_size(filters->filters) - 1 - i : i;
 		git_filter_entry *fe = git_array_get(filters->filters, filter_idx);
 		git_writestream *filter_stream;
-		
+
 		assert(fe->filter->stream || fe->filter->apply);
 
 		/* If necessary, create a stream that proxies the traditional
@@ -1021,4 +1021,10 @@ int git_filter_list_stream_blob(
 		git_oid_cpy(&filters->source.oid, git_blob_id(blob));
 
 	return git_filter_list_stream_data(filters, &in, target);
+}
+
+int git_filter_init(git_filter *filter, unsigned int version)
+{
+	GIT_INIT_STRUCTURE_FROM_TEMPLATE(filter, version, git_filter, GIT_FILTER_INIT);
+	return 0;
 }

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -1,5 +1,6 @@
 #include "clar_libgit2.h"
 #include <git2/sys/config.h>
+#include <git2/sys/filter.h>
 #include <git2/sys/odb_backend.h>
 #include <git2/sys/refdb_backend.h>
 #include <git2/sys/transport.h>
@@ -95,6 +96,11 @@ void test_core_structinit__compare(void)
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_diff_find_options, GIT_DIFF_FIND_OPTIONS_VERSION, \
 		GIT_DIFF_FIND_OPTIONS_INIT, git_diff_find_init_options);
+
+	/* filter */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_filter, GIT_FILTER_VERSION, \
+		GIT_FILTER_INIT, git_filter_init);
 
 	/* merge_file_input */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \


### PR DESCRIPTION
Adding GIT_FILTER_VERSION to GIT_FILTER_INIT. 
Stumbled on this while using custom filters via. filter struct.
Also on the recommendation of @implausible.

Similar convention seen in files:
include/git2/sys/blame.h (Line 82)
include/git2/sys/checkout.h (Line 298)
include/git2/sys/cherrypick.h (Line 37)
...