### PR TITLE
implement NTLM authentication

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -20,3 +20,4 @@ Edward Thomson <ethomson@github.com> <ethomson@microsoft.com>
 Edward Thomson <ethomson@github.com> <ethomson@edwardthomson.com>
 J. David Ibáñez <jdavid.ibp@gmail.com> <jdavid@itaapy.com>
 Russell Belfer <rb@github.com> <arrbee@arrbee.com>
+Bob Carroll <bob.carroll@alum.rit.edu> <bobc@qti.qualcomm.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -75,3 +75,4 @@ Tim Harder
 Torsten Bögershausen
 Trent Mick
 Vicent Marti
+Bob Carroll

--- a/cmake/Modules/FindUnistring.cmake
+++ b/cmake/Modules/FindUnistring.cmake
@@ -1,0 +1,24 @@
+# - Find UNISTRING
+# Find the unistring includes and library
+#
+#  UNISTRING_INCLUDE_DIR - where to find unistr.h, etc.
+#  UNISTRING_LIBRARY     - unistring library.
+#  UNISTRING_FOUND       - True if unistring found.
+
+IF (UNISTRING_INCLUDE_DIR)
+    # Already in cache, be silent
+    SET(UNISTRING_FIND_QUIETLY TRUE)
+ENDIF (UNISTRING_INCLUDE_DIR)
+
+FIND_PATH(UNISTRING_INCLUDE_DIR unistr.h)
+
+SET(UNISTRING_NAMES unistring libunistring)
+FIND_LIBRARY(UNISTRING_LIBRARY NAMES ${UNISTRING_NAMES})
+
+# handle the QUIETLY and REQUIRED arguments and set UNISTRING_FOUND to
+# TRUE if all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(UNISTRING DEFAULT_MSG
+    UNISTRING_INCLUDE_DIR UNISTRING_LIBRARY)
+
+MARK_AS_ADVANCED(UNISTRING_LIBRARY UNISTRING_INCLUDE_DIR UNISTRING_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,6 +241,17 @@ IF(WIN32 OR AMIGA OR CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
 	LIST(APPEND LIBGIT2_OBJECTS $<TARGET_OBJECTS:regex>)
 ENDIF()
 
+# NTLM support requires libunistring
+IF (USE_NTLM)
+	FIND_PACKAGE(Unistring)
+ENDIF()
+IF (UNISTRING_FOUND)
+	SET(GIT_NTLM 1)
+	LIST(APPEND LIBGIT2_INCLUDES ${UNISTRING_INCLUDE_DIR})
+	LIST(APPEND LIBGIT2_LIBS ${UNISTRING_LIBRARY})
+ENDIF()
+ADD_FEATURE_INFO(NTLM GIT_NTLM "NTLM authentication support")
+
 # Optional external dependency: http-parser
 FIND_PACKAGE(HTTP_Parser)
 IF (USE_EXT_HTTP_PARSER AND HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
@@ -307,6 +318,7 @@ IF (USE_GSSAPI)
 ENDIF()
 IF (GSSAPI_FOUND)
 	SET(GIT_GSSAPI 1)
+	LIST(APPEND LIBGIT2_INCLUDES ${GSSAPI_INCLUDE_DIR})
 	LIST(APPEND LIBGIT2_LIBS ${GSSAPI_LIBRARIES})
 ENDIF()
 ADD_FEATURE_INFO(SPNEGO GIT_GSSAPI "SPNEGO authentication support")
@@ -373,6 +385,13 @@ FILE(GLOB SRC_GIT2 *.c *.h
 	streams/*.c streams/*.h
 	transports/*.c transports/*.h
 	xdiff/*.c xdiff/*.h)
+
+# Build NTLM sources if this feature is enabled
+IF (GIT_NTLM)
+	FILE(GLOB SRC_NTLM
+		transports/ntlm/*.c transports/ntlm/*.h)
+	SET(SRC_GIT2 ${SRC_GIT2} ${SRC_NTLM})
+ENDIF()
 
 # Determine architecture of the machine
 IF (CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/src/features.h.in
+++ b/src/features.h.in
@@ -20,6 +20,8 @@
 #cmakedefine GIT_SSH 1
 #cmakedefine GIT_SSH_MEMORY_CREDENTIALS 1
 
+#cmakedefine GIT_NTLM 1
+
 #cmakedefine GIT_GSSAPI 1
 #cmakedefine GIT_WINHTTP 1
 #cmakedefine GIT_CURL 1

--- a/src/transports/auth.h
+++ b/src/transports/auth.h
@@ -16,6 +16,7 @@
 typedef enum {
 	GIT_AUTHTYPE_BASIC = 1,
 	GIT_AUTHTYPE_NEGOTIATE = 2,
+	GIT_AUTHTYPE_NTLM = 2,
 } git_http_authtype_t;
 
 typedef struct git_http_auth_context git_http_auth_context;

--- a/src/transports/auth_ntlm.c
+++ b/src/transports/auth_ntlm.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "git2.h"
+#include "common.h"
+#include "buffer.h"
+#include "auth.h"
+#include "auth_ntlm.h"
+
+#ifdef GIT_NTLM
+
+#include <transports/ntlm/ntlm.h>
+#include <transports/ntlm/crypto.h>
+
+typedef struct {
+	git_http_auth_context parent;
+	char *challenge;
+	unsigned int state;
+	struct ntlm_ctx *ntctx;
+} http_auth_ntlm_context;
+
+static int ntlm_set_challenge(
+	git_http_auth_context *c,
+	const char *challenge)
+{
+	http_auth_ntlm_context *ctx = (http_auth_ntlm_context *)c;
+
+	assert(ctx && ctx->state && challenge);
+
+	git__free(ctx->challenge);
+
+	ctx->challenge = git__strdup(challenge);
+	GITERR_CHECK_ALLOC(ctx->challenge);
+
+	return 0;
+}
+
+static int ntlm_next_token(
+	git_buf *buf,
+	git_http_auth_context *c,
+	git_cred *cred)
+{
+	http_auth_ntlm_context *ctx = (http_auth_ntlm_context *)c;
+	git_cred_userpass_plaintext *userpw;
+	uint32_t flags = 0;
+	char *target = NULL;
+	uint8_t s_chal_data[8] = { 0 };
+	uint8_t c_chal_data[8] = { 0 };
+	uint8_t msg_data = 0;
+	struct ntlm_buffer msg = { 0 };
+	struct ntlm_buffer s_chal = { (uint8_t *)&s_chal_data, 8 };
+	struct ntlm_buffer c_chal = { (uint8_t *)&c_chal_data, 8 };
+	struct ntlm_buffer s_ti = { 0 };
+	struct ntlm_buffer c_ti = { 0 };
+	struct ntlm_buffer cb = { 0 };
+	struct ntlm_buffer nt_resp = { 0 };
+	struct ntlm_buffer nt_proof = { 0 };
+	struct ntlm_buffer s_key = { 0 };
+	struct ntlm_key nt_key = { .length = 16 };
+	struct ntlm_key nt_key2 = { .length = 16 };
+	struct ntlm_key kex_key = { .length = 16 };
+	struct ntlm_key exp_key = { .length = 16 };
+	struct ntlm_key enc_key = { .length = 16 };
+	git_buf challenge_buf = GIT_BUF_INIT;
+	size_t challenge_len;
+	uint64_t srv_time = 0;
+	bool protect = false, kex = false;
+	int error = 0, ret = 0;
+
+	assert(buf && ctx && ctx->state && cred &&
+			cred->credtype == GIT_CREDTYPE_USERPASS_PLAINTEXT);
+	userpw = (git_cred_userpass_plaintext *)cred;
+
+	if (ctx->state == NTLMSSP_STAGE_NEGOTIATE) {
+		flags = NTLMSSP_NEGOTIATE_UNICODE | NTLMSSP_REQUEST_TARGET;
+
+		if ((ret = ntlm_encode_neg_msg(ctx->ntctx, flags, NULL, NULL, &msg))) {
+			giterr_set(GITERR_NET, "failed to encode NTLM negotiate message (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		ctx->state = NTLMSSP_STAGE_CHALLENGE;
+	} else if (ctx->state == NTLMSSP_STAGE_CHALLENGE) {
+		if ((challenge_len = ctx->challenge ? strlen(ctx->challenge) : 0) < 6) {
+			giterr_set(GITERR_NET, "no NTLM challenge sent from server");
+			error = -1;
+			goto done;
+		}
+
+		if (git_buf_decode_base64(
+						&challenge_buf,
+						ctx->challenge + 5,
+						challenge_len - 5)) {
+			giterr_set(GITERR_NET, "invalid NTLM challenge from server");
+			error = -1;
+			goto done;
+		}
+
+		msg.data = (uint8_t *)challenge_buf.ptr;
+		msg.length = challenge_buf.size;
+
+		if ((ret = ntlm_decode_chal_msg(
+						ctx->ntctx,
+						&msg,
+						&flags,
+						&target,
+						&s_chal,
+						&s_ti))) {
+			git_buf_free(&challenge_buf);
+			giterr_set(GITERR_NET, "failed to decode NTLM challenge message (%d)", ret);
+			error = -1;
+			goto done;
+		} else {
+			git_buf_free(&challenge_buf);
+			memset(&msg, 0, sizeof(msg));
+		}
+
+		protect = flags & (NTLMSSP_NEGOTIATE_SIGN | NTLMSSP_NEGOTIATE_SEAL);
+
+		if ((ret = ntlm_process_target_info(
+						ctx->ntctx,
+						protect,
+						&s_ti,
+						NULL,
+						&cb,
+						&c_ti,
+						&srv_time,
+						NULL))) {
+			giterr_set(GITERR_NET, "failed to process server target info (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		if ((ret = NTOWFv1(userpw->password, &nt_key))) {
+			giterr_set(GITERR_NET, "failed to compute NTLM key (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		if ((ret = NTOWFv2(
+						ctx->ntctx,
+						&nt_key,
+						userpw->username,
+						target,
+						&nt_key2))) {
+			giterr_set(GITERR_NET, "failed to compute NTLMv2 key (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		if ((ret = RAND_BUFFER(&c_chal))) {
+			giterr_set(GITERR_NET, "failed to compute client challenge (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		if ((ret = ntlmv2_compute_nt_response(
+						&nt_key2,
+						s_chal.data,
+						c_chal.data,
+						srv_time,
+						&c_ti,
+						&nt_resp))) {
+			giterr_set(GITERR_NET, "failed to compute NTLMv2 response (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		kex = flags & NTLMSSP_NEGOTIATE_KEY_EXCH;
+
+		if (kex) {
+			nt_proof.data = nt_resp.data;
+			nt_proof.length = 16;
+
+			if ((ret = ntlmv2_session_base_key(&nt_key2, &nt_proof, &kex_key))) {
+				giterr_set(GITERR_NET, "failed to compute session key (%d)", ret);
+				error = -1;
+				goto done;
+			}
+
+			if ((ret = ntlm_exported_session_key(&kex_key, kex, &exp_key))) {
+				giterr_set(GITERR_NET, "failed to export session key (%d)", ret);
+				error = -1;
+				goto done;
+			}
+
+			if ((ret = ntlm_encrypted_session_key(&kex_key, &exp_key, &enc_key))) {
+				giterr_set(GITERR_NET, "failed to encrypt session key (%d)", ret);
+				error = -1;
+				goto done;
+			}
+
+			s_key.data = enc_key.data;
+			s_key.length = enc_key.length;
+		}
+
+		msg.data = &msg_data;
+		msg.length = sizeof(msg_data);
+
+		if ((ret = ntlm_encode_auth_msg(
+						ctx->ntctx,
+						flags,
+						NULL,
+						&nt_resp,
+						target,
+						userpw->username,
+						NULL,
+						&s_key,
+						NULL,
+						&msg))) {
+			giterr_set(GITERR_NET, "failed to encode NTLM auth message (%d)", ret);
+			error = -1;
+			goto done;
+		}
+
+		ctx->state = NTLMSSP_STAGE_AUTHENTICATE;
+	} else if (ctx->state == NTLMSSP_STAGE_AUTHENTICATE) {
+		if ((ctx->challenge ? strlen(ctx->challenge) : 0) == 4) {
+			giterr_set(GITERR_NET, "authentication failure");
+			error = -1;
+			goto done;
+		} else {
+			goto done;
+		}
+	} else {
+		giterr_set(GITERR_NET, "unknown NTLM handshake state (%d)", ctx->state);
+		error = -1;
+		goto done;
+	}
+
+	git_buf_puts(buf, "Authorization: NTLM ");
+	git_buf_encode_base64(buf, (const char *)msg.data, msg.length);
+	git_buf_puts(buf, "\r\n");
+
+	ntlm_free_buffer_data(&msg);
+
+	if (git_buf_oom(buf))
+		error = -1;
+
+done:
+	if (target) free(target);
+	if (nt_resp.length) ntlm_free_buffer_data(&nt_resp);
+	if (s_ti.length) ntlm_free_buffer_data(&s_ti);
+	if (c_ti.length) ntlm_free_buffer_data(&c_ti);
+
+	return error;
+}
+
+static void ntlm_context_free(git_http_auth_context *c)
+{
+	http_auth_ntlm_context *ctx = (http_auth_ntlm_context *)c;
+
+	git__free(ctx->challenge);
+	ctx->state = NTLMSSP_STAGE_INIT;
+
+	if (ctx->ntctx) {
+		ntlm_free_ctx(&(ctx->ntctx));
+		ctx->ntctx = NULL;
+	}
+
+	git__free(ctx);
+}
+
+int git_http_auth_ntlm(
+	git_http_auth_context **out,
+	const gitno_connection_data *connection_data)
+{
+	http_auth_ntlm_context *ctx;
+
+	GIT_UNUSED(connection_data);
+
+	*out = NULL;
+
+	ctx = git__calloc(1, sizeof(http_auth_ntlm_context));
+	GITERR_CHECK_ALLOC(ctx);
+
+	ctx->parent.type = GIT_AUTHTYPE_NTLM;
+	ctx->parent.credtypes = GIT_CREDTYPE_USERPASS_PLAINTEXT;
+	ctx->parent.set_challenge = ntlm_set_challenge;
+	ctx->parent.next_token = ntlm_next_token;
+	ctx->parent.free = ntlm_context_free;
+	ctx->state = NTLMSSP_STAGE_NEGOTIATE;
+	ctx->ntctx = NULL;
+
+	ntlm_init_ctx(&(ctx->ntctx));
+
+	*out = (git_http_auth_context *)ctx;
+
+	return 0;
+}
+
+#endif /* GIT_NTLM */
+

--- a/src/transports/auth_ntlm.h
+++ b/src/transports/auth_ntlm.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_transports_auth_ntlm_h__
+#define INCLUDE_transports_auth_ntlm_h__
+
+#include "git2.h"
+#include "auth.h"
+
+#ifdef GIT_NTLM
+
+#define NTLMSSP_STAGE_INIT          0
+#define NTLMSSP_STAGE_NEGOTIATE     1
+#define NTLMSSP_STAGE_CHALLENGE     2
+#define NTLMSSP_STAGE_AUTHENTICATE  3
+
+extern int git_http_auth_ntlm(
+	git_http_auth_context **out,
+	const gitno_connection_data *connection_data);
+
+#else
+
+#define git_http_auth_ntlm git_http_auth_dummy
+
+#endif /* GIT_NTLM */
+
+#endif
+

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -19,12 +19,14 @@
 #include "auth.h"
 #include "http.h"
 #include "auth_negotiate.h"
+#include "auth_ntlm.h"
 #include "streams/tls.h"
 #include "streams/socket.h"
 #include "streams/curl.h"
 
 git_http_auth_scheme auth_schemes[] = {
 	{ GIT_AUTHTYPE_NEGOTIATE, "Negotiate", GIT_CREDTYPE_DEFAULT, git_http_auth_negotiate },
+	{ GIT_AUTHTYPE_NTLM, "NTLM", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_ntlm },
 	{ GIT_AUTHTYPE_BASIC, "Basic", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_basic },
 };
 

--- a/src/transports/ntlm/crypto.c
+++ b/src/transports/ntlm/crypto.c
@@ -1,0 +1,337 @@
+/*
+   Copyright (C) 2013 Simo Sorce <simo@samba.org>
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <string.h>
+
+#include <openssl/des.h>
+#include <openssl/rc4.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include <zlib.h>
+
+#include "crypto.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+HMAC_CTX *HMAC_CTX_new(void)
+{
+    HMAC_CTX *ctx;
+
+    ctx = OPENSSL_malloc(sizeof(HMAC_CTX));
+    if (!ctx) return NULL;
+
+    HMAC_CTX_init(ctx);
+
+    return ctx;
+}
+
+void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+    if (ctx == NULL) return;
+
+    HMAC_CTX_cleanup(ctx);
+    OPENSSL_free(ctx);
+}
+
+#define EVP_MD_CTX_new EVP_MD_CTX_create
+#define EVP_MD_CTX_free EVP_MD_CTX_destroy
+
+#endif
+
+int RAND_BUFFER(struct ntlm_buffer *random)
+{
+    int ret;
+
+    ret = RAND_bytes(random->data, random->length);
+    if (ret != 1) {
+        return ERR_CRYPTO;
+    }
+    return 0;
+}
+
+int HMAC_MD5_IOV(struct ntlm_buffer *key,
+                 struct ntlm_iov *iov,
+                 struct ntlm_buffer *result)
+{
+    HMAC_CTX *hmac_ctx;
+    unsigned int len;
+    size_t i;
+    int ret = 0;
+
+    if (result->length != 16) return EINVAL;
+
+    hmac_ctx = HMAC_CTX_new();
+    if (!hmac_ctx) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    ret = HMAC_Init_ex(hmac_ctx, key->data, key->length, EVP_md5(), NULL);
+    if (ret == 0) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    for (i = 0; i < iov->num; i++) {
+        ret = HMAC_Update(hmac_ctx, iov->data[i]->data, iov->data[i]->length);
+        if (ret == 0) {
+            ret = ERR_CRYPTO;
+            goto done;
+        }
+    }
+
+    ret = HMAC_Final(hmac_ctx, result->data, &len);
+    if (ret == 0) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    HMAC_CTX_free(hmac_ctx);
+    return ret;
+}
+
+int HMAC_MD5(struct ntlm_buffer *key,
+             struct ntlm_buffer *payload,
+             struct ntlm_buffer *result)
+{
+    struct ntlm_iov iov;
+
+    iov.num = 1;
+    iov.data = &payload;
+    return HMAC_MD5_IOV(key, &iov, result);
+}
+
+static int mdx_hash(const EVP_MD *type,
+                    struct ntlm_buffer *payload,
+                    struct ntlm_buffer *result)
+{
+    EVP_MD_CTX *ctx;
+    unsigned int len;
+    int ret;
+
+    if (result->length != 16) return EINVAL;
+
+    ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    EVP_MD_CTX_init(ctx);
+    ret = EVP_DigestInit_ex(ctx, type, NULL);
+    if (ret == 0) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    ret = EVP_DigestUpdate(ctx, payload->data, payload->length);
+    if (ret == 0) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    ret = EVP_DigestFinal_ex(ctx, result->data, &len);
+    if (ret == 0) {
+        ret = ERR_CRYPTO;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    if (ctx) EVP_MD_CTX_free(ctx);
+    return ret;
+}
+
+int MD4_HASH(struct ntlm_buffer *payload,
+             struct ntlm_buffer *result)
+{
+    return mdx_hash(EVP_md4(), payload, result);
+}
+
+int MD5_HASH(struct ntlm_buffer *payload,
+             struct ntlm_buffer *result)
+{
+    return mdx_hash(EVP_md5(), payload, result);
+}
+
+struct ntlm_rc4_handle {
+    RC4_KEY key;
+};
+
+int RC4_INIT(struct ntlm_buffer *rc4_key,
+             enum ntlm_cipher_mode mode,
+             struct ntlm_rc4_handle **out)
+{
+    struct ntlm_rc4_handle *handle;
+
+    handle = malloc(sizeof(struct ntlm_rc4_handle));
+    if (!handle) return ENOMEM;
+
+    RC4_set_key(&handle->key, rc4_key->length, rc4_key->data);
+
+    *out = handle;
+    return 0;
+}
+
+int RC4_UPDATE(struct ntlm_rc4_handle *handle,
+               struct ntlm_buffer *in, struct ntlm_buffer *out)
+{
+    if (out->length < in->length) return EINVAL;
+
+    if (in->length > 0) {
+        RC4(&handle->key, in->length, in->data, out->data);
+    }
+
+    out->length = in->length;
+    return 0;
+}
+
+void RC4_FREE(struct ntlm_rc4_handle **handle)
+{
+    if (!handle || !*handle) return;
+    safezero((uint8_t *)(&((*handle)->key)), sizeof(RC4_KEY));
+    safefree(*handle);
+}
+
+int RC4_EXPORT(struct ntlm_rc4_handle *handle, struct ntlm_buffer *out)
+{
+    RC4_INT *data = (RC4_INT *)out->data;
+    int len = 258 * sizeof(RC4_INT);
+
+    if (out->length < len) return EINVAL;
+
+    data[0] = handle->key.x;
+    data[1] = handle->key.y;
+    memcpy(&data[2], handle->key.data, sizeof(RC4_INT) * 256);
+    out->length = len;
+    return 0;
+}
+
+int RC4_IMPORT(struct ntlm_rc4_handle **_handle, struct ntlm_buffer *in)
+{
+    struct ntlm_rc4_handle *handle;
+    RC4_INT *data = (RC4_INT *)in->data;
+    int len = 258 * sizeof(RC4_INT);
+
+    if (in->length != len) return EINVAL;
+
+    handle = malloc(sizeof(struct ntlm_rc4_handle));
+    if (!handle) return ENOMEM;
+
+    handle->key.x = data[0];
+    handle->key.y = data[1];
+    memcpy(handle->key.data, &data[2], sizeof(RC4_INT) * 256);
+
+    *_handle = handle;
+    return 0;
+}
+
+int RC4K(struct ntlm_buffer *key,
+         enum ntlm_cipher_mode mode,
+         struct ntlm_buffer *payload,
+         struct ntlm_buffer *result)
+{
+    struct ntlm_rc4_handle *handle;
+    int ret;
+
+    if (result->length < payload->length) return EINVAL;
+
+    ret = RC4_INIT(key, mode, &handle);
+    if (ret) return ret;
+
+    ret = RC4_UPDATE(handle, payload, result);
+
+    RC4_FREE(&handle);
+    return ret;
+}
+
+int WEAK_DES(struct ntlm_buffer *key,
+             struct ntlm_buffer *payload,
+             struct ntlm_buffer *result)
+{
+    DES_key_schedule schedule;
+    DES_cblock key8;
+
+    if ((key->length != 7) ||
+        (payload->length != 8) ||
+        (result->length != 8)) {
+        return EINVAL;
+    }
+
+    /* Undocumented shuffle needed before calling DES_set_key_unchecked */
+    key8[0] =  key->data[0];
+    key8[1] = (key->data[0] << 7) | (key->data[1] >> 1);
+    key8[2] = (key->data[1] << 6) | (key->data[2] >> 2);
+    key8[3] = (key->data[2] << 5) | (key->data[3] >> 3);
+    key8[4] = (key->data[3] << 4) | (key->data[4] >> 4);
+    key8[5] = (key->data[4] << 3) | (key->data[5] >> 5);
+    key8[6] = (key->data[5] << 2) | (key->data[6] >> 6);
+    key8[7] = (key->data[6] << 1);
+
+    DES_set_key_unchecked(&key8, &schedule);
+    DES_ecb_encrypt((DES_cblock *)payload->data,
+                    (DES_cblock *)result->data, &schedule, 1);
+    return 0;
+}
+
+int DESL(struct ntlm_buffer *key,
+         struct ntlm_buffer *payload,
+         struct ntlm_buffer *result)
+{
+    uint8_t buf7[7];
+    struct ntlm_buffer key7;
+    struct ntlm_buffer res8;
+
+    if ((key->length != 16) ||
+        (payload->length != 8) ||
+        (result->length != 24)) {
+        return EINVAL;
+    }
+
+    /* part 1 */
+    key7.data = key->data;
+    key7.length = 7;
+    res8.data = result->data;
+    res8.length = 8;
+    WEAK_DES(&key7, payload, &res8);
+    /* part 2 */
+    key7.data = &key->data[7];
+    key7.length = 7;
+    res8.data = &result->data[8];
+    res8.length = 8;
+    WEAK_DES(&key7, payload, &res8);
+    /* part 3 */
+    memcpy(buf7, &key->data[14], 2);
+    memset(&buf7[2], 0, 5);
+    key7.data = buf7;
+    key7.length = 7;
+    res8.data = &result->data[16];
+    res8.length = 8;
+    WEAK_DES(&key7, payload, &res8);
+
+    return 0;
+}
+
+uint32_t CRC32(uint32_t crc, struct ntlm_buffer *payload)
+{
+    return crc32(crc, payload->data, payload->length);
+}

--- a/src/transports/ntlm/crypto.h
+++ b/src/transports/ntlm/crypto.h
@@ -1,0 +1,186 @@
+/*
+   Copyright (C) 2013 Simo Sorce <simo@samba.org>
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _SRC_CRYPTO_H_
+#define _SRC_CRYPTO_H_
+
+#include <stdbool.h>
+#include "ntlm_common.h"
+
+/**
+ * @brief   Fills the provided preallocated buffer with random data
+ *
+ * @param random        A preallocated buffer, length determines the amount of
+ *                      random bytes the function will return.
+ *
+ * @return 0 for success or error otherwise
+ */
+int RAND_BUFFER(struct ntlm_buffer *random);
+
+/**
+ * @brief HMAC-MD5 function
+ *
+ * @param key           The authentication key
+ * @param payload       The payload to be authenticated
+ * @param result        A preallocated 16 byte buffer
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int HMAC_MD5(struct ntlm_buffer *key,
+             struct ntlm_buffer *payload,
+             struct ntlm_buffer *result);
+
+/**
+ * @brief HMAC-MD5 function that operats on multiple buffers
+ *
+ * @param key           The authentication key
+ * @param iov           The IOVec of the payloads to authenticate
+ * @param result        A preallocated 16 byte buffer
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int HMAC_MD5_IOV(struct ntlm_buffer *key,
+                 struct ntlm_iov *iov,
+                 struct ntlm_buffer *result);
+
+/**
+ * @brief MD4 Hash Function
+ *
+ * @param payload   The payoad to hash
+ * @param result    The resulting Hash (preallocated, length must be 16)
+ *
+ * @return 0 on success or an error
+ */
+int MD4_HASH(struct ntlm_buffer *payload,
+             struct ntlm_buffer *result);
+
+/**
+ * @brief MD5 Hash Function
+ *
+ * @param payload   The payoad to hash
+ * @param result    The resulting Hash (preallocated, length must be 16)
+ *
+ * @return 0 on success or an error
+ */
+int MD5_HASH(struct ntlm_buffer *payload,
+             struct ntlm_buffer *result);
+
+/**
+ * @brief RC4 engine initialization
+ *
+ * @param rc4_key   The encryption/decryption key
+ * @param mode      The cipher mode
+ * @param state     Allocated ntlm_rc4_state structure
+ *
+ * @return 0 on success or error
+ */
+int RC4_INIT(struct ntlm_buffer *rc4_key,
+             enum ntlm_cipher_mode mode,
+             struct ntlm_rc4_handle **handle);
+
+
+/**
+ * @brief RC4 encrypt/decrypt function
+ *
+ * @param state     The state initialized by RC4_INIT
+ * @param in        Input buffer (plaintext for enc or ciphertext for dec)
+ * @param out       Resulting buffer. Must be preallocated.
+ *
+ * @return 0 on success or error
+ */
+int RC4_UPDATE(struct ntlm_rc4_handle *handle,
+               struct ntlm_buffer *in, struct ntlm_buffer *out);
+
+/**
+ * @brief           Release an rc4 handle
+ *
+ * @param state     A pointer to the rc4 handle
+ */
+void RC4_FREE(struct ntlm_rc4_handle **handle);
+
+/**
+ * @brief Exports the RC4 state
+ *
+ * @param handle    The RC4 handle to export from
+ * @param out       A buffer at least 258 bytes long
+ *
+ * @return  0 on success or EAGAIN if the buffer is too small
+ */
+int RC4_EXPORT(struct ntlm_rc4_handle *handle, struct ntlm_buffer *out);
+
+/**
+ * @brief Import an RC4 state
+ *
+ * @param handle    A new ntlm_rc4_handle on success
+ * @param in        A buffer containing an exported state
+ *
+ * @return 0 on success or EINVAL if the buffer is not an exported state
+ */
+int RC4_IMPORT(struct ntlm_rc4_handle **handle, struct ntlm_buffer *in);
+
+/**
+ * @brief RC4 encryption/decryption all in one
+ *
+ * @param key       The encryption/decryption key
+ * @param mode      The cipher mode
+ * @param payload   Input buffer (plaintext for enc or ciphertext for dec)
+ * @param result    Resulting buffer. Must be preallocated.
+ *
+ * @return 0 on success or error
+ */
+int RC4K(struct ntlm_buffer *key,
+         enum ntlm_cipher_mode mode,
+         struct ntlm_buffer *payload,
+         struct ntlm_buffer *result);
+
+/**
+ * @brief Extreely weak DES encryption
+ *
+ * @param key       The encryption/decryption key (must be 8 bytes)
+ * @param payload   Input buffer (must be 8 bytes)
+ * @param result    Output buffer (must be 8 bytes)
+ *
+ * @return 0 on success or EINVAL if any buffer is not 8 in length
+ */
+int WEAK_DES(struct ntlm_buffer *key,
+             struct ntlm_buffer *payload,
+             struct ntlm_buffer *result);
+
+/**
+ * @brief A sad weak encryption/expansion scheme needed by NTLMv1
+ *
+ * @param key       The encryption/decryption key (must be 16 bytes)
+ * @param payload   Input buffer (must be 8 bytes)
+ * @param result    Output buffer (must be 24 bytes)
+ *
+ * @return 0 on success or EINVAL if any buffer is not of proper length
+ */
+int DESL(struct ntlm_buffer *key,
+         struct ntlm_buffer *payload,
+         struct ntlm_buffer *result);
+
+/**
+ * @brief The CRC32 checksum
+ *
+ * @param crc       Initial crc, usually 0
+ * @param payload   The data to checksum
+ *
+ * @return          The resulting CRC.
+ */
+uint32_t CRC32(uint32_t crc, struct ntlm_buffer *payload);
+
+#endif /* _SRC_CRYPTO_H_ */

--- a/src/transports/ntlm/ntlm.c
+++ b/src/transports/ntlm/ntlm.c
@@ -1,0 +1,1435 @@
+/*
+   Copyright (C) 2013 Simo Sorce <simo@samba.org>
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/* This File implements the NTLM protocol as specified by:
+ *      [MS-NLMP]: NT LAN Manager (NTLM) Authentication Protocol
+ *
+ * Additional cross checking with:
+ * http://davenport.sourceforge.net/ntlm.html
+ */
+
+#include <alloca.h>
+#include <endian.h>
+#include <errno.h>
+#include <iconv.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include <unicase.h>
+
+#include "ntlm.h"
+
+#pragma pack(push, 1)
+struct wire_av_pair {
+    uint16_t av_id;
+    uint16_t av_len;
+    uint8_t value[]; /* variable */
+};
+#pragma pack(pop)
+
+enum msv_av_ids {
+    MSV_AV_EOL = 0,
+    MSV_AV_NB_COMPUTER_NAME,
+    MSV_AV_NB_DOMAIN_NAME,
+    MSV_AV_DNS_COMPUTER_NAME,
+    MSV_AV_DNS_DOMAIN_NAME,
+    MSV_AV_DNS_TREE_NAME,
+    MSV_AV_FLAGS,
+    MSV_AV_TIMESTAMP,
+    MSV_AV_SINGLE_HOST,
+    MSV_AV_TARGET_NAME,
+    MSV_AV_CHANNEL_BINDINGS
+};
+
+/* Used only on the same host */
+#pragma pack(push, 1)
+struct wire_single_host_data {
+    uint32_t size;
+    uint32_t Z4;
+    uint32_t data_present;
+    uint32_t custom_data;
+    uint8_t machine_id[32];
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct wire_channel_binding {
+    uint8_t md5_hash[16];
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct wire_ntlm_cli_chal {
+    uint8_t resp_type;
+    uint8_t hi_resp_type;
+    uint16_t reserved1;
+    uint32_t reserved2;
+    uint64_t timestamp;
+    uint8_t cli_chal[8];
+    uint32_t reserved3;
+    uint8_t av_pairs[]; /* variable */
+};
+#pragma pack(pop)
+
+struct ntlm_ctx {
+    iconv_t from_oem;
+    iconv_t to_oem;
+};
+
+int ntlm_init_ctx(struct ntlm_ctx **ctx)
+{
+    struct ntlm_ctx *_ctx;
+    int ret = 0;
+
+    _ctx = calloc(1, sizeof(struct ntlm_ctx));
+    if (!_ctx) return ENOMEM;
+
+    _ctx->from_oem = iconv_open("UCS-2LE", "UTF-8");
+    if (_ctx->from_oem == (iconv_t) -1) {
+        ret = errno;
+    }
+
+    _ctx->to_oem = iconv_open("UTF-8", "UCS-2LE");
+    if (_ctx->to_oem == (iconv_t) -1) {
+        iconv_close(_ctx->from_oem);
+        ret = errno;
+    }
+
+    if (ret) {
+        safefree(_ctx);
+    } else {
+        *ctx = _ctx;
+    }
+    return ret;
+}
+
+int ntlm_free_ctx(struct ntlm_ctx **ctx)
+{
+    int ret;
+
+    if (!ctx || !*ctx) return 0;
+
+    if ((*ctx)->from_oem) {
+        ret = iconv_close((*ctx)->from_oem);
+        if (ret) goto done;
+    }
+
+    if ((*ctx)->to_oem) {
+        ret = iconv_close((*ctx)->to_oem);
+    }
+
+done:
+    if (ret) ret = errno;
+    safefree(*ctx);
+    return ret;
+}
+
+void ntlm_free_buffer_data(struct ntlm_buffer *buf)
+{
+    if (!buf) return;
+
+    safefree(buf->data);
+    buf->length = 0;
+}
+
+/* A FILETIME structure is effectively a little endian 64 bit integer
+ * with the time from January 1, 1601 UTC with 10s of microsecond resolution.
+ */
+#define FILETIME_EPOCH_VALUE 116444736000000000LL
+uint64_t ntlm_timestamp_now(void)
+{
+    struct timeval tv;
+    uint64_t filetime;
+
+    gettimeofday(&tv, NULL);
+
+    /* set filetime to the time representing the eopch */
+    filetime = FILETIME_EPOCH_VALUE;
+    /* add the number of seconds since the epoch */
+    filetime += (uint64_t)tv.tv_sec * 10000000;
+    /* add the number of microseconds since the epoch */
+    filetime += tv.tv_usec * 10;
+
+    return filetime;
+}
+
+bool ntlm_casecmp(const char *s1, const char *s2)
+{
+    size_t s1_len, s2_len;
+    int ret, res;
+
+    if (s1 == s2) return true;
+    if (!s1 || !s2) return false;
+
+    s1_len = strlen(s1);
+    s2_len = strlen(s2);
+
+    ret = ulc_casecmp(s1, s1_len, s2, s2_len,
+                      uc_locale_language(), NULL, &res);
+    if (ret || res != 0) return false;
+    return true;
+}
+
+
+/**
+ * @brief  Converts a string using the provided iconv context.
+ *         This function is ok only to convert utf8<->ucs2
+ *
+ * @param cd        The iconv context
+ * @param in        Input buffer
+ * @param out       Output buffer
+ * @param baselen   Input length
+ * @param outlen    Returned length of out buffer
+ *
+ * NOTE: out must be preallocated to a size of baselen * 2
+ *
+ * @return 0 on success or a standard error value on error.
+ */
+static int ntlm_str_convert(iconv_t cd,
+                            const char *in, char *out,
+                            size_t baselen, size_t *outlen)
+{
+    char *_in;
+    size_t inleft, outleft;
+    size_t ret;
+
+    ret = iconv(cd, NULL, NULL, NULL, NULL);
+    if (ret == -1) return errno;
+
+    _in = discard_const(in);
+    inleft = baselen;
+    /* conservative max_size calculation in case lots of octects end up
+     * being multiple bytes in length (in both directions) */
+    outleft = baselen * 2;
+
+    ret = iconv(cd, &_in, &inleft, &out, &outleft);
+    if (ret == -1) return errno;
+
+    if (outlen) {
+        *outlen = baselen * 2 - outleft;
+    }
+    return 0;
+}
+
+
+uint8_t ntlmssp_sig[8] = {'N', 'T', 'L', 'M', 'S', 'S', 'P', 0};
+
+static void ntlm_encode_header(struct wire_msg_hdr *hdr, uint32_t msg_type)
+{
+    memcpy(hdr->signature, ntlmssp_sig, 8);
+    hdr->msg_type = htole32(msg_type);
+}
+
+static int ntlm_decode_header(struct wire_msg_hdr *hdr, uint32_t *msg_type)
+{
+    if (memcmp(hdr->signature, ntlmssp_sig, 8) != 0) {
+        return ERR_DECODE;
+    }
+
+    *msg_type = le32toh(hdr->msg_type);
+    return 0;
+}
+
+static int ntlm_encode_oem_str(struct wire_field_hdr *hdr,
+                               struct ntlm_buffer *buffer,
+                               size_t *data_offs,
+                               const char *str, int str_len)
+{
+    if (*data_offs + str_len > buffer->length) {
+        return ERR_ENCODE;
+    }
+
+    memcpy(&buffer->data[*data_offs], str, str_len);
+    hdr->len = htole16(str_len);
+    hdr->max_len = htole16(str_len);
+    hdr->offset = htole32(*data_offs);
+
+    *data_offs += str_len;
+    return 0;
+}
+
+static int ntlm_decode_oem_str(struct wire_field_hdr *str_hdr,
+                               struct ntlm_buffer *buffer,
+                               size_t payload_offs, char **_str)
+{
+    uint16_t str_len;
+    uint32_t str_offs;
+    char *str = NULL;
+
+    str_len = le16toh(str_hdr->len);
+    if (str_len == 0) goto done;
+
+    str_offs = le32toh(str_hdr->offset);
+    if ((str_offs < payload_offs) ||
+        (str_offs > buffer->length) ||
+        (str_offs + str_len > buffer->length)) {
+        return ERR_DECODE;
+    }
+
+    str = strndup((const char *)&buffer->data[str_offs], str_len);
+    if (!str) return ENOMEM;
+
+done:
+    *_str = str;
+    return 0;
+}
+
+static int ntlm_encode_ucs2_str_hdr(struct ntlm_ctx *ctx,
+                                    struct wire_field_hdr *hdr,
+                                    struct ntlm_buffer *buffer,
+                                    size_t *data_offs,
+                                    const char *str, int str_len)
+{
+    char *out;
+    size_t outlen;
+    int ret;
+
+    out = (char *)&buffer->data[*data_offs];
+
+    ret = ntlm_str_convert(ctx->from_oem, str, out, str_len, &outlen);
+    if (ret) return ret;
+
+    hdr->len = htole16(outlen);
+    hdr->max_len = htole16(outlen);
+    hdr->offset = htole32(*data_offs);
+
+    *data_offs += outlen;
+    return 0;
+}
+
+static int ntlm_decode_ucs2_str_hdr(struct ntlm_ctx *ctx,
+                                    struct wire_field_hdr *str_hdr,
+                                    struct ntlm_buffer *buffer,
+                                    size_t payload_offs, char **str)
+{
+    char *in, *out = NULL;
+    uint16_t str_len;
+    uint32_t str_offs;
+    size_t outlen;
+    int ret = 0;
+
+    str_len = le16toh(str_hdr->len);
+    if (str_len == 0) goto done;
+
+    str_offs = le32toh(str_hdr->offset);
+    if ((str_offs < payload_offs) ||
+        (str_offs > buffer->length) ||
+        (str_offs + str_len > buffer->length)) {
+        return ERR_DECODE;
+    }
+
+    in = (char *)&buffer->data[str_offs];
+
+    out = malloc(str_len * 2 + 1);
+    if (!out) return ENOMEM;
+
+    ret = ntlm_str_convert(ctx->to_oem, in, out, str_len, &outlen);
+
+    /* make sure to terminate output string */
+    out[outlen] = '\0';
+
+done:
+    if (ret) {
+        safefree(out);
+    }
+    *str = out;
+    return ret;
+}
+
+struct wire_version ntlmssp_version = {
+    NTLMSSP_VERSION_MAJOR,
+    NTLMSSP_VERSION_MINOR,
+    NTLMSSP_VERSION_BUILD, /* 0 is always 0 even in LE */
+    { 0, 0, 0 },
+    NTLMSSP_VERSION_REV
+};
+
+void ntlm_internal_set_version(uint8_t major, uint8_t minor,
+                               uint16_t build, uint8_t revision)
+{
+    ntlmssp_version.major = major;
+    ntlmssp_version.minor = minor;
+    ntlmssp_version.build = htole16(build);
+    ntlmssp_version.revision = revision;
+}
+
+static int ntlm_encode_version(struct ntlm_ctx *ctx,
+                               struct ntlm_buffer *buffer,
+                               size_t *data_offs)
+{
+    if (*data_offs + sizeof(struct wire_version) > buffer->length) {
+        return ERR_ENCODE;
+    }
+
+    memcpy(&buffer->data[*data_offs], &ntlmssp_version,
+           sizeof(struct wire_version));
+    *data_offs += sizeof(struct wire_version);
+    return 0;
+}
+
+static int ntlm_encode_field(struct wire_field_hdr *hdr,
+                             struct ntlm_buffer *buffer,
+                             size_t *data_offs,
+                             struct ntlm_buffer *field)
+{
+    if (*data_offs + field->length > buffer->length) {
+        return ERR_ENCODE;
+    }
+
+    memcpy(&buffer->data[*data_offs], field->data, field->length);
+    hdr->len = htole16(field->length);
+    hdr->max_len = hdr->len;
+    hdr->offset = htole32(*data_offs);
+
+    *data_offs += field->length;
+    return 0;
+}
+
+static int ntlm_decode_field(struct wire_field_hdr *hdr,
+                             struct ntlm_buffer *buffer,
+                             size_t payload_offs,
+                             struct ntlm_buffer *field)
+{
+    struct ntlm_buffer b = { NULL, 0 };
+    uint32_t offs;
+    uint16_t len;
+
+    len = le16toh(hdr->len);
+    if (len == 0) goto done;
+
+    offs = le32toh(hdr->offset);
+    if ((offs < payload_offs) ||
+        (offs > buffer->length) ||
+        (offs + len > buffer->length)) {
+        return ERR_DECODE;
+    }
+
+    b.data = malloc(len);
+    if (!b.data) return ENOMEM;
+
+    b.length = len;
+    memcpy(b.data, &buffer->data[offs], b.length);
+
+done:
+    *field = b;
+    return 0;
+}
+
+static int ntlm_encode_av_pair_ucs2_str(struct ntlm_ctx *ctx,
+                                        struct ntlm_buffer *buffer,
+                                        size_t *data_offs,
+                                        enum msv_av_ids av_id,
+                                        const char *str, size_t str_len)
+{
+    struct wire_av_pair *av_pair;
+    char *out;
+    size_t outlen;
+    int ret;
+
+    if (*data_offs + 4 + str_len > buffer->length) {
+        return ERR_ENCODE;
+    }
+
+    av_pair = (struct wire_av_pair *)&buffer->data[*data_offs];
+    out = (char *)av_pair->value;
+
+    ret = ntlm_str_convert(ctx->from_oem, str, out, str_len, &outlen);
+    if (ret) return ret;
+
+    av_pair->av_len = htole16(outlen);
+    av_pair->av_id = htole16(av_id);
+
+    *data_offs += av_pair->av_len + 4;
+    return 0;
+}
+
+static int ntlm_decode_av_pair_ucs2_str(struct ntlm_ctx *ctx,
+                                        struct wire_av_pair *av_pair,
+                                        char **str)
+{
+    char *in, *out;
+    size_t inlen, outlen;
+    int ret;
+
+    in = (char *)av_pair->value;
+    inlen = le16toh(av_pair->av_len);
+    out = malloc(inlen * 2 + 1);
+
+    ret = ntlm_str_convert(ctx->to_oem, in, out, inlen, &outlen);
+    if (ret) {
+        safefree(out);
+        return ret;
+    }
+    /* terminate out string for sure */
+    out[outlen] = '\0';
+
+    *str = out;
+    return 0;
+}
+
+static int ntlm_encode_av_pair_value(struct ntlm_buffer *buffer,
+                                     size_t *data_offs,
+                                     enum msv_av_ids av_id,
+                                     struct ntlm_buffer *value)
+{
+    struct wire_av_pair *av_pair;
+
+    if (*data_offs + 4 + value->length > buffer->length) {
+        return ERR_ENCODE;
+    }
+
+    av_pair = (struct wire_av_pair *)&buffer->data[*data_offs];
+    av_pair->av_id = htole16(av_id);
+    av_pair->av_len = htole16(value->length);
+    if (value->length) {
+        memcpy(av_pair->value, value->data, value->length);
+    }
+
+    *data_offs += value->length + 4;
+    return 0;
+}
+
+int ntlm_encode_target_info(struct ntlm_ctx *ctx, char *nb_computer_name,
+                            char *nb_domain_name, char *dns_computer_name,
+                            char *dns_domain_name, char *dns_tree_name,
+                            uint32_t *av_flags, uint64_t *av_timestamp,
+                            struct ntlm_buffer *av_single_host,
+                            char *av_target_name, struct ntlm_buffer *av_cb,
+                            struct ntlm_buffer *target_info)
+{
+    struct ntlm_buffer buffer;
+    size_t data_offs;
+    size_t max_size;
+    size_t nb_computer_name_len = 0;
+    size_t nb_domain_name_len = 0;
+    size_t dns_computer_name_len = 0;
+    size_t dns_domain_name_len = 0;
+    size_t dns_tree_name_len = 0;
+    size_t av_target_name_len = 0;
+    struct ntlm_buffer value;
+    int ret = 0;
+
+    max_size = 4; /* MSV_AV_EOL */
+
+    if (nb_computer_name) {
+        nb_computer_name_len = strlen(nb_computer_name);
+        max_size += 4 + nb_computer_name_len * 2;
+    }
+    if (nb_domain_name) {
+        nb_domain_name_len = strlen(nb_domain_name);
+        max_size += 4 + nb_domain_name_len * 2;
+    }
+    if (dns_computer_name) {
+        dns_computer_name_len = strlen(dns_computer_name);
+        max_size += 4 + dns_computer_name_len * 2;
+    }
+    if (dns_domain_name) {
+        dns_domain_name_len = strlen(dns_domain_name);
+        max_size += 4 + dns_domain_name_len * 2;
+    }
+    if (dns_tree_name) {
+        dns_tree_name_len = strlen(dns_tree_name);
+        max_size += 4 + dns_tree_name_len * 2;
+    }
+    if (av_flags) {
+        max_size += 4 + 4;
+    }
+    if (av_timestamp) {
+        max_size += 4 + 8;
+    }
+    if (av_single_host) {
+        max_size += 4 + av_single_host->length;
+    }
+    if (av_target_name) {
+        av_target_name_len = strlen(av_target_name);
+        max_size += 4 + av_target_name_len * 2;
+    }
+    if (av_cb) {
+        max_size += 4 + av_cb->length;
+    }
+
+    data_offs = 0;
+    buffer.length = max_size;
+    buffer.data = calloc(1, buffer.length);
+    if (!buffer.data) return ENOMEM;
+
+    if (nb_computer_name) {
+        ret = ntlm_encode_av_pair_ucs2_str(ctx, &buffer, &data_offs,
+                                           MSV_AV_NB_COMPUTER_NAME,
+                                           nb_computer_name,
+                                           nb_computer_name_len);
+        if (ret) goto done;
+    }
+    if (nb_domain_name) {
+        ret = ntlm_encode_av_pair_ucs2_str(ctx, &buffer, &data_offs,
+                                           MSV_AV_NB_DOMAIN_NAME,
+                                           nb_domain_name,
+                                           nb_domain_name_len);
+        if (ret) goto done;
+    }
+    if (dns_computer_name) {
+        ret = ntlm_encode_av_pair_ucs2_str(ctx, &buffer, &data_offs,
+                                           MSV_AV_DNS_COMPUTER_NAME,
+                                           dns_computer_name,
+                                           dns_computer_name_len);
+        if (ret) goto done;
+    }
+    if (dns_domain_name) {
+        ret = ntlm_encode_av_pair_ucs2_str(ctx, &buffer, &data_offs,
+                                           MSV_AV_DNS_DOMAIN_NAME,
+                                           dns_domain_name,
+                                           dns_domain_name_len);
+        if (ret) goto done;
+    }
+    if (dns_tree_name) {
+        ret = ntlm_encode_av_pair_ucs2_str(ctx, &buffer, &data_offs,
+                                           MSV_AV_DNS_TREE_NAME,
+                                           dns_tree_name,
+                                           dns_tree_name_len);
+        if (ret) goto done;
+    }
+    if (av_flags) {
+        uint32_t flags = htole32(*av_flags);
+        value.data = (uint8_t *)&flags;
+        value.length = 4;
+        ret = ntlm_encode_av_pair_value(&buffer, &data_offs,
+                                        MSV_AV_FLAGS, &value);
+        if (ret) goto done;
+    }
+    if (av_timestamp) {
+        uint64_t timestamp = htole64(*av_timestamp);
+        value.data = (uint8_t *)&timestamp;
+        value.length = 8;
+        ret = ntlm_encode_av_pair_value(&buffer, &data_offs,
+                                        MSV_AV_TIMESTAMP, &value);
+        if (ret) goto done;
+    }
+    if (av_single_host) {
+        ret = ntlm_encode_av_pair_value(&buffer, &data_offs,
+                                        MSV_AV_SINGLE_HOST, av_single_host);
+        if (ret) goto done;
+    }
+    if (av_target_name) {
+        ret = ntlm_encode_av_pair_ucs2_str(ctx, &buffer, &data_offs,
+                                           MSV_AV_TARGET_NAME,
+                                           av_target_name,
+                                           av_target_name_len);
+        if (ret) goto done;
+    }
+    if (av_cb) {
+        ret = ntlm_encode_av_pair_value(&buffer, &data_offs,
+                                        MSV_AV_CHANNEL_BINDINGS, av_cb);
+        if (ret) goto done;
+    }
+
+    value.length = 0;
+    value.data = NULL;
+    ret = ntlm_encode_av_pair_value(&buffer, &data_offs, MSV_AV_EOL, &value);
+    buffer.length = data_offs;
+
+done:
+    if (ret) {
+       safefree(buffer.data);
+    } else {
+        *target_info = buffer;
+    }
+    return ret;
+}
+
+int ntlm_decode_target_info(struct ntlm_ctx *ctx, struct ntlm_buffer *buffer,
+                            char **nb_computer_name, char **nb_domain_name,
+                            char **dns_computer_name, char **dns_domain_name,
+                            char **dns_tree_name, char **av_target_name,
+                            uint32_t *av_flags, uint64_t *av_timestamp,
+                            struct ntlm_buffer *av_single_host,
+                            struct ntlm_buffer *av_cb)
+{
+    struct wire_av_pair *av_pair;
+    uint16_t av_id = (uint16_t)-1;
+    uint16_t av_len = (uint16_t)-1;
+    struct ntlm_buffer sh = { NULL, 0 };
+    struct ntlm_buffer cb = { NULL, 0 };
+    char *nb_computer = NULL;
+    char *nb_domain = NULL;
+    char *dns_computer = NULL;
+    char *dns_domain = NULL;
+    char *dns_tree = NULL;
+    char *av_target = NULL;
+    size_t data_offs = 0;
+    uint64_t timestamp = 0;
+    uint32_t flags = 0;
+    int ret = 0;
+
+    while (data_offs + 4 <= buffer->length) {
+        av_pair = (struct wire_av_pair *)&buffer->data[data_offs];
+        data_offs += 4;
+        av_id = le16toh(av_pair->av_id);
+        av_len = le16toh(av_pair->av_len);
+        if (av_len > buffer->length - data_offs) {
+            ret = ERR_DECODE;
+            goto done;
+        }
+        data_offs += av_len;
+
+        switch (av_id) {
+        case MSV_AV_CHANNEL_BINDINGS:
+            if (!av_cb) continue;
+            cb.data = av_pair->value;
+            cb.length = av_len;
+            break;
+        case MSV_AV_TARGET_NAME:
+            if (!av_target_name) continue;
+            ret = ntlm_decode_av_pair_ucs2_str(ctx, av_pair, &av_target);
+            if (ret) goto done;
+            break;
+        case MSV_AV_SINGLE_HOST:
+            if (!av_single_host) continue;
+            sh.data = av_pair->value;
+            sh.length = av_len;
+            break;
+        case MSV_AV_TIMESTAMP:
+            if (!av_timestamp) continue;
+            memcpy(&timestamp, av_pair->value, sizeof(timestamp));
+            timestamp = le64toh(timestamp);
+            break;
+        case MSV_AV_FLAGS:
+            if (!av_flags) continue;
+            memcpy(&flags, av_pair->value, sizeof(flags));
+            flags = le32toh(flags);
+            break;
+        case MSV_AV_DNS_TREE_NAME:
+            if (!dns_tree_name) continue;
+            ret = ntlm_decode_av_pair_ucs2_str(ctx, av_pair, &dns_tree);
+            if (ret) goto done;
+            break;
+        case MSV_AV_DNS_DOMAIN_NAME:
+            if (!dns_domain_name) continue;
+            ret = ntlm_decode_av_pair_ucs2_str(ctx, av_pair, &dns_domain);
+            if (ret) goto done;
+            break;
+        case MSV_AV_DNS_COMPUTER_NAME:
+            if (!dns_computer_name) continue;
+            ret = ntlm_decode_av_pair_ucs2_str(ctx, av_pair, &dns_computer);
+            if (ret) goto done;
+            break;
+        case MSV_AV_NB_DOMAIN_NAME:
+            if (!nb_domain_name) continue;
+            ret = ntlm_decode_av_pair_ucs2_str(ctx, av_pair, &nb_domain);
+            if (ret) goto done;
+            break;
+        case MSV_AV_NB_COMPUTER_NAME:
+            if (!nb_computer_name) continue;
+            ret = ntlm_decode_av_pair_ucs2_str(ctx, av_pair, &nb_computer);
+            if (ret) goto done;
+            break;
+        default:
+            /* unknown av_pair, or EOL */
+            break;
+        }
+        if (av_id == MSV_AV_EOL) break;
+    }
+
+    if (av_id != MSV_AV_EOL || av_len != 0) {
+        ret = ERR_DECODE;
+    }
+
+done:
+    if (ret) {
+        ntlm_free_buffer_data(&sh);
+        ntlm_free_buffer_data(&cb);
+        safefree(nb_computer);
+        safefree(nb_domain);
+        safefree(dns_computer);
+        safefree(dns_domain);
+        safefree(dns_tree);
+        safefree(av_target);
+    } else {
+        if (nb_computer_name) *nb_computer_name = nb_computer;
+        if (nb_domain_name) *nb_domain_name = nb_domain;
+        if (dns_computer_name) *dns_computer_name = dns_computer;
+        if (dns_domain_name) *dns_domain_name = dns_domain;
+        if (dns_tree_name) *dns_tree_name = dns_tree;
+        if (av_target_name) *av_target_name = av_target;
+        if (av_timestamp) *av_timestamp = timestamp;
+        if (av_single_host) *av_single_host = sh;
+        if (av_flags) *av_flags = flags;
+        if (av_cb) *av_cb = cb;
+    }
+    return ret;
+}
+
+int ntlm_process_target_info(struct ntlm_ctx *ctx, bool protect,
+                             struct ntlm_buffer *in,
+                             const char *server,
+                             struct ntlm_buffer *unhashed_cb,
+                             struct ntlm_buffer *out,
+                             uint64_t *out_srv_time,
+                             bool *add_mic)
+{
+    char *nb_computer_name = NULL;
+    char *nb_domain_name = NULL;
+    char *dns_computer_name = NULL;
+    char *dns_domain_name = NULL;
+    char *dns_tree_name = NULL;
+    char *av_target_name = NULL;
+    uint32_t av_flags = 0;
+    uint64_t srv_time = 0;
+    uint8_t cb[16] = { 0 };
+    struct ntlm_buffer av_cb = { cb, 16 };
+    int ret = 0;
+
+    /* TODO: check that returned netbios/dns names match ? */
+    /* TODO: support SingleHost buffers */
+    ret = ntlm_decode_target_info(ctx, in,
+                                  &nb_computer_name, &nb_domain_name,
+                                  &dns_computer_name, &dns_domain_name,
+                                  &dns_tree_name, &av_target_name,
+                                  &av_flags, &srv_time, NULL, NULL);
+    if (ret) goto done;
+
+    if (protect && (!nb_computer_name || nb_computer_name[0] == '\0')) {
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (server && av_target_name) {
+        if (strcasecmp(server, av_target_name) != 0) {
+            ret = EINVAL;
+            goto done;
+        }
+    }
+
+    /* the server did not send the timestamp, use current time */
+    if (srv_time == 0) {
+        srv_time = ntlm_timestamp_now();
+    } else if (add_mic) {
+        av_flags |= MSVAVFLAGS_MIC_PRESENT;
+        *add_mic = true;
+    }
+
+    if (unhashed_cb->length > 0) {
+        ret = ntlm_hash_channel_bindings(unhashed_cb, &av_cb);
+        if (ret) goto done;
+    }
+
+    if (!av_target_name && server) {
+        av_target_name = strdup(server);
+        if (!av_target_name) {
+            ret = ENOMEM;
+            goto done;
+        }
+    }
+    /* TODO: add way to tell if the target name is verified o not,
+     * if not set av_flags |= MSVAVFLAGS_UNVERIFIED_SPN; */
+
+    ret = ntlm_encode_target_info(ctx,
+                                  nb_computer_name, nb_domain_name,
+                                  dns_computer_name, dns_domain_name,
+                                  dns_tree_name, &av_flags, &srv_time,
+                                  NULL, av_target_name, &av_cb, out);
+
+done:
+    safefree(nb_computer_name);
+    safefree(nb_domain_name);
+    safefree(dns_computer_name);
+    safefree(dns_domain_name);
+    safefree(dns_tree_name);
+    safefree(av_target_name);
+    *out_srv_time = srv_time;
+    return ret;
+}
+
+int ntlm_decode_msg_type(struct ntlm_ctx *ctx,
+                         struct ntlm_buffer *buffer,
+                         uint32_t *type)
+{
+    struct wire_neg_msg *msg;
+    uint32_t msg_type;
+    int ret;
+
+    if (!ctx) return EINVAL;
+
+    if (buffer->length < sizeof(struct wire_msg_hdr)) {
+        return ERR_DECODE;
+    }
+
+    msg = (struct wire_neg_msg *)buffer->data;
+
+    ret = ntlm_decode_header(&msg->header, &msg_type);
+    if (ret) goto done;
+
+    switch (msg_type) {
+    case NEGOTIATE_MESSAGE:
+        if (buffer->length < sizeof(struct wire_neg_msg)) {
+            return ERR_DECODE;
+        }
+        break;
+    case CHALLENGE_MESSAGE:
+        if (buffer->length < sizeof(struct wire_chal_msg) &&
+            buffer->length != sizeof(struct wire_chal_msg_old)) {
+            return ERR_DECODE;
+        }
+        break;
+    case AUTHENTICATE_MESSAGE:
+        if (buffer->length < sizeof(struct wire_auth_msg)) {
+            return ERR_DECODE;
+        }
+        break;
+    default:
+        ret = ERR_DECODE;
+        break;
+    }
+
+done:
+    if (ret == 0) {
+        *type = msg_type;
+    }
+    return ret;
+}
+
+int ntlm_encode_neg_msg(struct ntlm_ctx *ctx, uint32_t flags,
+                        const char *domain, const char *workstation,
+                        struct ntlm_buffer *message)
+{
+    struct wire_neg_msg *msg;
+    struct ntlm_buffer buffer;
+    size_t data_offs;
+    size_t dom_len = 0;
+    size_t wks_len = 0;
+    int ret = 0;
+
+    if (!ctx) return EINVAL;
+
+    buffer.length = sizeof(struct wire_neg_msg);
+
+    /* Strings MUST use OEM charset in negotiate message */
+    if (flags & NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED) {
+        if (!domain) return EINVAL;
+        dom_len = strlen(domain);
+        buffer.length += dom_len;
+    }
+    if (flags & NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED) {
+        if (!workstation) return EINVAL;
+        wks_len = strlen(workstation);
+        buffer.length += wks_len;
+    }
+
+    buffer.data = calloc(1, buffer.length);
+    if (!buffer.data) return ENOMEM;
+
+    msg = (struct wire_neg_msg *)buffer.data;
+    data_offs = (char *)msg->payload - (char *)msg;
+
+    ntlm_encode_header(&msg->header, NEGOTIATE_MESSAGE);
+
+    msg->neg_flags = htole32(flags);
+
+    if (dom_len) {
+        ret = ntlm_encode_oem_str(&msg->domain_name, &buffer,
+                                  &data_offs, domain, dom_len);
+        if (ret) goto done;
+    }
+
+    if (wks_len) {
+        ret = ntlm_encode_oem_str(&msg->workstation_name, &buffer,
+                                  &data_offs, workstation, wks_len);
+        if (ret) goto done;
+    }
+
+done:
+    if (ret) {
+        safefree(buffer.data);
+    } else {
+        *message = buffer;
+    }
+    return ret;
+}
+
+int ntlm_decode_neg_msg(struct ntlm_ctx *ctx,
+                        struct ntlm_buffer *buffer, uint32_t *flags,
+                        char **domain, char **workstation)
+{
+    struct wire_neg_msg *msg;
+    size_t payload_offs;
+    uint32_t neg_flags;
+    char *dom = NULL;
+    char *wks = NULL;
+    int ret = 0;
+
+    if (!ctx) return EINVAL;
+
+    msg = (struct wire_neg_msg *)buffer->data;
+    payload_offs = (char *)msg->payload - (char *)msg;
+
+    neg_flags = le32toh(msg->neg_flags);
+
+    if (domain &&
+        (neg_flags & NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED)) {
+        ret = ntlm_decode_oem_str(&msg->domain_name, buffer,
+                                  payload_offs, &dom);
+        if (ret) goto done;
+    }
+    if (workstation &&
+        (neg_flags & NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED)) {
+        ret = ntlm_decode_oem_str(&msg->workstation_name, buffer,
+                                  payload_offs, &wks);
+        if (ret) goto done;
+    }
+
+done:
+    if (ret) {
+        safefree(dom);
+        safefree(wks);
+    } else {
+        *flags = neg_flags;
+        if (domain) *domain = dom;
+        if (workstation) *workstation = wks;
+    }
+    return ret;
+}
+
+/* TODO: support datagram style */
+int ntlm_encode_chal_msg(struct ntlm_ctx *ctx,
+                         uint32_t flags,
+                         const char *target_name,
+                         struct ntlm_buffer *challenge,
+                         struct ntlm_buffer *target_info,
+                         struct ntlm_buffer *message)
+{
+    struct wire_chal_msg *msg;
+    struct ntlm_buffer buffer;
+    size_t data_offs;
+    size_t target_len = 0;
+    int ret = 0;
+
+    if (!ctx) return EINVAL;
+
+    if (!challenge || challenge->length != 8) return EINVAL;
+
+    buffer.length = sizeof(struct wire_chal_msg);
+
+    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
+        buffer.length += sizeof(struct wire_version);
+    }
+
+    if ((flags & NTLMSSP_TARGET_TYPE_SERVER)
+        || (flags & NTLMSSP_TARGET_TYPE_DOMAIN)) {
+        if (!target_name) return EINVAL;
+
+        target_len = strlen(target_name);
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            buffer.length += target_len * 2;
+        } else {
+            buffer.length += target_len;
+        }
+    }
+
+    if (flags & NTLMSSP_NEGOTIATE_TARGET_INFO) {
+        if (!target_info) return EINVAL;
+
+        buffer.length += target_info->length;
+    }
+
+    buffer.data = calloc(1, buffer.length);
+    if (!buffer.data) return ENOMEM;
+
+    msg = (struct wire_chal_msg *)buffer.data;
+    data_offs = (char *)msg->payload - (char *)msg;
+
+    ntlm_encode_header(&msg->header, CHALLENGE_MESSAGE);
+
+    /* this must be first as it pushes the payload further down */
+    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
+        ret = ntlm_encode_version(ctx, &buffer, &data_offs);
+        if (ret) goto done;
+    }
+
+    if ((flags & NTLMSSP_TARGET_TYPE_SERVER)
+        || (flags & NTLMSSP_TARGET_TYPE_DOMAIN)) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_encode_ucs2_str_hdr(ctx, &msg->target_name, &buffer,
+                                           &data_offs, target_name, target_len);
+        } else {
+            ret = ntlm_encode_oem_str(&msg->target_name, &buffer,
+                                      &data_offs, target_name, target_len);
+        }
+        if (ret) goto done;
+    }
+
+    msg->neg_flags = htole32(flags);
+    memcpy(msg->server_challenge, challenge->data, 8);
+
+    if (flags & NTLMSSP_NEGOTIATE_TARGET_INFO) {
+        ret = ntlm_encode_field(&msg->target_info, &buffer,
+                                &data_offs, target_info);
+        if (ret) goto done;
+    }
+
+done:
+    if (ret) {
+        safefree(buffer.data);
+    } else {
+        *message = buffer;
+    }
+    return ret;
+}
+
+int ntlm_decode_chal_msg(struct ntlm_ctx *ctx,
+                         struct ntlm_buffer *buffer,
+                         uint32_t *_flags, char **target_name,
+                         struct ntlm_buffer *challenge,
+                         struct ntlm_buffer *target_info)
+{
+    struct wire_chal_msg *msg;
+    size_t payload_offs;
+    uint32_t flags;
+    char *trg = NULL;
+    int ret = 0;
+
+    if (!ctx) return EINVAL;
+
+    if (challenge->length < 8) return EINVAL;
+
+    msg = (struct wire_chal_msg *)buffer->data;
+    payload_offs = (char *)msg->payload - (char *)msg;
+
+    flags = le32toh(msg->neg_flags);
+
+    if ((flags & NTLMSSP_TARGET_TYPE_SERVER)
+        || (flags & NTLMSSP_TARGET_TYPE_DOMAIN)) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_decode_ucs2_str_hdr(ctx, &msg->target_name, buffer,
+                                           payload_offs, &trg);
+        } else {
+            ret = ntlm_decode_oem_str(&msg->target_name, buffer,
+                                      payload_offs, &trg);
+        }
+        if (ret) goto done;
+    }
+
+    memcpy(challenge->data, msg->server_challenge, 8);
+    challenge->length = 8;
+
+    /* if we allowed a broken short challenge message from an old
+     * server we must stop here */
+    if (buffer->length < sizeof(struct wire_chal_msg)) {
+        if (flags & NTLMSSP_NEGOTIATE_TARGET_INFO) {
+            ret = ERR_DECODE;
+        }
+        goto done;
+    }
+
+    if (flags & NTLMSSP_NEGOTIATE_TARGET_INFO) {
+        ret = ntlm_decode_field(&msg->target_info, buffer,
+                                payload_offs, target_info);
+        if (ret) goto done;
+    }
+
+done:
+    if (ret) {
+        safefree(trg);
+    } else {
+        *_flags = flags;
+        *target_name = trg;
+    }
+    return ret;
+}
+
+int ntlm_encode_auth_msg(struct ntlm_ctx *ctx,
+                         uint32_t flags,
+                         struct ntlm_buffer *lm_chalresp,
+                         struct ntlm_buffer *nt_chalresp,
+                         char *domain_name, char *user_name,
+                         char *workstation,
+                         struct ntlm_buffer *enc_sess_key,
+                         struct ntlm_buffer *mic,
+                         struct ntlm_buffer *message)
+{
+    struct wire_auth_msg *msg;
+    struct ntlm_buffer buffer;
+    struct ntlm_buffer empty_chalresp = { 0 };
+    size_t data_offs;
+    size_t domain_name_len = 0;
+    size_t user_name_len = 0;
+    size_t workstation_len = 0;
+    int ret = 0;
+
+    if (!ctx) return EINVAL;
+
+    buffer.length = sizeof(struct wire_auth_msg);
+
+    if (lm_chalresp) {
+        buffer.length += lm_chalresp->length;
+    } else {
+        lm_chalresp = &empty_chalresp;
+    }
+    if (nt_chalresp) {
+        buffer.length += nt_chalresp->length;
+    } else {
+        nt_chalresp = &empty_chalresp;
+    }
+    if (domain_name) {
+        domain_name_len = strlen(domain_name);
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            buffer.length += domain_name_len * 2;
+        } else {
+            buffer.length += domain_name_len;
+        }
+    }
+    if (user_name) {
+        user_name_len = strlen(user_name);
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            buffer.length += user_name_len * 2;
+        } else {
+            buffer.length += user_name_len;
+        }
+    }
+    if (workstation) {
+        workstation_len = strlen(workstation);
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            buffer.length += workstation_len * 2;
+        } else {
+            buffer.length += workstation_len;
+        }
+    }
+    if (enc_sess_key) {
+        buffer.length += enc_sess_key->length;
+    }
+    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
+        buffer.length += sizeof(struct wire_version);
+    }
+    if (mic) {
+        buffer.length += 16;
+    }
+
+    buffer.data = calloc(1, buffer.length);
+    if (!buffer.data) return ENOMEM;
+
+    msg = (struct wire_auth_msg *)buffer.data;
+    data_offs = (char *)msg->payload - (char *)msg;
+
+    ntlm_encode_header(&msg->header, AUTHENTICATE_MESSAGE);
+
+    /* this must be first as it pushes the payload further down */
+    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
+        ret = ntlm_encode_version(ctx, &buffer, &data_offs);
+        if (ret) goto done;
+    }
+
+    /* this must be second as it pushes the payload further down */
+    if (mic) {
+        memset(&buffer.data[data_offs], 0, mic->length);
+        /* return the actual pointer back in the mic, as it will
+         * be backfilled later by the caller */
+        mic->data = &buffer.data[data_offs];
+        data_offs += mic->length;
+    }
+
+    ret = ntlm_encode_field(&msg->lm_chalresp, &buffer,
+                            &data_offs, lm_chalresp);
+    if (ret) goto done;
+
+    ret = ntlm_encode_field(&msg->nt_chalresp, &buffer,
+                            &data_offs, nt_chalresp);
+    if (ret) goto done;
+
+    if (domain_name_len) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_encode_ucs2_str_hdr(ctx, &msg->domain_name,
+                                           &buffer, &data_offs,
+                                           domain_name, domain_name_len);
+        } else {
+            ret = ntlm_encode_oem_str(&msg->domain_name,
+                                      &buffer, &data_offs,
+                                      domain_name, domain_name_len);
+        }
+        if (ret) goto done;
+    }
+    if (user_name_len) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_encode_ucs2_str_hdr(ctx, &msg->user_name,
+                                           &buffer, &data_offs,
+                                           user_name, user_name_len);
+        } else {
+            ret = ntlm_encode_oem_str(&msg->user_name,
+                                      &buffer, &data_offs,
+                                      user_name, user_name_len);
+        }
+        if (ret) goto done;
+    }
+    if (workstation_len) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_encode_ucs2_str_hdr(ctx, &msg->workstation,
+                                           &buffer, &data_offs,
+                                           workstation, workstation_len);
+        } else {
+            ret = ntlm_encode_oem_str(&msg->workstation,
+                                      &buffer, &data_offs,
+                                      workstation, workstation_len);
+        }
+        if (ret) goto done;
+    }
+    if (enc_sess_key) {
+        ret = ntlm_encode_field(&msg->enc_sess_key, &buffer,
+                                &data_offs, enc_sess_key);
+        if (ret) goto done;
+    }
+
+    msg->neg_flags = htole32(flags);
+
+done:
+    if (ret) {
+        safefree(buffer.data);
+    } else {
+        *message = buffer;
+    }
+    return ret;
+}
+
+int ntlm_decode_auth_msg(struct ntlm_ctx *ctx,
+                         struct ntlm_buffer *buffer,
+                         uint32_t flags,
+                         struct ntlm_buffer *lm_chalresp,
+                         struct ntlm_buffer *nt_chalresp,
+                         char **domain_name, char **user_name,
+                         char **workstation,
+                         struct ntlm_buffer *enc_sess_key,
+                         struct ntlm_buffer *target_info,
+                         struct ntlm_buffer *mic)
+{
+    struct wire_auth_msg *msg;
+    size_t payload_offs;
+    char *dom = NULL;
+    char *usr = NULL;
+    char *wks = NULL;
+    int ret = 0;
+
+    if (!ctx) return EINVAL;
+
+    if (lm_chalresp) lm_chalresp->data = NULL;
+    if (nt_chalresp) nt_chalresp->data = NULL;
+    if (enc_sess_key) enc_sess_key->data = NULL;
+
+    msg = (struct wire_auth_msg *)buffer->data;
+    payload_offs = (char *)msg->payload - (char *)msg;
+
+    /* this must be first as it pushes the payload further down */
+    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
+        /* skip version for now */
+        payload_offs += sizeof(struct wire_version);
+    }
+
+    /* Unconditionally copy 16 bytes for the MIC, if it was really
+     * added by the client it will be flagged in the AV_PAIR contained
+     * in the NT Response, that will be fully decoded later by the caller
+     * and the MIC checked otherwise these 16 bytes will just be ignored */
+    if (mic) {
+        if (mic->length < 16) return ERR_DECODE;
+        /* mic is at payload_offs right now */
+        if (buffer->length - payload_offs < 16) return ERR_DECODE;
+        memcpy(mic->data, &buffer->data[payload_offs], 16);
+        /* NOTE: we do not push down the payload because we do not know that
+         * the MIC is actually present yet for real */
+    }
+
+    if (msg->lm_chalresp.len != 0 && lm_chalresp) {
+        ret = ntlm_decode_field(&msg->lm_chalresp, buffer,
+                                payload_offs, lm_chalresp);
+        if (ret) goto done;
+    }
+    if (msg->nt_chalresp.len != 0 && nt_chalresp) {
+        ret = ntlm_decode_field(&msg->nt_chalresp, buffer,
+                                payload_offs, nt_chalresp);
+        if (ret) goto done;
+
+        if (target_info) {
+            union wire_ntlm_response *resp;
+            struct wire_ntlmv2_cli_chal *chal;
+            uint8_t *data;
+            int len;
+            resp = (union wire_ntlm_response *)nt_chalresp->data;
+            chal = (struct wire_ntlmv2_cli_chal *)resp->v2.cli_chal;
+            len = nt_chalresp->length - sizeof(resp->v2.resp)
+                    - offsetof(struct wire_ntlmv2_cli_chal, target_info);
+            if (len > 0) {
+                data = chal->target_info;
+                target_info->data = malloc(len);
+                if (!target_info->data) {
+                    ret = ENOMEM;
+                    goto done;
+                }
+                memcpy(target_info->data, data, len);
+                target_info->length = len;
+            }
+        }
+    }
+    if (msg->domain_name.len != 0 && domain_name) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_decode_ucs2_str_hdr(ctx, &msg->domain_name, buffer,
+                                           payload_offs, &dom);
+        } else {
+            ret = ntlm_decode_oem_str(&msg->domain_name, buffer,
+                                      payload_offs, &dom);
+        }
+        if (ret) goto done;
+    }
+    if (msg->user_name.len != 0 && user_name) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_decode_ucs2_str_hdr(ctx, &msg->user_name, buffer,
+                                           payload_offs, &usr);
+        } else {
+            ret = ntlm_decode_oem_str(&msg->user_name, buffer,
+                                      payload_offs, &usr);
+        }
+        if (ret) goto done;
+    }
+    if (msg->workstation.len != 0 && workstation) {
+        if (flags & NTLMSSP_NEGOTIATE_UNICODE) {
+            ret = ntlm_decode_ucs2_str_hdr(ctx, &msg->workstation, buffer,
+                                           payload_offs, &wks);
+        } else {
+            ret = ntlm_decode_oem_str(&msg->workstation, buffer,
+                                      payload_offs, &wks);
+        }
+        if (ret) goto done;
+    }
+    if (msg->enc_sess_key.len != 0 && enc_sess_key) {
+        ret = ntlm_decode_field(&msg->enc_sess_key, buffer,
+                                payload_offs, enc_sess_key);
+    }
+
+    /* ignore returned flags, our flags are authoritative
+    flags = le32toh(msg->neg_flags);
+    */
+
+done:
+    if (ret) {
+        if (lm_chalresp) safefree(lm_chalresp->data);
+        if (nt_chalresp) safefree(nt_chalresp->data);
+        if (enc_sess_key) safefree(enc_sess_key->data);
+        safefree(dom);
+        safefree(usr);
+        safefree(wks);
+    } else {
+        if (domain_name) *domain_name = dom;
+        if (user_name) *user_name = usr;
+        if (workstation) *workstation = wks;
+    }
+    return ret;
+}

--- a/src/transports/ntlm/ntlm.h
+++ b/src/transports/ntlm/ntlm.h
@@ -1,0 +1,798 @@
+/*
+   Copyright (C) 2013 Simo Sorce <simo@samba.org>
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _NTLM_H_
+#define _NTLM_H
+
+#include <stdbool.h>
+
+#include "ntlm_common.h"
+
+/* Negotiate Flags */
+#define NTLMSSP_NEGOTIATE_56                        (1 << 31)
+#define NTLMSSP_NEGOTIATE_KEY_EXCH                  (1 << 30)
+#define NTLMSSP_NEGOTIATE_128                       (1 << 29)
+#define UNUSED_R1                                   (1 << 28)
+#define UNUSED_R2                                   (1 << 27)
+#define UNUSED_R3                                   (1 << 26)
+#define NTLMSSP_NEGOTIATE_VERSION                   (1 << 25)
+#define UNUSED_R4                                   (1 << 24)
+#define NTLMSSP_NEGOTIATE_TARGET_INFO               (1 << 23)
+#define NTLMSSP_REQUEST_NON_NT_SESSION_KEY          (1 << 22)
+#define UNUSED_R5 /* Davenport: NEGOTIATE_ACCEPT */ (1 << 21)
+#define NTLMSSP_NEGOTIATE_IDENTIFY                  (1 << 20)
+#define NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY  (1 << 19)
+#define UNUSED_R6 /* Davenport:TARGET_TYPE_SHARE */ (1 << 18)
+#define NTLMSSP_TARGET_TYPE_SERVER                  (1 << 17)
+#define NTLMSSP_TARGET_TYPE_DOMAIN                  (1 << 16)
+#define NTLMSSP_NEGOTIATE_ALWAYS_SIGN               (1 << 15)
+#define UNUSED_R7 /* Davenport:LOCAL_CALL */        (1 << 14)
+#define NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED  (1 << 13)
+#define NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED       (1 << 12)
+#define NTLMSSP_ANONYMOUS                           (1 << 11)
+#define UNUSED_R8                                   (1 << 10)
+#define NTLMSSP_NEGOTIATE_NTLM                      (1 << 9)
+#define UNUSED_R9                                   (1 << 8)
+#define NTLMSSP_NEGOTIATE_LM_KEY                    (1 << 7)
+#define NTLMSSP_NEGOTIATE_DATAGRAM                  (1 << 6)
+#define NTLMSSP_NEGOTIATE_SEAL                      (1 << 5)
+#define NTLMSSP_NEGOTIATE_SIGN                      (1 << 4)
+#define UNUSED_R10                                  (1 << 3)
+#define NTLMSSP_REQUEST_TARGET                      (1 << 2)
+#define NTLMSSP_NEGOTIATE_OEM                       (1 << 1)
+#define NTLMSSP_NEGOTIATE_UNICODE                   (1 << 0)
+
+/* (2.2.2.10 VERSION) */
+#define WINDOWS_MAJOR_VERSION_5 0x05
+#define WINDOWS_MAJOR_VERSION_6 0x06
+#define WINDOWS_MINOR_VERSION_0 0x00
+#define WINDOWS_MINOR_VERSION_1 0x01
+#define WINDOWS_MINOR_VERSION_2 0x02
+#define NTLMSSP_REVISION_W2K3 0x0F
+
+#define NTLMSSP_VERSION_MAJOR WINDOWS_MAJOR_VERSION_6
+#define NTLMSSP_VERSION_MINOR WINDOWS_MINOR_VERSION_2
+#define NTLMSSP_VERSION_BUILD 0
+#define NTLMSSP_VERSION_REV NTLMSSP_REVISION_W2K3
+
+#define NTLMSSP_MESSAGE_SIGNATURE_VERSION 0x00000001
+
+#define NEGOTIATE_MESSAGE       0x00000001
+#define CHALLENGE_MESSAGE       0x00000002
+#define AUTHENTICATE_MESSAGE    0x00000003
+
+#define MSVAVFLAGS_AUTH_CONSTRAINED 0x01
+#define MSVAVFLAGS_MIC_PRESENT      0x02
+#define MSVAVFLAGS_UNVERIFIED_SPN   0x04
+
+#define NTLM_SIGNATURE_SIZE 16
+
+struct ntlm_ctx;
+
+/**
+ * @brief           Create a ntlm_ctx initialized to the initial state
+ *
+ * @param ctx       The returned context
+ *
+ * @return 0 if successful, an error otherwise
+ */
+int ntlm_init_ctx(struct ntlm_ctx **ctx);
+
+/**
+ * @brief           Frees a ntlm_ctx
+ *
+ * @param ctx       Pointer to a context to be freed
+ *
+ * @return 0 if successful, an error otherwise
+ * NOTE: even if an error is returned the contetx is freed and NULLed
+ */
+int ntlm_free_ctx(struct ntlm_ctx **ctx);
+
+void ntlm_free_buffer_data(struct ntlm_buffer *buf);
+
+uint64_t ntlm_timestamp_now(void);
+
+bool ntlm_casecmp(const char *s1, const char *s2);
+
+/**
+ * @brief Sets the NTLMSSP version
+ *        Mostly used to emulate Windows versions for test vectors
+ *
+ * @param major     major version number (ex. 6)
+ * @param minor     minor version number (ex. 1)
+ * @param build     build version number (ex. 7600)
+ * @param revision  revision version number (ex. 16)
+ */
+void ntlm_internal_set_version(uint8_t major, uint8_t minor,
+                               uint16_t build, uint8_t revision);
+
+/* ############### CRYPTO FUNCTIONS ################ */
+
+struct ntlm_key {
+    uint8_t data[16]; /* up to 16 bytes (128 bits) */
+    size_t length;
+};
+
+struct ntlm_signseal_handle {
+    struct ntlm_key sign_key;
+    struct ntlm_key seal_key;
+    struct ntlm_rc4_handle *seal_handle;
+    uint32_t seq_num;
+};
+
+struct ntlm_signseal_state {
+    struct ntlm_signseal_handle send;
+    struct ntlm_signseal_handle recv;
+    bool datagram;
+    bool ext_sec;
+};
+
+#define NTLM_SEND 1
+#define NTLM_RECV 2
+
+/**
+ * @brief   Turns a utf8 password into an NT Hash
+ *
+ * @param password      The password
+ * @param result        The returned hash
+ *
+ * @return 0 on success or an error;
+ */
+int NTOWFv1(const char *password, struct ntlm_key *result);
+
+/**
+ * @brief   Turns a utf8 password into an LM Hash
+ *
+ * @param password      The password
+ * @param result        The returned hash
+ *
+ * @return 0 on success or an error;
+ */
+int LMOWFv1(const char *password, struct ntlm_key *result);
+
+/**
+ * @brief   Generate the challenge used in NTLMv1 w/ Extended Security
+ *
+ * @param server_chal   An 8 byte long buffer w/ the server challenge
+ * @param client_chal   An 8 byte long buffer w/ the client challenge
+ * @param result_chal   An 8 byte long buffer w/ for the result
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int ntlm_compute_ext_sec_challenge(uint8_t *server_chal,
+                                   uint8_t *client_chal,
+                                   uint8_t *result_chal);
+/**
+ * @brief   Generates a v1 NT Response
+ *
+ * @param nt_key            The NTLMv1 key computed by NTOWFv1()
+ * @param ext_sec           Whether Extended Security has been negotiated
+ * @param server_chal[8]    The server challenge
+ * @param client_chal[8]    The client challenge (only with Extended Security)
+ * @param nt_response       The output buffer (must be 24 bytes preallocated)
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int ntlm_compute_nt_response(struct ntlm_key *nt_key, bool ext_sec,
+                             uint8_t server_chal[8], uint8_t client_chal[8],
+                             struct ntlm_buffer *nt_response);
+
+/**
+ * @brief   Generates a v1 LM Response
+ *
+ * @param lm_key            The LMv1 key computed by LMOWFv1()
+ * @param ext_sec           Whether Extended Security has been negotiated
+ * @param server_chal[8]    The server challenge
+ * @param client_chal[8]    The client challenge (only with Extended Security)
+ * @param lm_response       The output buffer (must be 24 bytes preallocated)
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int ntlm_compute_lm_response(struct ntlm_key *lm_key, bool ext_sec,
+                             uint8_t server_chal[8], uint8_t client_chal[8],
+                             struct ntlm_buffer *lm_response);
+
+/**
+ * @brief   Returns the v1 session key
+ *
+ * @param nt_key            The NTLMv1 key computed by NTOWFv1()
+ * @param session_base_key  The output buffer (must be 16 bytes preallocated)
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int ntlm_session_base_key(struct ntlm_key *nt_key,
+                          struct ntlm_key *session_base_key);
+
+/**
+ * @brief   V1 Key Exchange Key calculation
+ *
+ * @param ctx               An ntlm context
+ * @param ext_sec           Whether Extended Security has been negotiated
+ * @param neg_lm_key        Whether LM KEY has been negotiated
+ * @param non_nt_sess_key   Whether non NT Session Key has been negotiated
+ * @param server_chal       The server challenge (only with Extended Security)
+ * @param lm_key            The LMv1 key computed by LMOWFv1()
+ * @param session_base_key  The Session Base Key
+ * @param lm_response       The LM v1 Response
+ * @param key_exchange_key  The output buffer (must be 16 bytes preallocated)
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int KXKEY(struct ntlm_ctx *ctx,
+          bool ext_sec,
+          bool neg_lm_key,
+          bool non_nt_sess_key,
+          uint8_t server_chal[8],
+          struct ntlm_key *lm_key,
+          struct ntlm_key *session_base_key,
+          struct ntlm_buffer *lm_response,
+          struct ntlm_key *key_exchange_key);
+
+/**
+ * @brief   Generates a NTLMv2 Response Key
+ *
+ * @param ctx           An ntlm context
+ * @param nt_hash       The NT Hash of the user password
+ * @param user          The user name
+ * @param domain        The user's domain
+ * @param result        The resulting key
+ *                          (must be a preallocated 16 bytes buffer)
+ *
+ * @return 0 on success or ERR_CRYPTO
+ */
+int NTOWFv2(struct ntlm_ctx *ctx, struct ntlm_key *nt_hash,
+            const char *user, const char *domain, struct ntlm_key *result);
+
+/**
+ * @brief   Computes The NTLMv2 Response
+ *
+ * @param ntlmv2_key         The NTLMv2 key computed by NTOWFv2()
+ * @param server_chal[8]     The server provided challenge
+ * @param client_chal[8]     A client generated random challenge
+ * @param timestamp          A FILETIME timestamp
+ * @param target_info        The target info
+ * @param nt_response        The resulting nt_response buffer
+ *
+ * @return 0 on success or error.
+ */
+int ntlmv2_compute_nt_response(struct ntlm_key *ntlmv2_key,
+                               uint8_t server_chal[8], uint8_t client_chal[8],
+                               uint64_t timestamp,
+                               struct ntlm_buffer *target_info,
+                               struct ntlm_buffer *nt_response);
+
+/**
+ * @brief   Computes The LMv2 Response
+ *
+ * @param ntlmv2_key         The NTLMv2 key computed by NTOWFv2()
+ * @param server_chal[8]     The server provided challenge
+ * @param client_chal[8]     A client generated random challenge
+ * @param lm_response        The resulting lm_response buffer
+ *
+ * @return 0 on success or error.
+ */
+int ntlmv2_compute_lm_response(struct ntlm_key *ntlmv2_key,
+                               uint8_t server_chal[8], uint8_t client_chal[8],
+                               struct ntlm_buffer *lm_response);
+
+/**
+ * @brief   Computes the NTLMv2 SessionBaseKey
+ *
+ * @param ntlmv2_key            The NTLMv2 key computed by NTOWFv2()
+ * @param nt_response           The NTLMv2 response
+ * @param session_base_key      The resulting session key
+ *
+ * @return 0 on success or error.
+ */
+int ntlmv2_session_base_key(struct ntlm_key *ntlmv2_key,
+                            struct ntlm_buffer *nt_response,
+                            struct ntlm_key *session_base_key);
+
+/**
+ * @brief   Comutes the NTLM session key
+ *
+ * @param key_exchange_key[16]          The Key Exchange Key
+ * @param key_exch                      KEY_EXCH has been negotited
+ * @param exported_session_key[16]      Resulting exported session key
+ *
+ * @return 0 on success or error.
+ */
+int ntlm_exported_session_key(struct ntlm_key *key_exchange_key,
+                              bool key_exch,
+                              struct ntlm_key *exported_session_key);
+
+/**
+ * @brief   Encrypts or Decrypts the NTLM session key using RC4K
+ *
+ * @param key_exchange_key[16]          The Key Exchange Key
+ * @param exported_session_key[16]      Resulting exported session key
+ * @param encrypted_random_session_key  Resulting encrypted session key
+ *
+ * @return 0 on success or error.
+ */
+int ntlm_encrypted_session_key(struct ntlm_key *key,
+                               struct ntlm_key *in, struct ntlm_key *out);
+
+/**
+ * @brief   Computes the extended security keys from the session key
+ *
+ * @param flags                 Incoming challenge/authenticate flags
+ * @param client                Wheter this ia a client or a server
+ * @param session_key           The session key
+ * @param signseal_state        Sign and seal keys and state
+ *
+ * @return 0 on success or error.
+ */
+int ntlm_signseal_keys(uint32_t flags, bool client,
+                       struct ntlm_key *session_key,
+                       struct ntlm_signseal_state *signseal_state);
+
+/**
+ * @brief   Resets the RC4 state for the send or receive handle
+ *
+ * @param flags                 Incoming challenge/authenticate flags
+ * @param recv                  Wheter to reset the send or recive buffer
+ * @param session_key           The session key
+ * @param signseal_state        Sign and seal keys and state
+ *
+ * @return 0 on success or error.
+ */
+int ntlm_reset_rc4_state(uint32_t flags, bool recv,
+                         struct ntlm_key *session_key,
+                         struct ntlm_signseal_state *state);
+
+/**
+ * @brief   Verifies a NTLM v1 NT Response
+ *
+ * @param nt_response       The NT Response buffer
+ * @param nt_key            The NTLMv1 NT Key
+ * @param ext_sec           Whether Extended Security was negotiated
+ * @param server_chal[8]    The Server Challenge
+ * @param client_chal[8]    The Client Challenge
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_verify_nt_response(struct ntlm_buffer *nt_response,
+                            struct ntlm_key *nt_key, bool ext_sec,
+                            uint8_t server_chal[8], uint8_t client_chal[8]);
+
+/**
+ * @brief   Verifies a NTLM v1 LM Response
+ *
+ * @param lm_response       The LM Response buffer
+ * @param lm_key            The NTLMv1 LM Key
+ * @param ext_sec           Whether Extended Security was negotiated
+ * @param server_chal[8]    The Server Challenge
+ * @param client_chal[8]    The Client Challenge
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_verify_lm_response(struct ntlm_buffer *lm_response,
+                            struct ntlm_key *lm_key, bool ext_sec,
+                            uint8_t server_chal[8], uint8_t client_chal[8]);
+
+/**
+ * @brief   Verifies a NTLM v1 NT Response
+ *
+ * @param nt_response       The NT Response buffer
+ * @param nt_key            The NTLMv1 NT Key
+ * @param ext_sec           Whether Extended Security was negotiated
+ * @param server_chal[8]    The Server Challenge
+ * @param client_chal[8]    The Client Challenge
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_verify_nt_response(struct ntlm_buffer *nt_response,
+                            struct ntlm_key *nt_key, bool ext_sec,
+                            uint8_t server_chal[8], uint8_t client_chal[8]);
+
+/**
+ * @brief   Verifies a NTLM v1 LM Response
+ *
+ * @param lm_response       The LM Response buffer
+ * @param lm_key            The NTLMv1 LM Key
+ * @param ext_sec           Whether Extended Security was negotiated
+ * @param server_chal[8]    The Server Challenge
+ * @param client_chal[8]    The Client Challenge
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_verify_lm_response(struct ntlm_buffer *lm_response,
+                            struct ntlm_key *lm_key, bool ext_sec,
+                            uint8_t server_chal[8], uint8_t client_chal[8]);
+
+/**
+ * @brief   Verifies a 16 bit NT Response
+ *
+ * @param nt_response       The NT Response buffer including client challenge
+ * @param ntlmv2_key        The NTLMv2 key
+ * @param server_chal[8]    The server challenge used to compute the response
+ *
+ * @return 0 on success, or an error
+ */
+int ntlmv2_verify_nt_response(struct ntlm_buffer *nt_response,
+                              struct ntlm_key *ntlmv2_key,
+                              uint8_t server_chal[8]);
+
+/**
+ * @brief   Verifies a 16 bit LM Response
+ *
+ * @param nt_response       The LM Response buffer including client challenge
+ * @param ntlmv2_key        The NTLMv2 key
+ * @param server_chal[8]    The server challenge used to compute the response
+ *
+ * @return 0 on success, or an error
+ */
+int ntlmv2_verify_lm_response(struct ntlm_buffer *nt_response,
+                              struct ntlm_key *ntlmv2_key,
+                              uint8_t server_chal[8]);
+
+/**
+ * @brief Create NTLM signature for the provided message
+ *
+ * @param flags         Negotiated flags
+ * @param state         Sign and seal keys and state
+ * @param direction     Direction (true for send)
+ * @param message       Message buffer
+ * @param signature     Preallocated byffer of 16 bytes for signature
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_sign(uint32_t flags, int direction,
+              struct ntlm_signseal_state *state,
+              struct ntlm_buffer *message,
+              struct ntlm_buffer *signature);
+
+/**
+ * @brief   NTLM seal the provided message
+ *
+ * @param flags         Negotiated flags
+ * @param state         Sign and seal keys and state
+ * @param message       Message buffer
+ * @param output        Output buffer
+ * @param signature     Signature
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_seal(uint32_t flags,
+              struct ntlm_signseal_state *state,
+              struct ntlm_buffer *message,
+              struct ntlm_buffer *output,
+              struct ntlm_buffer *signature);
+
+/**
+ * @brief   NTLM unseal the provided message
+ *
+ * @param flags         Negotiated flags
+ * @param state         Sign and seal keys and state
+ * @param message       Message buffer
+ * @param output        Output buffer
+ * @param signature     Signature
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_unseal(uint32_t flags,
+                struct ntlm_signseal_state *state,
+                struct ntlm_buffer *message,
+                struct ntlm_buffer *output,
+                struct ntlm_buffer *signature);
+
+/**
+ * @brief   Creates a NTLM MIC
+ *
+ * @param exported_session_key      The Exported Session Key
+ * @param negotiate_message         The NTLM Negotiate Message (or empty)
+ * @param challenge_message         The NTLM Challenge Message
+ * @param authenticate_message      The NTLM Authenticate Message
+ * @param mic                       Preallocated byffer of 16 bytes
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_mic(struct ntlm_key *exported_session_key,
+             struct ntlm_buffer *negotiate_message,
+             struct ntlm_buffer *challenge_message,
+             struct ntlm_buffer *authenticate_message,
+             struct ntlm_buffer *mic);
+
+/**
+ * @brief  Verifies a MIC
+ *
+ * @param key                       The keys used to generate the original MIC
+ * @param negotiate_message         The NTLM Negotiate Message (or empty)
+ * @param challenge_message         The NTLM Challenge Message
+ * @param authenticate_message      The NTLM Authenticate Message
+ * @param mic                       The original MIC
+ *
+ * NOTE: This function zeros the area of memory where the MIC is held in the
+ *       Authenticate Message
+ *
+ * @return 0 on success, EACCES if the MIC fails to verify, or an error
+ */
+int ntlm_verify_mic(struct ntlm_key *key,
+                    struct ntlm_buffer *negotiate_message,
+                    struct ntlm_buffer *challenge_message,
+                    struct ntlm_buffer *authenticate_message,
+                    struct ntlm_buffer *mic);
+
+/**
+ * @brief   NTLM hash client channel binding unhashed data
+ *
+ * @param unhashed      The unhashed channel bindings data
+ * @param signature     The MD5 signature
+ *
+ * @return 0 on success, or an error
+ */
+int ntlm_hash_channel_bindings(struct ntlm_buffer *unhashed,
+                               struct ntlm_buffer *signature);
+
+/**
+ * @brief   Verifies Channel binding signature from unhashed data.
+ *
+ * @param unhashed      The unhashed channel bindings data
+ * @param signature     The recieved MD5 signature to check against
+ *
+ * @return 0 on success, EACCES if the CBT fails to verify, or an error
+ */
+int ntlm_verify_channel_bindings(struct ntlm_buffer *unhashed,
+                                 struct ntlm_buffer *signature);
+
+/* ############## ENCODING / DECODING ############## */
+
+/**
+ * @brief   A utility function to construct a target_info structure
+ *
+ * @param ctx                   The ntlm context
+ * @param nb_computer_name      The NetBIOS Computer Name
+ * @param nb_domain_name        The NetBIOS Domain Name
+ * @param dns_computer_name     The DNS Fully Qualified Computer Name
+ * @param dns_domain_name       The DNS Fully Qualified Domain Name
+ * @param dns_tree_name         The DNS Tree Name
+ * @param av_flags              The av flags
+ * @param av_timestamp          A 64 bit FILETIME timestamp
+ * @param av_single_host        A ntlm_buffer with the single host data
+ * @param av_target_name        The target name
+ * @param av_cb                 A ntlm_buffer with channel binding data
+ * @param target_info           The buffer in which target_info is returned.
+ *
+ * NOTE: The caller is responsible for free()ing the buffer
+ *
+ * @return      0 if everyting parses correctly, or an error code
+ */
+int ntlm_encode_target_info(struct ntlm_ctx *ctx, char *nb_computer_name,
+                            char *nb_domain_name, char *dns_computer_name,
+                            char *dns_domain_name, char *dns_tree_name,
+                            uint32_t *av_flags, uint64_t *av_timestamp,
+                            struct ntlm_buffer *av_single_host,
+                            char *av_target_name, struct ntlm_buffer *av_cb,
+                            struct ntlm_buffer *target_info);
+
+
+/**
+ * @brief   A utility function to parse a target_info structure
+ *
+ * @param ctx                   The ntlm context
+ * @param buffer                A ntlm_buffer containing the info to be parsed
+ * @param nb_computer_name      The NetBIOS Computer Name
+ * @param nb_domain_name        The NetBIOS Domain Name
+ * @param dns_computer_name     The DNS Fully Qualified Computer Name
+ * @param dns_domain_name       The DNS Fully Qualified Domain Name
+ * @param dns_tree_name         The DNS Tree Name
+ * @param av_flags              The av flags
+ * @param av_timestamp          A 64 bit FILETIME timestamp
+ * @param av_single_host        A ntlm_buffer with the single host data
+ * @param av_target_name        The target name
+ * @param av_cb                 A ntlm_buffer with channel binding data
+ *
+ * NOTE: The caller is responsible for free()ing all strings, while the
+ *       ntlm_buffer types point directly at data in the provided buffer.
+ *
+ * @return      0 if everyting parses correctly, or an error code
+ */
+int ntlm_decode_target_info(struct ntlm_ctx *ctx, struct ntlm_buffer *buffer,
+                            char **nb_computer_name, char **nb_domain_name,
+                            char **dns_computer_name, char **dns_domain_name,
+                            char **dns_tree_name, char **av_target_name,
+                            uint32_t *av_flags, uint64_t *av_timestamp,
+                            struct ntlm_buffer *av_single_host,
+                            struct ntlm_buffer *av_cb);
+
+/**
+ * @brief   A utility function to process a target_info structure
+ *
+ * @param ctx                   The ntlm context
+ * @param protect               Set if signing or sealing has been requested
+ * @param in                    A ntlm_buffer containing the received info
+ * @param server                The Client Supplied Server Name if available
+ * @param unhashed_cb           A ntlm_buffer with channel binding data
+ * @param out                   The processed target_info buffer
+ * @param out_srv_time          A 64 bit FILETIME timestamp
+ * @param add_mic               A pointer to a boolean. If NULL MIC flags will
+ *                               not be set, otherwise if allowed the MIC flag
+ *                               will be set and true will be returned.
+ *
+ * @return      0 if everyting parses correctly, or an error code
+ */
+int ntlm_process_target_info(struct ntlm_ctx *ctx, bool protect,
+                             struct ntlm_buffer *in,
+                             const char *server,
+                             struct ntlm_buffer *unhashed_cb,
+                             struct ntlm_buffer *out,
+                             uint64_t *out_srv_time,
+                             bool *add_mic);
+
+/**
+ * @brief Verifies the message signature is valid and the message
+ * in sequence with the expected state
+ *
+ * @param ctx           The conversation context.
+ * @param buffer        A ntlm_buffer containing the raw NTLMSSP packet
+ *
+ * @return      0 if everyting parses correctly, or an error code
+ *
+ * NOTE: Always use ntlm_detect_msg_type before calling other functions,
+ * so that the signature and message type are checked, and the state is
+ * validated.
+ */
+int ntlm_decode_msg_type(struct ntlm_ctx *ctx,
+                         struct ntlm_buffer *buffer,
+                         uint32_t *type);
+
+/**
+ * @brief This function encodes a NEGTIATE_MESSAGE which is the first message
+ * a client will send to a server. It also updates the stage in the context.
+ *
+ * @param ctx           A fresh ntlm context.
+ * @param flags         Requested flags
+ * @param domain        Optional Domain Name
+ * @param workstation   Optional Workstation Name
+ * @param message       A ntlm_buffer containing the returned message
+ *
+ * NOTE: the caller is responsible for free()ing the message buffer.
+ *
+ * @return      0 if everyting encodes correctly, or an error code
+ */
+int ntlm_encode_neg_msg(struct ntlm_ctx *ctx, uint32_t flags,
+                        const char *domain, const char *workstation,
+                        struct ntlm_buffer *message);
+
+/**
+ * @brief This function decodes a NTLMSSP NEGTIATE_MESSAGE.
+ *
+ * @param ctx           A fresh ntlm context
+ * @param buffer        A ntlm_buffer containing the raw NTLMSSP packet
+ * @param flags         Returns the flags requested by the client
+ * @param domain        Returns the domain provided by the client if any
+ * @param workstation   Returns the workstation provided by the client if any
+ *
+ * @return      0 if everyting parses correctly, or an error code
+ *
+ */
+int ntlm_decode_neg_msg(struct ntlm_ctx *ctx,
+                        struct ntlm_buffer *buffer, uint32_t *flags,
+                        char **domain, char **workstation);
+
+/**
+ * @brief This function encodes a CHALLENGE_MESSAGE which is the first message
+ * a server will send to a client. It also updates the stage in the context.
+ *
+ * @param ctx           The ntlm context
+ * @param flags         The challenge flags
+ * @param target_name   The target name
+ * @param challenge     A 64 bit value with a challenge
+ * @param target_info   A buffer containing target_info data
+ * @param message       A ntlm_buffer containing the encoded message
+ *
+ * NOTE: the caller is responsible for free()ing the message buffer
+ *
+ * @return      0 if everyting encodes correctly, or an error code
+ */
+int ntlm_encode_chal_msg(struct ntlm_ctx *ctx,
+                         uint32_t flags,
+                         const char *target_name,
+                         struct ntlm_buffer *challenge,
+                         struct ntlm_buffer *target_info,
+                         struct ntlm_buffer *message);
+
+
+/**
+ * @brief This function decodes a NTLMSSP CHALLENGE_MESSAGE.
+ *
+ * @param ctx           The ntlm context
+ * @param buffer        A ntlm_buffer containing the raw NTLMSSP packet
+ * @param flags         The challenge flags
+ * @param target_name   The target name
+ * @param challenge     A 64 bit value with the server challenge
+ *                      The caller MUST provide a preallocated buffer of
+ *                      appropriate length (8 bytes)
+ * @param target_info   A buffer containing returned target_info data
+ *
+ * @return      0 if everyting encodes correctly, or an error code
+ */
+int ntlm_decode_chal_msg(struct ntlm_ctx *ctx,
+                         struct ntlm_buffer *buffer,
+                         uint32_t *flags, char **target_name,
+                         struct ntlm_buffer *challenge,
+                         struct ntlm_buffer *target_info);
+
+
+/**
+ * @brief This function encodes a AUTHENTICATE_MESSAGE which is the second
+ * message a client will send to a serve.
+ * It also updates the stage in the context.
+ *
+ * @param ctx           The ntlm context
+ * @param flags         The flags
+ * @param lm_chalresp   A LM or LMv2 response
+ * @param nt_chalresp   A NTLM or NTLMv2 response
+ * @param domain_name   The Domain name
+ * @param user_name     The User name
+ * @param workstation   The Workstation name
+ * @param enc_sess_key  The session key
+ * @param mic           A MIC of the messages
+ * @param message       A ntlm_buffer containing the encoded message
+ *
+ * @return      0 if everyting encodes correctly, or an error code
+ */
+int ntlm_encode_auth_msg(struct ntlm_ctx *ctx,
+                         uint32_t flags,
+                         struct ntlm_buffer *lm_chalresp,
+                         struct ntlm_buffer *nt_chalresp,
+                         char *domain_name, char *user_name,
+                         char *workstation,
+                         struct ntlm_buffer *enc_sess_key,
+                         struct ntlm_buffer *mic,
+                         struct ntlm_buffer *message);
+
+/**
+ * @brief This function decodes a NTLMSSP AUTHENTICATE_MESSAGE.
+ *
+ * @param ctx           The ntlm context
+ * @param buffer        A ntlm_buffer containing the raw NTLMSSP packet
+ * @param flags         The negotiated flags
+ * @param lm_chalresp   A LM or LMv2 response
+ * @param nt_chalresp   A NTLM or NTLMv2 response
+ * @param domain_name   The Domain name
+ * @param user_name     The User name
+ * @param workstation   The Workstation name
+ * @param enc_sess_key  The session key
+ * @param target_info   The target_info AV_PAIR embedded in the NT Response
+ * @param mic           A MIC of the messages
+ *                      Passing a pointer to a mic means the caller has
+ *                      previously requested the presence of a MIC field from
+ *                      the peer. If a MIC is not returned by the peer the
+ *                      secoding will fail. If not MIC ha sbeen previously
+ *                      requested set this pointer to NULL.
+ *                      The caller must provide a preallocated buffer of
+ *                      appropriate length (16 bytes)
+ *
+ * NOTE: the caller is reponsible for freeing all allocated buffers
+ * on success.
+ *
+ * @return      0 if everyting encodes correctly, or an error code
+ */
+int ntlm_decode_auth_msg(struct ntlm_ctx *ctx,
+                         struct ntlm_buffer *buffer,
+                         uint32_t flags,
+                         struct ntlm_buffer *lm_chalresp,
+                         struct ntlm_buffer *nt_chalresp,
+                         char **domain_name, char **user_name,
+                         char **workstation,
+                         struct ntlm_buffer *enc_sess_key,
+                         struct ntlm_buffer *target_info,
+                         struct ntlm_buffer *mic);
+
+#endif /* _NTLM_H_ */

--- a/src/transports/ntlm/ntlm_common.h
+++ b/src/transports/ntlm/ntlm_common.h
@@ -1,0 +1,196 @@
+/*
+   Copyright (C) 2013 Simo Sorce <simo@samba.org>
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _NTLM_COMMON_H_
+#define _NTLM_COMMON_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+
+enum ntlm_err_code {
+    ERR_BASE = 0x4E540000, /* base error space at 'NT00' */
+    ERR_DECODE,
+    ERR_ENCODE,
+    ERR_CRYPTO,
+    ERR_NOARG,
+    ERR_BADARG,
+    ERR_NONAME,
+    ERR_NOSRVNAME,
+    ERR_NOUSRNAME,
+    ERR_BADLMLVL,
+    ERR_IMPOSSIBLE,
+    ERR_BADCTX,
+    ERR_WRONGCTX,
+    ERR_WRONGMSG,
+    ERR_REQNEGFLAG,
+    ERR_FAILNEGFLAGS,
+    ERR_BADNEGFLAGS,
+    ERR_NOSRVCRED,
+    ERR_NOUSRCRED,
+    ERR_BADCRED,
+    ERR_NOTOKEN,
+    ERR_NOTSUPPORTED,
+    ERR_NOTAVAIL,
+    ERR_NAMETOOLONG,
+    ERR_NOBINDINGS,
+    ERR_TIMESKEW,
+    ERR_EXPIRED,
+    ERR_KEYLEN,
+    ERR_NONTLMV1,
+    ERR_NOUSRFOUND,
+    ERR_LAST
+};
+#define NTLM_ERR_MASK 0x4E54FFFF
+#define IS_NTLM_ERR_CODE(x) (((x) & NTLM_ERR_MASK) ? true : false)
+
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
+#define safefree(x) do { free(x); x = NULL; } while(0)
+#define safezero(x, s) do { \
+    volatile uint8_t *p = (x); \
+    size_t size = (s); \
+    while (size--) { *p++ = 0; } \
+} while(0)
+
+
+struct ntlm_buffer {
+    uint8_t *data;
+    size_t length;
+};
+
+struct ntlm_iov {
+    struct ntlm_buffer **data;
+    size_t num;
+};
+
+struct ntlm_rc4_handle;
+
+enum ntlm_cipher_mode {
+    NTLM_CIPHER_IGNORE,
+    NTLM_CIPHER_ENCRYPT,
+    NTLM_CIPHER_DECRYPT,
+};
+
+#pragma pack(push, 1)
+struct wire_msg_hdr {
+    uint8_t signature[8];
+    uint32_t msg_type;
+};
+#pragma pack(pop)
+
+/* A wire string, the offset is relative to the mesage and must fall into the
+ * payload section.
+ * max_len should be set equal to len and ignored by servers.
+ */
+#pragma pack(push, 1)
+struct wire_field_hdr {
+    uint16_t len;
+    uint16_t max_len;
+    uint32_t offset;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct wire_neg_msg {
+    struct wire_msg_hdr header;
+    uint32_t neg_flags;
+    struct wire_field_hdr domain_name;
+    struct wire_field_hdr workstation_name;
+    uint8_t payload[]; /* variable */
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct wire_chal_msg {
+    struct wire_msg_hdr header;
+    struct wire_field_hdr target_name;
+    uint32_t neg_flags;
+    uint8_t server_challenge[8];
+    uint8_t reserved[8];
+    struct wire_field_hdr target_info;
+    uint8_t payload[]; /* variable */
+};
+#pragma pack(pop)
+
+/* We have evidence of at least one old broken server
+ * that send shorter CHALLENGE msgs like this: */
+#pragma pack(push, 1)
+struct wire_chal_msg_old {
+    struct wire_msg_hdr header;
+    struct wire_field_hdr target_name;
+    uint32_t neg_flags;
+    uint8_t server_challenge[8];
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct wire_auth_msg {
+    struct wire_msg_hdr header;
+    struct wire_field_hdr lm_chalresp;
+    struct wire_field_hdr nt_chalresp;
+    struct wire_field_hdr domain_name;
+    struct wire_field_hdr user_name;
+    struct wire_field_hdr workstation;
+    struct wire_field_hdr enc_sess_key;
+    uint32_t neg_flags;
+    uint8_t payload[]; /* variable */
+};
+#pragma pack(pop)
+
+/* Version information.
+ * Used only for debugging and usually placed as the head of the payload when
+ * used */
+#pragma pack(push, 1)
+struct wire_version {
+    uint8_t major;
+    uint8_t minor;
+    uint16_t build;
+    uint8_t reserved[3];
+    uint8_t revision;
+};
+#pragma pack(pop)
+
+/* ln/ntlm response, v1 or v2 */
+#pragma pack(push, 1)
+union wire_ntlm_response {
+    struct {
+        uint8_t resp[24];
+    } v1;
+    struct {
+        uint8_t resp[16];
+        uint8_t cli_chal[];
+    } v2;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct wire_ntlmv2_cli_chal {
+    uint8_t resp_version;
+    uint8_t hi_resp_version;
+    uint8_t zero_6[6];
+    uint64_t timestamp;
+    uint8_t client_chal[8];
+    uint8_t zero_4[4];
+    uint8_t target_info[];
+        /* NOTE: the target_info array must terminate with 4 zero bytes.
+         * This is consistent with just copying the target_info array
+         * returned in the challenge message as the last AV_PAIR there is
+         * always MSV_AV_EOL which happens to be 4 bytes of zeros */
+
+};
+#pragma pack(pop)
+
+#endif /* _NTLM_COMMON_H_ */

--- a/src/transports/ntlm/ntlm_crypto.c
+++ b/src/transports/ntlm/ntlm_crypto.c
@@ -1,0 +1,1038 @@
+/*
+   Copyright (C) 2013 Simo Sorce <simo@samba.org>
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/* This File implements the NTLM protocol as specified by:
+ *      [MS-NLMP]: NT LAN Manager (NTLM) Authentication Protocol
+ *
+ * Additional cross checking with:
+ * http://davenport.sourceforge.net/ntlm.html
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <unicase.h>
+#include <uniconv.h>
+
+#include "ntlm.h"
+#include "crypto.h"
+
+/* signature structure, v1 or v2 */
+#pragma pack(push, 1)
+union wire_msg_signature {
+    struct {
+        uint32_t version;
+        uint32_t random_pad;
+        uint32_t checksum;
+        uint32_t seq_num;
+    } v1;
+    struct {
+        uint32_t version;
+        uint64_t checksum;
+        uint32_t seq_num;
+    } v2;
+};
+#pragma pack(pop)
+
+/* the max username is 20 chars, max NB domain len is 15, so 128 should be
+ * plenty including conversion to UTF8 using max lenght for each code point
+ */
+#define MAX_USER_DOM_LEN 512
+
+
+int NTOWFv1(const char *password, struct ntlm_key *result)
+{
+    struct ntlm_buffer payload;
+    struct ntlm_buffer hash;
+    char *retstr;
+    size_t out;
+    size_t len;
+    int ret;
+
+    len = strlen(password);
+    retstr = u8_conv_to_encoding("UCS-2LE", iconveh_error,
+                                 (const uint8_t *)password, len,
+                                 NULL, NULL, &out);
+    if (!retstr) return ERR_CRYPTO;
+
+    payload.data = (uint8_t *)retstr;
+    payload.length = out;
+    hash.data = result->data;
+    hash.length = result->length;
+
+    ret = MD4_HASH(&payload, &hash);
+    free(retstr);
+    return ret;
+}
+
+#define DES_CONST "KGS!@#$%"
+int LMOWFv1(const char *password, struct ntlm_key *result)
+{
+    struct ntlm_buffer key;
+    struct ntlm_buffer plain;
+    struct ntlm_buffer cipher;
+    char upcased[15];
+    char *retstr;
+    size_t out;
+    size_t len;
+    int ret;
+
+    if (result->length != 16) return EINVAL;
+
+    len = strlen(password);
+    if (len > 14) return ERANGE;
+
+    out = 15;
+    retstr = (char *)u8_toupper((const uint8_t *)password, len,
+                                NULL, NULL, (uint8_t *)upcased, &out);
+    if (!retstr) return ERR_CRYPTO;
+    if (retstr != upcased) {
+        free(retstr);
+        ret = EINVAL;
+    }
+    memset(&upcased[len], 0, 15 - len);
+
+    /* part1 */
+    key.data = (uint8_t *)upcased;
+    key.length = 7;
+    plain.data = discard_const(DES_CONST);
+    plain.length = 8;
+    cipher.data = result->data;
+    cipher.length = 8;
+    ret = WEAK_DES(&key, &plain, &cipher);
+    if (ret) return ret;
+
+    /* part2 */
+    key.data = (uint8_t *)&upcased[7];
+    key.length = 7;
+    plain.data = discard_const(DES_CONST);
+    plain.length = 8;
+    cipher.data = &result->data[8];
+    cipher.length = 8;
+    return WEAK_DES(&key, &plain, &cipher);
+}
+
+int ntlm_compute_ext_sec_challenge(uint8_t *server_chal,
+                                   uint8_t *client_chal,
+                                   uint8_t *result_chal)
+{
+    uint8_t scbuf[16];
+    uint8_t mdbuf[16];
+    struct ntlm_buffer challenges = { scbuf, 16 };
+    struct ntlm_buffer msgdigest = { mdbuf, 16 };
+    int ret;
+
+    memcpy(scbuf, server_chal, 8);
+    memcpy(&scbuf[8], client_chal, 8);
+    ret = MD5_HASH(&challenges, &msgdigest);
+    if (ret) return ret;
+
+    memcpy(result_chal, mdbuf, 8);
+    return 0;
+}
+
+int ntlm_compute_nt_response(struct ntlm_key *nt_key, bool ext_sec,
+                             uint8_t server_chal[8], uint8_t client_chal[8],
+                             struct ntlm_buffer *nt_response)
+{
+    struct ntlm_buffer key = { nt_key->data, nt_key->length };
+    uint8_t chal[8];
+    struct ntlm_buffer payload = { chal, 8};
+    int ret;
+
+    if (ext_sec) {
+        ret = ntlm_compute_ext_sec_challenge(server_chal, client_chal, chal);
+        if (ret) return ret;
+    } else {
+        memcpy(chal, server_chal, 8);
+    }
+
+    return DESL(&key, &payload, nt_response);
+}
+
+int ntlm_compute_lm_response(struct ntlm_key *lm_key, bool ext_sec,
+                             uint8_t server_chal[8], uint8_t client_chal[8],
+                             struct ntlm_buffer *lm_response)
+{
+    struct ntlm_buffer key = { lm_key->data, lm_key->length };
+    struct ntlm_buffer payload = { server_chal, 8 };
+
+    if (ext_sec) {
+        memcpy(lm_response->data, client_chal, 8);
+        memset(&lm_response->data[8], 0, 16);
+        return 0;
+    }
+    return DESL(&key, &payload, lm_response);
+}
+
+int ntlm_session_base_key(struct ntlm_key *nt_key,
+                          struct ntlm_key *session_base_key)
+{
+    struct ntlm_buffer payload = { nt_key->data, nt_key->length };
+    struct ntlm_buffer hash = { session_base_key->data,
+                                session_base_key->length };
+
+    return MD4_HASH(&payload, &hash);
+}
+
+int KXKEY(struct ntlm_ctx *ctx,
+          bool ext_sec,
+          bool neg_lm_key,
+          bool non_nt_sess_key,
+          uint8_t server_chal[8],
+          struct ntlm_key *lm_key,
+          struct ntlm_key *session_base_key,
+          struct ntlm_buffer *lm_response,
+          struct ntlm_key *key_exchange_key)
+{
+    struct ntlm_buffer payload;
+    struct ntlm_buffer result;
+    struct ntlm_buffer key;
+    uint8_t buf[16];
+    int ret = 0;
+
+    if (ext_sec) {
+        key.data = session_base_key->data;
+        key.length = session_base_key->length;
+        memcpy(buf, server_chal, 8);
+        memcpy(&buf[8], lm_response->data, 8);
+        payload.data = buf;
+        payload.length = 16;
+        result.data = key_exchange_key->data;
+        result.length = key_exchange_key->length;
+        ret = HMAC_MD5(&key, &payload, &result);
+    } else if (neg_lm_key) {
+        payload.data = lm_response->data;
+        payload.length = 8;
+        key.data = lm_key->data;
+        key.length = 7;
+        result.data = key_exchange_key->data;
+        result.length = 8;
+        ret = WEAK_DES(&key, &payload, &result);
+        if (ret) return ret;
+        buf[0] = lm_key->data[7];
+        memset(&buf[1], 0xbd, 6);
+        key.data = buf;
+        result.data = &key_exchange_key->data[8];
+        result.length = 8;
+        ret = WEAK_DES(&key, &payload, &result);
+    } else if (non_nt_sess_key) {
+        memcpy(key_exchange_key->data, lm_key, 8);
+        memset(&key_exchange_key->data[8], 0, 8);
+    } else {
+        memcpy(key_exchange_key->data, session_base_key->data, 16);
+    }
+    return ret;
+}
+
+int NTOWFv2(struct ntlm_ctx *ctx, struct ntlm_key *nt_hash,
+            const char *user, const char *domain, struct ntlm_key *result)
+{
+    struct ntlm_buffer key = { nt_hash->data, nt_hash->length };
+    struct ntlm_buffer hmac = { result->data, result->length };
+    struct ntlm_buffer payload;
+    uint8_t upcased[MAX_USER_DOM_LEN];
+    uint8_t *retstr;
+    size_t offs;
+    size_t out;
+    size_t len;
+    int ret;
+
+    len = strlen(user);
+    out = MAX_USER_DOM_LEN;
+    retstr = u8_toupper((const uint8_t *)user, len,
+                        NULL, NULL, upcased, &out);
+    if (!retstr) return ERR_CRYPTO;
+    offs = out;
+
+    if (domain) {
+        len = strlen(domain);
+        memcpy(&upcased[offs], domain, len);
+        offs += len;
+    }
+
+    retstr = (uint8_t *)u8_conv_to_encoding("UCS-2LE", iconveh_error,
+                                            upcased, offs, NULL, NULL, &out);
+    if (!retstr) return ERR_CRYPTO;
+
+    payload.data = (uint8_t *)retstr;
+    payload.length = out;
+
+    ret = HMAC_MD5(&key, &payload, &hmac);
+    free(retstr);
+    return ret;
+}
+
+int ntlmv2_compute_nt_response(struct ntlm_key *ntlmv2_key,
+                               uint8_t server_chal[8], uint8_t client_chal[8],
+                               uint64_t timestamp,
+                               struct ntlm_buffer *target_info,
+                               struct ntlm_buffer *nt_response)
+{
+    union wire_ntlm_response *nt_resp = NULL;
+    struct wire_ntlmv2_cli_chal *r;
+    struct ntlm_buffer key = { ntlmv2_key->data, ntlmv2_key->length };
+    struct ntlm_buffer payload;
+    struct ntlm_buffer nt_proof;
+    size_t r_len;
+    int ret;
+
+    /* add additional 4 0s trailing target_info */
+    r_len = sizeof(struct wire_ntlmv2_cli_chal) + target_info->length + 4;
+    nt_resp = calloc(1, sizeof(nt_resp->v2) + r_len);
+    if (!nt_resp) return ENOMEM;
+
+    r = (struct wire_ntlmv2_cli_chal *)nt_resp->v2.cli_chal;
+    r->resp_version = 1;
+    r->hi_resp_version = 1;
+    r->timestamp = htole64(timestamp);
+    memcpy(r->client_chal, client_chal, 8);
+    memcpy(r->target_info, target_info->data, target_info->length);
+
+    /* use nt_resp as a buffer to calculate the NT proof as they share
+     * the cli_chal part */
+    payload.data = &nt_resp->v2.resp[8];
+    payload.length = 8 + r_len;
+    memcpy(payload.data, server_chal, 8);
+    nt_proof.data = nt_resp->v2.resp;
+    nt_proof.length = 16;
+    ret = HMAC_MD5(&key, &payload, &nt_proof);
+
+    if (ret) {
+        safefree(nt_resp);
+    } else {
+        nt_response->data = (uint8_t *)nt_resp;
+        nt_response->length = 16 + r_len;
+    }
+    return ret;
+}
+
+int ntlmv2_compute_lm_response(struct ntlm_key *ntlmv2_key,
+                               uint8_t server_chal[8], uint8_t client_chal[8],
+                               struct ntlm_buffer *lm_response)
+{
+    union wire_ntlm_response *lm_resp = NULL;
+    struct ntlm_buffer key = { ntlmv2_key->data, ntlmv2_key->length };
+    uint8_t payload_buf[16];
+    struct ntlm_buffer payload = { payload_buf, 16 };
+    struct ntlm_buffer lm_proof;
+    int ret;
+
+    /* now caluclate the LM Proof */
+    lm_resp = malloc(sizeof(union wire_ntlm_response));
+    if (!lm_resp) {
+        ret = ENOMEM;
+        goto done;
+    }
+
+    memcpy(payload.data, server_chal, 8);
+    memcpy(&payload.data[8], client_chal, 8);
+    lm_proof.data = lm_resp->v2.resp;
+    lm_proof.length = 16;
+    ret = HMAC_MD5(&key, &payload, &lm_proof);
+
+done:
+    if (ret) {
+        safefree(lm_resp);
+    } else {
+        memcpy(lm_resp->v2.cli_chal, client_chal, 8);
+
+        lm_response->data = (uint8_t *)lm_resp;
+        lm_response->length = 24;
+    }
+    return ret;
+}
+
+int ntlmv2_session_base_key(struct ntlm_key *ntlmv2_key,
+                            struct ntlm_buffer *nt_response,
+                            struct ntlm_key *session_base_key)
+{
+    struct ntlm_buffer key = { ntlmv2_key->data, ntlmv2_key->length };
+    struct ntlm_buffer hmac = { session_base_key->data,
+                                session_base_key->length };
+
+    if (session_base_key->length != 16) return EINVAL;
+
+    return HMAC_MD5(&key, nt_response, &hmac);
+}
+
+int ntlm_exported_session_key(struct ntlm_key *key_exchange_key,
+                              bool key_exch,
+                              struct ntlm_key *exported_session_key)
+{
+    struct ntlm_buffer nonce;
+
+    if (!key_exch) {
+        *exported_session_key = *key_exchange_key;
+        return 0;
+    }
+
+    exported_session_key->length = 16;
+    nonce.data = exported_session_key->data;
+    nonce.length = exported_session_key->length;
+    return RAND_BUFFER(&nonce);
+}
+
+int ntlm_encrypted_session_key(struct ntlm_key *key,
+                               struct ntlm_key *in, struct ntlm_key *out)
+{
+    struct ntlm_buffer _key = { key->data, key->length };
+    struct ntlm_buffer data = { in->data, in->length };
+    struct ntlm_buffer result = { out->data, out->length };
+
+    return RC4K(&_key, NTLM_CIPHER_ENCRYPT, &data, &result);
+}
+
+static int ntlm_key_derivation_function(struct ntlm_key *key,
+                                        const char *magic_constant,
+                                        struct ntlm_key *derived_key)
+{
+    uint8_t buf[80]; /* key + constant is never larger than 80 */
+    struct ntlm_buffer payload = { buf, 0 };
+    struct ntlm_buffer result = { derived_key->data, 16 };
+    size_t len;
+    int ret;
+
+    if (key->length > 16) return ERR_CRYPTO;
+    len = strlen(magic_constant) + 1;
+    if (len > 64) return ERR_CRYPTO;
+
+    payload.length = key->length;
+    memcpy(payload.data, key->data, key->length);
+    memcpy(&payload.data[payload.length], magic_constant, len);
+    payload.length += len;
+
+    ret = MD5_HASH(&payload, &result);
+    if (ret == 0) {
+        derived_key->length = 16;
+    }
+    return ret;
+}
+
+#define NTLM_MODE_CLIENT true
+#define NTLM_MODE_SERVER false
+
+static int ntlm_signkey(bool mode,
+                        struct ntlm_key *session_key,
+                        struct ntlm_key *signing_key)
+{
+    const char *mc;
+
+    if (mode == NTLM_MODE_CLIENT) {
+        mc = "session key to client-to-server signing key magic constant";
+    } else {
+        mc = "session key to server-to-client signing key magic constant";
+    }
+    return ntlm_key_derivation_function(session_key,
+                                        mc, signing_key);
+}
+
+static int ntlm_sealkey(uint32_t flags, bool mode,
+                        struct ntlm_key *session_key,
+                        struct ntlm_key *sealing_key)
+{
+    struct ntlm_key key;
+    const char *mc;
+
+    if (flags & NTLMSSP_NEGOTIATE_128) {
+        key.length = 16;
+    } else if (flags & NTLMSSP_NEGOTIATE_56) {
+        key.length = 7;
+    } else {
+        key.length = 5;
+    }
+    memcpy(key.data, session_key->data, key.length);
+
+    if (mode == NTLM_MODE_CLIENT) {
+        mc = "session key to client-to-server sealing key magic constant";
+    } else {
+        mc = "session key to server-to-client sealing key magic constant";
+    }
+
+    return ntlm_key_derivation_function(&key, mc, sealing_key);
+}
+
+static void no_ext_sec_sealkey(uint32_t flags,
+                               struct ntlm_key *session_key,
+                               struct ntlm_buffer *sealing_key)
+{
+    if (flags & NTLMSSP_NEGOTIATE_LM_KEY) {
+        if (flags & NTLMSSP_NEGOTIATE_56) {
+            memcpy(sealing_key->data, session_key->data, 7);
+            sealing_key->data[7] = 0xA0;
+        } else {
+            memcpy(sealing_key->data, session_key->data, 5);
+            sealing_key->data[5] = 0xE5;
+            sealing_key->data[6] = 0x38;
+            sealing_key->data[7] = 0xB0;
+        }
+        sealing_key->length = 8;
+    } else {
+        memcpy(sealing_key->data, session_key->data, 16);
+        sealing_key->length = session_key->length;
+    }
+}
+
+static int no_ext_sec_handle(uint32_t flags,
+                             struct ntlm_key *session_key,
+                             struct ntlm_rc4_handle **seal_handle)
+{
+    uint8_t skbuf[16];
+    struct ntlm_buffer sealing_key = { skbuf, 16 };
+
+    no_ext_sec_sealkey(flags, session_key, &sealing_key);
+
+    return RC4_INIT(&sealing_key, NTLM_CIPHER_ENCRYPT, seal_handle);
+}
+
+
+static int ext_sec_keys(uint32_t flags, bool client,
+                        struct ntlm_key *session_key,
+                        struct ntlm_signseal_state *state)
+{
+    struct ntlm_buffer rc4_key;
+    bool mode;
+    int ret;
+
+    state->ext_sec = true;
+    if (flags & NTLMSSP_NEGOTIATE_DATAGRAM) {
+        state->datagram = true;
+    }
+
+    /* send key */
+    mode = client ? NTLM_MODE_CLIENT : NTLM_MODE_SERVER;
+    ret = ntlm_signkey(mode, session_key, &state->send.sign_key);
+    if (ret) return ret;
+    /* recv key */
+    mode = client ? NTLM_MODE_SERVER : NTLM_MODE_CLIENT;
+    ret = ntlm_signkey(mode, session_key, &state->recv.sign_key);
+    if (ret) return ret;
+
+    /* send key */
+    mode = client ? NTLM_MODE_CLIENT : NTLM_MODE_SERVER;
+    ret = ntlm_sealkey(flags, mode, session_key, &state->send.seal_key);
+    if (ret) return ret;
+    /* recv key */
+    mode = client ? NTLM_MODE_SERVER : NTLM_MODE_CLIENT;
+    ret = ntlm_sealkey(flags, mode, session_key, &state->recv.seal_key);
+    if (ret) return ret;
+
+    rc4_key.data = state->send.seal_key.data;
+    rc4_key.length = state->send.seal_key.length;
+    ret = RC4_INIT(&rc4_key, NTLM_CIPHER_ENCRYPT, &state->send.seal_handle);
+    if (ret) return ret;
+
+    rc4_key.data = state->recv.seal_key.data;
+    rc4_key.length = state->recv.seal_key.length;
+    ret = RC4_INIT(&rc4_key, NTLM_CIPHER_DECRYPT, &state->recv.seal_handle);
+    if (ret) return ret;
+
+    return 0;
+}
+
+int ntlm_signseal_keys(uint32_t flags, bool client,
+                       struct ntlm_key *session_key,
+                       struct ntlm_signseal_state *state)
+{
+
+    memset(state, 0, sizeof(struct ntlm_signseal_state));
+
+    if (flags & NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY) {
+        state->datagram = (flags & NTLMSSP_NEGOTIATE_DATAGRAM);
+        return ext_sec_keys(flags, client, session_key, state);
+    } else {
+        return no_ext_sec_handle(flags, session_key,
+                                 &state->send.seal_handle);
+    }
+}
+
+int ntlm_reset_rc4_state(uint32_t flags, bool recv,
+                         struct ntlm_key *session_key,
+                         struct ntlm_signseal_state *state)
+{
+    struct ntlm_buffer rc4_key;
+    int ret;
+
+    if (!(flags & NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY)) {
+        return no_ext_sec_handle(flags, session_key,
+                                 &state->send.seal_handle);
+    }
+
+    if (recv) {
+        RC4_FREE(&state->recv.seal_handle);
+        rc4_key.data = state->recv.seal_key.data;
+        rc4_key.length = state->recv.seal_key.length;
+        ret = RC4_INIT(&rc4_key, NTLM_CIPHER_DECRYPT,
+                       &state->recv.seal_handle);
+    } else {
+        RC4_FREE(&state->send.seal_handle);
+        rc4_key.data = state->send.seal_key.data;
+        rc4_key.length = state->send.seal_key.length;
+        ret = RC4_INIT(&rc4_key, NTLM_CIPHER_ENCRYPT,
+                       &state->send.seal_handle);
+    }
+    return ret;
+}
+
+static int ntlm_seal_regen(struct ntlm_signseal_handle *h)
+{
+    struct ntlm_buffer payload;
+    struct ntlm_buffer result;
+    uint8_t inbuf[20];
+    uint8_t outbuf[16];
+    uint32_t le;
+    int ret;
+
+    RC4_FREE(&h->seal_handle);
+
+    memcpy(inbuf, h->seal_key.data, h->seal_key.length);
+    le = htole32(h->seq_num);
+    memcpy(&inbuf[h->seal_key.length], &le, 4);
+
+    payload.data = inbuf;
+    payload.length = h->seal_key.length + 4;
+    result.data = outbuf;
+    result.length = 16;
+
+    ret = MD5_HASH(&payload, &result);
+    if (ret) return ret;
+
+    ret = RC4_INIT(&result, NTLM_CIPHER_ENCRYPT, &h->seal_handle);
+    return ret;
+}
+
+int ntlm_verify_nt_response(struct ntlm_buffer *nt_response,
+                            struct ntlm_key *nt_key, bool ext_sec,
+                            uint8_t server_chal[8], uint8_t client_chal[8])
+{
+    uint8_t buf[24];
+    struct ntlm_buffer expected_response = { buf, 24 };
+    int ret;
+
+    ret = ntlm_compute_nt_response(nt_key, ext_sec,
+                                   server_chal, client_chal,
+                                   &expected_response);
+    if (ret) return ret;
+
+    ret = EINVAL;
+    if (memcmp(nt_response->data, expected_response.data, 24) == 0) {
+        ret = 0;
+    }
+
+    return ret;
+}
+
+int ntlm_verify_lm_response(struct ntlm_buffer *lm_response,
+                            struct ntlm_key *lm_key, bool ext_sec,
+                            uint8_t server_chal[8], uint8_t client_chal[8])
+{
+    uint8_t buf[24];
+    struct ntlm_buffer expected_response = { buf, 24 };
+    int ret;
+
+    ret = ntlm_compute_lm_response(lm_key, ext_sec,
+                                   server_chal, client_chal,
+                                   &expected_response);
+    if (ret) return ret;
+
+    ret = EINVAL;
+    if (memcmp(lm_response->data, expected_response.data, 24) == 0) {
+        ret = 0;
+    }
+
+    return ret;
+}
+
+int ntlmv2_verify_nt_response(struct ntlm_buffer *nt_response,
+                              struct ntlm_key *ntlmv2_key,
+                              uint8_t server_chal[8])
+{
+    union wire_ntlm_response *nt_resp = NULL;
+    struct ntlm_buffer key = { ntlmv2_key->data, ntlmv2_key->length };
+    uint8_t proof[16];
+    struct ntlm_buffer nt_proof = { proof, 16 };
+    struct ntlm_buffer payload;
+    int ret;
+
+    if (nt_response->length < 24) return EINVAL;
+
+    nt_resp = (union wire_ntlm_response *)nt_response->data;
+
+    payload.length = nt_response->length - sizeof(nt_resp->v2.resp) + 8;
+    payload.data = malloc(payload.length);
+    if (!payload.data) return ENOMEM;
+    memcpy(payload.data, server_chal, 8);
+    memcpy(&payload.data[8], nt_resp->v2.cli_chal, payload.length - 8);
+
+    ret = HMAC_MD5(&key, &payload, &nt_proof);
+
+    if (ret) goto done;
+
+    ret = EINVAL;
+    if (memcmp(nt_resp->v2.resp, proof, 16) == 0) {
+        ret = 0;
+    }
+
+done:
+    safefree(payload.data);
+    return ret;
+}
+
+int ntlmv2_verify_lm_response(struct ntlm_buffer *lm_response,
+                              struct ntlm_key *ntlmv2_key,
+                              uint8_t server_chal[8])
+{
+    struct ntlm_buffer key = { ntlmv2_key->data, ntlmv2_key->length };
+    union wire_ntlm_response *lm_resp = NULL;
+    uint8_t payload_buf[16];
+    struct ntlm_buffer payload = { payload_buf, 16 };
+    uint8_t proof[16];
+    struct ntlm_buffer lm_proof = { proof, 16 };
+    int ret;
+
+    if (lm_response->length != 24) return EINVAL;
+
+    /* now caluclate the LM Proof */
+    lm_resp = (union wire_ntlm_response *)lm_response->data;
+
+    memcpy(payload.data, server_chal, 8);
+    memcpy(&payload.data[8], lm_resp->v2.cli_chal, 8);
+    ret = HMAC_MD5(&key, &payload, &lm_proof);
+
+    if (ret) return ret;
+
+    if (memcmp(lm_resp->v2.resp, proof, 16) == 0) return 0;
+
+    return EINVAL;
+}
+
+static int ntlmv2_sign(struct ntlm_key *sign_key, uint32_t seq_num,
+                       struct ntlm_rc4_handle *handle, bool keyex,
+                       struct ntlm_buffer *message,
+                       struct ntlm_buffer *signature)
+{
+    struct ntlm_buffer key = { sign_key->data, sign_key->length };
+    union wire_msg_signature *msg_sig;
+    uint32_t le_seq;
+    uint8_t le8seq[8];
+    struct ntlm_buffer seq = { le8seq, 4 };
+    struct ntlm_buffer *data[2];
+    struct ntlm_iov iov;
+    uint8_t hmac_sig[NTLM_SIGNATURE_SIZE];
+    struct ntlm_buffer hmac = { hmac_sig, NTLM_SIGNATURE_SIZE };
+    struct ntlm_buffer rc4buf;
+    struct ntlm_buffer rc4res;
+    int ret;
+
+    msg_sig = (union wire_msg_signature *)signature->data;
+    if (signature->length != NTLM_SIGNATURE_SIZE) {
+        return EINVAL;
+    }
+
+    le_seq = htole32(seq_num);
+    memcpy(seq.data, &le_seq, 4);
+    data[0] = &seq;
+    data[1] = message;
+    iov.data = data;
+    iov.num = 2;
+
+    ret = HMAC_MD5_IOV(&key, &iov, &hmac);
+    if (ret) return ret;
+
+    /* put version */
+    msg_sig->v2.version = htole32(NTLMSSP_MESSAGE_SIGNATURE_VERSION);
+
+    /* put actual MAC */
+    if (keyex) {
+        /* encrypt truncated hmac */
+        rc4buf.data = hmac.data;
+        rc4buf.length = 8;
+        /* and put it in the middle of the output signature */
+        rc4res.data = (uint8_t *)&msg_sig->v2.checksum;
+        rc4res.length = 8;
+        ret = RC4_UPDATE(handle, &rc4buf, &rc4res);
+        if (ret) return ret;
+    } else {
+        memcpy(&msg_sig->v2.checksum, hmac.data, 8);
+    }
+
+    /* put used seq_num */
+    msg_sig->v2.seq_num = le_seq;
+
+    return 0;
+}
+
+static int ntlmv1_sign(struct ntlm_rc4_handle *handle,
+                       uint32_t random_pad, uint32_t seq_num,
+                       struct ntlm_buffer *message,
+                       struct ntlm_buffer *signature)
+{
+    union wire_msg_signature *msg_sig;
+    uint32_t rc4buf[3];
+    struct ntlm_buffer payload;
+    struct ntlm_buffer result;
+    int ret;
+
+    msg_sig = (union wire_msg_signature *)signature->data;
+    if (signature->length != NTLM_SIGNATURE_SIZE) {
+        return EINVAL;
+    }
+
+    rc4buf[0] = random_pad;
+    rc4buf[1] = htole32(CRC32(0, message));
+    rc4buf[2] = htole32(seq_num);
+
+    payload.data = (uint8_t *)rc4buf;
+    payload.length = 12;
+    result.data = (uint8_t *)&msg_sig->v1.random_pad;
+    result.length = 12;
+    ret = RC4_UPDATE(handle, &payload, &result);
+    if (ret) return ret;
+
+    msg_sig->v1.version = htole32(NTLMSSP_MESSAGE_SIGNATURE_VERSION);
+    msg_sig->v1.random_pad = 0;
+
+    return 0;
+}
+
+int ntlm_sign(uint32_t flags, int direction,
+              struct ntlm_signseal_state *state,
+              struct ntlm_buffer *message,
+              struct ntlm_buffer *signature)
+{
+    struct ntlm_signseal_handle *h;
+    int ret;
+
+    if (direction == NTLM_SEND || !state->ext_sec) {
+        h = &state->send;
+    } else {
+        h = &state->recv;
+    }
+
+    if (flags & NTLMSSP_NEGOTIATE_SIGN) {
+        if (state->ext_sec) {
+            if (state->datagram) {
+                ret = ntlm_seal_regen(h);
+                if (ret) return ret;
+            }
+
+            ret = ntlmv2_sign(&h->sign_key, h->seq_num, h->seal_handle,
+                              (flags & NTLMSSP_NEGOTIATE_KEY_EXCH),
+                              message, signature);
+        } else {
+            ret = ntlmv1_sign(h->seal_handle, 0, h->seq_num,
+                              message, signature);
+        }
+        if (ret) return ret;
+
+        if (!state->datagram) {
+            h->seq_num++;
+        }
+        return 0;
+
+    } else if (flags & NTLMSSP_NEGOTIATE_ALWAYS_SIGN) {
+        uint32_t le_seq = htole32(h->seq_num);
+        memcpy(signature->data, &le_seq, 4);
+        memset(&signature->data[4], 0, 12);
+        return 0;
+    }
+
+    return ENOTSUP;
+}
+
+int ntlm_seal(uint32_t flags,
+              struct ntlm_signseal_state *state,
+              struct ntlm_buffer *message,
+              struct ntlm_buffer *output,
+              struct ntlm_buffer *signature)
+{
+    struct ntlm_signseal_handle *h;
+    int ret;
+
+    h = &state->send;
+
+    ret = RC4_UPDATE(h->seal_handle, message, output);
+    if (ret) return ret;
+
+    if (state->ext_sec) {
+        if (state->datagram) {
+            ret = ntlm_seal_regen(h);
+            if (ret) return ret;
+        }
+        ret = ntlmv2_sign(&h->sign_key, h->seq_num, h->seal_handle,
+                          (flags & NTLMSSP_NEGOTIATE_KEY_EXCH),
+                          message, signature);
+    } else {
+        ret = ntlmv1_sign(h->seal_handle, 0, h->seq_num, message, signature);
+    }
+    if (ret) return ret;
+
+    if (!state->datagram) {
+        h->seq_num++;
+    }
+    return 0;
+}
+
+int ntlm_unseal(uint32_t flags,
+                struct ntlm_signseal_state *state,
+                struct ntlm_buffer *message,
+                struct ntlm_buffer *output,
+                struct ntlm_buffer *signature)
+{
+    struct ntlm_signseal_handle *h;
+    int ret;
+
+    if (!state->ext_sec) {
+        h = &state->send;
+    } else {
+        h = &state->recv;
+    }
+
+    ret = RC4_UPDATE(h->seal_handle, message, output);
+    if (ret) return ret;
+
+    if (state->ext_sec) {
+        if (state->datagram) {
+            ret = ntlm_seal_regen(h);
+            if (ret) return ret;
+        }
+        ret = ntlmv2_sign(&h->sign_key, h->seq_num, h->seal_handle,
+                          (flags & NTLMSSP_NEGOTIATE_KEY_EXCH),
+                          output, signature);
+    } else {
+        ret = ntlmv1_sign(h->seal_handle, 0, h->seq_num, output, signature);
+    }
+    if (ret) return ret;
+
+    if (!state->datagram) {
+        h->seq_num++;
+    }
+    return 0;
+}
+
+int ntlm_mic(struct ntlm_key *exported_session_key,
+             struct ntlm_buffer *negotiate_message,
+             struct ntlm_buffer *challenge_message,
+             struct ntlm_buffer *authenticate_message,
+             struct ntlm_buffer *mic)
+{
+    struct ntlm_buffer key = { exported_session_key->data,
+                               exported_session_key->length };
+    struct ntlm_buffer *data[3] = { negotiate_message,
+                                    challenge_message,
+                                    authenticate_message };
+    struct ntlm_iov iov;
+
+    if (negotiate_message->length == 0) {
+        /* connectionless case */
+        iov.data = &data[1];
+        iov.num = 2;
+    } else {
+        iov.data = data;
+        iov.num = 3;
+    }
+
+    return HMAC_MD5_IOV(&key, &iov, mic);
+}
+
+int ntlm_verify_mic(struct ntlm_key *key,
+                    struct ntlm_buffer *negotiate_message,
+                    struct ntlm_buffer *challenge_message,
+                    struct ntlm_buffer *authenticate_message,
+                    struct ntlm_buffer *mic)
+{
+    uint8_t micbuf[NTLM_SIGNATURE_SIZE];
+    struct ntlm_buffer check_mic = { micbuf, NTLM_SIGNATURE_SIZE };
+    struct wire_auth_msg *msg;
+    size_t payload_offs;
+    uint32_t flags;
+    int ret;
+
+    msg = (struct wire_auth_msg *)authenticate_message->data;
+    payload_offs = offsetof(struct wire_auth_msg, payload);
+
+    /* flags must be checked as they may push the payload further down */
+    flags = le32toh(msg->neg_flags);
+    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
+        /* skip version for now */
+        payload_offs += sizeof(struct wire_version);
+    }
+
+    if (payload_offs + NTLM_SIGNATURE_SIZE > authenticate_message->length) {
+        return EINVAL;
+    }
+
+    /* payload_offs now points at the MIC buffer, clear it off in order
+     * to be able to calculate the original chcksum */
+    memset(&authenticate_message->data[payload_offs], 0, NTLM_SIGNATURE_SIZE);
+
+    ret = ntlm_mic(key, negotiate_message, challenge_message,
+                        authenticate_message, &check_mic);
+    if (ret) return ret;
+
+    if (memcmp(mic->data, check_mic.data, NTLM_SIGNATURE_SIZE) != 0) {
+        return EACCES;
+    }
+
+    return 0;
+}
+
+int ntlm_hash_channel_bindings(struct ntlm_buffer *unhashed,
+                               struct ntlm_buffer *signature)
+{
+    struct ntlm_buffer input;
+    uint32_t ulen;
+    int ret;
+
+    /* The channel bindings are calculated according to RFC4121, 4.1.1.2,
+     * with a all initiator and acceptor fields zeroed, so we need 4 zeroed
+     * 32bit fields, and one little endian length field to include in the
+     * MD5 calculation */
+    input.length = sizeof(uint32_t) * 5 + unhashed->length;
+    input.data = malloc(input.length);
+    if (!input.data) return EINVAL;
+
+    memset(input.data, 0, sizeof(uint32_t) * 4);
+    ulen = unhashed->length;
+    ulen = htole32(ulen);
+    memcpy(&input.data[sizeof(uint32_t) * 4], &ulen, sizeof(uint32_t));
+    memcpy(&input.data[sizeof(uint32_t) * 5], unhashed->data, unhashed->length);
+
+    ret = MD5_HASH(&input, signature);
+
+    safefree(input.data);
+    return ret;
+}
+
+int ntlm_verify_channel_bindings(struct ntlm_buffer *unhashed,
+                                 struct ntlm_buffer *signature)
+{
+    uint8_t cbbuf[16];
+    struct ntlm_buffer cb = { cbbuf, 16 };
+    int ret;
+
+    if (signature->length != 16) return EINVAL;
+
+    ret = ntlm_hash_channel_bindings(unhashed, &cb);
+    if (ret) return ret;
+
+    if (memcmp(cb.data, signature->data, 16) != 0) return EACCES;
+
+    return 0;
+}


### PR DESCRIPTION
This patch implements NTLMv2 session negotiation over HTTP. Git repositories served by Team Foundation Server are currently only accessible if IIS is configured for SPNEGO authentication, which isn't always the case. I excluded support for older LM/NTLM versions since they are strongly discouraged and unlikely to be used in the wild.