### PR TITLE
Include git2/worktree.h in git2.h

### DIFF
--- a/include/git2.h
+++ b/include/git2.h
@@ -62,5 +62,6 @@
 #include "git2/tree.h"
 #include "git2/types.h"
 #include "git2/version.h"
+#include "git2/worktree.h"
 
 #endif


### PR DESCRIPTION
I'm not sure if worktree.h was intentionally left out of git2.h. Looks like an oversight since it is in fact documented.