### PR TITLE
config_parse: do not use offset when checking for BOM

### DIFF
--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -217,7 +217,7 @@ static int skip_bom(git_parse_ctx *parser)
 {
 	git_buf buf = GIT_BUF_INIT_CONST(parser->content, parser->content_len);
 	git_bom_t bom;
-	int bom_offset = git_buf_text_detect_bom(&bom, &buf, parser->content_len);
+	int bom_offset = git_buf_text_detect_bom(&bom, &buf, 0);
 
 	if (bom == GIT_BOM_UTF8)
 		git_parse_advance_chars(parser, bom_offset);

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -703,3 +703,17 @@ void test_config_read__path(void)
 	git_buf_free(&expected_path);
 	git_config_free(cfg);
 }
+
+void test_config_read__read_utf8_bom(void) {
+	git_config *cfg;
+	git_buf path = GIT_BUF_INIT;
+
+	cl_git_mkfile("./config-utf8bom", "\uFEFF[test]\n path = file.txt\n");
+	cl_git_pass(git_config_open_ondisk(&cfg, "./config-utf8bom"));
+
+	cl_git_pass(git_config_get_path(&path, cfg, "test.path"));
+	cl_assert_equal_s("file.txt", path.ptr);
+
+	git_buf_free(&path);
+	git_config_free(cfg);
+}


### PR DESCRIPTION
As we were using the length of the parsed text as the detection offset, we would never see any BOMs.

Fixes #4516.