### PR TITLE
diff: Add missing GIT_DELTA_TYPECHANGE -> 'T' mapping.

### DIFF
--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -130,6 +130,7 @@ char git_diff_status_char(git_delta_t status)
 	case GIT_DELTA_COPIED:     code = 'C'; break;
 	case GIT_DELTA_IGNORED:    code = 'I'; break;
 	case GIT_DELTA_UNTRACKED:  code = '?'; break;
+	case GIT_DELTA_TYPECHANGE: code = 'T'; break;
 	case GIT_DELTA_UNREADABLE: code = 'X'; break;
 	default:                   code = ' '; break;
 	}

--- a/tests/diff/stats.c
+++ b/tests/diff/stats.c
@@ -254,7 +254,7 @@ void test_diff_stats__rename_nochanges_no_find(void)
 	git_buf_free(&buf);
 }
 
-void test_diff_stats__rename_and_modifiy_no_find(void)
+void test_diff_stats__rename_and_modify_no_find(void)
 {
 	git_buf buf = GIT_BUF_INIT;
 	const char *stat =


### PR DESCRIPTION
 This adds the 'T' status character to git_diff_status_char() for diff entries that change type.

@ethomson This follows from our Slack chat earlier today.