### PR TITLE
Custom memory allocators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ v0.27 + 1
 
 ### API additions
 
+* You can now swap out memory allocators via the
+  `GIT_OPT_SET_ALLOCATOR` option with `git_libgit2_opts()`.
+
 ### API removals
 
 ### Breaking API changes

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -183,6 +183,7 @@ typedef enum {
 	GIT_OPT_GET_WINDOWS_SHAREMODE,
 	GIT_OPT_SET_WINDOWS_SHAREMODE,
 	GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION,
+	GIT_OPT_SET_ALLOCATOR
 } git_libgit2_opt_t;
 
 /**
@@ -344,6 +345,12 @@ typedef enum {
  *		> objects from disk. This may impact performance due to an
  *		> additional checksum calculation on each object. This defaults
  *		> to enabled.
+ *
+ *	 opts(GIT_OPT_SET_ALLOCATOR, git_allocator *allocator)
+ *
+ *		> Set the memory allocator to a different memory allocator. This
+ *		> allocator will then be used to make all memory allocations for
+ *		> libgit2 operations.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/include/git2/sys/alloc.h
+++ b/include/git2/sys/alloc.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_sys_git_alloc_h__
+#define INCLUDE_sys_git_alloc_h__
+
+#include "git2/common.h"
+
+GIT_BEGIN_DECL
+
+/**
+ * An instance for a custom memory allocator
+ *
+ * Setting the pointers of this structure allows the developer to implement
+ * custom memory allocators. The global memory allocator can be set by using
+ * "GIT_OPT_SET_ALLOCATOR" with the `git_libgit2_opts` function. Keep in mind
+ * that all fields need to be set to a proper function.
+ */
+typedef struct {
+	/* Allocate `n` bytes of memory */
+	void *(*gmalloc)(size_t n, const char *file, int line);
+
+	/*
+	 * Allocate memory for an array of `nelem` elements, where each element
+	 * has a size of `elsize`. Returned memory shall be initialized to
+	 * all-zeroes
+	 */
+	void *(*gcalloc)(size_t nelem, size_t elsize, const char *file, int line);
+
+	/* Allocate memory for the string `str` and duplicate its contents. */
+	char *(*gstrdup)(const char *str, const char *file, int line);
+
+	/*
+	 * Equivalent to the `gstrdup` function, but only duplicating at most
+	 * `n + 1` bytes
+	 */
+	char *(*gstrndup)(const char *str, size_t n, const char *file, int line);
+
+	/*
+	 * Equivalent to `gstrndup`, but will always duplicate exactly `n` bytes
+	 * of `str`. Thus, out of bounds reads at `str` may happen.
+	 */
+	char *(*gsubstrdup)(const char *str, size_t n, const char *file, int line);
+
+	/*
+	 * This function shall deallocate the old object `ptr` and return a
+	 * pointer to a new object that has the size specified by `size`. In
+	 * case `ptr` is `NULL`, a new array shall be allocated.
+	 */
+	void *(*grealloc)(void *ptr, size_t size, const char *file, int line);
+
+	/*
+	 * This function shall be equivalent to `grealloc`, but allocating
+	 * `neleme * elsize` bytes.
+	 */
+	void *(*greallocarray)(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
+
+	/*
+	 * This function shall allocate a new array of `nelem` elements, where
+	 * each element has a size of `elsize` bytes.
+	 */
+	void *(*gmallocarray)(size_t nelem, size_t elsize, const char *file, int line);
+
+	/*
+	 * This function shall free the memory pointed to by `ptr`. In case
+	 * `ptr` is `NULL`, this shall be a no-op.
+	 */
+	void (*gfree)(void *ptr);
+} git_allocator;
+
+GIT_END_DECL
+
+#endif

--- a/include/git2/sys/alloc.h
+++ b/include/git2/sys/alloc.h
@@ -72,6 +72,30 @@ typedef struct {
 	void (*gfree)(void *ptr);
 } git_allocator;
 
+/**
+ * Initialize the allocator structure to use the `stdalloc` pointer.
+ *
+ * Set up the structure so that all of its members are using the standard
+ * "stdalloc" allocator functions. The structure can then be used with
+ * `git_allocator_setup`.
+ *
+ * @param allocator The allocator that is to be initialized.
+ * @return An error code or 0.
+ */
+int git_stdalloc_init_allocator(git_allocator *allocator);
+
+/**
+ * Initialize the allocator structure to use the `crtdbg` pointer.
+ *
+ * Set up the structure so that all of its members are using the "crtdbg"
+ * allocator functions. Note that this allocator is only available on Windows
+ * platforms and only if libgit2 is being compiled with "-DMSVC_CRTDBG".
+ *
+ * @param allocator The allocator that is to be initialized.
+ * @return An error code or 0.
+ */
+int git_win32_crtdbg_init_allocator(git_allocator *allocator);
+
 GIT_END_DECL
 
 #endif

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -29,3 +29,12 @@ int git_allocator_setup(git_allocator *allocator)
 	memcpy(&git__allocator, allocator, sizeof(*allocator));
 	return 0;
 }
+
+#if !defined(GIT_MSVC_CRTDBG)
+int git_win32_crtdbg_init_allocator(git_allocator *allocator)
+{
+	GIT_UNUSED(allocator);
+	giterr_set(GIT_EINVALID, "crtdbg memory allocator not available");
+	return -1;
+}
+#endif

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "alloc.h"
+
+#if defined(GIT_MSVC_CRTDBG)
+# include "win32/w32_crtdbg_stacktrace.h"
+#else
+# include "stdalloc.h"
+#endif
+
+git_allocator git__allocator;
+
+int git_allocator_global_init(void)
+{
+#if defined(GIT_MSVC_CRTDBG)
+	return git_win32_crtdbg_init_allocator(&git__allocator);
+#else
+	return git_stdalloc_init_allocator(&git__allocator);
+#endif
+}
+
+int git_allocator_setup(git_allocator *allocator)
+{
+	memcpy(&git__allocator, allocator, sizeof(*allocator));
+	return 0;
+}

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -54,14 +54,14 @@
 
 #include "stdalloc.h"
 
-#define git__malloc(len)                      git__stdalloc__malloc(len)
-#define git__calloc(nelem, elsize)            git__stdalloc__calloc(nelem, elsize)
-#define git__strdup(str)                      git__stdalloc__strdup(str)
-#define git__strndup(str, n)                  git__stdalloc__strndup(str, n)
-#define git__substrdup(str, n)                git__stdalloc__substrdup(str, n)
-#define git__realloc(ptr, size)               git__stdalloc__realloc(ptr, size)
-#define git__reallocarray(ptr, nelem, elsize) git__stdalloc__reallocarray(ptr, nelem, elsize)
-#define git__mallocarray(nelem, elsize)       git__stdalloc__mallocarray(nelem, elsize)
+#define git__malloc(len)                      git__stdalloc__malloc(len, __FILE__, __LINE__)
+#define git__calloc(nelem, elsize)            git__stdalloc__calloc(nelem, elsize, __FILE__, __LINE__)
+#define git__strdup(str)                      git__stdalloc__strdup(str, __FILE__, __LINE__)
+#define git__strndup(str, n)                  git__stdalloc__strndup(str, n, __FILE__, __LINE__)
+#define git__substrdup(str, n)                git__stdalloc__substrdup(str, n, __FILE__, __LINE__)
+#define git__realloc(ptr, size)               git__stdalloc__realloc(ptr, size, __FILE__, __LINE__)
+#define git__reallocarray(ptr, nelem, elsize) git__stdalloc__reallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
+#define git__mallocarray(nelem, elsize)       git__stdalloc__mallocarray(nelem, elsize, __FILE__, __LINE__)
 #define git__free                             git__stdalloc__free
 
 #endif /* !MSVC_CTRDBG */

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_alloc_h__
+#define INCLUDE_alloc_h__
+
+#include "common.h"
+
+#if defined(GIT_MSVC_CRTDBG)
+
+/* Enable MSVC CRTDBG memory leak reporting.
+ *
+ * We DO NOT use the "_CRTDBG_MAP_ALLOC" macro described in the MSVC
+ * documentation because all allocs/frees in libgit2 already go through
+ * the "git__" routines defined in this file.  Simply using the normal
+ * reporting mechanism causes all leaks to be attributed to a routine
+ * here in util.h (ie, the actual call to calloc()) rather than the
+ * caller of git__calloc().
+ *
+ * Therefore, we declare a set of "git__crtdbg__" routines to replace
+ * the corresponding "git__" routines and re-define the "git__" symbols
+ * as macros.  This allows us to get and report the file:line info of
+ * the real caller.
+ *
+ * We DO NOT replace the "git__free" routine because it needs to remain
+ * a function pointer because it is used as a function argument when
+ * setting up various structure "destructors".
+ *
+ * We also DO NOT use the "_CRTDBG_MAP_ALLOC" macro because it causes
+ * "free" to be remapped to "_free_dbg" and this causes problems for
+ * structures which define a field named "free".
+ *
+ * Finally, CRTDBG must be explicitly enabled and configured at program
+ * startup.  See tests/main.c for an example.
+ */
+
+#include "win32/w32_crtdbg_stacktrace.h"
+
+#define git__malloc(len)                      git__crtdbg__malloc(len, __FILE__, __LINE__)
+#define git__calloc(nelem, elsize)            git__crtdbg__calloc(nelem, elsize, __FILE__, __LINE__)
+#define git__strdup(str)                      git__crtdbg__strdup(str, __FILE__, __LINE__)
+#define git__strndup(str, n)                  git__crtdbg__strndup(str, n, __FILE__, __LINE__)
+#define git__substrdup(str, n)                git__crtdbg__substrdup(str, n, __FILE__, __LINE__)
+#define git__realloc(ptr, size)               git__crtdbg__realloc(ptr, size, __FILE__, __LINE__)
+#define git__reallocarray(ptr, nelem, elsize) git__crtdbg__reallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
+#define git__mallocarray(nelem, elsize)       git__crtdbg__mallocarray(nelem, elsize, __FILE__, __LINE__)
+#define git__free                             git__crtdbg__free
+
+#else
+
+#include "stdalloc.h"
+
+#define git__malloc(len)                      git__stdalloc__malloc(len)
+#define git__calloc(nelem, elsize)            git__stdalloc__calloc(nelem, elsize)
+#define git__strdup(str)                      git__stdalloc__strdup(str)
+#define git__strndup(str, n)                  git__stdalloc__strndup(str, n)
+#define git__substrdup(str, n)                git__stdalloc__substrdup(str, n)
+#define git__realloc(ptr, size)               git__stdalloc__realloc(ptr, size)
+#define git__reallocarray(ptr, nelem, elsize) git__stdalloc__reallocarray(ptr, nelem, elsize)
+#define git__mallocarray(nelem, elsize)       git__stdalloc__mallocarray(nelem, elsize)
+#define git__free                             git__stdalloc__free
+
+#endif /* !MSVC_CTRDBG */
+
+#endif

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -8,62 +8,33 @@
 #ifndef INCLUDE_alloc_h__
 #define INCLUDE_alloc_h__
 
-#include "common.h"
+#include "git2/sys/alloc.h"
 
-#if defined(GIT_MSVC_CRTDBG)
+extern git_allocator git__allocator;
 
-/* Enable MSVC CRTDBG memory leak reporting.
- *
- * We DO NOT use the "_CRTDBG_MAP_ALLOC" macro described in the MSVC
- * documentation because all allocs/frees in libgit2 already go through
- * the "git__" routines defined in this file.  Simply using the normal
- * reporting mechanism causes all leaks to be attributed to a routine
- * here in util.h (ie, the actual call to calloc()) rather than the
- * caller of git__calloc().
- *
- * Therefore, we declare a set of "git__crtdbg__" routines to replace
- * the corresponding "git__" routines and re-define the "git__" symbols
- * as macros.  This allows us to get and report the file:line info of
- * the real caller.
- *
- * We DO NOT replace the "git__free" routine because it needs to remain
- * a function pointer because it is used as a function argument when
- * setting up various structure "destructors".
- *
- * We also DO NOT use the "_CRTDBG_MAP_ALLOC" macro because it causes
- * "free" to be remapped to "_free_dbg" and this causes problems for
- * structures which define a field named "free".
- *
- * Finally, CRTDBG must be explicitly enabled and configured at program
- * startup.  See tests/main.c for an example.
+#define git__malloc(len)                      git__allocator.gmalloc(len, __FILE__, __LINE__)
+#define git__calloc(nelem, elsize)            git__allocator.gcalloc(nelem, elsize, __FILE__, __LINE__)
+#define git__strdup(str)                      git__allocator.gstrdup(str, __FILE__, __LINE__)
+#define git__strndup(str, n)                  git__allocator.gstrndup(str, n, __FILE__, __LINE__)
+#define git__substrdup(str, n)                git__allocator.gsubstrdup(str, n, __FILE__, __LINE__)
+#define git__realloc(ptr, size)               git__allocator.grealloc(ptr, size, __FILE__, __LINE__)
+#define git__reallocarray(ptr, nelem, elsize) git__allocator.greallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
+#define git__mallocarray(nelem, elsize)       git__allocator.gmallocarray(nelem, elsize, __FILE__, __LINE__)
+#define git__free                             git__allocator.gfree
+
+/**
+ * This function is being called by our global setup routines to
+ * initialize the standard allocator.
  */
+int git_allocator_global_init(void);
 
-#include "win32/w32_crtdbg_stacktrace.h"
-
-#define git__malloc(len)                      git__crtdbg__malloc(len, __FILE__, __LINE__)
-#define git__calloc(nelem, elsize)            git__crtdbg__calloc(nelem, elsize, __FILE__, __LINE__)
-#define git__strdup(str)                      git__crtdbg__strdup(str, __FILE__, __LINE__)
-#define git__strndup(str, n)                  git__crtdbg__strndup(str, n, __FILE__, __LINE__)
-#define git__substrdup(str, n)                git__crtdbg__substrdup(str, n, __FILE__, __LINE__)
-#define git__realloc(ptr, size)               git__crtdbg__realloc(ptr, size, __FILE__, __LINE__)
-#define git__reallocarray(ptr, nelem, elsize) git__crtdbg__reallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
-#define git__mallocarray(nelem, elsize)       git__crtdbg__mallocarray(nelem, elsize, __FILE__, __LINE__)
-#define git__free                             git__crtdbg__free
-
-#else
-
-#include "stdalloc.h"
-
-#define git__malloc(len)                      git__stdalloc__malloc(len, __FILE__, __LINE__)
-#define git__calloc(nelem, elsize)            git__stdalloc__calloc(nelem, elsize, __FILE__, __LINE__)
-#define git__strdup(str)                      git__stdalloc__strdup(str, __FILE__, __LINE__)
-#define git__strndup(str, n)                  git__stdalloc__strndup(str, n, __FILE__, __LINE__)
-#define git__substrdup(str, n)                git__stdalloc__substrdup(str, n, __FILE__, __LINE__)
-#define git__realloc(ptr, size)               git__stdalloc__realloc(ptr, size, __FILE__, __LINE__)
-#define git__reallocarray(ptr, nelem, elsize) git__stdalloc__reallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
-#define git__mallocarray(nelem, elsize)       git__stdalloc__mallocarray(nelem, elsize, __FILE__, __LINE__)
-#define git__free                             git__stdalloc__free
-
-#endif /* !MSVC_CTRDBG */
+/**
+ * Switch out libgit2's global memory allocator
+ *
+ * @param allocator The new allocator that should be used. All function pointers
+ *                  of it need to be set correctly.
+ * @return An error code or 0.
+ */
+int git_allocator_setup(git_allocator *allocator);
 
 #endif

--- a/src/global.c
+++ b/src/global.c
@@ -7,6 +7,7 @@
 
 #include "global.h"
 
+#include "alloc.h"
 #include "hash.h"
 #include "sysdir.h"
 #include "filter.h"
@@ -60,7 +61,8 @@ static int init_common(void)
 #endif
 
 	/* Initialize any other subsystems that have global state */
-	if ((ret = git_hash_global_init()) == 0 &&
+	if ((ret = git_allocator_global_init()) == 0 &&
+		(ret = git_hash_global_init()) == 0 &&
 		(ret = git_sysdir_global_init()) == 0 &&
 		(ret = git_filter_global_init()) == 0 &&
 		(ret = git_merge_driver_global_init()) == 0 &&

--- a/src/settings.c
+++ b/src/settings.c
@@ -16,6 +16,7 @@
 #endif
 
 #include <git2.h>
+#include "alloc.h"
 #include "sysdir.h"
 #include "cache.h"
 #include "global.h"
@@ -258,6 +259,10 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION:
 		git_odb__strict_hash_verification = (va_arg(ap, int) != 0);
+		break;
+
+	case GIT_OPT_SET_ALLOCATOR:
+		error = git_allocator_setup(va_arg(ap, git_allocator *));
 		break;
 
 	default:

--- a/src/stdalloc.c
+++ b/src/stdalloc.c
@@ -7,28 +7,40 @@
 
 #include "stdalloc.h"
 
-void *git__stdalloc__malloc(size_t len)
+void *git__stdalloc__malloc(size_t len, const char *file, int line)
 {
 	void *ptr = malloc(len);
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
 	if (!ptr) giterr_set_oom();
 	return ptr;
 }
 
-void *git__stdalloc__calloc(size_t nelem, size_t elsize)
+void *git__stdalloc__calloc(size_t nelem, size_t elsize, const char *file, int line)
 {
 	void *ptr = calloc(nelem, elsize);
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
 	if (!ptr) giterr_set_oom();
 	return ptr;
 }
 
-char *git__stdalloc__strdup(const char *str)
+char *git__stdalloc__strdup(const char *str, const char *file, int line)
 {
 	char *ptr = strdup(str);
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
 	if (!ptr) giterr_set_oom();
 	return ptr;
 }
 
-char *git__stdalloc__strndup(const char *str, size_t n)
+char *git__stdalloc__strndup(const char *str, size_t n, const char *file, int line)
 {
 	size_t length = 0, alloclength;
 	char *ptr;
@@ -36,7 +48,7 @@ char *git__stdalloc__strndup(const char *str, size_t n)
 	length = p_strnlen(str, n);
 
 	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
-		!(ptr = git__stdalloc__malloc(alloclength)))
+		!(ptr = git__stdalloc__malloc(alloclength, file, line)))
 		return NULL;
 
 	if (length)
@@ -47,13 +59,13 @@ char *git__stdalloc__strndup(const char *str, size_t n)
 	return ptr;
 }
 
-char *git__stdalloc__substrdup(const char *start, size_t n)
+char *git__stdalloc__substrdup(const char *start, size_t n, const char *file, int line)
 {
 	char *ptr;
 	size_t alloclen;
 
 	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
-		!(ptr = git__stdalloc__malloc(alloclen)))
+		!(ptr = git__stdalloc__malloc(alloclen, file, line)))
 		return NULL;
 
 	memcpy(ptr, start, n);
@@ -61,23 +73,31 @@ char *git__stdalloc__substrdup(const char *start, size_t n)
 	return ptr;
 }
 
-void *git__stdalloc__realloc(void *ptr, size_t size)
+void *git__stdalloc__realloc(void *ptr, size_t size, const char *file, int line)
 {
 	void *new_ptr = realloc(ptr, size);
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
 	if (!new_ptr) giterr_set_oom();
 	return new_ptr;
 }
 
-void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize)
+void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
 {
 	size_t newsize;
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
 	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
 		NULL : realloc(ptr, newsize);
 }
 
-void *git__stdalloc__mallocarray(size_t nelem, size_t elsize)
+void *git__stdalloc__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
 {
-	return git__stdalloc__reallocarray(NULL, nelem, elsize);
+	return git__stdalloc__reallocarray(NULL, nelem, elsize, file, line);
 }
 
 void git__stdalloc__free(void *ptr)

--- a/src/stdalloc.c
+++ b/src/stdalloc.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "stdalloc.h"
+
+void *git__stdalloc__malloc(size_t len)
+{
+	void *ptr = malloc(len);
+	if (!ptr) giterr_set_oom();
+	return ptr;
+}
+
+void *git__stdalloc__calloc(size_t nelem, size_t elsize)
+{
+	void *ptr = calloc(nelem, elsize);
+	if (!ptr) giterr_set_oom();
+	return ptr;
+}
+
+char *git__stdalloc__strdup(const char *str)
+{
+	char *ptr = strdup(str);
+	if (!ptr) giterr_set_oom();
+	return ptr;
+}
+
+char *git__stdalloc__strndup(const char *str, size_t n)
+{
+	size_t length = 0, alloclength;
+	char *ptr;
+
+	length = p_strnlen(str, n);
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
+		!(ptr = git__stdalloc__malloc(alloclength)))
+		return NULL;
+
+	if (length)
+		memcpy(ptr, str, length);
+
+	ptr[length] = '\0';
+
+	return ptr;
+}
+
+char *git__stdalloc__substrdup(const char *start, size_t n)
+{
+	char *ptr;
+	size_t alloclen;
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
+		!(ptr = git__stdalloc__malloc(alloclen)))
+		return NULL;
+
+	memcpy(ptr, start, n);
+	ptr[n] = '\0';
+	return ptr;
+}
+
+void *git__stdalloc__realloc(void *ptr, size_t size)
+{
+	void *new_ptr = realloc(ptr, size);
+	if (!new_ptr) giterr_set_oom();
+	return new_ptr;
+}
+
+void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize)
+{
+	size_t newsize;
+	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
+		NULL : realloc(ptr, newsize);
+}
+
+void *git__stdalloc__mallocarray(size_t nelem, size_t elsize)
+{
+	return git__stdalloc__reallocarray(NULL, nelem, elsize);
+}
+
+void git__stdalloc__free(void *ptr)
+{
+	free(ptr);
+}

--- a/src/stdalloc.h
+++ b/src/stdalloc.h
@@ -15,25 +15,25 @@
  * that set error code and error message
  * on allocation failure
  */
-void *git__stdalloc__malloc(size_t len);
-void *git__stdalloc__calloc(size_t nelem, size_t elsize);
-char *git__stdalloc__strdup(const char *str);
-char *git__stdalloc__strndup(const char *str, size_t n);
+void *git__stdalloc__malloc(size_t len, const char *file, int line);
+void *git__stdalloc__calloc(size_t nelem, size_t elsize, const char *file, int line);
+char *git__stdalloc__strdup(const char *str, const char *file, int line);
+char *git__stdalloc__strndup(const char *str, size_t n, const char *file, int line);
 /* NOTE: This doesn't do null or '\0' checking.  Watch those boundaries! */
-char *git__stdalloc__substrdup(const char *start, size_t n);
-void *git__stdalloc__realloc(void *ptr, size_t size);
+char *git__stdalloc__substrdup(const char *start, size_t n, const char *file, int line);
+void *git__stdalloc__realloc(void *ptr, size_t size, const char *file, int line);
 
 /**
  * Similar to `git__stdalloc__realloc`, except that it is suitable for reallocing an
  * array to a new number of elements of `nelem`, each of size `elsize`.
  * The total size calculation is checked for overflow.
  */
-void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize);
+void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
 
 /**
  * Similar to `git__stdalloc__calloc`, except that it does not zero memory.
  */
-void *git__stdalloc__mallocarray(size_t nelem, size_t elsize);
+void *git__stdalloc__mallocarray(size_t nelem, size_t elsize, const char *file, int line);
 
 void git__stdalloc__free(void *ptr);
 

--- a/src/stdalloc.h
+++ b/src/stdalloc.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_stdalloc_h__
+#define INCLUDE_stdalloc_h__
+
+#include "common.h"
+
+/*
+ * Custom memory allocation wrappers
+ * that set error code and error message
+ * on allocation failure
+ */
+void *git__stdalloc__malloc(size_t len);
+void *git__stdalloc__calloc(size_t nelem, size_t elsize);
+char *git__stdalloc__strdup(const char *str);
+char *git__stdalloc__strndup(const char *str, size_t n);
+/* NOTE: This doesn't do null or '\0' checking.  Watch those boundaries! */
+char *git__stdalloc__substrdup(const char *start, size_t n);
+void *git__stdalloc__realloc(void *ptr, size_t size);
+
+/**
+ * Similar to `git__stdalloc__realloc`, except that it is suitable for reallocing an
+ * array to a new number of elements of `nelem`, each of size `elsize`.
+ * The total size calculation is checked for overflow.
+ */
+void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize);
+
+/**
+ * Similar to `git__stdalloc__calloc`, except that it does not zero memory.
+ */
+void *git__stdalloc__mallocarray(size_t nelem, size_t elsize);
+
+void git__stdalloc__free(void *ptr);
+
+#endif

--- a/src/stdalloc.h
+++ b/src/stdalloc.h
@@ -8,33 +8,10 @@
 #ifndef INCLUDE_stdalloc_h__
 #define INCLUDE_stdalloc_h__
 
+#include "alloc.h"
+
 #include "common.h"
 
-/*
- * Custom memory allocation wrappers
- * that set error code and error message
- * on allocation failure
- */
-void *git__stdalloc__malloc(size_t len, const char *file, int line);
-void *git__stdalloc__calloc(size_t nelem, size_t elsize, const char *file, int line);
-char *git__stdalloc__strdup(const char *str, const char *file, int line);
-char *git__stdalloc__strndup(const char *str, size_t n, const char *file, int line);
-/* NOTE: This doesn't do null or '\0' checking.  Watch those boundaries! */
-char *git__stdalloc__substrdup(const char *start, size_t n, const char *file, int line);
-void *git__stdalloc__realloc(void *ptr, size_t size, const char *file, int line);
-
-/**
- * Similar to `git__stdalloc__realloc`, except that it is suitable for reallocing an
- * array to a new number of elements of `nelem`, each of size `elsize`.
- * The total size calculation is checked for overflow.
- */
-void *git__stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
-
-/**
- * Similar to `git__stdalloc__calloc`, except that it does not zero memory.
- */
-void *git__stdalloc__mallocarray(size_t nelem, size_t elsize, const char *file, int line);
-
-void git__stdalloc__free(void *ptr);
+int git_stdalloc_init_allocator(git_allocator *allocator);
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -79,6 +79,7 @@
 #define git__realloc(ptr, size)               git__crtdbg__realloc(ptr, size, __FILE__, __LINE__)
 #define git__reallocarray(ptr, nelem, elsize) git__crtdbg__reallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
 #define git__mallocarray(nelem, elsize)       git__crtdbg__mallocarray(nelem, elsize, __FILE__, __LINE__)
+#define git__free                             git__crtdbg__free
 
 #else
 
@@ -169,12 +170,12 @@ GIT_INLINE(void *) git__mallocarray(size_t nelem, size_t elsize)
 	return git__reallocarray(NULL, nelem, elsize);
 }
 
-#endif /* !MSVC_CTRDBG */
-
 GIT_INLINE(void) git__free(void *ptr)
 {
 	free(ptr);
 }
+
+#endif /* !MSVC_CTRDBG */
 
 #define STRCMP_CASESELECT(IGNORE_CASE, STR1, STR2) \
 	((IGNORE_CASE) ? strcasecmp((STR1), (STR2)) : strcmp((STR1), (STR2)))

--- a/src/util.h
+++ b/src/util.h
@@ -41,62 +41,6 @@
  */
 #define CONST_STRLEN(x) ((sizeof(x)/sizeof(x[0])) - 1)
 
-#if defined(GIT_MSVC_CRTDBG)
-
-/* Enable MSVC CRTDBG memory leak reporting.
- *
- * We DO NOT use the "_CRTDBG_MAP_ALLOC" macro described in the MSVC
- * documentation because all allocs/frees in libgit2 already go through
- * the "git__" routines defined in this file.  Simply using the normal
- * reporting mechanism causes all leaks to be attributed to a routine
- * here in util.h (ie, the actual call to calloc()) rather than the
- * caller of git__calloc().
- *
- * Therefore, we declare a set of "git__crtdbg__" routines to replace
- * the corresponding "git__" routines and re-define the "git__" symbols
- * as macros.  This allows us to get and report the file:line info of
- * the real caller.
- *
- * We DO NOT replace the "git__free" routine because it needs to remain
- * a function pointer because it is used as a function argument when
- * setting up various structure "destructors".
- *
- * We also DO NOT use the "_CRTDBG_MAP_ALLOC" macro because it causes
- * "free" to be remapped to "_free_dbg" and this causes problems for
- * structures which define a field named "free".
- *
- * Finally, CRTDBG must be explicitly enabled and configured at program
- * startup.  See tests/main.c for an example.
- */
-
-#include "win32/w32_crtdbg_stacktrace.h"
-
-#define git__malloc(len)                      git__crtdbg__malloc(len, __FILE__, __LINE__)
-#define git__calloc(nelem, elsize)            git__crtdbg__calloc(nelem, elsize, __FILE__, __LINE__)
-#define git__strdup(str)                      git__crtdbg__strdup(str, __FILE__, __LINE__)
-#define git__strndup(str, n)                  git__crtdbg__strndup(str, n, __FILE__, __LINE__)
-#define git__substrdup(str, n)                git__crtdbg__substrdup(str, n, __FILE__, __LINE__)
-#define git__realloc(ptr, size)               git__crtdbg__realloc(ptr, size, __FILE__, __LINE__)
-#define git__reallocarray(ptr, nelem, elsize) git__crtdbg__reallocarray(ptr, nelem, elsize, __FILE__, __LINE__)
-#define git__mallocarray(nelem, elsize)       git__crtdbg__mallocarray(nelem, elsize, __FILE__, __LINE__)
-#define git__free                             git__crtdbg__free
-
-#else
-
-#include "stdalloc.h"
-
-#define git__malloc(len)                      git__stdalloc__malloc(len)
-#define git__calloc(nelem, elsize)            git__stdalloc__calloc(nelem, elsize)
-#define git__strdup(str)                      git__stdalloc__strdup(str)
-#define git__strndup(str, n)                  git__stdalloc__strndup(str, n)
-#define git__substrdup(str, n)                git__stdalloc__substrdup(str, n)
-#define git__realloc(ptr, size)               git__stdalloc__realloc(ptr, size)
-#define git__reallocarray(ptr, nelem, elsize) git__stdalloc__reallocarray(ptr, nelem, elsize)
-#define git__mallocarray(nelem, elsize)       git__stdalloc__mallocarray(nelem, elsize)
-#define git__free                             git__stdalloc__free
-
-#endif /* !MSVC_CTRDBG */
-
 #define STRCMP_CASESELECT(IGNORE_CASE, STR1, STR2) \
 	((IGNORE_CASE) ? strcasecmp((STR1), (STR2)) : strcmp((STR1), (STR2)))
 
@@ -473,5 +417,7 @@ GIT_INLINE(double) git__timer(void)
 #endif
 
 extern int git__getenv(git_buf *out, const char *name);
+
+#include "alloc.h"
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -83,97 +83,17 @@
 
 #else
 
-/*
- * Custom memory allocation wrappers
- * that set error code and error message
- * on allocation failure
- */
-GIT_INLINE(void *) git__malloc(size_t len)
-{
-	void *ptr = malloc(len);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
+#include "stdalloc.h"
 
-GIT_INLINE(void *) git__calloc(size_t nelem, size_t elsize)
-{
-	void *ptr = calloc(nelem, elsize);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(char *) git__strdup(const char *str)
-{
-	char *ptr = strdup(str);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(char *) git__strndup(const char *str, size_t n)
-{
-	size_t length = 0, alloclength;
-	char *ptr;
-
-	length = p_strnlen(str, n);
-
-	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
-		!(ptr = git__malloc(alloclength)))
-		return NULL;
-
-	if (length)
-		memcpy(ptr, str, length);
-
-	ptr[length] = '\0';
-
-	return ptr;
-}
-
-/* NOTE: This doesn't do null or '\0' checking.  Watch those boundaries! */
-GIT_INLINE(char *) git__substrdup(const char *start, size_t n)
-{
-	char *ptr;
-	size_t alloclen;
-
-	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
-		!(ptr = git__malloc(alloclen)))
-		return NULL;
-
-	memcpy(ptr, start, n);
-	ptr[n] = '\0';
-	return ptr;
-}
-
-GIT_INLINE(void *) git__realloc(void *ptr, size_t size)
-{
-	void *new_ptr = realloc(ptr, size);
-	if (!new_ptr) giterr_set_oom();
-	return new_ptr;
-}
-
-/**
- * Similar to `git__realloc`, except that it is suitable for reallocing an
- * array to a new number of elements of `nelem`, each of size `elsize`.
- * The total size calculation is checked for overflow.
- */
-GIT_INLINE(void *) git__reallocarray(void *ptr, size_t nelem, size_t elsize)
-{
-	size_t newsize;
-	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
-		NULL : realloc(ptr, newsize);
-}
-
-/**
- * Similar to `git__calloc`, except that it does not zero memory.
- */
-GIT_INLINE(void *) git__mallocarray(size_t nelem, size_t elsize)
-{
-	return git__reallocarray(NULL, nelem, elsize);
-}
-
-GIT_INLINE(void) git__free(void *ptr)
-{
-	free(ptr);
-}
+#define git__malloc(len)                      git__stdalloc__malloc(len)
+#define git__calloc(nelem, elsize)            git__stdalloc__calloc(nelem, elsize)
+#define git__strdup(str)                      git__stdalloc__strdup(str)
+#define git__strndup(str, n)                  git__stdalloc__strndup(str, n)
+#define git__substrdup(str, n)                git__stdalloc__substrdup(str, n)
+#define git__realloc(ptr, size)               git__stdalloc__realloc(ptr, size)
+#define git__reallocarray(ptr, nelem, elsize) git__stdalloc__reallocarray(ptr, nelem, elsize)
+#define git__mallocarray(nelem, elsize)       git__stdalloc__mallocarray(nelem, elsize)
+#define git__free                             git__stdalloc__free
 
 #endif /* !MSVC_CTRDBG */
 

--- a/src/win32/w32_crtdbg_stacktrace.c
+++ b/src/win32/w32_crtdbg_stacktrace.c
@@ -145,6 +145,11 @@ void *git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, in
 	return git__crtdbg__reallocarray(NULL, nelem, elsize, file, line);
 }
 
+void git__crtdbg__free(void *ptr)
+{
+	free(ptr);
+}
+
 /**
  * Compare function for bsearch on g_cs_index table.
  */
@@ -415,4 +420,5 @@ const char *git_win32__crtdbg_stacktrace(int skip, const char *file)
 
 	return result;
 }
+
 #endif

--- a/src/win32/w32_crtdbg_stacktrace.c
+++ b/src/win32/w32_crtdbg_stacktrace.c
@@ -71,28 +71,28 @@ static bool g_limit_reached = false; /* had allocs after we filled row table */
 static unsigned int g_checkpoint_id = 0; /* to better label leak checkpoints */
 static bool g_transient_leaks_since_mark = false; /* payload for hook */
 
-void *git__crtdbg__malloc(size_t len, const char *file, int line)
+static void *crtdbg__malloc(size_t len, const char *file, int line)
 {
 	void *ptr = _malloc_dbg(len, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
 	if (!ptr) giterr_set_oom();
 	return ptr;
 }
 
-void *git__crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line)
+static void *crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line)
 {
 	void *ptr = _calloc_dbg(nelem, elsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
 	if (!ptr) giterr_set_oom();
 	return ptr;
 }
 
-char *git__crtdbg__strdup(const char *str, const char *file, int line)
+static char *crtdbg__strdup(const char *str, const char *file, int line)
 {
 	char *ptr = _strdup_dbg(str, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
 	if (!ptr) giterr_set_oom();
 	return ptr;
 }
 
-char *git__crtdbg__strndup(const char *str, size_t n, const char *file, int line)
+static char *crtdbg__strndup(const char *str, size_t n, const char *file, int line)
 {
 	size_t length = 0, alloclength;
 	char *ptr;
@@ -100,7 +100,7 @@ char *git__crtdbg__strndup(const char *str, size_t n, const char *file, int line
 	length = p_strnlen(str, n);
 
 	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
-		!(ptr = git__crtdbg__malloc(alloclength, file, line)))
+		!(ptr = crtdbg__malloc(alloclength, file, line)))
 		return NULL;
 
 	if (length)
@@ -111,13 +111,13 @@ char *git__crtdbg__strndup(const char *str, size_t n, const char *file, int line
 	return ptr;
 }
 
-char *git__crtdbg__substrdup(const char *start, size_t n, const char *file, int line)
+static char *crtdbg__substrdup(const char *start, size_t n, const char *file, int line)
 {
 	char *ptr;
 	size_t alloclen;
 
 	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
-		!(ptr = git__crtdbg__malloc(alloclen, file, line)))
+		!(ptr = crtdbg__malloc(alloclen, file, line)))
 		return NULL;
 
 	memcpy(ptr, start, n);
@@ -125,14 +125,14 @@ char *git__crtdbg__substrdup(const char *start, size_t n, const char *file, int 
 	return ptr;
 }
 
-void *git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line)
+static void *crtdbg__realloc(void *ptr, size_t size, const char *file, int line)
 {
 	void *new_ptr = _realloc_dbg(ptr, size, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
 	if (!new_ptr) giterr_set_oom();
 	return new_ptr;
 }
 
-void *git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
+static void *crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
 {
 	size_t newsize;
 
@@ -140,14 +140,28 @@ void *git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const ch
 		NULL : _realloc_dbg(ptr, newsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
 }
 
-void *git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
+static void *crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
 {
-	return git__crtdbg__reallocarray(NULL, nelem, elsize, file, line);
+	return crtdbg__reallocarray(NULL, nelem, elsize, file, line);
 }
 
-void git__crtdbg__free(void *ptr)
+static void crtdbg__free(void *ptr)
 {
 	free(ptr);
+}
+
+int git_win32_crtdbg_init_allocator(git_allocator *allocator)
+{
+	allocator->gmalloc = crtdbg__malloc;
+	allocator->gcalloc = crtdbg__calloc;
+	allocator->gstrdup = crtdbg__strdup;
+	allocator->gstrndup = crtdbg__strndup;
+	allocator->gsubstrdup = crtdbg__substrdup;
+	allocator->grealloc = crtdbg__realloc;
+	allocator->greallocarray = crtdbg__reallocarray;
+	allocator->gmallocarray = crtdbg__mallocarray;
+	allocator->gfree = crtdbg__free;
+	return 0;
 }
 
 /**

--- a/src/win32/w32_crtdbg_stacktrace.h
+++ b/src/win32/w32_crtdbg_stacktrace.h
@@ -97,80 +97,14 @@ GIT_EXTERN(int) git_win32__crtdbg_stacktrace__dump(
  */
 const char *git_win32__crtdbg_stacktrace(int skip, const char *file);
 
-GIT_INLINE(void *) git__crtdbg__malloc(size_t len, const char *file, int line)
-{
-	void *ptr = _malloc_dbg(len, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(void *) git__crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line)
-{
-	void *ptr = _calloc_dbg(nelem, elsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(char *) git__crtdbg__strdup(const char *str, const char *file, int line)
-{
-	char *ptr = _strdup_dbg(str, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!ptr) giterr_set_oom();
-	return ptr;
-}
-
-GIT_INLINE(char *) git__crtdbg__strndup(const char *str, size_t n, const char *file, int line)
-{
-	size_t length = 0, alloclength;
-	char *ptr;
-
-	length = p_strnlen(str, n);
-
-	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
-		!(ptr = git__crtdbg__malloc(alloclength, file, line)))
-		return NULL;
-
-	if (length)
-		memcpy(ptr, str, length);
-
-	ptr[length] = '\0';
-
-	return ptr;
-}
-
-GIT_INLINE(char *) git__crtdbg__substrdup(const char *start, size_t n, const char *file, int line)
-{
-	char *ptr;
-	size_t alloclen;
-
-	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
-		!(ptr = git__crtdbg__malloc(alloclen, file, line)))
-		return NULL;
-
-	memcpy(ptr, start, n);
-	ptr[n] = '\0';
-	return ptr;
-}
-
-GIT_INLINE(void *) git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line)
-{
-	void *new_ptr = _realloc_dbg(ptr, size, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-	if (!new_ptr) giterr_set_oom();
-	return new_ptr;
-}
-
-GIT_INLINE(void *) git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
-{
-	size_t newsize;
-
-	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
-		NULL : _realloc_dbg(ptr, newsize, _NORMAL_BLOCK, git_win32__crtdbg_stacktrace(1,file), line);
-}
-
-GIT_INLINE(void *) git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
-{
-	return git__crtdbg__reallocarray(NULL, nelem, elsize, file, line);
-}
-
+void *git__crtdbg__malloc(size_t len, const char *file, int line);
+void *git__crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line);
+char *git__crtdbg__strdup(const char *str, const char *file, int line);
+char *git__crtdbg__strndup(const char *str, size_t n, const char *file, int line);
+char *git__crtdbg__substrdup(const char *start, size_t n, const char *file, int line);
+void *git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line);
+void *git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
+void *git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line);
 
 #endif
 #endif

--- a/src/win32/w32_crtdbg_stacktrace.h
+++ b/src/win32/w32_crtdbg_stacktrace.h
@@ -17,6 +17,34 @@
 #include "git2/errors.h"
 #include "strnlen.h"
 
+/* MSVC CRTDBG memory leak reporting.
+ *
+ * We DO NOT use the "_CRTDBG_MAP_ALLOC" macro described in the MSVC
+ * documentation because all allocs/frees in libgit2 already go through
+ * the "git__" routines defined in this file.  Simply using the normal
+ * reporting mechanism causes all leaks to be attributed to a routine
+ * here in util.h (ie, the actual call to calloc()) rather than the
+ * caller of git__calloc().
+ *
+ * Therefore, we declare a set of "git__crtdbg__" routines to replace
+ * the corresponding "git__" routines and re-define the "git__" symbols
+ * as macros.  This allows us to get and report the file:line info of
+ * the real caller.
+ *
+ * We DO NOT replace the "git__free" routine because it needs to remain
+ * a function pointer because it is used as a function argument when
+ * setting up various structure "destructors".
+ *
+ * We also DO NOT use the "_CRTDBG_MAP_ALLOC" macro because it causes
+ * "free" to be remapped to "_free_dbg" and this causes problems for
+ * structures which define a field named "free".
+ *
+ * Finally, CRTDBG must be explicitly enabled and configured at program
+ * startup.  See tests/main.c for an example.
+ */
+
+int git_win32_crtdbg_init_allocator(git_allocator *allocator);
+
 /**
  * Initialize our memory leak tracking and de-dup data structures.
  * This should ONLY be called by git_libgit2_init().
@@ -96,16 +124,6 @@ GIT_EXTERN(int) git_win32__crtdbg_stacktrace__dump(
  * routines.
  */
 const char *git_win32__crtdbg_stacktrace(int skip, const char *file);
-
-void *git__crtdbg__malloc(size_t len, const char *file, int line);
-void *git__crtdbg__calloc(size_t nelem, size_t elsize, const char *file, int line);
-char *git__crtdbg__strdup(const char *str, const char *file, int line);
-char *git__crtdbg__strndup(const char *str, size_t n, const char *file, int line);
-char *git__crtdbg__substrdup(const char *start, size_t n, const char *file, int line);
-void *git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line);
-void *git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
-void *git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line);
-void *git__crtdbg__free(void *ptr);
 
 #endif
 #endif

--- a/src/win32/w32_crtdbg_stacktrace.h
+++ b/src/win32/w32_crtdbg_stacktrace.h
@@ -105,6 +105,7 @@ char *git__crtdbg__substrdup(const char *start, size_t n, const char *file, int 
 void *git__crtdbg__realloc(void *ptr, size_t size, const char *file, int line);
 void *git__crtdbg__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
 void *git__crtdbg__mallocarray(size_t nelem, size_t elsize, const char *file, int line);
+void *git__crtdbg__free(void *ptr);
 
 #endif
 #endif

--- a/tests/trace/windows/stacktrace.c
+++ b/tests/trace/windows/stacktrace.c
@@ -1,5 +1,6 @@
 #include "clar_libgit2.h"
 #include "win32/w32_stack.h"
+#include "win32/w32_crtdbg_stacktrace.h"
 
 #if defined(GIT_MSVC_CRTDBG)
 static void a(void)


### PR DESCRIPTION
This is an RFC regarding custom memory allocators. Existing standard allocators are being renamed to `git__stdalloc__<fn>`. By default, our usual allocators `git__<fn>` are being defined to `git__stdalloc__<fn>`. For CRTDBG, our allocators `git__<fn>` are being defined to `git__crtdbg__<fn>`.

If the CMake option "PLUGGABLE_ALLOCATORS" is set, we use an indirection. Instead of using typedefs, each of our allocator functions is not a define but instead a function pointer, which is by default set to the respecfive `git__stdalloc__<fn>` function. Our `git_libgit2_opts` function is extended by "GIT_OPT_SET_ALLOCATOR, which receives as argument a `git_allocator` structure. Its members will then be used to change the function pointers.

I don't know whether we really need to distinguish between builds with and without pluggable allocators. The question is whether there's a performance hit when using function pointers. I haven't measured that yet, though. 

The other thing I'm unhappy about is the CRTDBG stuff. It would be rather cool if we could allow users of libgit2 to swap in CRTDBG at runtime, in contrast to how we do it at compile time right now. It would also easily be possible, except for the fact that all CRTDBG functions have two additional parameters to create the correct trace: __LINE__ and __FILE__. We could just extend all our allocators by these parameters. But this could again have a performance penalty, I guess. Again, this needs to be measured.

Anyway. I first want your opinions on these points. The implementation would still need a bit of cleanup. The `git_allocator` stuff should probably be its own module "alloc.{c,h}", but that's minor stuff only.