### PR TITLE
win32: provide fast-path for retrying filesystem operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ v0.26 + 1
 
 ### Changes or improvements
 
+* Improved `p_unlink` in `posix_w32.c` to try and make a file writable
+  before sleeping in the retry loop to prevent unnecessary calls to sleep.
+
 ### API additions
 
 ### API removals

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -243,6 +243,11 @@ GIT_INLINE(int) unlink_once(const wchar_t *path)
 	if (DeleteFileW(path))
 		return 0;
 
+	set_errno();
+
+	if (errno == EACCES && ensure_writable(path) == 0 && DeleteFileW(path))
+		return 0;
+
 	if (last_error_retryable())
 		return GIT_RETRY;
 
@@ -257,7 +262,7 @@ int p_unlink(const char *path)
 	if (git_win32_path_from_utf8(wpath, path) < 0)
 		return -1;
 
-	do_with_retries(unlink_once(wpath), ensure_writable(wpath));
+	do_with_retries(unlink_once(wpath), 0);
 }
 
 int p_fsync(int fd)


### PR DESCRIPTION
When using the `do_with_retries` macro for retrying filesystem operations in the posix emulation layer, allow the remediation function to return `GIT_RETRY`, meaning that the error was believed to be remediated, and the operation should be retried immediately, without a sleep.

Use this in the `ensure_writable` remediation function - if the function is able to set the file writable, then retry the operation immediately.  This will prevent a 5ms sleep in the common case.