### PR TITLE
travis: replace use of deprecated homebrew/dupes tap

### DIFF
--- a/script/install-deps-osx.sh
+++ b/script/install-deps-osx.sh
@@ -3,7 +3,7 @@
 set -x
 
 brew update
-brew install homebrew/dupes/zlib
+brew install zlib
 brew install curl
 brew install openssl
 brew install libssh2


### PR DESCRIPTION
The formulae provided by the homebrew/dupes tap are deprecated since at
least April 4, 2017, with formulae having been migrated to
homebrew/core.

Replace the deprecated reference to "homebrew/dupes/zlib" with only
"zlib".