### PR TITLE
Plug some leaks in curl's proxy handling

### DIFF
--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -195,6 +195,7 @@ static int curls_set_proxy(git_stream *stream, const git_proxy_options *proxy_op
 	CURLcode res;
 	curl_stream *s = (curl_stream *) stream;
 
+	git_proxy_options_free(&s->proxy);
 	if ((error = git_proxy_options_dup(&s->proxy, proxy_opts)) < 0)
 		return error;
 
@@ -295,6 +296,7 @@ static void curls_free(git_stream *stream)
 
 	curls_close(stream);
 	git_strarray_free(&s->cert_info_strings);
+	git_proxy_options_free(&s->proxy);
 	git__free(s);
 }
 

--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -297,6 +297,7 @@ static void curls_free(git_stream *stream)
 	curls_close(stream);
 	git_strarray_free(&s->cert_info_strings);
 	git_proxy_options_free(&s->proxy);
+	git_cred_free(s->proxy_cred);
 	git__free(s);
 }
 

--- a/src/curl_stream.c
+++ b/src/curl_stream.c
@@ -195,7 +195,7 @@ static int curls_set_proxy(git_stream *stream, const git_proxy_options *proxy_op
 	CURLcode res;
 	curl_stream *s = (curl_stream *) stream;
 
-	git_proxy_options_free(&s->proxy);
+	git_proxy_options_clear(&s->proxy);
 	if ((error = git_proxy_options_dup(&s->proxy, proxy_opts)) < 0)
 		return error;
 
@@ -296,7 +296,7 @@ static void curls_free(git_stream *stream)
 
 	curls_close(stream);
 	git_strarray_free(&s->cert_info_strings);
-	git_proxy_options_free(&s->proxy);
+	git_proxy_options_clear(&s->proxy);
 	git_cred_free(s->proxy_cred);
 	git__free(s);
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -32,7 +32,7 @@ int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src)
 	return 0;
 }
 
-void git_proxy_options_free(git_proxy_options *opts)
+void git_proxy_options_clear(git_proxy_options *opts)
 {
 	git__free((char *) opts->url);
 	opts->url = NULL;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -31,3 +31,9 @@ int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src)
 
 	return 0;
 }
+
+void git_proxy_options_free(git_proxy_options *opts)
+{
+	git__free((char *) opts->url);
+	opts->url = NULL;
+}

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -12,5 +12,6 @@
 #include "git2/proxy.h"
 
 extern int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src);
+extern void git_proxy_options_free(git_proxy_options *opts);
 
 #endif

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -12,6 +12,6 @@
 #include "git2/proxy.h"
 
 extern int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src);
-extern void git_proxy_options_free(git_proxy_options *opts);
+extern void git_proxy_options_clear(git_proxy_options *opts);
 
 #endif


### PR DESCRIPTION
I was trying to reproduce the segfault we see in Travis when talking to the proxy, but instead I found a few leaks.