### PR TITLE
tests: index::filemodes: fix use of uninitialized memory

### DIFF
--- a/tests/index/filemodes.c
+++ b/tests/index/filemodes.c
@@ -264,6 +264,7 @@ void test_index_filemodes__frombuffer_requires_files(void)
 	const git_index_entry *ret_entry;
 	const char *content = "hey there\n";
 
+	memset(&new_entry, 0, sizeof(new_entry));
 	cl_git_pass(git_repository_index(&index, g_repo));
 
 	/* regular blob */


### PR DESCRIPTION
The new index entry structure was not being initialized to all-zeroes.
As that structure is used to add a new entry to the current index, and
the hashing algorithm of the index making use of the uninitialized flags
to calculate the state, we might miscompute the hash of the entry and
add it at the wrong position. Later lookups would then fail.

Initialize the structure with `memset` to fix the test breaking on some
platforms.