### PR TITLE
win32: strncmp -> git__strncmp for win32 STDCALL

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -59,7 +59,7 @@ static int does_negate_pattern(git_attr_fnmatch *rule, git_attr_fnmatch *neg)
 	if (neg->flags & GIT_ATTR_FNMATCH_ICASE)
 		cmp = git__strncasecmp;
 	else
-		cmp = strncmp;
+		cmp = git__strncmp;
 
 	/* If lengths match we need to have an exact match */
 	if (rule->length == neg->length) {


### PR DESCRIPTION
We presently fail to build on win32 when `STDCALL=ON`, which is what LibGit2Sharp uses.  At present, we're trying to assign a `__cdecl` function to a `__stdcall` declared function pointer.

The win32 C library is compiled cdecl, however when configured with `STDCALL=ON`, our functions (and function pointers) will use the stdcall calling convention.  You cannot set a `__stdcall` function pointer to a `__cdecl` function, so it's easier to just use our `git__strncmp` instead of sorting that mess out.
