### PR TITLE
odb: fix writing to fake write streams

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -369,7 +369,7 @@ static int fake_wstream__write(git_odb_stream *_stream, const char *data, size_t
 {
 	fake_wstream *stream = (fake_wstream *)_stream;
 
-	assert(stream->written + len > stream->size);
+	assert(stream->written + len <= stream->size);
 
 	memcpy(stream->buffer + stream->written, data, len);
 	stream->written += len;

--- a/tests/odb/backend/mempack.c
+++ b/tests/odb/backend/mempack.c
@@ -1,0 +1,52 @@
+#include "clar_libgit2.h"
+#include "repository.h"
+#include "backend_helpers.h"
+#include "git2/sys/mempack.h"
+
+static git_odb *_odb;
+static git_oid _oid;
+static git_odb_object *_obj;
+static git_repository *_repo;
+
+void test_odb_backend_mempack__initialize(void)
+{
+	git_odb_backend *backend;
+
+	cl_git_pass(git_mempack_new(&backend));
+	cl_git_pass(git_odb_new(&_odb));
+	cl_git_pass(git_odb_add_backend(_odb, backend, 10));
+	cl_git_pass(git_repository_wrap_odb(&_repo, _odb));
+}
+
+void test_odb_backend_mempack__cleanup(void)
+{
+	git_odb_object_free(_obj);
+	git_odb_free(_odb);
+	git_repository_free(_repo);
+}
+
+void test_odb_backend_mempack__write_succeeds(void)
+{
+	const char *data = "data";
+	cl_git_pass(git_odb_write(&_oid, _odb, data, strlen(data) + 1, GIT_OBJ_BLOB));
+	cl_git_pass(git_odb_read(&_obj, _odb, &_oid));
+}
+
+void test_odb_backend_mempack__read_of_missing_object_fails(void)
+{
+	cl_git_pass(git_oid_fromstr(&_oid, "f6ea0495187600e7b2288c8ac19c5886383a4633"));
+	cl_git_fail_with(GIT_ENOTFOUND, git_odb_read(&_obj, _odb, &_oid));
+}
+
+void test_odb_backend_mempack__exists_of_missing_object_fails(void)
+{
+	cl_git_pass(git_oid_fromstr(&_oid, "f6ea0495187600e7b2288c8ac19c5886383a4633"));
+	cl_assert(git_odb_exists(_odb, &_oid) == 0);
+}
+
+void test_odb_backend_mempack__exists_with_existing_objects_succeeds(void)
+{
+	const char *data = "data";
+	cl_git_pass(git_odb_write(&_oid, _odb, data, strlen(data) + 1, GIT_OBJ_BLOB));
+	cl_assert(git_odb_exists(_odb, &_oid) == 1);
+}

--- a/tests/odb/backend/mempack.c
+++ b/tests/odb/backend/mempack.c
@@ -50,3 +50,11 @@ void test_odb_backend_mempack__exists_with_existing_objects_succeeds(void)
 	cl_git_pass(git_odb_write(&_oid, _odb, data, strlen(data) + 1, GIT_OBJ_BLOB));
 	cl_assert(git_odb_exists(_odb, &_oid) == 1);
 }
+
+void test_odb_backend_mempack__blob_create_frombuffer_succeeds(void)
+{
+	const char *data = "data";
+
+	cl_git_pass(git_blob_create_frombuffer(&_oid, _repo, data, strlen(data) + 1));
+	cl_assert(git_odb_exists(_odb, &_oid) == 1);
+}


### PR DESCRIPTION
In commit 7ec7aa4 (odb: assert on logic errors when writing objects,
2018-02-01), the check for whether we are trying to overflowing the fake
stream buffer was changed from returning an error to raising an assert.
The conversion forgot though that the logic around `assert`s are
basically inverted. Previously, if the statement

    stream->written + len > steram->size

evaluated to true, we would return a `-1`. Now we are asserting that
this statement is true, and in case it is not we will raise an error. So
the conversion to the `assert` in fact changed the behaviour to the
complete opposite intention.

Fix the assert by inverting its condition again and add a regression
test.

---

/cc @ethomson 