### PR TITLE
refs: include " sorted " in our packed-refs header

### DIFF
--- a/src/refs.h
+++ b/src/refs.h
@@ -30,7 +30,7 @@ extern bool git_reference__enable_symbolic_ref_target_validation;
 
 #define GIT_SYMREF "ref: "
 #define GIT_PACKEDREFS_FILE "packed-refs"
-#define GIT_PACKEDREFS_HEADER "# pack-refs with: peeled fully-peeled "
+#define GIT_PACKEDREFS_HEADER "# pack-refs with: peeled fully-peeled sorted "
 #define GIT_PACKEDREFS_FILE_MODE 0666
 
 #define GIT_HEAD_FILE "HEAD"


### PR DESCRIPTION
This lets git know that we do in fact have written our packed-refs file
sorted (which is apparently not necessarily the case) and it can then use the
new-ish mmaped access which lets it avoid significant amounts of effort parsing
potentially large files to get to a single piece of data.