### PR TITLE
WIP: travis: fail on memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
 
 # Run Tests
 after_success:
- - if [ "$TRAVIS_OS_NAME" = "linux" -a -n "$VALGRIND" ]; then valgrind --leak-check=full --show-reachable=yes --suppressions=./libgit2_clar.supp _build/libgit2_clar -ionline; fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" -a -n "$VALGRIND" ]; then valgrind --leak-check=full --show-reachable=yes --error-exitcode=125 --suppressions=./libgit2_clar.supp _build/libgit2_clar -ionline; fi
 
 # Only watch the development and master branches
 branches:


### PR DESCRIPTION
Pass `--error-exitcode=125` to valgrind so that it will exit with a non-zero exit code when it detects a memory leak.  Use an exit code of `125` to stay safely above any clar errors and safely below any shell errors.

**Note**: I suspect that there are some tests that we'll need to either exclude from valgrind's examination, or perhaps not run at all.