### PR TITLE
travis: use custom libssh2 package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
    libcurl3
    libcurl3-gnutls
    libcurl4-gnutls-dev
-   libssh2-1-dev
+   libssh2-1
    openssh-client
    openssh-server
    valgrind


### PR DESCRIPTION
Use a custom libssh package that is a backport of libssh2 1.8.0 to Ubuntu trusty.