### PR TITLE
types: remove unused git_merge_result

### DIFF
--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -181,9 +181,6 @@ typedef struct git_transaction git_transaction;
 /** Annotated commits, the input to merge and rebase. */
 typedef struct git_annotated_commit git_annotated_commit;
 
-/** Merge result */
-typedef struct git_merge_result git_merge_result;
-
 /** Representation of a status collection */
 typedef struct git_status_list git_status_list;
 


### PR DESCRIPTION
`git_merge_result` is currently unused in the codebase and generates a blank page in the [documentation](https://libgit2.github.com/libgit2/#HEAD/type/git_merge_result).

Not sure if this type had a use at one point, but it doesn't seem to now so I figured I would remove it.