### PR TITLE
libFuzzer: Fix a git_packfile_stream leak

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -1119,6 +1119,9 @@ void git_indexer_free(git_indexer *idx)
 	if (idx == NULL)
 		return;
 
+	if (idx->have_stream)
+		git_packfile_stream_free(&idx->stream);
+
 	git_vector_free_deep(&idx->objects);
 
 	if (idx->pack->idx_cache) {


### PR DESCRIPTION
This change ensures that the git_packfile_stream object in
git_indexer_append() does not leak when the stream has errors.

Found using libFuzzer.