### PR TITLE
Ask for SSH credentials again when passphrase is wrong

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -419,8 +419,10 @@ static int _git_ssh_authenticate_session(
 		}
 	} while (LIBSSH2_ERROR_EAGAIN == rc || LIBSSH2_ERROR_TIMEOUT == rc);
 
-        if (rc == LIBSSH2_ERROR_PASSWORD_EXPIRED || rc == LIBSSH2_ERROR_AUTHENTICATION_FAILED)
-                return GIT_EAUTH;
+	if (rc == LIBSSH2_ERROR_PASSWORD_EXPIRED ||
+		rc == LIBSSH2_ERROR_AUTHENTICATION_FAILED ||
+		rc == LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED)
+			return GIT_EAUTH;
 
 	if (rc != LIBSSH2_ERROR_NONE) {
 		if (!giterr_last())


### PR DESCRIPTION
When trying to decode the private key it looks like LibSSH2 returns a `LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED` when the passphrase is incorrect. This change allows callback to be called again giving the user the chance to correct the passphrase or provide alternative credentials.

Additionally, switched the indentation from spaces to tabs which matches the surrounding code.