### PR TITLE
diff_generate: fix unsetting diff flags

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -13,13 +13,6 @@
 #include "commit.h"
 #include "index.h"
 
-#define DIFF_FLAG_IS_SET(DIFF,FLAG) \
-	(((DIFF)->opts.flags & (FLAG)) != 0)
-#define DIFF_FLAG_ISNT_SET(DIFF,FLAG) \
-	(((DIFF)->opts.flags & (FLAG)) == 0)
-#define DIFF_FLAG_SET(DIFF,FLAG,VAL) (DIFF)->opts.flags = \
-	(VAL) ? ((DIFF)->opts.flags | (FLAG)) : ((DIFF)->opts.flags & ~(VAL))
-
 struct patch_id_args {
 	git_hash_ctx ctx;
 	git_oid result;

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -24,7 +24,7 @@
 	(((DIFF)->base.opts.flags & (FLAG)) == 0)
 #define DIFF_FLAG_SET(DIFF,FLAG,VAL) (DIFF)->base.opts.flags = \
 	(VAL) ? ((DIFF)->base.opts.flags | (FLAG)) : \
-	((DIFF)->base.opts.flags & ~(VAL))
+	((DIFF)->base.opts.flags & ~(FLAG))
 
 typedef struct {
 	struct git_diff base;


### PR DESCRIPTION
The macro `DIFF_FLAG_SET` can be used to set or unset a flag by
modifying the diff's bitmask. While the case of setting the flag is
handled correctly, the case of unsetting the flag was not. Instead of
inverting the flags, we are inverting the value which is used to decide
whether we want to set or unset the bits.

The value being used here is a simple `bool` which is `false`. As that
is being uplifted to `int` when getting the bitwise-complement, we will
end up retaining all bits inside of the bitmask. As that's only ever
used to set `GIT_DIFF_IGNORE_CASE`, we were actually always ignoring
case for generated diffs.

Fix that by instead getting the bitwise-complement of `FLAG`, not `VAL`.