### PR TITLE
Checkout typechange-only deltas

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -161,7 +161,15 @@ GIT_INLINE(bool) is_workdir_base_or_new(
 
 GIT_INLINE(bool) is_file_mode_changed(git_filemode_t a, git_filemode_t b)
 {
+#ifdef GIT_WIN32
+	/*
+	 * On Win32 we do not support the executable bit; the file will
+	 * always be 0100644 on disk, don't bother doing a test.
+	 */
+	return false;
+#else
 	return (S_ISREG(a) && S_ISREG(b) && a != b);
+#endif
 }
 
 static bool checkout_is_workdir_modified(

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -1514,6 +1514,51 @@ void test_checkout_tree__baseline_is_empty_when_no_index(void)
 	git_reference_free(head);
 }
 
+void test_checkout_tree__mode_change_is_force_updated(void)
+{
+	git_index *index;
+	git_reference *head;
+	git_object *obj;
+	git_status_list *status;
+
+	if (!cl_is_chmod_supported())
+		clar__skip();
+
+	assert_on_branch(g_repo, "master");
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_repository_head(&head, g_repo));
+	cl_git_pass(git_reference_peel(&obj, head, GIT_OBJ_COMMIT));
+
+	cl_git_pass(git_reset(g_repo, obj, GIT_RESET_HARD, NULL));
+
+	cl_git_pass(git_status_list_new(&status, g_repo, NULL));
+	cl_assert_equal_i(0, git_status_list_entrycount(status));
+	git_status_list_free(status);
+
+	/* update the mode on-disk */
+	cl_must_pass(p_chmod("testrepo/README", 0755));
+
+	cl_git_pass(git_checkout_tree(g_repo, obj, &g_opts));
+
+	cl_git_pass(git_status_list_new(&status, g_repo, NULL));
+	cl_assert_equal_i(0, git_status_list_entrycount(status));
+	git_status_list_free(status);
+
+	/* update the mode on-disk and in the index */
+	cl_must_pass(p_chmod("testrepo/README", 0755));
+	cl_must_pass(git_index_add_bypath(index, "README"));
+
+	cl_git_pass(git_checkout_tree(g_repo, obj, &g_opts));
+
+	cl_git_pass(git_status_list_new(&status, g_repo, NULL));
+	cl_assert_equal_i(0, git_status_list_entrycount(status));
+	git_status_list_free(status);
+
+	git_object_free(obj);
+	git_reference_free(head);
+	git_index_free(index);
+}
+
 void test_checkout_tree__nullopts(void)
 {
 	cl_git_pass(git_checkout_tree(g_repo, NULL, NULL));


### PR DESCRIPTION
When performing a forced checkout, treat files as modified when the workdir or the index is identical *except for the mode*.  This ensures that force checkout will update the mode to the target.

Without this change, we examine the contents of the file on-disk and determine that it's identical to the tree we're checking out, and continue without making any changes.  By including the filemode in the difference check, checkout will now make a file executable (or remove the executable bit) as appropriate to match the checkout target.

We apply this check for regular files only: in the case where one of the items was a file and the other item was *not*, then this would be a typechange (not a file mode change) and would be handled by other codepaths.