### PR TITLE
branches: Check symlinked subdirectories

### DIFF
--- a/src/iterator.h
+++ b/src/iterator.h
@@ -39,6 +39,8 @@ typedef enum {
 	GIT_ITERATOR_DONT_PRECOMPOSE_UNICODE = (1u << 5),
 	/** include conflicts */
 	GIT_ITERATOR_INCLUDE_CONFLICTS = (1u << 6),
+	/** descend into symlinked directories when looking for references */
+	GIT_ITERATOR_INCLUDE_SYMLINK_REFSDIR = (1u << 7),
 } git_iterator_flag_t;
 
 typedef enum {

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -2035,6 +2035,7 @@ int git_refdb_backend_fs(
 	if ((!git_repository__cvar(&t, backend->repo, GIT_CVAR_FSYNCOBJECTFILES) && t) ||
 		git_repository__fsync_gitdir)
 		backend->fsync = 1;
+	backend->iterator_flags |= GIT_ITERATOR_INCLUDE_SYMLINK_REFSDIR;
 
 	backend->parent.exists = &refdb_fs_backend__exists;
 	backend->parent.lookup = &refdb_fs_backend__lookup;


### PR DESCRIPTION
This is a bit of an RFC as I've never contributed to this project. I'm
hoping to get support in libgit2 and thought I'd share my suggestion
for how you might implement such a feature.

Native Git allows symlinked directories under .git/refs/heads. This
change allows libgit2 to also look for references that live under
symlinked directories.

Signed-off-by: Andy Doan <andy@opensourcefoundries.com>