### PR TITLE
Cast less blindly between configuration objects

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -86,13 +86,13 @@ typedef struct {
 	/* mutex to coordinate accessing the values */
 	git_mutex values_mutex;
 	refcounted_strmap *values;
+	const git_repository *repo;
 } diskfile_header;
 
 typedef struct {
 	diskfile_header header;
 
 	git_config_level_t level;
-	const git_repository *repo;
 
 	git_array_t(git_config_parser) readers;
 
@@ -271,7 +271,7 @@ static int config_open(git_config_backend *cfg, git_config_level_t level, const 
 	diskfile_backend *b = (diskfile_backend *)cfg;
 
 	b->level = level;
-	b->repo = repo;
+	b->header.repo = repo;
 
 	if ((res = refcounted_strmap_alloc(&b->header.values)) < 0)
 		return res;
@@ -343,7 +343,7 @@ static int config_refresh(git_config_backend *cfg)
 	}
 	git_array_clear(b->file.includes);
 
-	if ((error = config_read(values->values, b->repo, &b->file, b->level, 0)) < 0)
+	if ((error = config_read(values->values, b->header.repo, &b->file, b->level, 0)) < 0)
 		goto out;
 
 	if ((error = git_mutex_lock(&b->header.values_mutex)) < 0) {
@@ -423,7 +423,7 @@ static int config_iterator_new(
 	if ((error = config_snapshot(&snapshot, backend)) < 0)
 		return error;
 
-	if ((error = snapshot->open(snapshot, b->level, b->repo)) < 0)
+	if ((error = snapshot->open(snapshot, b->level, b->header.repo)) < 0)
 		return error;
 
 	it = git__calloc(1, sizeof(git_config_file_iter));

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -326,6 +326,9 @@ static int config_refresh(git_config_backend *cfg)
 	int error, modified;
 	uint32_t i;
 
+	if (b->header.parent.readonly)
+		return 0;
+
 	error = config_is_modified(&modified, &b->file);
 	if (error < 0 && error != GIT_ENOTFOUND)
 		goto out;
@@ -416,13 +419,13 @@ static int config_iterator_new(
 	diskfile_header *h;
 	git_config_file_iter *it;
 	git_config_backend *snapshot;
-	diskfile_backend *b = (diskfile_backend *) backend;
+	diskfile_header *bh = (diskfile_header *) backend;
 	int error;
 
 	if ((error = config_snapshot(&snapshot, backend)) < 0)
 		return error;
 
-	if ((error = snapshot->open(snapshot, b->header.level, b->header.repo)) < 0)
+	if ((error = snapshot->open(snapshot, bh->level, bh->repo)) < 0)
 		return error;
 
 	it = git__calloc(1, sizeof(git_config_file_iter));

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -87,12 +87,11 @@ typedef struct {
 	git_mutex values_mutex;
 	refcounted_strmap *values;
 	const git_repository *repo;
+	git_config_level_t level;
 } diskfile_header;
 
 typedef struct {
 	diskfile_header header;
-
-	git_config_level_t level;
 
 	git_array_t(git_config_parser) readers;
 
@@ -270,7 +269,7 @@ static int config_open(git_config_backend *cfg, git_config_level_t level, const 
 	int res;
 	diskfile_backend *b = (diskfile_backend *)cfg;
 
-	b->level = level;
+	b->header.level = level;
 	b->header.repo = repo;
 
 	if ((res = refcounted_strmap_alloc(&b->header.values)) < 0)
@@ -343,7 +342,7 @@ static int config_refresh(git_config_backend *cfg)
 	}
 	git_array_clear(b->file.includes);
 
-	if ((error = config_read(values->values, b->header.repo, &b->file, b->level, 0)) < 0)
+	if ((error = config_read(values->values, b->header.repo, &b->file, b->header.level, 0)) < 0)
 		goto out;
 
 	if ((error = git_mutex_lock(&b->header.values_mutex)) < 0) {
@@ -423,7 +422,7 @@ static int config_iterator_new(
 	if ((error = config_snapshot(&snapshot, backend)) < 0)
 		return error;
 
-	if ((error = snapshot->open(snapshot, b->level, b->header.repo)) < 0)
+	if ((error = snapshot->open(snapshot, b->header.level, b->header.repo)) < 0)
 		return error;
 
 	it = git__calloc(1, sizeof(git_config_file_iter));

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -327,7 +327,7 @@ static int config_refresh(git_config_backend *cfg)
 	uint32_t i;
 
 	if (b->header.parent.readonly)
-		return 0;
+		return config_error_readonly();
 
 	error = config_is_modified(&modified, &b->file);
 	if (error < 0 && error != GIT_ENOTFOUND)


### PR DESCRIPTION
As discussed in #4551 we were cowboying it up with the casts which meant we were passing in nonsense values for levels and reading unallocated memory for the repository pointer.

This fixes that and hardens the code a bit by casting to the common structure rather than the one for the live object.

/cc @tiennou 
//c @ethomson @pks-t this should go in before the release