### PR TITLE
branch: refuse creating branches named 'HEAD'

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -70,6 +70,12 @@ static int create_branch(
 	assert(branch_name && commit && ref_out);
 	assert(git_object_owner((const git_object *)commit) == repository);
 
+	if (!git__strcmp(branch_name, "HEAD")) {
+		giterr_set(GITERR_REFERENCE, "'HEAD' is not a valid branch name");
+		error = -1;
+		goto cleanup;
+	}
+
 	if (force && !bare && git_branch_lookup(&branch, repository, branch_name, GIT_BRANCH_LOCAL) == 0) {
 		error = git_branch_is_head(branch);
 		git_reference_free(branch);


### PR DESCRIPTION
Since a625b092c (branch: correctly reject refs/heads/{-dash,HEAD},
2017-11-14), which is included in v2.16.0, upstream git refuses to
create branches which are named HEAD to avoid ambiguity with the
symbolic HEAD reference. Adjust our own code to match that behaviour and
reject creating branches names HEAD.