### PR TITLE
diff: expose the "indent heuristic" in the diff options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ v0.26 + 1
 
 * We now support conditional includes in configuration files.
 
+* There is a new diff option, `GIT_DIFF_INDENT_HEURISTIC` which activates a
+  heuristic which takes into account whitespace and indentation in order to
+  produce better diffs when dealing with ambiguous diff hunks.
+
 ### API additions
 
 * `git_remote_create_detached()` creates a remote that is not associated

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -206,6 +206,12 @@ typedef enum {
 	 *  can apply given diff information to binary files.
 	 */
 	GIT_DIFF_SHOW_BINARY = (1 << 30),
+
+	/** Use a heuristic that takes indentation and whitespace into account
+	 * which generally can produce better diffs when dealing with ambiguous
+	 * diff hunks.
+	 */
+	GIT_DIFF_INDENT_HEURISTIC = (1 << 31),
 } git_diff_option_t;
 
 /**

--- a/src/diff_xdiff.c
+++ b/src/diff_xdiff.c
@@ -239,6 +239,8 @@ void git_xdiff_init(git_xdiff_output *xo, const git_diff_options *opts)
 		xo->params.flags |= XDF_IGNORE_WHITESPACE_CHANGE;
 	if (flags & GIT_DIFF_IGNORE_WHITESPACE_EOL)
 		xo->params.flags |= XDF_IGNORE_WHITESPACE_AT_EOL;
+	if (flags & GIT_DIFF_INDENT_HEURISTIC)
+		xo->params.flags |= XDF_INDENT_HEURISTIC;
 
 	if (flags & GIT_DIFF_PATIENCE)
 		xo->params.flags |= XDF_PATIENCE_DIFF;


### PR DESCRIPTION
We default to off, but we might want to consider changing `GIT_DIFF_NORMAL` to
include it.

This is a followup to #3944  that lets consumers of the library activate it.