### PR TITLE
Re-enable the RC4 test

### DIFF
--- a/tests/online/badssl.c
+++ b/tests/online/badssl.c
@@ -70,8 +70,6 @@ void test_online_badssl__old_cipher(void)
 	if (!g_has_ssl)
 		cl_skip();
 
-	cl_git_fail_with(GIT_ECERTIFICATE,
-			 git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
-	cl_git_fail_with(GIT_ECERTIFICATE,
-			 git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", &opts));
+	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
+	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", &opts));
 }

--- a/tests/online/badssl.c
+++ b/tests/online/badssl.c
@@ -67,9 +67,6 @@ void test_online_badssl__old_cipher(void)
 	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
 	opts.fetch_opts.callbacks.certificate_check = cert_check_assert_invalid;
 
-	/* FIXME: we don't actually reject RC4 anywhere, figure out what to tweak */
-	cl_skip();
-
 	if (!g_has_ssl)
 		cl_skip();
 


### PR DESCRIPTION
We disabled this test while dealing with a security issue. Enable it again and make the error handling in the OpenSSL stream let us return the actual error due to trying to talk to RC4.

`GIT_ECERTIFICATE` is likely not _really_ the right thing to return here since it's not really about the certificate but about not supporting our cipherlist. We will likely want a specific error code for this (or we can overload this one, but TLS is confusing enough as it is).