### PR TITLE
refdb_fs: enhance performance of globbing

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -505,26 +505,29 @@ static int iter_load_loose_paths(refdb_fs_backend *backend, refdb_fs_iter *iter)
 	git_iterator *fsit = NULL;
 	git_iterator_options fsit_opts = GIT_ITERATOR_OPTIONS_INIT;
 	const git_index_entry *entry = NULL;
+	const char *ref_prefix = GIT_REFS_DIR;
+	size_t ref_prefix_len = strlen(ref_prefix);
 
 	if (!backend->commonpath) /* do nothing if no commonpath for loose refs */
 		return 0;
 
 	fsit_opts.flags = backend->iterator_flags;
 
-	if ((error = git_buf_printf(&path, "%s/refs", backend->commonpath)) < 0 ||
+	if ((error = git_buf_printf(&path, "%s/", backend->commonpath)) < 0 ||
+		(error = git_buf_put(&path, ref_prefix, ref_prefix_len)) < 0 ||
 		(error = git_iterator_for_filesystem(&fsit, path.ptr, &fsit_opts)) < 0) {
 		git_buf_free(&path);
 		return error;
 	}
 
-	error = git_buf_sets(&path, GIT_REFS_DIR);
+	error = git_buf_sets(&path, ref_prefix);
 
 	while (!error && !git_iterator_advance(&entry, fsit)) {
 		const char *ref_name;
 		struct packref *ref;
 		char *ref_dup;
 
-		git_buf_truncate(&path, strlen(GIT_REFS_DIR));
+		git_buf_truncate(&path, ref_prefix_len);
 		git_buf_puts(&path, entry->path);
 		ref_name = git_buf_cstr(&path);
 


### PR DESCRIPTION
This patch-set addresses the performance of reference iteration with a glob specified. The enhancement is specific to FS-based repositories.

libgit2 provides facilities for iterating over references of a repository. The references may be filtered using a glob, e.g. using an iterator created via `git_reference_iterator_glob_new()`. At least for FS-based repositories, all references are visited during the iteration and each of the references encountered is matches against the glob. For the general case, this is the only option.

However, a glob may also start with a literal path. In this case, we may scan only the corresponding subdirectory of `refs` rather than the entire reference space. The cost of this optimization is a single scan of the glob.

Targets #4619.

TODO:
 * [x] Fix errors shown by the test-suite. I do something wrong, probably during path assembly.
 * [x] Measure the performance enhancement/impact for both the "usual" case and repositories with _lots_ of refs.