### PR TITLE
editorconfig: allow trailing whitespace in markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,4 @@ insert_final_newline = true
 [*.md]
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
Markdown uses trailing whitespace to indicate context; eg, a blank line
with four spaces indicates that there is a hard break between the
(indented) lines surrounding that line.  Ensure that editors do not
remove this blank.