### PR TITLE
Include fixups

### DIFF
--- a/deps/zlib/zconf.h
+++ b/deps/zlib/zconf.h
@@ -8,7 +8,8 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 
-#include "../../src/common.h"
+#include "../../include/git2/types.h"
+#include <stdarg.h>
 
 /* Jeez, don't complain about non-prototype
  * forms, we didn't write zlib */

--- a/src/annotated_commit.c
+++ b/src/annotated_commit.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "annotated_commit.h"
+
 #include "refs.h"
 #include "cache.h"
 

--- a/src/annotated_commit.h
+++ b/src/annotated_commit.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_annotated_commit_h__
 #define INCLUDE_annotated_commit_h__
 
+#include "common.h"
+
 #include "oidarray.h"
 
 #include "git2/oid.h"

--- a/src/apply.c
+++ b/src/apply.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "apply.h"
+
 #include <assert.h>
 
 #include "git2/patch.h"
@@ -12,7 +14,6 @@
 #include "array.h"
 #include "patch.h"
 #include "fileops.h"
-#include "apply.h"
 #include "delta.h"
 #include "zstream.h"
 

--- a/src/apply.h
+++ b/src/apply.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_apply_h__
 #define INCLUDE_apply_h__
 
+#include "common.h"
+
 #include "git2/patch.h"
 #include "buffer.h"
 

--- a/src/attr.c
+++ b/src/attr.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "attr.h"
+
 #include "repository.h"
 #include "sysdir.h"
 #include "config.h"

--- a/src/attr.c
+++ b/src/attr.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
 #include "common.h"
 #include "repository.h"
 #include "sysdir.h"

--- a/src/attr.h
+++ b/src/attr.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_attr_h__
 #define INCLUDE_attr_h__
 
+#include "common.h"
+
 #include "attr_file.h"
 #include "attrcache.h"
 

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
 #include "common.h"
 #include "repository.h"
 #include "filebuf.h"

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -5,10 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "attr_file.h"
+
 #include "repository.h"
 #include "filebuf.h"
-#include "attr_file.h"
 #include "attrcache.h"
 #include "git2/blob.h"
 #include "git2/tree.h"

--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_attr_file_h__
 #define INCLUDE_attr_file_h__
 
+#include "common.h"
+
 #include "git2/oid.h"
 #include "git2/attr.h"
 #include "vector.h"

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
 #include "common.h"
 #include "repository.h"
 #include "attr_file.h"

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "attrcache.h"
+
 #include "repository.h"
 #include "attr_file.h"
 #include "config.h"

--- a/src/attrcache.h
+++ b/src/attrcache.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_attrcache_h__
 #define INCLUDE_attrcache_h__
 
+#include "common.h"
+
 #include "attr_file.h"
 #include "strmap.h"
 

--- a/src/blame.c
+++ b/src/blame.c
@@ -6,6 +6,7 @@
  */
 
 #include "blame.h"
+
 #include "git2/commit.h"
 #include "git2/revparse.h"
 #include "git2/revwalk.h"

--- a/src/blame.h
+++ b/src/blame.h
@@ -1,8 +1,9 @@
 #ifndef INCLUDE_blame_h__
 #define INCLUDE_blame_h__
 
-#include "git2/blame.h"
 #include "common.h"
+
+#include "git2/blame.h"
 #include "vector.h"
 #include "diff.h"
 #include "array.h"

--- a/src/blame_git.c
+++ b/src/blame_git.c
@@ -6,6 +6,7 @@
  */
 
 #include "blame_git.h"
+
 #include "commit.h"
 #include "blob.h"
 #include "xdiff/xinclude.h"

--- a/src/blame_git.h
+++ b/src/blame_git.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_blame_git__
 #define INCLUDE_blame_git__
 
+#include "common.h"
+
 #include "blame.h"
 
 int git_blame__get_origin(

--- a/src/blob.c
+++ b/src/blob.c
@@ -5,14 +5,14 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "blob.h"
+
 #include "git2/common.h"
 #include "git2/object.h"
 #include "git2/repository.h"
 #include "git2/odb_backend.h"
 
-#include "common.h"
 #include "filebuf.h"
-#include "blob.h"
 #include "filter.h"
 #include "buf_text.h"
 

--- a/src/blob.h
+++ b/src/blob.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_blob_h__
 #define INCLUDE_blob_h__
 
+#include "common.h"
+
 #include "git2/blob.h"
 #include "repository.h"
 #include "odb.h"

--- a/src/branch.c
+++ b/src/branch.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "branch.h"
+
 #include "commit.h"
 #include "tag.h"
 #include "config.h"

--- a/src/branch.h
+++ b/src/branch.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_branch_h__
 #define INCLUDE_branch_h__
 
+#include "common.h"
+
 #include "buffer.h"
 
 int git_branch_upstream__name(

--- a/src/buf_text.h
+++ b/src/buf_text.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_buf_text_h__
 #define INCLUDE_buf_text_h__
 
+#include "common.h"
+
 #include "buffer.h"
 
 typedef enum {

--- a/src/cache.c
+++ b/src/cache.c
@@ -5,12 +5,12 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "cache.h"
+
 #include "repository.h"
 #include "commit.h"
 #include "thread-utils.h"
 #include "util.h"
-#include "cache.h"
 #include "odb.h"
 #include "object.h"
 #include "git2/oid.h"

--- a/src/cache.h
+++ b/src/cache.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_cache_h__
 #define INCLUDE_cache_h__
 
+#include "common.h"
+
 #include "git2/common.h"
 #include "git2/oid.h"
 #include "git2/odb.h"

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include <assert.h>
-
 #include "checkout.h"
+
+#include <assert.h>
 
 #include "git2/repository.h"
 #include "git2/refs.h"

--- a/src/checkout.h
+++ b/src/checkout.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_checkout_h__
 #define INCLUDE_checkout_h__
 
+#include "common.h"
+
 #include "git2/checkout.h"
 #include "iterator.h"
 

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -6,6 +6,7 @@
 */
 
 #include "common.h"
+
 #include "repository.h"
 #include "filebuf.h"
 #include "merge.h"

--- a/src/clone.c
+++ b/src/clone.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "clone.h"
+
 #include <assert.h>
 
 #include "git2/clone.h"
@@ -16,7 +18,6 @@
 #include "git2/commit.h"
 #include "git2/tree.h"
 
-#include "common.h"
 #include "remote.h"
 #include "fileops.h"
 #include "refs.h"

--- a/src/clone.h
+++ b/src/clone.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_clone_h__
 #define INCLUDE_clone_h__
 
+#include "git2/clone.h"
+
 extern int git_clone__should_clone_local(const char *url, git_clone_local_t local);
 
 #endif

--- a/src/clone.h
+++ b/src/clone.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_clone_h__
 #define INCLUDE_clone_h__
 
+#include "common.h"
+
 #include "git2/clone.h"
 
 extern int git_clone__should_clone_local(const char *url, git_clone_local_t local);

--- a/src/commit.c
+++ b/src/commit.c
@@ -5,13 +5,14 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "commit.h"
+
 #include "git2/common.h"
 #include "git2/object.h"
 #include "git2/repository.h"
 #include "git2/signature.h"
 #include "git2/sys/commit.h"
 
-#include "common.h"
 #include "odb.h"
 #include "commit.h"
 #include "signature.h"

--- a/src/commit.h
+++ b/src/commit.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_commit_h__
 #define INCLUDE_commit_h__
 
+#include "common.h"
+
 #include "git2/commit.h"
 #include "tree.h"
 #include "repository.h"

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -6,7 +6,7 @@
  */
 
 #include "commit_list.h"
-#include "common.h"
+
 #include "revwalk.h"
 #include "pool.h"
 #include "odb.h"

--- a/src/commit_list.h
+++ b/src/commit_list.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_commit_list_h__
 #define INCLUDE_commit_list_h__
 
+#include "common.h"
+
 #include "git2/oid.h"
 
 #define PARENT1  (1 << 0)

--- a/src/common.h
+++ b/src/common.h
@@ -47,10 +47,6 @@
 # ifdef GIT_THREADS
 #	include "win32/thread.h"
 # endif
-# if defined(GIT_MSVC_CRTDBG)
-#   include "win32/w32_stack.h"
-#   include "win32/w32_crtdbg_stacktrace.h"
-# endif
 
 #else
 

--- a/src/config.c
+++ b/src/config.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
-#include "sysdir.h"
 #include "config.h"
+
+#include "sysdir.h"
 #include "git2/config.h"
 #include "git2/sys/config.h"
 #include "vector.h"

--- a/src/config.h
+++ b/src/config.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_config_h__
 #define INCLUDE_config_h__
 
+#include "common.h"
+
 #include "git2.h"
 #include "git2/config.h"
 #include "vector.h"

--- a/src/config_cache.c
+++ b/src/config_cache.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "fileops.h"
 #include "repository.h"
 #include "config.h"

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "config_file.h"
+
 #include "config.h"
 #include "filebuf.h"
 #include "sysdir.h"

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_config_file_h__
 #define INCLUDE_config_file_h__
 
+#include "common.h"
+
 #include "git2/sys/config.h"
 #include "git2/config.h"
 

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -5,12 +5,13 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #include "git2/attr.h"
 #include "git2/blob.h"
 #include "git2/index.h"
 #include "git2/sys/filter.h"
 
-#include "common.h"
 #include "fileops.h"
 #include "hash.h"
 #include "filter.h"

--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "curl_stream.h"
+
 #ifdef GIT_CURL
 
 #include <curl/curl.h>

--- a/src/curl_stream.h
+++ b/src/curl_stream.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_curl_stream_h__
 #define INCLUDE_curl_stream_h__
 
+#include "common.h"
+
 #include "git2/sys/stream.h"
 
 extern int git_curl_stream_new(git_stream **out, const char *host, const char *port);

--- a/src/delta.h
+++ b/src/delta.h
@@ -6,6 +6,7 @@
 #define INCLUDE_git_delta_h__
 
 #include "common.h"
+
 #include "pack.h"
 
 typedef struct git_delta_index git_delta_index;

--- a/src/describe.c
+++ b/src/describe.c
@@ -4,12 +4,14 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "common.h"
+
 #include "git2/describe.h"
 #include "git2/strarray.h"
 #include "git2/diff.h"
 #include "git2/status.h"
 
-#include "common.h"
 #include "commit.h"
 #include "commit_list.h"
 #include "oidmap.h"

--- a/src/diff.c
+++ b/src/diff.c
@@ -4,9 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "git2/version.h"
-#include "common.h"
+
 #include "diff.h"
+
+#include "git2/version.h"
 #include "diff_generate.h"
 #include "patch.h"
 #include "commit.h"

--- a/src/diff.h
+++ b/src/diff.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_diff_h__
 #define INCLUDE_diff_h__
 
+#include "common.h"
+
 #include "git2/diff.h"
 #include "git2/patch.h"
 #include "git2/sys/diff.h"

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -4,12 +4,12 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
+#include "diff_driver.h"
 
 #include "git2/attr.h"
 
 #include "diff.h"
-#include "diff_driver.h"
 #include "strmap.h"
 #include "map.h"
 #include "buf_text.h"

--- a/src/diff_driver.h
+++ b/src/diff_driver.h
@@ -8,6 +8,7 @@
 #define INCLUDE_diff_driver_h__
 
 #include "common.h"
+
 #include "buffer.h"
 
 typedef struct git_diff_driver_registry git_diff_driver_registry;

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -4,12 +4,13 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
+#include "diff_file.h"
+
 #include "git2/blob.h"
 #include "git2/submodule.h"
 #include "diff.h"
 #include "diff_generate.h"
-#include "diff_file.h"
 #include "odb.h"
 #include "fileops.h"
 #include "filter.h"

--- a/src/diff_file.h
+++ b/src/diff_file.h
@@ -8,6 +8,7 @@
 #define INCLUDE_diff_file_h__
 
 #include "common.h"
+
 #include "diff.h"
 #include "diff_driver.h"
 #include "map.h"

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -4,9 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
-#include "diff.h"
+
 #include "diff_generate.h"
+
+#include "diff.h"
 #include "patch_generate.h"
 #include "fileops.h"
 #include "config.h"

--- a/src/diff_generate.h
+++ b/src/diff_generate.h
@@ -7,6 +7,10 @@
 #ifndef INCLUDE_diff_generate_h__
 #define INCLUDE_diff_generate_h__
 
+#include "diff.h"
+#include "pool.h"
+#include "index.h"
+
 enum {
 	GIT_DIFFCAPS_HAS_SYMLINKS     = (1 << 0), /* symlinks on platform? */
 	GIT_DIFFCAPS_IGNORE_STAT      = (1 << 1), /* use stat? */

--- a/src/diff_generate.h
+++ b/src/diff_generate.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_diff_generate_h__
 #define INCLUDE_diff_generate_h__
 
+#include "common.h"
+
 #include "diff.h"
 #include "pool.h"
 #include "index.h"

--- a/src/diff_parse.c
+++ b/src/diff_parse.c
@@ -4,9 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
-#include "diff.h"
+
 #include "diff_parse.h"
+
+#include "diff.h"
 #include "patch.h"
 #include "patch_parse.h"
 

--- a/src/diff_parse.h
+++ b/src/diff_parse.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_diff_parse_h__
 #define INCLUDE_diff_parse_h__
 
+#include "common.h"
+
 #include "diff.h"
 
 typedef struct {

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -4,7 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
 #include "common.h"
+
 #include "diff.h"
 #include "diff_file.h"
 #include "patch_generate.h"

--- a/src/diff_stats.c
+++ b/src/diff_stats.c
@@ -4,7 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
 #include "common.h"
+
 #include "vector.h"
 #include "diff.h"
 #include "patch_generate.h"

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -4,7 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
+#include "diff_tform.h"
 
 #include "git2/config.h"
 #include "git2/blob.h"

--- a/src/diff_tform.h
+++ b/src/diff_tform.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_diff_tform_h__
 #define INCLUDE_diff_tform_h__
 
+#include "diff_file.h"
+
 extern int git_diff_find_similar__hashsig_for_file(
 	void **out, const git_diff_file *f, const char *path, void *p);
 

--- a/src/diff_tform.h
+++ b/src/diff_tform.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_diff_tform_h__
 #define INCLUDE_diff_tform_h__
 
+#include "common.h"
+
 #include "diff_file.h"
 
 extern int git_diff_find_similar__hashsig_for_file(

--- a/src/diff_xdiff.c
+++ b/src/diff_xdiff.c
@@ -4,11 +4,12 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "diff_xdiff.h"
+
 #include "git2/errors.h"
-#include "common.h"
 #include "diff.h"
 #include "diff_driver.h"
-#include "diff_xdiff.h"
 #include "patch_generate.h"
 
 static int git_xdiff_scan_int(const char **str, int *value)

--- a/src/diff_xdiff.h
+++ b/src/diff_xdiff.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_diff_xdiff_h__
 #define INCLUDE_diff_xdiff_h__
 
+#include "common.h"
+
 #include "diff.h"
 #include "xdiff/xdiff.h"
 #include "patch_generate.h"

--- a/src/errors.c
+++ b/src/errors.c
@@ -4,7 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
 #include "common.h"
+
 #include "global.h"
 #include "posix.h"
 #include "buffer.h"

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -5,16 +5,16 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "fetch.h"
+
 #include "git2/oid.h"
 #include "git2/refs.h"
 #include "git2/revwalk.h"
 #include "git2/transport.h"
 
-#include "common.h"
 #include "remote.h"
 #include "refspec.h"
 #include "pack.h"
-#include "fetch.h"
 #include "netops.h"
 #include "repository.h"
 #include "refs.h"

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_fetch_h__
 #define INCLUDE_fetch_h__
 
+#include "git2/remote.h"
+
 #include "netops.h"
 
 int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts);

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_fetch_h__
 #define INCLUDE_fetch_h__
 
+#include "common.h"
+
 #include "git2/remote.h"
 
 #include "netops.h"

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -5,11 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "fetchhead.h"
+
 #include "git2/types.h"
 #include "git2/oid.h"
 
-#include "fetchhead.h"
-#include "common.h"
 #include "buffer.h"
 #include "fileops.h"
 #include "filebuf.h"

--- a/src/fetchhead.h
+++ b/src/fetchhead.h
@@ -7,6 +7,7 @@
 #ifndef INCLUDE_fetchhead_h__
 #define INCLUDE_fetchhead_h__
 
+#include "oid.h"
 #include "vector.h"
 
 typedef struct git_fetchhead_ref {

--- a/src/fetchhead.h
+++ b/src/fetchhead.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_fetchhead_h__
 #define INCLUDE_fetchhead_h__
 
+#include "common.h"
+
 #include "oid.h"
 #include "vector.h"
 

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -4,8 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
 #include "filebuf.h"
+
 #include "fileops.h"
 
 static const size_t WRITE_BUFFER_SIZE = (4096 * 2);

--- a/src/filebuf.h
+++ b/src/filebuf.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_filebuf_h__
 #define INCLUDE_filebuf_h__
 
+#include "common.h"
+
 #include "fileops.h"
 #include "hash.h"
 #include <zlib.h>

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -4,8 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
 #include "fileops.h"
+
 #include "global.h"
 #include "strmap.h"
 #include <ctype.h>

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -8,6 +8,7 @@
 #define INCLUDE_fileops_h__
 
 #include "common.h"
+
 #include "map.h"
 #include "posix.h"
 #include "path.h"

--- a/src/filter.c
+++ b/src/filter.c
@@ -5,10 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "filter.h"
+
 #include "common.h"
 #include "fileops.h"
 #include "hash.h"
-#include "filter.h"
 #include "repository.h"
 #include "global.h"
 #include "git2/sys/filter.h"

--- a/src/filter.h
+++ b/src/filter.h
@@ -8,6 +8,7 @@
 #define INCLUDE_filter_h__
 
 #include "common.h"
+
 #include "attr_file.h"
 #include "git2/filter.h"
 

--- a/src/fnmatch.c
+++ b/src/fnmatch.c
@@ -44,11 +44,11 @@
  * Compares a filename or pathname to a pattern.
  */
 
+#include "fnmatch.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-
-#include "fnmatch.h"
 
 #define EOS		'\0'
 

--- a/src/global.c
+++ b/src/global.c
@@ -4,8 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
 #include "global.h"
+
 #include "hash.h"
 #include "sysdir.h"
 #include "filter.h"

--- a/src/global.h
+++ b/src/global.h
@@ -8,6 +8,7 @@
 #define INCLUDE_global_h__
 
 #include "common.h"
+
 #include "mwindow.h"
 #include "hash.h"
 

--- a/src/graph.c
+++ b/src/graph.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #include "revwalk.h"
 #include "merge.h"
 #include "git2/graph.h"

--- a/src/hash.c
+++ b/src/hash.c
@@ -5,7 +5,6 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "hash.h"
 
 int git_hash_buf(git_oid *out, const void *data, size_t len)

--- a/src/hash.h
+++ b/src/hash.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_hash_h__
 #define INCLUDE_hash_h__
 
+#include "common.h"
+
 #include "git2/oid.h"
 
 typedef struct git_hash_prov git_hash_prov;

--- a/src/hash/hash_generic.c
+++ b/src/hash/hash_generic.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "hash_generic.h"
+
 #include "hash.h"
-#include "hash/hash_generic.h"
 
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 

--- a/src/hash/hash_generic.h
+++ b/src/hash/hash_generic.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_hash_generic_h__
 #define INCLUDE_hash_generic_h__
 
+#include "common.h"
+
 #include "hash.h"
 
 struct git_hash_ctx {

--- a/src/hash/hash_win32.c
+++ b/src/hash/hash_win32.c
@@ -5,10 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "hash_win32.h"
+
 #include "global.h"
 #include "hash.h"
-#include "hash/hash_win32.h"
 
 #include <wincrypt.h>
 #include <strsafe.h>

--- a/src/hash/hash_win32.h
+++ b/src/hash/hash_win32.h
@@ -9,6 +9,7 @@
 #define INCLUDE_hash_win32_h__
 
 #include "common.h"
+
 #include "hash.h"
 
 #include <wincrypt.h>

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "common.h"
+
 #include "git2/sys/hashsig.h"
 #include "fileops.h"
 #include "util.h"

--- a/src/ident.c
+++ b/src/ident.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #include "git2/sys/filter.h"
 #include "filter.h"
 #include "buffer.h"

--- a/src/idxmap.h
+++ b/src/idxmap.h
@@ -7,8 +7,9 @@
 #ifndef INCLUDE_idxmap_h__
 #define INCLUDE_idxmap_h__
 
-#include <ctype.h>
 #include "common.h"
+
+#include <ctype.h>
 #include "git2/index.h"
 
 #define kmalloc git__malloc

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "ignore.h"
+
 #include "git2/ignore.h"
 #include "common.h"
-#include "ignore.h"
 #include "attrcache.h"
 #include "path.h"
 #include "config.h"

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
 #include "git2/ignore.h"
 #include "common.h"
 #include "ignore.h"

--- a/src/ignore.h
+++ b/src/ignore.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_ignore_h__
 #define INCLUDE_ignore_h__
 
+#include "common.h"
+
 #include "repository.h"
 #include "vector.h"
 #include "attr_file.h"

--- a/src/index.c
+++ b/src/index.c
@@ -5,11 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "index.h"
+
 #include <stddef.h>
 
-#include "common.h"
 #include "repository.h"
-#include "index.h"
 #include "tree.h"
 #include "tree-cache.h"
 #include "hash.h"

--- a/src/index.h
+++ b/src/index.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_index_h__
 #define INCLUDE_index_h__
 
+#include "common.h"
+
 #include "fileops.h"
 #include "filebuf.h"
 #include "vector.h"

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -5,10 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "indexer.h"
+
 #include "git2/indexer.h"
 #include "git2/object.h"
 
-#include "common.h"
 #include "pack.h"
 #include "mwindow.h"
 #include "posix.h"

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_indexer_h__
 #define INCLUDE_indexer_h__
 
+#include "common.h"
+
 #include "git2/indexer.h"
 
 extern void git_indexer__set_fsync(git_indexer *idx, int do_fsync);

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_indexer_h__
 #define INCLUDE_indexer_h__
 
-extern int git_indexer__set_fsync(git_indexer *idx, int do_fsync);
+#include "git2/indexer.h"
+
+extern void git_indexer__set_fsync(git_indexer *idx, int do_fsync);
 
 #endif

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -6,6 +6,7 @@
  */
 
 #include "iterator.h"
+
 #include "tree.h"
 #include "index.h"
 

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -8,6 +8,7 @@
 #define INCLUDE_iterator_h__
 
 #include "common.h"
+
 #include "git2/index.h"
 #include "vector.h"
 #include "buffer.h"

--- a/src/merge.c
+++ b/src/merge.c
@@ -5,13 +5,13 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "merge.h"
+
 #include "posix.h"
 #include "buffer.h"
 #include "repository.h"
 #include "revwalk.h"
 #include "commit_list.h"
-#include "merge.h"
 #include "path.h"
 #include "refs.h"
 #include "object.h"

--- a/src/merge.h
+++ b/src/merge.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_merge_h__
 #define INCLUDE_merge_h__
 
+#include "common.h"
+
 #include "vector.h"
 #include "commit_list.h"
 #include "pool.h"

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -5,11 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "merge_driver.h"
+
 #include "vector.h"
 #include "global.h"
 #include "merge.h"
-#include "merge_driver.h"
 #include "git2/merge.h"
 #include "git2/sys/merge.h"
 

--- a/src/merge_driver.h
+++ b/src/merge_driver.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_merge_driver_h__
 #define INCLUDE_merge_driver_h__
 
+#include "common.h"
+
 #include "git2/merge.h"
 #include "git2/index.h"
 #include "git2/sys/merge.h"

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "repository.h"
 #include "posix.h"
 #include "fileops.h"

--- a/src/message.h
+++ b/src/message.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_message_h__
 #define INCLUDE_message_h__
 
+#include "common.h"
+
 #include "git2/message.h"
 #include "buffer.h"
 

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "mwindow.h"
+
 #include "vector.h"
 #include "fileops.h"
 #include "map.h"

--- a/src/mwindow.h
+++ b/src/mwindow.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_mwindow__
 #define INCLUDE_mwindow__
 
+#include "common.h"
+
 #include "map.h"
 #include "vector.h"
 

--- a/src/netops.c
+++ b/src/netops.c
@@ -5,11 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "netops.h"
+
 #include <ctype.h>
 #include "git2/errors.h"
 
-#include "common.h"
-#include "netops.h"
 #include "posix.h"
 #include "buffer.h"
 #include "http_parser.h"

--- a/src/netops.h
+++ b/src/netops.h
@@ -7,8 +7,9 @@
 #ifndef INCLUDE_netops_h__
 #define INCLUDE_netops_h__
 
-#include "posix.h"
 #include "common.h"
+
+#include "posix.h"
 #include "stream.h"
 
 #ifdef GIT_OPENSSL

--- a/src/object.c
+++ b/src/object.c
@@ -4,9 +4,11 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "object.h"
+
 #include "git2/object.h"
 
-#include "common.h"
 #include "repository.h"
 
 #include "commit.h"

--- a/src/object.h
+++ b/src/object.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_object_h__
 #define INCLUDE_object_h__
 
+#include "common.h"
+
 #include "repository.h"
 
 extern bool git_object__strict_input_validation;

--- a/src/object_api.c
+++ b/src/object_api.c
@@ -4,11 +4,12 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "git2/object.h"
 
 #include "common.h"
-#include "repository.h"
 
+#include "git2/object.h"
+
+#include "repository.h"
 #include "commit.h"
 #include "tree.h"
 #include "blob.h"

--- a/src/odb.c
+++ b/src/odb.c
@@ -5,13 +5,13 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "odb.h"
+
 #include <zlib.h>
 #include "git2/object.h"
 #include "git2/sys/odb_backend.h"
 #include "fileops.h"
 #include "hash.h"
-#include "odb.h"
 #include "delta.h"
 #include "filter.h"
 #include "repository.h"

--- a/src/odb.h
+++ b/src/odb.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_odb_h__
 #define INCLUDE_odb_h__
 
+#include "common.h"
+
 #include "git2/odb.h"
 #include "git2/oid.h"
 #include "git2/types.h"

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include <zlib.h>
 #include "git2/object.h"
 #include "git2/sys/odb_backend.h"

--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "git2/object.h"
 #include "git2/sys/odb_backend.h"
 #include "fileops.h"

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include <zlib.h>
 #include "git2/repository.h"
 #include "git2/indexer.h"

--- a/src/offmap.h
+++ b/src/offmap.h
@@ -8,6 +8,7 @@
 #define INCLUDE_offmap_h__
 
 #include "common.h"
+
 #include "git2/types.h"
 
 #define kmalloc git__malloc

--- a/src/oid.c
+++ b/src/oid.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "oid.h"
+
 #include "git2/oid.h"
 #include "repository.h"
 #include "global.h"

--- a/src/oid.h
+++ b/src/oid.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_oid_h__
 #define INCLUDE_oid_h__
 
+#include "common.h"
+
 #include "git2/oid.h"
 
 /**

--- a/src/oidarray.c
+++ b/src/oidarray.c
@@ -5,8 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "git2/oidarray.h"
 #include "oidarray.h"
+
+#include "git2/oidarray.h"
 #include "array.h"
 
 void git_oidarray_free(git_oidarray *arr)

--- a/src/oidarray.h
+++ b/src/oidarray.h
@@ -8,6 +8,7 @@
 #define INCLUDE_oidarray_h__
 
 #include "common.h"
+
 #include "git2/oidarray.h"
 #include "array.h"
 

--- a/src/oidmap.h
+++ b/src/oidmap.h
@@ -8,6 +8,7 @@
 #define INCLUDE_oidmap_h__
 
 #include "common.h"
+
 #include "git2/oid.h"
 
 #define kmalloc git__malloc

--- a/src/openssl_stream.c
+++ b/src/openssl_stream.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "openssl_stream.h"
+
 #ifdef GIT_OPENSSL
 
 #include <ctype.h>
@@ -13,7 +15,6 @@
 #include "posix.h"
 #include "stream.h"
 #include "socket_stream.h"
-#include "openssl_stream.h"
 #include "netops.h"
 #include "git2/transport.h"
 #include "git2/sys/openssl.h"

--- a/src/openssl_stream.h
+++ b/src/openssl_stream.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_openssl_stream_h__
 #define INCLUDE_openssl_stream_h__
 
+#include "common.h"
+
 #include "git2/sys/stream.h"
 
 extern int git_openssl_stream_global_init(void);

--- a/src/pack.c
+++ b/src/pack.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
-#include "odb.h"
 #include "pack.h"
+
+#include "odb.h"
 #include "delta.h"
 #include "sha1_lookup.h"
 #include "mwindow.h"

--- a/src/pack.h
+++ b/src/pack.h
@@ -8,11 +8,12 @@
 #ifndef INCLUDE_pack_h__
 #define INCLUDE_pack_h__
 
+#include "common.h"
+
 #include <zlib.h>
 
 #include "git2/oid.h"
 
-#include "common.h"
 #include "map.h"
 #include "mwindow.h"
 #include "odb.h"

--- a/src/patch.c
+++ b/src/patch.c
@@ -5,10 +5,10 @@
 * a Linking Exception. For full terms see the included COPYING file.
 */
 
-#include "git2/patch.h"
-#include "diff.h"
 #include "patch.h"
 
+#include "git2/patch.h"
+#include "diff.h"
 
 int git_patch__invoke_callbacks(
 	git_patch *patch,

--- a/src/patch.c
+++ b/src/patch.c
@@ -1,3 +1,10 @@
+/*
+* Copyright (C) the libgit2 contributors. All rights reserved.
+*
+* This file is part of libgit2, distributed under the GNU GPL v2 with
+* a Linking Exception. For full terms see the included COPYING file.
+*/
+
 #include "git2/patch.h"
 #include "diff.h"
 #include "patch.h"

--- a/src/patch.h
+++ b/src/patch.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_patch_h__
 #define INCLUDE_patch_h__
 
+#include "common.h"
+
 #include "git2/patch.h"
 #include "array.h"
 

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -4,13 +4,14 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
+#include "patch_generate.h"
+
 #include "git2/blob.h"
 #include "diff.h"
 #include "diff_generate.h"
 #include "diff_file.h"
 #include "diff_driver.h"
-#include "patch_generate.h"
 #include "diff_xdiff.h"
 #include "delta.h"
 #include "zstream.h"

--- a/src/patch_generate.h
+++ b/src/patch_generate.h
@@ -8,6 +8,7 @@
 #define INCLUDE_patch_generate_h__
 
 #include "common.h"
+
 #include "diff.h"
 #include "diff_file.h"
 #include "patch.h"

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -4,9 +4,11 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "patch_parse.h"
+
 #include "git2/patch.h"
 #include "patch.h"
-#include "patch_parse.h"
 #include "diff_parse.h"
 #include "path.h"
 

--- a/src/patch_parse.h
+++ b/src/patch_parse.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_patch_parse_h__
 #define INCLUDE_patch_parse_h__
 
+#include "common.h"
+
 #include "patch.h"
 
 typedef struct {

--- a/src/patch_parse.h
+++ b/src/patch_parse.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_patch_parse_h__
 #define INCLUDE_patch_parse_h__
 
+#include "patch.h"
+
 typedef struct {
 	git_refcount rc;
 

--- a/src/path.c
+++ b/src/path.c
@@ -4,8 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
 #include "path.h"
+
 #include "posix.h"
 #include "repository.h"
 #ifdef GIT_WIN32

--- a/src/path.h
+++ b/src/path.h
@@ -8,6 +8,7 @@
 #define INCLUDE_path_h__
 
 #include "common.h"
+
 #include "posix.h"
 #include "buffer.h"
 #include "vector.h"

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "pathspec.h"
+
 #include "git2/pathspec.h"
 #include "git2/diff.h"
-#include "pathspec.h"
 #include "buf_text.h"
 #include "attr_file.h"
 #include "iterator.h"

--- a/src/pathspec.h
+++ b/src/pathspec.h
@@ -8,7 +8,8 @@
 #define INCLUDE_pathspec_h__
 
 #include "common.h"
-#include <git2/pathspec.h>
+
+#include "git2/pathspec.h"
 #include "buffer.h"
 #include "vector.h"
 #include "pool.h"

--- a/src/pool.c
+++ b/src/pool.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
 #include "pool.h"
 #include "posix.h"
 #ifndef GIT_WIN32

--- a/src/pool.c
+++ b/src/pool.c
@@ -6,6 +6,7 @@
  */
 
 #include "pool.h"
+
 #include "posix.h"
 #ifndef GIT_WIN32
 #include <unistd.h>

--- a/src/pool.h
+++ b/src/pool.h
@@ -8,6 +8,7 @@
 #define INCLUDE_pool_h__
 
 #include "common.h"
+
 #include "vector.h"
 
 typedef struct git_pool_page git_pool_page;

--- a/src/posix.c
+++ b/src/posix.c
@@ -4,8 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "common.h"
+
 #include "posix.h"
+
 #include "path.h"
 #include <stdio.h>
 #include <ctype.h>

--- a/src/posix.h
+++ b/src/posix.h
@@ -8,6 +8,7 @@
 #define INCLUDE_posix_h__
 
 #include "common.h"
+
 #include <fcntl.h>
 #include <time.h>
 #include "fnmatch.h"

--- a/src/pqueue.c
+++ b/src/pqueue.c
@@ -6,6 +6,7 @@
  */
 
 #include "pqueue.h"
+
 #include "util.h"
 
 #define PQUEUE_LCHILD_OF(I) (((I)<<1)+1)

--- a/src/pqueue.h
+++ b/src/pqueue.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_pqueue_h__
 #define INCLUDE_pqueue_h__
 
+#include "common.h"
+
 #include "vector.h"
 
 typedef git_vector git_pqueue;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "proxy.h"
+
 #include "git2/proxy.h"
 
 int git_proxy_init_options(git_proxy_options *opts, unsigned int version)

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_proxy_h__
 #define INCLUDE_proxy_h__
 
+#include "common.h"
+
 #include "git2/proxy.h"
 
 extern int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src);

--- a/src/push.c
+++ b/src/push.c
@@ -5,14 +5,14 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "push.h"
+
 #include "git2.h"
 
-#include "common.h"
 #include "pack.h"
 #include "pack-objects.h"
 #include "remote.h"
 #include "vector.h"
-#include "push.h"
 #include "tree.h"
 
 static int push_spec_rref_cmp(const void *a, const void *b)

--- a/src/push.h
+++ b/src/push.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_push_h__
 #define INCLUDE_push_h__
 
+#include "common.h"
+
 #include "git2.h"
 #include "refspec.h"
 

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "buffer.h"
 #include "repository.h"
 #include "posix.h"

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -5,8 +5,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
-#include "posix.h"
+#include "refdb.h"
 
 #include "git2/object.h"
 #include "git2/refs.h"
@@ -14,9 +13,9 @@
 #include "git2/sys/refdb_backend.h"
 
 #include "hash.h"
-#include "refdb.h"
 #include "refs.h"
 #include "reflog.h"
+#include "posix.h"
 
 int git_refdb_new(git_refdb **out, git_repository *repo)
 {

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_refdb_h__
 #define INCLUDE_refdb_h__
 
+#include "common.h"
+
 #include "git2/refdb.h"
 #include "repository.h"
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "refdb_fs.h"
+
 #include "refs.h"
 #include "hash.h"
 #include "repository.h"
@@ -13,7 +15,6 @@
 #include "pack.h"
 #include "reflog.h"
 #include "refdb.h"
-#include "refdb_fs.h"
 #include "iterator.h"
 #include "sortedcache.h"
 #include "signature.h"

--- a/src/refdb_fs.h
+++ b/src/refdb_fs.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_refdb_fs_h__
 #define INCLUDE_refdb_fs_h__
 
+#include "strmap.h"
+
 typedef struct {
 	git_strmap *packfile;
 	time_t packfile_time;

--- a/src/refdb_fs.h
+++ b/src/refdb_fs.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_refdb_fs_h__
 #define INCLUDE_refdb_fs_h__
 
+#include "common.h"
+
 #include "strmap.h"
 
 typedef struct {

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -6,6 +6,7 @@
  */
 
 #include "reflog.h"
+
 #include "repository.h"
 #include "filebuf.h"
 #include "signature.h"

--- a/src/reflog.h
+++ b/src/reflog.h
@@ -8,6 +8,7 @@
 #define INCLUDE_reflog_h__
 
 #include "common.h"
+
 #include "git2/reflog.h"
 #include "vector.h"
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -6,6 +6,7 @@
  */
 
 #include "refs.h"
+
 #include "hash.h"
 #include "repository.h"
 #include "fileops.h"

--- a/src/refs.h
+++ b/src/refs.h
@@ -8,6 +8,7 @@
 #define INCLUDE_refs_h__
 
 #include "common.h"
+
 #include "git2/oid.h"
 #include "git2/refs.h"
 #include "git2/refdb.h"

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -5,10 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "refspec.h"
+
 #include "git2/errors.h"
 
-#include "common.h"
-#include "refspec.h"
 #include "util.h"
 #include "posix.h"
 #include "refs.h"

--- a/src/refspec.h
+++ b/src/refspec.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_refspec_h__
 #define INCLUDE_refspec_h__
 
+#include "common.h"
+
 #include "git2/refspec.h"
 #include "buffer.h"
 #include "vector.h"

--- a/src/remote.c
+++ b/src/remote.c
@@ -5,15 +5,15 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "remote.h"
+
 #include "git2/config.h"
 #include "git2/types.h"
 #include "git2/oid.h"
 #include "git2/net.h"
 
-#include "common.h"
 #include "config.h"
 #include "repository.h"
-#include "remote.h"
 #include "fetch.h"
 #include "refs.h"
 #include "refspec.h"

--- a/src/remote.h
+++ b/src/remote.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_remote_h__
 #define INCLUDE_remote_h__
 
+#include "common.h"
+
 #include "git2/remote.h"
 #include "git2/transport.h"
 #include "git2/sys/transport.h"

--- a/src/repository.c
+++ b/src/repository.c
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "repository.h"
+
 #include <ctype.h>
 
 #include "git2/object.h"
@@ -11,7 +14,6 @@
 #include "git2/sys/repository.h"
 
 #include "common.h"
-#include "repository.h"
 #include "commit.h"
 #include "tag.h"
 #include "blob.h"

--- a/src/repository.h
+++ b/src/repository.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_repository_h__
 #define INCLUDE_repository_h__
 
+#include "common.h"
+
 #include "git2/common.h"
 #include "git2/oid.h"
 #include "git2/odb.h"

--- a/src/reset.c
+++ b/src/reset.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "commit.h"
 #include "tag.h"
 #include "merge.h"

--- a/src/revert.c
+++ b/src/revert.c
@@ -6,6 +6,7 @@
 */
 
 #include "common.h"
+
 #include "repository.h"
 #include "filebuf.h"
 #include "merge.h"

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #include <assert.h>
 
-#include "common.h"
 #include "buffer.h"
 #include "tree.h"
 #include "refdb.h"

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -5,12 +5,12 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "revwalk.h"
+
 #include "commit.h"
 #include "odb.h"
 #include "pool.h"
 
-#include "revwalk.h"
 #include "git2/revparse.h"
 #include "merge.h"
 #include "vector.h"

--- a/src/revwalk.h
+++ b/src/revwalk.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_revwalk_h__
 #define INCLUDE_revwalk_h__
 
+#include "common.h"
+
 #include "git2/revwalk.h"
 #include "oidmap.h"
 #include "commit_list.h"

--- a/src/settings.c
+++ b/src/settings.c
@@ -5,12 +5,13 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #ifdef GIT_OPENSSL
 # include <openssl/err.h>
 #endif
 
 #include <git2.h>
-#include "common.h"
 #include "sysdir.h"
 #include "cache.h"
 #include "global.h"

--- a/src/sha1_lookup.c
+++ b/src/sha1_lookup.c
@@ -5,10 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "sha1_lookup.h"
+
 #include <stdio.h>
 
-#include "sha1_lookup.h"
-#include "common.h"
 #include "oid.h"
 
 /*

--- a/src/sha1_lookup.h
+++ b/src/sha1_lookup.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_sha1_lookup_h__
 #define INCLUDE_sha1_lookup_h__
 
+#include "common.h"
+
 #include <stdlib.h>
 
 int sha1_entry_pos(const void *table,

--- a/src/signature.c
+++ b/src/signature.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "signature.h"
+
 #include "repository.h"
 #include "git2/common.h"
 #include "posix.h"

--- a/src/signature.h
+++ b/src/signature.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_signature_h__
 #define INCLUDE_signature_h__
 
+#include "common.h"
+
 #include "git2/common.h"
 #include "git2/signature.h"
 #include "repository.h"

--- a/src/socket_stream.c
+++ b/src/socket_stream.c
@@ -5,11 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "socket_stream.h"
+
 #include "posix.h"
 #include "netops.h"
 #include "stream.h"
-#include "socket_stream.h"
 
 #ifndef _WIN32
 #	include <sys/types.h>

--- a/src/socket_stream.h
+++ b/src/socket_stream.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_socket_stream_h__
 #define INCLUDE_socket_stream_h__
 
+#include "common.h"
+
 #include "netops.h"
 
 typedef struct {

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
 #include "sortedcache.h"
 
 int git_sortedcache_new(

--- a/src/sortedcache.h
+++ b/src/sortedcache.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_sorted_cache_h__
 #define INCLUDE_sorted_cache_h__
 
+#include "common.h"
+
 #include "util.h"
 #include "fileops.h"
 #include "vector.h"

--- a/src/stash.c
+++ b/src/stash.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "repository.h"
 #include "commit.h"
 #include "message.h"

--- a/src/status.c
+++ b/src/status.c
@@ -5,13 +5,13 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "status.h"
+
 #include "git2.h"
 #include "fileops.h"
 #include "hash.h"
 #include "vector.h"
 #include "tree.h"
-#include "status.h"
 #include "git2/status.h"
 #include "repository.h"
 #include "ignore.h"

--- a/src/status.h
+++ b/src/status.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_status_h__
 #define INCLUDE_status_h__
 
+#include "common.h"
+
 #include "diff.h"
 #include "git2/status.h"
 #include "git2/diff.h"

--- a/src/stransport_stream.c
+++ b/src/stransport_stream.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "stransport_stream.h"
+
 #ifdef GIT_SECURE_TRANSPORT
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/src/stransport_stream.h
+++ b/src/stransport_stream.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_stransport_stream_h__
 #define INCLUDE_stransport_stream_h__
 
+#include "common.h"
+
 #include "git2/sys/stream.h"
 
 extern int git_stransport_stream_new(git_stream **out, const char *host, const char *port);

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "submodule.h"
+
 #include "git2/config.h"
 #include "git2/sys/config.h"
 #include "git2/types.h"
@@ -17,7 +18,6 @@
 #include "config_file.h"
 #include "config.h"
 #include "repository.h"
-#include "submodule.h"
 #include "tree.h"
 #include "iterator.h"
 #include "path.h"

--- a/src/submodule.h
+++ b/src/submodule.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_submodule_h__
 #define INCLUDE_submodule_h__
 
+#include "common.h"
+
 #include "git2/submodule.h"
 #include "git2/repository.h"
 #include "fileops.h"

--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "sysdir.h"
+
 #include "global.h"
 #include "buffer.h"
 #include "path.h"

--- a/src/sysdir.h
+++ b/src/sysdir.h
@@ -8,6 +8,7 @@
 #define INCLUDE_sysdir_h__
 
 #include "common.h"
+
 #include "posix.h"
 #include "buffer.h"
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
-#include "commit.h"
 #include "tag.h"
+
+#include "commit.h"
 #include "signature.h"
 #include "message.h"
 #include "git2/object.h"

--- a/src/tag.h
+++ b/src/tag.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_tag_h__
 #define INCLUDE_tag_h__
 
+#include "common.h"
+
 #include "git2/tag.h"
 #include "repository.h"
 #include "odb.h"

--- a/src/thread-utils.c
+++ b/src/thread-utils.c
@@ -4,6 +4,7 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
 #include "common.h"
 #include "thread-utils.h"
 

--- a/src/tls_stream.c
+++ b/src/tls_stream.c
@@ -5,8 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "tls_stream.h"
+
 #include "git2/errors.h"
-#include "common.h"
 
 #include "openssl_stream.h"
 #include "stransport_stream.h"

--- a/src/tls_stream.h
+++ b/src/tls_stream.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_tls_stream_h__
 #define INCLUDE_tls_stream_h__
 
+#include "common.h"
+
 #include "git2/sys/stream.h"
 
 /**

--- a/src/trace.c
+++ b/src/trace.c
@@ -5,10 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "buffer.h"
-#include "common.h"
-#include "global.h"
 #include "trace.h"
+
+#include "buffer.h"
+#include "global.h"
 #include "git2/trace.h"
 
 #ifdef GIT_TRACE

--- a/src/trace.h
+++ b/src/trace.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_trace_h__
 #define INCLUDE_trace_h__
 
+#include "common.h"
+
 #include <git2/trace.h>
 #include "buffer.h"
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -5,7 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "transaction.h"
+
 #include "repository.h"
 #include "strmap.h"
 #include "refdb.h"

--- a/src/transport.c
+++ b/src/transport.c
@@ -4,7 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
 #include "common.h"
+
 #include "git2/types.h"
 #include "git2/remote.h"
 #include "git2/net.h"

--- a/src/transports/auth.c
+++ b/src/transports/auth.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "auth.h"
+
 #include "git2.h"
 #include "buffer.h"
-#include "auth.h"
 
 static int basic_next_token(
 	git_buf *out, git_http_auth_context *ctx, git_cred *c)

--- a/src/transports/auth.h
+++ b/src/transports/auth.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_http_auth_h__
 #define INCLUDE_http_auth_h__
 
+#include "common.h"
+
 #include "git2.h"
 #include "netops.h"
 

--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -5,10 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "auth_negotiate.h"
+
 #ifdef GIT_GSSAPI
 
 #include "git2.h"
-#include "common.h"
 #include "buffer.h"
 #include "auth.h"
 

--- a/src/transports/auth_negotiate.h
+++ b/src/transports/auth_negotiate.h
@@ -8,6 +8,7 @@
 #ifndef INCLUDE_auth_negotiate_h__
 #define INCLUDE_auth_negotiate_h__
 
+#include "common.h"
 #include "git2.h"
 #include "auth.h"
 

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "cred.h"
+
 #include "git2.h"
 #include "smart.h"
 #include "git2/cred_helpers.h"

--- a/src/transports/cred.h
+++ b/src/transports/cred.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_git_cred_h__
 #define INCLUDE_git_cred_h__
 
+#include "common.h"
+
 #include "git2/transport.h"
 
 const char *git_cred__username(git_cred *cred);

--- a/src/transports/cred_helpers.c
+++ b/src/transports/cred_helpers.c
@@ -6,6 +6,7 @@
  */
 
 #include "common.h"
+
 #include "git2/cred_helpers.h"
 
 int git_cred_userpass(

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #include "git2.h"
 #include "buffer.h"
 #include "netops.h"

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "common.h"
+
 #ifndef GIT_WINHTTP
 
 #include "git2.h"

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -4,7 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
 #include "common.h"
+
 #include "git2/types.h"
 #include "git2/net.h"
 #include "git2/repository.h"
@@ -16,6 +18,7 @@
 #include "git2/pack.h"
 #include "git2/commit.h"
 #include "git2/revparse.h"
+
 #include "pack-objects.h"
 #include "refs.h"
 #include "posix.h"

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -4,8 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include "git2.h"
+
 #include "smart.h"
+
+#include "git2.h"
 #include "refs.h"
 #include "refspec.h"
 #include "proxy.h"

--- a/src/transports/smart.h
+++ b/src/transports/smart.h
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "common.h"
+
 #include "git2.h"
 #include "vector.h"
 #include "netops.h"

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "common.h"
+
 #include "git2.h"
 #include "git2/odb_backend.h"
 

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "ssh.h"
+
 #ifdef GIT_SSH
 #include <libssh2.h>
 #endif
@@ -16,7 +18,6 @@
 #include "smart.h"
 #include "cred.h"
 #include "socket_stream.h"
-#include "ssh.h"
 
 #ifdef GIT_SSH
 

--- a/src/transports/ssh.h
+++ b/src/transports/ssh.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_ssh_h__
 #define INCLUDE_ssh_h__
 
+#include "common.h"
+
 int git_transport_ssh_global_init(void);
 
 #endif

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #ifdef GIT_WINHTTP
 
 #include "git2.h"

--- a/src/tree-cache.c
+++ b/src/tree-cache.c
@@ -6,6 +6,7 @@
  */
 
 #include "tree-cache.h"
+
 #include "pool.h"
 #include "tree.h"
 

--- a/src/tree-cache.h
+++ b/src/tree-cache.h
@@ -9,6 +9,7 @@
 #define INCLUDE_tree_cache_h__
 
 #include "common.h"
+
 #include "pool.h"
 #include "buffer.h"
 #include "git2/oid.h"

--- a/src/tree.c
+++ b/src/tree.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
-#include "commit.h"
 #include "tree.h"
+
+#include "commit.h"
 #include "git2/repository.h"
 #include "git2/object.h"
 #include "fileops.h"

--- a/src/tree.h
+++ b/src/tree.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_tree_h__
 #define INCLUDE_tree_h__
 
+#include "common.h"
+
 #include "git2/tree.h"
 #include "repository.h"
 #include "odb.h"

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -4,7 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include <git2/common.h>
+
+#include "common.h"
+
+#include "git2/common.h"
 
 #if !defined(GIT_WIN32) && !defined(NO_MMAP)
 

--- a/src/unix/realpath.c
+++ b/src/unix/realpath.c
@@ -4,7 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include <git2/common.h>
+
+#include "common.h"
+
+#include "git2/common.h"
 
 #ifndef GIT_WIN32
 

--- a/src/util.c
+++ b/src/util.c
@@ -4,8 +4,10 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#include <git2.h>
-#include "common.h"
+
+#include "util.h"
+
+#include "git2.h"
 #include <stdio.h>
 #include <ctype.h>
 #include "posix.h"

--- a/src/util.h
+++ b/src/util.h
@@ -10,37 +10,6 @@
 #include "git2/buffer.h"
 #include "buffer.h"
 
-#if defined(GIT_MSVC_CRTDBG)
-/* Enable MSVC CRTDBG memory leak reporting.
- *
- * We DO NOT use the "_CRTDBG_MAP_ALLOC" macro described in the MSVC
- * documentation because all allocs/frees in libgit2 already go through
- * the "git__" routines defined in this file.  Simply using the normal
- * reporting mechanism causes all leaks to be attributed to a routine
- * here in util.h (ie, the actual call to calloc()) rather than the
- * caller of git__calloc().
- *
- * Therefore, we declare a set of "git__crtdbg__" routines to replace
- * the corresponding "git__" routines and re-define the "git__" symbols
- * as macros.  This allows us to get and report the file:line info of
- * the real caller.
- *
- * We DO NOT replace the "git__free" routine because it needs to remain
- * a function pointer because it is used as a function argument when
- * setting up various structure "destructors".
- *
- * We also DO NOT use the "_CRTDBG_MAP_ALLOC" macro because it causes
- * "free" to be remapped to "_free_dbg" and this causes problems for
- * structures which define a field named "free".
- *
- * Finally, CRTDBG must be explicitly enabled and configured at program
- * startup.  See tests/main.c for an example.
- */
-#include <stdlib.h>
-#include <crtdbg.h>
-#include "win32/w32_crtdbg_stacktrace.h"
-#endif
-
 #include "common.h"
 #include "strnlen.h"
 
@@ -67,79 +36,33 @@
 
 #if defined(GIT_MSVC_CRTDBG)
 
-GIT_INLINE(void *) git__crtdbg__malloc(size_t len, const char *file, int line)
-{
-	void *ptr = _malloc_dbg(len, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
+/* Enable MSVC CRTDBG memory leak reporting.
+ *
+ * We DO NOT use the "_CRTDBG_MAP_ALLOC" macro described in the MSVC
+ * documentation because all allocs/frees in libgit2 already go through
+ * the "git__" routines defined in this file.  Simply using the normal
+ * reporting mechanism causes all leaks to be attributed to a routine
+ * here in util.h (ie, the actual call to calloc()) rather than the
+ * caller of git__calloc().
+ *
+ * Therefore, we declare a set of "git__crtdbg__" routines to replace
+ * the corresponding "git__" routines and re-define the "git__" symbols
+ * as macros.  This allows us to get and report the file:line info of
+ * the real caller.
+ *
+ * We DO NOT replace the "git__free" routine because it needs to remain
+ * a function pointer because it is used as a function argument when
+ * setting up various structure "destructors".
+ *
+ * We also DO NOT use the "_CRTDBG_MAP_ALLOC" macro because it causes
+ * "free" to be remapped to "_free_dbg" and this causes problems for
+ * structures which define a field named "free".
+ *
+ * Finally, CRTDBG must be explicitly enabled and configured at program
+ * startup.  See tests/main.c for an example.
+ */
 
-GIT_INLINE(void *) git__crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line)
-{
-	void *ptr = _calloc_dbg(nelem, elsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(char *) git__crtdbg__strdup(const char *str, const char *file, int line)
-{
-	char *ptr = _strdup_dbg(str, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(char *) git__crtdbg__strndup(const char *str, size_t n, const char *file, int line)
-{
-	size_t length = 0, alloclength;
-	char *ptr;
-
-	length = p_strnlen(str, n);
-
-	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
-		!(ptr = git__crtdbg__malloc(alloclength, file, line)))
-		return NULL;
-
-	if (length)
-		memcpy(ptr, str, length);
-
-	ptr[length] = '\0';
-
-	return ptr;
-}
-
-GIT_INLINE(char *) git__crtdbg__substrdup(const char *start, size_t n, const char *file, int line)
-{
-	char *ptr;
-	size_t alloclen;
-
-	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
-		!(ptr = git__crtdbg__malloc(alloclen, file, line)))
-		return NULL;
-
-	memcpy(ptr, start, n);
-	ptr[n] = '\0';
-	return ptr;
-}
-
-GIT_INLINE(void *) git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line)
-{
-	void *new_ptr = _realloc_dbg(ptr, size, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!new_ptr) giterr_set_oom();
-	return new_ptr;
-}
-
-GIT_INLINE(void *) git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
-{
-	size_t newsize;
-
-	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
-		NULL : _realloc_dbg(ptr, newsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-}
-
-GIT_INLINE(void *) git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
-{
-	return git__crtdbg__reallocarray(NULL, nelem, elsize, file, line);
-}
+#include "win32/w32_crtdbg_stacktrace.h"
 
 #define git__malloc(len)                      git__crtdbg__malloc(len, __FILE__, __LINE__)
 #define git__calloc(nelem, elsize)            git__crtdbg__calloc(nelem, elsize, __FILE__, __LINE__)

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_util_h__
 #define INCLUDE_util_h__
 
+#include "common.h"
+
 #include "git2/buffer.h"
 #include "buffer.h"
 #include "thread-utils.h"

--- a/src/util.h
+++ b/src/util.h
@@ -9,6 +9,7 @@
 
 #include "git2/buffer.h"
 #include "buffer.h"
+#include "thread-utils.h"
 
 #include "common.h"
 #include "strnlen.h"
@@ -285,8 +286,6 @@ extern int git__strncmp(const char *a, const char *b, size_t sz);
 extern int git__strncasecmp(const char *a, const char *b, size_t sz);
 
 extern int git__strcasesort_cmp(const char *a, const char *b);
-
-#include "thread-utils.h"
 
 typedef struct {
 	git_atomic refcount;

--- a/src/varint.c
+++ b/src/varint.c
@@ -5,7 +5,6 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "varint.h"
 
 uintmax_t git_decode_varint(const unsigned char *bufp, size_t *varint_len)

--- a/src/varint.h
+++ b/src/varint.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_varint_h__
 #define INCLUDE_varint_h__
 
+#include "common.h"
+
 #include <stdint.h>
 
 extern int git_encode_varint(unsigned char *, size_t, uintmax_t);

--- a/src/vector.c
+++ b/src/vector.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "vector.h"
+
 #include "integer.h"
 
 /* In elements, not bytes */

--- a/src/win32/dir.c
+++ b/src/win32/dir.c
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "dir.h"
+
 #define GIT__WIN32_NO_WRAP_DIR
 #include "posix.h"
 

--- a/src/win32/dir.h
+++ b/src/win32/dir.h
@@ -8,6 +8,7 @@
 #define INCLUDE_dir_h__
 
 #include "common.h"
+
 #include "w32_util.h"
 
 struct git__dirent {

--- a/src/win32/error.c
+++ b/src/win32/error.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "error.h"
+
 #include "utf-conv.h"
 
 #ifdef GIT_WINHTTP

--- a/src/win32/error.h
+++ b/src/win32/error.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_git_win32_error_h__
 #define INCLUDE_git_win32_error_h__
 
+#include "common.h"
+
 extern char *git_win32_get_error_message(DWORD error_code);
 
 #endif

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -5,10 +5,11 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "findfile.h"
+
 #include "path_w32.h"
 #include "utf-conv.h"
 #include "path.h"
-#include "findfile.h"
 
 #define REG_MSYSGIT_INSTALL_LOCAL L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Git_is1"
 

--- a/src/win32/findfile.h
+++ b/src/win32/findfile.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_git_findfile_h__
 #define INCLUDE_git_findfile_h__
 
+#include "common.h"
+
 extern int git_win32__find_system_dirs(git_buf *out, const wchar_t *subpath);
 extern int git_win32__find_global_dirs(git_buf *out);
 extern int git_win32__find_xdg_dirs(git_buf *out);

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -5,6 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "common.h"
+
 #include "map.h"
 #include <errno.h>
 

--- a/src/win32/path_w32.c
+++ b/src/win32/path_w32.c
@@ -5,9 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
-#include "path.h"
 #include "path_w32.h"
+
+#include "path.h"
 #include "utf-conv.h"
 #include "posix.h"
 #include "reparse.h"

--- a/src/win32/path_w32.h
+++ b/src/win32/path_w32.h
@@ -8,6 +8,7 @@
 #define INCLUDE_git_path_w32_h__
 
 #include "common.h"
+
 #include "vector.h"
 
 /*

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+
+#include "common.h"
+
 #include "../posix.h"
 #include "../fileops.h"
 #include "path.h"

--- a/src/win32/precompiled.h
+++ b/src/win32/precompiled.h
@@ -1,3 +1,5 @@
+#include "common.h"
+
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
@@ -20,4 +22,3 @@
 #endif
 
 #include "git2.h"
-#include "common.h"

--- a/src/win32/thread.c
+++ b/src/win32/thread.c
@@ -6,6 +6,7 @@
  */
 
 #include "thread.h"
+
 #include "../global.h"
 
 #define CLEAN_THREAD_EXIT 0x6F012842

--- a/src/win32/thread.h
+++ b/src/win32/thread.h
@@ -8,7 +8,7 @@
 #ifndef INCLUDE_win32_thread_h__
 #define INCLUDE_win32_thread_h__
 
-#include "../common.h"
+#include "common.h"
 
 #if defined (_MSC_VER)
 #	define GIT_RESTRICT __restrict

--- a/src/win32/utf-conv.c
+++ b/src/win32/utf-conv.c
@@ -5,7 +5,6 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "utf-conv.h"
 
 GIT_INLINE(void) git__set_errno(void)

--- a/src/win32/utf-conv.h
+++ b/src/win32/utf-conv.h
@@ -7,8 +7,9 @@
 #ifndef INCLUDE_git_utfconv_h__
 #define INCLUDE_git_utfconv_h__
 
-#include <wchar.h>
 #include "common.h"
+
+#include <wchar.h>
 
 #ifndef WC_ERR_INVALID_CHARS
 # define WC_ERR_INVALID_CHARS	0x80

--- a/src/win32/w32_buffer.c
+++ b/src/win32/w32_buffer.c
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
 #include "w32_buffer.h"
+
 #include "../buffer.h"
 #include "utf-conv.h"
 

--- a/src/win32/w32_buffer.h
+++ b/src/win32/w32_buffer.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_git_win32_buffer_h__
 #define INCLUDE_git_win32_buffer_h__
 
+#include "common.h"
+
 #include "../buffer.h"
 
 /**

--- a/src/win32/w32_crtdbg_stacktrace.c
+++ b/src/win32/w32_crtdbg_stacktrace.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "w32_crtdbg_stacktrace.h"
+
 #if defined(GIT_MSVC_CRTDBG)
 #include "w32_stack.h"
-#include "w32_crtdbg_stacktrace.h"
 
 #define CRTDBG_STACKTRACE__UID_LEN (15)
 

--- a/src/win32/w32_crtdbg_stacktrace.h
+++ b/src/win32/w32_crtdbg_stacktrace.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_w32_crtdbg_stacktrace_h__
 #define INCLUDE_w32_crtdbg_stacktrace_h__
 
+#include "common.h"
+
 #if defined(GIT_MSVC_CRTDBG)
 
 #include <stdlib.h>

--- a/src/win32/w32_crtdbg_stacktrace.h
+++ b/src/win32/w32_crtdbg_stacktrace.h
@@ -9,6 +9,12 @@
 
 #if defined(GIT_MSVC_CRTDBG)
 
+#include <stdlib.h>
+#include <crtdbg.h>
+
+#include "git2/errors.h"
+#include "strnlen.h"
+
 /**
  * Initialize our memory leak tracking and de-dup data structures.
  * This should ONLY be called by git_libgit2_init().
@@ -88,6 +94,81 @@ GIT_EXTERN(int) git_win32__crtdbg_stacktrace__dump(
  * routines.
  */
 const char *git_win32__crtdbg_stacktrace(int skip, const char *file);
+
+GIT_INLINE(void *) git__crtdbg__malloc(size_t len, const char *file, int line)
+{
+	void *ptr = _malloc_dbg(len, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
+	if (!ptr) giterr_set_oom();
+	return ptr;
+}
+
+GIT_INLINE(void *) git__crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line)
+{
+	void *ptr = _calloc_dbg(nelem, elsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
+	if (!ptr) giterr_set_oom();
+	return ptr;
+}
+
+GIT_INLINE(char *) git__crtdbg__strdup(const char *str, const char *file, int line)
+{
+	char *ptr = _strdup_dbg(str, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
+	if (!ptr) giterr_set_oom();
+	return ptr;
+}
+
+GIT_INLINE(char *) git__crtdbg__strndup(const char *str, size_t n, const char *file, int line)
+{
+	size_t length = 0, alloclength;
+	char *ptr;
+
+	length = p_strnlen(str, n);
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
+		!(ptr = git__crtdbg__malloc(alloclength, file, line)))
+		return NULL;
+
+	if (length)
+		memcpy(ptr, str, length);
+
+	ptr[length] = '\0';
+
+	return ptr;
+}
+
+GIT_INLINE(char *) git__crtdbg__substrdup(const char *start, size_t n, const char *file, int line)
+{
+	char *ptr;
+	size_t alloclen;
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
+		!(ptr = git__crtdbg__malloc(alloclen, file, line)))
+		return NULL;
+
+	memcpy(ptr, start, n);
+	ptr[n] = '\0';
+	return ptr;
+}
+
+GIT_INLINE(void *) git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line)
+{
+	void *new_ptr = _realloc_dbg(ptr, size, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
+	if (!new_ptr) giterr_set_oom();
+	return new_ptr;
+}
+
+GIT_INLINE(void *) git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
+{
+	size_t newsize;
+
+	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
+		NULL : _realloc_dbg(ptr, newsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
+}
+
+GIT_INLINE(void *) git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
+{
+	return git__crtdbg__reallocarray(NULL, nelem, elsize, file, line);
+}
+
 
 #endif
 #endif

--- a/src/win32/w32_stack.c
+++ b/src/win32/w32_stack.c
@@ -5,11 +5,12 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "w32_stack.h"
+
 #if defined(GIT_MSVC_CRTDBG)
 #include "Windows.h"
 #include "Dbghelp.h"
 #include "win32/posix.h"
-#include "w32_stack.h"
 #include "hash.h"
 
 /**

--- a/src/win32/w32_stack.h
+++ b/src/win32/w32_stack.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_w32_stack_h__
 #define INCLUDE_w32_stack_h__
 
+#include "common.h"
+
 #if defined(GIT_MSVC_CRTDBG)
 
 /**

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -8,6 +8,8 @@
 #ifndef INCLUDE_w32_util_h__
 #define INCLUDE_w32_util_h__
 
+#include "common.h"
+
 #include "utf-conv.h"
 #include "posix.h"
 #include "path_w32.h"

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -5,14 +5,13 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "common.h"
+#include "worktree.h"
 
 #include "git2/branch.h"
 #include "git2/commit.h"
 #include "git2/worktree.h"
 
 #include "repository.h"
-#include "worktree.h"
 
 static bool is_worktree_dir(const char *dir)
 {

--- a/src/worktree.h
+++ b/src/worktree.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_worktree_h__
 #define INCLUDE_worktree_h__
 
+#include "common.h"
+
 #include "git2/common.h"
 #include "git2/worktree.h"
 

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
+#include "zstream.h"
+
 #include <zlib.h>
 
-#include "zstream.h"
 #include "buffer.h"
 
 #define ZSTREAM_BUFFER_SIZE (1024 * 1024)

--- a/src/zstream.h
+++ b/src/zstream.h
@@ -7,9 +7,10 @@
 #ifndef INCLUDE_zstream_h__
 #define INCLUDE_zstream_h__
 
+#include "common.h"
+
 #include <zlib.h>
 
-#include "common.h"
 #include "buffer.h"
 
 typedef enum {


### PR DESCRIPTION
Up front: sorry for this big commit, I know it sucks. But as such I'm splitting this out from #4282 as it's too big to make it port of that one.

The first two commits fix up some small stuff regarding missing license headers and to fix some header files from not compiling which weren't included anywhere before. The next commit establishes a common include pattern across all our files in the "src/" folder. Quoting from its commit message:

"""
 Make sure to always include "common.h" first

 Next to including several files, our "common.h" header also declares
 various macros which are then used throughout the project. As such, we
 have to make sure to always include this file first in all
 implementation files. Otherwise, we might encounter problems or even
 silent behavioural differences due to macros or defines not being
 defined as they should be. So in fact, our header and implementation
 files should make sure to always include "common.h" first.

 This commit does so by establishing a common include pattern. Header
 files inside of "src" will now always include "common.h" as its first
 other file, separated by a newline from all the other includes to make
 it stand out as special. There are two cases for the implementation
 files. If they do have a matching header file, they will always include
 this one first, leading to "common.h" being transitively included as
 first file. If they do not have a matching header file, they instead
 include "common.h" as first file themselves.

 This fixes the outlined problems and will become our standard practice
 for header and source files inside of the "src/" from now on.
"""