### PR TITLE
Add Jonathan Tan to git.git-authors

### DIFF
--- a/git.git-authors
+++ b/git.git-authors
@@ -53,6 +53,7 @@ ok	Jeff King <peff@peff.net>
 ok	Johannes Schindelin <Johannes.Schindelin@gmx.de>
 ok	Johannes Sixt <j6t@kdbg.org>
 ask	Jonathan Nieder <jrnieder@gmail.com>
+ok	Jonathan Tan <jonathantanmy@google.com>
 ok	Junio C Hamano <gitster@pobox.com>
 ok	Kristian Høgsberg <krh@redhat.com>
 ok	Linus Torvalds <torvalds@linux-foundation.org>


### PR DESCRIPTION
Jonathan (@jonathantanmy) has given the ok via email to be listed here.

cc @peff @vmg @brianmario 