### PR TITLE
curl: initialize and cleanup global curl state

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -11,6 +11,7 @@
 #include "sysdir.h"
 #include "filter.h"
 #include "merge_driver.h"
+#include "streams/curl.h"
 #include "streams/openssl.h"
 #include "thread-utils.h"
 #include "git2/global.h"
@@ -23,7 +24,7 @@
 
 git_mutex git__mwindow_mutex;
 
-#define MAX_SHUTDOWN_CB 9
+#define MAX_SHUTDOWN_CB 10
 
 static git_global_shutdown_fn git__shutdown_callbacks[MAX_SHUTDOWN_CB];
 static git_atomic git__n_shutdown_callbacks;
@@ -63,7 +64,8 @@ static int init_common(void)
 		(ret = git_filter_global_init()) == 0 &&
 		(ret = git_merge_driver_global_init()) == 0 &&
 		(ret = git_transport_ssh_global_init()) == 0 &&
-		(ret = git_openssl_stream_global_init()) == 0)
+		(ret = git_openssl_stream_global_init()) == 0 &&
+		(ret = git_curl_stream_global_init()) == 0)
 		ret = git_mwindow_global_init();
 
 	GIT_MEMORY_BARRIER;

--- a/src/streams/curl.c
+++ b/src/streams/curl.c
@@ -14,6 +14,7 @@
 #include "stream.h"
 #include "git2/transport.h"
 #include "buffer.h"
+#include "global.h"
 #include "vector.h"
 #include "proxy.h"
 
@@ -37,6 +38,18 @@ typedef struct {
 	git_proxy_options proxy;
 	git_cred *proxy_cred;
 } curl_stream;
+
+int git_curl_stream_global_init(void)
+{
+	if (curl_global_init(CURL_GLOBAL_ALL) != 0) {
+		giterr_set(GITERR_NET, "could not initialize curl");
+		return -1;
+	}
+
+	/* `curl_global_cleanup` is provided by libcurl */
+	git__on_shutdown(curl_global_cleanup);
+	return 0;
+}
 
 static int seterr_curl(curl_stream *s)
 {
@@ -352,6 +365,11 @@ int git_curl_stream_new(git_stream **out, const char *host, const char *port)
 #else
 
 #include "stream.h"
+
+int git_curl_stream_global_init(void)
+{
+	return 0;
+}
 
 int git_curl_stream_new(git_stream **out, const char *host, const char *port)
 {

--- a/src/streams/curl.h
+++ b/src/streams/curl.h
@@ -11,6 +11,7 @@
 
 #include "git2/sys/stream.h"
 
+extern int git_curl_stream_global_init(void);
 extern int git_curl_stream_new(git_stream **out, const char *host, const char *port);
 
 #endif


### PR DESCRIPTION
The documentation of curl states that any program making use of libcurl
is responsible for calling `curl_global_init` previous to using any
curl functions, and `curl_global_cleanup` when the program is about to
terminate. We currently call neither. While this seems to work just
fine, Valgrind may complain about unfree'd memory.

Fix the issue by correctly setting up and tearing down libcurl.

---

Edit for the corrected reasoning behind this PR:



Our curl-based streams make use of the easy curl interface. This
interface automatically initializes and de-initializes the global curl
state by calling out to `curl_global_init` and `curl_global_cleanup`.
Thus, all global state will be repeatedly re-initialized when creating
multiple curl streams in succession. Despite being inefficient, this is
not thread-safe due to `curl_global_init` being not thread-safe itself.
Thus a multi-threaded programing handling multiple curl streams at the
same time is inherently racy.

Fix the issue by globally initializing and cleaning up curl's state.

