### PR TITLE
travis: grab pgp key from www.edwardthomson.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
  apt:
   sources:
    - sourceline: 'deb http://libgit2deps.edwardthomson.com trusty libgit2deps'
-     key_url: 'https://pgp.mit.edu/pks/lookup?op=get&search=0x5656187599131CD5'
+     key_url: 'https://www.edwardthomson.com/keys/ethomson@libgit2.org'
   packages:
    cmake
    curl


### PR DESCRIPTION
Getting the key from the MIT keyserver is surprisingly unreliable.
Try getting it from my website instead...