### PR TITLE
Clear the remote_ref_name buffer in git_push_update_tips()

### DIFF
--- a/src/push.c
+++ b/src/push.c
@@ -178,6 +178,9 @@ int git_push_update_tips(git_push *push, const git_remote_callbacks *callbacks)
 		if (!fetch_spec)
 			continue;
 
+		/* Clear the buffer which can be dirty from previous iteration */
+		git_buf_clear(&remote_ref_name);
+
 		if ((error = git_refspec_transform(&remote_ref_name, fetch_spec, status->ref)) < 0)
 			goto on_error;
 


### PR DESCRIPTION
If `fetch_spec` was a non-pattern, and it is not the first iteration of `push_status` vector, then `git_refspec_transform()` would result in the new value appended via `git_buf_puts` to the previous iteration value.

Forcibly clearing the buffer on each iteration to prevent this behavior.