### PR TITLE
 transports: ssh: disconnect session before freeing it 

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -490,7 +490,7 @@ static int _git_ssh_session_create(
 	}
 
 	do {
-		rc = libssh2_session_startup(s, socket->s);
+		rc = libssh2_session_handshake(s, socket->s);
 	} while (LIBSSH2_ERROR_EAGAIN == rc || LIBSSH2_ERROR_TIMEOUT == rc);
 
 	if (rc != LIBSSH2_ERROR_NONE) {

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -212,6 +212,7 @@ static void ssh_stream_free(git_smart_subtransport_stream *stream)
 	}
 
 	if (s->session) {
+		libssh2_session_disconnect(s->session, "closing transport");
 		libssh2_session_free(s->session);
 		s->session = NULL;
 	}


### PR DESCRIPTION
The function `ssh_stream_free` takes over the responsibility of closing
channels and streams just before freeing their memory, but it does not
do so for the session. In fact, we never disconnect the session
ourselves at all, as libssh2 will not do so itself upon freeing the
structure. Quoting the documentation of `libssh2_session_free`:

    > Frees all resources associated with a session instance. Typically
    > called after libssh2_session_disconnect_ex,

The missing disconnect probably stems from a misunderstanding what it
actually does. As we are already closing the TCP socket ourselves, the
assumption was that no additional disconnect is required. But calling
`libssh2_session_disconnect` will notify the server that we are cleanly
closing the connection, such that the server can free his own resources.

Add a call to `libssh2_session_disconnect` to fix that issue.

[1]: https://www.libssh2.org/libssh2_session_free.html

---

This fixes #3473. After all, it seems to me like the issue report is valid.

The other commit is just swapping out a deprecated function for its newer equivalent.

/cc @carlosmn 