### PR TITLE
refspec: add public parsing api

### DIFF
--- a/include/git2/refspec.h
+++ b/include/git2/refspec.h
@@ -22,6 +22,23 @@
 GIT_BEGIN_DECL
 
 /**
+ * Parse a given refspec string
+ *
+ * @param refspec a pointer to hold the refspec handle
+ * @param input the refspec string
+ * @param is_fetch is this a refspec for a fetch
+ * @return 0 if the refspec string could be parsed, -1 otherwise
+ */
+GIT_EXTERN(int) git_refspec_parse(git_refspec **refspec, const char *input, int is_fetch);
+
+/**
+ * Free a refspec object which has been created by git_refspec_parse
+ *
+ * @param refspec the refspec object
+ */
+GIT_EXTERN(void) git_refspec_free(git_refspec *refspec);
+
+/**
  * Get the source specifier
  *
  * @param refspec the refspec

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -160,6 +160,31 @@ void git_refspec__free(git_refspec *refspec)
 	memset(refspec, 0x0, sizeof(git_refspec));
 }
 
+int git_refspec_parse(git_refspec **out_refspec, const char *input, int is_fetch)
+{
+	git_refspec *refspec;
+	assert(out_refspec && input);
+
+	*out_refspec = NULL;
+
+	refspec = git__malloc(sizeof(git_refspec));
+	GITERR_CHECK_ALLOC(refspec);
+
+	if (git_refspec__parse(refspec, input, !!is_fetch) != 0) {
+		git__free(refspec);
+		return -1;
+	}
+
+	*out_refspec = refspec;
+	return 0;
+}
+
+void git_refspec_free(git_refspec *refspec)
+{
+	git_refspec__free(refspec);
+	git__free(refspec);
+}
+
 const char *git_refspec_src(const git_refspec *refspec)
 {
 	return refspec == NULL ? NULL : refspec->src;

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -158,3 +158,15 @@ void test_network_refspecs__matching(void)
 
 	git_refspec__free(&spec);
 }
+
+void test_network_refspecs__parse_free(void)
+{
+	git_refspec *spec = NULL;
+
+	cl_git_fail(git_refspec_parse(&spec, "", 0));
+	cl_git_fail(git_refspec_parse(&spec, ":::", 0));
+	cl_git_pass(git_refspec_parse(&spec, "HEAD:", 1));
+
+	cl_assert(spec != NULL);
+	git_refspec_free(spec);
+}


### PR DESCRIPTION
This PR adds public apis for parsing refspec strings. This already exists but they are all internal.
I am not sure if tests are required here because I guess that the internal api must have tests already and this PR just adds trivial wrapping. But I am happy to add tests if it's really requested.