### PR TITLE
Regcomp with LC_COLLATE

### DIFF
--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -283,7 +283,9 @@ static int git_diff_driver_load(
 	/* TODO: warn if diff.<name>.command or diff.<name>.textconv are set */
 
 	git_buf_truncate(&name, namelen + strlen("diff.."));
-	git_buf_put(&name, "xfuncname", strlen("xfuncname"));
+	if ((error = git_buf_PUTS(&name, "xfuncname")) < 0)
+		goto done;
+
 	if ((error = git_config_get_multivar_foreach(
 			cfg, name.ptr, NULL, diff_driver_xfuncname, drv)) < 0) {
 		if (error != GIT_ENOTFOUND)
@@ -292,7 +294,9 @@ static int git_diff_driver_load(
 	}
 
 	git_buf_truncate(&name, namelen + strlen("diff.."));
-	git_buf_put(&name, "funcname", strlen("funcname"));
+	if ((error = git_buf_PUTS(&name, "funcname")) < 0)
+		goto done;
+
 	if ((error = git_config_get_multivar_foreach(
 			cfg, name.ptr, NULL, diff_driver_funcname, drv)) < 0) {
 		if (error != GIT_ENOTFOUND)
@@ -307,7 +311,9 @@ static int git_diff_driver_load(
 	}
 
 	git_buf_truncate(&name, namelen + strlen("diff.."));
-	git_buf_put(&name, "wordregex", strlen("wordregex"));
+	if ((error = git_buf_PUTS(&name, "wordregex")) < 0)
+		goto done;
+
 	if ((error = git_config__lookup_entry(&ce, cfg, name.ptr, false)) < 0)
 		goto done;
 	if (!ce || !ce->value)

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -73,7 +73,7 @@ static int maybe_describe(git_object**out, git_repository *repo, const char *spe
 	if (substr == NULL)
 		return GIT_ENOTFOUND;
 
-	if (build_regex(&regex, ".+-[0-9]+-g[0-9a-fA-F]+") < 0)
+	if (build_regex(&regex, ".+-[[:digit:]]+-g[[:xdigit:]]+") < 0)
 		return -1;
 
 	error = regexec(&regex, spec, 0, NULL, 0);

--- a/src/userdiff.h
+++ b/src/userdiff.h
@@ -20,7 +20,7 @@ typedef struct {
 	int flags;
 } git_diff_driver_definition;
 
-#define WORD_DEFAULT "|[^[:space:]]|[\xc0-\xff][\x80-\xbf]+"
+#define WORD_DEFAULT "|[^[:space:]]"
 
 /*
  * These builtin driver definition macros have same signature as in core
@@ -50,22 +50,22 @@ IPATTERN("ada",
 	 "^[ \t]*((procedure|function)[ \t]+.*)$\n"
 	 "^[ \t]*((package|protected|task)[ \t]+.*)$",
 	 /* -- */
-	 "[a-zA-Z][a-zA-Z0-9_]*"
-	 "|[-+]?[0-9][0-9#_.aAbBcCdDeEfF]*([eE][+-]?[0-9_]+)?"
+	 "[[:alpha:]][[:alnum:]_]*"
+	 "|[-+]?[[:digit:]][[:xdigit:]#_.]*([eE][+-]?[[:digit:]_]+)?"
 	 "|=>|\\.\\.|\\*\\*|:=|/=|>=|<=|<<|>>|<>"),
 
 IPATTERN("fortran",
 	 "!^([C*]|[ \t]*!)\n"
 	 "!^[ \t]*MODULE[ \t]+PROCEDURE[ \t]\n"
 	 "^[ \t]*((END[ \t]+)?(PROGRAM|MODULE|BLOCK[ \t]+DATA"
-		"|([^'\" \t]+[ \t]+)*(SUBROUTINE|FUNCTION))[ \t]+[A-Z].*)$",
+		"|([^'\" \t]+[ \t]+)*(SUBROUTINE|FUNCTION))[ \t]+[[:upper:]].*)$",
 	 /* -- */
-	 "[a-zA-Z][a-zA-Z0-9_]*"
+	 "[[:alpha:]][[:alnum:]_]*"
 	 "|\\.([Ee][Qq]|[Nn][Ee]|[Gg][TtEe]|[Ll][TtEe]|[Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee]|[Aa][Nn][Dd]|[Oo][Rr]|[Nn]?[Ee][Qq][Vv]|[Nn][Oo][Tt])\\."
 	 /* numbers and format statements like 2E14.4, or ES12.6, 9X.
 	  * Don't worry about format statements without leading digits since
 	  * they would have been matched above as a variable anyway. */
-	 "|[-+]?[0-9.]+([AaIiDdEeFfLlTtXx][Ss]?[-+]?[0-9.]*)?(_[a-zA-Z0-9][a-zA-Z0-9_]*)?"
+	 "|[-+]?[[:digit:].]+([AaIiDdEeFfLlTtXx][Ss]?[-+]?[[:digit:].]*)?(_[[:alnum:]][[:alnum:]_]*)?"
 	 "|//|\\*\\*|::|[/<>=]="),
 
 PATTERNS("html", "^[ \t]*(<[Hh][1-6][ \t].*>.*)$",
@@ -73,29 +73,29 @@ PATTERNS("html", "^[ \t]*(<[Hh][1-6][ \t].*>.*)$",
 
 PATTERNS("java",
 	 "!^[ \t]*(catch|do|for|if|instanceof|new|return|switch|throw|while)\n"
-	 "^[ \t]*(([A-Za-z_][A-Za-z_0-9]*[ \t]+)+[A-Za-z_][A-Za-z_0-9]*[ \t]*\\([^;]*)$",
+	 "^[ \t]*(([[:alpha:]_][[:alnum:]_]*[ \t]+)+[[:alpha:]_][[:alnum:]_]*[ \t]*\\([^;]*)$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lL]?"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[:digit:].e]+[fFlL]?|0[xXbB]?[[:xdigit:]]+[lL]?"
 	 "|[-+*/<>%&^|=!]="
 	 "|--|\\+\\+|<<=?|>>>?=?|&&|\\|\\|"),
 
 PATTERNS("matlab",
 	 "^[[:space:]]*((classdef|function)[[:space:]].*)$|^%%[[:space:]].*$",
-	 "[a-zA-Z_][a-zA-Z0-9_]*|[-+0-9.e]+|[=~<>]=|\\.[*/\\^']|\\|\\||&&"),
+	 "[[:alpha:]_][[:alnum:]_]*|[-+[[:digit:]].e]+|[=~<>]=|\\.[*/\\^']|\\|\\||&&"),
 
 PATTERNS("objc",
 	 /* Negate C statements that can look like functions */
 	 "!^[ \t]*(do|for|if|else|return|switch|while)\n"
 	 /* Objective-C methods */
-	 "^[ \t]*([-+][ \t]*\\([ \t]*[A-Za-z_][A-Za-z_0-9* \t]*\\)[ \t]*[A-Za-z_].*)$\n"
+	 "^[ \t]*([-+][ \t]*\\([ \t]*[[:alpha:]_][[:alnum:]_* \t]*\\)[ \t]*[[:alpha:]z_].*)$\n"
 	 /* C functions */
-	 "^[ \t]*(([A-Za-z_][A-Za-z_0-9]*[ \t]+)+[A-Za-z_][A-Za-z_0-9]*[ \t]*\\([^;]*)$\n"
+	 "^[ \t]*(([[:alpha:]_][[:alnum]_]*[ \t]+)+[[:alpha]_][[:alnum:]_]*[ \t]*\\([^;]*)$\n"
 	 /* Objective-C class/protocol definitions */
 	 "^(@(implementation|interface|protocol)[ \t].*)$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lL]?"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+[fFlL]?|0[xXbB]?[[:xdigit:]]+[lL]?"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->"),
 
 PATTERNS("pascal",
@@ -104,8 +104,8 @@ PATTERNS("pascal",
 	 "\n"
 	 "^(.*=[ \t]*(class|record).*)$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+|0[xXbB]?[0-9a-fA-F]+"
+	 "[[:alpha:]_][[:alpha:]_]*"
+	 "|[-+[[:digit:]].e]+|0[xXbB]?[[:xdigit:]]+"
 	 "|<>|<=|>=|:=|\\.\\."),
 
 PATTERNS("perl",
@@ -126,12 +126,12 @@ PATTERNS("perl",
 	 "^(BEGIN|END|INIT|CHECK|UNITCHECK|AUTOLOAD|DESTROY)[ \t]*"
 		"(\\{[ \t]*)?" /* brace can come here or on the next line */
 		"(#.*)?$\n"
-	 "^=head[0-9] .*",	/* POD */
+	 "^=head[[:digit:]] .*",	/* POD */
 	 /* -- */
 	 "[[:alpha:]_'][[:alnum:]_']*"
-	 "|0[xb]?[0-9a-fA-F_]*"
+	 "|0[xb]?[[:xdigit:]_]*"
 	 /* taking care not to interpret 3..5 as (3.)(.5) */
-	 "|[0-9a-fA-F_]+(\\.[0-9a-fA-F_]+)?([eE][-+]?[0-9_]+)?"
+	 "|[[:xdigit:]_]+(\\.[[:xdigit:]_]+)?([eE][-+]?[[:digit:]_]+)?"
 	 "|=>|-[rwxoRWXOezsfdlpSugkbctTBMAC>]|~~|::"
 	 "|&&=|\\|\\|=|//=|\\*\\*="
 	 "|&&|\\|\\||//|\\+\\+|--|\\*\\*|\\.\\.\\.?"
@@ -141,30 +141,30 @@ PATTERNS("perl",
 
 PATTERNS("python", "^[ \t]*((class|def)[ \t].*)$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[jJlL]?|0[xX]?[0-9a-fA-F]+[lL]?"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+[jJlL]?|0[xX]?[[:xdigit:]]+[lL]?"
 	 "|[-+*/<>%&^|=!]=|//=?|<<=?|>>=?|\\*\\*=?"),
 
 PATTERNS("ruby", "^[ \t]*((class|module|def)[ \t].*)$",
 	 /* -- */
-	 "(@|@@|\\$)?[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+|0[xXbB]?[0-9a-fA-F]+|\\?(\\\\C-)?(\\\\M-)?."
+	 "(@|@@|\\$)?[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+|0[xXbB]?[[:xdigit:]]+|\\?(\\\\C-)?(\\\\M-)?."
 	 "|//=?|[-+*/<>%&^|=!]=|<<=?|>>=?|===|\\.{1,3}|::|[!=]~"),
 
-PATTERNS("bibtex", "(@[a-zA-Z]{1,}[ \t]*\\{{0,1}[ \t]*[^ \t\"@',\\#}{~%]*).*$",
+PATTERNS("bibtex", "(@[[:alpha:]]{1,}[ \t]*\\{{0,1}[ \t]*[^ \t\"@',\\#}{~%]*).*$",
 	 "[={}\"]|[^={}\" \t]+"),
 
 PATTERNS("tex", "^(\\\\((sub)*section|chapter|part)\\*{0,1}\\{.*)$",
-	 "\\\\[a-zA-Z@]+|\\\\.|[a-zA-Z0-9\x80-\xff]+"),
+	 "\\\\[[:alpha:]@]+|\\\\.|[[:alnum:]\x80-\xff]+"),
 
 PATTERNS("cpp",
 	 /* Jump targets or access declarations */
-	 "!^[ \t]*[A-Za-z_][A-Za-z_0-9]*:[[:space:]]*($|/[/*])\n"
+	 "!^[ \t]*[[:alpha:]_][[:alnum:]_]*:[[:space:]]*($|/[/*])\n"
 	 /* functions/methods, variables, and compounds at top level */
-	 "^((::[[:space:]]*)?[A-Za-z_].*)$",
+	 "^((::[[:space:]]*)?[[:alpha:]_].*)$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lLuU]*"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+[fFlL]?|0[xXbB]?[[:xdigit:]]+[lLuU]*"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->\\*?|\\.\\*"),
 
 PATTERNS("csharp",
@@ -179,24 +179,24 @@ PATTERNS("csharp",
 	 /* Namespace */
 	 "^[ \t]*(namespace[ \t]+.*)$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[fFlL]?|0[xXbB]?[0-9a-fA-F]+[lL]?"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+[fFlL]?|0[xXbB]?[[:xdigit:]]+[lL]?"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->"),
 
 PATTERNS("php",
 	 "^[ \t]*(((public|private|protected|static|final)[ \t]+)*((class|function)[ \t].*))$",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[fFlL]?|0[xX]?[0-9a-fA-F]+[lL]?"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+[fFlL]?|0[xX]?[[:xdigit:]]+[lL]?"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->"),
 
 PATTERNS("javascript",
-	 "([a-zA-Z_$][a-zA-Z0-9_$]*(\\.[a-zA-Z0-9_$]+)*[ \t]*=[ \t]*function([ \t][a-zA-Z_$][a-zA-Z0-9_$]*)?[^\\{]*)\n"
-	 "([a-zA-Z_$][a-zA-Z0-9_$]*[ \t]*:[ \t]*function([ \t][a-zA-Z_$][a-zA-Z0-9_$]*)?[^\\{]*)\n"
-	 "[^a-zA-Z0-9_\\$](function([ \t][a-zA-Z_$][a-zA-Z0-9_$]*)?[^\\{]*)",
+	 "([[:alpha:]_$][[:alnum:]_$]*(\\.[[:alnum:]_$]+)*[ \t]*=[ \t]*function([ \t][[:alpha:]_$][[:alnum:]_$]*)?[^\\{]*)\n"
+	 "([[:alpha:]_$][[:alnum:]_$]*[ \t]*:[ \t]*function([ \t][[:alpha:]_$][[:alnum:]_$]*)?[^\\{]*)\n"
+	 "[^[:alnum:]_\\$](function([ \t][[:alpha:]_$][[:alnum:]_$]*)?[^\\{]*)",
 	 /* -- */
-	 "[a-zA-Z_][a-zA-Z0-9_]*"
-	 "|[-+0-9.e]+[fFlL]?|0[xX]?[0-9a-fA-F]+[lL]?"
+	 "[[:alpha:]_][[:alnum:]_]*"
+	 "|[-+[[:digit:]].e]+[fFlL]?|0[xX]?[[:xdigit:]]+[lL]?"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->"),
 };
 

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -200,6 +200,48 @@ void test_core_posix__p_regcomp_ignores_global_locale_collate(void)
 #endif
 }
 
+void test_core_posix__p_regcomp_matches_digits_with_locale(void)
+{
+	regex_t preg;
+	char c, str[2];
+
+	try_set_locale(LC_COLLATE);
+	try_set_locale(LC_CTYPE);
+
+	cl_must_pass(p_regcomp(&preg, "[:digit:]", REG_EXTENDED));
+
+	str[1] = '\0';
+	for (c = '0'; c <= '9'; c++) {
+	    str[0] = c;
+	    cl_must_pass(regexec(&preg, str, 0, NULL, 0));
+	}
+
+	regfree(&preg);
+}
+
+void test_core_posix__p_regcomp_matches_alphabet_with_locale(void)
+{
+	regex_t preg;
+	char c, str[2];
+
+	try_set_locale(LC_COLLATE);
+	try_set_locale(LC_CTYPE);
+
+	cl_must_pass(p_regcomp(&preg, "[:alpha:]", REG_EXTENDED));
+
+	str[1] = '\0';
+	for (c = 'a'; c <= 'z'; c++) {
+	    str[0] = c;
+	    cl_must_pass(regexec(&preg, str, 0, NULL, 0));
+	}
+	for (c = 'A'; c <= 'Z'; c++) {
+	    str[0] = c;
+	    cl_must_pass(regexec(&preg, str, 0, NULL, 0));
+	}
+
+	regfree(&preg);
+}
+
 void test_core_posix__p_regcomp_compile_userdiff_regexps(void)
 {
 	size_t idx;

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -164,7 +164,7 @@ void test_core_posix__p_regcomp_ignores_global_locale_ctype(void)
 		cl_fail("Expected locale to be switched to multibyte");
 	}
 
-	p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED);
+	error = p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED);
 	regfree(&preg);
 
 	setlocale(LC_CTYPE, oldlocale);

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -172,6 +172,35 @@ void test_core_posix__p_regcomp_ignores_global_locale_ctype(void)
 	cl_must_pass(error);
 }
 
+void test_core_posix__p_regcomp_ignores_global_locale_collate(void)
+{
+#ifdef GIT_USE_REGCOMP_L
+	regex_t preg;
+	int error = 0;
+
+	const char* oldlocale = setlocale(LC_COLLATE, NULL);
+
+	if (!setlocale(LC_COLLATE, "UTF-8") &&
+	    !setlocale(LC_COLLATE, "c.utf8") &&
+			!setlocale(LC_COLLATE, "en_US.UTF-8"))
+		cl_skip();
+
+	if (MB_CUR_MAX == 1) {
+		setlocale(LC_COLLATE, oldlocale);
+		cl_fail("Expected locale to be switched to multibyte");
+	}
+
+	error = p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED);
+	regfree(&preg);
+
+	setlocale(LC_COLLATE, oldlocale);
+
+	cl_must_pass(error);
+#else
+	cl_skip();
+#endif
+}
+
 void test_core_posix__p_regcomp_compile_userdiff_regexps(void)
 {
 	size_t idx;

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -15,8 +15,12 @@
 #include "posix.h"
 #include "userdiff.h"
 
+static const char *old_locales[LC_ALL];
+
 void test_core_posix__initialize(void)
 {
+	memset(&old_locales, 0, sizeof(old_locales));
+
 #ifdef GIT_WIN32
 	/* on win32, the WSA context needs to be initialized
 	 * before any socket calls can be performed */
@@ -26,6 +30,17 @@ void test_core_posix__initialize(void)
 	cl_assert(LOBYTE(wsd.wVersion) == 2 && HIBYTE(wsd.wVersion) == 2);
 #endif
 }
+
+void test_core_posix__cleanup(void)
+{
+	int i;
+
+	for (i = 0; i < LC_ALL; i++) {
+		if (old_locales[i])
+		    setlocale(LC_COLLATE, old_locales[i]);
+	}
+}
+
 
 static bool supports_ipv6(void)
 {
@@ -147,55 +162,39 @@ void test_core_posix__utimes(void)
 	p_unlink("foo");
 }
 
+static void try_set_locale(int category)
+{
+	old_locales[category] = setlocale(category, NULL);
+
+	if (!setlocale(category, "UTF-8") &&
+	    !setlocale(category, "c.utf8") &&
+	    !setlocale(category, "en_US.UTF-8"))
+		cl_skip();
+
+	if (MB_CUR_MAX == 1)
+		cl_fail("Expected locale to be switched to multibyte");
+}
+
 void test_core_posix__p_regcomp_ignores_global_locale_ctype(void)
 {
 	regex_t preg;
-	int error = 0;
 
-	const char* oldlocale = setlocale(LC_CTYPE, NULL);
+	try_set_locale(LC_CTYPE);
 
-	if (!setlocale(LC_CTYPE, "UTF-8") &&
-	    !setlocale(LC_CTYPE, "c.utf8") &&
-			!setlocale(LC_CTYPE, "en_US.UTF-8"))
-		cl_skip();
+	cl_must_pass(p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED));
 
-	if (MB_CUR_MAX == 1) {
-		setlocale(LC_CTYPE, oldlocale);
-		cl_fail("Expected locale to be switched to multibyte");
-	}
-
-	error = p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED);
 	regfree(&preg);
-
-	setlocale(LC_CTYPE, oldlocale);
-
-	cl_must_pass(error);
 }
 
 void test_core_posix__p_regcomp_ignores_global_locale_collate(void)
 {
 #ifdef GIT_USE_REGCOMP_L
 	regex_t preg;
-	int error = 0;
 
-	const char* oldlocale = setlocale(LC_COLLATE, NULL);
+	try_set_locale(LC_COLLATE);
+	cl_must_pass(p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED));
 
-	if (!setlocale(LC_COLLATE, "UTF-8") &&
-	    !setlocale(LC_COLLATE, "c.utf8") &&
-			!setlocale(LC_COLLATE, "en_US.UTF-8"))
-		cl_skip();
-
-	if (MB_CUR_MAX == 1) {
-		setlocale(LC_COLLATE, oldlocale);
-		cl_fail("Expected locale to be switched to multibyte");
-	}
-
-	error = p_regcomp(&preg, "[\xc0-\xff][\x80-\xbf]", REG_EXTENDED);
 	regfree(&preg);
-
-	setlocale(LC_COLLATE, oldlocale);
-
-	cl_must_pass(error);
 #else
 	cl_skip();
 #endif


### PR DESCRIPTION
This is inspired by #4528, where we do fail certain regexes when LC_COLLATE is being set to something other than the default. This is unfortunate, and I actually wasn't able to come up with a satisfying solution. Pulling the following message from my commits. Feedback and ideas would be highly appreciated.

---

Our user diff patterns make heavy use of range notation (e.g. "[a-z]")
which are being passed to `regcomp`. Problem is though that these ranges
heavily depend on locale value of LC_COLLATE, as these ranges might be
different depending on the language. This is why character classes like
[:alnum:], [:digit:] etc. exist for regular expressions, which easily
fix the problem in a locale-independent way.

Convert our user patterns to use these character classes instead.
There's two problems, though:

1. The character classes might include characters which are not allowed
   in an actual function name. E.g. if the current language has any
   weird UTF8 characters which belong to the alphabet of that language,
   we may get invalid matches for these regexes.

2. We have inherited a catch-all word delimiter from git.git, which
   catches multibyte characters not part of ASCII with the high-bit set.
   git.git does this to ensure that unmatched words are not being
   treated as whitespace-only changes and thus not be shown. With
   LC_COLLATE set to a non-C locale, the pattern
   "[\xc0-\xff][\x80-\xbf]+" will actually cause the regex compilation
   to fail. See git.git, commit 664d44ee7 (userdiff: simplify word-diff
   safeguard, 2011-01-11).

   There are multiple possibilities here:

   - Just bail on systems without `regcomp_l`. By default, we use
     `regcomp_l` and pass it no locale, which instructs it to use the
     default locale. This is the best-case scenario. Unfortunately,
     `regcomp_l` is not specified by POSIX and thus is missing on many
     systems.

   - We could obviously open-code it and just write down the complete
     range of characters, but this is _very_ unhandy.

   - We could instruct callers to never set LC_COLLATE to something
     other than the C locale. But this is simply won't work out, and
     expecting callers to always do a `setlocale` dance around calls to
     libgit2 is not going to fly well.

   - Otherwise, there is not much to help us. The only option remaining
     is to remove this range altogether and rely on the calling program
     to correctly set up locales. In this case, we might be lucky and
     all characters with the high-bit set will be matched by the
     respective character classes. But... yeah.

   Nothing is really satisfying at all. This commit uses the last
   option, as it seems to be the least likely to upset everybody.