### PR TITLE
Unescape special characters in SSH repo paths

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -207,7 +207,7 @@ void gitno_connection_data_free_ptrs(gitno_connection_data *d)
 }
 
 #define hex2c(c) ((c | 32) % 39 - 9)
-static char* unescape(char *str)
+char* gitno_unescape(char *str)
 {
 	int x, y;
 	int len = (int)strlen(str);
@@ -274,8 +274,8 @@ int gitno_extract_url_parts(
 	if (u.field_set & (1 << UF_USERINFO)) {
 		const char *colon = memchr(_userinfo, ':', u.field_data[UF_USERINFO].len);
 		if (colon) {
-			*username = unescape(git__substrdup(_userinfo, colon - _userinfo));
-			*password = unescape(git__substrdup(colon+1, u.field_data[UF_USERINFO].len - (colon+1-_userinfo)));
+			*username = gitno_unescape(git__substrdup(_userinfo, colon - _userinfo));
+			*password = gitno_unescape(git__substrdup(colon+1, u.field_data[UF_USERINFO].len - (colon+1-_userinfo)));
 			GITERR_CHECK_ALLOC(*password);
 		} else {
 			*username = git__substrdup(_userinfo, u.field_data[UF_USERINFO].len);

--- a/src/netops.c
+++ b/src/netops.c
@@ -278,7 +278,7 @@ int gitno_extract_url_parts(
 			*password = gitno_unescape(git__substrdup(colon+1, u.field_data[UF_USERINFO].len - (colon+1-_userinfo)));
 			GITERR_CHECK_ALLOC(*password);
 		} else {
-			*username = git__substrdup(_userinfo, u.field_data[UF_USERINFO].len);
+			*username = gitno_unescape(git__substrdup(_userinfo, u.field_data[UF_USERINFO].len));
 		}
 		GITERR_CHECK_ALLOC(*username);
 

--- a/src/netops.h
+++ b/src/netops.h
@@ -96,4 +96,6 @@ int gitno_extract_url_parts(
 		const char *url,
 		const char *default_port);
 
+char* gitno_unescape(char *str);
+
 #endif

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -89,15 +89,19 @@ done:
 		return -1;
 	}
 
+	repo = gitno_unescape(git__strdup(repo));
+
 	len = strlen(cmd) + 1 /* Space */ + 1 /* Quote */ + strlen(repo) + 1 /* Quote */ + 1;
 
 	git_buf_grow(request, len);
 	git_buf_printf(request, "%s '%s'", cmd, repo);
 	git_buf_putc(request, '\0');
 
+	git__free(repo);
+
 	if (git_buf_oom(request))
 		return -1;
-
+	
 	return 0;
 }
 

--- a/tests/transport/register.c
+++ b/tests/transport/register.c
@@ -45,6 +45,8 @@ void test_transport_register__custom_transport_ssh(void)
 		"ssh+git://somehost:somepath",
 		"git+ssh://somehost:somepath",
 		"git@somehost:somepath",
+		"ssh://somehost:somepath%20with%20%spaces",
+		"ssh://somehost:somepath with spaces"
 	};
 	git_transport *transport;
 	unsigned i;


### PR DESCRIPTION
Some repositories (i.e. VSTS repos) may have spaces in the repo path. The Git CLI is successfully able to handle this special case by unescaping special characters when constructing a command, e.g. `git-upload-pack '/Project with Spaces/_ssh/Repo with Spaces'`. The proposed change would ensure the same in libgit2.