### PR TITLE
Honor 'GIT_USE_NSEC' option in `filesystem_iterator_set_current`

### DIFF
--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1458,10 +1458,12 @@ static void filesystem_iterator_set_current(
 	filesystem_iterator_entry *entry)
 {
 	iter->entry.ctime.seconds = entry->st.st_ctime;
-	iter->entry.ctime.nanoseconds = entry->st.st_ctime_nsec;
-
 	iter->entry.mtime.seconds = entry->st.st_mtime;
+
+#if defined(GIT_USE_NSEC)	
+	iter->entry.ctime.nanoseconds = entry->st.st_ctime_nsec;
 	iter->entry.mtime.nanoseconds = entry->st.st_mtime_nsec;
+#endif
 
 	iter->entry.dev = entry->st.st_dev;
 	iter->entry.ino = entry->st.st_ino;

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -1463,6 +1463,9 @@ static void filesystem_iterator_set_current(
 #if defined(GIT_USE_NSEC)	
 	iter->entry.ctime.nanoseconds = entry->st.st_ctime_nsec;
 	iter->entry.mtime.nanoseconds = entry->st.st_mtime_nsec;
+#else
+	iter->entry.ctime.nanoseconds = 0;
+	iter->entry.mtime.nanoseconds = 0;
 #endif
 
 	iter->entry.dev = entry->st.st_dev;


### PR DESCRIPTION
This should have been part of PR #3638 (for issue #3635). Without this, we still get nsec-related errors, even when using -DGIT_USE_NSEC:

`error: ‘struct stat’ has no member named ‘st_mtime_nsec’`