### PR TITLE
Detect duplicated submodules for the same path

### DIFF
--- a/src/submodule.c
+++ b/src/submodule.c
@@ -572,7 +572,6 @@ int git_submodule__map(git_repository *repo, git_strmap *map)
 	git_buf path = GIT_BUF_INIT;
 	git_submodule *sm;
 	git_config *mods = NULL;
-	uint32_t mask;
 
 	assert(repo && map);
 
@@ -585,22 +584,6 @@ int git_submodule__map(git_repository *repo, git_strmap *map)
 	wd = git_repository_workdir(repo);
 	if (wd && (error = git_buf_joinpath(&path, wd, GIT_MODULES_FILE)) < 0)
 		goto cleanup;
-
-	/* clear submodule flags that are to be refreshed */
-	mask = 0;
-	mask |= GIT_SUBMODULE_STATUS_IN_INDEX |
-		GIT_SUBMODULE_STATUS__INDEX_FLAGS |
-		GIT_SUBMODULE_STATUS__INDEX_OID_VALID |
-		GIT_SUBMODULE_STATUS__INDEX_MULTIPLE_ENTRIES;
-
-	mask |= GIT_SUBMODULE_STATUS_IN_HEAD |
-		GIT_SUBMODULE_STATUS__HEAD_OID_VALID;
-	mask |= GIT_SUBMODULE_STATUS_IN_CONFIG;
-	if (mask != 0)
-		mask |= GIT_SUBMODULE_STATUS_IN_WD |
-			GIT_SUBMODULE_STATUS__WD_SCANNED |
-			GIT_SUBMODULE_STATUS__WD_FLAGS |
-			GIT_SUBMODULE_STATUS__WD_OID_VALID;
 
 	/* add submodule information from .gitmodules */
 	if (wd) {
@@ -630,7 +613,7 @@ int git_submodule__map(git_repository *repo, git_strmap *map)
 			goto cleanup;
 	}
 	/* shallow scan submodules in work tree as needed */
-	if (wd && mask != 0) {
+	if (wd) {
 		git_strmap_foreach_value(map, sm, {
 				submodule_load_from_wd_lite(sm);
 			});

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -231,6 +231,13 @@ static int load_submodule_names(git_strmap *out, git_repository *repo, git_confi
 		fdot = strchr(entry->name, '.');
 		ldot = strrchr(entry->name, '.');
 
+		if (git_strmap_exists(out, entry->value)) {
+			giterr_set(GITERR_SUBMODULE,
+				   "duplicated submodule path '%s'", entry->value);
+			error = -1;
+			goto out;
+		}
+
 		git_buf_clear(&buf);
 		git_buf_put(&buf, fdot + 1, ldot - fdot - 1);
 		isvalid = git_submodule_name_is_valid(repo, buf.ptr, 0);

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -132,6 +132,32 @@ void test_submodule_lookup__foreach(void)
 	cl_assert_equal_i(8, data.count);
 }
 
+static int sm_dummy_cb(git_submodule *sm, const char *name, void *payload)
+{
+	GIT_UNUSED(sm);
+	GIT_UNUSED(name);
+	GIT_UNUSED(payload);
+	return 0;
+}
+
+void test_submodule_lookup__duplicated_path(void)
+{
+	/*
+	 * Manually invoke cleanup methods to remove leftovers
+	 * from `setup_fixture_submod2`
+	 */
+	cl_git_sandbox_cleanup();
+	cl_fixture_cleanup("submod2_target");
+
+	g_repo = setup_fixture_submodules();
+
+	/*
+	 * This should fail, as the submodules repo has an
+	 * invalid gitmodules file with duplicated paths.
+	 */
+	cl_git_fail(git_submodule_foreach(g_repo, sm_dummy_cb, NULL));
+}
+
 void test_submodule_lookup__lookup_even_with_unborn_head(void)
 {
 	git_reference *head;


### PR DESCRIPTION
We currently have a memory leak in AppVeyor wrt handling submodules. The issue is that we're accepting duplicated submodules for the same path, silently updating an already existing key in the submodule names hash map and leaking its previous value. Git does not allow for duplicated submodule paths, so we shouldn't either.