### PR TITLE
sha1_position: convert do-while to while

### DIFF
--- a/src/sha1_lookup.c
+++ b/src/sha1_lookup.c
@@ -232,7 +232,7 @@ int sha1_position(const void *table,
 {
 	const unsigned char *base = table;
 
-	do {
+	while (lo < hi) {
 		unsigned mi = (lo + hi) / 2;
 		int cmp = git_oid__hashcmp(base + mi * stride, key);
 
@@ -243,7 +243,7 @@ int sha1_position(const void *table,
 			hi = mi;
 		else
 			lo = mi+1;
-	} while (lo < hi);
+	}
 
 	return -((int)lo)-1;
 }


### PR DESCRIPTION
If we enter the sha1_position() function with "lo == hi", we have no elements. But the do-while loop means that we'll enter the loop body once anyway, picking "mi" at that same value and comparing nonsense to our desired key. This is unlikely to match in practice, but we still shouldn't be looking at the memory in the first place.

This bug is inherited from git.git; it was fixed there in git/git@e01580cfe01526ec2c4eb4899f776a82ade7e0e1.
