### PR TITLE
examples: ls-files: add ls-files to list paths in the index

### DIFF
--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -83,7 +83,7 @@ static int print_paths(ls_options *opts, git_index *index)
 {
 	size_t i;
 	const git_index_entry *entry;
-	
+
 	/* if there are not files explicitly listed by the user print all entries in the index */
 	if (opts->file_count == 0) {
 		size_t entry_count = git_index_entrycount(index);
@@ -99,14 +99,13 @@ static int print_paths(ls_options *opts, git_index *index)
 	for (i = 0; i < opts->file_count; ++i) {
 		const char *path = opts->files[i];
 
-		entry = git_index_get_bypath(index, path, GIT_INDEX_STAGE_NORMAL);
-		if (!entry && opts->error_unmatch) {
+		if ((entry = git_index_get_bypath(index, path, GIT_INDEX_STAGE_NORMAL)) != NULL) {
+			printf("%s\n", path);
+		} else if (opts->error_unmatch) {
 			fprintf(stderr, "error: pathspec '%s' did not match any file(s) known to git.\n", path);
 			fprintf(stderr, "Did you forget to 'git add'?\n");
 			return -1;
 		}
-
-		printf("%s\n", path);
 	}
 
 	return 0;

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -49,7 +49,7 @@ static void usage(const char *message, const char *arg)
 	exit(1);
 }
 
-static void parse_options(ls_options *opts, int argc, char *argv[])
+static int parse_options(ls_options *opts, int argc, char *argv[])
 {
 	int parsing_files = 0;
 	struct args_info args = ARGS_INFO_INIT;
@@ -58,7 +58,7 @@ static void parse_options(ls_options *opts, int argc, char *argv[])
 	memset(opts, 0, sizeof(ls_options));
 
 	if (argc < 2)
-		return;
+		return 0;
 
 	for (args.pos = 1; args.pos < argc; ++args.pos) {
 		char *a = argv[args.pos];
@@ -77,8 +77,11 @@ static void parse_options(ls_options *opts, int argc, char *argv[])
 			opts->error_unmatch = 1;
 		} else {
 			usage("Unsupported argument", a);
+			return -1;
 		}
 	}
+
+	return 0;
 }
 
 static int print_paths(ls_options *opts, git_index *index) 
@@ -113,7 +116,8 @@ int main(int argc, char *argv[])
 	size_t i = 0;
 	int error;
 
-	parse_options(&opts, argc, argv);
+	if ((error = parse_options(&opts, argc, argv)) < 0)
+		return error;
 
 	git_libgit2_init();
 

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -28,7 +28,7 @@
 
 typedef struct {
 	int error_unmatch;
-	char * files[1024];
+	char *files[1024];
 	size_t file_count;
 } ls_options;
 
@@ -84,13 +84,13 @@ static int print_paths(ls_options *opts, git_index *index)
 	size_t i;
 	const git_index_entry *entry;
 
-	/* if there are not files explicitly listed by the user print all entries in the index */
+	/* if there are no files explicitly listed by the user print all entries in the index */
 	if (opts->file_count == 0) {
 		size_t entry_count = git_index_entrycount(index);
 
 		for (i = 0; i < entry_count; i++) {
 			entry = git_index_get_byindex(index, i);
-			printf("%s\n", entry->path);
+			puts(entry->path);
 		}
 		return 0;
 	}
@@ -100,7 +100,7 @@ static int print_paths(ls_options *opts, git_index *index)
 		const char *path = opts->files[i];
 
 		if ((entry = git_index_get_bypath(index, path, GIT_INDEX_STAGE_NORMAL)) != NULL) {
-			printf("%s\n", path);
+			puts(path);
 		} else if (opts->error_unmatch) {
 			fprintf(stderr, "error: pathspec '%s' did not match any file(s) known to git.\n", path);
 			fprintf(stderr, "Did you forget to 'git add'?\n");

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -45,6 +45,7 @@ static void usage(const char *message, const char *arg)
 static int parse_options(ls_options *opts, int argc, char *argv[])
 {
 	int parsing_files = 0;
+	int i;
 	char **file;
 
 	memset(opts, 0, sizeof(ls_options));
@@ -53,7 +54,6 @@ static int parse_options(ls_options *opts, int argc, char *argv[])
 	if (argc < 2)
 		return 0;
 
-	int i;
 	for (i = 1; i < argc; ++i) {
 		char *a = argv[i];
 

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -1,37 +1,126 @@
-#include <common.h>
+/*
+ * libgit2 "ls-files" example - shows how to view all files currently in the index
+ *
+ * Written by the libgit2 contributors
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
 
-typedef struct ls_files_state {
+#include "common.h"
+
+/**
+ * This example demonstrates the libgit2 index APIs to roughly
+ * simulate the output of `git ls-files`.
+ * `git ls-files` has many options and this currently does not show them.
+ * 
+ * `git ls-files` base command shows all paths in the index at that time.
+ * This includes staged and committed files, but unstaged files will not display.
+ */
+
+#define MAX_FILES 64
+
+typedef struct ls_options {
+	int error_unmatch;
+	char *files[MAX_FILES];
+	int file_count;
+} ls_options;
+
+void parse_options(ls_options *opts, int argc, char *argv[]);
+
+int main(int argc, char *argv[]) {
+	ls_options opts;
 	git_repository *repo;
 	git_index *index;
-	char **files;
-	size_t num_entries;
-} ls_files;
+	const git_index_entry *entry;
+	size_t entry_count;
+	size_t i = 0;
+	int error;
 
-void create_ls_files(ls_files **ls);
+	parse_options(&opts, argc, argv);
 
-int main(int argc, char[] *argv) {
-	ls_files *ls;
-	git_index_entry *entry;
-	size_t i;
-
+	/* we need to initialize libgit2 */
 	git_libgit2_init();
 
-	ls = git__malloc(sizeof(ls_files));
+	/* we need to open the repo */
+	if ((error = git_repository_open_ext(&repo, ".", 0, NULL)) != 0)
+		goto cleanup;
 
-	// TODO err
-	git_repository_open_ext(&ls->repo, ".", 0, NULL);
+	/* we need to load the repo's index */
+	if ((error = git_repository_index(&index, repo)) != 0)
+		goto cleanup;
 
-	// TODO err
-	git_repository_index__weakptr(&ls->index, ls->repo);
+	if (opts.error_unmatch) {
+		for (i = 0; i < opts.file_count; i++) {
+			const char *path = opts.files[i];
+			printf("Checking first path '%s'\n", path);
+			entry = git_index_get_bypath(index, path, GIT_INDEX_STAGE_NORMAL);
+			if (!entry) {
+				printf("Could not find path '%s'\n", path);
+				return -1;
+			}
+		}
+		goto cleanup;
+	}
 
+	/* we need to know how many entries exist in the index */
+	entry_count = git_index_entrycount(index);
 
-	git_vector_foreach(&ls->index->entries, i, entry) {
+	/* loop through the entries by index and display their pathes */
+	for (i = 0; i < entry_count; i++) {
+		entry = git_index_get_byindex(index, i);
 		printf("%s\n", entry->path);
 	}
 
-	git_repository_free(ls->repo);
-	git__free(ls);
+cleanup:
+	/* free our allocated resources */
+	git_index_free(index);
+	git_repository_free(repo);
+
+	/* we need to shutdown libgit2 */
 	git_libgit2_shutdown();
 
-	return 0;
+	return error;
 }
+
+void parse_options(ls_options *opts, int argc, char *argv[]) {
+	int parsing_files = 0;
+	int file_idx = 0;
+	struct args_info args = ARGS_INFO_INIT;
+	
+	memset(opts, 0, sizeof(ls_options));
+	opts->error_unmatch = 0;
+	opts->file_count = 0;
+
+	if (argc < 2)
+		return;
+
+	for (args.pos = 1; args.pos < argc; ++args.pos) {
+		char *a = argv[args.pos];
+
+		if (a[0] != '-' || !strcmp(a, "--")) {
+			if (parsing_files) {
+				printf("%s\n", a);
+				opts->files[opts->file_count++] = a;
+			} else { 
+				parsing_files = 1;
+			}
+		} else if (!strcmp(a, "--error-unmatch")) {
+			opts->error_unmatch = 1;
+			parsing_files = 1;
+		} else {
+			printf("Bad command\n");
+		}
+	}
+
+	printf("file count: %d\n", opts->file_count);
+	int i;
+	for (i = 0; i < opts->file_count; i++) {
+		printf("Path ids %d: %s\n", i, opts->files[i]);
+	}
+ }

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -1,0 +1,37 @@
+#include <common.h>
+
+typedef struct ls_files_state {
+	git_repository *repo;
+	git_index *index;
+	char **files;
+	size_t num_entries;
+} ls_files;
+
+void create_ls_files(ls_files **ls);
+
+int main(int argc, char[] *argv) {
+	ls_files *ls;
+	git_index_entry *entry;
+	size_t i;
+
+	git_libgit2_init();
+
+	ls = git__malloc(sizeof(ls_files));
+
+	// TODO err
+	git_repository_open_ext(&ls->repo, ".", 0, NULL);
+
+	// TODO err
+	git_repository_index__weakptr(&ls->index, ls->repo);
+
+
+	git_vector_foreach(&ls->index->entries, i, entry) {
+		printf("%s\n", entry->path);
+	}
+
+	git_repository_free(ls->repo);
+	git__free(ls);
+	git_libgit2_shutdown();
+
+	return 0;
+}

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -19,17 +19,17 @@
  * This example demonstrates the libgit2 index APIs to roughly
  * simulate the output of `git ls-files`.
  * `git ls-files` has many options and this currently does not show them.
- * 
+ *
  * `git ls-files` base command shows all paths in the index at that time.
  * This includes staged and committed files, but unstaged files will not display.
- * 
+ *
  * This currently supports:
  * 	- The --error-unmatch paramter with the same output as the git cli
  *  - default ls-files behavior
- * 
+ *
  * This currently does not support:
  * 	- anything else
- * 
+ *
  */
 
 typedef struct {
@@ -84,7 +84,7 @@ static int parse_options(ls_options *opts, int argc, char *argv[])
 	return 0;
 }
 
-static int print_paths(ls_options *opts, git_index *index) 
+static int print_paths(ls_options *opts, git_index *index)
 {
 	int i;
 	const git_index_entry *entry;
@@ -109,8 +109,8 @@ static int print_paths(ls_options *opts, git_index *index)
 int main(int argc, char *argv[])
 {
 	ls_options opts;
-	git_repository *repo;
-	git_index *index;
+	git_repository *repo = NULL;
+	git_index *index = NULL;
 	const git_index_entry *entry;
 	size_t entry_count;
 	size_t i = 0;
@@ -121,10 +121,10 @@ int main(int argc, char *argv[])
 
 	git_libgit2_init();
 
-	if ((error = git_repository_open_ext(&repo, ".", 0, NULL)) != 0)
+	if ((error = git_repository_open_ext(&repo, ".", 0, NULL)) < 0)
 		goto cleanup;
 
-	if ((error = git_repository_index(&index, repo)) != 0)
+	if ((error = git_repository_index(&index, repo)) < 0)
 		goto cleanup;
 
 	/* if there are files explicitly listed by the user, we need to treat this command differently */

--- a/examples/ls-files.c
+++ b/examples/ls-files.c
@@ -13,6 +13,7 @@
  */
 
 #include "common.h"
+#include "array.h"
 
 /**
  * This example demonstrates the libgit2 index APIs to roughly
@@ -31,19 +32,79 @@
  * 
  */
 
-#define MAX_FILES 64
-
-typedef struct ls_options {
+typedef struct {
 	int error_unmatch;
-	char *files[MAX_FILES];
+	char **files;
 	int file_count;
 } ls_options;
 
-static void usage(const char *message, const char *arg);
-void parse_options(ls_options *opts, int argc, char *argv[]);
-int print_error_unmatch(ls_options *opts, git_index *index);
+/* Print a usage message for the program. */
+static void usage(const char *message, const char *arg)
+{
+	if (message && arg)
+		fprintf(stderr, "%s: %s\n", message, arg);
+	else if (message)
+		fprintf(stderr, "%s\n", message);
+	fprintf(stderr, "usage: ls-files [--error-unmatch] [--] [<file>...]\n");
+	exit(1);
+}
 
-int main(int argc, char *argv[]) {
+static void parse_options(ls_options *opts, int argc, char *argv[])
+{
+	int parsing_files = 0;
+	struct args_info args = ARGS_INFO_INIT;
+	git_array_t(char *) files = GIT_ARRAY_INIT;
+
+	memset(opts, 0, sizeof(ls_options));
+
+	if (argc < 2)
+		return;
+
+	for (args.pos = 1; args.pos < argc; ++args.pos) {
+		char *a = argv[args.pos];
+
+		/* if it doesn't start with a '-' or is after the '--' then it is a file */
+		if (a[0] != '-') {
+			parsing_files = 1;
+
+			opts->files = git_array_alloc(files);
+			GITERR_CHECK_ALLOC(opts->files);
+
+			opts->files[opts->file_count++] = a;
+		} else if (!strcmp(a, "--")) {
+			parsing_files = 1;
+		} else if (!strcmp(a, "--error-unmatch") && !parsing_files) {
+			opts->error_unmatch = 1;
+		} else {
+			usage("Unsupported argument", a);
+		}
+	}
+}
+
+static int print_paths(ls_options *opts, git_index *index) 
+{
+	int i;
+	const git_index_entry *entry;
+
+	/* loop through the files found in the args and print them if they exist */
+	for (i = 0; i < opts->file_count; i++) {
+		const char *path = opts->files[i];
+
+		entry = git_index_get_bypath(index, path, GIT_INDEX_STAGE_NORMAL);
+		if (!entry && opts->error_unmatch) {
+			printf("error: pathspec '%s' did not match any file(s) known to git.\n", path);
+			printf("Did you forget to 'git add'?\n");
+			return -1;
+		}
+
+		printf("%s\n", path);
+	}
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
 	ls_options opts;
 	git_repository *repo;
 	git_index *index;
@@ -54,20 +115,17 @@ int main(int argc, char *argv[]) {
 
 	parse_options(&opts, argc, argv);
 
-	/* we need to initialize libgit2 */
 	git_libgit2_init();
 
-	/* we need to open the repo */
 	if ((error = git_repository_open_ext(&repo, ".", 0, NULL)) != 0)
 		goto cleanup;
 
-	/* we need to load the repo's index */
 	if ((error = git_repository_index(&index, repo)) != 0)
 		goto cleanup;
 
-	/* if the error_unmatch flag is set, we need to print it differently */
-	if (opts.error_unmatch) {
-		error = print_error_unmatch(&opts, index);
+	/* if there are files explicitly listed by the user, we need to treat this command differently */
+	if (opts.file_count > 0) {
+		error = print_paths(&opts, index);
 		goto cleanup;
 	}
 
@@ -84,70 +142,7 @@ cleanup:
 	/* free our allocated resources */
 	git_index_free(index);
 	git_repository_free(repo);
-
-	/* we need to shutdown libgit2 */
 	git_libgit2_shutdown();
 
 	return error;
-}
-
-/* Print a usage message for the program. */
-static void usage(const char *message, const char *arg)
-{
-	if (message && arg)
-		fprintf(stderr, "%s: %s\n", message, arg);
-	else if (message)
-		fprintf(stderr, "%s\n", message);
-	fprintf(stderr, "usage: ls-files [--error-unmatch] [--] [<file>...]\n");
-	exit(1);
-}
-
-void parse_options(ls_options *opts, int argc, char *argv[]) {
-	int parsing_files = 0;
-	struct args_info args = ARGS_INFO_INIT;
-	
-	memset(opts, 0, sizeof(ls_options));
-	opts->error_unmatch = 0;
-	opts->file_count = 0;
-
-	if (argc < 2)
-		return;
-
-	for (args.pos = 1; args.pos < argc; ++args.pos) {
-		char *a = argv[args.pos];
-
-		/* if it doesn't start with a '-' or is after the '--' then it is a file */
-		if (a[0] != '-' || !strcmp(a, "--")) {
-			if (parsing_files) {
-				opts->files[opts->file_count++] = a;
-			} else { 
-				parsing_files = 1;
-			}
-		} else if (!strcmp(a, "--error-unmatch")) {
-			opts->error_unmatch = 1;
-			parsing_files = 1;
-		} else {
-			usage("Unsupported argument", a);
-		}
-	}
-}
-
-int print_error_unmatch(ls_options *opts, git_index *index) {
-	int i;
-	const git_index_entry *entry;
-
-	/* loop through the files found in the args and print them if they exist */
-	for (i = 0; i < opts->file_count; i++) {
-		const char *path = opts->files[i];
-
-		entry = git_index_get_bypath(index, path, GIT_INDEX_STAGE_NORMAL);
-		if (!entry) {
-			printf("error: pathspec '%s' did not match any file(s) known to git.\n", path);
-			printf("Did you forget to 'git add'?\n");
-			return -1;
-		}
-
-		printf("%s\n", path);
-	}
-	return 0;
 }


### PR DESCRIPTION
Added an example to mimic `git ls-files` using the libgit2 library. It also supports the `--error-unmatch` parameter to determine if the specified paths are in the index. This will hopefully be a useful example for new libgit2 users.