### PR TITLE
oid: use memcmp in git_oid__hashcmp

### DIFF
--- a/src/oid.h
+++ b/src/oid.h
@@ -22,14 +22,7 @@ char *git_oid_allocfmt(const git_oid *id);
 
 GIT_INLINE(int) git_oid__hashcmp(const unsigned char *sha1, const unsigned char *sha2)
 {
-	int i;
-
-	for (i = 0; i < GIT_OID_RAWSZ; i++, sha1++, sha2++) {
-		if (*sha1 != *sha2)
-			return *sha1 - *sha2;
-	}
-
-	return 0;
+	return memcmp(sha1, sha2, GIT_OID_RAWSZ);
 }
 
 /*


### PR DESCRIPTION
The open-coded version was inherited from git.git. But it turns out it was based on an older version of glibc, whose memcmp was not very optimized.

Modern glibc does much better, and some compilers (like gcc 7) can even inline the memcmp into a series of multi-byte xors.

Upstream is switching to using memcmp in git/git@0b006014c87f400bd9a86267ed30fd3e7b383884.

Note that this is definitively faster on modern Linux systems, but there's been no benchmark on other platforms. It's possible that a bad libc/compiler combination may perform worse. In my opinion it's best to trust in memcmp by default, though. The current open-coded version was certainly did _not_ come from benchmarks on non-Linux systems.
