### PR TITLE
diff: fix enum value being out of allowed range

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -171,6 +171,12 @@ typedef enum {
 	 * Options controlling how output will be generated
 	 */
 
+	/** Use a heuristic that takes indentation and whitespace into account
+	 * which generally can produce better diffs when dealing with ambiguous
+	 * diff hunks.
+	 */
+	GIT_DIFF_INDENT_HEURISTIC = (1u << 18),
+
 	/** Treat all files as text, disabling binary attributes & detection */
 	GIT_DIFF_FORCE_TEXT = (1u << 20),
 	/** Treat all files as binary, disabling text diffs */
@@ -206,12 +212,6 @@ typedef enum {
 	 *  can apply given diff information to binary files.
 	 */
 	GIT_DIFF_SHOW_BINARY = (1u << 30),
-
-	/** Use a heuristic that takes indentation and whitespace into account
-	 * which generally can produce better diffs when dealing with ambiguous
-	 * diff hunks.
-	 */
-	GIT_DIFF_INDENT_HEURISTIC = (1u << 31),
 } git_diff_option_t;
 
 /**


### PR DESCRIPTION
The C89 standard states in §6.7.2.2 "Enumeration specifiers":

> The expression that defines the value of an enumeration constant shall
> be an integer constant expression that has a value representable as an
> int.

On most platforms, this effectively limits the range to a 32 bit signed
integer. The enum `git_diff_option_t` though recently gained an entry
`GIT_DIFF_INDENT_HEURISTIC = (1u << 31)`, which breaks this limit.

Fix the issue by using a gap in `git_diff_option_t`'s enum values. While
this has the benefit of retaining our API, it may break applications
which do not get recompiled after upgrading libgit2. But as we are
bumping the soversion on each release anyway and thus force a recompile
of dependents, this is not a problem.

---

Fixes #4657 