### PR TITLE
Fix error handling of odb_object__alloc() in odb_read_1()

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1040,10 +1040,8 @@ static int odb_read_1(git_odb_object **out, git_odb *db, const git_oid *id,
 	}
 
 	giterr_clear();
-	if ((object = odb_object__alloc(id, &raw)) == NULL) {
-		giterr_set(GITERR_ODB, "object could not be allocated");
-		return -1;
-	}
+	object = odb_object__alloc(id, &raw);
+	GITERR_CHECK_ALLOC(object);
 
 	*out = git_cache_store_raw(odb_cache(db), object);
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -1040,8 +1040,10 @@ static int odb_read_1(git_odb_object **out, git_odb *db, const git_oid *id,
 	}
 
 	giterr_clear();
-	if ((object = odb_object__alloc(id, &raw)) == NULL)
-		goto out;
+	if ((object = odb_object__alloc(id, &raw)) == NULL) {
+		giterr_set(GITERR_ODB, "object could not be allocated");
+		return -1;
+	}
 
 	*out = git_cache_store_raw(odb_cache(db), object);
 


### PR DESCRIPTION
If `odb_object__alloc()` returns `NULL` (fails to allocate) it currently goes to `out`. If error is != 0 we will try to free raw.data, when raw couldn't be allocated. If error is 0, then we are silently swallowing the allocation error, and possibly causing access to a wrong `out` pointer. Let's return an error instead.