### PR TITLE
tsort: remove idempotent conditional assignment

### DIFF
--- a/src/tsort.c
+++ b/src/tsort.c
@@ -310,7 +310,6 @@ static ssize_t collapse(void **dst, struct tsort_run *stack, ssize_t stack_curr,
 #define PUSH_NEXT() do {\
 	len = count_run(dst, curr, size, store);\
 	run = minrun;\
-	if (run < minrun) run = minrun;\
 	if (run > (ssize_t)size - curr) run = size - curr;\
 	if (run > len) {\
 		bisort(&dst[curr], len, run, cmp, payload);\


### PR DESCRIPTION
The conditional `run < minrun` can never be true directly after
assigning `run = minrun`. Remove it to avoid confusion.