### PR TITLE
add a more verbose mode to the test runner with better progress reporting

### DIFF
--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -1,19 +1,35 @@
 
 static void clar_print_init(int test_count, int suite_count, const char *suite_names)
 {
-	(void)test_count;
-	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
-	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
+	(void)suite_names;
+	printf("Loaded %d suites, with %d tests, starting\n", suite_count, test_count);
+	printf("test status codes: OK='.' FAILURE='F' SKIPPED='S'\n");
 }
 
-static void clar_print_shutdown(int test_count, int suite_count, int error_count)
+static void clar_print_shutdown(const double evaluation_duration,
+    int test_count, int suite_count, int error_count, int skip_count)
 {
-	(void)test_count;
-	(void)suite_count;
-	(void)error_count;
-
+	int success_count;
 	printf("\n\n");
 	clar_report_errors();
+
+	if (_clar.verbosity > 1) {
+		if (test_count == 0)
+			printf("no tests found");
+		else {
+			printf("\nran %d [", test_count);
+			success_count = test_count - skip_count - error_count;
+			if (success_count)
+				printf("%d passed", success_count);
+			if (skip_count)
+				printf(" %d skipped", skip_count);
+			if (error_count)
+				printf(" %d failed", error_count);
+			printf("] in %d suits", suite_count);
+			printf(" in %.4f seconds", evaluation_duration);
+		}
+		printf("\n");
+	}
 }
 
 static void clar_print_error(int num, const struct clar_error *error)
@@ -37,8 +53,8 @@ static void clar_print_error(int num, const struct clar_error *error)
 
 static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
-	(void)test_name;
-	(void)test_number;
+	if (_clar.verbosity > 1)
+		printf("\n  %s [#%d] ", test_name, test_number);
 
 	switch(status) {
 	case CL_TEST_OK: printf("."); break;
@@ -49,12 +65,13 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	fflush(stdout);
 }
 
-static void clar_print_onsuite(const char *suite_name, int suite_index)
+static void clar_print_onsuite(const char *suite_name, int suite_index, size_t tests_in_suite)
 {
-	if (_clar.report_suite_names)
+	if (_clar.verbosity > 0 || _clar.report_suite_names)
 		printf("\n%s", suite_name);
 
-	(void)suite_index;
+	if (_clar.verbosity > 1)
+		printf(" [#%d with %zu tests]", suite_index, tests_in_suite);
 }
 
 static void clar_print_onabort(const char *msg, ...)

--- a/tests/main.c
+++ b/tests/main.c
@@ -21,9 +21,7 @@ int main(int argc, char *argv[])
 	cl_sandbox_set_search_path_defaults();
 
 	/* Run the test suite */
-	res = clar_test_run();
-
-	clar_test_shutdown();
+	res = clar_test(argc, argv);
 
 	cl_global_trace_disable();
 	git_libgit2_shutdown();


### PR DESCRIPTION
```bash
Loaded 340 suites, with 2504 tests, starting

attr::ignore [#1 with 18 tests]
  honor_temporary_rules [#1] .
  allow_root [#2] .
  ignore_space [#3] .
  ignore_root [#4] .
  full_paths [#5] F
  more_starstar_cases [#6] .
  leading_stars [#7] .
  globs_and_path_delimiters [#8] .
  skip_gitignore_directory [#9] .
  subdirectory_gitignore [#10] .
  expand_tilde_to_homedir [#11] .
  gitignore_in_subdir [#12] .
  dont_ignore_files_for_folder [#13] .
  symlink_to_outside [#14] S
  test [#15] .
  unignore_dir_succeeds [#16] .
  case_insensitive_unignores_previous_rule [#17] .
  case_sensitive_unignore_does_nothing [#18] .

  1) Failure:
attr::ignore::full_paths [C:\Users\berna\git\libgit2\tests\attr\ignore.c:83]
  expected != is_ignored
  0 != 1


ran 18 [16 passed 1 skipped 1 failed] in 1 suits in 2.9370 seconds
```