### PR TITLE
worktree: Add new git_worktree_name and git_worktree_path functions

### DIFF
--- a/include/git2/worktree.h
+++ b/include/git2/worktree.h
@@ -153,19 +153,19 @@ GIT_EXTERN(int) git_worktree_is_locked(git_buf *reason, const git_worktree *wt);
  * Retrieve the name of the worktree
  *
  * @param wt Worktree to get the name for
- * @param name Buffer to store the name in. If NULL an error will be returned
- * @return 0 when the name was stored in the buffer, error-code otherwise
+ * @return The worktrees name or NULL for an error. The pointer returned
+ *  is valid for the lifetime of the git_worktree
  */
-GIT_EXTERN(int) git_worktree_name(const git_worktree *wt, git_buf *name);
+GIT_EXTERN(const char *) git_worktree_name(const git_worktree *wt);
 
 /**
  * Retrieve the filesystem path for the worktree
  *
  * @param wt Worktree to get the path for
- * @param path Buffer to store the name in. If NULL an error will be returned
- * @return 0 when the path was stored in the buffer, error-code otherwise
+ * @return The worktrees filesystem path or NULL for an error. The pointer
+ *  returned is valid for the lifetime of the git_worktree.
  */
-GIT_EXTERN(int) git_worktree_path(const git_worktree *wt, git_buf *path);
+GIT_EXTERN(const char *) git_worktree_path(const git_worktree *wt);
  
 /**
  * Flags which can be passed to git_worktree_prune to alter its

--- a/include/git2/worktree.h
+++ b/include/git2/worktree.h
@@ -148,6 +148,25 @@ GIT_EXTERN(int) git_worktree_unlock(git_worktree *wt);
  */
 GIT_EXTERN(int) git_worktree_is_locked(git_buf *reason, const git_worktree *wt);
 
+
+/**
+ * Retrieve the name of the worktree
+ *
+ * @param wt Worktree to get the name for
+ * @param name Buffer to store the name in. If NULL an error will be returned
+ * @return 0 when the name was stored in the buffer, error-code otherwise
+ */
+GIT_EXTERN(int) git_worktree_name(const git_worktree *wt, git_buf *name);
+
+/**
+ * Retrieve the filesystem path for the worktree
+ *
+ * @param wt Worktree to get the path for
+ * @param path Buffer to store the name in. If NULL an error will be returned
+ * @return 0 when the path was stored in the buffer, error-code otherwise
+ */
+GIT_EXTERN(int) git_worktree_path(const git_worktree *wt, git_buf *path);
+ 
 /**
  * Flags which can be passed to git_worktree_prune to alter its
  * behavior.

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -144,7 +144,7 @@ static int open_worktree_dir(git_worktree **out, const char *parent, const char 
 		goto out;
 	}
 	
-	if ((error == git_path_dirname_r(&buf, wt->gitlink_path)) < 0)
+	if ((error = git_path_dirname_r(&buf, wt->gitlink_path)) < 0)
 		goto out;
 	wt->worktree_path = git_buf_detach(&buf);
 	

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -455,6 +455,26 @@ out:
 	return ret;
 }
 
+int git_worktree_name(const git_worktree *wt, git_buf *name)
+{
+	if (!name || !wt)
+		return -1;
+	
+	git_buf_clear(name);
+	return git_buf_puts(name, wt->name);	
+}
+
+int git_worktree_path(const git_worktree *wt, git_buf *path)
+{
+	if (!path || !wt)
+		return -1;
+	
+	git_buf_clear(path);
+	if ( git_path_dirname_r(path, wt->gitlink_path) > 0 )
+		return 0;
+	return -1;
+}
+
 int git_worktree_prune_init_options(
 	git_worktree_prune_options *opts,
 	unsigned int version)

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -122,7 +122,7 @@ out:
 
 static int open_worktree_dir(git_worktree **out, const char *parent, const char *dir, const char *name)
 {
-	git_buf gitdir = GIT_BUF_INIT;
+	git_buf buf = GIT_BUF_INIT;
 	git_worktree *wt = NULL;
 	int error = 0;
 
@@ -143,10 +143,14 @@ static int open_worktree_dir(git_worktree **out, const char *parent, const char 
 		error = -1;
 		goto out;
 	}
-
-	if ((error = git_path_prettify_dir(&gitdir, dir, NULL)) < 0)
+	
+	if ((error == git_path_dirname_r(&buf, wt->gitlink_path)) < 0)
 		goto out;
-	wt->gitdir_path = git_buf_detach(&gitdir);
+	wt->worktree_path = git_buf_detach(&buf);
+	
+	if ((error = git_path_prettify_dir(&buf, dir, NULL)) < 0)
+		goto out;
+	wt->gitdir_path = git_buf_detach(&buf);
 
 	wt->locked = !!git_worktree_is_locked(NULL, wt);
 
@@ -155,7 +159,7 @@ static int open_worktree_dir(git_worktree **out, const char *parent, const char 
 out:
 	if (error)
 		git_worktree_free(wt);
-	git_buf_free(&gitdir);
+	git_buf_free(&buf);
 
 	return error;
 }
@@ -223,6 +227,7 @@ void git_worktree_free(git_worktree *wt)
 		return;
 
 	git__free(wt->commondir_path);
+	git__free(wt->worktree_path);
 	git__free(wt->gitlink_path);
 	git__free(wt->gitdir_path);
 	git__free(wt->parent_path);
@@ -455,24 +460,16 @@ out:
 	return ret;
 }
 
-int git_worktree_name(const git_worktree *wt, git_buf *name)
+const char * git_worktree_name(const git_worktree *wt)
 {
-	if (!name || !wt)
-		return -1;
-	
-	git_buf_clear(name);
-	return git_buf_puts(name, wt->name);	
+	assert(wt);
+	return wt->name;
 }
 
-int git_worktree_path(const git_worktree *wt, git_buf *path)
+const char * git_worktree_path(const git_worktree *wt)
 {
-	if (!path || !wt)
-		return -1;
-	
-	git_buf_clear(path);
-	if ( git_path_dirname_r(path, wt->gitlink_path) > 0 )
-		return 0;
-	return -1;
+	assert(wt);
+	return wt->worktree_path;
 }
 
 int git_worktree_prune_init_options(

--- a/src/worktree.h
+++ b/src/worktree.h
@@ -18,6 +18,8 @@ struct git_worktree {
 	 * directory. */
 	char *name;
 
+	/* Path to the where the worktree lives in the filesystem */
+	char *worktree_path;
 	/* Path to the .git file in the working tree's repository */
 	char *gitlink_path;
 	/* Path to the .git directory inside the parent's

--- a/tests/clar/sandbox.h
+++ b/tests/clar/sandbox.h
@@ -1,3 +1,7 @@
+#ifdef __APPLE__
+#include <sys/syslimits.h>
+#endif
+
 static char _clar_path[4096];
 
 static int
@@ -31,6 +35,10 @@ find_tmp_path(char *buffer, size_t length)
 			continue;
 
 		if (is_valid_tmp_path(env)) {
+#ifdef __APPLE__
+			if ( length >= PATH_MAX && realpath(env, buffer) != NULL )
+				return 0;
+#endif
 			strncpy(buffer, env, length);
 			return 0;
 		}
@@ -38,6 +46,10 @@ find_tmp_path(char *buffer, size_t length)
 
 	/* If the environment doesn't say anything, try to use /tmp */
 	if (is_valid_tmp_path("/tmp")) {
+#ifdef __APPLE__
+		if ( length >= PATH_MAX && realpath("/tmp", buffer) != NULL )
+			return 0;
+#endif
 		strncpy(buffer, "/tmp", length);
 		return 0;
 	}

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -358,27 +358,21 @@ void test_worktree_worktree__validate(void)
 void test_worktree_worktree__name(void)
 {
 	git_worktree *wt;
-	git_buf name = GIT_BUF_INIT;
+	const char * name;
 
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
-	cl_git_pass(git_worktree_name(wt, &name));
-	cl_assert_equal_s(name.ptr, "testrepo-worktree");
-	
-	git_buf_free(&name);
+	cl_assert_equal_s(git_worktree_name(wt), "testrepo-worktree");
 }
 
 void test_worktree_worktree__path(void)
 {
 	git_worktree *wt;
-	git_buf actual_path = GIT_BUF_INIT;
 	git_buf expected_path = GIT_BUF_INIT;
 
 	cl_git_pass(git_buf_joinpath(&expected_path, clar_sandbox_path(), "testrepo-worktree"));
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
-	cl_git_pass(git_worktree_path(wt, &actual_path));
-	cl_assert_equal_s(actual_path.ptr, expected_path.ptr);
+	cl_assert_equal_s(git_worktree_path(wt), expected_path.ptr);
 	
-	git_buf_free(&actual_path);
 	git_buf_free(&expected_path);
 }
 

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -358,7 +358,6 @@ void test_worktree_worktree__validate(void)
 void test_worktree_worktree__name(void)
 {
 	git_worktree *wt;
-	const char * name;
 
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_assert_equal_s(git_worktree_name(wt), "testrepo-worktree");

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -355,6 +355,33 @@ void test_worktree_worktree__validate(void)
 	git_worktree_free(wt);
 }
 
+void test_worktree_worktree__name(void)
+{
+	git_worktree *wt;
+	git_buf name = GIT_BUF_INIT;
+
+	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
+	cl_git_pass(git_worktree_name(wt, &name));
+	cl_assert_equal_s(name.ptr, "testrepo-worktree");
+	
+	git_buf_free(&name);
+}
+
+void test_worktree_worktree__path(void)
+{
+	git_worktree *wt;
+	git_buf actual_path = GIT_BUF_INIT;
+	git_buf expected_path = GIT_BUF_INIT;
+
+	cl_git_pass(git_buf_joinpath(&expected_path, clar_sandbox_path(), "testrepo-worktree"));
+	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
+	cl_git_pass(git_worktree_path(wt, &actual_path));
+	cl_assert_equal_s(actual_path.ptr, expected_path.ptr);
+	
+	git_buf_free(&actual_path);
+	git_buf_free(&expected_path);
+}
+
 void test_worktree_worktree__validate_invalid_commondir(void)
 {
 	git_worktree *wt;


### PR DESCRIPTION
I was starting to write some code using the rust git2-rs library utilizing worktrees and found that there was no way given an already open worktree to look at what the name of the worktree is or to figure out where on the filesystem it is expected to live. The main goal behind this was to be able to get at the information that would be available in `git worktree list` command output without having to iterate through the worktree strarray and open a git_repository for each worktree and then query things. This PR adds two new worktree related functions. git_worktree_name just copies the name field of the internal git_worktree structure into the provided git_buf. git_worktree_path puts the dirname of the gitlink_path into the provided git_buf. 

The tests for git_worktree_path do string comparisons on two paths and on macOS the default temp/var dirs are usually symlinked. This made direct string comparisons impossible as the path as stored in the worktree structure had links already resolved. So the sandbox.h changes attempt to get the realpath for the tmp directory on macOS.

One thing I had questions about regarding the PR was whether I should include the CHANGELOG.md updates in my PR or whether that was handled by a maintainer.