### PR TITLE
appveyor: build examples

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ build_script:
     mkdir build
     cd build
     if ($env:GENERATOR -ne "MSYS Makefiles") {
-      cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON -D MSVC_CRTDBG=ON .. -G"$env:GENERATOR"
+      cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON -D BUILD_EXAMPLES=ON -D MSVC_CRTDBG=ON .. -G"$env:GENERATOR"
       cmake --build . --config Debug
     }
 - cmd: |

--- a/script/appveyor-mingw.sh
+++ b/script/appveyor-mingw.sh
@@ -19,5 +19,5 @@ fi
 cd build
 gcc --version
 cmake --version
-cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON .. -G"$GENERATOR"
+cmake -D ENABLE_TRACE=ON -D BUILD_CLAR=ON -D BUILD_EXAMPLES=ON .. -G"$GENERATOR"
 cmake --build . --config RelWithDebInfo


### PR DESCRIPTION
By default, CMake will not build our examples directory. As we do not
instruct either the MinGW or MSVC builds on AppVeyor to enable building
these examples, we cannot verify that those examples at least build on
Windows systems.

Fix that by passing `-DBUILD_EXAMPLES=ON` to AppVeyor's CMake
invocation.