### PR TITLE
patch_parse: implement state machine for parsing patch headers

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -439,6 +439,7 @@ static const parse_header_transition transitions[] = {
 	/* Next patch */
 	{ "diff --git "         , STATE_END,        0,                NULL },
 	{ "@@ -"                , STATE_END,        0,                NULL },
+	{ "-- "                 , STATE_END,        0,                NULL },
 };
 
 static int parse_header_git(

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -57,6 +57,27 @@ static void test_parse_invalid_diff(const char *invalid_diff)
 	git_buf_free(&buf);
 }
 
+void test_diff_parse__exact_rename(void)
+{
+	const char *content =
+	    "---\n"
+	    " old_name.c => new_name.c | 0\n"
+	    " 1 file changed, 0 insertions(+), 0 deletions(-)\n"
+	    " rename old_name.c => new_name.c  (100%)\n"
+	    "\n"
+	    "diff --git a/old_name.c b/new_name.c\n"
+	    "similarity index 100%\n"
+	    "rename from old_name.c\n"
+	    "rename to new_name.c\n"
+	    "-- \n"
+	    "2.9.3\n";
+	git_diff *diff;
+
+	cl_git_pass(git_diff_from_buffer(
+		&diff, content, strlen(content)));
+	git_diff_free(diff);
+}
+
 void test_diff_parse__invalid_patches_fails(void)
 {
 	test_parse_invalid_diff(PATCH_CORRUPT_MISSING_NEW_FILE);


### PR DESCRIPTION
Our code parsing Git patch headers is rather lax in parsing headers of a
Git-style patch. Most notably, we do not care for the exact order in
which header lines appear and as such, we may parse patch files which
are not really valid after all. Furthermore, the state transitions
inside of the parser are not as obvious as they could be, making it
harder than required to follow its logic.

To improve upon this situation, this patch introduces a real state
machine to parse the patches. Instead of simply parsing each line
without caring for previous state and the exact ordering, we define a
set of states with their allowed transitions. This makes the patch
parser more strict in only allowing valid successions of header lines.
As the transition table is defined inside of a single structure with
the expected line, required state as well as the state that we end up
in, all state transitions are immediately obvious from just having a
look at this structure. This improves both maintainability and eases
reasoning about the patch parser.