### PR TITLE
travis: use custom libssh2-1-dev package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
    libcurl3
    libcurl3-gnutls
    libcurl4-gnutls-dev
-   libssh2-1
+   libssh2-1-dev
    openssh-client
    openssh-server
    valgrind


### PR DESCRIPTION
To avoid pull requests needing to rebase, keep the libssh2-1-dev
package as the development package for libssh2.  Reverting to the
original Debian package structure.