### PR TITLE
fixed win32 p_unlink retry sleep issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ v0.26 + 1
 
 ### Changes or improvements
 
-* Improved `p_unlink` in `posix_w32.c` to try and make a file writable before sleeping in the retry loop to prevent unnecessary sleep calls.
+* Improved `p_unlink` in `posix_w32.c` to try and make a file writable before sleeping in
+  the retry loop to prevent unnecessary calls to sleep.
 
 ### API additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ v0.26 + 1
 
 ### Changes or improvements
 
+* Improved `p_unlink` in `posix_w32.c` to try and make a file writable before sleeping in the retry loop to prevent unnecessary sleep calls.
+
 ### API additions
 
 ### API removals

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -243,6 +243,11 @@ GIT_INLINE(int) unlink_once(const wchar_t *path)
 	if (DeleteFileW(path))
 		return 0;
 
+	set_errno();
+
+	if (errno == EACCES && ensure_writable(path) == 0 && DeleteFileW(path))
+		return 0;
+
 	if (last_error_retryable())
 		return GIT_RETRY;
 
@@ -257,7 +262,7 @@ int p_unlink(const char *path)
 	if (git_win32_path_from_utf8(wpath, path) < 0)
 		return -1;
 
-	do_with_retries(unlink_once(wpath), ensure_writable(wpath));
+	do_with_retries(unlink_once(wpath), 0);
 }
 
 int p_fsync(int fd)


### PR DESCRIPTION
Fixed an issue where the retry logic on `p_unlink` in `posix_w32.c` sleeps before it tries setting a file to write mode causing unnecessary slowdown.

This affects windows only.

The issue was introduced [in this commit](https://github.com/nodegit/libgit2/commit/a0f67e4a262cfdc6d430d969a9a257397e4b0406) as the `do_with_retries` macro tries the `unlink_once` routine and sleeps on failure before calling `ensure_writable`.

This is particularly noticeable when staging large groups of files at once as staging creates a temporary git object that is set to read only. When this temporary git object is deleted via `p_unlink` it always ends up hitting the sleep causing a 5ms delay per file.

I spoke with @ethomson on slack about this briefly.