### PR TITLE
Use SOCK_CLOEXEC when creating sockets

### DIFF
--- a/src/posix.h
+++ b/src/posix.h
@@ -60,6 +60,9 @@
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
+#endif
 
 /* access() mode parameter #defines	*/
 #ifndef F_OK

--- a/src/socket_stream.c
+++ b/src/socket_stream.c
@@ -104,7 +104,7 @@ int socket_connect(git_stream *stream)
 	}
 
 	for (p = info; p != NULL; p = p->ai_next) {
-		s = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+		s = socket(p->ai_family, p->ai_socktype | SOCK_CLOEXEC, p->ai_protocol);
 
 		if (s == INVALID_SOCKET)
 			continue;


### PR DESCRIPTION
Similar to how O_CLOEXEC is used for `open()` libgit2 should also use SOCK_CLOEXEC (when available) for opening sockets.
