### PR TITLE
Use longer conflict markers in recursive merge base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ v0.26 + 1
 
 ### Breaking API changes
 
+* The `git_merge_file_options` structure now contains a new setting,
+  `marker_size`.  This allows users to set the size of markers that
+  delineate the sides of merged files in the output conflict file.
+  By default this is 7 (`GIT_MERGE_CONFLICT_MARKER_SIZE`), which
+  produces output markers like `<<<<<<<` and `>>>>>>>`.
+
 v0.26
 -----
 

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -162,6 +162,8 @@ typedef enum {
 	GIT_MERGE_FILE_DIFF_MINIMAL = (1 << 7),
 } git_merge_file_flag_t;
 
+#define GIT_MERGE_CONFLICT_MARKER_SIZE	7
+
 /**
  * Options for merging a file
  */
@@ -191,6 +193,10 @@ typedef struct {
 
 	/** see `git_merge_file_flag_t` above */
 	git_merge_file_flag_t flags;
+
+	/** The size of conflict markers (eg, "<<<<<<<").  Default is
+	 * GIT_MERGE_CONFLICT_MARKER_SIZE. */
+	unsigned short marker_size;
 } git_merge_file_options;
 
 #define GIT_MERGE_FILE_OPTIONS_VERSION 1

--- a/src/merge.c
+++ b/src/merge.c
@@ -2075,6 +2075,7 @@ int git_merge__iterators(
 		file_opts.our_label = "Temporary merge branch 1";
 		file_opts.their_label = "Temporary merge branch 2";
 		file_opts.flags |= GIT_MERGE_FILE_FAVOR__CONFLICTED;
+		file_opts.marker_size = GIT_MERGE_CONFLICT_MARKER_SIZE + 2;
 	}
 
 	diff_list = git_merge_diff_list__alloc(repo);

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -126,6 +126,8 @@ static int merge_file__xdiff(
 	if (options.flags & GIT_MERGE_FILE_DIFF_MINIMAL)
 		xmparam.xpp.flags |= XDF_NEED_MINIMAL;
 
+	xmparam.marker_size = options.marker_size;
+
 	if ((xdl_result = xdl_merge(&ancestor_mmfile, &our_mmfile,
 		&their_mmfile, &xmparam, &mmbuffer)) < 0) {
 		giterr_set(GITERR_MERGE, "failed to merge files");

--- a/tests/merge/conflict_data.h
+++ b/tests/merge/conflict_data.h
@@ -76,13 +76,13 @@
 	"<<<<<<< HEAD\n" \
 	"put into a pot three quarts of water, three onions cut small, one\n" \
 	"||||||| merged common ancestors\n" \
-	"<<<<<<< Temporary merge branch 1\n" \
+	"<<<<<<<<< Temporary merge branch 1\n" \
 	"Put into a pot three quarts of water, THREE ONIONS CUT SMALL, one\n" \
-	"||||||| merged common ancestors\n" \
+	"||||||||| merged common ancestors\n" \
 	"Put into a pot three quarts of water, three onions cut small, one\n" \
-	"=======\n" \
+	"=========\n" \
 	"PUT INTO A POT three quarts of water, three onions cut small, one\n" \
-	">>>>>>> Temporary merge branch 2\n" \
+	">>>>>>>>> Temporary merge branch 2\n" \
 	"=======\n" \
 	"Put Into A Pot Three Quarts of Water, Three Onions Cut Small, One\n" \
 	">>>>>>> branchH-2\n" \

--- a/tests/merge/trees/recursive.c
+++ b/tests/merge/trees/recursive.c
@@ -312,7 +312,7 @@ void test_merge_trees_recursive__conflicting_merge_base(void)
 		{ 0100644, "4b7c5650008b2e747fe1809eeb5a1dde0e80850a", 0, "bouilli.txt" },
 		{ 0100644, "c4e6cca3ec6ae0148ed231f97257df8c311e015f", 0, "gravy.txt" },
 		{ 0100644, "68af1fc7407fd9addf1701a87eb1c95c7494c598", 0, "oyster.txt" },
-		{ 0100644, "3a66812fed1e03ea4a6a7ee28d8a57aec1ca6537", 1, "veal.txt" },
+		{ 0100644, "ba5714aa3d5aebfd8e19d19cb1ddcfda63426a44", 1, "veal.txt" },
 		{ 0100644, "d604c75019c282144bdbbf3fd3462ba74b240efc", 2, "veal.txt" },
 		{ 0100644, "37a5054a9f9b4628e3924c5cb8f2147c6e2a3efc", 3, "veal.txt" },
 	};
@@ -339,7 +339,7 @@ void test_merge_trees_recursive__conflicting_merge_base_with_diff3(void)
 		{ 0100644, "4b7c5650008b2e747fe1809eeb5a1dde0e80850a", 0, "bouilli.txt" },
 		{ 0100644, "c4e6cca3ec6ae0148ed231f97257df8c311e015f", 0, "gravy.txt" },
 		{ 0100644, "68af1fc7407fd9addf1701a87eb1c95c7494c598", 0, "oyster.txt" },
-		{ 0100644, "cd17a91513f3aee9e44114d1ede67932dd41d2fc", 1, "veal.txt" },
+		{ 0100644, "adb1bf17d112a0b4ecbd4e75bef6db3335d8ddcf", 1, "veal.txt" },
 		{ 0100644, "d604c75019c282144bdbbf3fd3462ba74b240efc", 2, "veal.txt" },
 		{ 0100644, "37a5054a9f9b4628e3924c5cb8f2147c6e2a3efc", 3, "veal.txt" },
 	};

--- a/tests/merge/workdir/recursive.c
+++ b/tests/merge/workdir/recursive.c
@@ -44,7 +44,7 @@ void test_merge_workdir_recursive__writes_conflict_with_virtual_base(void)
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf, "merge-recursive/veal.txt"));
 
 	cl_assert_equal_s(CONFLICTING_RECURSIVE_F1_TO_F2, conflicting_buf.ptr);
-	
+
 	git_index_free(index);
 	git_buf_free(&conflicting_buf);
 }
@@ -62,7 +62,7 @@ void test_merge_workdir_recursive__conflicting_merge_base_with_diff3(void)
 		{ 0100644, "4b7c5650008b2e747fe1809eeb5a1dde0e80850a", 0, "bouilli.txt" },
 		{ 0100644, "c4e6cca3ec6ae0148ed231f97257df8c311e015f", 0, "gravy.txt" },
 		{ 0100644, "68af1fc7407fd9addf1701a87eb1c95c7494c598", 0, "oyster.txt" },
-		{ 0100644, "cd17a91513f3aee9e44114d1ede67932dd41d2fc", 1, "veal.txt" },
+		{ 0100644, "adb1bf17d112a0b4ecbd4e75bef6db3335d8ddcf", 1, "veal.txt" },
 		{ 0100644, "d604c75019c282144bdbbf3fd3462ba74b240efc", 2, "veal.txt" },
 		{ 0100644, "37a5054a9f9b4628e3924c5cb8f2147c6e2a3efc", 3, "veal.txt" },
 	};


### PR DESCRIPTION
When producing a virtual merge base during a recursive merge (because our branches have multiple merge bases from a criss-cross merge), our merge base may contain conflicts.

[Git updated their virtual merge base building to use 9 character conflict markers](https://github.com/git/git/commit/d694a17986a28bbc19e2a6c32404ca24572e400f), which allows users (and programs like `rerere`) to better identify conflicts that occur in the virtual merge base vs conflicts that occur in the actual merge.