### PR TITLE
refs: do not use peeled OID if peeling to a tag

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -1360,7 +1360,13 @@ int git_reference_peel(
 			return peel_error(error, ref, "Cannot resolve reference");
 	}
 
-	if (!git_oid_iszero(&resolved->peel)) {
+	/*
+	 * If we try to peel an object to a tag, we cannot use
+	 * the fully peeled object, as that will always resolve
+	 * to a commit. So we only want to use the peeled value
+	 * if it is not zero and the target is not a tag.
+	 */
+	if (target_type != GIT_OBJ_TAG && !git_oid_iszero(&resolved->peel)) {
 		error = git_object_lookup(&target,
 			git_reference_owner(ref), &resolved->peel, GIT_OBJ_ANY);
 	} else {

--- a/tests/refs/peel.c
+++ b/tests/refs/peel.c
@@ -117,3 +117,15 @@ void test_refs_peel__can_peel_fully_peeled_packed_refs(void)
 			    "0df1a5865c8abfc09f1f2182e6a31be550e99f07",
 			    GIT_OBJ_COMMIT);
 }
+
+void test_refs_peel__can_peel_fully_peeled_tag_to_tag(void)
+{
+	assert_peel_generic(g_peel_repo,
+			    "refs/tags/tag-inside-tags", GIT_OBJ_TAG,
+			    "c2596aa0151888587ec5c0187f261e63412d9e11",
+			    GIT_OBJ_TAG);
+	assert_peel_generic(g_peel_repo,
+			    "refs/foo/tag-outside-tags", GIT_OBJ_TAG,
+			    "c2596aa0151888587ec5c0187f261e63412d9e11",
+			    GIT_OBJ_TAG);
+}


### PR DESCRIPTION
If a reference stored inside of the packed-refs file does not directly
point to a commit object, it will always have a fully-peeled value
pointing to the underlying commit object. If we peel a reference to an
object, we will use that peeled value to speed up resolving the object.
This works as intended for all objects, except for annotated tags.

As a reference for an annotated tag does not directly point to the
commit but instead to the tag object, the packed-refs file will have an
accomodating fully-peeled object ID pointing to the commit of that tag.
When we use that fully-peeled OID pointing to that commit, though, we
obviously cannot peel that to the tag anymore.

Fix this issue by not using the fully-peeled OID whenever we want to
peel to a tag. Note that this does not include the case where we want to
resolve to _any_ object type. Existing code may make use from the fact
that we resolve those to commit objects instead of tag objects, even
though that behaviour is inconsistent between packed and loose
references. Furthermore, some tests of ours make the assumption that we
in fact resolve those references to a commit.