### PR TITLE
Free OpenSSL peer certificate

### DIFF
--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -341,7 +341,7 @@ static int verify_server_cert(SSL *ssl, const char *host)
 	struct in6_addr addr6;
 	struct in_addr addr4;
 	void *addr;
-	int i = -1,j;
+	int i = -1, j, error = 0;
 
 	if (SSL_get_verify_result(ssl) != X509_V_OK) {
 		giterr_set(GITERR_SSL, "the SSL certificate is invalid");
@@ -362,8 +362,9 @@ static int verify_server_cert(SSL *ssl, const char *host)
 
 	cert = SSL_get_peer_certificate(ssl);
 	if (!cert) {
+		error = -1;
 		giterr_set(GITERR_SSL, "the server did not provide a certificate");
-		return -1;
+		goto cleanup;
 	}
 
 	/* Check the alternative names */
@@ -401,8 +402,9 @@ static int verify_server_cert(SSL *ssl, const char *host)
 	if (matched == 0)
 		goto cert_fail_name;
 
-	if (matched == 1)
-		return 0;
+	if (matched == 1) {
+		goto cleanup;
+	}
 
 	/* If no alternative names are available, check the common name */
 	peer_name = X509_get_subject_name(cert);
@@ -444,18 +446,20 @@ static int verify_server_cert(SSL *ssl, const char *host)
 	if (check_host_name((char *)peer_cn, host) < 0)
 		goto cert_fail_name;
 
-	OPENSSL_free(peer_cn);
-
-	return 0;
-
-on_error:
-	OPENSSL_free(peer_cn);
-	return ssl_set_error(ssl, 0);
+	goto cleanup;
 
 cert_fail_name:
-	OPENSSL_free(peer_cn);
+	error = GIT_ECERTIFICATE;
 	giterr_set(GITERR_SSL, "hostname does not match certificate");
-	return GIT_ECERTIFICATE;
+	goto cleanup;
+
+on_error:
+	error = ssl_set_error(ssl, 0);
+	goto cleanup;
+
+cleanup:
+	OPENSSL_free(peer_cn);
+	return error;
 }
 
 typedef struct {

--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -332,7 +332,7 @@ static int check_host_name(const char *name, const char *host)
 
 static int verify_server_cert(SSL *ssl, const char *host)
 {
-	X509 *cert;
+	X509 *cert = NULL;
 	X509_NAME *peer_name;
 	ASN1_STRING *str;
 	unsigned char *peer_cn = NULL;
@@ -458,6 +458,7 @@ on_error:
 	goto cleanup;
 
 cleanup:
+	X509_free(cert);
 	OPENSSL_free(peer_cn);
 	return error;
 }


### PR DESCRIPTION
First commit adds more gotos for "simplicity" (sorry about that :wink:).

I happened to stumble onto the documentation while investigating something else. Per SSL_get_peer_certificate docs:

```
The reference count of the X509 object is incremented by one, so that
it will not be destroyed when the session containing the peer certificate
is freed. The X509 object must be explicitly freed using X509_free().
```