### PR TITLE
example-log: add support for --log-size

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -36,10 +36,6 @@ These are good small projects to get started with libgit2.
       trick to this one will be doing it in a manner that is clean and
       simple, but still handles the various cases correctly (e.g. `-B/70%`
       is apparently a legal setting).
-    * Implement the `--log-size` option for `examples/log.c`. I think all
-      the data is available, you would just need to add the code into the
-      `print_commit()` routine (along with a way of passing the option
-      into that function).
     * As an extension to the matching idea for `examples/log.c`, add the
       `-i` option to use `strcasestr()` for matches.
     * For `examples/log.c`, implement the `--first-parent` option now that

--- a/examples/log.c
+++ b/examples/log.c
@@ -49,7 +49,8 @@ static int add_revision(struct log_state *s, const char *revstr);
 
 /** log_options holds other command line options that affect log output */
 struct log_options {
-	int show_diff, show_log_size;
+	int show_diff;
+	int show_log_size;
 	int skip, limit;
 	int min_parents, max_parents;
 	git_time_t before;
@@ -63,7 +64,7 @@ struct log_options {
 static int parse_options(
 	struct log_state *s, struct log_options *opt, int argc, char **argv);
 static void print_time(const git_time *intime, const char *prefix);
-static void print_commit(git_commit *commit, int show_log_size);
+static void print_commit(git_commit *commit, struct log_options *opts);
 static int match_with_parent(git_commit *commit, int i, git_diff_options *);
 
 /** utility functions for filtering */
@@ -148,7 +149,7 @@ int main(int argc, char *argv[])
 			break;
 		}
 
-		print_commit(commit, opt.show_log_size);
+		print_commit(commit, &opt);
 
 		if (opt.show_diff) {
 			git_tree *a = NULL, *b = NULL;
@@ -337,7 +338,7 @@ static void print_time(const git_time *intime, const char *prefix)
 }
 
 /** Helper to print a commit object. */
-static void print_commit(git_commit *commit, int show_log_size)
+static void print_commit(git_commit *commit, struct log_options *opts)
 {
 	char buf[GIT_OID_HEXSZ + 1];
 	int i, count;
@@ -347,9 +348,8 @@ static void print_commit(git_commit *commit, int show_log_size)
 	git_oid_tostr(buf, sizeof(buf), git_commit_id(commit));
 	printf("commit %s\n", buf);
 
-	if (show_log_size) {
-		printf("log size %d", (int)strlen(git_commit_message(commit)));
-		printf("\n");
+	if (opts->show_log_size) {
+		printf("log size %d\n", (int)strlen(git_commit_message(commit)));
 	}
 
 	if ((count = (int)git_commit_parentcount(commit)) > 1) {

--- a/examples/log.c
+++ b/examples/log.c
@@ -49,7 +49,7 @@ static int add_revision(struct log_state *s, const char *revstr);
 
 /** log_options holds other command line options that affect log output */
 struct log_options {
-	int show_diff;
+	int show_diff, show_log_size;
 	int skip, limit;
 	int min_parents, max_parents;
 	git_time_t before;
@@ -63,7 +63,7 @@ struct log_options {
 static int parse_options(
 	struct log_state *s, struct log_options *opt, int argc, char **argv);
 static void print_time(const git_time *intime, const char *prefix);
-static void print_commit(git_commit *commit);
+static void print_commit(git_commit *commit, int show_log_size);
 static int match_with_parent(git_commit *commit, int i, git_diff_options *);
 
 /** utility functions for filtering */
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 			break;
 		}
 
-		print_commit(commit);
+		print_commit(commit, opt.show_log_size);
 
 		if (opt.show_diff) {
 			git_tree *a = NULL, *b = NULL;
@@ -337,7 +337,7 @@ static void print_time(const git_time *intime, const char *prefix)
 }
 
 /** Helper to print a commit object. */
-static void print_commit(git_commit *commit)
+static void print_commit(git_commit *commit, int show_log_size)
 {
 	char buf[GIT_OID_HEXSZ + 1];
 	int i, count;
@@ -346,6 +346,11 @@ static void print_commit(git_commit *commit)
 
 	git_oid_tostr(buf, sizeof(buf), git_commit_id(commit));
 	printf("commit %s\n", buf);
+
+	if (show_log_size) {
+		printf("log size %d", (int)strlen(git_commit_message(commit)));
+		printf("\n");
+	}
 
 	if ((count = (int)git_commit_parentcount(commit)) > 1) {
 		printf("Merge:");
@@ -470,6 +475,8 @@ static int parse_options(
 			/** Found valid --min_parents. */;
 		else if (!strcmp(a, "-p") || !strcmp(a, "-u") || !strcmp(a, "--patch"))
 			opt->show_diff = 1;
+		else if (!strcmp(a, "--log-size"))
+			opt->show_log_size = 1;
 		else
 			usage("Unsupported argument", a);
 	}


### PR DESCRIPTION
Updated the `log` example to use the `--log-size` parameter.