### PR TITLE
refs: preserve the owning refdb when duping reference

### DIFF
--- a/src/refs.c
+++ b/src/refs.c
@@ -115,6 +115,9 @@ int git_reference_dup(git_reference **dest, git_reference *source)
 
 	GITERR_CHECK_ALLOC(*dest);
 
+	(*dest)->db = source->db;
+	GIT_REFCOUNT_INC((*dest)->db);
+
 	return 0;
 }
 

--- a/src/refs.h
+++ b/src/refs.h
@@ -116,6 +116,10 @@ int git_reference_lookup_resolved(
  * with the given name pointing to the reference pointed to by
  * the file. If it is not a symbolic reference, it will return
  * the resolved reference.
+ *
+ * Note that because the refdb is not involved for symbolic references, they
+ * won't be owned, hence you should either not make the returned reference
+ * 'externally visible', or perform the lookup before returning it to the user.
  */
 int git_reference__read_head(
 	git_reference **out,

--- a/tests/refs/dup.c
+++ b/tests/refs/dup.c
@@ -21,6 +21,7 @@ void test_refs_dup__direct(void)
 	cl_git_pass(git_reference_dup(&b, a));
 
 	cl_assert(git_reference_cmp(a, b) == 0);
+	cl_assert(git_reference_owner(b) == g_repo);
 
 	git_reference_free(b);
 	git_reference_free(a);
@@ -34,6 +35,7 @@ void test_refs_dup__symbolic(void)
 	cl_git_pass(git_reference_dup(&b, a));
 
 	cl_assert(git_reference_cmp(a, b) == 0);
+	cl_assert(git_reference_owner(b) == g_repo);
 
 	git_reference_free(b);
 	git_reference_free(a);

--- a/tests/worktree/repository.c
+++ b/tests/worktree/repository.c
@@ -27,6 +27,7 @@ void test_worktree_repository__head(void)
 	cl_git_pass(git_reference_lookup(&ref, fixture.repo, "refs/heads/testrepo-worktree"));
 	cl_git_pass(git_repository_head_for_worktree(&head, fixture.repo, "testrepo-worktree"));
 	cl_assert(git_reference_cmp(ref, head) == 0);
+	cl_assert(git_reference_owner(ref) == fixture.repo);
 
 	git_reference_free(ref);
 	git_reference_free(head);


### PR DESCRIPTION
This fixes a segfault in `git_reference_owner` on references returned from `git_reference__read_head` and `git_reference_dup` ones.