### PR TITLE
Sanitize the hunk header to ensure it contains UTF-8 valid data

### DIFF
--- a/src/diff_xdiff.c
+++ b/src/diff_xdiff.c
@@ -6,6 +6,7 @@
  */
 
 #include "diff_xdiff.h"
+#include "util.h"
 
 #include "git2/errors.h"
 #include "diff.h"
@@ -115,6 +116,7 @@ static int git_xdiff_cb(void *priv, mmbuffer_t *bufs, int len)
 	const git_diff_delta *delta = patch->base.delta;
 	git_patch_generated_output *output = &info->xo->output;
 	git_diff_line line;
+	size_t buffer_len;
 
 	if (len == 1) {
 		output->error = git_xdiff_parse_hunk(&info->hunk, bufs[0].ptr);
@@ -124,6 +126,16 @@ static int git_xdiff_cb(void *priv, mmbuffer_t *bufs, int len)
 		info->hunk.header_len = bufs[0].size;
 		if (info->hunk.header_len >= sizeof(info->hunk.header))
 			info->hunk.header_len = sizeof(info->hunk.header) - 1;
+
+		/* Sanitize the hunk header in case there is invalid Unicode */
+		buffer_len = git__utf8_valid_buf_length((const uint8_t *) bufs[0].ptr, info->hunk.header_len);
+		/* Sanitizing the hunk header may delete the newline, so add it back again if there is room */
+		if (buffer_len < info->hunk.header_len) {
+			bufs[0].ptr[buffer_len] = '\n';
+			buffer_len += 1;
+			info->hunk.header_len = buffer_len;
+		}
+
 		memcpy(info->hunk.header, bufs[0].ptr, info->hunk.header_len);
 		info->hunk.header[info->hunk.header_len] = '\0';
 

--- a/src/util.c
+++ b/src/util.c
@@ -806,6 +806,22 @@ double git_time_monotonic(void)
 	return git__timer();
 }
 
+size_t git__utf8_valid_buf_length(const uint8_t *str, size_t str_len)
+{
+	size_t offset = 0;
+
+	while (offset < str_len) {
+		int length = git__utf8_charlen(str + offset, str_len - offset);
+
+		if (length < 0)
+			break;
+
+		offset += length;
+	}
+
+	return offset;
+}
+
 #ifdef GIT_WIN32
 int git__getenv(git_buf *out, const char *name)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -454,6 +454,16 @@ extern size_t git__unescape(char *str);
 extern int git__utf8_iterate(const uint8_t *str, int str_len, int32_t *dst);
 
 /*
+ * Iterate through an UTF-8 string and stops after finding any invalid UTF-8
+ * codepoints.
+ *
+ * @param str string to scan
+ * @param str_len size of the string
+ * @return length in bytes of the string that contains valid data
+ */
+extern size_t git__utf8_valid_buf_length(const uint8_t *str, size_t str_len);
+
+/*
  * Safely zero-out memory, making sure that the compiler
  * doesn't optimize away the operation.
  */


### PR DESCRIPTION
The diff driver truncates the hunk header text to 80 bytes, which
can  cut off 4-byte Unicode characters and introduce garbage characters in the
diff output. This change sanitizes the hunk header before it is displayed.

This is consistent with what git does: https://github.com/git/git/blob/e3a80781f5932f5fea12a49eb06f3ade4ed8945c/diff.c#L1927-L1941

Closes https://github.com/libgit2/rugged/issues/716