### PR TITLE
Fix GCC 8.1 warnings

### DIFF
--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -252,7 +252,8 @@ int git_openssl_stream_global_init(void)
 #if defined(GIT_THREADS)
 static void threadid_cb(CRYPTO_THREADID *threadid)
 {
-    CRYPTO_THREADID_set_numeric(threadid, git_thread_currentid());
+	GIT_UNUSED(threadid);
+	CRYPTO_THREADID_set_numeric(threadid, git_thread_currentid());
 }
 #endif
 

--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -460,7 +460,7 @@ void test_iterator_workdir__icase_starts_and_ends(void)
 static void build_workdir_tree(const char *root, int dirs, int subs)
 {
 	int i, j;
-	char buf[64], sub[64];
+	char buf[64], sub[80];
 
 	for (i = 0; i < dirs; ++i) {
 		if (i % 2 == 0) {

--- a/tests/refs/normalize.c
+++ b/tests/refs/normalize.c
@@ -193,10 +193,7 @@ void test_refs_normalize__jgit_suite(void)
 		char c;
 		char buffer[GIT_REFNAME_MAX];
 		for (c = '\1'; c < ' '; c++) {
-			strncpy(buffer, "refs/heads/mast", 15);
-			strncpy(buffer + 15, (const char *)&c, 1);
-			strncpy(buffer + 16, "er", 2);
-			buffer[18 - 1] = '\0';
+			p_snprintf(buffer, sizeof(buffer), "refs/heads/mast%cer", c);
 			ensure_refname_invalid(GIT_REF_FORMAT_ALLOW_ONELEVEL, buffer);
 		}
 	}


### PR DESCRIPTION
Fixes required to build with -DENABLE_WERROR=ON and GCC 8.1