### PR TITLE
Consistent header guards

### DIFF
--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_compat_h__
-#define INCLUDE_compat_h__
+#ifndef INCLUDE_cc_compat_h__
+#define INCLUDE_cc_compat_h__
 
 #include <stdarg.h>
 
@@ -84,4 +84,4 @@
 #	endif
 #endif
 
-#endif /* INCLUDE_compat_h__ */
+#endif

--- a/src/common.h
+++ b/src/common.h
@@ -238,4 +238,4 @@ GIT_INLINE(void) git__init_structure(void *structure, size_t len, unsigned int v
 
 #include "util.h"
 
-#endif /* INCLUDE_common_h__ */
+#endif

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -71,4 +71,3 @@ GIT_INLINE(int) git_config_file_unlock(git_config_backend *cfg, int success)
 extern int git_config_file_normalize_section(char *start, char *end);
 
 #endif
-

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -4,6 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+#ifndef INCLUDE_config_parse_h__
+#define INCLUDE_config_parse_h__
 
 #include "common.h"
 #include "array.h"
@@ -58,3 +60,5 @@ int git_config_parse(
 	git_config_parser_comment_cb on_comment,
 	git_config_parser_eof_cb on_eof,
 	void *data);
+
+#endif

--- a/src/diff.h
+++ b/src/diff.h
@@ -66,4 +66,3 @@ extern int git_diff__entry_cmp(const void *a, const void *b);
 extern int git_diff__entry_icmp(const void *a, const void *b);
 
 #endif
-

--- a/src/diff_generate.h
+++ b/src/diff_generate.h
@@ -126,4 +126,3 @@ GIT_INLINE(int) git_diff_file__resolve_zero_size(
 }
 
 #endif
-

--- a/src/diff_tform.h
+++ b/src/diff_tform.h
@@ -23,4 +23,3 @@ extern int git_diff_find_similar__calc_similarity(
 	int *score, void *siga, void *sigb, void *payload);
 
 #endif
-

--- a/src/fileops.h
+++ b/src/fileops.h
@@ -387,4 +387,4 @@ extern int git_futils_fsync_dir(const char *path);
  */
 extern int git_futils_fsync_parent(const char *path);
 
-#endif /* INCLUDE_fileops_h__ */
+#endif

--- a/src/fnmatch.h
+++ b/src/fnmatch.h
@@ -25,8 +25,8 @@
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#ifndef INCLUDE_fnmatch__compat_h__
-#define INCLUDE_fnmatch__compat_h__
+#ifndef INCLUDE_fnmatch_h__
+#define INCLUDE_fnmatch_h__
 
 #include "common.h"
 
@@ -45,5 +45,4 @@
 
 extern int p_fnmatch(const char *pattern, const char *string, int flags);
 
-#endif /* _FNMATCH_H */
-
+#endif

--- a/src/hash.h
+++ b/src/hash.h
@@ -42,4 +42,4 @@ int git_hash_final(git_oid *out, git_hash_ctx *c);
 int git_hash_buf(git_oid *out, const void *data, size_t len);
 int git_hash_vec(git_oid *out, git_buf_vec *vec, size_t n);
 
-#endif /* INCLUDE_hash_h__ */
+#endif

--- a/src/hash/hash_collisiondetect.h
+++ b/src/hash/hash_collisiondetect.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_hash_collisiondetect_h__
-#define INCLUDE_hash_collisiondetect_h__
+#ifndef INCLUDE_hash_hash_collisiondetect_h__
+#define INCLUDE_hash_hash_collisiondetect_h__
 
 #include "hash.h"
 #include "sha1dc/sha1.h"
@@ -44,4 +44,4 @@ GIT_INLINE(int) git_hash_final(git_oid *out, git_hash_ctx *ctx)
 	return 0;
 }
 
-#endif /* INCLUDE_hash_collisiondetect_h__ */
+#endif

--- a/src/hash/hash_common_crypto.h
+++ b/src/hash/hash_common_crypto.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_hash_common_crypto_h__
-#define INCLUDE_hash_common_crypto_h__
+#ifndef INCLUDE_hash_hash_common_crypto_h__
+#define INCLUDE_hash_hash_common_crypto_h__
 
 #include "hash.h"
 
@@ -54,4 +54,4 @@ GIT_INLINE(int) git_hash_final(git_oid *out, git_hash_ctx *ctx)
 	return 0;
 }
 
-#endif /* INCLUDE_hash_common_crypto_h__ */
+#endif

--- a/src/hash/hash_generic.h
+++ b/src/hash/hash_generic.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_hash_generic_h__
-#define INCLUDE_hash_generic_h__
+#ifndef INCLUDE_hash_hash_generic_h__
+#define INCLUDE_hash_hash_generic_h__
 
 #include "common.h"
 
@@ -22,4 +22,4 @@ struct git_hash_ctx {
 #define git_hash_ctx_init(ctx) git_hash_init(ctx)
 #define git_hash_ctx_cleanup(ctx)
 
-#endif /* INCLUDE_hash_generic_h__ */
+#endif

--- a/src/hash/hash_openssl.h
+++ b/src/hash/hash_openssl.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_hash_openssl_h__
-#define INCLUDE_hash_openssl_h__
+#ifndef INCLUDE_hash_hash_openssl_h__
+#define INCLUDE_hash_hash_openssl_h__
 
 #include "hash.h"
 
@@ -56,4 +56,4 @@ GIT_INLINE(int) git_hash_final(git_oid *out, git_hash_ctx *ctx)
 	return 0;
 }
 
-#endif /* INCLUDE_hash_openssl_h__ */
+#endif

--- a/src/hash/hash_win32.h
+++ b/src/hash/hash_win32.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_hash_win32_h__
-#define INCLUDE_hash_win32_h__
+#ifndef INCLUDE_hash_hash_win32_h__
+#define INCLUDE_hash_hash_win32_h__
 
 #include "common.h"
 
@@ -138,4 +138,4 @@ struct git_hash_ctx {
 	} ctx;
 };
 
-#endif /* INCLUDE_hash_openssl_h__ */
+#endif

--- a/src/integer.h
+++ b/src/integer.h
@@ -93,4 +93,4 @@ GIT_INLINE(bool) git__multiply_sizet_overflow(size_t *out, size_t one, size_t tw
 
 #endif
 
-#endif /* INCLUDE_integer_h__ */
+#endif

--- a/src/map.h
+++ b/src/map.h
@@ -43,4 +43,4 @@ typedef struct { /* memory mapped buffer	*/
 extern int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset);
 extern int p_munmap(git_map *map);
 
-#endif /* INCLUDE_map_h__ */
+#endif

--- a/src/message.h
+++ b/src/message.h
@@ -14,4 +14,4 @@
 
 int git_message__prettify(git_buf *message_out, const char *message, int strip_comments);
 
-#endif /* INCLUDE_message_h__ */
+#endif

--- a/src/notes.h
+++ b/src/notes.h
@@ -29,4 +29,4 @@ struct git_note {
 	char *message;
 };
 
-#endif /* INCLUDE_notes_h__ */
+#endif

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -104,4 +104,4 @@ struct git_packbuilder {
 
 int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb);
 
-#endif /* INCLUDE_pack_objects_h__ */
+#endif

--- a/src/parse.h
+++ b/src/parse.h
@@ -4,6 +4,9 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+#ifndef INCLUDE_parse_h__
+#define INCLUDE_parse_h__
+
 #include "common.h"
 
 typedef struct {
@@ -54,3 +57,5 @@ enum GIT_PARSE_PEEK_FLAGS {
 };
 
 int git_parse_peek(char *out, git_parse_ctx *ctx, int flags);
+
+#endif

--- a/src/reflog.h
+++ b/src/reflog.h
@@ -38,4 +38,4 @@ GIT_INLINE(size_t) reflog_inverse_index(size_t idx, size_t total)
 	return (total - 1) - idx;
 }
 
-#endif /* INCLUDE_reflog_h__ */
+#endif

--- a/src/sysdir.h
+++ b/src/sysdir.h
@@ -116,4 +116,4 @@ extern int git_sysdir_get_str(char *out, size_t outlen, git_sysdir_t which);
  */
 extern int git_sysdir_set(git_sysdir_t which, const char *paths);
 
-#endif /* INCLUDE_sysdir_h__ */
+#endif

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -243,4 +243,4 @@ extern int git_online_cpus(void);
 # define GIT_MEMORY_BARRIER /* noop */
 #endif
 
-#endif /* INCLUDE_thread_utils_h__ */
+#endif

--- a/src/transports/auth.h
+++ b/src/transports/auth.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_http_auth_h__
-#define INCLUDE_http_auth_h__
+#ifndef INCLUDE_transports_auth_h__
+#define INCLUDE_transports_auth_h__
 
 #include "common.h"
 
@@ -62,4 +62,3 @@ int git_http_auth_basic(
 	const gitno_connection_data *connection_data);
 
 #endif
-

--- a/src/transports/auth_negotiate.h
+++ b/src/transports/auth_negotiate.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_auth_negotiate_h__
-#define INCLUDE_auth_negotiate_h__
+#ifndef INCLUDE_transports_auth_negotiate_h__
+#define INCLUDE_transports_auth_negotiate_h__
 
 #include "common.h"
 #include "git2.h"
@@ -25,4 +25,3 @@ extern int git_http_auth_negotiate(
 #endif /* GIT_GSSAPI */
 
 #endif
-

--- a/src/transports/cred.h
+++ b/src/transports/cred.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_git_cred_h__
-#define INCLUDE_git_cred_h__
+#ifndef INCLUDE_transports_cred_h__
+#define INCLUDE_transports_cred_h__
 
 #include "common.h"
 

--- a/src/transports/smart.h
+++ b/src/transports/smart.h
@@ -4,6 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
+#ifndef INCLUDE_transports_smart_h__
+#define INCLUDE_transports_smart_h__
 
 #include "common.h"
 
@@ -194,3 +196,5 @@ int git_pkt_buffer_done(git_buf *buf);
 int git_pkt_buffer_wants(const git_remote_head * const *refs, size_t count, transport_smart_caps *caps, git_buf *buf);
 int git_pkt_buffer_have(git_oid *oid, git_buf *buf);
 void git_pkt_free(git_pkt *pkt);
+
+#endif

--- a/src/transports/ssh.h
+++ b/src/transports/ssh.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_ssh_h__
-#define INCLUDE_ssh_h__
+#ifndef INCLUDE_transports_ssh_h__
+#define INCLUDE_transports_ssh_h__
 
 #include "common.h"
 

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_posix__unix_h__
-#define INCLUDE_posix__unix_h__
+#ifndef INCLUDE_unix_posix_h__
+#define INCLUDE_unix_posix_h__
 
 #ifndef LIBGIT2_NO_FEATURES_H
 # include "git2/sys/features.h"

--- a/src/unix/pthread.h
+++ b/src/unix/pthread.h
@@ -53,4 +53,4 @@ typedef struct {
 #define git_rwlock_free(a)	pthread_rwlock_destroy(a)
 #define GIT_RWLOCK_STATIC_INIT	PTHREAD_RWLOCK_INITIALIZER
 
-#endif /* INCLUDE_unix_pthread_h__ */
+#endif

--- a/src/util.h
+++ b/src/util.h
@@ -539,4 +539,4 @@ GIT_INLINE(double) git__timer(void)
 
 extern int git__getenv(git_buf *out, const char *name);
 
-#endif /* INCLUDE_util_h__ */
+#endif

--- a/src/win32/dir.h
+++ b/src/win32/dir.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_dir_h__
-#define INCLUDE_dir_h__
+#ifndef INCLUDE_win32_dir_h__
+#define INCLUDE_win32_dir_h__
 
 #include "common.h"
 
@@ -41,4 +41,4 @@ extern int git__closedir(git__DIR *);
 #	define closedir git__closedir
 # endif
 
-#endif /* INCLUDE_dir_h__ */
+#endif

--- a/src/win32/error.h
+++ b/src/win32/error.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_git_win32_error_h__
-#define INCLUDE_git_win32_error_h__
+#ifndef INCLUDE_win32_error_h__
+#define INCLUDE_win32_error_h__
 
 #include "common.h"
 

--- a/src/win32/findfile.h
+++ b/src/win32/findfile.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_git_findfile_h__
-#define INCLUDE_git_findfile_h__
+#ifndef INCLUDE_win32_findfile_h__
+#define INCLUDE_win32_findfile_h__
 
 #include "common.h"
 

--- a/src/win32/mingw-compat.h
+++ b/src/win32/mingw-compat.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_mingw_compat__
-#define INCLUDE_mingw_compat__
+#ifndef INCLUDE_win32_mingw_compat_h__
+#define INCLUDE_win32_mingw_compat_h__
 
 #if defined(__MINGW32__)
 
@@ -20,4 +20,4 @@ void __mingworg_MemoryBarrier(void);
 
 #endif
 
-#endif /* INCLUDE_mingw_compat__ */
+#endif

--- a/src/win32/msvc-compat.h
+++ b/src/win32/msvc-compat.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_msvc_compat__
-#define INCLUDE_msvc_compat__
+#ifndef INCLUDE_win32_msvc_compat_h__
+#define INCLUDE_win32_msvc_compat_h__
 
 #if defined(_MSC_VER)
 
@@ -19,4 +19,4 @@ typedef SSIZE_T ssize_t;
 
 #define GIT_STDLIB_CALL __cdecl
 
-#endif /* INCLUDE_msvc_compat__ */
+#endif

--- a/src/win32/path_w32.h
+++ b/src/win32/path_w32.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_git_path_w32_h__
-#define INCLUDE_git_path_w32_h__
+#ifndef INCLUDE_win32_path_w32_h__
+#define INCLUDE_win32_path_w32_h__
 
 #include "common.h"
 

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_posix__w32_h__
-#define INCLUDE_posix__w32_h__
+#ifndef INCLUDE_win32_posix_h__
+#define INCLUDE_win32_posix_h__
 
 #include "common.h"
 #include "../posix.h"

--- a/src/win32/reparse.h
+++ b/src/win32/reparse.h
@@ -5,8 +5,8 @@
 * a Linking Exception. For full terms see the included COPYING file.
 */
 
-#ifndef INCLUDE_git_win32_reparse_h__
-#define INCLUDE_git_win32_reparse_h__
+#ifndef INCLUDE_win32_reparse_h__
+#define INCLUDE_win32_reparse_h__
 
 /* This structure is defined on MSDN at
 * http://msdn.microsoft.com/en-us/library/windows/hardware/ff552012(v=vs.85).aspx

--- a/src/win32/thread.h
+++ b/src/win32/thread.h
@@ -61,4 +61,4 @@ int git_rwlock_wrlock(git_rwlock *);
 int git_rwlock_wrunlock(git_rwlock *);
 int git_rwlock_free(git_rwlock *);
 
-#endif /* INCLUDE_win32_thread_h__ */
+#endif

--- a/src/win32/utf-conv.h
+++ b/src/win32/utf-conv.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_git_utfconv_h__
-#define INCLUDE_git_utfconv_h__
+#ifndef INCLUDE_win32_utf_conv_h__
+#define INCLUDE_win32_utf_conv_h__
 
 #include "common.h"
 

--- a/src/win32/w32_buffer.h
+++ b/src/win32/w32_buffer.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_git_win32_buffer_h__
-#define INCLUDE_git_win32_buffer_h__
+#ifndef INCLUDE_win32_w32_buffer_h__
+#define INCLUDE_win32_w32_buffer_h__
 
 #include "common.h"
 

--- a/src/win32/w32_crtdbg_stacktrace.h
+++ b/src/win32/w32_crtdbg_stacktrace.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_w32_crtdbg_stacktrace_h__
-#define INCLUDE_w32_crtdbg_stacktrace_h__
+#ifndef INCLUDE_win32_w32_crtdbg_stacktrace_h__
+#define INCLUDE_win32_w32_crtdbg_stacktrace_h__
 
 #include "common.h"
 

--- a/src/win32/w32_stack.h
+++ b/src/win32/w32_stack.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_w32_stack_h__
-#define INCLUDE_w32_stack_h__
+#ifndef INCLUDE_win32_w32_stack_h__
+#define INCLUDE_win32_w32_stack_h__
 
 #include "common.h"
 
@@ -137,4 +137,4 @@ int git_win32__stack(
 	const char *prefix, const char *suffix);
 
 #endif /* GIT_MSVC_CRTDBG */
-#endif /* INCLUDE_w32_stack_h__ */
+#endif

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -5,8 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#ifndef INCLUDE_w32_util_h__
-#define INCLUDE_w32_util_h__
+#ifndef INCLUDE_win32_w32_util_h__
+#define INCLUDE_win32_w32_util_h__
 
 #include "common.h"
 

--- a/src/win32/win32-compat.h
+++ b/src/win32/win32-compat.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_win32_compat__
-#define INCLUDE_win32_compat__
+#ifndef INCLUDE_win32_win32_compat_h__
+#define INCLUDE_win32_win32_compat_h__
 
 #include <stdint.h>
 #include <time.h>
@@ -49,4 +49,4 @@ struct p_stat {
 
 #define stat p_stat
 
-#endif /* INCLUDE_win32_compat__ */
+#endif

--- a/src/zstream.h
+++ b/src/zstream.h
@@ -44,4 +44,4 @@ void git_zstream_reset(git_zstream *zstream);
 int git_zstream_deflatebuf(git_buf *out, const void *in, size_t in_len);
 int git_zstream_inflatebuf(git_buf *out, const void *in, size_t in_len);
 
-#endif /* INCLUDE_zstream_h__ */
+#endif


### PR DESCRIPTION
Use consistent names for the #include / #define header guard pattern.