### PR TITLE
Add git_status_file_at

### DIFF
--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -173,12 +173,16 @@ typedef enum {
  * The `pathspec` is an array of path patterns to match (using
  * fnmatch-style matching), or just an array of paths to match exactly if
  * `GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH` is specified in the flags.
+ *
+ * The `baseline` is the tree to be used for comparison to the working directory
+ * and index; defaults to HEAD.
  */
 typedef struct {
 	unsigned int      version;
 	git_status_show_t show;
 	unsigned int      flags;
 	git_strarray      pathspec;
+	git_tree          *baseline;
 } git_status_options;
 
 #define GIT_STATUS_OPTIONS_VERSION 1


### PR DESCRIPTION
This change takes `git_status_list_new` and splits out a new function called `git_status_list_new_at` (I'm totally open to alternative names) which takes a tree parameter to compare against instead of the HEAD tree.

The purpose of this is to get a preview of an amend commit, where the supplied tree will be from the head commit's first parent.