### PR TITLE
patch_generate: represent buffers as void pointers

### DIFF
--- a/include/git2/patch.h
+++ b/include/git2/patch.h
@@ -96,7 +96,7 @@ GIT_EXTERN(int) git_patch_from_blob_and_buffer(
 	git_patch **out,
 	const git_blob *old_blob,
 	const char *old_as_path,
-	const char *buffer,
+	const void *buffer,
 	size_t buffer_len,
 	const char *buffer_as_path,
 	const git_diff_options *opts);
@@ -124,7 +124,7 @@ GIT_EXTERN(int) git_patch_from_buffers(
 	const void *old_buffer,
 	size_t old_len,
 	const char *old_as_path,
-	const char *new_buffer,
+	const void *new_buffer,
 	size_t new_len,
 	const char *new_as_path,
 	const git_diff_options *opts);

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -641,7 +641,7 @@ int git_patch_from_blob_and_buffer(
 	git_patch **out,
 	const git_blob *old_blob,
 	const char *old_path,
-	const char *buf,
+	const void *buf,
 	size_t buflen,
 	const char *buf_path,
 	const git_diff_options *opts)
@@ -680,7 +680,7 @@ int git_patch_from_buffers(
 	const void *old_buf,
 	size_t old_len,
 	const char *old_path,
-	const char *new_buf,
+	const void *new_buf,
 	size_t new_len,
 	const char *new_path,
 	const git_diff_options *opts)


### PR DESCRIPTION
Pointers to general data should usually be used as a void pointer such
that it is possible to hand in variables of a different pointer type
without the need to cast. This is the same when creating patches from
buffers, where the buffers may contain arbitrary data. Instead of
requiring the caller to care whether his buffer is e.g. `char *` or
`unsigned char *`, we should instead just accept a `void *`. This is
also consistent in how we tread other types like for example `git_blob`,
which also just has a void pointer as its raw contents.

---

Fixes #3986 