### PR TITLE
Fix deletion of unrelated branch on worktree

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -1319,7 +1319,7 @@ static int refdb_fs_backend__delete_tail(
 	}
 
 	/* If a loose reference exists, remove it from the filesystem */
-	if (git_buf_joinpath(&loose_path, backend->gitpath, ref_name) < 0)
+	if (git_buf_joinpath(&loose_path, backend->commonpath, ref_name) < 0)
 		return -1;
 
 

--- a/tests/worktree/refs.c
+++ b/tests/worktree/refs.c
@@ -134,6 +134,28 @@ void test_worktree_refs__delete_succeeds_after_pruning_worktree(void)
 	git_reference_free(branch);
 }
 
+void test_worktree_refs__delete_unrelated_branch_on_worktree(void)
+{
+	git_reference *branch;
+
+	cl_git_pass(git_branch_lookup(&branch, fixture.worktree,
+		    "merge-conflict", GIT_BRANCH_LOCAL));
+	cl_git_pass(git_branch_delete(branch));
+
+	git_reference_free(branch);
+}
+
+void test_worktree_refs__delete_unrelated_branch_on_parent(void)
+{
+	git_reference *branch;
+
+	cl_git_pass(git_branch_lookup(&branch, fixture.repo,
+		    "merge-conflict", GIT_BRANCH_LOCAL));
+	cl_git_pass(git_branch_delete(branch));
+
+	git_reference_free(branch);
+}
+
 void test_worktree_refs__renaming_reference_updates_worktree_heads(void)
 {
 	git_reference *head, *branch, *renamed;


### PR DESCRIPTION
libgit2 fails to delete an unrelated branch on the worktree.

Cross-ref: https://gitlab.com/tortoisegit/tortoisegit/issues/3202