### PR TITLE
http: standardize user-agent addition

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -17,6 +17,7 @@
 #include "remote.h"
 #include "smart.h"
 #include "auth.h"
+#include "http.h"
 #include "auth_negotiate.h"
 #include "streams/tls.h"
 #include "streams/socket.h"
@@ -190,16 +191,6 @@ static int apply_credentials(git_buf *buf, http_subtransport *t)
 	return context->next_token(buf, context, cred);
 }
 
-static const char *user_agent(void)
-{
-	const char *custom = git_libgit2__user_agent();
-
-	if (custom)
-		return custom;
-
-	return "libgit2 " LIBGIT2_VERSION;
-}
-
 static int gen_request(
 	git_buf *buf,
 	http_stream *s,
@@ -211,7 +202,9 @@ static int gen_request(
 
 	git_buf_printf(buf, "%s %s%s HTTP/1.1\r\n", s->verb, path, s->service_url);
 
-	git_buf_printf(buf, "User-Agent: git/2.0 (%s)\r\n", user_agent());
+	git_buf_puts(buf, "User-Agent: ");
+	git_http__user_agent(buf);
+	git_buf_puts(buf, "\r\n");
 	git_buf_printf(buf, "Host: %s\r\n", t->connection_data.host);
 
 	if (s->chunked || content_length > 0) {

--- a/src/transports/http.h
+++ b/src/transports/http.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_transports_http_h__
+#define INCLUDE_transports_http_h__
+
+#include "buffer.h"
+
+GIT_INLINE(int) git_http__user_agent(git_buf *buf)
+{
+	const char *ua = git_libgit2__user_agent();
+
+	if (!ua)
+		ua = "libgit2 " LIBGIT2_VERSION;
+
+	return git_buf_printf(buf, "git/2.0 (%s)", ua);
+}
+
+#endif

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -18,6 +18,7 @@
 #include "remote.h"
 #include "repository.h"
 #include "global.h"
+#include "http.h"
 
 #include <wincrypt.h>
 #include <winhttp.h>
@@ -701,21 +702,6 @@ static int winhttp_close_connection(winhttp_subtransport *t)
 	return ret;
 }
 
-static int user_agent(git_buf *ua)
-{
-	const char *custom = git_libgit2__user_agent();
-
-	git_buf_clear(ua);
-	git_buf_PUTS(ua, "git/1.0 (");
-
-	if (custom)
-		git_buf_puts(ua, custom);
-	else
-		git_buf_PUTS(ua, "libgit2 " LIBGIT2_VERSION);
-
-	return git_buf_putc(ua, ')');
-}
-
 static void CALLBACK winhttp_status(
 	HINTERNET connection,
 	DWORD_PTR ctx,
@@ -772,7 +758,8 @@ static int winhttp_connect(
 		return -1;
 	}
 
-	if ((error = user_agent(&ua)) < 0) {
+
+	if ((error = git_http__user_agent(&ua)) < 0) {
 		git__free(wide_host);
 		return error;
 	}


### PR DESCRIPTION
The winhttp and posix http each need to add the user-agent to their requests.  Standardize on a single function to include this so that we do not get the version numbers we're sending out of sync.

Currently we send `git/2.0 (libgit2 something)` on non-Windows and `git/1.0 (libgit2 something)` on Windows.  :(