### PR TITLE
travis: put clar's sandbox in a ramdisk on macOS

### DIFF
--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -10,6 +10,15 @@ fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	export PKG_CONFIG_PATH=$(ls -d /usr/local/Cellar/{curl,zlib}/*/lib/pkgconfig | paste -s -d':' -)
+
+	# Set up a ramdisk for us to put our test data on to speed up tests on macOS
+	export CLAR_TMP="$HOME"/_clar_tmp
+	mkdir -p $CLAR_TMP
+
+	# 2M sectors aka ~1GB of space
+	device=$(hdiutil attach -nomount ram://$((2 * 1024 * 1024)))
+	newfs_hfs $device
+	mount -t hfs $device $CLAR_TMP
 fi
 
 # Should we ask Travis to cache this file?

--- a/script/cibuild.sh
+++ b/script/cibuild.sh
@@ -15,8 +15,8 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	export CLAR_TMP="$HOME"/_clar_tmp
 	mkdir -p $CLAR_TMP
 
-	# 2M sectors aka ~1GB of space
-	device=$(hdiutil attach -nomount ram://$((2 * 1024 * 1024)))
+	# 5*2M sectors aka ~5GB of space
+	device=$(hdiutil attach -nomount ram://$((5 * 2 * 1024 * 1024)))
 	newfs_hfs $device
 	mount -t hfs $device $CLAR_TMP
 fi


### PR DESCRIPTION
The macOS tests are by far the slowest right now. This attempts to remedy the
situation somewhat by asking clar to put its test data on a ramdisk.