### PR TITLE
Fix build with LibreSSL 2.7

### DIFF
--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -104,7 +104,8 @@ int git_openssl_stream_global_init(void)
 	ssl_opts |= SSL_OP_NO_COMPRESSION;
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 	SSL_load_error_strings();
 	OpenSSL_add_ssl_algorithms();
 #else

--- a/src/streams/openssl.h
+++ b/src/streams/openssl.h
@@ -31,7 +31,8 @@ extern int git_openssl__set_cert_location(const char *file, const char *path);
 
 
 
-# if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+# if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+     (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 
 GIT_INLINE(BIO_METHOD*) BIO_meth_new(int type, const char *name)
 {


### PR DESCRIPTION
LibreSSL 2.7 adds OpenSSL 1.1 API

Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>