### PR TITLE
Streaming read support for the loose ODB backend

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -357,11 +357,18 @@ GIT_EXTERN(void) git_odb_stream_free(git_odb_stream *stream);
  * @see git_odb_stream
  *
  * @param out pointer where to store the stream
+ * @param len pointer where to store the length of the object
+ * @param type pointer where to store the type of the object
  * @param db object database where the stream will read from
  * @param oid oid of the object the stream will read from
  * @return 0 if the stream was created; error code otherwise
  */
-GIT_EXTERN(int) git_odb_open_rstream(git_odb_stream **out, git_odb *db, const git_oid *oid);
+GIT_EXTERN(int) git_odb_open_rstream(
+	git_odb_stream **out,
+	size_t *len,
+	git_otype *type,
+	git_odb *db,
+	const git_oid *oid);
 
 /**
  * Open a stream for writing a pack file to the ODB.

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -56,7 +56,8 @@ struct git_odb_backend {
 		git_odb_stream **, git_odb_backend *, git_off_t, git_otype);
 
 	int (* readstream)(
-		git_odb_stream **, git_odb_backend *, const git_oid *);
+		git_odb_stream **, size_t *, git_otype *,
+		git_odb_backend *, const git_oid *);
 
 	int (* exists)(
 		git_odb_backend *, const git_oid *);

--- a/src/odb.c
+++ b/src/odb.c
@@ -1396,7 +1396,12 @@ void git_odb_stream_free(git_odb_stream *stream)
 	stream->free(stream);
 }
 
-int git_odb_open_rstream(git_odb_stream **stream, git_odb *db, const git_oid *oid)
+int git_odb_open_rstream(
+	git_odb_stream **stream,
+	size_t *len,
+	git_otype *type,
+	git_odb *db,
+	const git_oid *oid)
 {
 	size_t i, reads = 0;
 	int error = GIT_ERROR;
@@ -1409,7 +1414,7 @@ int git_odb_open_rstream(git_odb_stream **stream, git_odb *db, const git_oid *oi
 
 		if (b->readstream != NULL) {
 			++reads;
-			error = b->readstream(stream, b, oid);
+			error = b->readstream(stream, len, type, b, oid);
 		}
 	}
 

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -22,7 +22,7 @@
 #include "git2/types.h"
 
 /* maximum possible header length */
-#define HEADER_LEN 64
+#define MAX_HEADER_LEN 64
 
 typedef struct { /* object header data */
 	git_otype type; /* object type */
@@ -37,7 +37,7 @@ typedef struct {
 typedef struct {
 	git_odb_stream stream;
 	git_map map;
-	char start[HEADER_LEN];
+	char start[MAX_HEADER_LEN];
 	size_t start_len;
 	size_t start_read;
 	git_zstream zstream;
@@ -273,7 +273,7 @@ done:
 static int read_loose_standard(git_rawobj *out, git_buf *obj)
 {
 	git_zstream zstream = GIT_ZSTREAM_INIT;
-	unsigned char head[HEADER_LEN], *body = NULL;
+	unsigned char head[MAX_HEADER_LEN], *body = NULL;
 	size_t decompressed, head_len, body_len, alloc_size;
 	obj_hdr hdr;
 	int error;
@@ -387,7 +387,7 @@ static int read_header_loose_standard(
 {
 	git_zstream zs = GIT_ZSTREAM_INIT;
 	obj_hdr hdr;
-	unsigned char inflated[HEADER_LEN];
+	unsigned char inflated[MAX_HEADER_LEN];
 	size_t header_len, inflated_len = sizeof(inflated);
 	int error;
 
@@ -822,7 +822,7 @@ static int loose_backend__writestream(git_odb_stream **stream_out, git_odb_backe
 {
 	loose_backend *backend;
 	loose_writestream *stream = NULL;
-	char hdr[HEADER_LEN];
+	char hdr[MAX_HEADER_LEN];
 	git_buf tmp_path = GIT_BUF_INIT;
 	int hdrlen;
 
@@ -934,7 +934,7 @@ static int loose_backend__readstream_standard(
 	obj_hdr *hdr,
 	loose_readstream *stream)
 {
-	unsigned char head[HEADER_LEN];
+	unsigned char head[MAX_HEADER_LEN];
 	size_t init, head_len;
 	int error;
 
@@ -1038,7 +1038,7 @@ static int loose_backend__write(git_odb_backend *_backend, const git_oid *oid, c
 {
 	int error = 0, header_len;
 	git_buf final_path = GIT_BUF_INIT;
-	char header[HEADER_LEN];
+	char header[MAX_HEADER_LEN];
 	git_filebuf fbuf = GIT_FILEBUF_INIT;
 	loose_backend *backend;
 

--- a/src/zstream.h
+++ b/src/zstream.h
@@ -23,6 +23,7 @@ typedef struct {
 	git_zstream_t type;
 	const char *in;
 	size_t in_len;
+	int flush;
 	int zerr;
 } git_zstream;
 
@@ -35,6 +36,11 @@ int git_zstream_set_input(git_zstream *zstream, const void *in, size_t in_len);
 
 size_t git_zstream_suggest_output_len(git_zstream *zstream);
 
+/* get as much output as is available in the input buffer */
+int git_zstream_get_output_chunk(
+	void *out, size_t *out_len, git_zstream *zstream);
+
+/* get all the output from the entire input buffer */
 int git_zstream_get_output(void *out, size_t *out_len, git_zstream *zstream);
 
 bool git_zstream_done(git_zstream *zstream);

--- a/tests/odb/largefiles.c
+++ b/tests/odb/largefiles.c
@@ -158,3 +158,19 @@ void test_odb_largefiles__read_into_memory_rejected_on_32bit(void)
 
 	git_odb_object_free(obj);
 }
+
+void test_odb_largefiles__read_header(void)
+{
+	git_oid oid;
+	size_t len;
+	git_otype type;
+
+	if (!cl_is_env_set("GITTEST_INVASIVE_FS_SIZE"))
+		cl_skip();
+
+	writefile(&oid);
+	cl_git_pass(git_odb_read_header(&len, &type, odb, &oid));
+
+	cl_assert_equal_sz(LARGEFILE_SIZE, len);
+	cl_assert_equal_i(GIT_OBJ_BLOB, type);
+}

--- a/tests/odb/largefiles.c
+++ b/tests/odb/largefiles.c
@@ -67,6 +67,10 @@ void test_odb_largefiles__streamwrite(void)
 {
 	git_oid expected, oid;
 
+#ifndef GIT_ARCH_64
+	cl_skip();
+#endif
+
 	if (!cl_is_env_set("GITTEST_INVASIVE_FS_SIZE") ||
 		!cl_is_env_set("GITTEST_SLOW"))
 		cl_skip();
@@ -87,6 +91,10 @@ void test_odb_largefiles__streamread(void)
 	git_hash_ctx hash;
 	git_otype type;
 	int hdr_len, ret;
+
+#ifndef GIT_ARCH_64
+	cl_skip();
+#endif
 
 	if (!cl_is_env_set("GITTEST_INVASIVE_FS_SIZE") ||
 		!cl_is_env_set("GITTEST_SLOW"))
@@ -165,7 +173,12 @@ void test_odb_largefiles__read_header(void)
 	size_t len;
 	git_otype type;
 
-	if (!cl_is_env_set("GITTEST_INVASIVE_FS_SIZE"))
+#ifndef GIT_ARCH_64
+	cl_skip();
+#endif
+
+	if (!cl_is_env_set("GITTEST_INVASIVE_FS_SIZE") ||
+		!cl_is_env_set("GITTEST_SLOW"))
 		cl_skip();
 
 	writefile(&oid);

--- a/tests/odb/loose.c
+++ b/tests/odb/loose.c
@@ -55,6 +55,44 @@ static void test_read_object(object_data *data)
 	git_odb_free(odb);
 }
 
+static void test_readstream_object(object_data *data, size_t blocksize)
+{
+	git_oid id;
+	git_odb *odb;
+	git_odb_stream *stream;
+	git_rawobj tmp;
+	char buf[2048], *ptr = buf;
+	size_t remain;
+	int ret;
+
+	write_object_files(data);
+
+	cl_git_pass(git_odb_open(&odb, "test-objects"));
+	cl_git_pass(git_oid_fromstr(&id, data->id));
+	cl_git_pass(git_odb_open_rstream(&stream, &tmp.len, &tmp.type, odb, &id));
+
+	remain = tmp.len;
+
+	while (remain) {
+		cl_assert((ret = git_odb_stream_read(stream, ptr, blocksize)) >= 0);
+		if (ret == 0)
+			break;
+
+		cl_assert(remain >= (size_t)ret);
+		remain -= ret;
+		ptr += ret;
+	}
+
+	cl_assert(remain == 0);
+
+	tmp.data = buf;
+
+	cmp_objects(&tmp, data);
+
+	git_odb_stream_free(stream);
+	git_odb_free(odb);
+}
+
 void test_odb_loose__initialize(void)
 {
 	p_fsync__cnt = 0;
@@ -101,6 +139,22 @@ void test_odb_loose__simple_reads(void)
 	test_read_object(&one);
 	test_read_object(&two);
 	test_read_object(&some);
+}
+
+void test_odb_loose__streaming_reads(void)
+{
+	size_t blocksizes[] = { 1, 2, 4, 16, 99, 1024, 123456789 };
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(blocksizes); i++) {
+		test_readstream_object(&commit, blocksizes[i]);
+		test_readstream_object(&tree, blocksizes[i]);
+		test_readstream_object(&tag, blocksizes[i]);
+		test_readstream_object(&zero, blocksizes[i]);
+		test_readstream_object(&one, blocksizes[i]);
+		test_readstream_object(&two, blocksizes[i]);
+		test_readstream_object(&some, blocksizes[i]);
+	}
 }
 
 void test_write_object_permission(

--- a/tests/odb/loose.c
+++ b/tests/odb/loose.c
@@ -55,6 +55,25 @@ static void test_read_object(object_data *data)
 	git_odb_free(odb);
 }
 
+static void test_read_header(object_data *data)
+{
+	git_oid id;
+	git_odb *odb;
+	size_t len;
+	git_otype type;
+
+	write_object_files(data);
+
+	cl_git_pass(git_odb_open(&odb, "test-objects"));
+	cl_git_pass(git_oid_fromstr(&id, data->id));
+	cl_git_pass(git_odb_read_header(&len, &type, odb, &id));
+
+	cl_assert_equal_sz(data->dlen, len);
+	cl_assert_equal_i(git_object_string2type(data->type), type);
+
+	git_odb_free(odb);
+}
+
 static void test_readstream_object(object_data *data, size_t blocksize)
 {
 	git_oid id;
@@ -155,6 +174,17 @@ void test_odb_loose__streaming_reads(void)
 		test_readstream_object(&two, blocksizes[i]);
 		test_readstream_object(&some, blocksizes[i]);
 	}
+}
+
+void test_odb_loose__read_header(void)
+{
+	test_read_header(&commit);
+	test_read_header(&tree);
+	test_read_header(&tag);
+	test_read_header(&zero);
+	test_read_header(&one);
+	test_read_header(&two);
+	test_read_header(&some);
 }
 
 void test_write_object_permission(


### PR DESCRIPTION
Change the streaming reader API a bit, to provide the type and length of the object when initializing the stream. This would be a breaking API change - except, of course, that nobody is actually using the streaming reader API since none of the backends support it. So I feel pretty good breaking this API that nobody could be using.

Add streaming reader support to the loose object ODB backend. I cleaned up a bit while I was in there to add some more tests for things like read_header which had no explicit tests (and in fact failed on some of the loose ODB test corpus), teach read_header how to cope with "packlike loose objects" (which were a weird loose object format that was attempted for a bit and will never actually be seen in the wild) and drop the odb_loose internal zstream abstraction layer that ultimately became git_zstream.

Note that this depends on #4443.