### PR TITLE
Use the same cert checking payload in WinHTTP

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -269,7 +269,7 @@ static int certificate_check(winhttp_stream *s, int valid)
 	cert.parent.cert_type = GIT_CERT_X509;
 	cert.data = cert_ctx->pbCertEncoded;
 	cert.len = cert_ctx->cbCertEncoded;
-	error = t->owner->certificate_check_cb((git_cert *) &cert, valid, t->connection_data.host, t->owner->cred_acquire_payload);
+	error = t->owner->certificate_check_cb((git_cert *) &cert, valid, t->connection_data.host, t->owner->message_cb_payload);
 	CertFreeCertificateContext(cert_ctx);
 
 	if (error < 0 && !giterr_last())


### PR DESCRIPTION
As recently discussed in Slack, this makes the WinHTTP transport use the same user-specified payload as the other transports.