### PR TITLE
status::renames: test update for APFS (write NFD instead of NFC filename)

### DIFF
--- a/tests/status/renames.c
+++ b/tests/status/renames.c
@@ -590,6 +590,12 @@ static char *nfc = "\xC3\x85\x73\x74\x72\xC3\xB6\x6D";
 static char *nfd = "\x41\xCC\x8A\x73\x74\x72\x6F\xCC\x88\x6D";
 #endif
 
+/*
+ * Create a file in NFD (canonically decomposed) format.  Ensure
+ * that when core.precomposeunicode is false that we return paths
+ * in NFD, but when core.precomposeunicode is true, then we
+ * return paths precomposed (in NFC).
+ */
 void test_status_renames__precomposed_unicode_rename(void)
 {
 #ifdef GIT_USE_ICONV
@@ -610,7 +616,7 @@ void test_status_renames__precomposed_unicode_rename(void)
 		{ GIT_STATUS_WT_RENAMED, "sixserving.txt", nfc },
 	};
 
-	rename_file(g_repo, "sixserving.txt", nfc);
+	rename_file(g_repo, "sixserving.txt", nfd);
 
 	opts.flags |= GIT_STATUS_OPT_INCLUDE_UNTRACKED;
 


### PR DESCRIPTION
Update the status::renames test to create an NFD format filename in the `core.precomposedunicode` tests.

Previously, we would create an NFC format filename.  This was to take advantage of HFS+ filesystems, which always use canonically decomposed formats, and would actually write the filename to disk as an NFD filename.  So previously, we could create an NFC filename, but read it normally as an NFD filename.

But APFS formats do not force canonically decomposed formats for filenames, so creating an NFC filename does not get converted to NFD.  Instead, the filename will be written in NFC format.  Our test, therefore, does not work - when we write an NFC filename, it will _remain_ NFC.

Update the test to write NFD always.  This will ensure that the file will actually be canonically decomposed on all platforms:  HFS+, which forces NFD, and APFS, which does not.

Thus, our test will continue to ensure that an NFD filename is canonically precomposed on all filesystems.