### PR TITLE
travis: fetch trusty dependencies from Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
  apt:
   sources:
    - sourceline: 'deb https://dl.bintray.com/libgit2/ci-dependencies trusty libgit2deps'
-     key_url: 'https://www.edwardthomson.com/keys/ethomson@libgit2.org'
+     key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
   packages:
    cmake
    curl

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ sudo: false
 addons:
  apt:
   sources:
-   - sourceline: 'deb http://libgit2deps.edwardthomson.com trusty libgit2deps'
+   - sourceline: 'deb https://dl.bintray.com/libgit2/ci-dependencies trusty libgit2deps'
      key_url: 'https://www.edwardthomson.com/keys/ethomson@libgit2.org'
   packages:
    cmake


### PR DESCRIPTION
I would like to host the trusty dependencies in an Azure Web App - currently I'm hosting them on a linux VM in Azure.  This is a lower-cost option that hurts my pocketbook less.