### PR TITLE
pack: rename `git_packfile_stream_free`

### DIFF
--- a/examples/diff.c
+++ b/examples/diff.c
@@ -332,6 +332,6 @@ static void diff_print_stats(git_diff *diff, struct opts *o)
 
 	fputs(b.ptr, stdout);
 
-	git_buf_free(&b);
+	git_buf_dispose(&b);
 	git_diff_stats_free(stats);
 }

--- a/examples/remote.c
+++ b/examples/remote.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 
 	check_lg2(git_repository_open(&repo, buf.ptr),
 		"Could not open repository", NULL);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	switch (opt.cmd)
 	{

--- a/examples/tag.c
+++ b/examples/tag.c
@@ -184,7 +184,7 @@ static void action_delete_tag(tag_state *state)
 
 	printf("Deleted tag '%s' (was %s)\n", opts->tag_name, abbrev_oid.ptr);
 
-	git_buf_free(&abbrev_oid);
+	git_buf_dispose(&abbrev_oid);
 	git_object_free(obj);
 }
 

--- a/include/git2/buffer.h
+++ b/include/git2/buffer.h
@@ -69,7 +69,19 @@ typedef struct {
  *
  * @param buffer The buffer to deallocate
  */
-GIT_EXTERN(void) git_buf_free(git_buf *buffer);
+GIT_EXTERN(void) git_buf_dispose(git_buf *buffer);
+
+/**
+ * Alias of `git_buf_dispose`.
+ *
+ * This function is directly calls `git_buf_dispose` now and is deprecated.
+ * Going forward, we refer to functions freeing the internal state of a
+ * structure a `dispose` function, while functions freeing the structure
+ * themselves will be called a `free` function.
+ *
+ * This function is going to be removed in v0.30.0.
+ */
+GIT_EXTERN(void) GIT_DEPRECATED(git_buf_free)(git_buf *buffer);
 
 /**
  * Resize the buffer allocation to make more space.

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -48,6 +48,17 @@ typedef size_t size_t;
 # define GIT_EXTERN(type) extern type
 #endif
 
+/** Declare a function as deprecated. */
+#if defined(__GNUC__)
+# define GIT_DEPRECATED(func) \
+			 __attribute__((deprecated)) \
+			 func
+#elif defined(_MSC_VER)
+# define GIT_DEPRECATED(func) __declspec(deprecated) func
+#else
+# define GIT_DEPRECATED(func) func
+#endif
+
 /** Declare a function's takes printf style arguments. */
 #ifdef __GNUC__
 # define GIT_FORMAT_PRINTF(a,b) __attribute__((format (printf, a, b)))

--- a/src/apply.c
+++ b/src/apply.c
@@ -255,7 +255,7 @@ static int apply_binary_delta(
 
 	if (!error && inflated.size != binary_file->inflatedlen) {
 		error = apply_err("inflated delta does not match expected length");
-		git_buf_free(out);
+		git_buf_dispose(out);
 	}
 
 	if (error < 0)
@@ -281,7 +281,7 @@ static int apply_binary_delta(
 	}
 
 done:
-	git_buf_free(&inflated);
+	git_buf_dispose(&inflated);
 	return error;
 }
 
@@ -320,9 +320,9 @@ static int apply_binary(
 
 done:
 	if (error < 0)
-		git_buf_free(out);
+		git_buf_dispose(out);
 
-	git_buf_free(&reverse);
+	git_buf_dispose(&reverse);
 	return error;
 }
 

--- a/src/attr.c
+++ b/src/attr.c
@@ -298,7 +298,7 @@ static int system_attr_file(
 
 	/* We can safely provide a git_buf with no allocation (asize == 0) to
 	 * a consumer. This allows them to treat this as a regular `git_buf`,
-	 * but their call to `git_buf_free` will not attempt to free it.
+	 * but their call to `git_buf_dispose` will not attempt to free it.
 	 */
 	git_buf_attach_notowned(
 		out, attr_session->sysdir.ptr, attr_session->sysdir.size);
@@ -359,7 +359,7 @@ static int attr_setup(git_repository *repo, git_attr_session *attr_session)
 		attr_session->init_setup = 1;
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -565,8 +565,8 @@ static int collect_attr_files(
  cleanup:
 	if (error < 0)
 		release_attr_files(files);
-	git_buf_free(&attrfile);
-	git_buf_free(&dir);
+	git_buf_dispose(&attrfile);
+	git_buf_dispose(&dir);
 
 	return error;
 }

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -178,7 +178,7 @@ int git_attr_file__load(
 
 cleanup:
 	git_blob_free(blob);
-	git_buf_free(&content);
+	git_buf_dispose(&content);
 
 	return error;
 }
@@ -348,7 +348,7 @@ int git_attr_file__load_standalone(git_attr_file **out, const char *path)
 
 	if (!(error = git_futils_readbuffer(&content, path))) {
 		error = git_attr_file__parse_buffer(NULL, file, content.ptr);
-		git_buf_free(&content);
+		git_buf_dispose(&content);
 	}
 
 	if (error < 0)
@@ -518,7 +518,7 @@ int git_attr_path__init(
 
 void git_attr_path__free(git_attr_path *info)
 {
-	git_buf_free(&info->full);
+	git_buf_dispose(&info->full);
 	info->path = NULL;
 	info->basename = NULL;
 }
@@ -875,8 +875,8 @@ void git_attr_session__free(git_attr_session *session)
 	if (!session)
 		return;
 
-	git_buf_free(&session->sysdir);
-	git_buf_free(&session->tmp);
+	git_buf_dispose(&session->sysdir);
+	git_buf_dispose(&session->tmp);
 
 	memset(session, 0, sizeof(git_attr_session));
 }

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -204,7 +204,7 @@ cleanup:
 	*out_file  = file;
 	*out_entry = entry;
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return error;
 }
 
@@ -310,7 +310,7 @@ static int attr_cache__lookup_path(
 	}
 
 	git_config_entry_free(entry);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }

--- a/src/blob.c
+++ b/src/blob.c
@@ -126,7 +126,7 @@ static int write_file_filtered(
 		error = git_odb_write(id, odb, tgt.ptr, tgt.size, GIT_OBJ_BLOB);
 	}
 
-	git_buf_free(&tgt);
+	git_buf_dispose(&tgt);
 	return error;
 }
 
@@ -238,7 +238,7 @@ int git_blob__create_from_paths(
 
 done:
 	git_odb_free(odb);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -257,7 +257,7 @@ int git_blob_create_fromdisk(
 	const char *workdir, *hintpath;
 
 	if ((error = git_path_prettify(&full_path, path, NULL)) < 0) {
-		git_buf_free(&full_path);
+		git_buf_dispose(&full_path);
 		return error;
 	}
 
@@ -270,7 +270,7 @@ int git_blob_create_fromdisk(
 	error = git_blob__create_from_paths(
 		id, NULL, repo, git_buf_cstr(&full_path), hintpath, 0, true);
 
-	git_buf_free(&full_path);
+	git_buf_dispose(&full_path);
 	return error;
 }
 
@@ -340,7 +340,7 @@ cleanup:
 	if (error < 0)
 		blob_writestream_free((git_writestream *) stream);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return error;
 }
 

--- a/src/branch.c
+++ b/src/branch.c
@@ -40,7 +40,7 @@ static int retrieve_branch_reference(
 
 	*branch_reference_out = branch; /* will be NULL on error */
 
-	git_buf_free(&ref_name);
+	git_buf_dispose(&ref_name);
 	return error;
 }
 
@@ -108,8 +108,8 @@ static int create_branch(
 		*ref_out = branch;
 
 cleanup:
-	git_buf_free(&canonical_branch_name);
-	git_buf_free(&log_message);
+	git_buf_dispose(&canonical_branch_name);
+	git_buf_dispose(&log_message);
 	return error;
 }
 
@@ -199,7 +199,7 @@ int git_branch_delete(git_reference *branch)
 	error = git_reference_delete(branch);
 
 on_error:
-	git_buf_free(&config_section);
+	git_buf_dispose(&config_section);
 	return error;
 }
 
@@ -310,10 +310,10 @@ int git_branch_move(
 		git_buf_cstr(&new_config_section));
 
 done:
-	git_buf_free(&new_reference_name);
-	git_buf_free(&old_config_section);
-	git_buf_free(&new_config_section);
-	git_buf_free(&log_message);
+	git_buf_dispose(&new_reference_name);
+	git_buf_dispose(&old_config_section);
+	git_buf_dispose(&new_config_section);
+	git_buf_dispose(&log_message);
 
 	return error;
 }
@@ -366,7 +366,7 @@ static int retrieve_upstream_configuration(
 			return -1;
 
 	error = git_config_get_string_buf(out, config, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -429,9 +429,9 @@ int git_branch_upstream_name(
 cleanup:
 	git_config_free(config);
 	git_remote_free(remote);
-	git_buf_free(&remote_name);
-	git_buf_free(&merge_name);
-	git_buf_free(&buf);
+	git_buf_dispose(&remote_name);
+	git_buf_dispose(&merge_name);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -522,7 +522,7 @@ int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refna
 
 cleanup:
 	if (error < 0)
-		git_buf_free(buf);
+		git_buf_dispose(buf);
 
 	git_strarray_free(&remote_list);
 	return error;
@@ -544,7 +544,7 @@ int git_branch_upstream(
 		git_reference_owner(branch),
 		git_buf_cstr(&tracking_name));
 
-	git_buf_free(&tracking_name);
+	git_buf_dispose(&tracking_name);
 	return error;
 }
 
@@ -565,11 +565,11 @@ static int unset_upstream(git_config *config, const char *shortname)
 	if (git_config_delete_entry(config, git_buf_cstr(&buf)) < 0)
 		goto on_error;
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return 0;
 
 on_error:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return -1;
 }
 
@@ -655,15 +655,15 @@ int git_branch_set_upstream(git_reference *branch, const char *upstream_name)
 		goto on_error;
 
 	git_reference_free(upstream);
-	git_buf_free(&key);
-	git_buf_free(&value);
+	git_buf_dispose(&key);
+	git_buf_dispose(&value);
 
 	return 0;
 
 on_error:
 	git_reference_free(upstream);
-	git_buf_free(&key);
-	git_buf_free(&value);
+	git_buf_dispose(&key);
+	git_buf_dispose(&value);
 	git_remote_free(remote);
 
 	return -1;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -116,7 +116,7 @@ int git_buf_grow_by(git_buf *buffer, size_t additional_size)
 	return git_buf_try_grow(buffer, newsize, true);
 }
 
-void git_buf_free(git_buf *buf)
+void git_buf_dispose(git_buf *buf)
 {
 	if (!buf) return;
 
@@ -124,6 +124,11 @@ void git_buf_free(git_buf *buf)
 		git__free(buf->ptr);
 
 	git_buf_init(buf, 0);
+}
+
+void git_buf_free(git_buf *buf)
+{
+	git_buf_dispose(buf);
 }
 
 void git_buf_sanitize(git_buf *buf)

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -615,7 +615,7 @@ char *git_buf_detach(git_buf *buf)
 
 int git_buf_attach(git_buf *buf, char *ptr, size_t asize)
 {
-	git_buf_free(buf);
+	git_buf_dispose(buf);
 
 	if (ptr) {
 		buf->ptr = ptr;
@@ -633,7 +633,7 @@ int git_buf_attach(git_buf *buf, char *ptr, size_t asize)
 void git_buf_attach_notowned(git_buf *buf, const char *ptr, size_t size)
 {
 	if (git_buf_is_allocated(buf))
-		git_buf_free(buf);
+		git_buf_dispose(buf);
 
 	if (!size) {
 		git_buf_init(buf, 0);
@@ -954,7 +954,7 @@ int git_buf_quote(git_buf *buf)
 	git_buf_swap(&quoted, buf);
 
 done:
-	git_buf_free(&quoted);
+	git_buf_dispose(&quoted);
 	return error;
 }
 

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1604,7 +1604,7 @@ static int blob_content_to_link(
 		st->st_mode = GIT_FILEMODE_LINK;
 	}
 
-	git_buf_free(&linktarget);
+	git_buf_dispose(&linktarget);
 
 	return error;
 }
@@ -2161,13 +2161,13 @@ static int checkout_write_merge(
 done:
 	git_filter_list_free(fl);
 
-	git_buf_free(&out_data);
-	git_buf_free(&our_label);
-	git_buf_free(&their_label);
+	git_buf_dispose(&out_data);
+	git_buf_dispose(&our_label);
+	git_buf_dispose(&their_label);
 
 	git_merge_file_result_free(&result);
-	git_buf_free(&path_workdir);
-	git_buf_free(&path_suffixed);
+	git_buf_dispose(&path_workdir);
+	git_buf_dispose(&path_suffixed);
 
 	return error;
 }
@@ -2347,8 +2347,8 @@ static void checkout_data_clear(checkout_data *data)
 	git__free(data->pfx);
 	data->pfx = NULL;
 
-	git_buf_free(&data->target_path);
-	git_buf_free(&data->tmp);
+	git_buf_dispose(&data->target_path);
+	git_buf_dispose(&data->tmp);
 
 	git_index_free(data->index);
 	data->index = NULL;

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -37,7 +37,7 @@ static int write_cherrypick_head(
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -61,7 +61,7 @@ cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -216,7 +216,7 @@ done:
 	git_index_free(index);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);
-	git_buf_free(&their_label);
+	git_buf_dispose(&their_label);
 
 	return error;
 }

--- a/src/clone.c
+++ b/src/clone.c
@@ -48,7 +48,7 @@ static int create_branch(
 		return error;
 
 	error = git_reference_create(&branch_ref, repo, git_buf_cstr(&refname), target, 0, log_message);
-	git_buf_free(&refname);
+	git_buf_dispose(&refname);
 	git_commit_free(head_obj);
 
 	if (!error)
@@ -87,8 +87,8 @@ static int setup_tracking_config(
 	error = 0;
 
 cleanup:
-	git_buf_free(&remote_key);
-	git_buf_free(&merge_key);
+	git_buf_dispose(&remote_key);
+	git_buf_dispose(&merge_key);
 	return error;
 }
 
@@ -195,8 +195,8 @@ static int update_head_to_remote(
 		reflog_message);
 
 cleanup:
-	git_buf_free(&remote_master_name);
-	git_buf_free(&branch);
+	git_buf_dispose(&remote_master_name);
+	git_buf_dispose(&branch);
 
 	return error;
 }
@@ -225,7 +225,7 @@ static int update_head_to_branch(
 
 cleanup:
 	git_reference_free(remote_ref);
-	git_buf_free(&remote_branch_name);
+	git_buf_dispose(&remote_branch_name);
 	return retcode;
 }
 
@@ -351,7 +351,7 @@ static int clone_into(git_repository *repo, git_remote *_remote, const git_fetch
 
 cleanup:
 	git_remote_free(remote);
-	git_buf_free(&reflog_message);
+	git_buf_dispose(&reflog_message);
 
 	return error;
 }
@@ -378,7 +378,7 @@ int git_clone__should_clone_local(const char *url_or_path, git_clone_local_t loc
 		git_path_isdir(path);
 
 done:
-	git_buf_free(&fromurl);
+	git_buf_dispose(&fromurl);
 	return is_local;
 }
 
@@ -510,7 +510,7 @@ static int clone_local_into(git_repository *repo, git_remote *remote, const git_
 
 	/* Copy .git/objects/ from the source to the target */
 	if ((error = git_repository_open(&src, git_buf_cstr(&src_path))) < 0) {
-		git_buf_free(&src_path);
+		git_buf_dispose(&src_path);
 		return error;
 	}
 
@@ -549,10 +549,10 @@ static int clone_local_into(git_repository *repo, git_remote *remote, const git_
 	error = checkout_branch(repo, remote, co_opts, branch, git_buf_cstr(&reflog_message));
 
 cleanup:
-	git_buf_free(&reflog_message);
-	git_buf_free(&src_path);
-	git_buf_free(&src_odb);
-	git_buf_free(&dst_odb);
+	git_buf_dispose(&reflog_message);
+	git_buf_dispose(&src_path);
+	git_buf_dispose(&src_odb);
+	git_buf_dispose(&dst_odb);
 	git_repository_free(src);
 	return error;
 }

--- a/src/commit.c
+++ b/src/commit.c
@@ -74,7 +74,7 @@ static int git_commit__create_buffer_internal(
 	return 0;
 
 on_error:
-	git_buf_free(out);
+	git_buf_dispose(out);
 	return -1;
 }
 
@@ -176,7 +176,7 @@ static int git_commit__create_internal(
 cleanup:
 	git_array_clear(parents);
 	git_reference_free(ref);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -886,6 +886,6 @@ int git_commit_create_with_signature(
 		goto cleanup;
 
 cleanup:
-	git_buf_free(&commit);
+	git_buf_dispose(&commit);
 	return error;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -1164,7 +1164,7 @@ int git_config_open_default(git_config **out)
 		error = git_config_add_file_ondisk(cfg, buf.ptr,
 			GIT_CONFIG_LEVEL_PROGRAMDATA, NULL, 0);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (error) {
 		git_config_free(cfg);
@@ -1478,8 +1478,8 @@ int git_config_rename_section(
 		config, git_buf_cstr(&pattern), rename_config_entries_cb, &data);
 
 cleanup:
-	git_buf_free(&pattern);
-	git_buf_free(&replace);
+	git_buf_dispose(&pattern);
+	git_buf_dispose(&replace);
 
 	return error;
 }

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -300,7 +300,7 @@ static int config_is_modified(int *modified, struct config_file *file)
 	}
 
 out:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -688,7 +688,7 @@ static int config_unlock(git_config_backend *_cfg, int success)
 	}
 
 	git_filebuf_cleanup(&cfg->locked_buf);
-	git_buf_free(&cfg->locked_content);
+	git_buf_dispose(&cfg->locked_content);
 	cfg->locked = false;
 
 	return error;
@@ -877,7 +877,7 @@ static char *escape_value(const char *ptr)
 	}
 
 	if (git_buf_oom(&buf)) {
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		return NULL;
 	}
 
@@ -956,7 +956,7 @@ static int do_match_gitdir(
 	*matches = (error == 0);
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return error;
 }
 
@@ -1111,7 +1111,7 @@ static int config_read(
 	error = git_config_parse(&reader, NULL, read_on_variable, NULL, NULL, &parse_data);
 
 out:
-	git_buf_free(&contents);
+	git_buf_dispose(&contents);
 	return error;
 }
 
@@ -1140,7 +1140,7 @@ static int write_section(git_buf *fbuf, const char *key)
 		return -1;
 
 	result = git_buf_put(fbuf, git_buf_cstr(&buf), buf.size);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return result;
 }
@@ -1359,7 +1359,7 @@ static int config_write(diskfile_backend *cfg, const char *orig_key, const char 
 		/* Lock the file */
 		if ((result = git_filebuf_open(
 			     &file, cfg->file.path, GIT_FILEBUF_HASH_CONTENTS, GIT_CONFIG_FILE_MODE)) < 0) {
-			git_buf_free(&contents);
+			git_buf_dispose(&contents);
 			return result;
 		}
 
@@ -1404,7 +1404,7 @@ static int config_write(diskfile_backend *cfg, const char *orig_key, const char 
 		&write_data);
 	git__free(section);
 	git__free(orig_section);
-	git_buf_free(&write_data.buffered_comment);
+	git_buf_dispose(&write_data.buffered_comment);
 
 	if (result < 0) {
 		git_filebuf_cleanup(&file);
@@ -1414,7 +1414,7 @@ static int config_write(diskfile_backend *cfg, const char *orig_key, const char 
 	if (cfg->locked) {
 		size_t len = buf.asize;
 		/* Update our copy with the modified contents */
-		git_buf_free(&cfg->locked_content);
+		git_buf_dispose(&cfg->locked_content);
 		git_buf_attach(&cfg->locked_content, git_buf_detach(&buf), len);
 	} else {
 		git_filebuf_write(&file, git_buf_cstr(&buf), git_buf_len(&buf));
@@ -1422,8 +1422,8 @@ static int config_write(diskfile_backend *cfg, const char *orig_key, const char 
 	}
 
 done:
-	git_buf_free(&buf);
-	git_buf_free(&contents);
+	git_buf_dispose(&buf);
+	git_buf_dispose(&contents);
 	git_parse_ctx_clear(&reader.ctx);
 	return result;
 }

--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -130,7 +130,7 @@ end_parse:
 
 	if (line[rpos] != '"' || line[rpos + 1] != ']') {
 		set_parse_error(reader, rpos, "Unexpected text after closing quotes");
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		return -1;
 	}
 
@@ -138,7 +138,7 @@ end_parse:
 	return 0;
 
 end_error:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return -1;
 }
@@ -437,7 +437,7 @@ static int parse_variable(git_config_parser *reader, char **var_name, char **var
 
 			if (parse_multiline_variable(reader, &multi_value, quote_count) < 0 ||
 				git_buf_oom(&multi_value)) {
-				git_buf_free(&multi_value);
+				git_buf_dispose(&multi_value);
 				goto on_error;
 			}
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -439,7 +439,7 @@ static int file_cb(
 		goto out;
 
 out:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -477,7 +477,7 @@ static int line_cb(
 		goto out;
 
 out:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -121,7 +121,7 @@ static int diff_driver_add_patterns(
 
 	if (error && pat != NULL)
 		(void)git_array_pop(drv->fn_patterns); /* release last item */
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* We want to ignore bad patterns, so return success regardless */
 	return 0;
@@ -338,7 +338,7 @@ static int git_diff_driver_load(
 
 done:
 	git_config_entry_free(ce);
-	git_buf_free(&name);
+	git_buf_dispose(&name);
 	git_config_free(cfg);
 
 	if (!*out) {
@@ -516,7 +516,7 @@ void git_diff_find_context_init(
 void git_diff_find_context_clear(git_diff_find_context_payload *payload)
 {
 	if (payload) {
-		git_buf_free(&payload->line);
+		git_buf_dispose(&payload->line);
 		payload->driver = NULL;
 	}
 }

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -280,7 +280,7 @@ static int diff_file_content_load_workdir_symlink_fake(
 	fc->map.data = git_buf_detach(&target);
 	fc->flags |= GIT_DIFF_FLAG__FREE_DATA;
 
-	git_buf_free(&target);
+	git_buf_dispose(&target);
 	return error;
 }
 
@@ -361,7 +361,7 @@ static int diff_file_content_load_workdir_file(
 		error = git_filter_list_apply_to_data(&out, fl, &raw);
 
 		if (out.ptr != raw.ptr)
-			git_buf_free(&raw);
+			git_buf_dispose(&raw);
 
 		if (!error) {
 			fc->map.len  = out.size;
@@ -406,7 +406,7 @@ static int diff_file_content_load_workdir(
 		fc->file->flags |= GIT_DIFF_FLAG_VALID_ID;
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return error;
 }
 

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -600,7 +600,7 @@ int git_diff__oid_for_entry(
 
 		if (p_stat(full_path.ptr, &st) < 0) {
 			error = git_path_set_error(errno, entry.path, "stat");
-			git_buf_free(&full_path);
+			git_buf_dispose(&full_path);
 			return error;
 		}
 
@@ -663,7 +663,7 @@ int git_diff__oid_for_entry(
 		}
  	}
 
-	git_buf_free(&full_path);
+	git_buf_dispose(&full_path);
 	return error;
 }
 

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -373,8 +373,8 @@ int diff_delta_format_similarity_header(
 		error = -1;
 
 done:
-	git_buf_free(&old_path);
-	git_buf_free(&new_path);
+	git_buf_dispose(&old_path);
+	git_buf_dispose(&new_path);
 
 	return error;
 }
@@ -446,8 +446,8 @@ int git_diff_delta__format_file_header(
 		error = -1;
 
 done:
-	git_buf_free(&old_path);
-	git_buf_free(&new_path);
+	git_buf_dispose(&old_path);
+	git_buf_dispose(&new_path);
 
 	return error;
 }
@@ -509,8 +509,8 @@ static int diff_print_patch_file_binary_noshow(
 		old_path.ptr, new_path.ptr);
 
 done:
-	git_buf_free(&old_path);
-	git_buf_free(&new_path);
+	git_buf_dispose(&old_path);
+	git_buf_dispose(&new_path);
 
 	return error;
 }
@@ -696,7 +696,7 @@ int git_diff_print(
 			giterr_set_after_callback_function(error, "git_diff_print");
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -776,7 +776,7 @@ int git_patch_print(
 			giterr_set_after_callback_function(error, "git_patch_print");
 	}
 
-	git_buf_free(&temp);
+	git_buf_dispose(&temp);
 
 	return error;
 }

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -529,7 +529,7 @@ static void similarity_unload(similarity_info *info)
 	if (info->blob)
 		git_blob_free(info->blob);
 	else
-		git_buf_free(&info->data);
+		git_buf_dispose(&info->data);
 }
 
 #define FLAG_SET(opts,flag_name) (((opts)->flags & flag_name) != 0)

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -119,11 +119,11 @@ int git_fetchhead_write(git_repository *repo, git_vector *fetchhead_refs)
 		return -1;
 
 	if (git_filebuf_open(&file, path.ptr, GIT_FILEBUF_APPEND, GIT_REFS_FILE_MODE) < 0) {
-		git_buf_free(&path);
+		git_buf_dispose(&path);
 		return -1;
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	git_vector_sort(fetchhead_refs);
 
@@ -283,9 +283,9 @@ int git_repository_fetchhead_foreach(git_repository *repo,
 	}
 
 done:
-	git_buf_free(&file);
-	git_buf_free(&path);
-	git_buf_free(&name);
+	git_buf_dispose(&file);
+	git_buf_dispose(&path);
+	git_buf_dispose(&name);
 
 	return error;
 }

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -256,7 +256,7 @@ static int resolve_symlink(git_buf *out, const char *path)
 				goto cleanup;
 
 			git_buf_swap(&curpath, &dir);
-			git_buf_free(&dir);
+			git_buf_dispose(&dir);
 
 			if ((error = git_path_apply_relative(&curpath, target.ptr)) < 0)
 				goto cleanup;
@@ -267,8 +267,8 @@ static int resolve_symlink(git_buf *out, const char *path)
 	error = -1;
 
 cleanup:
-	git_buf_free(&curpath);
-	git_buf_free(&target);
+	git_buf_dispose(&curpath);
+	git_buf_dispose(&target);
 	return error;
 }
 
@@ -343,7 +343,7 @@ int git_filebuf_open_withsize(git_filebuf *file, const char *path, int flags, mo
 		file->fd = git_futils_mktmp(&tmp_path, path, mode);
 
 		if (file->fd < 0) {
-			git_buf_free(&tmp_path);
+			git_buf_dispose(&tmp_path);
 			goto cleanup;
 		}
 		file->fd_is_open = true;

--- a/src/fileops.c
+++ b/src/fileops.c
@@ -159,7 +159,7 @@ int git_futils_readbuffer_fd(git_buf *buf, git_file fd, size_t len)
 
 	if (read_size != (ssize_t)len) {
 		giterr_set(GITERR_OS, "failed to read descriptor");
-		git_buf_free(buf);
+		git_buf_dispose(buf);
 		return -1;
 	}
 
@@ -209,7 +209,7 @@ int git_futils_readbuffer_updated(
 
 	if (checksum) {
 		if ((error = git_hash_buf(&checksum_new, buf.ptr, buf.size)) < 0) {
-			git_buf_free(&buf);
+			git_buf_dispose(&buf);
 			return error;
 		}
 
@@ -217,7 +217,7 @@ int git_futils_readbuffer_updated(
 		 * If we were given a checksum, we only want to use it if it's different
 		 */
 		if (!git_oid__cmp(checksum, &checksum_new)) {
-			git_buf_free(&buf);
+			git_buf_dispose(&buf);
 			if (updated)
 				*updated = 0;
 
@@ -234,7 +234,7 @@ int git_futils_readbuffer_updated(
 		*updated = 1;
 
 	git_buf_swap(out, &buf);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return 0;
 }
@@ -526,8 +526,8 @@ int git_futils_mkdir(
 		parent_path.size ? parent_path.ptr : NULL, mode, flags, &opts);
 
 done:
-	git_buf_free(&make_path);
-	git_buf_free(&parent_path);
+	git_buf_dispose(&make_path);
+	git_buf_dispose(&parent_path);
 	return error;
 }
 
@@ -661,7 +661,7 @@ retry_lstat:
 	}
 
 done:
-	git_buf_free(&make_path);
+	git_buf_dispose(&make_path);
 	return error;
 }
 
@@ -822,7 +822,7 @@ int git_futils_rmdir_r(
 		error = 0;
 	}
 
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 
 	return error;
 }
@@ -1081,8 +1081,8 @@ int git_futils_cp_r(
 
 	error = _cp_r_callback(&info, &path);
 
-	git_buf_free(&path);
-	git_buf_free(&info.to);
+	git_buf_dispose(&path);
+	git_buf_dispose(&info.to);
 
 	return error;
 }

--- a/src/filter.c
+++ b/src/filter.c
@@ -841,8 +841,8 @@ static void proxy_stream_free(git_writestream *s)
 	struct proxy_stream *proxy_stream = (struct proxy_stream *)s;
 	assert(proxy_stream);
 
-	git_buf_free(&proxy_stream->input);
-	git_buf_free(&proxy_stream->temp_buf);
+	git_buf_dispose(&proxy_stream->input);
+	git_buf_dispose(&proxy_stream->temp_buf);
 	git__free(proxy_stream);
 }
 
@@ -977,7 +977,7 @@ done:
 	if (fd >= 0)
 		p_close(fd);
 	stream_list_free(&filter_streams);
-	git_buf_free(&abspath);
+	git_buf_dispose(&abspath);
 	return error;
 }
 

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -169,7 +169,7 @@ static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match
 
 out:
 	git__free(path);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -323,7 +323,7 @@ int git_ignore__for_path(
 		    (error = git_path_to_dir(&local)) < 0 ||
 		    (error = git_buf_joinpath(&ignores->dir, workdir, local.ptr)) < 0)
 		{;} /* Nothing, we just want to stop on the first error */
-		git_buf_free(&local);
+		git_buf_dispose(&local);
 	} else {
 		error = git_buf_joinpath(&ignores->dir, path, "");
 	}
@@ -363,7 +363,7 @@ int git_ignore__for_path(
 			git_repository_attr_cache(repo)->cfg_excl_file);
 
 cleanup:
-	git_buf_free(&infopath);
+	git_buf_dispose(&infopath);
 	if (error < 0)
 		git_ignore__free(ignores);
 
@@ -435,7 +435,7 @@ void git_ignore__free(git_ignores *ignores)
 	}
 	git_vector_free(&ignores->ign_global);
 
-	git_buf_free(&ignores->dir);
+	git_buf_dispose(&ignores->dir);
 }
 
 static bool ignore_lookup_in_rules(
@@ -637,7 +637,7 @@ int git_ignore__check_pathspec_for_exact_ignores(
 	}
 
 	git_index_free(idx);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }

--- a/src/index.c
+++ b/src/index.c
@@ -668,7 +668,7 @@ int git_index_read(git_index *index, int force)
 	if (!error)
 		git_futils_filestamp_set(&index->stamp, &stamp);
 
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 	return error;
 }
 
@@ -949,7 +949,7 @@ static int index_entry_init(
 		return -1;
 
 	error = git_path_lstat(path.ptr, &st);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	if (error < 0)
 		return error;
@@ -1509,7 +1509,7 @@ static int add_repo_as_submodule(git_index_entry **out, git_index *index, const 
 
 	git_reference_free(head);
 	git_repository_free(sub);
-	git_buf_free(&abspath);
+	git_buf_dispose(&abspath);
 
 	*out = entry;
 	return 0;
@@ -1693,7 +1693,7 @@ int git_index_remove_directory(git_index *index, const char *dir, int stage)
 		/* removed entry at 'pos' so we don't need to increment */
 	}
 
-	git_buf_free(&pfx);
+	git_buf_dispose(&pfx);
 
 	return error;
 }
@@ -2819,7 +2819,7 @@ static int write_name_extension(git_index *index, git_filebuf *file)
 
 	error = write_extension(file, &extension, &name_buf);
 
-	git_buf_free(&name_buf);
+	git_buf_dispose(&name_buf);
 
 done:
 	return error;
@@ -2867,7 +2867,7 @@ static int write_reuc_extension(git_index *index, git_filebuf *file)
 
 	error = write_extension(file, &extension, &reuc_buf);
 
-	git_buf_free(&reuc_buf);
+	git_buf_dispose(&reuc_buf);
 
 done:
 	return error;
@@ -2891,7 +2891,7 @@ static int write_tree_extension(git_index *index, git_filebuf *file)
 
 	error = write_extension(file, &extension, &buf);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -3008,7 +3008,7 @@ static int read_tree_cb(
 	}
 
 	index_entry_adjust_namemask(entry, path.size);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	if (git_vector_insert(data->new_entries, entry) < 0) {
 		index_entry_free(entry);
@@ -3463,7 +3463,7 @@ static int index_apply_to_all(
 		}
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_pathspec__clear(&ps);
 
 	return error;

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -134,12 +134,12 @@ int git_indexer_new(
 		goto cleanup;
 
 	fd = git_futils_mktmp(&tmp_path, git_buf_cstr(&path), idx->mode);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	if (fd < 0)
 		goto cleanup;
 
 	error = git_packfile_alloc(&idx->pack, git_buf_cstr(&tmp_path));
-	git_buf_free(&tmp_path);
+	git_buf_dispose(&tmp_path);
 
 	if (error < 0)
 		goto cleanup;
@@ -161,8 +161,8 @@ cleanup:
 	if (idx->pack != NULL)
 		p_unlink(idx->pack->pack_name);
 
-	git_buf_free(&path);
-	git_buf_free(&tmp_path);
+	git_buf_dispose(&path);
+	git_buf_dispose(&tmp_path);
 	git__free(idx);
 	return -1;
 }
@@ -758,7 +758,7 @@ static int inject_object(git_indexer *idx, git_oid *id)
 
 	idx->pack->mwf.size += buf.size;
 	entry->crc = htonl(crc32(entry->crc, (unsigned char *)buf.ptr, (uInt)buf.size));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Write a fake trailer so the pack functions play ball */
 
@@ -1121,13 +1121,13 @@ int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
 
 	idx->pack_committed = 1;
 
-	git_buf_free(&filename);
+	git_buf_dispose(&filename);
 	return 0;
 
 on_error:
 	git_mwindow_free_all(&idx->pack->mwf);
 	git_filebuf_cleanup(&index_file);
-	git_buf_free(&filename);
+	git_buf_dispose(&filename);
 	return -1;
 }
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -650,7 +650,7 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_tran
 
 		/* We want to free the stream reasorces no matter what here */
 		idx->have_stream = 0;
-		git_packfile_stream_free(stream);
+		git_packfile_stream_dispose(stream);
 
 		if (error < 0)
 			goto on_error;
@@ -1137,7 +1137,7 @@ void git_indexer_free(git_indexer *idx)
 		return;
 
 	if (idx->have_stream)
-		git_packfile_stream_free(&idx->stream);
+		git_packfile_stream_dispose(&idx->stream);
 
 	git_vector_free_deep(&idx->objects);
 

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -701,7 +701,7 @@ static void tree_iterator_frame_pop(tree_iterator *iter)
 
 	do {
 		buf = git_array_pop(frame->similar_paths);
-		git_buf_free(buf);
+		git_buf_dispose(buf);
 	} while (buf != NULL);
 
 	git_array_clear(frame->similar_paths);
@@ -711,7 +711,7 @@ static void tree_iterator_frame_pop(tree_iterator *iter)
 
 	git_vector_free(&frame->similar_trees);
 
-	git_buf_free(&frame->path);
+	git_buf_dispose(&frame->path);
 }
 
 static int tree_iterator_current(
@@ -929,7 +929,7 @@ static void tree_iterator_free(git_iterator *i)
 	tree_iterator_clear(iter);
 
 	git_tree_free(iter->root);
-	git_buf_free(&iter->entry_path);
+	git_buf_dispose(&iter->entry_path);
 }
 
 int git_iterator_for_tree(
@@ -1435,7 +1435,7 @@ done:
 	if (error < 0)
 		git_array_pop(iter->frames);
 
-	git_buf_free(&root);
+	git_buf_dispose(&root);
 	git_path_diriter_free(&diriter);
 	return error;
 }
@@ -1523,7 +1523,7 @@ static int filesystem_iterator_is_dir(
 	*is_dir = S_ISDIR(st.st_mode);
 
 done:
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 	return error;
 }
 
@@ -1804,7 +1804,7 @@ static void filesystem_iterator_clear(filesystem_iterator *iter)
 	git_array_clear(iter->frames);
 	git_ignore__free(&iter->ignores);
 
-	git_buf_free(&iter->tmp_buf);
+	git_buf_dispose(&iter->tmp_buf);
 
 	iterator_clear(&iter->base);
 }
@@ -1838,7 +1838,7 @@ static void filesystem_iterator_free(git_iterator *i)
 {
 	filesystem_iterator *iter = (filesystem_iterator *)i;
 	git__free(iter->root);
-	git_buf_free(&iter->current_path);
+	git_buf_dispose(&iter->current_path);
 	git_tree_free(iter->tree);
 	if (iter->index)
 		git_index_snapshot_release(&iter->index_snapshot, iter->index);
@@ -2176,7 +2176,7 @@ static void index_iterator_free(git_iterator *i)
 	index_iterator *iter = (index_iterator *)i;
 
 	git_index_snapshot_release(&iter->entries, iter->base.index);
-	git_buf_free(&iter->tree_buf);
+	git_buf_dispose(&iter->tree_buf);
 }
 
 int git_iterator_for_index(

--- a/src/merge.c
+++ b/src/merge.c
@@ -599,8 +599,8 @@ int git_repository_mergehead_foreach(
 	}
 
 cleanup:
-	git_buf_free(&merge_head_path);
-	git_buf_free(&merge_head_file);
+	git_buf_dispose(&merge_head_path);
+	git_buf_dispose(&merge_head_file);
 
 	return error;
 }
@@ -875,7 +875,7 @@ static int merge_conflict_invoke_driver(
 	*out = result;
 
 done:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_odb_free(odb);
 
 	return error;
@@ -2444,7 +2444,7 @@ cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -2470,7 +2470,7 @@ cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -2770,7 +2770,7 @@ cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	git_vector_free(&matching);
 	git__free(entries);
@@ -3090,7 +3090,7 @@ cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }

--- a/src/netops.c
+++ b/src/netops.c
@@ -292,10 +292,10 @@ int gitno_extract_url_parts(
 	*password_out = git_buf_detach(&password);
 
 done:
-	git_buf_free(&host);
-	git_buf_free(&port);
-	git_buf_free(&path);
-	git_buf_free(&username);
-	git_buf_free(&password);
+	git_buf_dispose(&host);
+	git_buf_dispose(&port);
+	git_buf_dispose(&path);
+	git_buf_dispose(&username);
+	git_buf_dispose(&password);
 	return error;
 }

--- a/src/notes.c
+++ b/src/notes.c
@@ -710,7 +710,7 @@ static int process_entry_path(
 	error = git_oid_fromstr(annotated_object_id, buf.ptr);
 
 cleanup:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -260,12 +260,12 @@ int git_odb__hashfd_filtered(
 
 		error = git_filter_list_apply_to_data(&post, fl, &raw);
 
-		git_buf_free(&raw);
+		git_buf_dispose(&raw);
 
 		if (!error)
 			error = git_odb_hash(out, post.ptr, post.size, type);
 
-		git_buf_free(&post);
+		git_buf_dispose(&post);
 	}
 
 	return error;
@@ -588,12 +588,12 @@ static int load_alternates(git_odb *odb, const char *objects_dir, int alternate_
 		return -1;
 
 	if (git_path_exists(alternates_path.ptr) == false) {
-		git_buf_free(&alternates_path);
+		git_buf_dispose(&alternates_path);
 		return 0;
 	}
 
 	if (git_futils_readbuffer(&alternates_buf, alternates_path.ptr) < 0) {
-		git_buf_free(&alternates_path);
+		git_buf_dispose(&alternates_path);
 		return -1;
 	}
 
@@ -619,8 +619,8 @@ static int load_alternates(git_odb *odb, const char *objects_dir, int alternate_
 			break;
 	}
 
-	git_buf_free(&alternates_path);
-	git_buf_free(&alternates_buf);
+	git_buf_dispose(&alternates_path);
+	git_buf_dispose(&alternates_buf);
 
 	return result;
 }
@@ -1181,7 +1181,7 @@ static int read_prefix_1(git_odb_object **out, git_odb *db,
 					git_oid_tostr_s(&found_full_oid));
 
 				error = git_odb__error_ambiguous(buf.ptr);
-				git_buf_free(&buf);
+				git_buf_dispose(&buf);
 				goto out;
 			}
 

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -266,7 +266,7 @@ static int read_loose_packlike(git_rawobj *out, git_buf *obj)
 	out->data = git_buf_detach(&body);
 
 done:
-	git_buf_free(&body);
+	git_buf_dispose(&body);
 	return error;
 }
 
@@ -362,7 +362,7 @@ static int read_loose(git_rawobj *out, git_buf *loc)
 		error = read_loose_standard(out, &obj);
 
 done:
-	git_buf_free(&obj);
+	git_buf_dispose(&obj);
 	return error;
 }
 
@@ -593,7 +593,7 @@ static int loose_backend__read_header(size_t *len_p, git_otype *type_p, git_odb_
 		*type_p = raw.type;
 	}
 
-	git_buf_free(&object_path);
+	git_buf_dispose(&object_path);
 
 	return error;
 }
@@ -615,7 +615,7 @@ static int loose_backend__read(void **buffer_p, size_t *len_p, git_otype *type_p
 		*type_p = raw.type;
 	}
 
-	git_buf_free(&object_path);
+	git_buf_dispose(&object_path);
 
 	return error;
 }
@@ -653,7 +653,7 @@ static int loose_backend__read_prefix(
 			*type_p = raw.type;
 		}
 
-		git_buf_free(&object_path);
+		git_buf_dispose(&object_path);
 	}
 
 	return error;
@@ -668,7 +668,7 @@ static int loose_backend__exists(git_odb_backend *backend, const git_oid *oid)
 
 	error = locate_object(&object_path, (loose_backend *)backend, oid);
 
-	git_buf_free(&object_path);
+	git_buf_dispose(&object_path);
 
 	return !error;
 }
@@ -684,7 +684,7 @@ static int loose_backend__exists_prefix(
 	error = locate_object_short_oid(
 		&object_path, out, (loose_backend *)backend, short_id, len);
 
-	git_buf_free(&object_path);
+	git_buf_dispose(&object_path);
 
 	return error;
 }
@@ -770,7 +770,7 @@ static int loose_backend__foreach(git_odb_backend *_backend, git_odb_foreach_cb 
 
 	error = git_path_direach(&buf, 0, foreach_cb, &state);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -789,7 +789,7 @@ static int loose_backend__writestream_finalize(git_odb_stream *_stream, const gi
 		error = git_filebuf_commit_at(
 			&stream->fbuf, final_path.ptr);
 
-	git_buf_free(&final_path);
+	git_buf_dispose(&final_path);
 
 	return error;
 }
@@ -856,7 +856,7 @@ static int loose_backend__writestream(git_odb_stream **stream_out, git_odb_backe
 		git__free(stream);
 		stream = NULL;
 	}
-	git_buf_free(&tmp_path);
+	git_buf_dispose(&tmp_path);
 	*stream_out = (git_odb_stream *)stream;
 
 	return !stream ? -1 : 0;
@@ -1035,7 +1035,7 @@ done:
 		git__free(stream);
 	}
 
-	git_buf_free(&object_path);
+	git_buf_dispose(&object_path);
 	return error;
 }
 
@@ -1074,7 +1074,7 @@ static int loose_backend__write(git_odb_backend *_backend, const git_oid *oid, c
 cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&fbuf);
-	git_buf_free(&final_path);
+	git_buf_dispose(&final_path);
 	return error;
 }
 
@@ -1090,7 +1090,7 @@ static int loose_backend__freshen(
 		return -1;
 
 	error = git_futils_touch(path.ptr, NULL);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -346,7 +346,7 @@ static int pack_backend__refresh(git_odb_backend *backend_)
 	/* reload all packs */
 	error = git_path_direach(&path, 0, packfile_load__cb, backend);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_vector_sort(&backend->packs);
 
 	return error;
@@ -635,7 +635,7 @@ int git_odb_backend_pack(git_odb_backend **backend_out, const char *objects_dir)
 
 	*backend_out = (git_odb_backend *)backend;
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1095,7 +1095,7 @@ on_error:
 		git__free(array[i].data);
 	}
 	git__free(array);
-	git_buf_free(&zbuf);
+	git_buf_dispose(&zbuf);
 
 	return error;
 }
@@ -1463,7 +1463,7 @@ int git_packbuilder_insert_tree(git_packbuilder *pb, const git_oid *oid)
 		error = git_tree_walk(tree, GIT_TREEWALK_PRE, cb_tree_walk, &context);
 
 	git_tree_free(tree);
-	git_buf_free(&context.buf);
+	git_buf_dispose(&context.buf);
 	return error;
 }
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -326,19 +326,19 @@ static int pack_index_open(struct git_pack_file *p)
 	git_buf_put(&idx_name, p->pack_name, name_len - strlen(".pack"));
 	git_buf_puts(&idx_name, ".idx");
 	if (git_buf_oom(&idx_name)) {
-		git_buf_free(&idx_name);
+		git_buf_dispose(&idx_name);
 		return -1;
 	}
 
 	if ((error = git_mutex_lock(&p->lock)) < 0) {
-		git_buf_free(&idx_name);
+		git_buf_dispose(&idx_name);
 		return error;
 	}
 
 	if (p->index_version == -1)
 		error = pack_index_check(idx_name.ptr, p);
 
-	git_buf_free(&idx_name);
+	git_buf_dispose(&idx_name);
 
 	git_mutex_unlock(&p->lock);
 

--- a/src/pack.c
+++ b/src/pack.c
@@ -499,7 +499,7 @@ int git_packfile_resolve_header(
 		if ((error = git_packfile_stream_open(&stream, p, curpos)) < 0)
 			return error;
 		error = git_delta_read_header_fromstream(&base_size, size_p, &stream);
-		git_packfile_stream_free(&stream);
+		git_packfile_stream_dispose(&stream);
 		if (error < 0)
 			return error;
 	} else {
@@ -840,7 +840,7 @@ ssize_t git_packfile_stream_read(git_packfile_stream *obj, void *buffer, size_t 
 
 }
 
-void git_packfile_stream_free(git_packfile_stream *obj)
+void git_packfile_stream_dispose(git_packfile_stream *obj)
 {
 	inflateEnd(&obj->zstream);
 }

--- a/src/pack.h
+++ b/src/pack.h
@@ -144,7 +144,7 @@ int git_packfile_unpack(git_rawobj *obj, struct git_pack_file *p, git_off_t *obj
 
 int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, git_off_t curpos);
 ssize_t git_packfile_stream_read(git_packfile_stream *obj, void *buffer, size_t len);
-void git_packfile_stream_free(git_packfile_stream *obj);
+void git_packfile_stream_dispose(git_packfile_stream *obj);
 
 git_off_t get_delta_base(struct git_pack_file *p, git_mwindow **w_curs,
 		git_off_t *curpos, git_otype type,

--- a/src/patch.c
+++ b/src/patch.c
@@ -84,7 +84,7 @@ size_t git_patch_size(
 		else
 			out += git_buf_len(&file_header);
 
-		git_buf_free(&file_header);
+		git_buf_dispose(&file_header);
 	}
 
 	return out;

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -314,8 +314,8 @@ static int create_binary(
 	}
 
 done:
-	git_buf_free(&deflate);
-	git_buf_free(&delta);
+	git_buf_dispose(&deflate);
+	git_buf_dispose(&delta);
 
 	return error;
 }

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -98,7 +98,7 @@ static int parse_header_git_oldpath(
 	patch->old_path = git_buf_detach(&old_path);
 
 out:
-	git_buf_free(&old_path);
+	git_buf_dispose(&old_path);
 	return error;
 }
 
@@ -114,7 +114,7 @@ static int parse_header_git_newpath(
 	patch->new_path = git_buf_detach(&new_path);
 
 out:
-	git_buf_free(&new_path);
+	git_buf_dispose(&new_path);
 	return error;
 }
 
@@ -770,8 +770,8 @@ static int parse_patch_binary_side(
 	binary->data = git_buf_detach(&decoded);
 
 done:
-	git_buf_free(&base85);
-	git_buf_free(&decoded);
+	git_buf_dispose(&base85);
+	git_buf_dispose(&decoded);
 	return error;
 }
 

--- a/src/path.c
+++ b/src/path.c
@@ -207,7 +207,7 @@ char *git_path_dirname(const char *path)
 
 	git_path_dirname_r(&buf, path);
 	dirname = git_buf_detach(&buf);
-	git_buf_free(&buf); /* avoid memleak if error occurs */
+	git_buf_dispose(&buf); /* avoid memleak if error occurs */
 
 	return dirname;
 }
@@ -219,7 +219,7 @@ char *git_path_basename(const char *path)
 
 	git_path_basename_r(&buf, path);
 	basename = git_buf_detach(&buf);
-	git_buf_free(&buf); /* avoid memleak if error occurs */
+	git_buf_dispose(&buf); /* avoid memleak if error occurs */
 
 	return basename;
 }
@@ -642,7 +642,7 @@ bool git_path_is_empty_dir(const char *path)
 	else
 		error = git_path_direach(&dir, 0, path_found_entry, NULL);
 
-	git_buf_free(&dir);
+	git_buf_dispose(&dir);
 
 	return !error;
 }
@@ -956,7 +956,7 @@ void git_path_iconv_clear(git_path_iconv_t *ic)
 	if (ic) {
 		if (ic->map != (iconv_t)-1)
 			iconv_close(ic->map);
-		git_buf_free(&ic->buf);
+		git_buf_dispose(&ic->buf);
 	}
 }
 
@@ -1060,7 +1060,7 @@ bool git_path_does_fs_decompose_unicode(const char *root)
 	(void)p_unlink(path.ptr);
 
 done:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return found_decomposed;
 }
 
@@ -1308,7 +1308,7 @@ void git_path_diriter_free(git_path_diriter *diriter)
 	if (diriter == NULL)
 		return;
 
-	git_buf_free(&diriter->path_utf8);
+	git_buf_dispose(&diriter->path_utf8);
 
 	if (diriter->handle != INVALID_HANDLE_VALUE) {
 		FindClose(diriter->handle);
@@ -1338,7 +1338,7 @@ int git_path_diriter_init(
 	}
 
 	if ((diriter->dir = opendir(diriter->path.ptr)) == NULL) {
-		git_buf_free(&diriter->path);
+		git_buf_dispose(&diriter->path);
 
 		giterr_set(GITERR_OS, "failed to open directory '%s'", path);
 		return -1;
@@ -1448,7 +1448,7 @@ void git_path_diriter_free(git_path_diriter *diriter)
 	git_path_iconv_clear(&diriter->ic);
 #endif
 
-	git_buf_free(&diriter->path);
+	git_buf_dispose(&diriter->path);
 }
 
 #endif

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -36,7 +36,7 @@ char *git_pathspec_prefix(const git_strarray *pathspec)
 	git_buf_truncate(&prefix, scan - prefix.ptr);
 
 	if (prefix.size <= 0) {
-		git_buf_free(&prefix);
+		git_buf_dispose(&prefix);
 		return NULL;
 	}
 

--- a/src/push.c
+++ b/src/push.c
@@ -228,7 +228,7 @@ int git_push_update_tips(git_push *push, const git_remote_callbacks *callbacks)
 	error = 0;
 
 on_error:
-	git_buf_free(&remote_ref_name);
+	git_buf_dispose(&remote_ref_name);
 	return error;
 }
 

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -116,7 +116,7 @@ done:
 	if (type != GIT_REBASE_TYPE_NONE && path_out)
 		*path_out = git_buf_detach(&path);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return 0;
 }
@@ -251,9 +251,9 @@ static int rebase_open_merge(git_rebase *rebase)
 	rebase->onto_name = git_buf_detach(&buf);
 
 done:
-	git_buf_free(&cmt);
-	git_buf_free(&state_path);
-	git_buf_free(&buf);
+	git_buf_dispose(&cmt);
+	git_buf_dispose(&state_path);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -390,10 +390,10 @@ done:
 	else
 		git_rebase_free(rebase);
 
-	git_buf_free(&path);
-	git_buf_free(&orig_head_name);
-	git_buf_free(&orig_head_id);
-	git_buf_free(&onto_id);
+	git_buf_dispose(&path);
+	git_buf_dispose(&orig_head_name);
+	git_buf_dispose(&orig_head_id);
+	git_buf_dispose(&onto_id);
 	return error;
 }
 
@@ -421,8 +421,8 @@ static int rebase_setupfile(git_rebase *rebase, const char *filename, int flags,
 	if ((error = git_buf_joinpath(&path, rebase->state_path, filename)) == 0)
 		error = git_futils_writebuffer(&contents, path.ptr, flags, REBASE_FILE_MODE);
 
-	git_buf_free(&path);
-	git_buf_free(&contents);
+	git_buf_dispose(&path);
+	git_buf_dispose(&contents);
 
 	return error;
 }
@@ -463,7 +463,7 @@ static int rebase_setupfiles_merge(git_rebase *rebase)
 	}
 
 done:
-	git_buf_free(&commit_filename);
+	git_buf_dispose(&commit_filename);
 	return error;
 }
 
@@ -659,8 +659,8 @@ static int rebase_init_merge(
 done:
 	git_reference_free(head_ref);
 	git_commit_free(onto_commit);
-	git_buf_free(&reflog);
-	git_buf_free(&state_path);
+	git_buf_dispose(&reflog);
+	git_buf_dispose(&state_path);
 
 	return error;
 }
@@ -839,7 +839,7 @@ done:
 	git_tree_free(parent_tree);
 	git_commit_free(parent_commit);
 	git_commit_free(current_commit);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -1263,9 +1263,9 @@ on_error:
 	error = -1;
 
 done:
-	git_buf_free(&rewritten);
-	git_buf_free(&path);
-	git_buf_free(&notes_ref);
+	git_buf_dispose(&rewritten);
+	git_buf_dispose(&path);
+	git_buf_dispose(&notes_ref);
 
 	return error;
 }
@@ -1297,8 +1297,8 @@ static int return_to_orig_head(git_rebase *rebase)
 			rebase->repo, GIT_HEAD_FILE, rebase->orig_head_name, 1,
 			head_msg.ptr);
 
-	git_buf_free(&head_msg);
-	git_buf_free(&branch_msg);
+	git_buf_dispose(&head_msg);
+	git_buf_dispose(&branch_msg);
 	git_commit_free(terminal_commit);
 	git_reference_free(head_ref);
 	git_reference_free(branch_ref);

--- a/src/refs.c
+++ b/src/refs.c
@@ -282,7 +282,7 @@ int git_reference__read_head(
 
 out:
 	git__free(name);
-	git_buf_free(&reference);
+	git_buf_dispose(&reference);
 
 	return error;
 }
@@ -346,8 +346,8 @@ cleanup:
 	if (error == GIT_ENOTFOUND)
 		giterr_set(GITERR_REFERENCE, "no reference found for shorthand '%s'", refname);
 
-	git_buf_free(&name);
-	git_buf_free(&refnamebuf);
+	git_buf_dispose(&name);
+	git_buf_dispose(&refnamebuf);
 	return error;
 }
 
@@ -1076,7 +1076,7 @@ cleanup:
 			"the given reference name '%s' is not valid", name);
 
 	if (error && normalize)
-		git_buf_free(buf);
+		git_buf_dispose(buf);
 
 #ifdef GIT_USE_ICONV
 	git_path_iconv_clear(&ic);
@@ -1110,7 +1110,7 @@ int git_reference_normalize_name(
 	error = 0;
 
 cleanup:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -1262,7 +1262,7 @@ int git_reference__update_for_commit(
 
 done:
 	git_reference_free(ref_new);
-	git_buf_free(&reflog_msg);
+	git_buf_dispose(&reflog_msg);
 	git_commit_free(commit);
 	return error;
 }

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -359,7 +359,7 @@ int git_refspec__dwim_one(git_vector *out, git_refspec *spec, git_vector *refs)
 		cur->dst = git_buf_detach(&buf);
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (cur->dst == NULL && spec->dst != NULL) {
 		cur->dst = git__strdup(spec->dst);

--- a/src/remote.c
+++ b/src/remote.c
@@ -67,7 +67,7 @@ static int download_tags_value(git_remote *remote, git_config *cfg)
 		return -1;
 
 	error = git_config__lookup_entry(&ce, cfg, git_buf_cstr(&buf), false);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (!error && ce && ce->value) {
 		if (!strcmp(ce->value, "--no-tags"))
@@ -132,7 +132,7 @@ static int write_add_refspec(git_repository *repo, const char *name, const char 
 	}
 
 cleanup:
-	git_buf_free(&var);
+	git_buf_dispose(&var);
 	return 0;
 }
 
@@ -255,7 +255,7 @@ static int create_internal(git_remote **out, git_repository *repo, const char *n
 		remote->download_tags = GIT_REMOTE_DOWNLOAD_TAGS_AUTO;
 
 
-	git_buf_free(&var);
+	git_buf_dispose(&var);
 
 	*out = remote;
 	error = 0;
@@ -265,8 +265,8 @@ on_error:
 		git_remote_free(remote);
 
 	git_config_free(config_ro);
-	git_buf_free(&canonical_url);
-	git_buf_free(&var);
+	git_buf_dispose(&canonical_url);
+	git_buf_dispose(&var);
 	return error;
 }
 
@@ -302,7 +302,7 @@ int git_remote_create(git_remote **out, git_repository *repo, const char *name, 
 		return -1;
 
 	error = git_remote_create_with_fetchspec(out, repo, name, url, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -524,7 +524,7 @@ int git_remote_lookup(git_remote **out, git_repository *repo, const char *name)
 
 cleanup:
 	git_config_free(config);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (error < 0)
 		git_remote_free(remote);
@@ -552,7 +552,7 @@ static int lookup_remote_prune_config(git_remote *remote, git_config *config, co
 		}
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -601,8 +601,8 @@ static int set_url(git_repository *repo, const char *remote, const char *pattern
 	}
 
 cleanup:
-	git_buf_free(&canonical_url);
-	git_buf_free(&buf);
+	git_buf_dispose(&canonical_url);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -761,7 +761,7 @@ int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_ur
 			return error;
 
 		error = git_config__lookup_entry(&ce, cfg, git_buf_cstr(&buf), false);
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 
 		if (error < 0)
 			return error;
@@ -985,7 +985,7 @@ int git_remote_fetch(
 
 	/* Create "remote/foo" branches for all remote branches */
 	error = git_remote_update_tips(remote, cbs, update_fetchhead, tagopt, git_buf_cstr(&reflog_msg_buf));
-	git_buf_free(&reflog_msg_buf);
+	git_buf_dispose(&reflog_msg_buf);
 	if (error < 0)
 		return error;
 
@@ -1050,8 +1050,8 @@ static int ref_to_update(int *update, git_buf *remote_name, git_remote *remote, 
 		*update = 1;
 	}
 
-	git_buf_free(&upstream_remote);
-	git_buf_free(&upstream_name);
+	git_buf_dispose(&upstream_remote);
+	git_buf_dispose(&upstream_name);
 	return error;
 }
 
@@ -1084,7 +1084,7 @@ static int remote_head_for_ref(git_remote_head **out, git_remote *remote, git_re
 		error = remote_head_for_fetchspec_src(out, update_heads, git_buf_cstr(&remote_name));
 
 cleanup:
-	git_buf_free(&remote_name);
+	git_buf_dispose(&remote_name);
 	git_reference_free(resolved_ref);
 	git_config_free(config);
 	return error;
@@ -1235,7 +1235,7 @@ int git_remote_prune(git_remote *remote, const git_remote_callbacks *callbacks)
 
 			key.name = (char *) git_buf_cstr(&buf);
 			error = git_vector_search(&pos, &remote_refs, &key);
-			git_buf_free(&buf);
+			git_buf_dispose(&buf);
 
 			if (error < 0 && error != GIT_ENOTFOUND)
 				goto cleanup;
@@ -1417,13 +1417,13 @@ static int update_tips_for_spec(
 
 	git_vector_free(&update_heads);
 	git_refspec__free(&tagspec);
-	git_buf_free(&refname);
+	git_buf_dispose(&refname);
 	return 0;
 
 on_error:
 	git_vector_free(&update_heads);
 	git_refspec__free(&tagspec);
-	git_buf_free(&refname);
+	git_buf_dispose(&refname);
 	return -1;
 
 }
@@ -1537,7 +1537,7 @@ static int opportunistic_updates(const git_remote *remote, const git_remote_call
 		error = 0;
 
 cleanup:
-	git_buf_free(&refname);
+	git_buf_dispose(&refname);
 	return error;
 }
 
@@ -1550,7 +1550,7 @@ static int truncate_fetch_head(const char *gitdir)
 		return error;
 
 	error = git_futils_truncate(path.ptr, GIT_REFS_FILE_MODE);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -1759,7 +1759,7 @@ int git_remote_set_autotag(git_repository *repo, const char *remote, git_remote_
 		error = -1;
 	}
 
-	git_buf_free(&var);
+	git_buf_dispose(&var);
 	return error;
 }
 
@@ -1790,8 +1790,8 @@ static int rename_remote_config_section(
 		new_name ? git_buf_cstr(&new_section_name) : NULL);
 
 cleanup:
-	git_buf_free(&old_section_name);
-	git_buf_free(&new_section_name);
+	git_buf_dispose(&old_section_name);
+	git_buf_dispose(&new_section_name);
 
 	return error;
 }
@@ -1887,10 +1887,10 @@ static int rename_one_remote_reference(
 cleanup:
 	git_reference_free(reference_in);
 	git_reference_free(ref);
-	git_buf_free(&namespace);
-	git_buf_free(&old_namespace);
-	git_buf_free(&new_name);
-	git_buf_free(&log_message);
+	git_buf_dispose(&namespace);
+	git_buf_dispose(&old_namespace);
+	git_buf_dispose(&new_name);
+	git_buf_dispose(&log_message);
 	return error;
 }
 
@@ -1908,7 +1908,7 @@ static int rename_remote_references(
 		return error;
 
 	error = git_reference_iterator_glob_new(&iter, repo, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (error < 0)
 		return error;
@@ -1976,9 +1976,9 @@ static int rename_fetch_refspecs(git_vector *problems, git_remote *remote, const
 			break;
 	}
 
-	git_buf_free(&base);
-	git_buf_free(&var);
-	git_buf_free(&val);
+	git_buf_dispose(&base);
+	git_buf_dispose(&var);
+	git_buf_dispose(&val);
 
 	if (error < 0) {
 		char *str;
@@ -2044,7 +2044,7 @@ int git_remote_is_valid_name(
 	git_buf_printf(&buf, "refs/heads/test:refs/remotes/%s/test", remote_name);
 	error = git_refspec__parse(&refspec, git_buf_cstr(&buf), true);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_refspec__free(&refspec);
 
 	giterr_clear();
@@ -2219,7 +2219,7 @@ static int remove_branch_config_related_entries(
 	if (error == GIT_ITEROVER)
 		error = 0;
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_iterator_free(iter);
 	return error;
 }

--- a/src/repository.c
+++ b/src/repository.c
@@ -166,7 +166,7 @@ void git_repository_free(git_repository *repo)
 	repo->diff_drivers = NULL;
 
 	for (i = 0; i < repo->reserved_names.size; i++)
-		git_buf_free(git_array_get(repo->reserved_names, i));
+		git_buf_dispose(git_array_get(repo->reserved_names, i));
 	git_array_clear(repo->reserved_names);
 
 	git__free(repo->gitlink);
@@ -203,7 +203,7 @@ static bool valid_repository_path(git_buf *repository_path, git_buf *common_path
 			git_buf_swap(common_path, &common_link);
 		}
 
-		git_buf_free(&common_link);
+		git_buf_dispose(&common_link);
 	}
 	else {
 		git_buf_set(common_path, repository_path->ptr, repository_path->size);
@@ -333,7 +333,7 @@ static int load_workdir(git_repository *repo, git_config *config, git_buf *paren
 
 	GITERR_CHECK_ALLOC(repo->workdir);
 cleanup:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_config_entry_free(ce);
 	return error;
 }
@@ -425,7 +425,7 @@ static int read_gitfile(git_buf *path_out, const char *file_path)
 			path_out, gitlink, git_buf_cstr(path_out));
 	}
 
-	git_buf_free(&file);
+	git_buf_dispose(&file);
 	return error;
 }
 
@@ -556,9 +556,9 @@ static int find_repo(
 		error = GIT_ENOTFOUND;
 	}
 
-	git_buf_free(&path);
-	git_buf_free(&repo_link);
-	git_buf_free(&common_link);
+	git_buf_dispose(&path);
+	git_buf_dispose(&repo_link);
+	git_buf_dispose(&common_link);
 	return error;
 }
 
@@ -574,8 +574,8 @@ int git_repository_open_bare(
 		return error;
 
 	if (!valid_repository_path(&path, &common_path)) {
-		git_buf_free(&path);
-		git_buf_free(&common_path);
+		git_buf_dispose(&path);
+		git_buf_dispose(&common_path);
 		giterr_set(GITERR_REPOSITORY, "path is not a repository: %s", bare_path);
 		return GIT_ENOTFOUND;
 	}
@@ -754,15 +754,15 @@ error:
 success:
 	git_odb_free(odb);
 	git_index_free(index);
-	git_buf_free(&common_dir_buf);
-	git_buf_free(&work_tree_buf);
-	git_buf_free(&alts_buf);
-	git_buf_free(&object_dir_buf);
-	git_buf_free(&namespace_buf);
-	git_buf_free(&index_file_buf);
-	git_buf_free(&across_fs_buf);
-	git_buf_free(&ceiling_dirs_buf);
-	git_buf_free(&dir_buf);
+	git_buf_dispose(&common_dir_buf);
+	git_buf_dispose(&work_tree_buf);
+	git_buf_dispose(&alts_buf);
+	git_buf_dispose(&object_dir_buf);
+	git_buf_dispose(&namespace_buf);
+	git_buf_dispose(&index_file_buf);
+	git_buf_dispose(&across_fs_buf);
+	git_buf_dispose(&ceiling_dirs_buf);
+	git_buf_dispose(&dir_buf);
 	return error;
 }
 
@@ -785,7 +785,7 @@ static int repo_is_worktree(unsigned *out, const git_repository *repo)
 	 * only used when the repository is a working tree. */
 	*out = !!git_path_exists(gitdir_link.ptr);
 
-	git_buf_free(&gitdir_link);
+	git_buf_dispose(&gitdir_link);
 	return error;
 }
 
@@ -856,8 +856,8 @@ int git_repository_open_ext(
 	}
 
 cleanup:
-	git_buf_free(&gitdir);
-	git_buf_free(&workdir);
+	git_buf_dispose(&gitdir);
+	git_buf_dispose(&workdir);
 	git_config_free(config);
 
 	if (error < 0)
@@ -899,7 +899,7 @@ int git_repository_open_from_worktree(git_repository **repo_out, git_worktree *w
 	*repo_out = repo;
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return err;
 }
@@ -955,7 +955,7 @@ static int load_config(
 	if (error && error != GIT_ENOTFOUND)
 		goto on_error;
 
-	git_buf_free(&config_path);
+	git_buf_dispose(&config_path);
 
 	if (global_config_path != NULL &&
 		(error = git_config_add_file_ondisk(
@@ -987,7 +987,7 @@ static int load_config(
 	return 0;
 
 on_error:
-	git_buf_free(&config_path);
+	git_buf_dispose(&config_path);
 	git_config_free(cfg);
 	*out = NULL;
 	return error;
@@ -1034,10 +1034,10 @@ int git_repository_config__weakptr(git_config **out, git_repository *repo)
 			}
 		}
 
-		git_buf_free(&global_buf);
-		git_buf_free(&xdg_buf);
-		git_buf_free(&system_buf);
-		git_buf_free(&programdata_buf);
+		git_buf_dispose(&global_buf);
+		git_buf_dispose(&xdg_buf);
+		git_buf_dispose(&system_buf);
+		git_buf_dispose(&programdata_buf);
 	}
 
 	*out = repo->_config;
@@ -1099,7 +1099,7 @@ int git_repository_odb__weakptr(git_odb **out, git_repository *repo)
 			git_odb_free(odb);
 		}
 
-		git_buf_free(&odb_path);
+		git_buf_dispose(&odb_path);
 	}
 
 	*out = repo->_odb;
@@ -1187,7 +1187,7 @@ int git_repository_index__weakptr(git_index **out, git_repository *repo)
 			error = git_index_set_caps(repo->_index, GIT_INDEXCAP_FROM_OWNER);
 		}
 
-		git_buf_free(&index_path);
+		git_buf_dispose(&index_path);
 	}
 
 	*out = repo->_index;
@@ -1372,11 +1372,11 @@ int git_repository_create_head(const char *git_dir, const char *ref_name)
 		git_filebuf_commit(&ref) < 0)
 		goto fail;
 
-	git_buf_free(&ref_path);
+	git_buf_dispose(&ref_path);
 	return 0;
 
 fail:
-	git_buf_free(&ref_path);
+	git_buf_dispose(&ref_path);
 	git_filebuf_cleanup(&ref);
 	return -1;
 }
@@ -1405,7 +1405,7 @@ static bool is_filesystem_case_insensitive(const char *gitdir_path)
 	if (!git_buf_joinpath(&path, gitdir_path, "CoNfIg"))
 		is_insensitive = git_path_exists(git_buf_cstr(&path));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return is_insensitive;
 }
 
@@ -1426,7 +1426,7 @@ static bool are_symlinks_supported(const char *wd_path)
 		symlinks_supported = (S_ISLNK(st.st_mode) != 0);
 
 	(void)p_unlink(path.ptr);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return symlinks_supported;
 }
@@ -1586,8 +1586,8 @@ static int repo_init_config(
 	}
 
 cleanup:
-	git_buf_free(&cfg_path);
-	git_buf_free(&worktree_path);
+	git_buf_dispose(&cfg_path);
+	git_buf_dispose(&worktree_path);
 	git_config_free(config);
 
 	return error;
@@ -1618,7 +1618,7 @@ int git_repository_reinit_filesystem(git_repository *repo, int recurse)
 			config, path.ptr, repo_dir, git_repository_workdir(repo), true);
 
 	git_config_free(config);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	git_repository__cvar_cache_clear(repo);
 
@@ -1666,7 +1666,7 @@ static int repo_write_template(
 	GIT_UNUSED(hidden);
 #endif
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	if (error)
 		giterr_set(GITERR_OS,
@@ -1720,8 +1720,8 @@ static int repo_write_gitlink(
 		error = repo_write_template(in_dir, true, DOT_GIT, 0666, true, buf.ptr);
 
 cleanup:
-	git_buf_free(&buf);
-	git_buf_free(&path_to_repo);
+	git_buf_dispose(&buf);
+	git_buf_dispose(&path_to_repo);
 	return error;
 }
 
@@ -1805,7 +1805,7 @@ static int repo_init_structure(
 			error = git_futils_cp_r(tdir, repo_dir, cpflags, dmode);
 		}
 
-		git_buf_free(&template_buf);
+		git_buf_dispose(&template_buf);
 		git_config_free(cfg);
 
 		if (error < 0) {
@@ -2065,9 +2065,9 @@ int git_repository_init_ext(
 		error = repo_init_create_origin(*out, opts->origin_url);
 
 cleanup:
-	git_buf_free(&common_path);
-	git_buf_free(&repo_path);
-	git_buf_free(&wd_path);
+	git_buf_dispose(&common_path);
+	git_buf_dispose(&repo_path);
+	git_buf_dispose(&wd_path);
 
 	return error;
 }
@@ -2165,7 +2165,7 @@ out:
 	if (error)
 		git_reference_free(head);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -2197,7 +2197,7 @@ int git_repository_foreach_head(git_repository *repo, git_repository_foreach_hea
 	}
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_strarray_free(&worktrees);
 	return error;
 }
@@ -2440,7 +2440,7 @@ int git_repository__set_orig_head(git_repository *repo, const git_oid *orig_head
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -2464,7 +2464,7 @@ int git_repository_message(git_buf *out, git_repository *repo)
 		error = git_futils_readbuffer(out, git_buf_cstr(&path));
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -2478,7 +2478,7 @@ int git_repository_message_remove(git_repository *repo)
 		return -1;
 
 	error = p_unlink(git_buf_cstr(&path));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -2548,7 +2548,7 @@ cleanup:
 	if (fd >= 0)
 		p_close(fd);
 	git_filter_list_free(fl);
-	git_buf_free(&full_path);
+	git_buf_dispose(&full_path);
 
 	return error;
 }
@@ -2604,7 +2604,7 @@ static int detach(git_repository *repo, const git_oid *id, const char *new)
 	error = git_reference_create(&new_head, repo, GIT_HEAD_FILE, git_object_id(peeled), true, git_buf_cstr(&log_message));
 
 cleanup:
-	git_buf_free(&log_message);
+	git_buf_dispose(&log_message);
 	git_object_free(object);
 	git_object_free(peeled);
 	git_reference_free(current);
@@ -2654,7 +2654,7 @@ int git_repository_set_head(
 	}
 
 cleanup:
-	git_buf_free(&log_message);
+	git_buf_dispose(&log_message);
 	git_reference_free(current);
 	git_reference_free(ref);
 	git_reference_free(new_head);
@@ -2702,7 +2702,7 @@ int git_repository_detach_head(git_repository* repo)
 			1, git_buf_cstr(&log_message));
 
 cleanup:
-	git_buf_free(&log_message);
+	git_buf_dispose(&log_message);
 	git_object_free(object);
 	git_reference_free(old_head);
 	git_reference_free(new_head);
@@ -2749,7 +2749,7 @@ int git_repository_state(git_repository *repo)
 	} else if (git_path_contains_file(&repo_path, GIT_BISECT_LOG_FILE))
 		state = GIT_REPOSITORY_STATE_BISECT;
 
-	git_buf_free(&repo_path);
+	git_buf_dispose(&repo_path);
 	return state;
 }
 
@@ -2778,7 +2778,7 @@ int git_repository__cleanup_files(
 		git_buf_clear(&buf);
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -2811,7 +2811,7 @@ int git_repository_is_shallow(git_repository *repo)
 		return error;
 
 	error = git_path_lstat(path.ptr, &st);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	if (error == GIT_ENOTFOUND) {
 		giterr_clear();

--- a/src/reset.c
+++ b/src/reset.c
@@ -176,7 +176,7 @@ cleanup:
 	git_object_free(commit);
 	git_index_free(index);
 	git_tree_free(tree);
-	git_buf_free(&log_message);
+	git_buf_dispose(&log_message);
 
 	return error;
 }

--- a/src/revert.c
+++ b/src/revert.c
@@ -36,7 +36,7 @@ static int write_revert_head(
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -62,7 +62,7 @@ cleanup:
 	if (error < 0)
 		git_filebuf_cleanup(&file);
 
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	return error;
 }
@@ -219,7 +219,7 @@ done:
 	git_index_free(index);
 	git_commit_free(our_commit);
 	git_reference_free(our_ref);
-	git_buf_free(&their_label);
+	git_buf_dispose(&their_label);
 
 	return error;
 }

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -197,7 +197,7 @@ static int retrieve_previously_checked_out_branch_or_revision(git_object **out, 
 
 cleanup:
 	git_reference_free(ref);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	regfree(&preg);
 	git_reflog_free(reflog);
 	return error;
@@ -350,7 +350,7 @@ static int handle_at_syntax(git_object **out, git_reference **ref, const char *s
 	error = retrieve_revobject_from_reflog(out, ref, repo, git_buf_cstr(&identifier), (size_t)timestamp);
 
 cleanup:
-	git_buf_free(&identifier);
+	git_buf_dispose(&identifier);
 	return error;
 }
 
@@ -624,7 +624,7 @@ static int ensure_base_rev_loaded(git_object **object, git_reference **reference
 		return -1;
 
 	error = revparse_lookup_object(object, reference, repo, git_buf_cstr(&identifier));
-	git_buf_free(&identifier);
+	git_buf_dispose(&identifier);
 
 	return error;
 }
@@ -820,7 +820,7 @@ cleanup:
 		git_reference_free(reference);
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -152,7 +152,7 @@ static int push_glob(git_revwalk *walk, const char *glob, int hide)
 	if (error == GIT_ITEROVER)
 		error = 0;
 out:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -149,7 +149,7 @@ static int commit_index(
 
 cleanup:
 	git_tree_free(i_tree);
-	git_buf_free(&msg);
+	git_buf_dispose(&msg);
 	return error;
 }
 
@@ -291,7 +291,7 @@ static int commit_untracked(
 
 cleanup:
 	git_tree_free(u_tree);
-	git_buf_free(&msg);
+	git_buf_dispose(&msg);
 	return error;
 }
 
@@ -423,7 +423,7 @@ static int prepare_worktree_commit_message(
 	error = (git_buf_oom(msg) || git_buf_oom(&buf)) ? -1 : 0;
 
 cleanup:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return error;
 }
@@ -565,7 +565,7 @@ int git_stash_save(
 
 cleanup:
 
-	git_buf_free(&msg);
+	git_buf_dispose(&msg);
 	git_commit_free(i_commit);
 	git_commit_free(b_commit);
 	git_commit_free(u_commit);

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -190,7 +190,7 @@ static int is_path_occupied(bool *occupied, git_repository *repo, const char *pa
 	error = 0;
 
 out:
-	git_buf_free(&dir);
+	git_buf_dispose(&dir);
 	return error;
 }
 
@@ -271,7 +271,7 @@ static int load_submodule_names(git_strmap **out, git_repository *repo, git_conf
 
 out:
 	free_submodule_names(names);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_iterator_free(iter);
 	return error;
 }
@@ -338,7 +338,7 @@ int git_submodule_lookup(
 
 		if (error < 0) {
 			git_submodule_free(sm);
-			git_buf_free(&path);
+			git_buf_dispose(&path);
 			return error;
 		}
 
@@ -354,7 +354,7 @@ int git_submodule_lookup(
 			}
 		}
 
-		git_buf_free(&path);
+		git_buf_dispose(&path);
 	}
 
 	if ((error = git_submodule_location(&location, sm)) < 0) {
@@ -377,7 +377,7 @@ int git_submodule_lookup(
 			if (git_path_exists(path.ptr))
 				error = GIT_EEXISTS;
 
-			git_buf_free(&path);
+			git_buf_dispose(&path);
 		}
 
 		submodule_set_lookup_error(error, name);
@@ -409,7 +409,7 @@ int git_submodule_name_is_valid(git_repository *repo, const char *name, int flag
 	}
 
 	isvalid =  git_path_isvalid(repo, buf.ptr, 0, flags);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return isvalid;
 }
@@ -624,7 +624,7 @@ cleanup:
 	/* TODO: if we got an error, mark submodule config as invalid? */
 	git_index_free(idx);
 	git_tree_free(head);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return error;
 }
 
@@ -729,8 +729,8 @@ static int submodule_repo_init(
 		error = git_repository_init_ext(&subrepo, workdir.ptr, &initopt);
 
 cleanup:
-	git_buf_free(&workdir);
-	git_buf_free(&repodir);
+	git_buf_dispose(&workdir);
+	git_buf_dispose(&repodir);
 
 	*out = subrepo;
 
@@ -835,8 +835,8 @@ cleanup:
 
 	git_config_file_free(mods);
 	git_repository_free(subrepo);
-	git_buf_free(&real_url);
-	git_buf_free(&name);
+	git_buf_dispose(&real_url);
+	git_buf_dispose(&name);
 
 	return error;
 }
@@ -865,7 +865,7 @@ int git_submodule_repo_init(
 
 done:
 	git_config_free(cfg);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -949,7 +949,7 @@ int git_submodule_add_to_index(git_submodule *sm, int write_index)
 
 cleanup:
 	git_repository_free(sm_repo);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return error;
 }
 
@@ -1014,7 +1014,7 @@ int git_submodule_resolve_url(git_buf *out, git_repository *repo, const char *ur
 		error = -1;
 	}
 
-	git_buf_free(&normalized);
+	git_buf_dispose(&normalized);
 	return error;
 }
 
@@ -1036,7 +1036,7 @@ static int write_var(git_repository *repo, const char *name, const char *var, co
 	else
 		error = git_config_file_delete(mods, key.ptr);
 
-	git_buf_free(&key);
+	git_buf_dispose(&key);
 
 cleanup:
 	git_config_file_free(mods);
@@ -1201,8 +1201,8 @@ static int submodule_repo_create(
 	error = git_repository_init_ext(&subrepo, repodir.ptr, &initopt);
 
 cleanup:
-	git_buf_free(&workdir);
-	git_buf_free(&repodir);
+	git_buf_dispose(&workdir);
+	git_buf_dispose(&repodir);
 
 	*out = subrepo;
 
@@ -1355,7 +1355,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 	}
 
 done:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(config);
 	git_object_free(target_commit);
 	git_remote_free(remote);
@@ -1402,8 +1402,8 @@ int git_submodule_init(git_submodule *sm, int overwrite)
 
 cleanup:
 	git_config_free(cfg);
-	git_buf_free(&key);
-	git_buf_free(&effective_submodule_url);
+	git_buf_dispose(&key);
+	git_buf_dispose(&effective_submodule_url);
 
 	return error;
 }
@@ -1443,7 +1443,7 @@ int git_submodule_sync(git_submodule *sm)
 		} else {
 			error = git_buf_join3(
 				&key, '.', "remote", remote_name.ptr, "url");
-			git_buf_free(&remote_name);
+			git_buf_dispose(&remote_name);
 		}
 
 		if (!error)
@@ -1452,7 +1452,7 @@ int git_submodule_sync(git_submodule *sm)
 		git_repository_free(smrepo);
 	}
 
-	git_buf_free(&key);
+	git_buf_dispose(&key);
 
 	return error;
 }
@@ -1506,7 +1506,7 @@ static int git_submodule__open(
 			sm->flags |= GIT_SUBMODULE_STATUS__WD_SCANNED;
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -1938,7 +1938,7 @@ static int submodule_read_config(git_submodule *sm, git_config *cfg)
 	error = 0;
 
 cleanup:
-	git_buf_free(&key);
+	git_buf_dispose(&key);
 	return error;
 }
 
@@ -2000,7 +2000,7 @@ static int submodule_load_each(const git_config_entry *entry, void *payload)
 	error = 0;
 
 done:
-	git_buf_free(&name);
+	git_buf_dispose(&name);
 	return error;
 }
 
@@ -2017,7 +2017,7 @@ static int submodule_load_from_wd_lite(git_submodule *sm)
 	if (git_path_contains(&path, DOT_GIT))
 		sm->flags |= GIT_SUBMODULE_STATUS_IN_WD;
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	return 0;
 }
 
@@ -2041,6 +2041,7 @@ static int gitmodules_snapshot(git_config **snap, git_repository *repo)
 
 	if ((error = git_config_open_ondisk(&mods, path.ptr)) < 0)
 		goto cleanup;
+	git_buf_dispose(&path);
 
 	if ((error = git_config_snapshot(snap, mods)) < 0)
 		goto cleanup;
@@ -2050,7 +2051,7 @@ static int gitmodules_snapshot(git_config **snap, git_repository *repo)
 cleanup:
 	if (mods)
 		git_config_free(mods);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -2079,7 +2080,7 @@ static git_config_backend *open_gitmodules(
 		}
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return mods;
 }
@@ -2119,7 +2120,7 @@ static int lookup_head_remote_key(git_buf *remote_name, git_repository *repo)
 		goto done;
 
 done:
-	git_buf_free(&upstream_name);
+	git_buf_dispose(&upstream_name);
 	git_reference_free(head);
 
 	return error;
@@ -2135,7 +2136,7 @@ static int lookup_head_remote(git_remote **remote, git_repository *repo)
 	if (!(error = lookup_head_remote_key(&remote_name, repo)))
 		error = git_remote_lookup(remote, repo, remote_name.ptr);
 
-	git_buf_free(&remote_name);
+	git_buf_dispose(&remote_name);
 
 	return error;
 }

--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -136,7 +136,7 @@ static int git_sysdir_guess_xdg_dirs(git_buf *out)
 		error = 0;
 	}
 
-	git_buf_free(&env);
+	git_buf_dispose(&env);
 	return error;
 #endif
 }
@@ -168,7 +168,7 @@ static void git_sysdir_global_shutdown(void)
 	size_t i;
 
 	for (i = 0; i < ARRAY_SIZE(git_sysdir__dirs); ++i)
-		git_buf_free(&git_sysdir__dirs[i].buf);
+		git_buf_dispose(&git_sysdir__dirs[i].buf);
 }
 
 int git_sysdir_global_init(void)
@@ -262,7 +262,7 @@ int git_sysdir_set(git_sysdir_t which, const char *search_path)
 		git_buf_join(&merge, GIT_PATH_LIST_SEPARATOR, merge.ptr, expand_path);
 
 	git_buf_swap(&git_sysdir__dirs[which].buf, &merge);
-	git_buf_free(&merge);
+	git_buf_dispose(&merge);
 
 done:
 	if (git_buf_oom(&git_sysdir__dirs[which].buf))
@@ -307,7 +307,7 @@ static int git_sysdir_find_in_dirlist(
 	}
 
 done:
-	git_buf_free(path);
+	git_buf_dispose(path);
 	giterr_set(GITERR_OS, "the %s file '%s' doesn't exist", label, name);
 	return GIT_ENOTFOUND;
 }

--- a/src/tag.c
+++ b/src/tag.c
@@ -229,11 +229,11 @@ static int write_tag_annotation(
 	if (git_odb_write(oid, odb, tag.ptr, tag.size, GIT_OBJ_TAG) < 0)
 		goto on_error;
 
-	git_buf_free(&tag);
+	git_buf_dispose(&tag);
 	return 0;
 
 on_error:
-	git_buf_free(&tag);
+	git_buf_dispose(&tag);
 	giterr_set(GITERR_OBJECT, "failed to create tag annotation");
 	return -1;
 }
@@ -268,7 +268,7 @@ static int git_tag_create__internal(
 	/** Ensure the tag name doesn't conflict with an already existing
 	 *	reference unless overwriting has explicitly been requested **/
 	if (error == 0 && !allow_ref_overwrite) {
-		git_buf_free(&ref_name);
+		git_buf_dispose(&ref_name);
 		giterr_set(GITERR_TAG, "tag already exists");
 		return GIT_EEXISTS;
 	}
@@ -283,7 +283,7 @@ static int git_tag_create__internal(
 
 cleanup:
 	git_reference_free(new_ref);
-	git_buf_free(&ref_name);
+	git_buf_dispose(&ref_name);
 	return error;
 }
 
@@ -381,7 +381,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 	git_odb_stream_free(stream);
 
 	if (error < 0) {
-		git_buf_free(&ref_name);
+		git_buf_dispose(&ref_name);
 		return error;
 	}
 
@@ -389,7 +389,7 @@ int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *bu
 		&new_ref, repo, ref_name.ptr, oid, allow_ref_overwrite, NULL);
 
 	git_reference_free(new_ref);
-	git_buf_free(&ref_name);
+	git_buf_dispose(&ref_name);
 
 	return error;
 
@@ -409,7 +409,7 @@ int git_tag_delete(git_repository *repo, const char *tag_name)
 
 	error = retrieve_tag_reference(&tag_ref, &ref_name, repo, tag_name);
 
-	git_buf_free(&ref_name);
+	git_buf_dispose(&ref_name);
 
 	if (error < 0)
 		return error;

--- a/src/trace.h
+++ b/src/trace.h
@@ -35,7 +35,7 @@ GIT_INLINE(void) git_trace__write_fmt(
 
 	callback(level, git_buf_cstr(&message));
 
-	git_buf_free(&message);
+	git_buf_dispose(&message);
 }
 
 #define git_trace_level()		(git_trace__data.level)

--- a/src/transport.c
+++ b/src/transport.c
@@ -174,7 +174,7 @@ int git_transport_register(
 	return 0;
 
 on_error:
-	git_buf_free(&prefix);
+	git_buf_dispose(&prefix);
 	git__free(definition);
 	return error;
 }
@@ -210,7 +210,7 @@ int git_transport_unregister(const char *scheme)
 	error = GIT_ENOTFOUND;
 
 done:
-	git_buf_free(&prefix);
+	git_buf_dispose(&prefix);
 	return error;
 }
 

--- a/src/transports/auth.c
+++ b/src/transports/auth.c
@@ -40,7 +40,7 @@ on_error:
 	if (raw.size)
 		git__memzero(raw.ptr, raw.size);
 
-	git_buf_free(&raw);
+	git_buf_dispose(&raw);
 	return error;
 }
 

--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -165,7 +165,7 @@ static int negotiate_next_token(
 done:
 	gss_release_name(&status_minor, &server);
 	gss_release_buffer(&status_minor, (gss_buffer_t) &output_token);
-	git_buf_free(&input_buf);
+	git_buf_dispose(&input_buf);
 	return error;
 }
 
@@ -180,7 +180,7 @@ static void negotiate_context_free(git_http_auth_context *c)
 		ctx->gss_context = GSS_C_NO_CONTEXT;
 	}
 
-	git_buf_free(&ctx->target);
+	git_buf_dispose(&ctx->target);
 
 	git__free(ctx->challenge);
 

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -87,7 +87,7 @@ static int send_command(git_proto_stream *s)
 		s->sent_command = 1;
 
 cleanup:
-	git_buf_free(&request);
+	git_buf_dispose(&request);
 	return error;
 }
 

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -449,14 +449,14 @@ static int on_headers_complete(http_parser *parser)
 		return t->parse_error = PARSE_ERROR_GENERIC;
 
 	if (strcmp(t->content_type, git_buf_cstr(&buf))) {
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		giterr_set(GITERR_NET,
 			"invalid Content-Type: %s",
 			t->content_type);
 		return t->parse_error = PARSE_ERROR_GENERIC;
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return 0;
 }
@@ -508,10 +508,10 @@ static void clear_parser_state(http_subtransport *t)
 	t->parse_error = 0;
 	t->parse_finished = 0;
 
-	git_buf_free(&t->parse_header_name);
+	git_buf_dispose(&t->parse_header_name);
 	git_buf_init(&t->parse_header_name, 0);
 
-	git_buf_free(&t->parse_header_value);
+	git_buf_dispose(&t->parse_header_value);
 	git_buf_init(&t->parse_header_value, 0);
 
 	git__free(t->content_type);
@@ -534,11 +534,11 @@ static int write_chunk(git_stream *io, const char *buffer, size_t len)
 		return -1;
 
 	if (git_stream_write(io, buf.ptr, buf.size, 0) < 0) {
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		return -1;
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Chunk body */
 	if (len > 0 && git_stream_write(io, buffer, len, 0) < 0)
@@ -671,11 +671,11 @@ replay:
 			return -1;
 
 		if (git_stream_write(t->io, request.ptr, request.size, 0) < 0) {
-			git_buf_free(&request);
+			git_buf_dispose(&request);
 			return -1;
 		}
 
-		git_buf_free(&request);
+		git_buf_dispose(&request);
 
 		s->sent_request = 1;
 	}
@@ -792,11 +792,11 @@ static int http_stream_write_chunked(
 			return -1;
 
 		if (git_stream_write(t->io, request.ptr, request.size, 0) < 0) {
-			git_buf_free(&request);
+			git_buf_dispose(&request);
 			return -1;
 		}
 
-		git_buf_free(&request);
+		git_buf_dispose(&request);
 
 		s->sent_request = 1;
 	}
@@ -870,13 +870,13 @@ static int http_stream_write_single(
 	if (len && git_stream_write(t->io, buffer, len, 0) < 0)
 		goto on_error;
 
-	git_buf_free(&request);
+	git_buf_dispose(&request);
 	s->sent_request = 1;
 
 	return 0;
 
 on_error:
-	git_buf_free(&request);
+	git_buf_dispose(&request);
 	return -1;
 }
 

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -228,14 +228,14 @@ static int local_connect(
 
 	/* 'url' may be a url or path; convert to a path */
 	if ((error = git_path_from_url_or_path(&buf, url)) < 0) {
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		return error;
 	}
 	path = git_buf_cstr(&buf);
 
 	error = git_repository_open(&repo, path);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (error < 0)
 		return -1;
@@ -354,14 +354,14 @@ static int local_push(
 
 	/* 'push->remote->url' may be a url or path; convert to a path */
 	if ((error = git_path_from_url_or_path(&buf, push->remote->url)) < 0) {
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		return error;
 	}
 	path = git_buf_cstr(&buf);
 
 	error = git_repository_open(&remote_repo, path);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	if (error < 0)
 		return error;
@@ -383,7 +383,7 @@ static int local_push(
 		goto on_error;
 
 	error = git_packbuilder_write(push->pb, odb_path.ptr, 0, transfer_to_push_transfer, (void *) cbs);
-	git_buf_free(&odb_path);
+	git_buf_dispose(&odb_path);
 
 	if (error < 0)
 		goto on_error;
@@ -502,7 +502,7 @@ static int local_counting(int stage, unsigned int current, unsigned int total, v
 		return -1;
 
 	error = t->progress_cb(git_buf_cstr(&progress_info), git_buf_len(&progress_info), t->message_cb_payload);
-	git_buf_free(&progress_info);
+	git_buf_dispose(&progress_info);
 
 	return error;
 }
@@ -627,7 +627,7 @@ static int local_download_pack(
 
 cleanup:
 	if (writepack) writepack->free(writepack);
-	git_buf_free(&progress_info);
+	git_buf_dispose(&progress_info);
 	git_packbuilder_free(pack);
 	git_revwalk_free(walk);
 	return error;

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -171,7 +171,7 @@ int git_smart__update_heads(transport_smart *t, git_vector *symrefs)
 					ref->head.symref_target = git_buf_detach(&buf);
 			}
 
-			git_buf_free(&buf);
+			git_buf_dispose(&buf);
 
 			if (error < 0)
 				return error;

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -551,7 +551,7 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
 	git_oid_fmt(oid, &head->oid);
 	git_buf_printf(buf,
 		"%04xwant %s %s\n", (unsigned int)len, oid, git_buf_cstr(&str));
-	git_buf_free(&str);
+	git_buf_dispose(&str);
 
 	GITERR_CHECK_ALLOC_BUF(buf);
 

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -106,7 +106,7 @@ static int append_symref(const char **out, git_vector *symrefs, const char *ptr)
 	GITERR_CHECK_ALLOC(mapping);
 
 	error = git_refspec__parse(mapping, git_buf_cstr(&buf), true);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* if the error isn't OOM, then it's a parse error; let's use a nicer message */
 	if (error < 0) {
@@ -465,7 +465,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 	if ((error = git_smart__negotiation_step(&t->parent, data.ptr, data.size)) < 0)
 		goto on_error;
 
-	git_buf_free(&data);
+	git_buf_dispose(&data);
 	git_revwalk_free(walk);
 
 	/* Now let's eat up whatever the server gives us */
@@ -485,7 +485,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 
 on_error:
 	git_revwalk_free(walk);
-	git_buf_free(&data);
+	git_buf_dispose(&data);
 	return error;
 }
 
@@ -862,7 +862,7 @@ static int parse_report(transport_smart *transport, git_push *push)
 		}
 	}
 done:
-	git_buf_free(&data_pkt_buf);
+	git_buf_dispose(&data_pkt_buf);
 	return error;
 }
 
@@ -1085,6 +1085,6 @@ int git_smart__push(git_transport *transport, git_push *push, const git_remote_c
 	}
 
 done:
-	git_buf_free(&pktline);
+	git_buf_dispose(&pktline);
 	return error;
 }

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -121,7 +121,7 @@ static int send_command(ssh_stream *s)
 	s->sent_command = 1;
 
 cleanup:
-	git_buf_free(&request);
+	git_buf_dispose(&request);
 	return error;
 }
 

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -455,7 +455,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 
 		/* Convert URL to wide characters */
 		error = git__utf8_to_16_alloc(&proxy_wide, processed_url.ptr);
-		git_buf_free(&processed_url);
+		git_buf_dispose(&processed_url);
 		if (error < 0)
 			goto on_error;
 
@@ -599,7 +599,7 @@ on_error:
 		winhttp_stream_close(s);
 
 	git__free(proxy_url);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -659,12 +659,12 @@ static int write_chunk(HINTERNET request, const char *buffer, size_t len)
 	if (!WinHttpWriteData(request,
 		git_buf_cstr(&buf),	(DWORD)git_buf_len(&buf),
 		&bytes_written)) {
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		giterr_set(GITERR_OS, "failed to write chunk header");
 		return -1;
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Chunk body */
 	if (!WinHttpWriteData(request,
@@ -779,11 +779,11 @@ static int winhttp_connect(
 	if (git__utf8_to_16_alloc(&wide_ua, git_buf_cstr(&ua)) < 0) {
 		giterr_set(GITERR_OS, "unable to convert host to wide characters");
 		git__free(wide_host);
-		git_buf_free(&ua);
+		git_buf_dispose(&ua);
 		return -1;
 	}
 
-	git_buf_free(&ua);
+	git_buf_dispose(&ua);
 
 	/* Establish session */
 	t->session = WinHttpOpen(

--- a/src/tree.c
+++ b/src/tree.c
@@ -650,7 +650,7 @@ int git_tree__write_index(
 	}
 
 	ret = write_tree(oid, repo, index, "", 0, &shared_buf);
-	git_buf_free(&shared_buf);
+	git_buf_dispose(&shared_buf);
 
 	if (old_ignore_case)
 		git_index__set_ignore_case(index, true);
@@ -814,7 +814,7 @@ int git_treebuilder_write(git_oid *oid, git_treebuilder *bld)
 
 	error = git_treebuilder_write_with_buffer(oid, bld, &buffer);
 
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 	return error;
 }
 
@@ -1055,7 +1055,7 @@ int git_tree_walk(
 	error = tree_walk(
 		tree, callback, &root_path, payload, (mode == GIT_TREEWALK_PRE));
 
-	git_buf_free(&root_path);
+	git_buf_dispose(&root_path);
 
 	return error;
 }
@@ -1320,7 +1320,7 @@ cleanup:
 		}
 	}
 
-	git_buf_free(&component);
+	git_buf_dispose(&component);
 	git_array_clear(stack);
 	git_vector_free(&entries);
 	return error;

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -158,7 +158,7 @@ static int win32_find_existing_dirs(
 		}
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return (git_buf_oom(out) ? -1 : 0);
 }
@@ -185,7 +185,7 @@ int git_win32__find_system_dirs(git_buf *out, const wchar_t *subdir)
 			&buf, HKEY_LOCAL_MACHINE, REG_MSYSGIT_INSTALL, subdir) && buf.size)
 		git_buf_join(out, GIT_PATH_LIST_SEPARATOR, out->ptr, buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return (git_buf_oom(out) ? -1 : 0);
 }

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -25,7 +25,7 @@ static bool is_worktree_dir(const char *dir)
 		&& git_path_contains_file(&buf, "gitdir")
 		&& git_path_contains_file(&buf, "HEAD");
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return error;
 }
 
@@ -64,7 +64,7 @@ int git_worktree_list(git_strarray *wts, git_repository *repo)
 	wts->strings = (char **)git_vector_detach(&wts->count, NULL, &worktrees);
 
 exit:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return error;
 }
@@ -79,7 +79,7 @@ char *git_worktree__read_link(const char *base, const char *file)
 		goto err;
 	if (git_futils_readbuffer(&buf, path.ptr) < 0)
 		goto err;
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	git_buf_rtrim(&buf);
 
@@ -90,13 +90,13 @@ char *git_worktree__read_link(const char *base, const char *file)
 		goto err;
 	if (git_path_apply_relative(&path, buf.ptr) < 0)
 		goto err;
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return git_buf_detach(&path);
 
 err:
-	git_buf_free(&buf);
-	git_buf_free(&path);
+	git_buf_dispose(&buf);
+	git_buf_dispose(&path);
 
 	return NULL;
 }
@@ -115,7 +115,7 @@ static int write_wtfile(const char *base, const char *file, const git_buf *buf)
 		goto out;
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return err;
 }
@@ -156,7 +156,7 @@ static int open_worktree_dir(git_worktree **out, const char *parent, const char 
 out:
 	if (error)
 		git_worktree_free(wt);
-	git_buf_free(&gitdir);
+	git_buf_dispose(&gitdir);
 
 	return error;
 }
@@ -178,7 +178,7 @@ int git_worktree_lookup(git_worktree **out, git_repository *repo, const char *na
 		goto out;
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	if (error)
 		git_worktree_free(wt);
@@ -213,7 +213,7 @@ int git_worktree_open_from_repository(git_worktree **out, git_repository *repo)
 
 out:
 	git__free(name);
-	git_buf_free(&parent);
+	git_buf_dispose(&parent);
 
 	return error;
 }
@@ -265,7 +265,7 @@ int git_worktree_validate(const git_worktree *wt)
 	}
 
 out:
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	return err;
 }
@@ -391,9 +391,9 @@ int git_worktree_add(git_worktree **out, git_repository *repo,
 		goto out;
 
 out:
-	git_buf_free(&gitdir);
-	git_buf_free(&wddir);
-	git_buf_free(&buf);
+	git_buf_dispose(&gitdir);
+	git_buf_dispose(&wddir);
+	git_buf_dispose(&buf);
 	git_reference_free(ref);
 	git_reference_free(head);
 	git_commit_free(commit);
@@ -424,7 +424,7 @@ int git_worktree_lock(git_worktree *wt, const char *reason)
 	wt->locked = 1;
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return err;
 }
@@ -442,13 +442,13 @@ int git_worktree_unlock(git_worktree *wt)
 		return -1;
 
 	if (p_unlink(path.ptr) != 0) {
-		git_buf_free(&path);
+		git_buf_dispose(&path);
 		return -1;
 	}
 
 	wt->locked = 0;
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return 0;
 }
@@ -469,7 +469,7 @@ int git_worktree_is_locked(git_buf *reason, const git_worktree *wt)
 		git_futils_readbuffer(reason, path.ptr);
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return ret;
 }
@@ -514,7 +514,7 @@ int git_worktree_is_prunable(git_worktree *wt,
 		if (!reason.size)
 			git_buf_attach_notowned(&reason, "no reason given", 15);
 		giterr_set(GITERR_WORKTREE, "Not pruning locked working tree: '%s'", reason.ptr);
-		git_buf_free(&reason);
+		git_buf_dispose(&reason);
 
 		return 0;
 	}
@@ -582,7 +582,7 @@ int git_worktree_prune(git_worktree *wt,
 		goto out;
 
 out:
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	return err;
 }

--- a/tests/apply/fromdiff.c
+++ b/tests/apply/fromdiff.c
@@ -63,8 +63,8 @@ static int apply_gitbuf(
 	}
 
 	git__free(filename);
-	git_buf_free(&result);
-	git_buf_free(&patchbuf);
+	git_buf_dispose(&result);
+	git_buf_dispose(&patchbuf);
 	git_patch_free(patch);
 
 	return error;

--- a/tests/apply/fromfile.c
+++ b/tests/apply/fromfile.c
@@ -50,8 +50,8 @@ static int apply_patchfile(
 	}
 
 	git__free(filename);
-	git_buf_free(&result);
-	git_buf_free(&patchbuf);
+	git_buf_dispose(&result);
+	git_buf_dispose(&patchbuf);
 	git_patch_free(patch);
 
 	return error;
@@ -81,7 +81,7 @@ static int validate_and_apply_patchfile(
 
 	error = apply_patchfile(old, old_len, new, new_len, patchfile, filename_expected, mode_expected);
 
-	git_buf_free(&validated);
+	git_buf_dispose(&validated);
 	git_patch_free(patch_fromdiff);
 
 	return error;

--- a/tests/attr/repo.c
+++ b/tests/attr/repo.c
@@ -303,7 +303,7 @@ static void add_to_workdir(const char *filename, const char *content)
 	cl_git_pass(git_buf_joinpath(&buf, "attr", filename));
 	cl_git_rewritefile(git_buf_cstr(&buf), content);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static void assert_proper_normalization(git_index *index, const char *filename, const char *expected_sha)

--- a/tests/buf/basic.c
+++ b/tests/buf/basic.c
@@ -12,7 +12,7 @@ void test_buf_basic__resize(void)
 
 	git_buf_puts(&buf1, test_string);
 	cl_assert(strlen(git_buf_cstr(&buf1)) == strlen(test_string) * 2);
-	git_buf_free(&buf1);
+	git_buf_dispose(&buf1);
 }
 
 void test_buf_basic__resize_incremental(void)
@@ -34,7 +34,7 @@ void test_buf_basic__resize_incremental(void)
 	cl_assert_equal_i(5, buf1.size);
 	cl_assert(buf1.asize > 8);
 
-	git_buf_free(&buf1);
+	git_buf_dispose(&buf1);
 }
 
 void test_buf_basic__printf(void)
@@ -47,5 +47,5 @@ void test_buf_basic__printf(void)
 	git_buf_printf(&buf2, "%s %d", "woop", 42);
 	cl_assert(git_buf_oom(&buf2) == 0);
 	cl_assert_equal_s(git_buf_cstr(&buf2), "shoop da 23 woop 42");
-	git_buf_free(&buf2);
+	git_buf_dispose(&buf2);
 }

--- a/tests/buf/oom.c
+++ b/tests/buf/oom.c
@@ -27,7 +27,7 @@ void test_buf_oom__grow(void)
 	cl_assert(git_buf_grow(&buf, TOOBIG) == -1);
 	cl_assert(git_buf_oom(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_buf_oom__grow_by(void)

--- a/tests/buf/percent.c
+++ b/tests/buf/percent.c
@@ -18,8 +18,8 @@ static void expect_decode_pass(const char *expected, const char *encoded)
 	cl_assert_equal_s(expected, git_buf_cstr(&out));
 	cl_assert_equal_i(strlen(expected), git_buf_len(&out));
 
-	git_buf_free(&in);
-	git_buf_free(&out);
+	git_buf_dispose(&in);
+	git_buf_dispose(&out);
 }
 
 void test_buf_percent__decode_succeeds(void)

--- a/tests/buf/quote.c
+++ b/tests/buf/quote.c
@@ -11,7 +11,7 @@ static void expect_quote_pass(const char *expected, const char *str)
 	cl_assert_equal_s(expected, git_buf_cstr(&buf));
 	cl_assert_equal_i(strlen(expected), git_buf_len(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_buf_quote__quote_succeeds(void)
@@ -38,7 +38,7 @@ static void expect_unquote_pass(const char *expected, const char *quoted)
 	cl_assert_equal_s(expected, git_buf_cstr(&buf));
 	cl_assert_equal_i(strlen(expected), git_buf_len(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static void expect_unquote_fail(const char *quoted)
@@ -48,7 +48,7 @@ static void expect_unquote_fail(const char *quoted)
 	cl_git_pass(git_buf_puts(&buf, quoted));
 	cl_git_fail(git_buf_unquote(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_buf_quote__unquote_succeeds(void)

--- a/tests/buf/splice.c
+++ b/tests/buf/splice.c
@@ -8,7 +8,7 @@ void test_buf_splice__initialize(void) {
 }
 
 void test_buf_splice__cleanup(void) {
-   git_buf_free(&_buf);
+   git_buf_dispose(&_buf);
 }
 
 void test_buf_splice__preprend(void)

--- a/tests/checkout/checkout_helpers.c
+++ b/tests/checkout/checkout_helpers.c
@@ -16,7 +16,7 @@ void assert_on_branch(git_repository *repo, const char *branch)
 	cl_assert_equal_s(bname.ptr, git_reference_symbolic_target(head));
 
 	git_reference_free(head);
-	git_buf_free(&bname);
+	git_buf_dispose(&bname);
 }
 
 void reset_index_to_treeish(git_object *treeish)

--- a/tests/checkout/conflict.c
+++ b/tests/checkout/conflict.c
@@ -109,7 +109,7 @@ static void create_index(struct checkout_index_entry *entries, size_t entries_le
 		cl_git_pass(git_index_add(g_index, &entry));
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void create_index_names(struct checkout_name_entry *entries, size_t entries_len)
@@ -146,8 +146,8 @@ static void ensure_workdir_contents(const char *path, const char *contents)
 	cl_git_pass(git_futils_readbuffer(&data_buf, git_buf_cstr(&fullpath)));
 	cl_assert(strcmp(git_buf_cstr(&data_buf), contents) == 0);
 
-	git_buf_free(&fullpath);
-	git_buf_free(&data_buf);
+	git_buf_dispose(&fullpath);
+	git_buf_dispose(&data_buf);
 }
 
 static void ensure_workdir_oid(const char *path, const char *oid_str)
@@ -174,7 +174,7 @@ static void ensure_workdir_mode(const char *path, int mode)
 	cl_git_pass(p_stat(git_buf_cstr(&fullpath), &st));
 	cl_assert_equal_i((mode & S_IRWXU), (st.st_mode & S_IRWXU));
 
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 #endif
 }
 
@@ -204,7 +204,7 @@ static void ensure_workdir_link(const char *path, const char *target)
 	actual[len] = '\0';
 	cl_assert(strcmp(actual, target) == 0);
 
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 #endif
 }
 

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -29,7 +29,7 @@ void test_checkout_crlf__cleanup(void)
 
 	if (expected_fixture.size) {
 		cl_fixture_cleanup(expected_fixture.ptr);
-		git_buf_free(&expected_fixture);
+		git_buf_dispose(&expected_fixture);
 	}
 }
 
@@ -84,13 +84,13 @@ done:
 			git_path_basename(actual_path->ptr), systype, cd->autocrlf, cd->attrs);
 		clar__fail(__FILE__, __LINE__,
 			"checked out contents did not match expected", details.ptr, 0);
-		git_buf_free(&details);
+		git_buf_dispose(&details);
 	}
 
 	git__free(basename);
-	git_buf_free(&expected_contents);
-	git_buf_free(&actual_contents);
-	git_buf_free(&expected_path);
+	git_buf_dispose(&expected_contents);
+	git_buf_dispose(&actual_contents);
+	git_buf_dispose(&expected_path);
 
 	return 0;
 }
@@ -139,13 +139,13 @@ static void test_checkout(const char *autocrlf, const char *attrs)
 	cl_git_pass(git_path_direach(&reponame, 0, compare_file, &compare_data));
 
 	cl_fixture_cleanup(expected_fixture.ptr);
-	git_buf_free(&expected_fixture);
+	git_buf_dispose(&expected_fixture);
 
-	git_buf_free(&attrbuf);
-	git_buf_free(&expected_fixture);
-	git_buf_free(&expected_dirname);
-	git_buf_free(&sandboxname);
-	git_buf_free(&reponame);
+	git_buf_dispose(&attrbuf);
+	git_buf_dispose(&expected_fixture);
+	git_buf_dispose(&expected_dirname);
+	git_buf_dispose(&sandboxname);
+	git_buf_dispose(&reponame);
 }
 
 static void empty_workdir(const char *name)

--- a/tests/checkout/icase.c
+++ b/tests/checkout/icase.c
@@ -89,7 +89,7 @@ static char *get_filename(const char *in)
 
 	git__free(search_dirname);
 	git__free(search_filename);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 
 	return filename;
 #endif

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -718,7 +718,7 @@ void test_checkout_index__writes_conflict_file(void)
 		"=======\n"
 		"this file is changed in branch and master\n"
 		">>>>>>> theirs\n") == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	git_index_free(index);
 }
@@ -768,7 +768,7 @@ void test_checkout_index__conflicts_honor_coreautocrlf(void)
 		"=======\r\n"
 		"this file is changed in branch and master\r\n"
 		">>>>>>> theirs\r\n") == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	git_index_free(index);
 #endif

--- a/tests/checkout/nasty.c
+++ b/tests/checkout/nasty.c
@@ -42,7 +42,7 @@ static void test_checkout_passes(const char *refname, const char *filename)
 	cl_assert(!git_path_exists(path.ptr));
 
 	git_commit_free(commit);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void test_checkout_fails(const char *refname, const char *filename)
@@ -63,7 +63,7 @@ static void test_checkout_fails(const char *refname, const char *filename)
 	cl_assert(!git_path_exists(path.ptr));
 
 	git_commit_free(commit);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 /* A tree that contains ".git" as a tree, with a blob inside

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -550,7 +550,7 @@ void assert_conflict(
 	/* Create a conflicting file */
 	cl_git_pass(git_buf_joinpath(&file_path, "./testrepo", entry_path));
 	cl_git_mkfile(git_buf_cstr(&file_path), new_content);
-	git_buf_free(&file_path);
+	git_buf_dispose(&file_path);
 
 	/* Trying to checkout the original commit */
 	cl_git_pass(git_revparse_single(&g_object, g_repo, commit_sha));
@@ -1044,7 +1044,7 @@ mode_t read_filemode(const char *path)
 	result = GIT_PERMS_IS_EXEC(st.st_mode) ?
 		GIT_FILEMODE_BLOB_EXECUTABLE : GIT_FILEMODE_BLOB;
 
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 
 	return result;
 }
@@ -1343,8 +1343,8 @@ void test_checkout_tree__caches_attributes_during_checkout(void)
 	cl_assert_equal_strn(ident1.ptr, "# $Id: ", 7);
 	cl_assert_equal_strn(ident2.ptr, "# $Id: ", 7);
 
-	git_buf_free(&ident1);
-	git_buf_free(&ident2);
+	git_buf_dispose(&ident1);
+	git_buf_dispose(&ident2);
 	git_object_free(obj);
 }
 

--- a/tests/checkout/typechange.c
+++ b/tests/checkout/typechange.c
@@ -139,7 +139,7 @@ static void assert_workdir_matches_tree(
 	}
 
 	git_tree_free(tree);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_checkout_typechange__checkout_typechanges_safe(void)
@@ -249,8 +249,8 @@ static int make_submodule_dirty(git_submodule *sm, const char *name, void *paylo
 		git_buf_joinpath(&dirtypath, git_repository_workdir(submodule_repo), "dirty"));
 	force_create_file(git_buf_cstr(&dirtypath));
 
-	git_buf_free(&dirtypath);
-	git_buf_free(&submodulepath);
+	git_buf_dispose(&dirtypath);
+	git_buf_dispose(&submodulepath);
 	git_repository_free(submodule_repo);
 
 	return 0;

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -228,8 +228,8 @@ void test_cherrypick_workdir__conflicts(void)
 
 	git_commit_free(commit);
 	git_commit_free(head);
-	git_buf_free(&mergemsg_buf);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&mergemsg_buf);
+	git_buf_dispose(&conflicting_buf);
 }
 
 /* git reset --hard bafbf6912c09505ac60575cd43d3f2aba3bd84d8
@@ -358,7 +358,7 @@ void test_cherrypick_workdir__both_renamed(void)
 		"\tfile3.txt.renamed\n" \
 		"\tfile3.txt.renamed_on_branch\n") == 0);
 
-	git_buf_free(&mergemsg_buf);
+	git_buf_dispose(&mergemsg_buf);
 	git_commit_free(commit);
 	git_commit_free(head);
 }

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -310,8 +310,8 @@ const char* cl_git_path_url(const char *path)
 	cl_assert(url_buf.size < 4096);
 
 	strncpy(url, git_buf_cstr(&url_buf), 4096);
-	git_buf_free(&url_buf);
-	git_buf_free(&path_buf);
+	git_buf_dispose(&url_buf);
+	git_buf_dispose(&path_buf);
 	return url;
 }
 
@@ -359,7 +359,7 @@ int cl_git_remove_placeholders(const char *directory_path, const char *filename)
 
 	error = remove_placeholders_recurs(&data, &buffer);
 
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 
 	return error;
 }
@@ -544,7 +544,7 @@ void cl_fake_home(void)
 	cl_git_pass(git_path_prettify(&path, "home", NULL));
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, path.ptr));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void cl_sandbox_set_search_path_defaults(void)
@@ -565,7 +565,7 @@ void cl_sandbox_set_search_path_defaults(void)
 	git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_PROGRAMDATA, path.ptr);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 #ifdef GIT_WIN32
@@ -584,7 +584,7 @@ bool cl_sandbox_supports_8dot3(void)
 	supported = (shortname != NULL);
 
 	git__free(shortname);
-	git_buf_free(&longpath);
+	git_buf_dispose(&longpath);
 
 	return supported;
 }

--- a/tests/clone/empty.c
+++ b/tests/clone/empty.c
@@ -53,13 +53,13 @@ void test_clone_empty__can_clone_an_empty_local_repo_barely(void)
 	cl_git_pass(git_branch_upstream_name(&buf, g_repo_cloned, local_name));
 
 	cl_assert_equal_s(expected_tracked_branch_name, buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* ...and the name of the remote... */
 	cl_git_pass(git_branch_remote_name(&buf, g_repo_cloned, expected_tracked_branch_name));
 
 	cl_assert_equal_s(expected_remote_name, buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* ...even when the remote HEAD is unborn as well */
 	cl_assert_equal_i(GIT_ENOTFOUND, git_reference_lookup(&ref, g_repo_cloned,

--- a/tests/clone/local.c
+++ b/tests/clone/local.c
@@ -91,7 +91,7 @@ void test_clone_local__should_clone_local(void)
 	cl_assert_equal_i(1,  git_clone__should_clone_local(path, GIT_CLONE_LOCAL_NO_LINKS));
 	cl_assert_equal_i(0, git_clone__should_clone_local(path, GIT_CLONE_NO_LOCAL));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_clone_local__hardlinks(void)
@@ -149,7 +149,7 @@ void test_clone_local__hardlinks(void)
 	cl_assert_equal_i(3, st.st_nlink);
 #endif
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_repository_free(repo);
 
 	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
@@ -179,8 +179,8 @@ void test_clone_local__standard_unc_paths_are_written_git_style(void)
 
 	git_remote_free(remote);
 	git_repository_free(repo);
-	git_buf_free(&unc);
-	git_buf_free(&git_unc);
+	git_buf_dispose(&unc);
+	git_buf_dispose(&git_unc);
 
 	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
 #endif
@@ -206,7 +206,7 @@ void test_clone_local__git_style_unc_paths(void)
 
 	git_remote_free(remote);
 	git_repository_free(repo);
-	git_buf_free(&git_unc);
+	git_buf_dispose(&git_unc);
 
 	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
 #endif

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -154,7 +154,7 @@ void test_clone_nonetwork__can_prevent_the_checkout_of_a_standard_repo(void)
 	cl_git_pass(git_buf_joinpath(&path, git_repository_workdir(g_repo), "master.txt"));
 	cl_assert_equal_i(false, git_path_isfile(git_buf_cstr(&path)));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_clone_nonetwork__can_checkout_given_branch(void)
@@ -309,7 +309,7 @@ static void assert_correct_reflog(const char *name)
 
 	git_reflog_free(log);
 
-	git_buf_free(&expected_message);
+	git_buf_dispose(&expected_message);
 }
 
 void test_clone_nonetwork__clone_updates_reflog_properly(void)

--- a/tests/commit/parse.c
+++ b/tests/commit/parse.c
@@ -464,7 +464,7 @@ cpxtDQQMGYFpXK/71stq\n\
 	cl_git_pass(git_commit_header_field(&buf, commit, "committer"));
 	cl_assert_equal_s("Vicent Marti <tanoku@gmail.com> 1273848544 +0200", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_commit__free(commit);
 }
 
@@ -547,7 +547,7 @@ corrupt signature\n";
 	cl_assert_equal_s(oneline_data, signed_data.ptr);
 
 
-	git_buf_free(&signature);
-	git_buf_free(&signed_data);
+	git_buf_dispose(&signature);
+	git_buf_dispose(&signed_data);
 
 }

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -130,7 +130,7 @@ This is a root commit\n\
    This is a root commit and should be the only one in this branch\n\
 ");
 
-	git_buf_free(&commit);
+	git_buf_dispose(&commit);
 	git_tree_free(tree);
 	git_commit_free(parent);
 	git_signature_free(author);

--- a/tests/config/conditionals.c
+++ b/tests/config/conditionals.c
@@ -43,7 +43,7 @@ static void assert_condition_includes(const char *keyword, const char *path, boo
 				 git_config_get_string_buf(&buf, cfg, "foo.bar"));
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 
@@ -77,7 +77,7 @@ void test_config_conditionals__gitdir(void)
 	assert_condition_includes("gitdir", path.ptr, false);
 
 	git__free(sandbox_path);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_config_conditionals__gitdir_i(void)
@@ -94,7 +94,7 @@ void test_config_conditionals__gitdir_i(void)
 	assert_condition_includes("gitdir/i", path.ptr, true);
 
 	git__free(sandbox_path);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_config_conditionals__invalid_conditional_fails(void)

--- a/tests/config/config_helpers.c
+++ b/tests/config/config_helpers.c
@@ -36,7 +36,7 @@ void assert_config_entry_value(
 	cl_git_pass(git_config_get_string_buf(&buf, config, name));
 
 	cl_assert_equal_s(expected_value, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static int count_config_entries_cb(

--- a/tests/config/configlevel.c
+++ b/tests/config/configlevel.c
@@ -33,7 +33,7 @@ void test_config_configlevel__can_replace_a_config_file_at_an_existing_level(voi
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.stringglobal"));
 	cl_assert_equal_s("don't find me!", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 
@@ -56,7 +56,7 @@ void test_config_configlevel__can_read_from_a_single_level_focused_file_after_pa
 	cl_git_pass(git_config_get_string_buf(&buf, single_level_cfg, "core.stringglobal"));
 	cl_assert_equal_s("don't find me!", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(single_level_cfg);
 }
 

--- a/tests/config/global.c
+++ b/tests/config/global.c
@@ -21,7 +21,7 @@ void test_config_global__initialize(void)
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_SYSTEM, path.ptr));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_config_global__cleanup(void)
@@ -60,7 +60,7 @@ void test_config_global__open_xdg(void)
 	cl_git_pass(git_config_get_string_buf(&buf, selected, key));
 	cl_assert_equal_s(str, buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(selected);
 	git_config_free(xdg);
 	git_config_free(cfg);
@@ -87,7 +87,7 @@ void test_config_global__open_programdata(void)
 	cl_git_pass(git_config_open_ondisk(&cfg, config_path.ptr));
 	cl_git_pass(git_config_set_string(cfg, "programdata.var", "even higher level"));
 
-	git_buf_free(&config_path);
+	git_buf_dispose(&config_path);
 	git_config_free(cfg);
 
 	git_config_open_default(&cfg);
@@ -95,7 +95,7 @@ void test_config_global__open_programdata(void)
 	cl_assert_equal_s("even higher level", var_contents.ptr);
 
 	git_config_free(cfg);
-	git_buf_free(&var_contents);
+	git_buf_dispose(&var_contents);
 
 	cl_git_pass(git_repository_init(&repo, "./foo.git", true));
 	cl_git_pass(git_repository_config(&cfg, repo));
@@ -103,7 +103,7 @@ void test_config_global__open_programdata(void)
 	cl_assert_equal_s("even higher level", var_contents.ptr);
 
 	git_config_free(cfg);
-	git_buf_free(&var_contents);
+	git_buf_dispose(&var_contents);
 	git_repository_free(repo);
 	cl_fixture_cleanup("./foo.git");
 }

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -14,7 +14,7 @@ void test_config_include__initialize(void)
 void test_config_include__cleanup(void)
 {
     git_config_free(cfg);
-    git_buf_free(&buf);
+    git_buf_dispose(&buf);
 }
 
 void test_config_include__relative(void)
@@ -30,7 +30,7 @@ void test_config_include__absolute(void)
 	cl_git_pass(git_buf_printf(&buf, "[include]\npath = %s/config-included", cl_fixture("config")));
 
 	cl_git_mkfile("config-include-absolute", git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	cl_git_pass(git_config_open_ondisk(&cfg, "config-include-absolute"));
 
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "foo.bar.baz"));

--- a/tests/config/new.c
+++ b/tests/config/new.c
@@ -27,7 +27,7 @@ void test_config_new__write_new_config(void)
 	cl_git_pass(git_config_get_string_buf(&buf, config, "core.editor"));
 	cl_assert_equal_s("ed", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(config);
 
 	p_unlink(TEST_CONFIG);

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -6,7 +6,7 @@ static git_buf buf = GIT_BUF_INIT;
 
 void test_config_read__cleanup(void)
 {
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_config_read__simple_read(void)
@@ -688,29 +688,29 @@ void test_config_read__path(void)
 	cl_git_pass(git_config_open_ondisk(&cfg, "./testconfig"));
 	cl_git_pass(git_config_get_path(&path, cfg, "some.path"));
 	cl_assert_equal_s(expected_path.ptr, path.ptr);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	cl_git_mkfile("./testconfig", "[some]\n path = ~/");
 	cl_git_pass(git_path_join_unrooted(&expected_path, "", home_path.ptr, NULL));
 
 	cl_git_pass(git_config_get_path(&path, cfg, "some.path"));
 	cl_assert_equal_s(expected_path.ptr, path.ptr);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	cl_git_mkfile("./testconfig", "[some]\n path = ~");
 	cl_git_pass(git_buf_sets(&expected_path, home_path.ptr));
 
 	cl_git_pass(git_config_get_path(&path, cfg, "some.path"));
 	cl_assert_equal_s(expected_path.ptr, path.ptr);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	cl_git_mkfile("./testconfig", "[some]\n path = ~user/foo");
 	cl_git_fail(git_config_get_path(&path, cfg, "some.path"));
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, old_path.ptr));
-	git_buf_free(&old_path);
-	git_buf_free(&home_path);
-	git_buf_free(&expected_path);
+	git_buf_dispose(&old_path);
+	git_buf_dispose(&home_path);
+	git_buf_dispose(&expected_path);
 	git_config_free(cfg);
 }
 
@@ -726,7 +726,7 @@ void test_config_read__crlf_style_line_endings(void)
 	cl_assert_equal_s(buf.ptr, "value");
 
 	git_config_free(cfg);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_config_read__trailing_crlf(void)
@@ -741,7 +741,7 @@ void test_config_read__trailing_crlf(void)
 	cl_assert_equal_s(buf.ptr, "value");
 
 	git_config_free(cfg);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_config_read__bom(void)
@@ -756,5 +756,5 @@ void test_config_read__bom(void)
 	cl_assert_equal_s(buf.ptr, "value");
 
 	git_config_free(cfg);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }

--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -22,7 +22,7 @@ void test_config_stress__initialize(void)
 
 void test_config_stress__cleanup(void)
 {
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	p_unlink(TEST_CONFIG);
 }
 

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -293,7 +293,7 @@ void test_config_write__write_subsection(void)
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "my.own.var"));
 	cl_assert_equal_s("works", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 
@@ -335,7 +335,7 @@ void test_config_write__value_containing_quotes(void)
 	cl_git_pass(git_config_open_ondisk(&cfg, "config9"));
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.somevar"));
 	cl_assert_equal_s("this also \"has\" quotes", git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 
@@ -354,7 +354,7 @@ void test_config_write__escape_value(void)
 	cl_git_pass(git_config_open_ondisk(&cfg, "config9"));
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.somevar"));
 	cl_assert_equal_s("this \"has\" quotes and \t", git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 
@@ -393,7 +393,7 @@ void test_config_write__add_value_at_specific_level(void)
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.stringglobal"));
 	cl_assert_equal_s("I'm a global config value!", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 
@@ -489,7 +489,7 @@ void test_config_write__can_set_an_empty_value(void)
 	cl_git_pass(git_config_get_string_buf(&buf, config, "core.somevar"));
 	cl_assert_equal_s("", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(config);
 	cl_git_sandbox_cleanup();
 }
@@ -581,7 +581,7 @@ void test_config_write__preserves_whitespace_and_comments(void)
 
 	cl_assert_equal_s("[newsection]\n\tnewname = new_value\n", n);
 
-	git_buf_free(&newfile);
+	git_buf_dispose(&newfile);
 	git_config_free(cfg);
 }
 
@@ -600,7 +600,7 @@ void test_config_write__preserves_entry_with_name_only(void)
 	cl_git_pass(git_futils_readbuffer(&newfile, file_name));
 	cl_assert_equal_s("[section \"foo\"]\n\tname\n\tother = otherval\n[newsection]\n\tnewname = new_value\n", newfile.ptr);
 
-	git_buf_free(&newfile);
+	git_buf_dispose(&newfile);
 	git_config_free(cfg);
 }
 
@@ -618,7 +618,7 @@ void test_config_write__to_empty_file(void)
 	cl_git_pass(git_futils_readbuffer(&result, "config-file"));
 	cl_assert_equal_s("[section]\n\tname = value\n", result.ptr);
 
-	git_buf_free(&result);
+	git_buf_dispose(&result);
 }
 
 void test_config_write__to_file_with_only_comment(void)
@@ -635,7 +635,7 @@ void test_config_write__to_file_with_only_comment(void)
 	cl_git_pass(git_futils_readbuffer(&result, "config-file"));
 	cl_assert_equal_s("\n\n[section]\n\tname = value\n", result.ptr);
 
-	git_buf_free(&result);
+	git_buf_dispose(&result);
 }
 
 void test_config_write__locking(void)
@@ -718,7 +718,7 @@ void test_config_write__repeated(void)
 
 	cl_git_pass(git_futils_readbuffer(&result, filename));
 	cl_assert_equal_s(expected, result.ptr);
-	git_buf_free(&result);
+	git_buf_dispose(&result);
 
 	git_config_free(cfg);
 }
@@ -741,7 +741,7 @@ void test_config_write__preserve_case(void)
 
 	cl_git_pass(git_futils_readbuffer(&result, filename));
 	cl_assert_equal_s(expected, result.ptr);
-	git_buf_free(&result);
+	git_buf_dispose(&result);
 
 	git_config_free(cfg);
 }

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -28,7 +28,7 @@ void test_core_buffer__0(void)
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(test_string_x2, git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 /* test git_buf_printf */
@@ -44,7 +44,7 @@ void test_core_buffer__1(void)
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s("shoop da 23 woop 42", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 /* more thorough test of concatenation options */
@@ -57,7 +57,7 @@ void test_core_buffer__2(void)
 	cl_assert(buf.size == 0);
 
 	/* this must be safe to do */
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	cl_assert(buf.size == 0);
 	cl_assert(buf.asize == 0);
 
@@ -67,7 +67,7 @@ void test_core_buffer__2(void)
 	/* cl_assert(buf.asize == 0); -- should not assume what git_buf does */
 
 	/* free should set us back to the beginning */
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	cl_assert(buf.size == 0);
 	cl_assert(buf.asize == 0);
 
@@ -88,7 +88,7 @@ void test_core_buffer__2(void)
 	}
 	cl_assert_equal_s("++++++++++++++++++", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* add data */
 	git_buf_put(&buf, "xo", 2);
@@ -108,7 +108,7 @@ void test_core_buffer__2(void)
 	cl_assert_equal_s("xoxoxoxoxoxoxoxoxoxoxoxoxoxoxoxoxoxo",
 					   git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* set to string */
 	git_buf_sets(&buf, test_string);
@@ -129,7 +129,7 @@ void test_core_buffer__2(void)
 	git_buf_clear(&buf);
 	cl_assert_equal_s("", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* test extracting data into buffer */
 	git_buf_puts(&buf, REP4("0123456789"));
@@ -153,7 +153,7 @@ void test_core_buffer__2(void)
 	cl_assert_equal_s(REP4(REP16("x")) REP16("x") REP16("x")
 					   REP16("x") "xxxxxxxxxxxxxxx", data);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	git_buf_copy_cstr(data, sizeof(data), &buf);
 	cl_assert_equal_s("", data);
@@ -179,7 +179,7 @@ void test_core_buffer__3(void)
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(test_4096, git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 /* let's try some producer/consumer tests */
@@ -212,7 +212,7 @@ void test_core_buffer__4(void)
 	git_buf_consume(&buf, buf.ptr + buf.size);
 	cl_assert_equal_s("", git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 
@@ -235,7 +235,7 @@ check_buf_append(
 	if (expected_asize > 0)
 		cl_assert(tgt.asize == expected_asize);
 
-	git_buf_free(&tgt);
+	git_buf_dispose(&tgt);
 }
 
 static void
@@ -275,7 +275,7 @@ check_buf_append_abc(
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(expected_abcabc, git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 /* more variations on append tests */
@@ -340,8 +340,8 @@ void test_core_buffer__6(void)
 	cl_assert_equal_s("bar", git_buf_cstr(&a));
 	cl_assert_equal_s("foo", git_buf_cstr(&b));
 
-	git_buf_free(&a);
-	git_buf_free(&b);
+	git_buf_dispose(&a);
+	git_buf_dispose(&b);
 }
 
 
@@ -367,7 +367,7 @@ void test_core_buffer__7(void)
 	cl_assert_equal_s(NULL, b);
 	cl_assert_equal_s("", a.ptr);
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 
 	b = git__strdup(fun);
 	git_buf_attach(&a, b, 0);
@@ -376,7 +376,7 @@ void test_core_buffer__7(void)
 	cl_assert(a.size == strlen(fun));
 	cl_assert(a.asize == strlen(fun) + 1);
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 
 	b = git__strdup(fun);
 	git_buf_attach(&a, b, strlen(fun) + 1);
@@ -385,7 +385,7 @@ void test_core_buffer__7(void)
 	cl_assert(a.size == strlen(fun));
 	cl_assert(a.asize == strlen(fun) + 1);
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 }
 
 
@@ -401,7 +401,7 @@ check_joinbuf_2(
 	git_buf_join(&buf, sep, a, b);
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(expected, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static void
@@ -418,7 +418,7 @@ check_joinbuf_overlapped(
 	git_buf_join(&buf, sep, buf.ptr + ofs_a, b);
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(expected, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static void
@@ -437,7 +437,7 @@ check_joinbuf_n_2(
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(expected, git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static void
@@ -453,7 +453,7 @@ check_joinbuf_n_4(
 	git_buf_join_n(&buf, sep, 4, a, b, c, d);
 	cl_assert(git_buf_oom(&buf) == 0);
 	cl_assert_equal_s(expected, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 /* test join */
@@ -473,7 +473,7 @@ void test_core_buffer__8(void)
 	cl_assert(git_buf_oom(&a) == 0);
 	cl_assert_equal_s("foo/bar/baz", git_buf_cstr(&a));
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 
 	check_joinbuf_2(NULL, "", "");
 	check_joinbuf_2(NULL, "a", "a");
@@ -578,7 +578,7 @@ void test_core_buffer__9(void)
 		}
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__10(void)
@@ -595,7 +595,7 @@ void test_core_buffer__10(void)
 	cl_git_pass(git_buf_join_n(&a, '/', 2, a.ptr, "more"));
 	cl_assert_equal_s(a.ptr, "test/string/join/test/string/join/more");
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 }
 
 void test_core_buffer__join3(void)
@@ -627,7 +627,7 @@ void test_core_buffer__join3(void)
 	cl_git_pass(git_buf_join3(&a, '/', "string/", "", "/join"));
 	cl_assert_equal_s("string/join", a.ptr);
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 }
 
 void test_core_buffer__11(void)
@@ -677,7 +677,7 @@ void test_core_buffer__11(void)
 	cl_git_pass(git_buf_text_common_prefix(&a, &t));
 	cl_assert_equal_s(a.ptr, "");
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 }
 
 void test_core_buffer__rfind_variants(void)
@@ -701,7 +701,7 @@ void test_core_buffer__rfind_variants(void)
 	cl_assert(git_buf_rfind(&a, 'q') == -1);
 	cl_assert(git_buf_rfind_next(&a, 'q') == -1);
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 }
 
 void test_core_buffer__puts_escaped(void)
@@ -724,7 +724,7 @@ void test_core_buffer__puts_escaped(void)
 	cl_git_pass(git_buf_text_puts_escape_regex(&a, "^match\\s*[A-Z]+.*"));
 	cl_assert_equal_s("\\^match\\\\s\\*\\[A-Z\\]\\+\\.\\*", a.ptr);
 
-	git_buf_free(&a);
+	git_buf_dispose(&a);
 }
 
 static void assert_unescape(char *expected, char *to_unescape) {
@@ -735,7 +735,7 @@ static void assert_unescape(char *expected, char *to_unescape) {
 	cl_assert_equal_s(expected, buf.ptr);
 	cl_assert_equal_sz(strlen(expected), buf.size);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__unescape(void)
@@ -769,7 +769,7 @@ void test_core_buffer__encode_base64(void)
 	cl_git_pass(git_buf_encode_base64(&buf, "this!\n", 6));
 	cl_assert_equal_s("dGhpcyEK", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__decode_base64(void)
@@ -790,7 +790,7 @@ void test_core_buffer__decode_base64(void)
 	cl_git_fail(git_buf_decode_base64(&buf, "This is not a valid base64 string!!!", 36));
 	cl_assert_equal_s("this!\n", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__encode_base85(void)
@@ -810,7 +810,7 @@ void test_core_buffer__encode_base85(void)
 	cl_assert_equal_s("bZBXFAZc?TVqtS-AUHK3Wo~0{WMyOk", buf.ptr);
 	git_buf_clear(&buf);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__decode_base85(void)
@@ -832,7 +832,7 @@ void test_core_buffer__decode_base85(void)
 	cl_assert_equal_s("this is base 85 encoded", buf.ptr);
 	git_buf_clear(&buf);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__decode_base85_fails_gracefully(void)
@@ -848,7 +848,7 @@ void test_core_buffer__decode_base85_fails_gracefully(void)
 	cl_assert_equal_sz(6, buf.size);
 	cl_assert_equal_s("foobar", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_buffer__classify_with_utf8(void)
@@ -977,7 +977,7 @@ void test_core_buffer__similarity_metric(void)
 	git_hashsig_free(a);
 	git_hashsig_free(b);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_futils_rmdir_r("scratch", NULL, GIT_RMDIR_REMOVE_FILES);
 }
 
@@ -1057,7 +1057,7 @@ void test_core_buffer__similarity_metric_whitespace(void)
 		}
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 #include "../filter/crlf.h"
@@ -1150,8 +1150,8 @@ void test_core_buffer__lf_and_crlf_conversions(void)
 	cl_git_pass(git_buf_text_crlf_to_lf(&tgt, &src));
 	check_buf("\rcr\r", tgt);
 
-	git_buf_free(&src);
-	git_buf_free(&tgt);
+	git_buf_dispose(&src);
+	git_buf_dispose(&tgt);
 
 	/* blob correspondence tests */
 
@@ -1161,8 +1161,8 @@ void test_core_buffer__lf_and_crlf_conversions(void)
 	git_buf_sets(&src, ALL_CRLF_TEXT_RAW);
 	cl_git_pass(git_buf_text_crlf_to_lf(&tgt, &src));
 	check_buf(ALL_CRLF_TEXT_AS_LF, tgt);
-	git_buf_free(&src);
-	git_buf_free(&tgt);
+	git_buf_dispose(&src);
+	git_buf_dispose(&tgt);
 
 	git_buf_sets(&src, ALL_LF_TEXT_RAW);
 	cl_git_pass(git_buf_text_lf_to_crlf(&tgt, &src));
@@ -1170,8 +1170,8 @@ void test_core_buffer__lf_and_crlf_conversions(void)
 	git_buf_sets(&src, ALL_LF_TEXT_RAW);
 	cl_git_pass(git_buf_text_crlf_to_lf(&tgt, &src));
 	check_buf(ALL_LF_TEXT_AS_LF, tgt);
-	git_buf_free(&src);
-	git_buf_free(&tgt);
+	git_buf_dispose(&src);
+	git_buf_dispose(&tgt);
 
 	git_buf_sets(&src, MORE_CRLF_TEXT_RAW);
 	cl_git_pass(git_buf_text_lf_to_crlf(&tgt, &src));
@@ -1179,8 +1179,8 @@ void test_core_buffer__lf_and_crlf_conversions(void)
 	git_buf_sets(&src, MORE_CRLF_TEXT_RAW);
 	cl_git_pass(git_buf_text_crlf_to_lf(&tgt, &src));
 	check_buf(MORE_CRLF_TEXT_AS_LF, tgt);
-	git_buf_free(&src);
-	git_buf_free(&tgt);
+	git_buf_dispose(&src);
+	git_buf_dispose(&tgt);
 
 	git_buf_sets(&src, MORE_LF_TEXT_RAW);
 	cl_git_pass(git_buf_text_lf_to_crlf(&tgt, &src));
@@ -1188,8 +1188,8 @@ void test_core_buffer__lf_and_crlf_conversions(void)
 	git_buf_sets(&src, MORE_LF_TEXT_RAW);
 	cl_git_pass(git_buf_text_crlf_to_lf(&tgt, &src));
 	check_buf(MORE_LF_TEXT_AS_LF, tgt);
-	git_buf_free(&src);
-	git_buf_free(&tgt);
+	git_buf_dispose(&src);
+	git_buf_dispose(&tgt);
 }
 
 void test_core_buffer__dont_grow_borrowed(void)

--- a/tests/core/dirent.c
+++ b/tests/core/dirent.c
@@ -55,7 +55,7 @@ static void dirent_cleanup__cb(void *_d)
 
 	cl_must_pass(p_rmdir(top_dir));
 
-	git_buf_free(&d->path);
+	git_buf_dispose(&d->path);
 }
 
 static void check_counts(walk_data *d)

--- a/tests/core/env.c
+++ b/tests/core/env.c
@@ -162,8 +162,8 @@ void test_core_env__0(void)
 		(void)p_rmdir(*val);
 	}
 
-	git_buf_free(&path);
-	git_buf_free(&found);
+	git_buf_dispose(&path);
+	git_buf_dispose(&found);
 }
 
 
@@ -206,7 +206,7 @@ void test_core_env__1(void)
 		GIT_ENOTFOUND, git_sysdir_find_system_file(&path, "nonexistentfile"));
 #endif
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void check_global_searchpath(
@@ -245,7 +245,7 @@ static void check_global_searchpath(
 	cl_assert_equal_i(
 		GIT_ENOTFOUND, git_sysdir_find_global_file(temp, file));
 
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_core_env__2(void)
@@ -295,8 +295,8 @@ void test_core_env__2(void)
 		(void)p_rmdir(*val);
 	}
 
-	git_buf_free(&path);
-	git_buf_free(&found);
+	git_buf_dispose(&path);
+	git_buf_dispose(&found);
 }
 
 void test_core_env__substitution(void)
@@ -316,6 +316,6 @@ void test_core_env__substitution(void)
   cl_git_pass(git_buf_join(&expected, GIT_PATH_LIST_SEPARATOR, "/tmp/a", "/tmp/b"));
   cl_assert_equal_s(expected.ptr, buf.ptr);
 
-  git_buf_free(&expected);
-  git_buf_free(&buf);
+  git_buf_dispose(&expected);
+  git_buf_dispose(&buf);
 }

--- a/tests/core/filebuf.c
+++ b/tests/core/filebuf.c
@@ -210,8 +210,8 @@ void test_core_filebuf__symlink_follow_absolute_paths(void)
 	cl_assert_equal_i(true, git_path_exists("linkdir/target"));
 
 	git_filebuf_cleanup(&file);
-	git_buf_free(&source);
-	git_buf_free(&target);
+	git_buf_dispose(&source);
+	git_buf_dispose(&target);
 
 	cl_git_pass(git_futils_rmdir_r("linkdir", NULL, GIT_RMDIR_REMOVE_FILES));
 }

--- a/tests/core/futils.c
+++ b/tests/core/futils.c
@@ -33,8 +33,8 @@ void test_core_futils__writebuffer(void)
 
 	cl_assert_equal_file(out.ptr, out.size, "futils/test-file");
 
-	git_buf_free(&out);
-	git_buf_free(&append);
+	git_buf_dispose(&out);
+	git_buf_dispose(&append);
 }
 
 void test_core_futils__write_hidden_file(void)
@@ -61,8 +61,8 @@ void test_core_futils__write_hidden_file(void)
 	cl_git_pass(git_win32__hidden(&hidden, "futils/test-file"));
 	cl_assert(hidden);
 
-	git_buf_free(&out);
-	git_buf_free(&append);
+	git_buf_dispose(&out);
+	git_buf_dispose(&append);
 #endif
 }
 

--- a/tests/core/link.c
+++ b/tests/core/link.c
@@ -147,7 +147,7 @@ static void do_junction(const char *old, const char *new)
 	CloseHandle(handle);
 	LocalFree(reparse_buf);
 
-	git_buf_free(&unparsed_buf);
+	git_buf_dispose(&unparsed_buf);
 }
 
 static void do_custom_reparse(const char *path)
@@ -322,7 +322,7 @@ void test_core_link__lstat_symlink(void)
 	cl_assert(S_ISLNK(st.st_mode));
 	cl_assert_equal_i(git_buf_len(&target_path), st.st_size);
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 }
 
 void test_core_link__lstat_symlink_directory(void)
@@ -345,7 +345,7 @@ void test_core_link__lstat_symlink_directory(void)
 	cl_assert(S_ISLNK(st.st_mode));
 	cl_assert_equal_i(git_buf_len(&target_path), st.st_size);
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 }
 
 void test_core_link__lstat_dangling_symlink(void)
@@ -397,7 +397,7 @@ void test_core_link__stat_junction(void)
 	cl_must_pass(p_stat("stat_junction", &st));
 	cl_assert(S_ISDIR(st.st_mode));
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 #endif
 }
 
@@ -417,7 +417,7 @@ void test_core_link__stat_dangling_junction(void)
 	cl_must_fail(p_stat("stat_nonexistent_junctarget", &st));
 	cl_must_fail(p_stat("stat_dangling_junction", &st));
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 #endif
 }
 
@@ -438,7 +438,7 @@ void test_core_link__lstat_junction(void)
 	cl_must_pass(p_lstat("lstat_junction", &st));
 	cl_assert(S_ISLNK(st.st_mode));
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 #endif
 }
 
@@ -461,7 +461,7 @@ void test_core_link__lstat_dangling_junction(void)
 	cl_assert(S_ISLNK(st.st_mode));
 	cl_assert_equal_i(git_buf_len(&target_path), st.st_size);
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 #endif
 }
 
@@ -573,7 +573,7 @@ void test_core_link__readlink_symlink(void)
 
 	cl_assert_equal_s(git_buf_cstr(&target_path), buf);
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 }
 
 void test_core_link__readlink_dangling(void)
@@ -596,7 +596,7 @@ void test_core_link__readlink_dangling(void)
 
 	cl_assert_equal_s(git_buf_cstr(&target_path), buf);
 
-	git_buf_free(&target_path);
+	git_buf_dispose(&target_path);
 }
 
 void test_core_link__readlink_multiple(void)
@@ -625,8 +625,8 @@ void test_core_link__readlink_multiple(void)
 
 	cl_assert_equal_s(git_buf_cstr(&path2), buf);
 
-	git_buf_free(&path1);
-	git_buf_free(&path2);
-	git_buf_free(&path3);
-	git_buf_free(&target_path);
+	git_buf_dispose(&path1);
+	git_buf_dispose(&path2);
+	git_buf_dispose(&path3);
+	git_buf_dispose(&target_path);
 }

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -49,7 +49,7 @@ void test_core_mkdir__absolute(void)
 	cl_git_fail(git_futils_mkdir(path.ptr, 0755, 0));
 	cl_assert(!git_path_isdir(path.ptr));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_core_mkdir__basic(void)
@@ -256,7 +256,7 @@ void test_core_mkdir__keeps_parent_symlinks(void)
 	cl_assert(git_path_isdir("d2/other/dir"));
 	cl_assert(git_path_isdir("d0/other/dir"));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 #endif
 }
 

--- a/tests/core/path.c
+++ b/tests/core/path.c
@@ -9,7 +9,7 @@ check_dirname(const char *A, const char *B)
 
 	cl_assert(git_path_dirname_r(&dir, A) >= 0);
 	cl_assert_equal_s(B, dir.ptr);
-	git_buf_free(&dir);
+	git_buf_dispose(&dir);
 
 	cl_assert((dir2 = git_path_dirname(A)) != NULL);
 	cl_assert_equal_s(B, dir2);
@@ -24,7 +24,7 @@ check_basename(const char *A, const char *B)
 
 	cl_assert(git_path_basename_r(&base, A) >= 0);
 	cl_assert_equal_s(B, base.ptr);
-	git_buf_free(&base);
+	git_buf_dispose(&base);
 
 	cl_assert((base2 = git_path_basename(A)) != NULL);
 	cl_assert_equal_s(B, base2);
@@ -48,7 +48,7 @@ check_joinpath(const char *path_a, const char *path_b, const char *expected_path
 	cl_git_pass(git_buf_joinpath(&joined_path, path_a, path_b));
 	cl_assert_equal_s(expected_path, joined_path.ptr);
 
-	git_buf_free(&joined_path);
+	git_buf_dispose(&joined_path);
 }
 
 static void
@@ -65,7 +65,7 @@ check_joinpath_n(
 							   path_a, path_b, path_c, path_d));
 	cl_assert_equal_s(expected_path, joined_path.ptr);
 
-	git_buf_free(&joined_path);
+	git_buf_dispose(&joined_path);
 }
 
 
@@ -204,7 +204,7 @@ check_path_to_dir(
 	cl_git_pass(git_path_to_dir(&tgt));
 	cl_assert_equal_s(expected, tgt.ptr);
 
-	git_buf_free(&tgt);
+	git_buf_dispose(&tgt);
 }
 
 static void
@@ -275,7 +275,7 @@ void test_core_path__08_self_join(void)
 	cl_assert_equal_s(path.ptr, "/foo/this is a new string/grow the buffer, grow the buffer, grow the buffer");
 	cl_assert(asize < path.asize);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	cl_git_pass(git_buf_sets(&path, "/foo/bar"));
 
 	cl_git_pass(git_buf_joinpath(&path, path.ptr + 4, "baz"));
@@ -286,7 +286,7 @@ void test_core_path__08_self_join(void)
 	cl_assert_equal_s(path.ptr, "/baz/somethinglongenoughtorealloc");
 	cl_assert(asize < path.asize);
 	
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void check_percent_decoding(const char *expected_result, const char *input)
@@ -296,7 +296,7 @@ static void check_percent_decoding(const char *expected_result, const char *inpu
 	cl_git_pass(git__percent_decode(&buf, input));
 	cl_assert_equal_s(expected_result, git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_path__09_percent_decode(void)
@@ -325,7 +325,7 @@ static void check_fromurl(const char *expected_result, const char *input, int sh
 	} else
 		cl_git_fail(git_path_fromurl(&buf, input));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 #ifdef GIT_WIN32
@@ -436,7 +436,7 @@ void test_core_path__11_walkup(void)
 		i = info.expect_idx;
 	}
 
-	git_buf_free(&p);
+	git_buf_dispose(&p);
 }
 
 void test_core_path__11a_walkup_cancel(void)
@@ -472,7 +472,7 @@ void test_core_path__11a_walkup_cancel(void)
 		while (expect[i] != NULL) i++;
 	}
 
-	git_buf_free(&p);
+	git_buf_dispose(&p);
 }
 
 void test_core_path__12_offset_to_path_root(void)
@@ -500,7 +500,7 @@ void test_core_path__13_cannot_prettify_a_non_existing_file(void)
 	cl_assert_equal_i(GIT_ENOTFOUND, git_path_prettify(&p, NON_EXISTING_FILEPATH, NULL));
 	cl_assert_equal_i(GIT_ENOTFOUND, git_path_prettify(&p, NON_EXISTING_FILEPATH "/so-do-i", NULL));
 
-	git_buf_free(&p);
+	git_buf_dispose(&p);
 }
 
 void test_core_path__14_apply_relative(void)
@@ -561,7 +561,7 @@ void test_core_path__14_apply_relative(void)
 
 	cl_git_pass(git_path_apply_relative(&p, "../there"));
 	cl_assert_equal_s("../../there", p.ptr);
-	git_buf_free(&p);
+	git_buf_dispose(&p);
 }
 
 static void assert_resolve_relative(
@@ -654,7 +654,7 @@ void test_core_path__15_resolve_relative(void)
 	assert_resolve_relative(&buf, "/", "//a/b/../..");
 #endif
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 #define assert_common_dirlen(i, p, q) \

--- a/tests/core/rmdir.c
+++ b/tests/core/rmdir.c
@@ -24,7 +24,7 @@ void test_core_rmdir__initialize(void)
 	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/two"));
 	cl_must_pass(p_mkdir(path.ptr, 0777));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 /* make sure empty dir can be deleted recusively */
@@ -47,7 +47,7 @@ void test_core_rmdir__fail_to_delete_non_empty_dir(void)
 	cl_must_pass(p_unlink(file.ptr));
 	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_EMPTY_HIERARCHY));
 
-	git_buf_free(&file);
+	git_buf_dispose(&file);
 }
 
 void test_core_rmdir__can_skip_non_empty_dir(void)
@@ -64,7 +64,7 @@ void test_core_rmdir__can_skip_non_empty_dir(void)
 	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_REMOVE_FILES));
 	cl_assert(git_path_exists(empty_tmp_dir) == false);
 
-	git_buf_free(&file);
+	git_buf_dispose(&file);
 }
 
 void test_core_rmdir__can_remove_empty_parents(void)
@@ -92,7 +92,7 @@ void test_core_rmdir__can_remove_empty_parents(void)
 
 	cl_assert(git_path_exists(empty_tmp_dir) == true);
 
-	git_buf_free(&file);
+	git_buf_dispose(&file);
 
 	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_EMPTY_HIERARCHY));
 }

--- a/tests/core/sortedcache.c
+++ b/tests/core/sortedcache.c
@@ -266,7 +266,7 @@ static void sortedcache_test_reload(git_sortedcache *sc)
 
 	git_sortedcache_wunlock(sc);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_core_sortedcache__on_disk(void)

--- a/tests/core/stat.c
+++ b/tests/core/stat.c
@@ -110,5 +110,5 @@ void test_core_stat__root(void)
 	cl_must_pass(p_stat(root.ptr, &st));
 	cl_assert(S_ISDIR(st.st_mode));
 
-	git_buf_free(&root);
+	git_buf_dispose(&root);
 }

--- a/tests/core/useragent.c
+++ b/tests/core/useragent.c
@@ -13,5 +13,5 @@ void test_core_useragent__get(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_USER_AGENT, &buf));
 	cl_assert_equal_s(custom_name, buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }

--- a/tests/core/zstream.c
+++ b/tests/core/zstream.c
@@ -73,8 +73,8 @@ void test_core_zstream__fails_on_trailing_garbage(void)
 
 	cl_git_fail(git_zstream_inflatebuf(&inflated, deflated.ptr, deflated.size));
 
-	git_buf_free(&deflated);
-	git_buf_free(&inflated);
+	git_buf_dispose(&deflated);
+	git_buf_dispose(&inflated);
 }
 
 void test_core_zstream__buffer(void)
@@ -82,7 +82,7 @@ void test_core_zstream__buffer(void)
 	git_buf out = GIT_BUF_INIT;
 	cl_git_pass(git_zstream_deflatebuf(&out, data, strlen(data) + 1));
 	assert_zlib_equal(data, strlen(data) + 1, out.ptr, out.size);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 #define BIG_STRING_PART "Big Data IS Big - Long Data IS Long - We need a buffer larger than 1024 x 1024 to make sure we trigger chunked compression - Big Big Data IS Bigger than Big - Long Long Data IS Longer than Long"
@@ -129,15 +129,15 @@ static void compress_and_decompress_input_various_ways(git_buf *input)
 		cl_assert_equal_sz(out1.size, out2.size);
 		cl_assert(!memcmp(out1.ptr, out2.ptr, out1.size));
 
-		git_buf_free(&out2);
+		git_buf_dispose(&out2);
 	}
 
 	cl_git_pass(git_zstream_inflatebuf(&inflated, out1.ptr, out1.size));
 	cl_assert_equal_i(input->size, inflated.size);
 	cl_assert(memcmp(input->ptr, inflated.ptr, inflated.size) == 0);
 
-	git_buf_free(&out1);
-	git_buf_free(&inflated);
+	git_buf_dispose(&out1);
+	git_buf_dispose(&inflated);
 	git__free(fixed);
 }
 
@@ -164,5 +164,5 @@ void test_core_zstream__big_data(void)
 		compress_and_decompress_input_various_ways(&in);
 	}
 
-	git_buf_free(&in);
+	git_buf_dispose(&in);
 }

--- a/tests/describe/describe.c
+++ b/tests/describe/describe.c
@@ -50,6 +50,6 @@ void test_describe_describe__describe_a_repo_with_no_refs(void)
 
 	git_describe_result_free(result);
 	git_object_free(object);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	cl_git_sandbox_cleanup();
 }

--- a/tests/describe/describe_helpers.c
+++ b/tests/describe/describe_helpers.c
@@ -20,7 +20,7 @@ void assert_describe(
 
 	git_describe_result_free(result);
 	git_object_free(object);
-	git_buf_free(&label);
+	git_buf_dispose(&label);
 }
 
 void assert_describe_workdir(
@@ -38,5 +38,5 @@ void assert_describe_workdir(
 	cl_must_pass(p_fnmatch(expected_output, git_buf_cstr(&label), 0));
 
 	git_describe_result_free(result);
-	git_buf_free(&label);
+	git_buf_dispose(&label);
 }

--- a/tests/diff/binary.c
+++ b/tests/diff/binary.c
@@ -57,7 +57,7 @@ void test_patch(
 
 	cl_assert_equal_s(expected, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 	git_tree_free(tree_one);
@@ -238,7 +238,7 @@ void test_diff_binary__delta(void)
 		expected);
 
 	git_index_free(index);
-	git_buf_free(&contents);
+	git_buf_dispose(&contents);
 }
 
 void test_diff_binary__delta_append(void)
@@ -298,7 +298,7 @@ void test_diff_binary__empty_for_no_diff(void)
 
 	cl_assert_equal_s("", actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_diff_free(diff);
 	git_commit_free(commit);
 	git_tree_free(tree);
@@ -346,7 +346,7 @@ void test_diff_binary__index_to_workdir(void)
 		&opts,
 		expected);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 	git_index_free(index);
@@ -402,7 +402,7 @@ void test_diff_binary__print_patch_from_diff(void)
 
 	cl_assert_equal_s(expected, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_diff_free(diff);
 	git_index_free(index);
 }
@@ -540,6 +540,6 @@ void test_diff_binary__blob_to_blob(void)
 	git__free(diff_data.old_path);
 	git__free(diff_data.new_path);
 
-	git_buf_free(&diff_data.old_binary_base85);
-	git_buf_free(&diff_data.new_binary_base85);
+	git_buf_dispose(&diff_data.old_binary_base85);
+	git_buf_dispose(&diff_data.new_binary_base85);
 }

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -101,7 +101,7 @@ void test_diff_blob__patch_with_freed_blobs(void)
 	cl_assert_equal_s(buf.ptr, BLOB_DIFF);
 
 	git_patch_free(p);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_blob__can_compare_text_blobs(void)
@@ -1016,7 +1016,7 @@ void test_diff_blob__using_path_and_attributes(void)
 	git_buf_clear(&buf);
 	git_patch_free(p);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_blob_free(nonbin);
 	git_blob_free(bin);
 }

--- a/tests/diff/diffiter.c
+++ b/tests/diff/diffiter.c
@@ -423,7 +423,7 @@ void test_diff_diffiter__iterate_and_generate_patch_text(void)
 
 		cl_assert_equal_s(expected_patch_text[d], buf.ptr);
 
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 		git_patch_free(patch);
 	}
 

--- a/tests/diff/drivers.c
+++ b/tests/diff/drivers.c
@@ -65,7 +65,7 @@ void test_diff_drivers__patterns(void)
 	cl_git_pass(git_patch_to_buf(&actual, patch));
 	cl_assert_equal_s(expected0, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -80,7 +80,7 @@ void test_diff_drivers__patterns(void)
 	cl_git_pass(git_patch_to_buf(&actual, patch));
 	cl_assert_equal_s(expected1, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -95,7 +95,7 @@ void test_diff_drivers__patterns(void)
 	cl_git_pass(git_patch_to_buf(&actual, patch));
 	cl_assert_equal_s(expected0, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -112,7 +112,7 @@ void test_diff_drivers__patterns(void)
 	cl_git_pass(git_patch_to_buf(&actual, patch));
 	cl_assert_equal_s(expected1, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -133,7 +133,7 @@ void test_diff_drivers__patterns(void)
 	cl_git_pass(git_patch_to_buf(&actual, patch));
 	cl_assert_equal_s(expected2, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 
@@ -169,7 +169,7 @@ void test_diff_drivers__long_lines(void)
 
 	cl_assert_equal_s(expected, actual.ptr);
 
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 	git_patch_free(patch);
 	git_diff_free(diff);
 }
@@ -245,9 +245,9 @@ void test_diff_drivers__builtins(void)
 		git__free(path);
 	}
 
-	git_buf_free(&file);
-	git_buf_free(&actual);
-	git_buf_free(&expected);
+	git_buf_dispose(&file);
+	git_buf_dispose(&actual);
+	git_buf_dispose(&expected);
 	git_vector_free(&files);
 }
 

--- a/tests/diff/format_email.c
+++ b/tests/diff/format_email.c
@@ -49,7 +49,7 @@ static void assert_email_match(
 
 	git_diff_free(diff);
 	git_commit_free(commit);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_format_email__simple(void)
@@ -255,7 +255,7 @@ void test_diff_format_email__multiple(void)
 
 	git_diff_free(diff);
 	git_commit_free(commit);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_format_email__exclude_marker(void)
@@ -331,7 +331,7 @@ void test_diff_format_email__invalid_no(void)
 
 	git_diff_free(diff);
 	git_commit_free(commit);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_format_email__mode_change(void)

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -54,7 +54,7 @@ static void test_parse_invalid_diff(const char *invalid_diff)
 	cl_git_fail_with(GIT_ERROR,
 		git_diff_from_buffer(&diff, buf.ptr, buf.size));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_parse__exact_rename(void)
@@ -125,7 +125,7 @@ static void test_tree_to_tree_computed_to_parsed(
 	git_diff_free(computed);
 	git_diff_free(parsed);
 
-	git_buf_free(&computed_buf);
+	git_buf_dispose(&computed_buf);
 
 	cl_git_sandbox_cleanup();
 }
@@ -213,7 +213,7 @@ void test_diff_parse__get_patch_from_diff(void)
 	git_diff_free(computed);
 	git_diff_free(parsed);
 
-	git_buf_free(&computed_buf);
+	git_buf_dispose(&computed_buf);
 
 	cl_git_sandbox_cleanup();
 }
@@ -265,7 +265,7 @@ void test_diff_parse__parsing_minimal_patch_succeeds(void)
 	cl_assert_equal_s(patch, buf.ptr);
 
 	git_diff_free(diff);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_parse__patch_roundtrip_succeeds(void)
@@ -285,6 +285,6 @@ void test_diff_parse__patch_roundtrip_succeeds(void)
 
 	git_patch_free(patch);
 	git_diff_free(diff);
-	git_buf_free(&patchbuf);
-	git_buf_free(&diffbuf);
+	git_buf_dispose(&patchbuf);
+	git_buf_dispose(&diffbuf);
 }

--- a/tests/diff/patch.c
+++ b/tests/diff/patch.c
@@ -171,7 +171,7 @@ void test_diff_patch__to_string(void)
 	cl_assert_equal_sz(31 + 16, git_patch_size(patch, 1, 1, 0));
 	cl_assert_equal_sz(strlen(expected), git_patch_size(patch, 1, 1, 1));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 	git_tree_free(another);
@@ -252,7 +252,7 @@ void test_diff_patch__config_options(void)
 	git_patch_free(patch);
 	git_diff_free(diff);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_tree_free(one);
 	git_config_free(cfg);
 }
@@ -440,8 +440,8 @@ void test_diff_patch__hunks_have_correct_line_numbers(void)
 	git_patch_free(patch);
 	git_diff_free(diff);
 
-	git_buf_free(&actual);
-	git_buf_free(&old_content);
+	git_buf_dispose(&actual);
+	git_buf_dispose(&old_content);
 	git_tree_free(head);
 }
 
@@ -476,7 +476,7 @@ static void check_single_patch_stats(
 		git_buf buf = GIT_BUF_INIT;
 		cl_git_pass(git_patch_to_buf(&buf, patch));
 		cl_assert_equal_s(expected, buf.ptr);
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 
 		cl_assert_equal_sz(
 			strlen(expected), git_patch_size(patch, 1, 1, 1));
@@ -614,7 +614,7 @@ void test_diff_patch__line_counts_with_eofnl(void)
 	check_single_patch_stats(
 		g_repo, 1, 1, 1, 6, expected_sizes, expected);
 
-	git_buf_free(&content);
+	git_buf_dispose(&content);
 }
 
 void test_diff_patch__can_strip_bad_utf8(void)
@@ -700,5 +700,5 @@ void test_diff_patch__can_strip_bad_utf8(void)
 	cl_assert_equal_s(expected, buf.ptr);
 
 	git_patch_free(patch);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -603,8 +603,8 @@ void test_diff_rename__working_directory_changes(void)
 	git_diff_free(diff);
 
 	git_tree_free(tree);
-	git_buf_free(&content);
-	git_buf_free(&old_content);
+	git_buf_dispose(&content);
+	git_buf_dispose(&old_content);
 }
 
 void test_diff_rename__patch(void)
@@ -645,7 +645,7 @@ void test_diff_rename__patch(void)
 
 	cl_git_pass(git_patch_to_buf(&buf, patch));
 	cl_assert_equal_s(expected, buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	git_patch_free(patch);
 
@@ -707,8 +707,8 @@ void test_diff_rename__file_exchange(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
-	git_buf_free(&c2);
+	git_buf_dispose(&c1);
+	git_buf_dispose(&c2);
 }
 
 void test_diff_rename__file_exchange_three(void)
@@ -759,9 +759,9 @@ void test_diff_rename__file_exchange_three(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
-	git_buf_free(&c2);
-	git_buf_free(&c3);
+	git_buf_dispose(&c1);
+	git_buf_dispose(&c2);
+	git_buf_dispose(&c3);
 }
 
 void test_diff_rename__file_partial_exchange(void)
@@ -812,8 +812,8 @@ void test_diff_rename__file_partial_exchange(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
-	git_buf_free(&c2);
+	git_buf_dispose(&c1);
+	git_buf_dispose(&c2);
 }
 
 void test_diff_rename__rename_and_copy_from_same_source(void)
@@ -869,8 +869,8 @@ void test_diff_rename__rename_and_copy_from_same_source(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
-	git_buf_free(&c2);
+	git_buf_dispose(&c1);
+	git_buf_dispose(&c2);
 }
 
 void test_diff_rename__from_deleted_to_split(void)
@@ -923,7 +923,7 @@ void test_diff_rename__from_deleted_to_split(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
+	git_buf_dispose(&c1);
 }
 
 struct rename_expected
@@ -1023,8 +1023,8 @@ void test_diff_rename__rejected_match_can_match_others(void)
 	git_index_free(index);
 	git_reference_free(head);
 	git_reference_free(selfsimilar);
-	git_buf_free(&one);
-	git_buf_free(&two);
+	git_buf_dispose(&one);
+	git_buf_dispose(&two);
 }
 
 static void write_similarity_file_two(const char *filename, size_t b_lines)
@@ -1041,7 +1041,7 @@ static void write_similarity_file_two(const char *filename, size_t b_lines)
 	cl_git_pass(
 		git_futils_writebuffer(&contents, filename, O_RDWR|O_CREAT, 0777));
 
-	git_buf_free(&contents);
+	git_buf_dispose(&contents);
 }
 
 void test_diff_rename__rejected_match_can_match_others_two(void)
@@ -1389,7 +1389,7 @@ void test_diff_rename__can_find_copy_to_split(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
+	git_buf_dispose(&c1);
 }
 
 void test_diff_rename__can_delete_unmodified_deltas(void)
@@ -1437,7 +1437,7 @@ void test_diff_rename__can_delete_unmodified_deltas(void)
 	git_tree_free(tree);
 	git_index_free(index);
 
-	git_buf_free(&c1);
+	git_buf_dispose(&c1);
 }
 
 void test_diff_rename__matches_config_behavior(void)
@@ -1759,7 +1759,7 @@ void test_diff_rename__identical(void)
 
 	cl_assert_equal_s(expected, diff_buf.ptr);
 
-	git_buf_free(&diff_buf);
+	git_buf_dispose(&diff_buf);
 	git_diff_free(diff);
 	git_tree_free(old_tree);
 	git_tree_free(new_tree);
@@ -1910,7 +1910,7 @@ void test_diff_rename__rewrite_and_delete(void)
 
 	cl_assert_equal_s(expected, diff_buf.ptr);
 
-	git_buf_free(&diff_buf);
+	git_buf_dispose(&diff_buf);
 	git_diff_free(diff);
 	git_tree_free(old_tree);
 	git_tree_free(new_tree);
@@ -1973,7 +1973,7 @@ void test_diff_rename__delete_and_rename(void)
 
 	cl_assert_equal_s(expected, diff_buf.ptr);
 
-	git_buf_free(&diff_buf);
+	git_buf_dispose(&diff_buf);
 	git_diff_free(diff);
 	git_tree_free(old_tree);
 	git_tree_free(new_tree);

--- a/tests/diff/stats.c
+++ b/tests/diff/stats.c
@@ -54,11 +54,11 @@ void test_diff_stats__stat(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert(strcmp(git_buf_cstr(&buf), stat) == 0);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 80));
 	cl_assert(strcmp(git_buf_cstr(&buf), stat) == 0);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__multiple_hunks(void)
@@ -78,7 +78,7 @@ void test_diff_stats__multiple_hunks(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__numstat(void)
@@ -93,7 +93,7 @@ void test_diff_stats__numstat(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_NUMBER, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__shortstat(void)
@@ -111,7 +111,7 @@ void test_diff_stats__shortstat(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_SHORT, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__shortstat_noinsertions(void)
@@ -129,7 +129,7 @@ void test_diff_stats__shortstat_noinsertions(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_SHORT, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__shortstat_nodeletions(void)
@@ -147,7 +147,7 @@ void test_diff_stats__shortstat_nodeletions(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_SHORT, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__rename(void)
@@ -167,7 +167,7 @@ void test_diff_stats__rename(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__rename_nochanges(void)
@@ -187,7 +187,7 @@ void test_diff_stats__rename_nochanges(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__rename_and_modifiy(void)
@@ -207,7 +207,7 @@ void test_diff_stats__rename_and_modifiy(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__rename_no_find(void)
@@ -229,7 +229,7 @@ void test_diff_stats__rename_no_find(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__rename_nochanges_no_find(void)
@@ -251,7 +251,7 @@ void test_diff_stats__rename_nochanges_no_find(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__rename_and_modify_no_find(void)
@@ -272,7 +272,7 @@ void test_diff_stats__rename_and_modify_no_find(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__binary(void)
@@ -292,7 +292,7 @@ void test_diff_stats__binary(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__binary_numstat(void)
@@ -306,7 +306,7 @@ void test_diff_stats__binary_numstat(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_NUMBER, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_diff_stats__mode_change(void)
@@ -322,5 +322,5 @@ void test_diff_stats__mode_change(void)
 
 	cl_git_pass(git_diff_stats_to_buf(&buf, _stats, GIT_DIFF_STATS_FULL | GIT_DIFF_STATS_INCLUDE_SUMMARY, 0));
 	cl_assert_equal_s(stat, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }

--- a/tests/diff/submodules.c
+++ b/tests/diff/submodules.c
@@ -50,7 +50,7 @@ static void check_diff_patches_at_line(
 		clar__assert_equal(
 			file, line, "expected diff did not match actual diff", 1,
 			"%s", expected[d], get_buf_ptr(&buf));
-		git_buf_free(&buf);
+		git_buf_dispose(&buf);
 	}
 
 	cl_assert_at_line(expected[d] && !strcmp(expected[d], "<END>"), file, line);

--- a/tests/diff/workdir.c
+++ b/tests/diff/workdir.c
@@ -1677,7 +1677,7 @@ void test_diff_workdir__patience_diff(void)
 	cl_assert_equal_s(expected_patience, buf.ptr);
 	git_buf_clear(&buf);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_patch_free(patch);
 	git_diff_free(diff);
 }
@@ -1807,7 +1807,7 @@ void test_diff_workdir__can_update_index(void)
 		git_buf path = GIT_BUF_INIT;
 		cl_git_pass(git_buf_sets(&path, "status"));
 		cl_git_pass(git_path_direach(&path, 0, touch_file, NULL));
-		git_buf_free(&path);
+		git_buf_dispose(&path);
 	}
 
 	opts.flags |= GIT_DIFF_INCLUDE_IGNORED | GIT_DIFF_INCLUDE_UNTRACKED;
@@ -1959,7 +1959,7 @@ void test_diff_workdir__binary_detection(void)
 	git_diff_free(diff);
 
 	git_index_free(idx);
-	git_buf_free(&b);
+	git_buf_dispose(&b);
 }
 
 void test_diff_workdir__to_index_conflicted(void) {
@@ -2050,7 +2050,7 @@ void test_diff_workdir__only_writes_index_when_necessary(void)
 	git_oid_cpy(&second, git_index_checksum(index));
 	cl_assert(!git_oid_equal(&first, &second));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_object_free(head_object);
 	git_reference_free(head);
 	git_index_free(index);

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -94,7 +94,7 @@ void test_fetchhead_nonetwork__write(void)
 
 	equals = (strcmp(fetchhead_buf.ptr, FETCH_HEAD_WILDCARD_DATA_LOCAL) == 0);
 
-	git_buf_free(&fetchhead_buf);
+	git_buf_dispose(&fetchhead_buf);
 
 	git_vector_foreach(&fetchhead_vector, i, fetchhead_ref) {
 		git_fetchhead_ref_free(fetchhead_ref);
@@ -427,7 +427,7 @@ void test_fetchhead_nonetwork__create_when_refpecs_given(void)
 	cl_assert(found_haacked);
 
 	git_remote_free(remote);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static bool count_refs_called;
@@ -491,5 +491,5 @@ void test_fetchhead_nonetwork__create_with_multiple_refspecs(void)
 	}
 
 	git_remote_free(remote);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }

--- a/tests/filter/blob.c
+++ b/tests/filter/blob.c
@@ -44,7 +44,7 @@ void test_filter_blob__all_crlf(void)
 	/* we never convert CRLF -> LF on platforms that have LF */
 	cl_assert_equal_s(ALL_CRLF_TEXT_AS_CRLF, buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_blob_free(blob);
 }
 
@@ -63,19 +63,19 @@ void test_filter_blob__sanitizes(void)
 	cl_git_pass(git_blob_filtered_content(&buf, blob, "file.bin", 1));
 	cl_assert_equal_sz(0, buf.size);
 	cl_assert_equal_s("", buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	memset(&buf, 0, sizeof(git_buf));
 	cl_git_pass(git_blob_filtered_content(&buf, blob, "file.crlf", 1));
 	cl_assert_equal_sz(0, buf.size);
 	cl_assert_equal_s("", buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	memset(&buf, 0, sizeof(git_buf));
 	cl_git_pass(git_blob_filtered_content(&buf, blob, "file.lf", 1));
 	cl_assert_equal_sz(0, buf.size);
 	cl_assert_equal_s("", buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	git_blob_free(blob);
 }
@@ -111,7 +111,7 @@ void test_filter_blob__ident(void)
 	cl_assert_equal_s(
 		"Some text\n$Id: 3164f585d548ac68027d22b104f2d8100b2b6845 $\nGoes there\n", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_blob_free(blob);
 
 }

--- a/tests/filter/crlf.c
+++ b/tests/filter/crlf.c
@@ -41,7 +41,7 @@ void test_filter_crlf__to_worktree(void)
 	cl_assert_equal_s("Some text\r\nRight here\r\n", out.ptr);
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_crlf__to_odb(void)
@@ -66,7 +66,7 @@ void test_filter_crlf__to_odb(void)
 	cl_assert_equal_s("Some text\nRight here\n", out.ptr);
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_crlf__with_safecrlf(void)
@@ -107,7 +107,7 @@ void test_filter_crlf__with_safecrlf(void)
 	cl_assert_equal_s(in.ptr, out.ptr);
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_crlf__with_safecrlf_and_unsafe_allowed(void)
@@ -150,7 +150,7 @@ void test_filter_crlf__with_safecrlf_and_unsafe_allowed(void)
 	cl_assert_equal_s("Normal\nLF\nonly\nline-endings.\n", out.ptr);
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_crlf__no_safecrlf(void)
@@ -189,7 +189,7 @@ void test_filter_crlf__no_safecrlf(void)
 	cl_assert_equal_s("Normal\nLF\nonly\nline-endings.\n", out.ptr);
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_crlf__safecrlf_warn(void)
@@ -231,5 +231,5 @@ void test_filter_crlf__safecrlf_warn(void)
 	cl_assert_equal_s(in.ptr, out.ptr);
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }

--- a/tests/filter/custom.c
+++ b/tests/filter/custom.c
@@ -109,7 +109,7 @@ void test_filter_custom__to_odb(void)
 		0, memcmp(bitflipped_and_reversed_data, out.ptr, out.size));
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_custom__to_workdir(void)
@@ -130,7 +130,7 @@ void test_filter_custom__to_workdir(void)
 		0, memcmp(workdir_data, out.ptr, out.size));
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_custom__can_register_a_custom_filter_in_the_repository(void)
@@ -228,7 +228,7 @@ void test_filter_custom__order_dependency(void)
 		git_blob_id(blob), "8ca0df630d728c0c72072b6101b301391ef10095"));
 	git_blob_free(blob);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_filter_custom__filter_registry_failure_cases(void)
@@ -254,5 +254,5 @@ void test_filter_custom__erroneous_filter_fails(void)
 	cl_git_fail(git_filter_list_apply_to_data(&out, filters, &in));
 
 	git_filter_list_free(filters);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }

--- a/tests/filter/file.c
+++ b/tests/filter/file.c
@@ -47,7 +47,7 @@ void test_filter_file__apply(void)
 	cl_git_pass(git_filter_list_apply_to_file(&buf, fl, g_repo, "all-crlf"));
 	cl_assert_equal_s("crlf\ncrlf\ncrlf\ncrlf\n", buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_filter_list_free(fl);
 }
 
@@ -71,7 +71,7 @@ int buf_writestream_close(git_writestream *s)
 void buf_writestream_free(git_writestream *s)
 {
 	struct buf_writestream *stream = (struct buf_writestream *)s;
-	git_buf_free(&stream->buf);
+	git_buf_dispose(&stream->buf);
 }
 
 void test_filter_file__apply_stream(void)

--- a/tests/filter/ident.c
+++ b/tests/filter/ident.c
@@ -31,7 +31,7 @@ static void add_blob_and_filter(
 	cl_assert_equal_s(expected, out.ptr);
 
 	git_blob_free(blob);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }
 
 void test_filter_ident__to_worktree(void)

--- a/tests/filter/stream.c
+++ b/tests/filter/stream.c
@@ -157,7 +157,7 @@ static void writefile(const char *filename, size_t numchunks)
 	}
 	p_close(fd);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void test_stream(size_t numchunks)

--- a/tests/filter/wildcard.c
+++ b/tests/filter/wildcard.c
@@ -137,8 +137,8 @@ void test_filter_wildcard__reverse(void)
 		0, memcmp(reversed, out.ptr, out.size));
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
-	git_buf_free(&in);
+	git_buf_dispose(&out);
+	git_buf_dispose(&in);
 }
 
 void test_filter_wildcard__flip(void)
@@ -158,8 +158,8 @@ void test_filter_wildcard__flip(void)
 		0, memcmp(flipped, out.ptr, out.size));
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
-	git_buf_free(&in);
+	git_buf_dispose(&out);
+	git_buf_dispose(&in);
 }
 
 void test_filter_wildcard__none(void)
@@ -179,6 +179,6 @@ void test_filter_wildcard__none(void)
 		0, memcmp(input, out.ptr, out.size));
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
-	git_buf_free(&in);
+	git_buf_dispose(&out);
+	git_buf_dispose(&in);
 }

--- a/tests/index/filemodes.c
+++ b/tests/index/filemodes.c
@@ -47,8 +47,8 @@ static void replace_file_with_mode(
 		path.ptr, content.ptr, content.size,
 		O_WRONLY|O_CREAT|O_TRUNC, create_mode);
 
-	git_buf_free(&path);
-	git_buf_free(&content);
+	git_buf_dispose(&path);
+	git_buf_dispose(&content);
 }
 
 #define add_and_check_mode(I,F,X) add_and_check_mode_(I,F,X,__FILE__,__LINE__)

--- a/tests/index/nsec.c
+++ b/tests/index/nsec.c
@@ -56,7 +56,7 @@ static bool should_expect_nsecs(void)
 
 	p_unlink(nsec_path.ptr);
 
-	git_buf_free(&nsec_path);
+	git_buf_dispose(&nsec_path);
 
 	return expect;
 }

--- a/tests/index/racy.c
+++ b/tests/index/racy.c
@@ -46,7 +46,7 @@ void test_index_racy__diff(void)
 
 	git_index_free(index);
 	git_diff_free(diff);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_index_racy__write_index_just_after_file(void)
@@ -95,7 +95,7 @@ void test_index_racy__write_index_just_after_file(void)
 	cl_git_pass(git_diff_index_to_workdir(&diff, g_repo, index, NULL));
 	cl_assert_equal_i(1, git_diff_num_deltas(diff));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_diff_free(diff);
 	git_index_free(index);
 }
@@ -129,7 +129,7 @@ static void setup_race(void)
 	entry->mtime.seconds = st.st_mtime;
 	entry->mtime.nanoseconds = st.st_mtime_nsec;
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_index_racy__smudges_index_entry_on_save(void)
@@ -196,7 +196,7 @@ static void setup_uptodate_files(void)
 	cl_git_pass(git_index_add_frombuffer(index, &new_entry, "hello!\n", 7));
 
 	git_index_free(index);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_index_racy__adding_to_index_is_uptodate(void)

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -40,7 +40,7 @@ static void copy_file(const char *src, const char *dst)
 	cl_git_pass(p_write(dst_fd, source_buf.ptr, source_buf.size));
 
 cleanup:
-	git_buf_free(&source_buf);
+	git_buf_dispose(&source_buf);
 	p_close(dst_fd);
 }
 
@@ -54,14 +54,14 @@ static void files_are_equal(const char *a, const char *b)
 		cl_assert(0);
 
 	if (git_futils_readbuffer(&buf_b, b) < 0) {
-		git_buf_free(&buf_a);
+		git_buf_dispose(&buf_a);
 		cl_assert(0);
 	}
 
 	pass = (buf_a.size == buf_b.size && !memcmp(buf_a.ptr, buf_b.ptr, buf_a.size));
 
-	git_buf_free(&buf_a);
-	git_buf_free(&buf_b);
+	git_buf_dispose(&buf_a);
+	git_buf_dispose(&buf_b);
 
 	cl_assert(pass);
 }
@@ -468,7 +468,7 @@ static void add_invalid_filename(git_repository *repo, const char *fn)
 
 	cl_assert(git_index_entrycount(index) == 0);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_index_free(index);
 }
 
@@ -545,7 +545,7 @@ static void write_invalid_filename(git_repository *repo, const char *fn_orig)
 	p_unlink(path.ptr);
 
 	cl_git_pass(git_index_remove_all(index, NULL, NULL, NULL));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_index_free(index);
 	git__free(fn);
 }

--- a/tests/iterator/index.c
+++ b/tests/iterator/index.c
@@ -284,7 +284,7 @@ void test_iterator_index__case_folding(void)
 
 	cl_git_pass(git_buf_joinpath(&path, cl_fixture("icase"), ".gitted/CoNfIg"));
 	fs_is_ci = git_path_exists(path.ptr);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	index_iterator_test(
 		"icase", NULL, NULL, 0, ARRAY_SIZE(expected_index_cs),
@@ -1007,7 +1007,7 @@ static void create_paths(git_index *index, const char *root, int depth)
 		}
 	}
 
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 }
 
 void test_iterator_index__pathlist_for_deeply_nested_item(void)

--- a/tests/iterator/tree.c
+++ b/tests/iterator/tree.c
@@ -653,7 +653,7 @@ static void build_test_tree(
 	cl_git_pass(git_treebuilder_write(out, builder));
 
 	git_treebuilder_free(builder);
-	git_buf_free(&name);
+	git_buf_dispose(&name);
 }
 
 void test_iterator_tree__case_conflicts_0(void)

--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -665,7 +665,7 @@ void test_iterator_workdir__filesystem_gunk(void)
 	 */
 	expect_iterator_items(i, 15, NULL, 15, NULL);
 	git_iterator_free(i);
-	git_buf_free(&parent);
+	git_buf_dispose(&parent);
 }
 
 void test_iterator_workdir__skips_unreadable_dirs(void)
@@ -1041,7 +1041,7 @@ static void create_paths(const char *root, int depth)
 		}
 	}
 
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 }
 
 void test_iterator_workdir__pathlist_for_deeply_nested_item(void)

--- a/tests/merge/driver.c
+++ b/tests/merge/driver.c
@@ -129,7 +129,7 @@ static void set_gitattributes_to(const char *driver)
 	cl_assert(!git_buf_oom(&line));
 
 	cl_git_mkfile(TEST_REPO_PATH "/.gitattributes", line.ptr);
-	git_buf_free(&line);
+	git_buf_dispose(&line);
 }
 
 static void merge_branch(void)

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -43,7 +43,7 @@ int merge_trees_from_branches(
 
 	error = git_merge_trees(index, repo, ancestor_tree, our_tree, their_tree, opts);
 
-	git_buf_free(&branch_buf);
+	git_buf_dispose(&branch_buf);
 	git_tree_free(our_tree);
 	git_tree_free(their_tree);
 	git_tree_free(ancestor_tree);
@@ -75,7 +75,7 @@ int merge_commits_from_branches(
 
 	error = git_merge_commits(index, repo, our_commit, their_commit, opts);
 
-	git_buf_free(&branch_buf);
+	git_buf_dispose(&branch_buf);
 	git_commit_free(our_commit);
 	git_commit_free(their_commit);
 
@@ -359,7 +359,7 @@ int merge_test_workdir(git_repository *repo, const struct merge_index_entry expe
 			return 0;
 	}
 
-	git_buf_free(&wd);
+	git_buf_dispose(&wd);
 
 	return 1;
 }

--- a/tests/merge/trees/trivial.c
+++ b/tests/merge/trees/trivial.c
@@ -51,7 +51,7 @@ static int merge_trivial(git_index **index, const char *ours, const char *theirs
 
 	cl_git_pass(git_merge_trees(index, repo, ancestor_tree, our_tree, their_tree, &opts));
 
-	git_buf_free(&branch_buf);
+	git_buf_dispose(&branch_buf);
 	git_tree_free(our_tree);
 	git_tree_free(their_tree);
 	git_tree_free(ancestor_tree);

--- a/tests/merge/workdir/analysis.c
+++ b/tests/merge/workdir/analysis.c
@@ -53,7 +53,7 @@ static void analysis_from_branch(
 
 	cl_git_pass(git_merge_analysis(merge_analysis, merge_pref, repo, (const git_annotated_commit **)&their_head, 1));
 
-	git_buf_free(&refname);
+	git_buf_dispose(&refname);
 	git_annotated_commit_free(their_head);
 	git_reference_free(their_ref);
 }
@@ -108,7 +108,7 @@ void test_merge_workdir_analysis__unborn(void)
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_FASTFORWARD, (merge_analysis & GIT_MERGE_ANALYSIS_FASTFORWARD));
 	cl_assert_equal_i(GIT_MERGE_ANALYSIS_UNBORN, (merge_analysis & GIT_MERGE_ANALYSIS_UNBORN));
 
-	git_buf_free(&master);
+	git_buf_dispose(&master);
 }
 
 void test_merge_workdir_analysis__fastforward_with_config_noff(void)

--- a/tests/merge/workdir/dirty.c
+++ b/tests/merge/workdir/dirty.c
@@ -123,8 +123,8 @@ static void write_files(char *files[])
 		cl_git_mkfile(path.ptr, content.ptr);
 	}
 
-	git_buf_free(&path);
-	git_buf_free(&content);
+	git_buf_dispose(&path);
+	git_buf_dispose(&content);
 }
 
 static void hack_index(char *files[])
@@ -178,7 +178,7 @@ static void hack_index(char *files[])
 		entry->file_size = (uint32_t)statbuf.st_size;
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void stage_random_files(char *files[])
@@ -218,7 +218,7 @@ static void stage_content(char *content[])
 
 	git_object_free(head_object);
 	git_reference_free(head);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static int merge_dirty_files(char *dirty_files[])

--- a/tests/merge/workdir/recursive.c
+++ b/tests/merge/workdir/recursive.c
@@ -46,7 +46,7 @@ void test_merge_workdir_recursive__writes_conflict_with_virtual_base(void)
 	cl_assert_equal_s(CONFLICTING_RECURSIVE_F1_TO_F2, conflicting_buf.ptr);
 
 	git_index_free(index);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 }
 
 void test_merge_workdir_recursive__conflicting_merge_base_with_diff3(void)
@@ -80,5 +80,5 @@ void test_merge_workdir_recursive__conflicting_merge_base_with_diff3(void)
 	cl_assert_equal_s(CONFLICTING_RECURSIVE_H2_TO_H1_WITH_DIFF3, conflicting_buf.ptr);
 
 	git_index_free(index);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 }

--- a/tests/merge/workdir/setup.c
+++ b/tests/merge/workdir/setup.c
@@ -54,8 +54,8 @@ static bool test_file_contents(const char *filename, const char *expected)
 	cl_git_pass(git_futils_readbuffer(&file_buf, file_path_buf.ptr));
 	equals = (strcmp(file_buf.ptr, expected) == 0);
 
-	git_buf_free(&file_path_buf);
-	git_buf_free(&file_buf);
+	git_buf_dispose(&file_path_buf);
+	git_buf_dispose(&file_buf);
 	
 	return equals;
 }
@@ -68,7 +68,7 @@ static void write_file_contents(const char *filename, const char *output)
 		filename);
 	cl_git_rewritefile(file_path_buf.ptr, output);
 
-	git_buf_free(&file_path_buf);
+	git_buf_dispose(&file_path_buf);
 }
 
 /* git merge --no-ff octo1 */
@@ -495,10 +495,10 @@ static int create_remote_tracking_branch(const char *branch_name, const char *oi
 	cl_git_rewritefile(git_buf_cstr(&filename), git_buf_cstr(&data));
 
 done:
-	git_buf_free(&remotes_path);
-	git_buf_free(&origin_path);
-	git_buf_free(&filename);
-	git_buf_free(&data);
+	git_buf_dispose(&remotes_path);
+	git_buf_dispose(&origin_path);
+	git_buf_dispose(&filename);
+	git_buf_dispose(&data);
 
 	return error;
 }

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -155,7 +155,7 @@ void test_merge_workdir_simple__automerge(void)
 	cl_git_pass(git_futils_readbuffer(&automergeable_buf,
 		TEST_REPO_PATH "/automergeable.txt"));
 	cl_assert(strcmp(automergeable_buf.ptr, AUTOMERGEABLE_MERGED_FILE) == 0);
-	git_buf_free(&automergeable_buf);
+	git_buf_dispose(&automergeable_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));
@@ -201,7 +201,7 @@ void test_merge_workdir_simple__automerge_crlf(void)
 	cl_git_pass(git_futils_readbuffer(&automergeable_buf,
 		TEST_REPO_PATH "/automergeable.txt"));
 	cl_assert(strcmp(automergeable_buf.ptr, AUTOMERGEABLE_MERGED_FILE_CRLF) == 0);
-	git_buf_free(&automergeable_buf);
+	git_buf_dispose(&automergeable_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));
@@ -252,8 +252,8 @@ void test_merge_workdir_simple__mergefile(void)
 		"\n" \
 		"Conflicts:\n" \
 		"\tconflicting.txt\n") == 0);
-	git_buf_free(&conflicting_buf);
-	git_buf_free(&mergemsg_buf);
+	git_buf_dispose(&conflicting_buf);
+	git_buf_dispose(&mergemsg_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));
@@ -289,7 +289,7 @@ void test_merge_workdir_simple__diff3(void)
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
 		TEST_REPO_PATH "/conflicting.txt"));
 	cl_assert(strcmp(conflicting_buf.ptr, CONFLICTING_DIFF3_FILE) == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));
@@ -324,7 +324,7 @@ void test_merge_workdir_simple__union(void)
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
 		TEST_REPO_PATH "/conflicting.txt"));
 	cl_assert(strcmp(conflicting_buf.ptr, CONFLICTING_UNION_FILE) == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 6));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 4));
@@ -360,7 +360,7 @@ void test_merge_workdir_simple__gitattributes_union(void)
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
 		TEST_REPO_PATH "/conflicting.txt"));
 	cl_assert(strcmp(conflicting_buf.ptr, CONFLICTING_UNION_FILE) == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 6));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 4));
@@ -400,7 +400,7 @@ void test_merge_workdir_simple__diff3_from_config(void)
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
 		TEST_REPO_PATH "/conflicting.txt"));
 	cl_assert(strcmp(conflicting_buf.ptr, CONFLICTING_DIFF3_FILE) == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));
@@ -442,7 +442,7 @@ void test_merge_workdir_simple__merge_overrides_config(void)
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
 		TEST_REPO_PATH "/conflicting.txt"));
 	cl_assert(strcmp(conflicting_buf.ptr, CONFLICTING_MERGE_FILE) == 0);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&conflicting_buf);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));

--- a/tests/merge/workdir/trivial.c
+++ b/tests/merge/workdir/trivial.c
@@ -49,7 +49,7 @@ static int merge_trivial(const char *ours, const char *theirs)
 
 	cl_git_pass(git_merge(repo, (const git_annotated_commit **)their_heads, 1, NULL, NULL));
 
-	git_buf_free(&branch_buf);
+	git_buf_dispose(&branch_buf);
 	git_reference_free(our_ref);
 	git_reference_free(their_ref);
 	git_annotated_commit_free(their_heads[0]);

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -97,7 +97,7 @@ static void assert_valid_transform(const char *refspec, const char *name, const 
 	cl_git_pass(git_refspec_transform(&buf, &spec, name));
 	cl_assert_equal_s(result, buf.ptr);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_refspec__free(&spec);
 }
 
@@ -119,7 +119,7 @@ static void assert_invalid_transform(const char *refspec, const char *name)
 	git_refspec__parse(&spec, refspec, true);
 	cl_git_fail(git_refspec_transform(&buf, &spec, name));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_refspec__free(&spec);
 }
 
@@ -137,7 +137,7 @@ static void assert_invalid_rtransform(const char *refspec, const char *name)
 	git_refspec__parse(&spec, refspec, true);
 	cl_git_fail(git_refspec_rtransform(&buf, &spec, name));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_refspec__free(&spec);
 }
 

--- a/tests/network/remote/defaultbranch.c
+++ b/tests/network/remote/defaultbranch.c
@@ -29,7 +29,7 @@ static void assert_default_branch(const char *should)
 	cl_git_pass(git_remote_connect(g_remote, GIT_DIRECTION_FETCH, NULL, NULL, NULL));
 	cl_git_pass(git_remote_default_branch(&name, g_remote));
 	cl_assert_equal_s(should, name.ptr);
-	git_buf_free(&name);
+	git_buf_dispose(&name);
 }
 
 void test_network_remote_defaultbranch__master(void)

--- a/tests/network/remote/local.c
+++ b/tests/network/remote/local.c
@@ -25,7 +25,7 @@ void test_network_remote_local__initialize(void)
 
 void test_network_remote_local__cleanup(void)
 {
-	git_buf_free(&file_path_buf);
+	git_buf_dispose(&file_path_buf);
 
 	git_remote_free(remote);
 	remote = NULL;

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -189,7 +189,7 @@ void test_network_remote_remotes__transform(void)
 
 	cl_git_pass(git_refspec_transform(&ref, _refspec, "refs/heads/master"));
 	cl_assert_equal_s(ref.ptr, "refs/remotes/test/master");
-	git_buf_free(&ref);
+	git_buf_dispose(&ref);
 }
 
 void test_network_remote_remotes__transform_destination_to_source(void)
@@ -198,7 +198,7 @@ void test_network_remote_remotes__transform_destination_to_source(void)
 
 	cl_git_pass(git_refspec_rtransform(&ref, _refspec, "refs/remotes/test/master"));
 	cl_assert_equal_s(ref.ptr, "refs/heads/master");
-	git_buf_free(&ref);
+	git_buf_dispose(&ref);
 }
 
 void test_network_remote_remotes__missing_refspecs(void)

--- a/tests/notes/notes.c
+++ b/tests/notes/notes.c
@@ -287,7 +287,7 @@ void test_notes_notes__inserting_a_note_without_passing_a_namespace_uses_the_def
 	assert_note_equal(note, "hello world\n", &note_oid);
 	assert_note_equal(default_namespace_note, "hello world\n", &note_oid);
 
-	git_buf_free(&default_ref);
+	git_buf_dispose(&default_ref);
 	git_note_free(note);
 	git_note_free(default_namespace_note);
 }

--- a/tests/notes/notesref.c
+++ b/tests/notes/notesref.c
@@ -64,5 +64,5 @@ void test_notes_notesref__config_corenotesref(void)
 	cl_git_pass(git_note_default_ref(&default_ref, _repo));
 	cl_assert_equal_s(GIT_NOTES_DEFAULT_REF, default_ref.ptr);
 
-	git_buf_free(&default_ref);
+	git_buf_dispose(&default_ref);
 }

--- a/tests/object/blob/filter.c
+++ b/tests/object/blob/filter.c
@@ -103,7 +103,7 @@ void test_object_blob_filter__stats(void)
 		git_blob_free(blob);
 	}
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_object_blob_filter__to_odb(void)
@@ -139,12 +139,12 @@ void test_object_blob_filter__to_odb(void)
 		cl_assert_equal_sz(g_crlf_filtered[i].size, zeroed.size);
 		cl_assert_equal_i(
 			0, memcmp(zeroed.ptr, g_crlf_filtered[i].ptr, zeroed.size));
-		git_buf_free(&zeroed);
+		git_buf_dispose(&zeroed);
 
 		git_blob_free(blob);
 	}
 
 	git_filter_list_free(fl);
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 	git_config_free(cfg);
 }

--- a/tests/object/blob/fromstream.c
+++ b/tests/object/blob/fromstream.c
@@ -56,7 +56,7 @@ static void write_attributes(git_repository *repo)
 	cl_git_pass(git_futils_mkpath2file(git_buf_cstr(&buf), 0777));
 	cl_git_rewritefile(git_buf_cstr(&buf), GITATTR);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 static void assert_named_chunked_blob(const char *expected_sha, const char *fake_name)

--- a/tests/object/blob/write.c
+++ b/tests/object/blob/write.c
@@ -48,7 +48,7 @@ void test_object_blob_write__can_create_a_blob_in_a_standard_repo_from_a_absolut
 
 	assert_blob_creation(ELSEWHERE "/test.txt", git_buf_cstr(&full_path), &git_blob_create_fromdisk);
 
-	git_buf_free(&full_path);
+	git_buf_dispose(&full_path);
 	cl_must_pass(git_futils_rmdir_r(ELSEWHERE, NULL, GIT_RMDIR_REMOVE_FILES));
 }
 
@@ -64,6 +64,6 @@ void test_object_blob_write__can_create_a_blob_in_a_bare_repo_from_a_absolute_fi
 
 	assert_blob_creation(ELSEWHERE "/test.txt", git_buf_cstr(&full_path), &git_blob_create_fromdisk);
 
-	git_buf_free(&full_path);
+	git_buf_dispose(&full_path);
 	cl_must_pass(git_futils_rmdir_r(ELSEWHERE, NULL, GIT_RMDIR_REMOVE_FILES));
 }

--- a/tests/object/commit/commitstagedfile.c
+++ b/tests/object/commit/commitstagedfile.c
@@ -127,7 +127,7 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 
 	cl_assert(git_oid_cmp(&expected_commit_oid, &commit_oid) == 0);
 
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 	git_signature_free(signature);
 	git_tree_free(tree);
 	git_index_free(index);

--- a/tests/object/lookup.c
+++ b/tests/object/lookup.c
@@ -88,8 +88,8 @@ void test_object_lookup__lookup_corrupt_object_returns_error(void)
 	cl_git_pass(git_object_lookup(&object, g_repo, &oid, GIT_OBJ_COMMIT));
 
 	git_object_free(object);
-	git_buf_free(&path);
-	git_buf_free(&contents);
+	git_buf_dispose(&path);
+	git_buf_dispose(&contents);
 }
 
 void test_object_lookup__lookup_object_with_wrong_hash_returns_error(void)
@@ -117,6 +117,6 @@ void test_object_lookup__lookup_object_with_wrong_hash_returns_error(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 1));
 
 	git_object_free(object);
-	git_buf_free(&oldpath);
-	git_buf_free(&newpath);
+	git_buf_dispose(&oldpath);
+	git_buf_dispose(&newpath);
 }

--- a/tests/object/message.c
+++ b/tests/object/message.c
@@ -9,7 +9,7 @@ static void assert_message_prettifying(char *expected_output, char *input, int s
 	git_message_prettify(&prettified_message, input, strip_comments, '#');
 	cl_assert_equal_s(expected_output, git_buf_cstr(&prettified_message));
 
-	git_buf_free(&prettified_message);
+	git_buf_dispose(&prettified_message);
 }
 
 #define t40 "A quick brown fox jumps over the lazy do"
@@ -177,23 +177,23 @@ void test_object_message__message_prettify(void)
 	memset(&buffer, 0, sizeof(buffer));
 	cl_git_pass(git_message_prettify(&buffer, "", 0, '#'));
 	cl_assert_equal_s(buffer.ptr, "");
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 	cl_git_pass(git_message_prettify(&buffer, "", 1, '#'));
 	cl_assert_equal_s(buffer.ptr, "");
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 
 	cl_git_pass(git_message_prettify(&buffer, "Short", 0, '#'));
 	cl_assert_equal_s("Short\n", buffer.ptr);
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 	cl_git_pass(git_message_prettify(&buffer, "Short", 1, '#'));
 	cl_assert_equal_s("Short\n", buffer.ptr);
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 
 	cl_git_pass(git_message_prettify(&buffer, "This is longer\nAnd multiline\n# with some comments still in\n", 0, '#'));
 	cl_assert_equal_s(buffer.ptr, "This is longer\nAnd multiline\n# with some comments still in\n");
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 
 	cl_git_pass(git_message_prettify(&buffer, "This is longer\nAnd multiline\n# with some comments still in\n", 1, '#'));
 	cl_assert_equal_s(buffer.ptr, "This is longer\nAnd multiline\n");
-	git_buf_free(&buffer);
+	git_buf_dispose(&buffer);
 }

--- a/tests/object/shortid.c
+++ b/tests/object/shortid.c
@@ -47,5 +47,5 @@ void test_object_shortid__select(void)
 	cl_assert_equal_s("dea509d0b", shorty.ptr);
 	git_object_free(obj);
 
-	git_buf_free(&shorty);
+	git_buf_dispose(&shorty);
 }

--- a/tests/object/tree/write.c
+++ b/tests/object/tree/write.c
@@ -399,7 +399,7 @@ void test_object_tree_write__cruel_paths(void)
 			cl_git_pass(git_tree_entry_bypath(&te, tree, b.ptr));
 			cl_assert_equal_s(the_paths[j], git_tree_entry_name(te));
 			git_tree_entry_free(te);
-			git_buf_free(&b);
+			git_buf_dispose(&b);
 		}
 	}
 

--- a/tests/odb/alternates.c
+++ b/tests/odb/alternates.c
@@ -13,8 +13,8 @@ void test_odb_alternates__cleanup(void)
 {
 	size_t i;
 
-	git_buf_free(&destpath);
-	git_buf_free(&filepath);
+	git_buf_dispose(&destpath);
+	git_buf_dispose(&filepath);
 
 	for (i = 0; i < ARRAY_SIZE(paths); i++)
 		cl_fixture_cleanup(paths[i]);

--- a/tests/odb/foreach.c
+++ b/tests/odb/foreach.c
@@ -114,7 +114,7 @@ void test_odb_foreach__files_in_objects_dir(void)
 
 	cl_git_pass(git_buf_printf(&buf, "%s/objects/somefile", git_repository_path(repo)));
 	cl_git_mkfile(buf.ptr, "");
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	cl_git_pass(git_repository_odb(&odb, repo));
 	cl_git_pass(git_odb_foreach(odb, foreach_cb, &nobj));

--- a/tests/odb/freshen.c
+++ b/tests/odb/freshen.c
@@ -31,7 +31,7 @@ static void set_time_wayback(struct stat *out, const char *fn)
 
 	cl_must_pass(p_utimes(git_buf_cstr(&fullpath), old));
 	cl_must_pass(p_lstat(git_buf_cstr(&fullpath), out));
-	git_buf_free(&fullpath);
+	git_buf_dispose(&fullpath);
 }
 
 #define LOOSE_STR     "my new file\n"

--- a/tests/odb/largefiles.c
+++ b/tests/odb/largefiles.c
@@ -36,7 +36,7 @@ static void writefile(git_oid *oid)
 	cl_git_pass(git_odb_stream_finalize_write(oid, stream));
 
 	git_odb_stream_free(stream);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_odb_largefiles__write_from_memory(void)

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -170,7 +170,7 @@ void test_online_clone__can_checkout_a_cloned_repo(void)
 	cl_assert_equal_i(true, fetch_progress_cb_was_called);
 
 	git_reference_free(head);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static int remote_mirror_cb(git_remote **out, git_repository *repo,
@@ -734,7 +734,7 @@ void test_online_clone__proxy_credentials_request(void)
 	cl_git_pass(git_clone(&g_repo, "http://github.com/libgit2/TestGitRepository", "./foo", &g_options));
 	cl_assert(called_proxy_creds);
 
-	git_buf_free(&url);
+	git_buf_dispose(&url);
 }
 
 void test_online_clone__proxy_credentials_in_url(void)
@@ -752,7 +752,7 @@ void test_online_clone__proxy_credentials_in_url(void)
 	cl_git_pass(git_clone(&g_repo, "http://github.com/libgit2/TestGitRepository", "./foo", &g_options));
 	cl_assert(called_proxy_creds == 0);
 
-	git_buf_free(&url);
+	git_buf_dispose(&url);
 }
 
 void test_online_clone__proxy_credentials_in_environment(void)
@@ -775,5 +775,5 @@ void test_online_clone__proxy_credentials_in_environment(void)
 
 	cl_git_pass(git_clone(&g_repo, "http://github.com/libgit2/TestGitRepository", "./foo", &g_options));
 
-	git_buf_free(&url);
+	git_buf_dispose(&url);
 }

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -72,7 +72,7 @@ static void fetchhead_test_fetch(const char *fetchspec, const char *expected_fet
 
 	equals = (strcmp(fetchhead_buf.ptr, expected_fetchhead) == 0);
 
-	git_buf_free(&fetchhead_buf);
+	git_buf_dispose(&fetchhead_buf);
 
 	cl_assert(equals);
 }

--- a/tests/online/push.c
+++ b/tests/online/push.c
@@ -149,7 +149,7 @@ static void do_verify_push_status(record_callbacks_data *data, const push_status
 
 		cl_fail(git_buf_cstr(&msg));
 
-		git_buf_free(&msg);
+		git_buf_dispose(&msg);
 	}
 
 	git_vector_foreach(actual, i, iter)
@@ -263,8 +263,8 @@ failed:
 		git__free(actual_ref);
 
 	git_vector_free(&actual_refs);
-	git_buf_free(&msg);
-	git_buf_free(&ref_name);
+	git_buf_dispose(&msg);
+	git_buf_dispose(&ref_name);
 }
 
 static void verify_update_tips_callback(git_remote *remote, expected_ref expected_refs[], size_t expected_refs_len)
@@ -309,8 +309,8 @@ failed:
 	if (failed)
 		cl_fail(git_buf_cstr(&msg));
 
-	git_buf_free(&ref_name);
-	git_buf_free(&msg);
+	git_buf_dispose(&ref_name);
+	git_buf_dispose(&msg);
 }
 
 void test_online_push__initialize(void)

--- a/tests/online/push_util.c
+++ b/tests/online/push_util.c
@@ -137,5 +137,5 @@ failed:
 
 	cl_fail(git_buf_cstr(&msg));
 
-	git_buf_free(&msg);
+	git_buf_dispose(&msg);
 }

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -249,7 +249,7 @@ void test_pack_indexer__no_tmp_files(void)
 	/* Precondition: there are no temporary files. */
 	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
 	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	cl_assert(git_buf_len(&first_tmp_file) == 0);
 
 	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL, NULL));
@@ -257,7 +257,7 @@ void test_pack_indexer__no_tmp_files(void)
 
 	cl_git_pass(git_buf_sets(&path, clar_sandbox_path()));
 	cl_git_pass(find_tmp_file_recurs(&first_tmp_file, &path));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	cl_assert(git_buf_len(&first_tmp_file) == 0);
-	git_buf_free(&first_tmp_file);
+	git_buf_dispose(&first_tmp_file);
 }

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -128,8 +128,8 @@ void test_pack_packbuilder__create_pack(void)
 	cl_git_pass(git_hash_final(&hash, &ctx));
 	git_hash_ctx_cleanup(&ctx);
 
-	git_buf_free(&path);
-	git_buf_free(&buf);
+	git_buf_dispose(&path);
+	git_buf_dispose(&buf);
 
 	git_oid_fmt(hex, &hash);
 

--- a/tests/patch/print.c
+++ b/tests/patch/print.c
@@ -20,7 +20,7 @@ void patch_print_from_patchfile(const char *data, size_t len)
 	cl_assert_equal_s(data, buf.ptr);
 
 	git_patch_free(patch);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_patch_print__change_middle(void)

--- a/tests/path/core.c
+++ b/tests/path/core.c
@@ -11,7 +11,7 @@ static void test_make_relative(
 	git_buf_puts(&buf, path);
 	cl_assert_equal_i(expected_status, git_path_make_relative(&buf, parent));
 	cl_assert_equal_s(expected_path, buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_path_core__make_relative(void)
@@ -319,7 +319,7 @@ static void test_join_unrooted(
 	cl_assert_equal_s(expected_result, result.ptr);
 	cl_assert_equal_i(expected_rootlen, root_at);
 
-	git_buf_free(&result);
+	git_buf_dispose(&result);
 }
 
 void test_path_core__join_unrooted(void)
@@ -350,5 +350,5 @@ void test_path_core__join_unrooted(void)
 	/* Trailing slash in the base is ignored */
 	test_join_unrooted("c:/foo/bar/foobar", 6, "c:/foo/bar/foobar", "c:/foo/");
 
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 }

--- a/tests/rebase/submodule.c
+++ b/tests/rebase/submodule.c
@@ -81,7 +81,7 @@ void test_rebase_submodule__init_untracked(void)
 	fp = fopen(git_buf_cstr(&untracked_path), "w");
 	fprintf(fp, "An untracked file in a submodule should not block a rebase\n");
 	fclose(fp);
-	git_buf_free(&untracked_path);
+	git_buf_dispose(&untracked_path);
 
 	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
 

--- a/tests/refs/branches/create.c
+++ b/tests/refs/branches/create.c
@@ -132,7 +132,7 @@ static void assert_branch_matches_name(
 		git_oid_cmp(git_reference_target(ref), git_commit_id(target)));
 
 	git_reference_free(ref);
-	git_buf_free(&b);
+	git_buf_dispose(&b);
 }
 
 void test_refs_branches_create__can_create_branch_with_unicode(void)

--- a/tests/refs/branches/remote.c
+++ b/tests/refs/branches/remote.c
@@ -26,7 +26,7 @@ void test_refs_branches_remote__can_get_remote_for_branch(void)
 	cl_git_pass(git_branch_remote_name(&remotename, g_repo, remote_tracking_branch_name));
 
 	cl_assert_equal_s("test", remotename.ptr);
-	git_buf_free(&remotename);
+	git_buf_dispose(&remotename);
 }
 
 void test_refs_branches_remote__no_matching_remote_returns_error(void)

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -68,7 +68,7 @@ void test_refs_branches_upstream__upstream_remote(void)
 
 	cl_git_pass(git_branch_upstream_remote(&buf, repo, "refs/heads/master"));
 	cl_assert_equal_s("test", buf.ptr);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 }
 
 void test_refs_branches_upstream__upstream_remote_empty_value(void)

--- a/tests/refs/branches/upstreamname.c
+++ b/tests/refs/branches/upstreamname.c
@@ -13,7 +13,7 @@ void test_refs_branches_upstreamname__initialize(void)
 
 void test_refs_branches_upstreamname__cleanup(void)
 {
-	git_buf_free(&upstream_name);
+	git_buf_dispose(&upstream_name);
 
 	git_repository_free(repo);
 	repo = NULL;

--- a/tests/refs/delete.c
+++ b/tests/refs/delete.c
@@ -52,7 +52,7 @@ void test_refs_delete__packed_loose(void)
 	cl_assert(!git_path_exists(temp_path.ptr));
 
 	git_reference_free(another_looked_up_ref);
-	git_buf_free(&temp_path);
+	git_buf_dispose(&temp_path);
 }
 
 void test_refs_delete__packed_only(void)

--- a/tests/refs/pack.c
+++ b/tests/refs/pack.c
@@ -37,7 +37,7 @@ void test_refs_pack__empty(void)
 
 	cl_git_pass(git_buf_join_n(&temp_path, '/', 3, git_repository_path(g_repo), GIT_REFS_HEADS_DIR, "empty_dir"));
 	cl_git_pass(git_futils_mkdir_r(temp_path.ptr, GIT_REFS_DIR_MODE));
-	git_buf_free(&temp_path);
+	git_buf_dispose(&temp_path);
 
 	packall();
 }
@@ -75,7 +75,7 @@ void test_refs_pack__loose(void)
 	cl_assert(!git_path_exists(temp_path.ptr));
 
 	git_reference_free(reference);
-	git_buf_free(&temp_path);
+	git_buf_dispose(&temp_path);
 }
 
 void test_refs_pack__symbolic(void)

--- a/tests/refs/read.c
+++ b/tests/refs/read.c
@@ -45,7 +45,7 @@ void test_refs_read__loose_tag(void)
 	/* Ensure the name of the tag matches the name of the reference */
 	cl_git_pass(git_buf_joinpath(&ref_name_from_tag_name, GIT_REFS_TAGS_DIR, git_tag_name((git_tag *)object)));
 	cl_assert_equal_s(ref_name_from_tag_name.ptr, loose_tag_ref_name);
-	git_buf_free(&ref_name_from_tag_name);
+	git_buf_dispose(&ref_name_from_tag_name);
 
 	git_object_free(object);
 

--- a/tests/refs/ref_helpers.c
+++ b/tests/refs/ref_helpers.c
@@ -19,7 +19,7 @@ int reference_is_packed(git_reference *ref)
 
 	packed = !git_path_isfile(ref_path.ptr);
 
-	git_buf_free(&ref_path);
+	git_buf_dispose(&ref_path);
 
 	return packed;
 }

--- a/tests/refs/reflog/messages.c
+++ b/tests/refs/reflog/messages.c
@@ -355,7 +355,7 @@ void test_refs_reflog_messages__creating_branches_default_messages(void)
 		g_email, "branch: Created from e90810b8df3");
 
 	git_annotated_commit_free(annotated);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_commit_free(target);
 	git_reference_free(branch1);
 	git_reference_free(branch2);

--- a/tests/refs/reflog/reflog.c
+++ b/tests/refs/reflog/reflog.c
@@ -120,8 +120,8 @@ void test_refs_reflog_reflog__renaming_the_reference_moves_the_reflog(void)
 	cl_assert_equal_i(true, git_path_isfile(git_buf_cstr(&moved_log_path)));
 
 	git_reference_free(new_master);
-	git_buf_free(&moved_log_path);
-	git_buf_free(&master_log_path);
+	git_buf_dispose(&moved_log_path);
+	git_buf_dispose(&master_log_path);
 }
 
 void test_refs_reflog_reflog__deleting_the_reference_deletes_the_reflog(void)
@@ -139,7 +139,7 @@ void test_refs_reflog_reflog__deleting_the_reference_deletes_the_reflog(void)
 	git_reference_free(master);
 
 	cl_assert_equal_i(false, git_path_isfile(git_buf_cstr(&master_log_path)));
-	git_buf_free(&master_log_path);
+	git_buf_dispose(&master_log_path);
 }
 
 void test_refs_reflog_reflog__removes_empty_reflog_dir(void)
@@ -165,7 +165,7 @@ void test_refs_reflog_reflog__removes_empty_reflog_dir(void)
 	cl_git_pass(git_reference_create(&ref, g_repo, "refs/heads/new-dir", &id, 0, NULL));
 	git_reference_free(ref);
 
-	git_buf_free(&log_path);
+	git_buf_dispose(&log_path);
 }
 
 void test_refs_reflog_reflog__fails_gracefully_on_nonempty_reflog_dir(void)
@@ -192,7 +192,7 @@ void test_refs_reflog_reflog__fails_gracefully_on_nonempty_reflog_dir(void)
 	cl_git_fail_with(GIT_EDIRECTORY, git_reference_create(&ref, g_repo, "refs/heads/new-dir", &id, 0, NULL));
 	git_reference_free(ref);
 
-	git_buf_free(&log_path);
+	git_buf_dispose(&log_path);
 }
 
 static void assert_has_reflog(bool expected_result, const char *name)
@@ -221,7 +221,7 @@ void test_refs_reflog_reflog__reading_the_reflog_from_a_reference_with_no_log_re
 	cl_assert_equal_i(0, (int)git_reflog_entrycount(reflog));
 
 	git_reflog_free(reflog);
-	git_buf_free(&subtrees_log_path);
+	git_buf_dispose(&subtrees_log_path);
 }
 
 void test_refs_reflog_reflog__reading_a_reflog_with_invalid_format_returns_error(void)
@@ -263,8 +263,8 @@ void test_refs_reflog_reflog__reading_a_reflog_with_invalid_format_returns_error
 	cl_assert_equal_s("unable to parse OID - contains invalid characters", error->message);
 
 	git_reference_free(ref);
-	git_buf_free(&logpath);
-	git_buf_free(&logcontents);
+	git_buf_dispose(&logpath);
+	git_buf_dispose(&logcontents);
 }
 
 void test_refs_reflog_reflog__cannot_write_a_moved_reflog(void)
@@ -285,8 +285,8 @@ void test_refs_reflog_reflog__cannot_write_a_moved_reflog(void)
 
 	git_reflog_free(reflog);
 	git_reference_free(new_master);
-	git_buf_free(&moved_log_path);
-	git_buf_free(&master_log_path);
+	git_buf_dispose(&moved_log_path);
+	git_buf_dispose(&master_log_path);
 }
 
 void test_refs_reflog_reflog__renaming_with_an_invalid_name_returns_EINVALIDSPEC(void)

--- a/tests/refs/reflog/reflog_helpers.c
+++ b/tests/refs/reflog/reflog_helpers.c
@@ -94,7 +94,7 @@ void cl_reflog_check_entry_(git_repository *repo, const char *reflog, size_t idx
 	if (git_buf_len(&result) != 0)
 		clar__fail(file, line, "Reflog entry mismatch", git_buf_cstr(&result), 1);
 
-	git_buf_free(&result);
+	git_buf_dispose(&result);
 	git_reflog_free(log);
 }
 
@@ -113,6 +113,6 @@ void reflog_print(git_repository *repo, const char *reflog_name)
 	}
 
 	fprintf(stderr, "%s", git_buf_cstr(&out));
-	git_buf_free(&out);
+	git_buf_dispose(&out);
 	git_reflog_free(reflog);
 }

--- a/tests/refs/rename.c
+++ b/tests/refs/rename.c
@@ -71,7 +71,7 @@ void test_refs_rename__loose(void)
 
 	git_reference_free(new_ref);
 	git_reference_free(another_looked_up_ref);
-	git_buf_free(&temp_path);
+	git_buf_dispose(&temp_path);
 }
 
 void test_refs_rename__packed(void)
@@ -113,7 +113,7 @@ void test_refs_rename__packed(void)
 
 	git_reference_free(new_ref);
 	git_reference_free(another_looked_up_ref);
-	git_buf_free(&temp_path);
+	git_buf_dispose(&temp_path);
 }
 
 void test_refs_rename__packed_doesnt_pack_others(void)
@@ -155,7 +155,7 @@ void test_refs_rename__packed_doesnt_pack_others(void)
 
 	git_reference_free(renamed_ref);
 	git_reference_free(another_looked_up_ref);
-	git_buf_free(&temp_path);
+	git_buf_dispose(&temp_path);
 }
 
 void test_refs_rename__name_collision(void)

--- a/tests/refs/revparse.c
+++ b/tests/refs/revparse.c
@@ -338,7 +338,7 @@ static void create_fake_stash_reference_and_reflog(git_repository *repo)
 
 	cl_assert_equal_i(true, git_path_isfile(git_buf_cstr(&log_path)));
 
-	git_buf_free(&log_path);
+	git_buf_dispose(&log_path);
 	git_reference_free(new_master);
 }
 

--- a/tests/repo/config.c
+++ b/tests/repo/config.c
@@ -21,7 +21,7 @@ void test_repo_config__cleanup(void)
 {
 	cl_sandbox_set_search_path_defaults();
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	cl_git_pass(
 		git_futils_rmdir_r("alternate", NULL, GIT_RMDIR_REMOVE_FILES));
@@ -70,7 +70,7 @@ void test_repo_config__can_open_missing_global_with_separators(void)
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, path.ptr));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
 	cl_git_pass(git_repository_config(&config, repo));

--- a/tests/repo/discover.c
+++ b/tests/repo/discover.c
@@ -37,8 +37,8 @@ static void ensure_repository_discover(const char *start_path,
 
 	cl_assert_equal_s(found_path.ptr, resolved.ptr);
 
-	git_buf_free(&resolved);
-	git_buf_free(&found_path);
+	git_buf_dispose(&resolved);
+	git_buf_dispose(&found_path);
 }
 
 static void write_file(const char *path, const char *content)
@@ -71,7 +71,7 @@ static void append_ceiling_dir(git_buf *ceiling_dirs, const char *path)
 
 	git_buf_puts(ceiling_dirs, pretty_path.ptr);
 
-	git_buf_free(&pretty_path);
+	git_buf_dispose(&pretty_path);
 	cl_assert(git_buf_oom(ceiling_dirs) == 0);
 }
 
@@ -114,8 +114,8 @@ void test_repo_discover__initialize(void)
 
 void test_repo_discover__cleanup(void)
 {
-	git_buf_free(&discovered);
-	git_buf_free(&ceiling_dirs);
+	git_buf_dispose(&discovered);
+	git_buf_dispose(&ceiling_dirs);
 	cl_git_pass(git_futils_rmdir_r(TEMP_REPO_FOLDER, NULL, GIT_RMDIR_REMOVE_FILES));
 }
 

--- a/tests/repo/env.c
+++ b/tests/repo/env.c
@@ -45,7 +45,7 @@ static int GIT_FORMAT_PRINTF(2, 3) cl_setenv_printf(const char *name, const char
 	va_end(args);
 
 	ret = cl_setenv(name, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	return ret;
 }
 
@@ -85,7 +85,7 @@ static void env_cd_(
 	cl_must_pass(p_chdir(path));
 	passfail_(NULL, file, line);
 	cl_must_pass(p_chdir(git_buf_cstr(&cwd_buf)));
-	git_buf_free(&cwd_buf);
+	git_buf_dispose(&cwd_buf);
 }
 #define env_cd_pass(path) env_cd_((path), env_pass_, __FILE__, __LINE__)
 #define env_cd_fail(path) env_cd_((path), env_fail_, __FILE__, __LINE__)
@@ -271,7 +271,7 @@ void test_repo_env__open(void)
 	cl_fixture_cleanup("testrepo.git");
 	cl_fixture_cleanup("attr");
 
-	git_buf_free(&repo_dir_buf);
+	git_buf_dispose(&repo_dir_buf);
 
 	clear_git_env();
 }

--- a/tests/repo/hashfile.c
+++ b/tests/repo/hashfile.c
@@ -35,7 +35,7 @@ void test_repo_hashfile__simple(void)
 	cl_git_fail(git_odb_hashfile(&a, full.ptr, GIT_OBJ_ANY));
 	cl_git_fail(git_repository_hashfile(&b, _repo, full.ptr, GIT_OBJ_OFS_DELTA, NULL));
 
-	git_buf_free(&full);
+	git_buf_dispose(&full);
 }
 
 void test_repo_hashfile__filtered(void)

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -33,11 +33,11 @@ void test_repo_init__cleanup(void)
 {
 	git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL,
 		_global_path.ptr);
-	git_buf_free(&_global_path);
+	git_buf_dispose(&_global_path);
 
 	if (_tmp_path.size > 0 && git_path_isdir(_tmp_path.ptr))
 		git_futils_rmdir_r(_tmp_path.ptr, NULL, GIT_RMDIR_REMOVE_FILES);
-	git_buf_free(&_tmp_path);
+	git_buf_dispose(&_tmp_path);
 }
 
 static void cleanup_repository(void *path)
@@ -131,8 +131,8 @@ void test_repo_init__bare_repo_escaping_current_workdir(void)
 
 	cl_git_pass(chdir(git_buf_cstr(&path_current_workdir)));
 
-	git_buf_free(&path_current_workdir);
-	git_buf_free(&path_repository);
+	git_buf_dispose(&path_current_workdir);
+	git_buf_dispose(&path_repository);
 
 	cleanup_repository("a");
 }
@@ -193,7 +193,7 @@ void test_repo_init__additional_templates(void)
 	cl_assert(git_path_isdir(git_buf_cstr(&path)));
 	/* won't confirm specific contents of hooks dir since it may vary */
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void assert_config_entry_on_init_bytype(
@@ -423,7 +423,7 @@ void test_repo_init__relative_gitdir(void)
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
 	cl_assert_equal_s("gitdir: ../my_repository/", dot_git_content.ptr);
 
-	git_buf_free(&dot_git_content);
+	git_buf_dispose(&dot_git_content);
 	cleanup_repository("root");
 }
 
@@ -444,7 +444,7 @@ void test_repo_init__relative_gitdir_2(void)
 
 	/* make the directory first, then it should succeed */
 	cl_git_pass(git_repository_init_ext(&_repo, "root/b/my_repository", &opts));
-	git_buf_free(&full_path);
+	git_buf_dispose(&full_path);
 
 	cl_assert(!git__suffixcmp(git_repository_workdir(_repo), "root/b/c_wd/"));
 	cl_assert(!git__suffixcmp(git_repository_path(_repo), "root/b/my_repository/"));
@@ -460,7 +460,7 @@ void test_repo_init__relative_gitdir_2(void)
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
 	cl_assert_equal_s("gitdir: ../my_repository/", dot_git_content.ptr);
 
-	git_buf_free(&dot_git_content);
+	git_buf_dispose(&dot_git_content);
 	cleanup_repository("root");
 }
 
@@ -497,8 +497,8 @@ static void assert_hooks_match(
 		cl_assert_equal_i_fmt(expected_mode, st.st_mode, "%07o");
 	}
 
-	git_buf_free(&expected);
-	git_buf_free(&actual);
+	git_buf_dispose(&expected);
+	git_buf_dispose(&actual);
 }
 
 static void assert_mode_seems_okay(
@@ -510,7 +510,7 @@ static void assert_mode_seems_okay(
 
 	cl_git_pass(git_buf_joinpath(&full, base, path));
 	cl_git_pass(git_path_lstat(full.ptr, &st));
-	git_buf_free(&full);
+	git_buf_dispose(&full);
 
 	if (!core_filemode) {
 		CLEAR_FOR_CORE_FILEMODE(expect_mode);
@@ -552,11 +552,11 @@ static const char *template_sandbox(const char *name)
 	/* create a file starting with a dot */
 	cl_git_pass(git_buf_joinpath(&dotfile_path, hooks_path.ptr, ".dotfile"));
 	cl_git_mkfile(dotfile_path.ptr, "something\n");
-	git_buf_free(&dotfile_path);
+	git_buf_dispose(&dotfile_path);
 
-	git_buf_free(&dotfile_path);
-	git_buf_free(&link_path);
-	git_buf_free(&hooks_path);
+	git_buf_dispose(&dotfile_path);
+	git_buf_dispose(&link_path);
+	git_buf_dispose(&hooks_path);
 
 	return path;
 }
@@ -581,8 +581,8 @@ static void configure_templatedir(const char *template_path)
 
 	cl_git_mkfile(config_path.ptr, config_data.ptr);
 
-	git_buf_free(&config_path);
-	git_buf_free(&config_data);
+	git_buf_dispose(&config_path);
+	git_buf_dispose(&config_data);
 }
 
 static void validate_templates(git_repository *repo, const char *template_path)
@@ -617,10 +617,10 @@ static void validate_templates(git_repository *repo, const char *template_path)
 		template_path, git_repository_path(repo),
 		"hooks/.dotfile", filemode);
 
-	git_buf_free(&expected);
-	git_buf_free(&actual);
-	git_buf_free(&repo_description);
-	git_buf_free(&template_description);
+	git_buf_dispose(&expected);
+	git_buf_dispose(&actual);
+	git_buf_dispose(&repo_description);
+	git_buf_dispose(&template_description);
 }
 
 void test_repo_init__external_templates_specified_in_options(void)
@@ -666,7 +666,7 @@ void test_repo_init__external_templates_specified_in_config(void)
 	validate_templates(_repo, "template");
 	cl_fixture_cleanup("template");
 
-	git_buf_free(&template_path);
+	git_buf_dispose(&template_path);
 }
 
 void test_repo_init__external_templates_with_leading_dot(void)
@@ -693,7 +693,7 @@ void test_repo_init__external_templates_with_leading_dot(void)
 	validate_templates(_repo, ".template_with_leading_dot");
 	cl_fixture_cleanup(".template_with_leading_dot");
 
-	git_buf_free(&template_path);
+	git_buf_dispose(&template_path);
 }
 
 void test_repo_init__extended_with_template_and_shared_mode(void)
@@ -833,6 +833,6 @@ void test_repo_init__at_filesystem_root(void)
 	cl_assert(git_path_isdir(root.ptr));
 	cl_git_pass(git_futils_rmdir_r(root.ptr, NULL, GIT_RMDIR_REMOVE_FILES));
 
-	git_buf_free(&root);
+	git_buf_dispose(&root);
 	git_repository_free(repo);
 }

--- a/tests/repo/message.c
+++ b/tests/repo/message.c
@@ -31,9 +31,9 @@ void test_repo_message__message(void)
 
 	cl_git_pass(git_repository_message(&actual, _repo));
 	cl_assert_equal_s(expected, git_buf_cstr(&actual));
-	git_buf_free(&actual);
+	git_buf_dispose(&actual);
 
 	cl_git_pass(p_unlink(git_buf_cstr(&path)));
 	cl_assert_equal_i(GIT_ENOTFOUND, git_repository_message(&actual, _repo));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -95,7 +95,7 @@ static void make_gitlink_dir(const char *dir, const char *linktext)
 	cl_git_pass(git_futils_mkdir(dir, 0777, GIT_MKDIR_VERIFY_DIR));
 	cl_git_pass(git_buf_joinpath(&path, dir, ".git"));
 	cl_git_rewritefile(path.ptr, linktext);
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_repo_open__gitlinked(void)
@@ -166,9 +166,9 @@ void test_repo_open__from_git_new_workdir(void)
 		}
 	}
 
-	git_buf_free(&link_tgt);
-	git_buf_free(&link);
-	git_buf_free(&body);
+	git_buf_dispose(&link_tgt);
+	git_buf_dispose(&link);
+	git_buf_dispose(&body);
 
 
 	cl_git_pass(git_repository_open(&repo2, "alternate"));
@@ -215,7 +215,7 @@ void test_repo_open__failures(void)
 		GIT_REPOSITORY_OPEN_NO_SEARCH | GIT_REPOSITORY_OPEN_NO_DOTGIT,
 		NULL));
 
-	git_buf_free(&ceiling);
+	git_buf_dispose(&ceiling);
 }
 
 void test_repo_open__bad_gitlinks(void)
@@ -308,7 +308,7 @@ void test_repo_open__win32_path(void)
 	cl_assert(git__suffixcmp(git_repository_workdir(repo2), repo_wd) == 0);
 	git_repository_free(repo2);
 
-	git_buf_free(&winpath);
+	git_buf_dispose(&winpath);
 #endif
 }
 
@@ -342,7 +342,7 @@ void test_repo_open__no_config(void)
 	cl_git_pass(git_libgit2_opts(
 		GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_XDG, path.ptr));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 
 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
 	cl_git_pass(git_repository_config(&config, repo));

--- a/tests/repo/repo_helpers.c
+++ b/tests/repo/repo_helpers.c
@@ -18,5 +18,5 @@ void delete_head(git_repository* repo)
 	cl_git_pass(git_buf_joinpath(&head_path, git_repository_path(repo), GIT_HEAD_FILE));
 	cl_git_pass(p_unlink(git_buf_cstr(&head_path)));
 
-	git_buf_free(&head_path);
+	git_buf_dispose(&head_path);
 }

--- a/tests/repo/reservedname.c
+++ b/tests/repo/reservedname.c
@@ -128,5 +128,5 @@ void test_repo_reservedname__submodule_pointer_during_create(void)
 	cl_git_pass(git_submodule_update(sm, 1, &update_options));
 
 	git_submodule_free(sm);
-	git_buf_free(&url);
+	git_buf_dispose(&url);
 }

--- a/tests/repo/setters.c
+++ b/tests/repo/setters.c
@@ -56,13 +56,13 @@ void test_repo_setters__setting_a_workdir_creates_a_gitlink(void)
 	cl_git_pass(git_futils_readbuffer(&content, "./new_workdir/.git"));
 	cl_assert(git__prefixcmp(git_buf_cstr(&content), "gitdir: ") == 0);
 	cl_assert(git__suffixcmp(git_buf_cstr(&content), "testrepo.git/") == 0);
-	git_buf_free(&content);
+	git_buf_dispose(&content);
 
 	cl_git_pass(git_repository_config(&cfg, repo));
 	cl_git_pass(git_config_get_string_buf(&buf, cfg, "core.worktree"));
 	cl_assert(git__suffixcmp(git_buf_cstr(&buf), "new_workdir/") == 0);
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_config_free(cfg);
 }
 

--- a/tests/repo/state.c
+++ b/tests/repo/state.c
@@ -15,7 +15,7 @@ void test_repo_state__initialize(void)
 void test_repo_state__cleanup(void)
 {
 	cl_git_sandbox_cleanup();
-	git_buf_free(&_path);
+	git_buf_dispose(&_path);
 }
 
 static void setup_simple_state(const char *filename)

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -83,8 +83,8 @@ void test_reset_hard__resetting_reverts_modified_files(void)
 		}
 	}
 
-	git_buf_free(&content);
-	git_buf_free(&path);
+	git_buf_dispose(&content);
+	git_buf_dispose(&path);
 }
 
 void test_reset_hard__cannot_reset_in_a_bare_repository(void)
@@ -192,10 +192,10 @@ void test_reset_hard__cleans_up_merge(void)
 	cl_assert(git_path_exists(git_buf_cstr(&orig_head_path)));
 	cl_git_pass(p_unlink(git_buf_cstr(&orig_head_path)));
 
-	git_buf_free(&merge_head_path);
-	git_buf_free(&merge_msg_path);
-	git_buf_free(&merge_mode_path);
-	git_buf_free(&orig_head_path);
+	git_buf_dispose(&merge_head_path);
+	git_buf_dispose(&merge_msg_path);
+	git_buf_dispose(&merge_mode_path);
+	git_buf_dispose(&orig_head_path);
 }
 
 void test_reset_hard__reflog_is_correct(void)
@@ -223,7 +223,7 @@ void test_reset_hard__reflog_is_correct(void)
 	reflog_check(repo, "HEAD", 4, NULL, git_buf_cstr(&buf));
 	reflog_check(repo, "refs/heads/master", 4, NULL, git_buf_cstr(&buf));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Moved branch, expect revspec in message */
 	exp_msg = "reset: moving to HEAD~^{commit}";

--- a/tests/reset/mixed.c
+++ b/tests/reset/mixed.c
@@ -73,7 +73,7 @@ void test_reset_mixed__reflog_is_correct(void)
 	cl_git_pass(git_reset(repo, target, GIT_RESET_MIXED, NULL));
 	reflog_check(repo, "HEAD", 10, NULL, git_buf_cstr(&buf));
 	reflog_check(repo, "refs/heads/master", 10, NULL, git_buf_cstr(&buf));
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Moved branch, expect revspec in message */
 	exp_msg = "reset: moving to HEAD~^{commit}";

--- a/tests/reset/soft.c
+++ b/tests/reset/soft.c
@@ -127,7 +127,7 @@ void test_reset_soft__fails_when_merging(void)
 	cl_assert_equal_i(GIT_EUNMERGED, git_reset(repo, target, GIT_RESET_SOFT, NULL));
 	cl_git_pass(p_unlink(git_buf_cstr(&merge_head_path)));
 
-	git_buf_free(&merge_head_path);
+	git_buf_dispose(&merge_head_path);
 }
 
 void test_reset_soft__fails_when_index_contains_conflicts_independently_of_MERGE_HEAD_file_existence(void)
@@ -142,7 +142,7 @@ void test_reset_soft__fails_when_index_contains_conflicts_independently_of_MERGE
 
 	cl_git_pass(git_buf_joinpath(&merge_head_path, git_repository_path(repo), "MERGE_HEAD"));
 	cl_git_pass(p_unlink(git_buf_cstr(&merge_head_path)));
-	git_buf_free(&merge_head_path);
+	git_buf_dispose(&merge_head_path);
 
 	cl_git_pass(git_repository_index(&index, repo));
 	cl_assert_equal_i(true, git_index_has_conflicts(index));

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -126,8 +126,8 @@ void test_revert_workdir__conflicts(void)
 	git_commit_free(commit);
 	git_commit_free(head);
 	git_reference_free(head_ref);
-	git_buf_free(&mergemsg_buf);
-	git_buf_free(&conflicting_buf);
+	git_buf_dispose(&mergemsg_buf);
+	git_buf_dispose(&conflicting_buf);
 }
 
 /* git reset --hard 39467716290f6df775a91cdb9a4eb39295018145
@@ -350,7 +350,7 @@ void test_revert_workdir__again_after_edit_two(void)
 	git_commit_free(revert_commit);
 	git_commit_free(head_commit);
 	git_config_free(config);
-	git_buf_free(&diff_buf);
+	git_buf_dispose(&diff_buf);
 }
 
 /* git reset --hard 72333f47d4e83616630ff3b0ffe4c0faebcc3c45

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -85,7 +85,7 @@ void test_stash_apply__with_default(void)
 	cl_git_pass(git_futils_readbuffer(&where, "stash/where"));
 	cl_assert_equal_s("....\n", where.ptr);
 
-	git_buf_free(&where);
+	git_buf_dispose(&where);
 }
 
 void test_stash_apply__with_existing_file(void)
@@ -132,7 +132,7 @@ void test_stash_apply__with_reinstate_index(void)
 	cl_git_pass(git_futils_readbuffer(&where, "stash/where"));
 	cl_assert_equal_s("....\n", where.ptr);
 
-	git_buf_free(&where);
+	git_buf_dispose(&where);
 }
 
 void test_stash_apply__conflict_index_with_default(void)

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -601,7 +601,7 @@ void test_status_ignore__filenames_with_special_prefixes_do_not_interfere_with_s
 		cl_assert(st.status == GIT_STATUS_WT_NEW);
 
 		cl_git_sandbox_cleanup();
-		git_buf_free(&file);
+		git_buf_dispose(&file);
 	}
 }
 

--- a/tests/status/renames.c
+++ b/tests/status/renames.c
@@ -35,8 +35,8 @@ static void _rename_helper(
 	if (extra)
 		cl_git_append2file(newpath.ptr, extra);
 
-	git_buf_free(&oldpath);
-	git_buf_free(&newpath);
+	git_buf_dispose(&oldpath);
+	git_buf_dispose(&newpath);
 }
 
 #define rename_file(R,O,N) _rename_helper((R), (O), (N), NULL)

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -127,7 +127,7 @@ void test_status_worktree__purged_worktree(void)
 	/* first purge the contents of the worktree */
 	cl_git_pass(git_buf_sets(&workdir, git_repository_workdir(repo)));
 	cl_git_pass(git_path_direach(&workdir, 0, remove_file_cb, NULL));
-	git_buf_free(&workdir);
+	git_buf_dispose(&workdir);
 
 	/* now get status */
 	memset(&counts, 0x0, sizeof(status_entry_counts));
@@ -378,7 +378,7 @@ void test_status_worktree__issue_592(void)
 
 	cl_git_pass(git_status_foreach(repo, cb_status__check_592, "l.txt"));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_status_worktree__issue_592_2(void)
@@ -393,7 +393,7 @@ void test_status_worktree__issue_592_2(void)
 
 	cl_git_pass(git_status_foreach(repo, cb_status__check_592, "c/a.txt"));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_status_worktree__issue_592_3(void)
@@ -409,7 +409,7 @@ void test_status_worktree__issue_592_3(void)
 
 	cl_git_pass(git_status_foreach(repo, cb_status__check_592, "c/a.txt"));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_status_worktree__issue_592_4(void)
@@ -424,7 +424,7 @@ void test_status_worktree__issue_592_4(void)
 
 	cl_git_pass(git_status_foreach(repo, cb_status__check_592, "t/b.txt"));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_status_worktree__issue_592_5(void)
@@ -440,7 +440,7 @@ void test_status_worktree__issue_592_5(void)
 
 	cl_git_pass(git_status_foreach(repo, cb_status__check_592, NULL));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_status_worktree__issue_592_ignores_0(void)
@@ -782,8 +782,8 @@ static void assert_ignore_case(
 	cl_assert_equal_i(expected_camel_cased_file_status, status);
 
 	git_repository_free(repo2);
-	git_buf_free(&lower_case_path);
-	git_buf_free(&camel_case_path);
+	git_buf_dispose(&lower_case_path);
+	git_buf_dispose(&camel_case_path);
 }
 
 void test_status_worktree__file_status_honors_core_ignorecase_true(void)

--- a/tests/stress/diff.c
+++ b/tests/stress/diff.c
@@ -108,7 +108,7 @@ void test_stress_diff__rename_big_files(void)
 		cl_git_pass(git_index_add_bypath(index, tmp + strlen("renames/")));
 	}
 
-	git_buf_free(&b);
+	git_buf_dispose(&b);
 	git_index_free(index);
 
 	test_with_many(100);
@@ -133,7 +133,7 @@ void test_stress_diff__rename_many_files(void)
 		b.ptr[8] = '\n';
 		cl_git_mkfile(tmp, b.ptr);
 	}
-	git_buf_free(&b);
+	git_buf_dispose(&b);
 
 	for (i = 0; i < 2500; i += 1) {
 		p_snprintf(tmp, sizeof(tmp), "renames/newfile%03d", i);

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -22,7 +22,7 @@ static void assert_submodule_url(const char* name, const char *url)
 	cl_git_pass(git_buf_printf(&key, "submodule.%s.url", name));
 	assert_config_entry_value(g_repo, git_buf_cstr(&key), url);
 
-	git_buf_free(&key);
+	git_buf_dispose(&key);
 }
 
 void test_submodule_add__url_absolute(void)
@@ -62,7 +62,7 @@ void test_submodule_add__url_absolute(void)
 	cl_assert_equal_s("gitdir: ../.git/modules/sm_libgit2/", dot_git_content.ptr);
 
 	git_repository_free(repo);
-	git_buf_free(&dot_git_content);
+	git_buf_dispose(&dot_git_content);
 
 	/* add a submodule not using a gitlink */
 
@@ -163,7 +163,7 @@ void test_submodule_add__path_exists_in_index(void)
 	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "subdirectory", 1), GIT_EEXISTS);
 
 	git_submodule_free(sm);
-	git_buf_free(&filename);
+	git_buf_dispose(&filename);
 }
 
 void test_submodule_add__file_exists_in_index(void)
@@ -181,5 +181,5 @@ void test_submodule_add__file_exists_in_index(void)
 	cl_git_fail_with(git_submodule_add_setup(&sm, g_repo, "./", "subdirectory", 1), GIT_EEXISTS);
 
 	git_submodule_free(sm);
-	git_buf_free(&name);
+	git_buf_dispose(&name);
 }

--- a/tests/submodule/escape.c
+++ b/tests/submodule/escape.c
@@ -43,7 +43,7 @@ void test_submodule_escape__from_gitdir(void)
 			   "[submodule \"" EVIL_SM_NAME "\"]\n"
 			   "    path = testrepo\n"
 			   "    url = ../testrepo.git\n");
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Find it all the different ways we know about it */
 	foundit = 0;
@@ -77,7 +77,7 @@ void test_submodule_escape__from_gitdir_windows(void)
 			   "[submodule \"" EVIL_SM_NAME_WINDOWS "\"]\n"
 			   "    path = testrepo\n"
 			   "    url = ../testrepo.git\n");
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* Find it all the different ways we know about it */
 	foundit = 0;

--- a/tests/submodule/init.c
+++ b/tests/submodule/init.c
@@ -39,7 +39,7 @@ void test_submodule_init__absolute_url(void)
 	cl_git_pass(git_config_get_string(&config_url, cfg, "submodule.testrepo.url"));
 	cl_assert_equal_s(absolute_url.ptr, config_url);
 
-	git_buf_free(&absolute_url);
+	git_buf_dispose(&absolute_url);
 	git_config_free(cfg);
 	git_submodule_free(sm);
 }
@@ -69,7 +69,7 @@ void test_submodule_init__relative_url(void)
 	cl_git_pass(git_config_get_string(&config_url, cfg, "submodule.testrepo.url"));
 	cl_assert_equal_s(absolute_url.ptr, config_url);
 
-	git_buf_free(&absolute_url);
+	git_buf_dispose(&absolute_url);
 	git_config_free(cfg);
 	git_submodule_free(sm);
 }
@@ -107,7 +107,7 @@ void test_submodule_init__relative_url_detached_head(void)
 	cl_git_pass(git_config_get_string(&config_url, cfg, "submodule.testrepo.url"));
 	cl_assert_equal_s(absolute_url.ptr, config_url);
 
-	git_buf_free(&absolute_url);
+	git_buf_dispose(&absolute_url);
 	git_config_free(cfg);
 	git_object_free(head_commit);
 	git_reference_free(head_ref);

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -195,7 +195,7 @@ void test_submodule_lookup__backslashes(void)
 
 	cl_git_pass(git_submodule_resolve_url(&buf, g_repo, backslashed_path));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_submodule_free(sm);
 	git_repository_free(subrepo);
 }
@@ -227,7 +227,7 @@ static void add_submodule_with_commit(const char *name)
 
 	cl_git_pass(git_buf_joinpath(&p, git_repository_workdir(smrepo), "file"));
 	cl_git_mkfile(p.ptr, "new file");
-	git_buf_free(&p);
+	git_buf_dispose(&p);
 
 	cl_git_pass(git_index_add_bypath(idx, "file"));
 	cl_git_pass(git_index_write(idx));
@@ -293,7 +293,7 @@ void test_submodule_lookup__just_added(void)
 	baseline_tests();
 
 	cl_git_rewritefile("submod2/.gitmodules", snap2.ptr);
-	git_buf_free(&snap2);
+	git_buf_dispose(&snap2);
 
 	refute_submodule_exists(g_repo, "mismatch_name", GIT_ENOTFOUND);
 	refute_submodule_exists(g_repo, "mismatch_path", GIT_ENOTFOUND);
@@ -304,7 +304,7 @@ void test_submodule_lookup__just_added(void)
 	baseline_tests();
 
 	cl_git_rewritefile("submod2/.gitmodules", snap1.ptr);
-	git_buf_free(&snap1);
+	git_buf_dispose(&snap1);
 
 	refute_submodule_exists(g_repo, "mismatch_name", GIT_ENOTFOUND);
 	refute_submodule_exists(g_repo, "mismatch_path", GIT_ENOTFOUND);

--- a/tests/submodule/nosubs.c
+++ b/tests/submodule/nosubs.c
@@ -85,7 +85,7 @@ void test_submodule_nosubs__add_and_delete(void)
 	cl_git_pass(git_futils_readbuffer(&buf, "status/.gitmodules"));
 	cl_assert(strstr(buf.ptr, "[submodule \"submodules/libgit2\"]") != NULL);
 	cl_assert(strstr(buf.ptr, "path = submodules/libgit2") != NULL);
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 
 	/* lookup */
 

--- a/tests/submodule/open.c
+++ b/tests/submodule/open.c
@@ -48,8 +48,8 @@ static void assert_sm_valid(git_repository *parent, git_repository *child, const
 	cl_git_pass(git_path_prettify_dir(&actual, actual.ptr, NULL));
 	cl_assert_equal_s(expected.ptr, actual.ptr);
 
-	git_buf_free(&expected);
-	git_buf_free(&actual);
+	git_buf_dispose(&expected);
+	git_buf_dispose(&actual);
 }
 
 void test_submodule_open__opening_via_lookup_succeeds(void)
@@ -67,7 +67,7 @@ void test_submodule_open__direct_open_succeeds(void)
 	cl_git_pass(git_repository_open(&g_child, path.ptr));
 	assert_sm_valid(g_parent, g_child, "sm_unchanged");
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_submodule_open__direct_open_succeeds_for_broken_sm_with_gitdir(void)
@@ -86,5 +86,5 @@ void test_submodule_open__direct_open_succeeds_for_broken_sm_with_gitdir(void)
 	cl_git_pass(git_repository_open(&g_child, path.ptr));
 	assert_sm_valid(g_parent, g_child, "sm_unchanged");
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }

--- a/tests/submodule/repository_init.c
+++ b/tests/submodule/repository_init.c
@@ -34,5 +34,5 @@ void test_submodule_repository_init__basic(void)
 
 	git_submodule_free(sm);
 	git_repository_free(repo);
-	git_buf_free(&dot_git_content);
+	git_buf_dispose(&dot_git_content);
 }

--- a/tests/submodule/status.c
+++ b/tests/submodule/status.c
@@ -34,7 +34,7 @@ static void rm_submodule(const char *name)
 	git_buf path = GIT_BUF_INIT;
 	cl_git_pass(git_buf_joinpath(&path, git_repository_workdir(g_repo), name));
 	cl_git_pass(git_futils_rmdir_r(path.ptr, NULL, GIT_RMDIR_REMOVE_FILES));
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 static void add_submodule_to_index(const char *name)

--- a/tests/submodule/submodule_helpers.c
+++ b/tests/submodule/submodule_helpers.c
@@ -79,9 +79,9 @@ void rewrite_gitmodules(const char *workdir)
 
 	cl_must_pass(p_unlink(in_f.ptr));
 
-	git_buf_free(&in_f);
-	git_buf_free(&out_f);
-	git_buf_free(&path);
+	git_buf_dispose(&in_f);
+	git_buf_dispose(&out_f);
+	git_buf_dispose(&path);
 }
 
 static void cleanup_fixture_submodules(void *payload)

--- a/tests/win32/longpath.c
+++ b/tests/win32/longpath.c
@@ -28,7 +28,7 @@ void test_win32_longpath__initialize(void)
 
 void test_win32_longpath__cleanup(void)
 {
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 #ifdef GIT_WIN32

--- a/tests/worktree/merge.c
+++ b/tests/worktree/merge.c
@@ -76,7 +76,7 @@ void test_worktree_merge__merge_setup(void)
 		cl_assert(git_path_exists(path.ptr));
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_reference_free(ours_ref);
 	git_reference_free(theirs_ref);
 	git_annotated_commit_free(ours);
@@ -115,7 +115,7 @@ void test_worktree_merge__merge_conflict(void)
 	cl_git_pass(git_futils_readbuffer(&buf, path.ptr));
 	cl_assert_equal_s(buf.ptr, CONFLICT_BRANCH_FILE_TXT);
 
-	git_buf_free(&path);
-	git_buf_free(&buf);
+	git_buf_dispose(&path);
+	git_buf_dispose(&buf);
 }
 

--- a/tests/worktree/open.c
+++ b/tests/worktree/open.c
@@ -32,7 +32,7 @@ static void assert_worktree_valid(git_repository *wt, const char *parentdir, con
 	cl_git_pass(git_path_to_dir(&path));
 	cl_assert_equal_s(wt->gitdir, path.ptr);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_worktree_open__initialize(void)
@@ -82,7 +82,7 @@ void test_worktree_open__repository_through_gitdir(void)
 	cl_git_pass(git_repository_open(&wt, gitdir_path.ptr));
 	assert_worktree_valid(wt, COMMON_REPO, WORKTREE_REPO);
 
-	git_buf_free(&gitdir_path);
+	git_buf_dispose(&gitdir_path);
 	git_repository_free(wt);
 }
 
@@ -97,7 +97,7 @@ void test_worktree_open__open_discovered_worktree(void)
 	cl_assert_equal_s(git_repository_workdir(fixture.worktree),
 		git_repository_workdir(repo));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_repository_free(repo);
 }
 

--- a/tests/worktree/refs.c
+++ b/tests/worktree/refs.c
@@ -191,5 +191,5 @@ void test_worktree_refs__creating_refs_uses_commondir(void)
 	   git_reference_free(branch);
 	   git_reference_free(head);
 	   git_commit_free(commit);
-	   git_buf_free(&refpath);
+	   git_buf_dispose(&refpath);
 }

--- a/tests/worktree/submodule.c
+++ b/tests/worktree/submodule.c
@@ -55,7 +55,7 @@ void test_worktree_submodule__open_discovered_submodule_worktree(void)
 	cl_assert_equal_s(git_repository_workdir(child.worktree),
 		git_repository_workdir(repo));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_repository_free(repo);
 }
 
@@ -86,7 +86,7 @@ void test_worktree_submodule__resolve_relative_url(void)
 
 	git_worktree_free(wt);
 	git_repository_free(repo);
-	git_buf_free(&wt_path);
-	git_buf_free(&sm_relative_path);
-	git_buf_free(&wt_relative_path);
+	git_buf_dispose(&wt_path);
+	git_buf_dispose(&sm_relative_path);
+	git_buf_dispose(&wt_relative_path);
 }

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -70,7 +70,7 @@ void test_worktree_worktree__list_with_invalid_worktree_dirs(void)
 		}
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_worktree_worktree__list_in_worktree_repo(void)
@@ -123,7 +123,7 @@ void test_worktree_worktree__lookup(void)
 	cl_assert_equal_s(wt->commondir_path, fixture.repo->gitdir);
 	cl_assert_equal_s(wt->commondir_path, fixture.repo->commondir);
 
-	git_buf_free(&gitdir_path);
+	git_buf_dispose(&gitdir_path);
 	git_worktree_free(wt);
 }
 
@@ -165,8 +165,8 @@ void test_worktree_worktree__open_invalid_commondir(void)
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_git_fail(git_repository_open_from_worktree(&repo, wt));
 
-	git_buf_free(&buf);
-	git_buf_free(&path);
+	git_buf_dispose(&buf);
+	git_buf_dispose(&path);
 	git_worktree_free(wt);
 }
 
@@ -185,8 +185,8 @@ void test_worktree_worktree__open_invalid_gitdir(void)
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_git_fail(git_repository_open_from_worktree(&repo, wt));
 
-	git_buf_free(&buf);
-	git_buf_free(&path);
+	git_buf_dispose(&buf);
+	git_buf_dispose(&path);
 	git_worktree_free(wt);
 }
 
@@ -203,7 +203,7 @@ void test_worktree_worktree__open_invalid_parent(void)
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_git_fail(git_repository_open_from_worktree(&repo, wt));
 
-	git_buf_free(&buf);
+	git_buf_dispose(&buf);
 	git_worktree_free(wt);
 }
 
@@ -222,7 +222,7 @@ void test_worktree_worktree__init(void)
 	cl_assert(git__suffixcmp(git_repository_workdir(repo), "worktree-new/") == 0);
 	cl_git_pass(git_branch_lookup(&branch, repo, "worktree-new", GIT_BRANCH_LOCAL));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_worktree_free(wt);
 	git_reference_free(branch);
 	git_repository_free(repo);
@@ -267,7 +267,7 @@ void test_worktree_worktree__add_locked(void)
 	cl_assert(git__suffixcmp(git_repository_workdir(repo), "worktree-locked/") == 0);
 	cl_git_pass(git_branch_lookup(&branch, repo, "worktree-locked", GIT_BRANCH_LOCAL));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_worktree_free(wt);
 	git_reference_free(branch);
 	git_repository_free(repo);
@@ -287,7 +287,7 @@ void test_worktree_worktree__init_existing_branch(void)
 	cl_git_pass(git_buf_joinpath(&path, fixture.repo->workdir, "../worktree-new"));
 	cl_git_fail(git_worktree_add(&wt, fixture.repo, "worktree-new", path.ptr, NULL));
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_commit_free(commit);
 	git_reference_free(head);
 	git_reference_free(branch);
@@ -314,7 +314,7 @@ void test_worktree_worktree__add_with_explicit_branch(void)
 	cl_git_pass(git_repository_head(&wthead, wtrepo));
 	cl_assert_equal_s(git_reference_name(wthead), "refs/heads/worktree-with-ref");
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_commit_free(commit);
 	git_reference_free(head);
 	git_reference_free(branch);
@@ -335,7 +335,7 @@ void test_worktree_worktree__init_existing_worktree(void)
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_assert_equal_s(wt->gitlink_path, fixture.worktree->gitlink);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_worktree_free(wt);
 }
 
@@ -364,7 +364,7 @@ void test_worktree_worktree__init_existing_path(void)
 		cl_assert(!git_path_exists(path.ptr));
 	}
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 }
 
 void test_worktree_worktree__init_submodule(void)
@@ -390,7 +390,7 @@ void test_worktree_worktree__init_submodule(void)
 	cl_git_pass(git_buf_joinpath(&path, sm->gitdir, "worktrees/repo-worktree/"));
 	cl_assert_equal_s(path.ptr, wt->gitdir);
 
-	git_buf_free(&path);
+	git_buf_dispose(&path);
 	git_worktree_free(worktree);
 	git_repository_free(sm);
 	git_repository_free(wt);
@@ -424,8 +424,8 @@ void test_worktree_worktree__path(void)
 	cl_git_pass(git_buf_joinpath(&expected_path, clar_sandbox_path(), "testrepo-worktree"));
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_assert_equal_s(git_worktree_path(wt), expected_path.ptr);
-	
-	git_buf_free(&expected_path);
+
+	git_buf_dispose(&expected_path);
 	git_worktree_free(wt);
 }
 
@@ -482,7 +482,7 @@ void test_worktree_worktree__lock_with_reason(void)
 	cl_assert_equal_s(reason.ptr, "because");
 	cl_assert(wt->locked);
 
-	git_buf_free(&reason);
+	git_buf_dispose(&reason);
 	git_worktree_free(wt);
 }
 
@@ -499,7 +499,7 @@ void test_worktree_worktree__lock_without_reason(void)
 	cl_assert_equal_i(reason.size, 0);
 	cl_assert(wt->locked);
 
-	git_buf_free(&reason);
+	git_buf_dispose(&reason);
 	git_worktree_free(wt);
 }
 


### PR DESCRIPTION
The function `git_packfile_stream_free` frees all state of the packfile
stream without freeing the structure itself. Thus, the function is
misnamed, as we usually call such a function a "clear" function. Rename
it to make clear that in fact it does not free the structure.