### PR TITLE
appveyor: fix typo in registry key to disable DHE

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ test_script:
     # provided was too small") due to SChannel bug. See e.g.
     # - https://github.com/aws/aws-sdk-cpp/issues/671
     # - https://github.com/dotnet/corefx/issues/7812
-    New-Item HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithm\Diffie-Hellman -Force | New-ItemProperty -Name Enabled -Value 0 -Force
+    New-Item HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman -Force | New-ItemProperty -Name Enabled -Value 0 -Force
     $ErrorActionPreference="Stop"
     Start-FileDownload https://github.com/ethomson/poxyproxy/releases/download/v0.1.0/poxyproxy-0.1.0.jar -FileName poxyproxy.jar
     # Run this early so we know it's ready by the time we need it


### PR DESCRIPTION
Commit 723e1e976 (appveyor: disable DHE to avoid spurious failures,
2018-03-29) added a workaround to fix spurious test failures due to a
bug in Windows' SChannel implementation. The workaround only worked by
accident, though, as the registry key was in fact mistyped. Fix the
typo.

---

 Sure enough #4603 succeeded three times in a row but failed as soon as I merged it to master.