### PR TITLE
Test library init/shutdown separately

### DIFF
--- a/tests/clar.h
+++ b/tests/clar.h
@@ -15,6 +15,8 @@ enum cl_test_status {
 	CL_TEST_SKIP
 };
 
+void clar_register_global_fn(int (*init)(void), int (*cleanup)(void));
+
 void clar_test_init(int argc, char *argv[]);
 int clar_test_run(void);
 void clar_test_shutdown(void);

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -590,3 +590,21 @@ bool cl_sandbox_supports_8dot3(void)
 }
 #endif
 
+int cl_git_global_init(void)
+{
+	int res = 0;
+	res = git_libgit2_init();
+	if (res < 0) {
+		fprintf(stderr, "failed to init libgit2: %d", res);
+		return -1;
+	}
+
+	cl_sandbox_set_search_path_defaults();
+	return 0;
+}
+
+int cl_git_global_cleanup(void)
+{
+	git_libgit2_shutdown();
+	return 0;
+}

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -216,4 +216,7 @@ void cl_sandbox_set_search_path_defaults(void);
 bool cl_sandbox_supports_8dot3(void);
 #endif
 
+int cl_git_global_init(void);
+int cl_git_global_cleanup(void);
+
 #endif

--- a/tests/main.c
+++ b/tests/main.c
@@ -11,14 +11,9 @@ int main(int argc, char *argv[])
 
 	clar_test_init(argc, argv);
 
-	res = git_libgit2_init();
-	if (res < 0) {
-		fprintf(stderr, "failed to init libgit2");
-		return res;
-	}
-
 	cl_global_trace_register();
-	cl_sandbox_set_search_path_defaults();
+
+	clar_register_global_fn(cl_git_global_init, cl_git_global_cleanup);
 
 	/* Run the test suite */
 	res = clar_test_run();


### PR DESCRIPTION
As it says on the tin. The goal is to see how we fare when the library goes through multiple init/shutdown cycles.