### PR TITLE
Include clib's package reference.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "libgit2",
   "version": "0.27.0",
   "repo": "https://github.com/libgit2/libgit2",
-  "desciption": " A cross-platform, linkable library implementation of Git that you can use in your application.",
+  "description": " A cross-platform, linkable library implementation of Git that you can use in your application.",
   "install": "mkdir build && cd build && cmake .. && cmake --build ."
 }


### PR DESCRIPTION
This PR introduces a new top-level file, `package.json`, which enables this repository compatibility with [`clib`](https://github.com/clibs/clib), an open source C package manager.  By doing this, users of `clib` can quickly include the `libgit2` library within their project.

I'm not sure how version numbering occurs in `libgit2`.  If it is done manually, then this file must also be updated when a new version is released.  If not, additional changes to the versioning system must ensue, so as to update this file.