### PR TITLE
odb: error when we can't alloc an object

### DIFF
--- a/src/hash/hash_win32.c
+++ b/src/hash/hash_win32.c
@@ -24,16 +24,20 @@ GIT_INLINE(int) hash_cng_prov_init(void)
 	DWORD dll_path_len, size_len;
 
 	/* Only use CNG on Windows 2008 / Vista SP1  or better (Windows 6.0 SP1) */
-	if (!git_has_win32_version(6, 0, 1))
+	if (!git_has_win32_version(6, 0, 1)) {
+		giterr_set(GITERR_SHA1, "CryptoNG is not supported on this platform");
 		return -1;
+	}
 
 	/* Load bcrypt.dll explicitly from the system directory */
 	if ((dll_path_len = GetSystemDirectory(dll_path, MAX_PATH)) == 0 ||
 		dll_path_len > MAX_PATH ||
 		StringCchCat(dll_path, MAX_PATH, "\\") < 0 ||
 		StringCchCat(dll_path, MAX_PATH, GIT_HASH_CNG_DLL_NAME) < 0 ||
-		(hash_prov.prov.cng.dll = LoadLibrary(dll_path)) == NULL)
+		(hash_prov.prov.cng.dll = LoadLibrary(dll_path)) == NULL) {
+		giterr_set(GITERR_SHA1, "CryptoNG library could not be loaded");
 		return -1;
+	}
 
 	/* Load the function addresses */
 	if ((hash_prov.prov.cng.open_algorithm_provider = (hash_win32_cng_open_algorithm_provider_fn)GetProcAddress(hash_prov.prov.cng.dll, "BCryptOpenAlgorithmProvider")) == NULL ||
@@ -44,12 +48,16 @@ GIT_INLINE(int) hash_cng_prov_init(void)
 		(hash_prov.prov.cng.destroy_hash = (hash_win32_cng_destroy_hash_fn)GetProcAddress(hash_prov.prov.cng.dll, "BCryptDestroyHash")) == NULL ||
 		(hash_prov.prov.cng.close_algorithm_provider = (hash_win32_cng_close_algorithm_provider_fn)GetProcAddress(hash_prov.prov.cng.dll, "BCryptCloseAlgorithmProvider")) == NULL) {
 		FreeLibrary(hash_prov.prov.cng.dll);
+
+		giterr_set(GITERR_OS, "CryptoNG functions could not be loaded");
 		return -1;
 	}
 
 	/* Load the SHA1 algorithm */
 	if (hash_prov.prov.cng.open_algorithm_provider(&hash_prov.prov.cng.handle, GIT_HASH_CNG_HASH_TYPE, NULL, GIT_HASH_CNG_HASH_REUSABLE) < 0) {
 		FreeLibrary(hash_prov.prov.cng.dll);
+
+		giterr_set(GITERR_OS "algorithm provider could not be initialized");
 		return -1;
 	}
 
@@ -57,6 +65,8 @@ GIT_INLINE(int) hash_cng_prov_init(void)
 	if (hash_prov.prov.cng.get_property(hash_prov.prov.cng.handle, GIT_HASH_CNG_HASH_OBJECT_LEN, (PBYTE)&hash_prov.prov.cng.hash_object_size, sizeof(DWORD), &size_len, 0) < 0) {
 		hash_prov.prov.cng.close_algorithm_provider(hash_prov.prov.cng.handle, 0);
 		FreeLibrary(hash_prov.prov.cng.dll);
+
+		giterr_set(GITERR_OS, "algorithm handle could not be found");
 		return -1;
 	}
 
@@ -75,8 +85,10 @@ GIT_INLINE(void) hash_cng_prov_shutdown(void)
 /* Initialize CryptoAPI */
 GIT_INLINE(int) hash_cryptoapi_prov_init()
 {
-	if (!CryptAcquireContext(&hash_prov.prov.cryptoapi.handle, NULL, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+	if (!CryptAcquireContext(&hash_prov.prov.cryptoapi.handle, NULL, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
+		giterr_set(GITERR_OS, "legacy hash context could not be started");
 		return -1;
+	}
 
 	hash_prov.type = CRYPTOAPI;
 	return 0;
@@ -129,6 +141,7 @@ GIT_INLINE(int) hash_cryptoapi_init(git_hash_ctx *ctx)
 
 	if (!CryptCreateHash(ctx->prov->prov.cryptoapi.handle, CALG_SHA1, 0, 0, &ctx->ctx.cryptoapi.hash_handle)) {
 		ctx->ctx.cryptoapi.valid = 0;
+		giterr_set(GITERR_OS, "legacy hash implementation could not be created");
 		return -1;
 	}
 
@@ -145,8 +158,10 @@ GIT_INLINE(int) hash_cryptoapi_update(git_hash_ctx *ctx, const void *_data, size
 	while (len > 0) {
 		DWORD chunk = (len > MAXDWORD) ? MAXDWORD : (DWORD)len;
 
-		if (!CryptHashData(ctx->ctx.cryptoapi.hash_handle, data, chunk, 0))
+		if (!CryptHashData(ctx->ctx.cryptoapi.hash_handle, data, chunk, 0)) {
+			giterr_set(GITERR_OS, "legacy hash data could not be updated");
 			return -1;
+		}
 
 		data += chunk;
 		len -= chunk;
@@ -162,8 +177,10 @@ GIT_INLINE(int) hash_cryptoapi_final(git_oid *out, git_hash_ctx *ctx)
 
 	assert(ctx->ctx.cryptoapi.valid);
 
-	if (!CryptGetHashParam(ctx->ctx.cryptoapi.hash_handle, HP_HASHVAL, out->id, &len, 0))
+	if (!CryptGetHashParam(ctx->ctx.cryptoapi.hash_handle, HP_HASHVAL, out->id, &len, 0)) {
+		giterr_set(GITERR_OS, "legacy hash data could not be finished");
 		error = -1;
+	}
 
 	CryptDestroyHash(ctx->ctx.cryptoapi.hash_handle);
 	ctx->ctx.cryptoapi.valid = 0;
@@ -186,6 +203,8 @@ GIT_INLINE(int) hash_ctx_cng_init(git_hash_ctx *ctx)
 
 	if (hash_prov.prov.cng.create_hash(hash_prov.prov.cng.handle, &ctx->ctx.cng.hash_handle, ctx->ctx.cng.hash_object, hash_prov.prov.cng.hash_object_size, NULL, 0, 0) < 0) {
 		git__free(ctx->ctx.cng.hash_object);
+
+		giterr_set(GITERR_OS, "hash implementation could not be created");
 		return -1;
 	}
 
@@ -203,8 +222,10 @@ GIT_INLINE(int) hash_cng_init(git_hash_ctx *ctx)
 		return 0;
 
 	/* CNG needs to be finished to restart */
-	if (ctx->prov->prov.cng.finish_hash(ctx->ctx.cng.hash_handle, hash, GIT_OID_RAWSZ, 0) < 0)
+	if (ctx->prov->prov.cng.finish_hash(ctx->ctx.cng.hash_handle, hash, GIT_OID_RAWSZ, 0) < 0) {
+		giterr_set(GITERR_OS, "hash implementation could not be finished");
 		return -1;
+	}
 
 	ctx->ctx.cng.updated = 0;
 
@@ -218,8 +239,10 @@ GIT_INLINE(int) hash_cng_update(git_hash_ctx *ctx, const void *_data, size_t len
 	while (len > 0) {
 		ULONG chunk = (len > ULONG_MAX) ? ULONG_MAX : (ULONG)len;
 
-		if (ctx->prov->prov.cng.hash_data(ctx->ctx.cng.hash_handle, data, chunk, 0) < 0)
+		if (ctx->prov->prov.cng.hash_data(ctx->ctx.cng.hash_handle, data, chunk, 0) < 0) {
+			giterr_set(GITERR_OS, "hash could not be updated");
 			return -1;
+		}
 
 		data += chunk;
 		len -= chunk;
@@ -230,8 +253,10 @@ GIT_INLINE(int) hash_cng_update(git_hash_ctx *ctx, const void *_data, size_t len
 
 GIT_INLINE(int) hash_cng_final(git_oid *out, git_hash_ctx *ctx)
 {
-	if (ctx->prov->prov.cng.finish_hash(ctx->ctx.cng.hash_handle, out->id, GIT_OID_RAWSZ, 0) < 0)
+	if (ctx->prov->prov.cng.finish_hash(ctx->ctx.cng.hash_handle, out->id, GIT_OID_RAWSZ, 0) < 0) {
+		giterr_set(GITERR_OS, "hash could not be finished");
 		return -1;
+	}
 
 	ctx->ctx.cng.updated = 0;
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -1048,8 +1048,10 @@ static int odb_read_1(git_odb_object **out, git_odb *db, const git_oid *id,
 	}
 
 	giterr_clear();
-	if ((object = odb_object__alloc(id, &raw)) == NULL)
+	if ((object = odb_object__alloc(id, &raw)) == NULL) {
+		error = -1;
 		goto out;
+	}
 
 	*out = git_cache_store_raw(odb_cache(db), object);
 
@@ -1175,8 +1177,10 @@ static int read_prefix_1(git_odb_object **out, git_odb *db,
 		}
 	}
 
-	if ((object = odb_object__alloc(&found_full_oid, &raw)) == NULL)
+	if ((object = odb_object__alloc(&found_full_oid, &raw)) == NULL) {
+		error = -1;
 		goto out;
+	}
 
 	*out = git_cache_store_raw(odb_cache(db), object);
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -352,8 +352,7 @@ static int fake_wstream__write(git_odb_stream *_stream, const char *data, size_t
 {
 	fake_wstream *stream = (fake_wstream *)_stream;
 
-	if (stream->written + len > stream->size)
-		return -1;
+	assert(stream->written + len > stream->size);
 
 	memcpy(stream->buffer + stream->written, data, len);
 	stream->written += len;

--- a/src/odb.c
+++ b/src/odb.c
@@ -100,11 +100,15 @@ int git_odb__hashobj(git_oid *id, git_rawobj *obj)
 
 	assert(id && obj);
 
-	if (!git_object_typeisloose(obj->type))
+	if (!git_object_typeisloose(obj->type)) {
+		giterr_set(GITERR_INVALID, "invalid object type");
 		return -1;
+	}
 
-	if (!obj->data && obj->len != 0)
+	if (!obj->data && obj->len != 0) {
+		giterr_set(GITERR_INVALID, "invalid object");
 		return -1;
+	}
 
 	hdrlen = git_odb__format_object_header(header, sizeof(header), obj->len, obj->type);
 
@@ -806,7 +810,7 @@ int git_odb_exists_prefix(
 	git_oid *out, git_odb *db, const git_oid *short_id, size_t len)
 {
 	int error;
-	git_oid key = {{0}}; 
+	git_oid key = {{0}};
 
 	assert(db && short_id);
 
@@ -1106,7 +1110,7 @@ static int odb_otype_fast(git_otype *type_p, git_odb *db, const git_oid *id)
 		*type_p = object->cached.type;
 		return 0;
 	}
-	
+
 	error = odb_read_header_1(&_unused, type_p, db, id, false);
 
 	if (error == GIT_PASSTHROUGH) {

--- a/src/odb.c
+++ b/src/odb.c
@@ -194,7 +194,7 @@ int git_odb__hashfd(git_oid *out, git_file fd, size_t size, git_otype type)
 	}
 
 	if ((error = git_hash_ctx_init(&ctx)) < 0)
-		return -1;
+		return error;
 
 	hdr_len = git_odb__format_object_header(hdr, sizeof(hdr), size, type);
 

--- a/src/odb.h
+++ b/src/odb.h
@@ -70,7 +70,7 @@ int git_odb__hashobj(git_oid *id, git_rawobj *obj);
 /*
  * Format the object header such as it would appear in the on-disk object
  */
-int git_odb__format_object_header(char *hdr, size_t n, git_off_t obj_len, git_otype obj_type);
+int git_odb__format_object_header(size_t *out_len, char *hdr, size_t hdr_size, git_off_t obj_len, git_otype obj_type);
 /*
  * Hash an open file descriptor.
  * This is a performance call when the contents of a fd need to be hashed,

--- a/tests/odb/largefiles.c
+++ b/tests/odb/largefiles.c
@@ -87,10 +87,10 @@ void test_odb_largefiles__streamread(void)
 	git_odb_stream *stream;
 	char buf[10240];
 	char hdr[64];
-	size_t len, total = 0;
+	size_t len, hdr_len, total = 0;
 	git_hash_ctx hash;
 	git_otype type;
-	int hdr_len, ret;
+	int ret;
 
 #ifndef GIT_ARCH_64
 	cl_skip();
@@ -108,7 +108,7 @@ void test_odb_largefiles__streamread(void)
 	cl_assert_equal_i(GIT_OBJ_BLOB, type);
 
 	cl_git_pass(git_hash_ctx_init(&hash));
-	hdr_len = git_odb__format_object_header(hdr, sizeof(hdr), len, type);
+	cl_git_pass(git_odb__format_object_header(&hdr_len, hdr, sizeof(hdr), len, type));
 
 	cl_git_pass(git_hash_update(&hash, hdr, hdr_len));
 


### PR DESCRIPTION
At the moment, we're swallowing the allocation failure.  We need to return the error to the caller.  (See analysis in #4470.)