### PR TITLE
Fix clar to verify command line arguments before execute

### DIFF
--- a/tests/clar.c
+++ b/tests/clar.c
@@ -313,11 +313,18 @@ clar_parse_args(int argc, char **argv)
 {
 	int i;
 
+	/* Verify options before execute */
 	for (i = 1; i < argc; ++i) {
 		char *argument = argv[i];
 
-		if (argument[0] != '-')
+		if (argument[0] != '-' || argument[1] == '\0'
+		    || strchr("sixvqQl", argument[1]) == NULL) {
 			clar_usage(argv[0]);
+		}
+	}
+
+	for (i = 1; i < argc; ++i) {
+		char *argument = argv[i];
 
 		switch (argument[1]) {
 		case 's':
@@ -391,7 +398,7 @@ clar_parse_args(int argc, char **argv)
 			break;
 
 		default:
-			clar_usage(argv[0]);
+			assert(!"Unexpected commandline argument!");
 		}
 	}
 }


### PR DESCRIPTION
Minor fix from git event at Bloomberg London.

Description from the board:

> When executing for example `libgit2_clar -smerge --help`, it will first execute the merge test suite and afterwards output help. This should be improved by first inspecting all parameters and outputting help if it is being requested, exiting without actually executing the test suites.  
