### PR TITLE
appveyor: workaround for intermittent test failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,11 @@ build_script:
     if "%GENERATOR%"=="MSYS Makefiles" (C:\MinGW\msys\1.0\bin\sh --login /c/projects/libgit2/script/appveyor-mingw.sh)
 test_script:
 - ps: |
+    # Disable DHE key exchange to fix intermittent build failures ("A buffer
+    # provided was too small") due to SChannel bug. See e.g.
+    # - https://github.com/aws/aws-sdk-cpp/issues/671
+    # - https://github.com/dotnet/corefx/issues/7812
+    New-Item HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithm\Diffie-Hellman -Force | New-ItemProperty -Name Enabled -Value 0 -Force
     $ErrorActionPreference="Stop"
     Start-FileDownload https://github.com/ethomson/poxyproxy/releases/download/v0.1.0/poxyproxy-0.1.0.jar -FileName poxyproxy.jar
     # Run this early so we know it's ready by the time we need it

--- a/src/util.c
+++ b/src/util.c
@@ -10,7 +10,12 @@
 #include "common.h"
 
 #ifdef GIT_WIN32
+# include "win32/utf-conv.h"
 # include "win32/w32_buffer.h"
+
+# ifdef HAVE_QSORT_S
+#  include <search.h>
+# endif
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Our CI builds have intermittent failures in our online tests, e.g. with
the message "A provided buffer was too small". This is not a programming
error in libgit2 but rather an error in the SChannel component of
Windows. Under certain circumstances involving Diffie-Hellman key
exchange, SChannel is unable to correctly handle input from the server.
This bug has already been fixed in recent patches for Windows 10 and
Windows Server 2016, but they are not yet available for AppVeyor.

Manually pamper over that issue by disabling all ciphersuites using DHE
via the registry. While this disables more ciphers than necessary, we
really don't care for that at all but just want to avoid build failures
due to that bug.

See [1], [2] or [3] for additional information.

1: aws/aws-sdk-cpp#671
2: dotnet/corefx#7812
3: https://support.microsoft.com/en-us/help/2992611/ms14-066-vulnerability-in-schannel-could-allow-remote-code-execution-n