### PR TITLE
revwalk: avoid walking the entire history when output is unsorted

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -453,43 +453,28 @@ static int limit_list(git_commit_list **out, git_revwalk *walk, git_commit_list 
 	return 0;
 }
 
-static int get_one_revision(git_commit_list_node **out, git_revwalk *walk, git_commit_list **list)
-{
-	int error;
-	git_commit_list_node *commit;
-
-	while(true) {
-		commit = git_commit_list_pop(list);
-		if (!commit) {
-			giterr_clear();
-			return GIT_ITEROVER;
-		}
-
-		/*
-		 * If we did not run limit_list and we must add parents to the
-		 * list ourselves.
-		 */
-		if (!walk->limited) {
-			if ((error = add_parents_to_list(walk, commit, list)) < 0)
-				return error;
-		}
-
-		*out = commit;
-		return 0;
-	}
-}
-
 static int get_revision(git_commit_list_node **out, git_revwalk *walk, git_commit_list **list)
 {
 	int error;
 	git_commit_list_node *commit;
 
-	if ((error = get_one_revision(&commit, walk, list)) < 0)
-		return error;
+  commit = git_commit_list_pop(list);
+  if (!commit) {
+    giterr_clear();
+    return GIT_ITEROVER;
+  }
 
-	/* Here is where we would handle boundary commits if we implement that */
-	*out = commit;
-	return 0;
+  /*
+   * If we did not run limit_list and we must add parents to the
+   * list ourselves.
+   */
+  if (!walk->limited) {
+    if ((error = add_parents_to_list(walk, commit, list)) < 0)
+      return error;
+  }
+
+  *out = commit;
+  return 0;
 }
 
 static int sort_in_topological_order(git_commit_list **out, git_revwalk *walk, git_commit_list *list)

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -458,23 +458,23 @@ static int get_revision(git_commit_list_node **out, git_revwalk *walk, git_commi
 	int error;
 	git_commit_list_node *commit;
 
-  commit = git_commit_list_pop(list);
-  if (!commit) {
-    giterr_clear();
-    return GIT_ITEROVER;
-  }
+	commit = git_commit_list_pop(list);
+	if (!commit) {
+		giterr_clear();
+		return GIT_ITEROVER;
+	}
 
-  /*
-   * If we did not run limit_list and we must add parents to the
-   * list ourselves.
-   */
-  if (!walk->limited) {
-    if ((error = add_parents_to_list(walk, commit, list)) < 0)
-      return error;
-  }
+	/*
+	 * If we did not run limit_list and we must add parents to the
+	 * list ourselves.
+	 */
+	if (!walk->limited) {
+		if ((error = add_parents_to_list(walk, commit, list)) < 0)
+		return error;
+	}
 
-  *out = commit;
-  return 0;
+	*out = commit;
+	return 0;
 }
 
 static int sort_in_topological_order(git_commit_list **out, git_revwalk *walk, git_commit_list *list)

--- a/src/revwalk.h
+++ b/src/revwalk.h
@@ -36,7 +36,8 @@ struct git_revwalk {
 	unsigned walking:1,
 		first_parent: 1,
 		did_hide: 1,
-		did_push: 1;
+		did_push: 1,
+		limited: 1;
 	unsigned int sorting;
 
 	/* the pushes and hides */


### PR DESCRIPTION
As part of reducing our divergence from git, its code for revwalk was ported
into our codebase. A detail about when to limit the list was lost and we ended
up always calling that code.

Limiting the list means performing the walk and creating the final list of
commits to be output during the preparation stage. This is unavoidable when
sorting and when there are negative refs.

We did this even when asked for unsorted output with no negative refs, which you
might do to retrieve something like the "last 10 commits on HEAD" for a
nominally unsorted meaning of "last".

This commit adds and sets a flag indicating when we do need to limit the list,
letting us avoid doing so when we can. The previously mentioned query thus no
longer loads the entire history of the project during the prepare stage, but
loads it iteratively during the walk.