### PR TITLE
submodule: check index for path and prefix before adding submodule

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -176,7 +176,10 @@ static int is_path_occupied(bool *occupied, git_repository *repo, const char *pa
 	if ((error = git_path_to_dir(&dir)) < 0)
 		goto out;
 
-	if ((error = git_index_find_prefix(NULL, index, dir.ptr)) == 0) {
+	if ((error = git_index_find_prefix(NULL, index, dir.ptr)) < 0 && error != GIT_ENOTFOUND)
+    goto out;
+
+	if (!error) {
 		giterr_set(GITERR_SUBMODULE,
 			"Directory '%s' already exists in the index", path);
 		*occupied = true;

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -163,10 +163,12 @@ static int is_path_occupied(bool *occupied, git_repository *repo, const char *pa
 	if ((error = git_repository_index__weakptr(&index, repo)) < 0)
 		goto out;
 
-	if ((error = git_index_find(NULL, index, path)) == 0) {
-		giterr_set(GITERR_SUBMODULE,
-			"File '%s' already exists in the index", path);
-		*occupied = true;
+	if ((error = git_index_find(NULL, index, path)) != GIT_ENOTFOUND) {
+		if (!error) {
+			giterr_set(GITERR_SUBMODULE,
+				"File '%s' already exists in the index", path);
+			*occupied = true;
+		}
 		goto out;
 	}
 
@@ -176,14 +178,15 @@ static int is_path_occupied(bool *occupied, git_repository *repo, const char *pa
 	if ((error = git_path_to_dir(&dir)) < 0)
 		goto out;
 
-	if ((error = git_index_find_prefix(NULL, index, dir.ptr)) < 0 && error != GIT_ENOTFOUND)
-    goto out;
-
-	if (!error) {
-		giterr_set(GITERR_SUBMODULE,
-			"Directory '%s' already exists in the index", path);
-		*occupied = true;
+	if ((error = git_index_find_prefix(NULL, index, dir.ptr)) != GIT_ENOTFOUND) {
+		if (!error) {
+			giterr_set(GITERR_SUBMODULE,
+				"Directory '%s' already exists in the index", path);
+			*occupied = true;
+		}
+		goto out;
 	}
+
 	error = 0;
 
 out:

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -140,8 +140,8 @@ void test_submodule_add__path_exists_in_index(void)
 	/* In this repo, HEAD (master) has no remote tracking branc h*/
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "/TestGitRepository");
-	git_buf_joinpath(&filename, dirname.ptr, "/test.txt");
+	git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "TestGitRepository");
+	git_buf_joinpath(&filename, dirname.ptr, "test.txt");
 
 	p_mkdir(dirname.ptr, 0700);
 	fd = fopen(filename.ptr, "w");
@@ -174,7 +174,7 @@ void test_submodule_add__file_exists_in_index(void)
 	/* In this repo, HEAD (master) has no remote tracking branc h*/
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	git_buf_joinpath(&name, git_repository_workdir(g_repo), "/TestGitRepository");
+	git_buf_joinpath(&name, git_repository_workdir(g_repo), "TestGitRepository");
 
 	fd = fopen(name.ptr, "w");
 	fclose(fd);

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -7,6 +7,7 @@
 #include "repository.h"
 
 static git_repository *g_repo = NULL;
+static const char *valid_blob_id = "fa49b077972391ad58037050f2a75f74e3671e92";
 
 void test_submodule_add__cleanup(void)
 {
@@ -129,31 +130,39 @@ void test_submodule_add__url_relative_to_workdir(void)
 	assert_submodule_url("TestGitRepository", git_repository_workdir(g_repo));
 }
 
+static void test_add_entry(
+	git_index *index,
+	const char *idstr,
+	const char *path,
+	git_filemode_t mode)
+{
+	git_index_entry entry = {{0}};
+
+	cl_git_pass(git_oid_fromstr(&entry.id, idstr));
+
+	entry.path = path;
+	entry.mode = mode;
+
+	cl_git_pass(git_index_add(index, &entry));
+}
+
 void test_submodule_add__path_exists_in_index(void)
 {
 	git_index *index;
 	git_submodule *sm;
-	git_buf dirname = GIT_BUF_INIT;
 	git_buf filename = GIT_BUF_INIT;
 
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	cl_git_pass(git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "subdirectory"));
-	cl_git_pass(git_buf_joinpath(&filename, dirname.ptr, "test.txt"));
+	cl_git_pass(git_buf_joinpath(&filename, "subdirectory", "test.txt"));
 
-	cl_git_pass(p_mkdir(dirname.ptr, 0700));
-	cl_git_mkfile(filename.ptr, "This is some content");
+	cl_git_pass(git_repository_index(&index, g_repo));
 
-	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
-	cl_git_pass(git_index_add_bypath(index, "subdirectory/test.txt"));
-
-	cl_git_pass(p_unlink(filename.ptr));
-	cl_git_pass(p_rmdir(dirname.ptr));
+	test_add_entry(index, valid_blob_id, filename.ptr, GIT_FILEMODE_BLOB);
 
 	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "subdirectory", 1), GIT_EEXISTS);
 
 	git_submodule_free(sm);
-	git_buf_free(&dirname);
 	git_buf_free(&filename);
 }
 
@@ -165,14 +174,9 @@ void test_submodule_add__file_exists_in_index(void)
 
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	cl_git_pass(git_buf_joinpath(&name, git_repository_workdir(g_repo), "subdirectory"));
+	cl_git_pass(git_repository_index(&index, g_repo));
 
-	cl_git_mkfile(name.ptr, "Test content");
-
-	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
-	cl_git_pass(git_index_add_bypath(index, "subdirectory"));
-
-	cl_git_pass(p_unlink(name.ptr));
+	test_add_entry(index, valid_blob_id, "subdirectory", GIT_FILEMODE_BLOB);
 
 	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "subdirectory", 1), GIT_EEXISTS);
 

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -135,31 +135,22 @@ void test_submodule_add__path_exists_in_index(void)
 	git_submodule *sm;
 	git_buf dirname = GIT_BUF_INIT;
 	git_buf filename = GIT_BUF_INIT;
-	FILE *fd;
 
 	/* In this repo, HEAD (master) has no remote tracking branc h*/
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "TestGitRepository");
-	git_buf_joinpath(&filename, dirname.ptr, "test.txt");
+	cl_git_pass(git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "TestGitRepository"));
+	cl_git_pass(git_buf_joinpath(&filename, dirname.ptr, "test.txt"));
 
-	p_mkdir(dirname.ptr, 0700);
-	fd = fopen(filename.ptr, "w");
-	fclose(fd);
+	cl_git_pass(p_mkdir(dirname.ptr, 0700));
+	cl_git_mkfile(filename.ptr, "This is some content");
 
-	cl_git_pass(
-		git_repository_index__weakptr(&index, g_repo)
-	);
+	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "TestGitRepository/test.txt"));
 
-	cl_git_pass(
-		git_index_add_bypath(index, "TestGitRepository/test.txt")
-	);
+	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1), GIT_EEXISTS);
 
-	cl_git_fail_with(
-		git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1),
-		GIT_EEXISTS
-	);
-
+	git_submodule_free(sm);
 	git_buf_free(&dirname);
 	git_buf_free(&filename);
 }
@@ -169,28 +160,19 @@ void test_submodule_add__file_exists_in_index(void)
 	git_index *index;
 	git_submodule *sm;
 	git_buf name = GIT_BUF_INIT;
-	FILE *fd;
 
 	/* In this repo, HEAD (master) has no remote tracking branc h*/
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	git_buf_joinpath(&name, git_repository_workdir(g_repo), "TestGitRepository");
+	cl_git_pass(git_buf_joinpath(&name, git_repository_workdir(g_repo), "TestGitRepository"));
 
-	fd = fopen(name.ptr, "w");
-	fclose(fd);
+	cl_git_mkfile(name.ptr, "Test content");
 
-	cl_git_pass(
-		git_repository_index__weakptr(&index, g_repo)
-	);
+	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "TestGitRepository"));
 
-	cl_git_pass(
-		git_index_add_bypath(index, "TestGitRepository")
-	);
+	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1), GIT_EEXISTS);
 
-	cl_git_fail_with(
-		git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1),
-		GIT_EEXISTS
-	);
-
+	git_submodule_free(sm);
 	git_buf_free(&name);
 }

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -156,7 +156,7 @@ void test_submodule_add__path_exists_in_index(void)
 
 	cl_git_pass(git_buf_joinpath(&filename, "subdirectory", "test.txt"));
 
-	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
 
 	test_add_entry(index, valid_blob_id, filename.ptr, GIT_FILEMODE_BLOB);
 
@@ -174,7 +174,7 @@ void test_submodule_add__file_exists_in_index(void)
 
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
 
 	test_add_entry(index, valid_blob_id, "subdirectory", GIT_FILEMODE_BLOB);
 

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -136,19 +136,21 @@ void test_submodule_add__path_exists_in_index(void)
 	git_buf dirname = GIT_BUF_INIT;
 	git_buf filename = GIT_BUF_INIT;
 
-	/* In this repo, HEAD (master) has no remote tracking branc h*/
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	cl_git_pass(git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "TestGitRepository"));
+	cl_git_pass(git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "subdirectory"));
 	cl_git_pass(git_buf_joinpath(&filename, dirname.ptr, "test.txt"));
 
 	cl_git_pass(p_mkdir(dirname.ptr, 0700));
 	cl_git_mkfile(filename.ptr, "This is some content");
 
 	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
-	cl_git_pass(git_index_add_bypath(index, "TestGitRepository/test.txt"));
+	cl_git_pass(git_index_add_bypath(index, "subdirectory/test.txt"));
 
-	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1), GIT_EEXISTS);
+	cl_git_pass(p_unlink(filename.ptr));
+	cl_git_pass(p_rmdir(dirname.ptr));
+
+	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "subdirectory", 1), GIT_EEXISTS);
 
 	git_submodule_free(sm);
 	git_buf_free(&dirname);
@@ -161,17 +163,18 @@ void test_submodule_add__file_exists_in_index(void)
 	git_submodule *sm;
 	git_buf name = GIT_BUF_INIT;
 
-	/* In this repo, HEAD (master) has no remote tracking branc h*/
 	g_repo = cl_git_sandbox_init("testrepo");
 
-	cl_git_pass(git_buf_joinpath(&name, git_repository_workdir(g_repo), "TestGitRepository"));
+	cl_git_pass(git_buf_joinpath(&name, git_repository_workdir(g_repo), "subdirectory"));
 
 	cl_git_mkfile(name.ptr, "Test content");
 
 	cl_git_pass(git_repository_index__weakptr(&index, g_repo));
-	cl_git_pass(git_index_add_bypath(index, "TestGitRepository"));
+	cl_git_pass(git_index_add_bypath(index, "subdirectory"));
 
-	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "TestGitRepository", 1), GIT_EEXISTS);
+	cl_git_pass(p_unlink(name.ptr));
+
+	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "subdirectory", 1), GIT_EEXISTS);
 
 	git_submodule_free(sm);
 	git_buf_free(&name);

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -143,7 +143,7 @@ void test_submodule_add__path_exists_in_index(void)
 	git_buf_joinpath(&dirname, git_repository_workdir(g_repo), "/TestGitRepository");
 	git_buf_joinpath(&filename, dirname.ptr, "/test.txt");
 
-	mkdir(dirname.ptr, 0700);
+	p_mkdir(dirname.ptr, 0700);
 	fd = fopen(filename.ptr, "w");
 	fclose(fd);
 


### PR DESCRIPTION
This is to fix an issue where libgit2 will allow you to add a submodule even if the path you are trying add is found on the index. In the CLI we get a nice error about this, but not in libgit2.

I would obviously like some pointers on how to do this, as I do not think it is 100% correct. For one, when I add the trailing slash to the path, I feel like I could clean that up or have a better implementation. I am also unsure if there is a more streamlined routine to check the index for the path.

Some advice on how I could clean this up would be awesome.