### PR TITLE
add test status codes legend to the 'Started' test trace

### DIFF
--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -3,7 +3,7 @@ static void clar_print_init(int test_count, int suite_count, const char *suite_n
 {
 	(void)test_count;
 	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
-	printf("Started\n");
+	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
 
 static void clar_print_shutdown(int test_count, int suite_count, int error_count)


### PR DESCRIPTION
motivation: (for someone new to the tests) it's puzzling to find the odd 'S' interspersed in the test output

proposed alternative test output (extract):

$ cmake --build . && ./libgit2_clar -srepo -v
...
Loaded 340 suites:
Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')

repo::config...
repo::discover..........
repo::env.
repo::getters...
repo::hashfile..
repo::head......................
repo::headtree....
repo::init.........................S
repo::message..
repo::new..
repo::open.............
repo::pathspec..........
repo::reservedname.....
repo::setters.....
repo::shallow....
repo::state.............