### PR TITLE
Pack file verification

### DIFF
--- a/examples/network/index-pack.c
+++ b/examples/network/index-pack.c
@@ -46,7 +46,7 @@ int index_pack(git_repository *repo, int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	if (git_indexer_new(&idx, ".", 0, NULL, NULL, NULL) < 0) {
+	if (git_indexer_new(&idx, ".", 0, NULL, NULL) < 0) {
 		puts("bad idx");
 		return -1;
 	}

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -15,6 +15,30 @@ GIT_BEGIN_DECL
 
 typedef struct git_indexer git_indexer;
 
+typedef struct git_indexer_options {
+	unsigned int version;
+
+	/** progress_cb function to call with progress information */
+	git_transfer_progress_cb progress_cb;
+	/** progress_cb_payload payload for the progress callback */
+	void *progress_cb_payload;
+} git_indexer_options;
+
+#define GIT_INDEXER_OPTIONS_VERSION 1
+#define GIT_INDEXER_OPTIONS_INIT { GIT_INDEXER_OPTIONS_VERSION }
+
+/**
+ * Initializes a `git_indexer_options` with default values. Equivalent to
+ * creating an instance with GIT_INDEXER_OPTIONS_INIT.
+ *
+ * @param opts the `git_indexer_options` struct to initialize.
+ * @param version Version of struct; pass `GIT_INDEXER_OPTIONS_VERSION`
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_indexer_init_options(
+	git_indexer_options *opts,
+	unsigned int version);
+
 /**
  * Create a new indexer instance
  *
@@ -24,16 +48,15 @@ typedef struct git_indexer git_indexer;
  * @param odb object database from which to read base objects when
  * fixing thin packs. Pass NULL if no thin pack is expected (an error
  * will be returned if there are bases missing)
- * @param progress_cb function to call with progress information
- * @param progress_cb_payload payload for the progress callback
+ * @param opts Optional structure containing additional options. See
+ * `git_indexer_options` above.
  */
 GIT_EXTERN(int) git_indexer_new(
 		git_indexer **out,
 		const char *path,
 		unsigned int mode,
 		git_odb *odb,
-		git_transfer_progress_cb progress_cb,
-		void *progress_cb_payload);
+		git_indexer_options *opts);
 
 /**
  * Add data to the indexer

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -22,6 +22,9 @@ typedef struct git_indexer_options {
 	git_transfer_progress_cb progress_cb;
 	/** progress_cb_payload payload for the progress callback */
 	void *progress_cb_payload;
+
+	/** Do connectivity checks for the received pack */
+	unsigned char verify;
 } git_indexer_options;
 
 #define GIT_INDEXER_OPTIONS_VERSION 1

--- a/src/blob.c
+++ b/src/blob.c
@@ -32,8 +32,8 @@ int git_blob__getbuf(git_buf *buffer, git_blob *blob)
 {
 	return git_buf_set(
 		buffer,
-		git_odb_object_data(blob->odb_object),
-		git_odb_object_size(blob->odb_object));
+		git_blob_rawcontent(blob),
+		git_blob_rawsize(blob));
 }
 
 void git_blob__free(void *blob)
@@ -372,8 +372,8 @@ int git_blob_is_binary(const git_blob *blob)
 
 	assert(blob);
 
-	git_buf_attach_notowned(&content, blob->odb_object->buffer,
-		min(blob->odb_object->cached.size,
+	git_buf_attach_notowned(&content, git_blob_rawcontent(blob),
+		min(git_blob_rawsize(blob),
 		GIT_FILTER_BYTES_TO_CHECK_NUL));
 	return git_buf_text_is_binary(&content);
 }

--- a/src/blob.h
+++ b/src/blob.h
@@ -16,11 +16,20 @@
 
 struct git_blob {
 	git_object object;
-	git_odb_object *odb_object;
+
+	union {
+		git_odb_object *odb;
+		struct {
+			const char *data;
+			git_off_t size;
+		} raw;
+	} data;
+	unsigned int raw:1;
 };
 
 void git_blob__free(void *blob);
 int git_blob__parse(void *blob, git_odb_object *obj);
+int git_blob__parse_raw(void *blob, const char *data, size_t size);
 int git_blob__getbuf(git_buf *buffer, git_blob *blob);
 
 extern int git_blob__create_from_paths(

--- a/src/commit.c
+++ b/src/commit.c
@@ -383,11 +383,11 @@ int git_commit_amend(
 	return error;
 }
 
-int git_commit__parse(void *_commit, git_odb_object *odb_obj)
+int git_commit__parse_raw(void *_commit, const char *data, size_t size)
 {
 	git_commit *commit = _commit;
-	const char *buffer_start = git_odb_object_data(odb_obj), *buffer;
-	const char *buffer_end = buffer_start + git_odb_object_size(odb_obj);
+	const char *buffer_start = data, *buffer;
+	const char *buffer_end = buffer_start + size;
 	git_oid parent_id;
 	size_t header_len;
 	git_signature dummy_sig;
@@ -475,6 +475,13 @@ int git_commit__parse(void *_commit, git_odb_object *odb_obj)
 bad_buffer:
 	giterr_set(GITERR_OBJECT, "failed to parse bad commit object");
 	return -1;
+}
+
+int git_commit__parse(void *_commit, git_odb_object *odb_obj)
+{
+	return git_commit__parse_raw(_commit,
+		git_odb_object_data(odb_obj),
+		git_odb_object_size(odb_obj));
 }
 
 #define GIT_COMMIT_GETTER(_rvalue, _name, _return) \

--- a/src/commit.h
+++ b/src/commit.h
@@ -35,5 +35,6 @@ struct git_commit {
 
 void git_commit__free(void *commit);
 int git_commit__parse(void *commit, git_odb_object *obj);
+int git_commit__parse_raw(void *commit, const char *data, size_t size);
 
 #endif

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -528,13 +528,10 @@ static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_transfer_progress *stats)
 {
 	int error = -1;
-	size_t processed;
 	struct git_pack_header *hdr = &idx->hdr;
 	git_mwindow_file *mwf = &idx->pack->mwf;
 
 	assert(idx && data && stats);
-
-	processed = stats->indexed_objects;
 
 	if ((error = append_to_pack(idx, data, size)) < 0)
 		return error;
@@ -578,7 +575,7 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_tran
 		stats->local_objects = 0;
 		stats->total_deltas = 0;
 		stats->indexed_deltas = 0;
-		processed = stats->indexed_objects = 0;
+		stats->indexed_objects = 0;
 		stats->total_objects = total_objects;
 
 		if ((error = do_progress_callback(idx, stats)) != 0)
@@ -590,7 +587,7 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_tran
 	/* As the file grows any windows we try to use will be out of date */
 	git_mwindow_free_all(mwf);
 
-	while (processed < idx->nr_objects) {
+	while (stats->indexed_objects < idx->nr_objects) {
 		git_packfile_stream *stream = &idx->stream;
 		git_off_t entry_start = idx->off;
 		size_t entry_size;
@@ -665,7 +662,7 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_tran
 			goto on_error;
 
 		if (!idx->have_delta) {
-			stats->indexed_objects = (unsigned int)++processed;
+			stats->indexed_objects++;
 		}
 		stats->received_objects++;
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -1000,7 +1000,7 @@ static int resolve_deltas(git_indexer *idx, git_transfer_progress *stats)
 		progressed = 0;
 		non_null = 0;
 		git_vector_foreach(&idx->deltas, i, delta) {
-			git_rawobj obj = {NULL};
+			git_rawobj obj = {0};
 
 			if (!delta)
 				continue;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -148,7 +148,7 @@ int git_indexer_new(
 	idx->expected_oids = git_oidmap_alloc();
 	GITERR_CHECK_ALLOC(idx->expected_oids);
 
-	idx->do_verify = !!idx->odb;
+	idx->do_verify = opts.verify;
 
 	if (git_repository__fsync_gitdir)
 		idx->do_fsync = 1;
@@ -315,7 +315,7 @@ static void add_expected_oid(git_indexer *idx, const git_oid *oid)
 	 * because we have already processed it as part of our pack file, we do
 	 * not have to expect it.
 	 */
-	if (!git_odb_exists(idx->odb, oid) &&
+	if ((!idx->odb || !git_odb_exists(idx->odb, oid)) &&
 	    !git_oidmap_exists(idx->pack->idx_cache, oid) &&
 	    !git_oidmap_exists(idx->expected_oids, oid)) {
 		    git_oid *dup = git__malloc(sizeof(*oid));
@@ -350,7 +350,7 @@ static int check_object_connectivity(git_indexer *idx, const git_rawobj *obj)
 	 * Check whether this is a known object. If so, we can just continue as
 	 * we assume that the ODB has a complete graph.
 	 */
-	if (git_odb_exists(idx->odb, &object->cached.oid))
+	if (idx->odb && git_odb_exists(idx->odb, &object->cached.oid))
 		return 0;
 
 	switch (obj->type) {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -10,6 +10,9 @@
 #include "git2/indexer.h"
 #include "git2/object.h"
 
+#include "commit.h"
+#include "tree.h"
+#include "tag.h"
 #include "pack.h"
 #include "mwindow.h"
 #include "posix.h"
@@ -36,12 +39,15 @@ struct git_indexer {
 		pack_committed :1,
 		have_stream :1,
 		have_delta :1,
-		do_fsync :1;
+		do_fsync :1,
+		do_verify :1;
 	struct git_pack_header hdr;
 	struct git_pack_file *pack;
 	unsigned int mode;
 	git_off_t off;
 	git_off_t entry_start;
+	git_otype entry_type;
+	git_buf entry_data;
 	git_packfile_stream stream;
 	size_t nr_objects;
 	git_vector objects;
@@ -52,6 +58,9 @@ struct git_indexer {
 	git_transfer_progress_cb progress_cb;
 	void *progress_payload;
 	char objbuf[8*1024];
+
+	/* OIDs referenced from pack objects. Used for verification. */
+	git_oidmap *expected_oids;
 
 	/* Needed to look up objects which we want to inject to fix a thin pack */
 	git_odb *odb;
@@ -125,6 +134,11 @@ int git_indexer_new(
 	idx->mode = mode ? mode : GIT_PACK_FILE_MODE;
 	git_hash_ctx_init(&idx->hash_ctx);
 	git_hash_ctx_init(&idx->trailer);
+	git_buf_init(&idx->entry_data, 0);
+	idx->expected_oids = git_oidmap_alloc();
+	GITERR_CHECK_ALLOC(idx->expected_oids);
+
+	idx->do_verify = !!idx->odb;
 
 	if (git_repository__fsync_gitdir)
 		idx->do_fsync = 1;
@@ -210,6 +224,9 @@ static int hash_object_stream(git_indexer*idx, git_packfile_stream *stream)
 		if ((read = git_packfile_stream_read(stream, idx->objbuf, sizeof(idx->objbuf))) < 0)
 			break;
 
+		if (idx->do_verify)
+			git_buf_put(&idx->entry_data, idx->objbuf, read);
+
 		git_hash_update(&idx->hash_ctx, idx->objbuf, read);
 	} while (read > 0);
 
@@ -279,6 +296,97 @@ static int crc_object(uint32_t *crc_out, git_mwindow_file *mwf, git_off_t start,
 	return 0;
 }
 
+static void add_expected_oid(git_indexer *idx, const git_oid *oid)
+{
+	int ret;
+
+	/*
+	 * If we know about that object because it is stored in our ODB or
+	 * because we have already processed it as part of our pack file, we do
+	 * not have to expect it.
+	 */
+	if (!git_odb_exists(idx->odb, oid) &&
+	    !git_oidmap_exists(idx->pack->idx_cache, oid) &&
+	    !git_oidmap_exists(idx->expected_oids, oid)) {
+		    git_oid *dup = git__malloc(sizeof(*oid));
+		    git_oid_cpy(dup, oid);
+		    git_oidmap_put(idx->expected_oids, dup, &ret);
+	}
+}
+
+static int check_object_connectivity(git_indexer *idx, const git_rawobj *obj)
+{
+	git_object *object;
+	size_t keyidx;
+	int error;
+
+	if (obj->type != GIT_OBJ_BLOB &&
+	    obj->type != GIT_OBJ_TREE &&
+	    obj->type != GIT_OBJ_COMMIT &&
+	    obj->type != GIT_OBJ_TAG)
+		return 0;
+
+	if ((error = git_object__from_raw(&object, obj->data, obj->len, obj->type)) < 0)
+		goto out;
+
+	keyidx = git_oidmap_lookup_index(idx->expected_oids, &object->cached.oid);
+	if (git_oidmap_valid_index(idx->expected_oids, keyidx)) {
+		const git_oid *key = git_oidmap_key(idx->expected_oids, keyidx);
+		git__free((git_oid *) key);
+		git_oidmap_delete_at(idx->expected_oids, keyidx);
+	}
+
+	/*
+	 * Check whether this is a known object. If so, we can just continue as
+	 * we assume that the ODB has a complete graph.
+	 */
+	if (git_odb_exists(idx->odb, &object->cached.oid))
+		return 0;
+
+	switch (obj->type) {
+		case GIT_OBJ_TREE:
+		{
+			git_tree *tree = (git_tree *) object;
+			git_tree_entry *entry;
+			size_t i;
+
+			git_array_foreach(tree->entries, i, entry)
+				add_expected_oid(idx, entry->oid);
+
+			break;
+		}
+		case GIT_OBJ_COMMIT:
+		{
+			git_commit *commit = (git_commit *) object;
+			git_oid *parent_oid;
+			size_t i;
+
+			git_array_foreach(commit->parent_ids, i, parent_oid)
+				add_expected_oid(idx, parent_oid);
+
+			add_expected_oid(idx, &commit->tree_id);
+
+			break;
+		}
+		case GIT_OBJ_TAG:
+		{
+			git_tag *tag = (git_tag *) object;
+
+			add_expected_oid(idx, &tag->target);
+
+			break;
+		}
+		case GIT_OBJ_BLOB:
+		default:
+			break;
+	}
+
+out:
+	git_object_free(object);
+
+	return error;
+}
+
 static int store_object(git_indexer *idx)
 {
 	int i, error;
@@ -302,6 +410,17 @@ static int store_object(git_indexer *idx)
 		entry->offset_long = entry_start;
 	} else {
 		entry->offset = (uint32_t)entry_start;
+	}
+
+	if (idx->do_verify) {
+		git_rawobj rawobj = {
+		    idx->entry_data.ptr,
+		    idx->entry_data.size,
+		    idx->entry_type
+		};
+
+		if ((error = check_object_connectivity(idx, &rawobj)) < 0)
+			goto on_error;
 	}
 
 	git_oid_cpy(&pentry->sha1, &oid);
@@ -549,6 +668,7 @@ static int read_stream_object(git_indexer *idx, git_transfer_progress *stats)
 		git_mwindow_close(&w);
 		idx->entry_start = entry_start;
 		git_hash_init(&idx->hash_ctx);
+		git_buf_clear(&idx->entry_data);
 
 		if (type == GIT_OBJ_REF_DELTA || type == GIT_OBJ_OFS_DELTA) {
 			error = advance_delta_offset(idx, type);
@@ -569,6 +689,7 @@ static int read_stream_object(git_indexer *idx, git_transfer_progress *stats)
 		}
 
 		idx->have_stream = 1;
+		idx->entry_type = type;
 
 		error = git_packfile_stream_open(stream, idx->pack, idx->off);
 		if (error < 0)
@@ -884,6 +1005,10 @@ static int resolve_deltas(git_indexer *idx, git_transfer_progress *stats)
 				return -1;
 			}
 
+			if (idx->do_verify && check_object_connectivity(idx, &obj) < 0)
+				/* TODO: error? continue? */
+				continue;
+
 			if (hash_and_save(idx, &obj, delta->delta_off) < 0)
 				continue;
 
@@ -1012,6 +1137,18 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 
 		git_hash_final(&trailer_hash, &idx->trailer);
 		write_at(idx, &trailer_hash, idx->pack->mwf.size - GIT_OID_RAWSZ, GIT_OID_RAWSZ);
+	}
+
+	/*
+	 * Is the resulting graph fully connected or are we still
+	 * missing some objects? In the second case, we can
+	 * bail out due to an incomplete and thus corrupt
+	 * packfile.
+	 */
+	if (git_oidmap_size(idx->expected_oids) > 0) {
+		giterr_set(GITERR_INDEXER, "packfile is missing %"PRIuZ" objects",
+			git_oidmap_size(idx->expected_oids));
+		return -1;
 	}
 
 	git_vector_sort(&idx->objects);
@@ -1143,6 +1280,8 @@ on_error:
 
 void git_indexer_free(git_indexer *idx)
 {
+	khiter_t pos;
+
 	if (idx == NULL)
 		return;
 
@@ -1170,7 +1309,18 @@ void git_indexer_free(git_indexer *idx)
 		git_mutex_unlock(&git__mwindow_mutex);
 	}
 
+	for (pos = git_oidmap_begin(idx->expected_oids);
+	    pos != git_oidmap_end(idx->expected_oids); pos++)
+	{
+		if (git_oidmap_has_data(idx->expected_oids, pos)) {
+			git__free((git_oid *) git_oidmap_key(idx->expected_oids, pos));
+			git_oidmap_delete_at(idx->expected_oids, pos);
+		}
+	}
+
 	git_hash_ctx_cleanup(&idx->trailer);
 	git_hash_ctx_cleanup(&idx->hash_ctx);
+	git_buf_dispose(&idx->entry_data);
+	git_oidmap_free(idx->expected_oids);
 	git__free(idx);
 }

--- a/src/object.h
+++ b/src/object.h
@@ -22,6 +22,17 @@ struct git_object {
 /* fully free the object; internal method, DO NOT EXPORT */
 void git_object__free(void *object);
 
+/*
+ * Parse object from raw data. Note that the resulting object is
+ * tied to the lifetime of the data, as some objects simply point
+ * into it.
+ */
+int git_object__from_raw(
+	git_object **object_out,
+	const char *data,
+	size_t size,
+	git_otype type);
+
 int git_object__from_odb_object(
 	git_object **object_out,
 	git_repository *repo,

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -519,6 +519,7 @@ static int pack_backend__writepack(struct git_odb_writepack **out,
 	git_transfer_progress_cb progress_cb,
 	void *progress_payload)
 {
+	git_indexer_options opts;
 	struct pack_backend *backend;
 	struct pack_writepack *writepack;
 
@@ -526,13 +527,16 @@ static int pack_backend__writepack(struct git_odb_writepack **out,
 
 	*out = NULL;
 
+	opts.progress_cb = progress_cb;
+	opts.progress_cb_payload = progress_payload;
+
 	backend = (struct pack_backend *)_backend;
 
 	writepack = git__calloc(1, sizeof(struct pack_writepack));
 	GITERR_CHECK_ALLOC(writepack);
 
 	if (git_indexer_new(&writepack->indexer,
-		backend->pack_folder, 0, odb, progress_cb, progress_payload) < 0) {
+		backend->pack_folder, 0, odb, &opts) < 0) {
 		git__free(writepack);
 		return -1;
 	}

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -519,7 +519,7 @@ static int pack_backend__writepack(struct git_odb_writepack **out,
 	git_transfer_progress_cb progress_cb,
 	void *progress_payload)
 {
-	git_indexer_options opts;
+	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
 	struct pack_backend *backend;
 	struct pack_writepack *writepack;
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1388,6 +1388,7 @@ int git_packbuilder_write(
 	git_transfer_progress_cb progress_cb,
 	void *progress_cb_payload)
 {
+	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
 	git_indexer *indexer;
 	git_transfer_progress stats;
 	struct pack_write_context ctx;
@@ -1395,8 +1396,11 @@ int git_packbuilder_write(
 
 	PREPARE_PACK;
 
+	opts.progress_cb = progress_cb;
+	opts.progress_cb_payload = progress_cb_payload;
+
 	if (git_indexer_new(
-		&indexer, path, mode, pb->odb, progress_cb, progress_cb_payload) < 0)
+		&indexer, path, mode, pb->odb, &opts) < 0)
 		return -1;
 
 	if (!git_repository__cvar(&t, pb->repo, GIT_CVAR_FSYNCOBJECTFILES) && t)

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -52,12 +52,6 @@ typedef struct git_pobject {
 	    filled:1;
 } git_pobject;
 
-typedef struct {
-	git_oid id;
-	unsigned int uninteresting:1,
-		seen:1;
-} git_walk_object;
-
 struct git_packbuilder {
 	git_repository *repo; /* associated repository */
 	git_odb *odb; /* associated object database */

--- a/src/tag.c
+++ b/src/tag.c
@@ -159,6 +159,11 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 	return 0;
 }
 
+int git_tag__parse_raw(void *_tag, const char *data, size_t size)
+{
+	return tag_parse(_tag, data, data + size);
+}
+
 int git_tag__parse(void *_tag, git_odb_object *odb_obj)
 {
 	git_tag *tag = _tag;

--- a/src/tag.h
+++ b/src/tag.h
@@ -26,5 +26,6 @@ struct git_tag {
 
 void git_tag__free(void *tag);
 int git_tag__parse(void *tag, git_odb_object *obj);
+int git_tag__parse_raw(void *tag, const char *data, size_t size);
 
 #endif

--- a/src/tree.h
+++ b/src/tree.h
@@ -41,6 +41,7 @@ GIT_INLINE(bool) git_tree_entry__is_tree(const struct git_tree_entry *e)
 
 void git_tree__free(void *tree);
 int git_tree__parse(void *tree, git_odb_object *obj);
+int git_tree__parse_raw(void *_tree, const char *data, size_t size);
 
 /**
  * Write a tree to the given repository

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -82,7 +82,7 @@ void test_pack_indexer__out_of_order(void)
 	git_indexer *idx = 0;
 	git_transfer_progress stats = { 0 };
 
-	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_indexer_append(
 		idx, out_of_order_pack, out_of_order_pack_len, &stats));
 	cl_git_pass(git_indexer_commit(idx, &stats));
@@ -99,7 +99,7 @@ void test_pack_indexer__missing_trailer(void)
 	git_indexer *idx = 0;
 	git_transfer_progress stats = { 0 };
 
-	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_indexer_append(
 		idx, missing_trailer_pack, missing_trailer_pack_len, &stats));
 	cl_git_fail(git_indexer_commit(idx, &stats));
@@ -115,7 +115,7 @@ void test_pack_indexer__leaky(void)
 	git_indexer *idx = 0;
 	git_transfer_progress stats = { 0 };
 
-	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_indexer_append(
 		idx, leaky_pack, leaky_pack_len, &stats));
 	cl_git_fail(git_indexer_commit(idx, &stats));
@@ -142,7 +142,7 @@ void test_pack_indexer__fix_thin(void)
 	git_oid_fromstr(&should_id, "e68fe8129b546b101aee9510c5328e7f21ca1d18");
 	cl_assert_equal_oid(&should_id, &id);
 
-	cl_git_pass(git_indexer_new(&idx, ".", 0, odb, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, odb, NULL));
 	cl_git_pass(git_indexer_append(idx, thin_pack, thin_pack_len, &stats));
 	cl_git_pass(git_indexer_commit(idx, &stats));
 
@@ -175,7 +175,7 @@ void test_pack_indexer__fix_thin(void)
 
 		cl_git_pass(p_stat(name, &st));
 
-		cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+		cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 		read = p_read(fd, buffer, sizeof(buffer));
 		cl_assert(read != -1);
 		p_close(fd);
@@ -208,7 +208,7 @@ void test_pack_indexer__corrupt_length(void)
 	git_oid_fromstr(&should_id, "e68fe8129b546b101aee9510c5328e7f21ca1d18");
 	cl_assert_equal_oid(&should_id, &id);
 
-	cl_git_pass(git_indexer_new(&idx, ".", 0, odb, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, odb, NULL));
 	cl_git_pass(git_indexer_append(
 		idx, corrupt_thin_pack, corrupt_thin_pack_len, &stats));
 	cl_git_fail(git_indexer_commit(idx, &stats));
@@ -252,7 +252,7 @@ void test_pack_indexer__no_tmp_files(void)
 	git_buf_dispose(&path);
 	cl_assert(git_buf_len(&first_tmp_file) == 0);
 
-	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	git_indexer_free(idx);
 
 	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -100,7 +100,7 @@ void test_pack_packbuilder__create_pack(void)
 
 	seed_packbuilder();
 
-	cl_git_pass(git_indexer_new(&_indexer, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&_indexer, ".", 0, NULL, NULL));
 	cl_git_pass(git_packbuilder_foreach(_packbuilder, feed_indexer, &stats));
 	cl_git_pass(git_indexer_commit(_indexer, &stats));
 
@@ -237,7 +237,7 @@ void test_pack_packbuilder__foreach(void)
 	git_indexer *idx;
 
 	seed_packbuilder();
-	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_packbuilder_foreach(_packbuilder, foreach_cb, idx));
 	cl_git_pass(git_indexer_commit(idx, &_stats));
 	git_indexer_free(idx);
@@ -255,7 +255,7 @@ void test_pack_packbuilder__foreach_with_cancel(void)
 	git_indexer *idx;
 
 	seed_packbuilder();
-	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
+	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_fail_with(
 		git_packbuilder_foreach(_packbuilder, foreach_cancel_cb, idx), -1111);
 	git_indexer_free(idx);


### PR DESCRIPTION
Warning: this is ugly and, at least to me, in many places it feels like I'm doing hacks over hacks to work around our object system. The main problem here is that we currently cannot parse objects which are not owned by the ODB system, because our objects point into the reference-counted memory of the ODB. So when I try to parse an object which is not owned by the ODB, then this will crash later on after `git_odb_object_deref`, as it tries to free objects which aren't owned by itself or not even part of the heap. So yeah, this doesn't look as nice as it could in an ideal world.

On the other hand, this seems to work just fine right now. After nearly a whole day of cursing and debugging I think I've finally got it right. So what do I do? This is mostly the implementation of `git index-pack --strict`, doing two things:

1. check whether all objects of a pack can be parsed correctly
2. check all references to other objects for commits, tags and trees

What this gets us is that we can verify that a pack is complete (we've got all objects such that we can resolve the complete graph) when we receive the pack.

I've discussed the design a bit in Slack with @carlosmn. My first thought was to just perform an object walk after fetching the complete pack file. But seeing that in most cases we're limited by network bandwidth while fetching the pack file, we agreed that it would be much nicer to just do as much of the heavy lifting as possible during retrieval of the pack. So the algorithm works as follows:

1. for every non-deltified object passed to the indexer
    * strike its object ID from `expected_oids`, which keeps track of OIDs we still expect to find as part of the pack file
    * parse the object
    * add object IDs referenced by the object to the `expected_oids`
2. when resolving delta objects, do the same with regards to the `expected_oids` map
3. afterwards, check that the `expected_oids` map has no entries anymore, as all object references should now be resolved correctly

I'm just putting this up early to get early feedback from the CI and reviewers. I'm not happy with some of the things I had to do here, even though they work.