### PR TITLE
tree: initialize the id we use for testing submodule insertions

### DIFF
--- a/tests/object/tree/write.c
+++ b/tests/object/tree/write.c
@@ -495,6 +495,7 @@ static void test_inserting_submodule(void)
 	git_treebuilder *bld;
 	git_oid sm_id;
 
+	cl_git_pass(git_oid_fromstr(&sm_id, "da39a3ee5e6b4b0d3255bfef95601890afd80709"));
 	cl_git_pass(git_treebuilder_new(&bld, g_repo, NULL));
 	cl_git_pass(git_treebuilder_insert(NULL, bld, "sm", &sm_id, GIT_FILEMODE_COMMIT));
 	git_treebuilder_free(bld);


### PR DESCRIPTION
Instead of laving it uninitialized and relying on luck for it to be non-zero,
let's give it a dummy hash so we make valgrind happy (in this case the hash
comes from `sha1sum </dev/null`.

This is just in the test so it's not _that_ important, but it'd be good to release with a clean valgrind output.

/cc @ethomson @pks-t this should go in before the release