### PR TITLE
message: update docs for git_message_prettify

### DIFF
--- a/include/git2/message.h
+++ b/include/git2/message.h
@@ -19,10 +19,9 @@
 GIT_BEGIN_DECL
 
 /**
- * Clean up message from excess whitespace and make sure that the last line
- * ends with a '\n'.
+ * Clean up excess whitespace and make sure there is a trailing newline in the message.
  *
- * Optionally, can remove lines starting with a "#".
+ * Optionally, it can remove lines which start with the comment character.
  *
  * @param out The user-allocated git_buf which will be filled with the
  *     cleaned up message.


### PR DESCRIPTION
We used to hard-code the octothorpe as the comment character and the
documentation still mentions this even though we accept the comment character as
a parameter.

Update the line to indicate this and clean up the first paragraph a bit.