### PR TITLE
ODB write stream backend prioritization

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1353,12 +1353,14 @@ int git_odb_open_wstream(
 		}
 	}
 
+	if (!writes) {
+		error = git_odb__error_unsupported_in_backend("write object");
+		goto done;
+	}
+
 	if (error < 0) {
 		if (error == GIT_PASSTHROUGH)
 			error = 0;
-		else if (!writes)
-			error = git_odb__error_unsupported_in_backend("write object");
-
 		goto done;
 	}
 


### PR DESCRIPTION
When opening a write stream for the ODB, we loop through each backend
and try to either open it as a normal write stream or, in case
`writestream` has not been implented by the backend, a fake write
stream. The fake write stream simply wraps the backend's `write`
callback. This has the problem though that even if there is a backend
with write streams being supported, we will never use them as long as
there is another backend without a `writestream`, but a `write`
function. This is kind of an awkward interface to use, as it effectively
hinders you to use a lower-prioritized `writestream` only backend for
e.g. streaming out large objects as soon as you have another backend
with simple write support.

Rewrite the logic to make two passes over the list of backends. In the
first pass, we will for each of the backends try to use the
`writestream` function, if it exists. Only in the second pass will we
now try to open a fake write stream. This effectively gives backends
implementing `writestream` a higher priority as every other backend only
implementing `write`. As the most important purpose of using streams is
to help in writing huge objects, this is the right thing to do, as we do
not want to silently fall back on `write`.

---

Inspired by #1146. I don't really know if this PR fixes his request, but I feel like prioritizing any backend which implements `writestream` should be the correct thing to do. This is probably up for discussion, though, as I can see arguments for both sides. Anyway, I'd find it rather unexpected in the case where I e.g. have two backends, one high priority one with write and one with writestream, only, to see that the first one would be opened.

So I'm on the edge, please help :(