### PR TITLE
refs: traverse symlinked directories

### DIFF
--- a/src/iterator.h
+++ b/src/iterator.h
@@ -39,6 +39,8 @@ typedef enum {
 	GIT_ITERATOR_DONT_PRECOMPOSE_UNICODE = (1u << 5),
 	/** include conflicts */
 	GIT_ITERATOR_INCLUDE_CONFLICTS = (1u << 6),
+	/** descend into symlinked directories when looking for references */
+	GIT_ITERATOR_INCLUDE_SYMLINK_REFSDIR = (1u << 7),
 } git_iterator_flag_t;
 
 typedef enum {

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -39,8 +39,8 @@ typedef enum {
 	GIT_ITERATOR_DONT_PRECOMPOSE_UNICODE = (1u << 5),
 	/** include conflicts */
 	GIT_ITERATOR_INCLUDE_CONFLICTS = (1u << 6),
-	/** descend into symlinked directories when looking for references */
-	GIT_ITERATOR_INCLUDE_SYMLINK_REFSDIR = (1u << 7),
+	/** descend into symlinked directories */
+	GIT_ITERATOR_DESCEND_SYMLINKS = (1u << 7),
 } git_iterator_flag_t;
 
 typedef enum {

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -2035,6 +2035,7 @@ int git_refdb_backend_fs(
 	if ((!git_repository__cvar(&t, backend->repo, GIT_CVAR_FSYNCOBJECTFILES) && t) ||
 		git_repository__fsync_gitdir)
 		backend->fsync = 1;
+	backend->iterator_flags |= GIT_ITERATOR_INCLUDE_SYMLINK_REFSDIR;
 
 	backend->parent.exists = &refdb_fs_backend__exists;
 	backend->parent.lookup = &refdb_fs_backend__lookup;

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -2035,7 +2035,7 @@ int git_refdb_backend_fs(
 	if ((!git_repository__cvar(&t, backend->repo, GIT_CVAR_FSYNCOBJECTFILES) && t) ||
 		git_repository__fsync_gitdir)
 		backend->fsync = 1;
-	backend->iterator_flags |= GIT_ITERATOR_INCLUDE_SYMLINK_REFSDIR;
+	backend->iterator_flags |= GIT_ITERATOR_DESCEND_SYMLINKS;
 
 	backend->parent.exists = &refdb_fs_backend__exists;
 	backend->parent.lookup = &refdb_fs_backend__lookup;


### PR DESCRIPTION
When enumerating the references in the loose refs storage area, we should traverse symlinked directories.  eg, if I create `refs/heads/foo` -> `/tmp/refs`, and create a loose ref `/tmp/refs/asdf`, then I should be able to resolve `refs/heads/foo/asdf`.

This is @doanac's change in #4388, with some minor cleanups for error checking and adding a test to easily validate this locally.  I'm opening a PR to put it through the paces on the CI machines.