### PR TITLE
odb: mempack: fix leaking objects when freeing mempacks

### DIFF
--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -157,6 +157,7 @@ static void impl__free(git_odb_backend *_backend)
 {
 	struct memory_packer_db *db = (struct memory_packer_db *)_backend;
 
+	git_mempack_reset(_backend);
 	git_oidmap_free(db->objects);
 	git__free(db);
 }


### PR DESCRIPTION
When a ODB mempack gets free'd, we take no measures at all to free its
contents, most notably the objects added to the database, resulting in a
memory leak. Call `git_mempack_reset` previous to freeing the ODB
structures themselves, which takes care of releasing all associated
data structures.