### PR TITLE
Reorder entries to decrease struct sizes

### DIFF
--- a/src/blame.h
+++ b/src/blame.h
@@ -13,10 +13,10 @@
  * One blob in a commit that is being suspected
  */
 typedef struct git_blame__origin {
-	int refcnt;
 	struct git_blame__origin *previous;
 	git_commit *commit;
 	git_blob *blob;
+	int refcnt;
 	char path[GIT_FLEX_ARRAY];
 } git_blame__origin;
 
@@ -29,16 +29,26 @@ typedef struct git_blame__entry {
 	struct git_blame__entry *prev;
 	struct git_blame__entry *next;
 
+	/* the commit that introduced this group into the final image */
+	git_blame__origin *suspect;
+
 	/* the first line of this group in the final image;
 	 * internally all line numbers are 0 based.
 	 */
 	size_t lno;
 
+	/* the line number of the first line of this group in the
+	 * suspect's file; internally all line numbers are 0 based.
+	 */
+	size_t s_lno;
+
 	/* how many lines this group has */
 	size_t num_lines;
 
-	/* the commit that introduced this group into the final image */
-	git_blame__origin *suspect;
+	/* how significant this entry is -- cached to avoid
+	 * scanning the lines over and over.
+	 */
+	unsigned score;
 
 	/* true if the suspect is truly guilty; false while we have not
 	 * checked if the group came from one of its parents.
@@ -48,16 +58,6 @@ typedef struct git_blame__entry {
 	/* true if the entry has been scanned for copies in the current parent
 	 */
 	bool scanned;
-
-	/* the line number of the first line of this group in the
-	 * suspect's file; internally all line numbers are 0 based.
-	 */
-	size_t s_lno;
-
-	/* how significant this entry is -- cached to avoid
-	 * scanning the lines over and over.
-	 */
-	unsigned score;
 
 	/* Whether this entry has been tracked to a boundary commit.
 	 */

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -28,23 +28,22 @@
 #define GIT_PACK_BIG_FILE_THRESHOLD (512 * 1024 * 1024)
 
 typedef struct git_pobject {
-	git_oid id;
-	git_otype type;
-	git_off_t offset;
-
-	size_t size;
-
-	unsigned int hash; /* name hint hash */
-
 	struct git_pobject *delta; /* delta base object */
 	struct git_pobject *delta_child; /* deltified objects who bases me */
 	struct git_pobject *delta_sibling; /* other deltified objects
 					    * who uses the same base as
 					    * me */
-
 	void *delta_data;
+
+	git_off_t offset;
+	size_t size;
 	size_t delta_size;
 	size_t z_delta_size;
+
+	unsigned int hash; /* name hint hash */
+
+	git_oid id;
+	git_otype type;
 
 	int written:1,
 	    recursing:1,

--- a/src/tree-cache.h
+++ b/src/tree-cache.h
@@ -19,8 +19,8 @@ typedef struct git_tree_cache {
 	size_t children_count;
 
 	ssize_t entry_count;
-	git_oid oid;
 	size_t namelen;
+	git_oid oid;
 	char name[GIT_FLEX_ARRAY];
 } git_tree_cache;
 


### PR DESCRIPTION
Members of structures may have several requirements regarding alignment,
depending on platform. Because of this, the order of members can
actually impact how big the overall structure is, with a more efficient
ordering saving space. In general, pointers should be first and scalar
types should be ordered by descending width.

We have some internal data structures whose members are not accessible
to the user of libgit2, where we can easily reorder members without
breaking anything. Depending on the platform, this may save a few bytes
for each structure. While this is not a lot, the savings may add up in
certain scenarios.