### PR TITLE
Configuration entry iteration in order

### DIFF
--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -64,6 +64,7 @@ typedef enum {
 typedef struct git_config_entry {
 	const char *name; /**< Name of the entry (normalised) */
 	const char *value; /**< String value of the entry */
+	unsigned int include_depth; /**< Depth of includes where this variable was found */
 	git_config_level_t level; /**< Which config file this was found in */
 	void (*free)(struct git_config_entry *entry); /**< Free function for this entry */
 	void *payload; /**< Opaque value for the free function. Do not read or write */

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -549,7 +549,8 @@ static int config_delete(git_config_backend *cfg, const char *name)
 {
 	config_entry_list *var;
 	diskfile_backend *b = (diskfile_backend *)cfg;
-	refcounted_strmap *map;	git_strmap *values;
+	refcounted_strmap *map;
+	git_strmap *values;
 	char *key;
 	int result;
 	khiter_t pos;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -38,44 +38,6 @@ typedef struct git_config_file_iter {
 /* Max depth for [include] directives */
 #define MAX_INCLUDE_DEPTH 10
 
-#define CVAR_LIST_HEAD(list) ((list)->head)
-
-#define CVAR_LIST_TAIL(list) ((list)->tail)
-
-#define CVAR_LIST_NEXT(var) ((var)->next)
-
-#define CVAR_LIST_EMPTY(list) ((list)->head == NULL)
-
-#define CVAR_LIST_APPEND(list, var) do {\
-	if (CVAR_LIST_EMPTY(list)) {\
-		CVAR_LIST_HEAD(list) = CVAR_LIST_TAIL(list) = var;\
-	} else {\
-		CVAR_LIST_NEXT(CVAR_LIST_TAIL(list)) = var;\
-		CVAR_LIST_TAIL(list) = var;\
-	}\
-} while(0)
-
-#define CVAR_LIST_REMOVE_HEAD(list) do {\
-	CVAR_LIST_HEAD(list) = CVAR_LIST_NEXT(CVAR_LIST_HEAD(list));\
-} while(0)
-
-#define CVAR_LIST_REMOVE_AFTER(var) do {\
-	CVAR_LIST_NEXT(var) = CVAR_LIST_NEXT(CVAR_LIST_NEXT(var));\
-} while(0)
-
-#define CVAR_LIST_FOREACH(list, iter)\
-	for ((iter) = CVAR_LIST_HEAD(list);\
-		 (iter) != NULL;\
-		 (iter) = CVAR_LIST_NEXT(iter))
-
-/*
- * Inspired by the FreeBSD functions
- */
-#define CVAR_LIST_FOREACH_SAFE(start, iter, tmp)\
-	for ((iter) = CVAR_LIST_HEAD(vars);\
-		 (iter) && (((tmp) = CVAR_LIST_NEXT(iter) || 1));\
-		 (iter) = (tmp))
-
 typedef struct {
 	git_atomic refcount;
 	git_strmap *values;
@@ -188,7 +150,7 @@ static void free_vars(git_strmap *values)
 
 	git_strmap_foreach_value(values, var,
 		while (var != NULL) {
-			cvar_t *next = CVAR_LIST_NEXT(var);
+			cvar_t *next = var->next;
 			cvar_free(var);
 			var = next;
 		});
@@ -407,7 +369,7 @@ static int config_iterator_next(
 	}
 
 	*entry = var->entry;
-	it->next_var = CVAR_LIST_NEXT(var);
+	it->next_var = var->next;
 
 	return 0;
 }

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -306,6 +306,15 @@ void test_config_read__foreach(void)
 
 void test_config_read__iterator(void)
 {
+	const char *keys[] = {
+		"core.dummy2",
+		"core.verylong",
+		"core.dummy",
+		"remote.ab.url",
+		"remote.abba.url",
+		"core.dummy2",
+		"core.global"
+	};
 	git_config *cfg;
 	git_config_iterator *iter;
 	git_config_entry *entry;
@@ -321,6 +330,7 @@ void test_config_read__iterator(void)
 	cl_git_pass(git_config_iterator_new(&iter, cfg));
 
 	while ((ret = git_config_next(&entry, iter)) == 0) {
+		cl_assert_equal_s(entry->name, keys[count]);
 		count++;
 	}
 


### PR DESCRIPTION
I've finally pulled myself together and tackled my itch of iterating through configuration entries in the order they appear in the file. At first, I started getting annoyed again by the unnecessarily complex config file code, so I preceded the actual logic by quite a lot of refactoring and renaming of structures and functions. The result is actually very pleasant: while maintaining a second data structure alongside the map of entries, this PR still has more deletions than additions. So I definitly think that this PR helps a whole lot regarding readability.