### PR TITLE
Build with patched libcurl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # see travis-ci.org for details
 
 language: c
+dist: trusty
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,8 @@ env:
   - OPTIONS="-DTHREADSAFE=ON -DCMAKE_BUILD_TYPE=Release"
   - OPTIONS="-DTHREADSAFE=OFF -DBUILD_EXAMPLES=ON"
 
-addons:
-  apt:
-    packages:
-    - cmake
-    - libssh2-1-dev
-    - openssh-client
-    - openssh-server
-    - valgrind
-
 dist: trusty
-sudo: false
+sudo: true
 
 matrix:
  fast_finish: true
@@ -56,7 +47,7 @@ matrix:
    - env: COVERITY=1
 
 install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./script/install-deps-${TRAVIS_OS_NAME}.sh; fi
+  - ./script/install-deps-${TRAVIS_OS_NAME}.sh
 
 # Run the Build script and tests
 script:

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -50,6 +50,7 @@ cat >~/sshd/sshd_config<<-EOF
 	ListenAddress 0.0.0.0
 	Protocol 2
 	HostKey ${HOME}/sshd/id_rsa
+	PidFile ${HOME}/sshd/pid
 	RSAAuthentication yes
 	PasswordAuthentication yes
 	PubkeyAuthentication yes
@@ -99,7 +100,7 @@ if [ -e ./libgit2_clar ]; then
 
 fi
 
-killall sshd
+kill $(cat "$HOME/sshd/pid")
 
 export GITTEST_REMOTE_URL="https://github.com/libgit2/non-existent"
 export GITTEST_REMOTE_USER="libgit2test"

--- a/script/install-deps-linux.sh
+++ b/script/install-deps-linux.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -x
+
+echo "deb http://libgit2deps.edwardthomson.com trusty libgit2deps" | sudo tee -a /etc/apt/sources.list
+sudo apt-key adv --keyserver pgp.mit.edu --recv 99131CD5
+sudo apt-get update -qq
+sudo apt-get install -y cmake curl libcurl3 libcurl3-gnutls libcurl4-gnutls-dev libssh2-1-dev openssh-client openssh-server valgrind

--- a/script/install-deps-linux.sh
+++ b/script/install-deps-linux.sh
@@ -2,7 +2,11 @@
 
 set -x
 
-echo "deb http://libgit2deps.edwardthomson.com trusty libgit2deps" | sudo tee -a /etc/apt/sources.list
-sudo apt-key adv --keyserver pgp.mit.edu --recv 99131CD5
-sudo apt-get update -qq
-sudo apt-get install -y cmake curl libcurl3 libcurl3-gnutls libcurl4-gnutls-dev libssh2-1-dev openssh-client openssh-server valgrind
+if [ -z "$PRECISE" ]; then
+    echo "deb http://libgit2deps.edwardthomson.com trusty libgit2deps" | sudo tee -a /etc/apt/sources.list
+    sudo apt-key adv --keyserver pgp.mit.edu --recv 99131CD5
+    sudo apt-get update -qq
+    sudo apt-get install -y curl libcurl3 libcurl3-gnutls libcurl4-gnutls-dev
+fi
+
+sudo apt-get install -y cmake libssh2-1-dev openssh-client openssh-server valgrind


### PR DESCRIPTION
This builds with a custom version of libcurl, which includes a fix for proxies and NTLM credentials.  It comes as quite a shock to curl 7.35, but you do not need to necessarily use proxy credentials when you are using a proxy with NTLM credentials (on the overall connection) and curl's connection pooling mechanism will segfault if you in fact do not.

This fix skips a `strcmp` against `NULL` proxy username/password:

```
--- curl-7.35.0.orig/lib/url.c
+++ curl-7.35.0/lib/url.c
@@ -3135,6 +3135,11 @@ ConnectionExists(struct SessionHandle *d

         /* Same for Proxy NTLM authentication */
         if(wantProxyNTLMhttp) {
+          /* Both check->http_proxy.user and check->http_proxy.passwd can be
+           * NULL */
+          if(!check->proxyuser || !check->proxypasswd)
+            continue;
+
           if(strcmp(needle->proxyuser, check->proxyuser) ||
              strcmp(needle->proxypasswd, check->proxypasswd))
             continue;
```

Regrettably, we need to move away from the container-based build system so that we can install custom packages that aren't actually part of the ubuntu distribution.