### PR TITLE
cmake: fix linking in Xcode with object libraries only

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,10 @@ IF(DEBUG_POOL)
 	SET(GIT_DEBUG_POOL 1)
 ENDIF()
 
-SET(LIBGIT2_OBJECTS "")
+# Add the features.h file as a dummy. This is required for Xcode
+# to successfully build the libgit2 library when using only
+# object libraries.
+SET(LIBGIT2_OBJECTS "${CMAKE_CURRENT_BINARY_DIR}/git2/sys/features.h")
 
 # This variable will contain the libraries we need to put into
 # libgit2.pc's Requires.private. That is, what we're linking to or


### PR DESCRIPTION
CMake is unable to generate a correct Xcode project when trying to link
libraries with only object libraries as its input. As our new build
infrastructure makes heavy use of object libraries now, this affects our
libgit2 library target, as well, leading to linking errors.

Fix the issue by adding a dummy file to the libgit2 objects. As we
always have the "features.h" header ready which contains defines only,
we can simply link it into the resulting library without any effect
whatsoever. This fixes building with Xcode.

---

Thanks to @tiennou. This should fix #4352.