### PR TITLE
worktree: Read worktree specific reflog for HEAD

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1603,6 +1603,8 @@ static int create_new_reflog_file(const char *filepath)
 
 GIT_INLINE(int) retrieve_reflog_path(git_buf *path, git_repository *repo, const char *name)
 {
+	if (strcmp(name, GIT_HEAD_FILE) == 0)
+		return git_buf_join3(path, '/', repo->gitdir, GIT_REFLOG_DIR, name);
 	return git_buf_join3(path, '/', repo->commondir, GIT_REFLOG_DIR, name);
 }
 

--- a/tests/worktree/reflog.c
+++ b/tests/worktree/reflog.c
@@ -22,6 +22,32 @@ void test_worktree_reflog__cleanup(void)
 	cleanup_fixture_worktree(&fixture);
 }
 
+void test_worktree_reflog__read_worktree_HEAD(void)
+{
+	git_reflog *reflog;
+	const git_reflog_entry *entry;
+
+	cl_git_pass(git_reflog_read(&reflog, fixture.worktree, "HEAD"));
+	cl_assert_equal_i(1, git_reflog_entrycount(reflog));
+
+	entry = git_reflog_entry_byindex(reflog, 0);
+	cl_assert(entry != NULL);
+	cl_assert_equal_s("checkout: moving from 099fabac3a9ea935598528c27f866e34089c2eff to testrepo-worktree", git_reflog_entry_message(entry));
+
+	git_reflog_free(reflog);
+}
+
+void test_worktree_reflog__read_parent_HEAD(void)
+{
+	git_reflog *reflog;
+
+	cl_git_pass(git_reflog_read(&reflog, fixture.repo, "HEAD"));
+	/* there is no logs/HEAD in the parent repo */
+	cl_assert_equal_i(0, git_reflog_entrycount(reflog));
+
+	git_reflog_free(reflog);
+}
+
 void test_worktree_reflog__read(void)
 {
 	git_reflog *reflog;


### PR DESCRIPTION
Wrong reflog for `HEAD` is read for worktree.

Fixes issue #4566.