### PR TITLE
merge: fix potential free of uninitialized memory

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -1165,7 +1165,7 @@ static int merge_diff_mark_similarity_exact(
 {
 	size_t i, j;
 	git_merge_diff *conflict_src, *conflict_tgt;
-	git_oidmap *ours_deletes_by_oid, *theirs_deletes_by_oid;
+	git_oidmap *ours_deletes_by_oid = NULL, *theirs_deletes_by_oid = NULL;
 	int error = 0;
 
 	if (!(ours_deletes_by_oid = git_oidmap_alloc()) ||


### PR DESCRIPTION
The function `merge_diff_mark_similarity_exact` may error our early and,
when it does so, free the `ours_deletes_by_oid` and
`theirs_deletes_by_oid` variables. While the first one can never be
uninitialized due to the first call actually assigning to it, the second
variable can be freed without being initialized.

Fix the issue by initializing both variables to `NULL`.