### PR TITLE
features.h: allow building without CMake-generated feature header

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -7,7 +7,10 @@
 #ifndef INCLUDE_common_h__
 #define INCLUDE_common_h__
 
-#include "git2/sys/features.h"
+#ifndef LIBGIT2_NO_FEATURES_H
+# include "git2/sys/features.h"
+#endif
+
 #include "git2/common.h"
 #include "cc-compat.h"
 

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -7,7 +7,10 @@
 #ifndef INCLUDE_posix__unix_h__
 #define INCLUDE_posix__unix_h__
 
-#include "git2/sys/features.h"
+#ifndef LIBGIT2_NO_FEATURES_H
+# include "git2/sys/features.h"
+#endif
+
 #include <stdio.h>
 #include <dirent.h>
 #include <sys/param.h>


### PR DESCRIPTION
In commit a390a8464 (cmake: move defines into "features.h" header,
2017-07-01), we have introduced a new "features.h" header. This file is
being generated by the CMake build system based on how the libgit2 build
has been configured, replacing the preexisting method of simply setting
the defines inside of the CMake build system. This was done to help
splitting up the build instructions into multiple separate
subdirectories.

An overlooked shortcoming of this approach is that some projects making
use of libgit2 build the library with custom build systems, without
making use of CMake. For those users, the introduction of the
"features.h" file makes their life harder as they would have to also
generate this file.

Fix this issue by guarding all inclusions of the generated header file
by the `LIBGIT2_NO_FEATURES_H` define. Like this, other build systems
can skip the feature header and simply define all used features by
specifying `-D` flags for the compiler again.