### PR TITLE
Special-casing null OIDs

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -498,6 +498,9 @@ static int append_entry(
 	if (!valid_entry_name(bld->repo, filename))
 		return tree_error("failed to insert entry: invalid name for a tree entry", filename);
 
+	if (git_oid_iszero(id))
+		return tree_error("failed to insert entry: invalid null OID for a tree entry", filename);
+
 	entry = alloc_entry(filename, strlen(filename), id);
 	GITERR_CHECK_ALLOC(entry);
 
@@ -739,6 +742,9 @@ int git_treebuilder_insert(
 
 	if (!valid_entry_name(bld->repo, filename))
 		return tree_error("failed to insert entry: invalid name for a tree entry", filename);
+
+	if (git_oid_iszero(id))
+		return tree_error("failed to insert entry: invalid null OID", filename);
 
 	if (filemode != GIT_FILEMODE_COMMIT &&
 	    !git_object__is_valid(bld->repo, id, otype_from_mode(filemode)))

--- a/tests/object/tree/write.c
+++ b/tests/object/tree/write.c
@@ -512,3 +512,14 @@ void test_object_tree_write__object_validity(void)
 	test_inserting_submodule();
 }
 
+void test_object_tree_write__invalid_null_oid(void)
+{
+	git_treebuilder *bld;
+	git_oid null_oid = {{0}};
+
+	cl_git_pass(git_treebuilder_new(&bld, g_repo, NULL));
+	cl_git_fail(git_treebuilder_insert(NULL, bld, "null_oid_file", &null_oid, GIT_FILEMODE_BLOB));
+	cl_assert(giterr_last() && strstr(giterr_last()->message, "null OID") != NULL);
+
+	git_treebuilder_free(bld);
+}

--- a/tests/odb/backend/simple.c
+++ b/tests/odb/backend/simple.c
@@ -230,3 +230,21 @@ void test_odb_backend_simple__exists_with_highly_ambiguous_prefix(void)
 	cl_git_pass(git_odb_exists_prefix(&found, _odb, &_oid, 40));
 	cl_assert(git_oid_equal(&found, &_oid));
 }
+
+void test_odb_backend_simple__null_oid_is_ignored(void)
+{
+	const fake_object objs[] = {
+		{ "0000000000000000000000000000000000000000", "null oid content" },
+		{ NULL, NULL }
+	};
+	git_oid null_oid = {{0}};
+	git_odb_object *obj;
+
+	setup_backend(objs);
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, 0));
+	cl_assert(!git_odb_exists(_odb, &null_oid));
+
+	cl_git_fail_with(GIT_ENOTFOUND, git_odb_read(&obj, _odb, &null_oid));
+	cl_assert(giterr_last() && strstr(giterr_last()->message, "null OID"));
+}


### PR DESCRIPTION
I've been triggered by the not-so-recent discussion in upstream git.git around null OIDs (see [1]) to implement some defensive mechanisms about ever reading or writing null OIDs either via the ODB layer or into trees. For the ODB part, I now reject writing and shorcut reading null OIDs while for trees I've only implemented the rejection on inserting entries into the treebuilder. So I've not changed the reading part for our trees.

[1]: https://marc.info/?l=git&m=151120958313567&w=2