### PR TITLE
libFuzzer: Prevent a potential shift overflow

### DIFF
--- a/src/pack.c
+++ b/src/pack.c
@@ -934,18 +934,20 @@ git_off_t get_delta_base(
 	if (type == GIT_OBJ_OFS_DELTA) {
 		unsigned used = 0;
 		unsigned char c = base_info[used++];
-		base_offset = c & 127;
+		size_t unsigned_base_offset = c & 127;
 		while (c & 128) {
 			if (left <= used)
 				return GIT_EBUFS;
-			base_offset += 1;
-			if (!base_offset || MSB(base_offset, 8))
+			unsigned_base_offset += 1;
+			if (!unsigned_base_offset || MSB(unsigned_base_offset, 7))
 				return 0; /* overflow */
 			c = base_info[used++];
-			base_offset = (base_offset << 7) + (c & 127);
+			unsigned_base_offset = (unsigned_base_offset << 7) + (c & 127);
 		}
-		base_offset = delta_obj_offset - base_offset;
-		if (base_offset <= 0 || base_offset >= delta_obj_offset)
+		if ((size_t)delta_obj_offset <= unsigned_base_offset)
+			return 0; /* out of bound */
+		base_offset = delta_obj_offset - unsigned_base_offset;
+		if (base_offset >= delta_obj_offset)
 			return 0; /* out of bound */
 		*curpos += used;
 	} else if (type == GIT_OBJ_REF_DELTA) {

--- a/src/pack.c
+++ b/src/pack.c
@@ -944,11 +944,9 @@ git_off_t get_delta_base(
 			c = base_info[used++];
 			unsigned_base_offset = (unsigned_base_offset << 7) + (c & 127);
 		}
-		if ((size_t)delta_obj_offset <= unsigned_base_offset)
+		if (unsigned_base_offset == 0 || (size_t)delta_obj_offset <= unsigned_base_offset)
 			return 0; /* out of bound */
 		base_offset = delta_obj_offset - unsigned_base_offset;
-		if (base_offset >= delta_obj_offset)
-			return 0; /* out of bound */
 		*curpos += used;
 	} else if (type == GIT_OBJ_REF_DELTA) {
 		/* If we have the cooperative cache, search in it first */

--- a/src/pack.c
+++ b/src/pack.c
@@ -939,7 +939,7 @@ git_off_t get_delta_base(
 			if (left <= used)
 				return GIT_EBUFS;
 			base_offset += 1;
-			if (!base_offset || MSB(base_offset, 7))
+			if (!base_offset || MSB(base_offset, 8))
 				return 0; /* overflow */
 			c = base_info[used++];
 			base_offset = (base_offset << 7) + (c & 127);


### PR DESCRIPTION
The type of |base_offset| in get_delta_base() is `git_off_t`, which is a
signed `long`. That means that we need to make sure that the 8 most
significant bits are zero (instead of 7) to avoid an overflow when it is
shifted by 7 bits.

Found using libFuzzer.