### PR TITLE
hash: openssl: check return values of SHA1_* functions

### DIFF
--- a/src/hash/hash_openssl.h
+++ b/src/hash/hash_openssl.h
@@ -23,21 +23,36 @@ struct git_hash_ctx {
 GIT_INLINE(int) git_hash_init(git_hash_ctx *ctx)
 {
 	assert(ctx);
-	SHA1_Init(&ctx->c);
+
+	if (SHA1_Init(&ctx->c) != 1) {
+		giterr_set(GITERR_SHA1, "hash_openssl: failed to initialize hash context");
+		return -1;
+	}
+
 	return 0;
 }
 
 GIT_INLINE(int) git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)
 {
 	assert(ctx);
-	SHA1_Update(&ctx->c, data, len);
+
+	if (SHA1_Update(&ctx->c, data, len) != 1) {
+		giterr_set(GITERR_SHA1, "hash_openssl: failed to update hash");
+		return -1;
+	}
+
 	return 0;
 }
 
 GIT_INLINE(int) git_hash_final(git_oid *out, git_hash_ctx *ctx)
 {
 	assert(ctx);
-	SHA1_Final(out->id, &ctx->c);
+
+	if (SHA1_Final(out->id, &ctx->c) != 1) {
+		giterr_set(GITERR_SHA1, "hash_openssl: failed to finalize hash");
+		return -1;
+	}
+
 	return 0;
 }
 

--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -282,8 +282,9 @@ static int ssl_set_error(SSL *ssl, int error)
 	case SSL_ERROR_SYSCALL:
 		e = ERR_get_error();
 		if (e > 0) {
-			giterr_set(GITERR_NET, "SSL error: %s",
-					ERR_error_string(e, NULL));
+			char errmsg[256];
+			ERR_error_string_n(e, errmsg, sizeof(errmsg));
+			giterr_set(GITERR_NET, "SSL error: %s", errmsg);
 			break;
 		} else if (error < 0) {
 			giterr_set(GITERR_OS, "SSL error: syscall failure");
@@ -293,10 +294,13 @@ static int ssl_set_error(SSL *ssl, int error)
 		return GIT_EEOF;
 		break;
 	case SSL_ERROR_SSL:
+	{
+		char errmsg[256];
 		e = ERR_get_error();
-		giterr_set(GITERR_NET, "SSL error: %s",
-				ERR_error_string(e, NULL));
+		ERR_error_string_n(e, errmsg, sizeof(errmsg));
+		giterr_set(GITERR_NET, "SSL error: %s", errmsg);
 		break;
+	}
 	case SSL_ERROR_NONE:
 	case SSL_ERROR_ZERO_RETURN:
 	default:
@@ -640,8 +644,12 @@ out_err:
 int git_openssl__set_cert_location(const char *file, const char *path)
 {
 	if (SSL_CTX_load_verify_locations(git__ssl_ctx, file, path) == 0) {
+		char errmsg[256];
+
+		ERR_error_string_n(ERR_get_error(), errmsg, sizeof(errmsg));
 		giterr_set(GITERR_SSL, "OpenSSL error: failed to load certificates: %s",
-				   ERR_error_string(ERR_get_error(), NULL));
+			errmsg);
+
 		return -1;
 	}
 	return 0;


### PR DESCRIPTION
The OpenSSL functions `SHA1_Init`, `SHA1_Update` and `SHA1_Final` all
return 1 for success and 0 otherwise, but we never check their return
values. Do so.