### PR TITLE
tests: config: fix missing declaration causing error

### DIFF
--- a/tests/config/readonly.c
+++ b/tests/config/readonly.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 #include "config_file.h"
 #include "config.h"
+#include "path.h"
 
 static git_config *cfg;
 


### PR DESCRIPTION
On systems where we pull in our distributed version of the regex
library, all tests in config::readonly fail. This error is actually
quite interesting: the test suite is unable to find the declaration of
`git_path_exists` and assumes it has a signature of `int
git_path_exists(const char *)`. But actually, it has a `bool` return
value. Due to this confusion, some wrong conversion is done by the
compiler and the `cl_assert(!git_path_exists("file"))` checks
erroneously fail, even when the function does in fact return the correct
value.

The error is actually introduced by 56893bb9a (cmake: consistently use
TARGET_INCLUDE_DIRECTORIES if available, 2017-06-28), unfortunately
introduced by myself. Due to the delayed addition of include
directories, we will now find the "config.h" header inside of the
"deps/regex" directory instead of inside the "src/" directory, where it
should be. As such, we are missing definitions for the
`git_config_file__ondisk` and `git_path_exists` symbols.

The correct fix here would be to fix the order in which include search
directories are added. But due to the current restructuring of
CMakeBuild.txt, I'm refraining from doing so and delay the proper fix a
bit. Instead, we paper over the issue by explicitly including "path.h"
to fix its prototype. This ignores the issue that
`git_config_file__ondisk` is undeclared, as its signature is correctly
identified by the compiler.