### PR TITLE
scripts: add backporting script

### DIFF
--- a/script/backport.sh
+++ b/script/backport.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if test $# -eq 0
+then
+    echo "USAGE: $0 <#PR> [<#PR>...]"
+    exit
+fi
+
+commits=
+
+for pr in $*
+do
+    mergecommit=$(git rev-parse ":/Merge pull request #$pr" || exit 1)
+    mergebase=$(git merge-base "$mergecommit"^1 "$mergecommit"^2 || exit 1)
+
+    commits="$commits $(git rev-list --reverse "$mergecommit"^2 ^"$mergebase")"
+done
+
+echo "Cherry-picking the following commits:"
+git rev-list --no-walk --oneline $commits
+echo
+
+git cherry-pick $commits


### PR DESCRIPTION
This adds a simple script for backporting pull requests to older
branches. It accepts as parameters a list of pull request numbers which
whose commits are to be cherry-picked. The identification of PRs
currently happens by using the commit message of the merge of the PR,
which should conform to the message "Merge pull request #<PR>".

While the heuristic works in practice, we could instead also use the
direct references from GitHub via "pull/#<PR>/head". This requires the
user to have all these references fetched, though, so we can just use
the current heuristic until we experience any issues with that.

---

Dunno if we want this. I've used this script to create #4475, and I think a bit of automation is nice to have.