### PR TITLE
Worktrees can be made from bare repositories

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -268,11 +268,15 @@ static int load_config_data(git_repository *repo, const git_config *config)
 {
 	int is_bare;
 
+	int err = git_config_get_bool(&is_bare, config, "core.bare");
+	if (err < 0 && err != GIT_ENOTFOUND)
+		return err;
+
 	/* Try to figure out if it's bare, default to non-bare if it's not set */
-	if (git_config_get_bool(&is_bare, config, "core.bare") < 0)
-		repo->is_bare = 0;
+	if (err != GIT_ENOTFOUND)
+		repo->is_bare = is_bare && !repo->is_worktree;
 	else
-		repo->is_bare = is_bare;
+		repo->is_bare = 0;
 
 	return 0;
 }

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -139,7 +139,7 @@ static int open_worktree_dir(git_worktree **out, const char *parent, const char 
 	if ((wt->name = git__strdup(name)) == NULL
 	    || (wt->commondir_path = git_worktree__read_link(dir, "commondir")) == NULL
 	    || (wt->gitlink_path = git_worktree__read_link(dir, "gitdir")) == NULL
-	    || (wt->parent_path = git__strdup(parent)) == NULL
+	    || (parent && (wt->parent_path = git__strdup(parent)) == NULL)
 	    || (wt->worktree_path = git_path_dirname(wt->gitlink_path)) == NULL) {
 		error = -1;
 		goto out;

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -228,6 +228,26 @@ void test_worktree_worktree__init(void)
 	git_repository_free(repo);
 }
 
+void test_worktree_worktree__add_from_bare(void)
+{
+	git_worktree *wt;
+	git_repository *repo, *wtrepo;
+
+	repo = cl_git_sandbox_init("short_tag.git");
+
+	cl_assert_equal_i(1, git_repository_is_bare(repo));
+	cl_assert_equal_i(0, git_repository_is_worktree(repo));
+
+	cl_git_pass(git_worktree_add(&wt, repo, "worktree-frombare", "worktree-frombare", NULL));
+	cl_git_pass(git_repository_open(&wtrepo, "worktree-frombare"));
+	cl_assert_equal_i(0, git_repository_is_bare(wtrepo));
+	cl_assert_equal_i(1, git_repository_is_worktree(wtrepo));
+
+	git_worktree_free(wt);
+	git_repository_free(repo);
+	git_repository_free(wtrepo);
+}
+
 void test_worktree_worktree__add_locked(void)
 {
 	git_worktree *wt;


### PR DESCRIPTION
Supersedes #4628, fixes #4626.

It fixes the issue by globally disabling the check in `ensure_not_bare` when working against a "worktree repo". I haven't given any thought to what this actually can provoke.

My gut feeling says it's not clean enough, as I don't like :
- all those remaining `repo->is_bare` tests which might now not work against a "worktree repo".
- you can have bare repo (`git_repository_is_bare = true`) with a workdir, since the bare-ness of the parent repo percolates down to the worktree repoes.

Maybe renaming `ensure_not_bare` to `ensure_has_workdir` and using that everywhere ? I'm unsure about the 2nd point though. Opinions, as always, welcome.