### PR TITLE
diff: cleanup hash ctx in `git_diff_patchid`

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -517,5 +517,6 @@ int git_diff_patchid(git_oid *out, git_diff *diff, git_diff_patchid_options *opt
 	git_oid_cpy(out, &args.result);
 
 out:
+	git_hash_ctx_cleanup(&args.ctx);
 	return error;
 }


### PR DESCRIPTION
After initializing the hash context in `git_diff_patchid`, we never
proceed to call `git_hash_ctx_cleanup` on it. While this doesn't really
matter on most hash implementations, this causes a memory leak on Win32
due to CNG system requiring a `malloc` call.

Fix the memory leak by always calling `git_hash_ctx_cleanup` before
exiting.