### PR TITLE
merge: reload index before git_merge

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -3239,9 +3239,6 @@ int git_merge(
 
 	assert(repo && their_heads);
 
-	git_repository_index(&index, repo);
-	git_index_read(index, 0);
-
 	if (their_heads_len != 1) {
 		giterr_set(GITERR_MERGE, "can only merge a single branch");
 		return -1;
@@ -3256,6 +3253,10 @@ int git_merge(
 
 	if ((error = git_indexwriter_init_for_operation(&indexwriter, repo,
 		&checkout_strategy)) < 0)
+		goto done;
+
+	if ((error = git_repository_index(&index, repo) < 0) ||
+	    (error = git_index_read(index, 0) < 0))
 		goto done;
 
 	/* Write the merge setup files to the repository. */

--- a/src/merge.c
+++ b/src/merge.c
@@ -3239,6 +3239,9 @@ int git_merge(
 
 	assert(repo && their_heads);
 
+	git_repository_index(&index, repo);
+	git_index_read(index, 0);
+
 	if (their_heads_len != 1) {
 		giterr_set(GITERR_MERGE, "can only merge a single branch");
 		return -1;

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -168,6 +168,35 @@ void test_merge_workdir_simple__automerge(void)
 	git_index_free(index);
 }
 
+void test_merge_workdir_simple__index_reload(void)
+{
+	git_repository *tmp_repo;
+	git_annotated_commit *their_heads[1];
+	git_oid their_oid;
+	git_index_entry entry = {{0}};
+	git_index *tmp_index;
+
+	cl_git_pass(git_repository_open(&tmp_repo, git_repository_workdir(repo)));
+	cl_git_pass(git_repository_index(&tmp_index, tmp_repo));
+	cl_git_pass(git_index_read(repo_index, 0));
+
+	entry.mode = GIT_FILEMODE_BLOB;
+	cl_git_pass(git_oid_fromstr(&entry.id, "11deab00b2d3a6f5a3073988ac050c2d7b6655e2"));
+	entry.path = "automergeable.txt";
+	cl_git_pass(git_index_add(repo_index, &entry));
+
+	cl_git_pass(git_index_add_bypath(tmp_index, "automergeable.txt"));
+	cl_git_pass(git_index_write(tmp_index));
+
+	cl_git_pass(git_oid_fromstr(&their_oid, THEIRS_SIMPLE_OID));
+	cl_git_pass(git_annotated_commit_lookup(&their_heads[0], repo, &their_oid));
+	cl_git_pass(git_merge(repo, (const git_annotated_commit **)their_heads, 1, NULL, NULL));
+
+	git_index_free(tmp_index);
+	git_repository_free(tmp_repo);
+	git_annotated_commit_free(their_heads[0]);
+}
+
 void test_merge_workdir_simple__automerge_crlf(void)
 {
 #ifdef GIT_WIN32


### PR DESCRIPTION
When the index in memory diverges from the index in disk `git_merge`
aborts with `GIT_ECONFLICT`. More details about this are found in the 
issue #4203, which this PR attempts to fix.

A further discussion is needed wether this behaviour is actually desired.
(Suppose someone actually is writing something to the index in memory
and a concurrent task is merging. A possible argument is that the index
should be written to disk then.)

Closes #4203 