### PR TITLE
refdb_fs: fix regression: failure when globbing for non-existant references

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -538,10 +538,14 @@ static int iter_load_loose_paths(refdb_fs_backend *backend, refdb_fs_iter *iter)
 	}
 
 	if ((error = git_buf_printf(&path, "%s/", backend->commonpath)) < 0 ||
-		(error = git_buf_put(&path, ref_prefix, ref_prefix_len)) < 0 ||
-		(error = git_iterator_for_filesystem(&fsit, path.ptr, &fsit_opts)) < 0) {
+		(error = git_buf_put(&path, ref_prefix, ref_prefix_len)) < 0) {
 		git_buf_free(&path);
 		return error;
+	}
+
+	if ((error = git_iterator_for_filesystem(&fsit, path.ptr, &fsit_opts)) < 0) {
+		git_buf_free(&path);
+		return (iter->glob && error == GIT_ENOTFOUND)? 0 : error;
 	}
 
 	error = git_buf_sets(&path, ref_prefix);

--- a/tests/refs/foreachglob.c
+++ b/tests/refs/foreachglob.c
@@ -62,6 +62,11 @@ void test_refs_foreachglob__retrieve_local_branches(void)
 	assert_retrieval("refs/heads/*", 12);
 }
 
+void test_refs_foreachglob__retrieve_nonexistant(void)
+{
+	assert_retrieval("refs/nonexistent/*", 0);
+}
+
 void test_refs_foreachglob__retrieve_partially_named_references(void)
 {
 	/*


### PR DESCRIPTION
Fixes #4664.