### PR TITLE
online::clone: skip creds fallback test

### DIFF
--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -357,15 +357,45 @@ void test_online_clone__bitbucket_style(void)
 	cl_git_pass(git_clone(&g_repo, BB_REPO_URL, "./foo", &g_options));
 	git_repository_free(g_repo); g_repo = NULL;
 	cl_fixture_cleanup("./foo");
+}
 
-	/* User and pass from URL */
-	user_pass.password = "wrong";
+void test_online_clone__bitbucket_uses_creds_in_url(void)
+{
+	git_cred_userpass_payload user_pass = {
+		"libgit2", "wrong"
+	};
+
+	g_options.fetch_opts.callbacks.credentials = git_cred_userpass;
+	g_options.fetch_opts.callbacks.payload = &user_pass;
+
+	/*
+	 * Correct user and pass are in the URL; the (incorrect) creds in
+	 * the `git_cred_userpass_payload` should be ignored.
+	 */
 	cl_git_pass(git_clone(&g_repo, BB_REPO_URL_WITH_PASS, "./foo", &g_options));
 	git_repository_free(g_repo); g_repo = NULL;
 	cl_fixture_cleanup("./foo");
+}
 
-	/* Wrong password in URL, fall back to user_pass */
-	user_pass.password = "libgit2";
+void test_online_clone__bitbucket_falls_back_to_specified_creds(void)
+{
+	git_cred_userpass_payload user_pass = {
+		"libgit2", "libgit2"
+	};
+
+	g_options.fetch_opts.callbacks.credentials = git_cred_userpass;
+	g_options.fetch_opts.callbacks.payload = &user_pass;
+
+	/*
+	 * TODO: as of March 2018, bitbucket sporadically fails with
+	 * 403s instead of replying with a 401 - but only sometimes.
+	 */
+	cl_skip();
+
+	/*
+	 * Incorrect user and pass are in the URL; the (correct) creds in
+	 * the `git_cred_userpass_payload` should be used as a fallback.
+	 */
 	cl_git_pass(git_clone(&g_repo, BB_REPO_URL_WITH_WRONG_PASS, "./foo", &g_options));
 	git_repository_free(g_repo); g_repo = NULL;
 	cl_fixture_cleanup("./foo");


### PR DESCRIPTION
At present, we have three online tests against bitbucket: one which
specifies the credentials in the payload, one which specifies the
correct credentials in the URL and a final one that specifies the
incorrect credentials in the URL.  Bitbucket has begun responding to the
latter test with a 403, which causes us to fail.

Break these three tests into separate tests so that we can skip the
latter until this is resolved on Bitbucket's end or until we can change
the test to a different provider.