### PR TITLE
streams: openssl: add missing check on OPENSSL_LEGACY_API

### DIFF
--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -249,7 +249,7 @@ int git_openssl_stream_global_init(void)
 	return 0;
 }
 
-#if defined(GIT_THREADS)
+#if defined(GIT_THREADS) && defined(OPENSSL_LEGACY_API)
 static void threadid_cb(CRYPTO_THREADID *threadid)
 {
 	GIT_UNUSED(threadid);


### PR DESCRIPTION
The `CRYPTO_THREADID` type is no longer available in OpenSSL ≥ 1.1.0 with deprecated features disabled, and causes build failures. Since the `threadid_cb()` function is only ever called by `git_openssl_set_locking()` when `defined(OPENSSL_LEGACY_API)`, only define it then.