### PR TITLE
signature: don't leave a dangling pointer to the strings on parse failure

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -231,6 +231,7 @@ int git_signature__parse(git_signature *sig, const char **buffer_out,
 		if (git__strtol64(&sig->when.time, time_start, &time_end, 10) < 0) {
 			git__free(sig->name);
 			git__free(sig->email);
+			sig->name = sig->email = NULL;
 			return signature_error("invalid Unix timestamp");
 		}
 


### PR DESCRIPTION
If the signature is invalid but we detect that after allocating the strings, we
free them. We however leave that pointer dangling in the structure the caller
gave us, which can lead to double-free.

Set these pointers to `NULL` after freeing their memory to avoid this.