### PR TITLE
docs: fix statement about tab width

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -199,7 +199,7 @@ GIT_EXTERN(int) git_foo_id(
 	int b);
 ```
 
-Indent with tabs; set your editor's tab width to 4 for best effect.
+Indent with tabs; set your editor's tab width to eight for best effect.
 
 Avoid trailing whitespace and only commit Unix-style newlines (i.e. no CRLF
 in the repository - just set `core.autocrlf` to true if you are writing code


### PR DESCRIPTION
The libgit2 project mostly follows the coding style of git and thus
the linux project. While those two projects use a recommended tab width
of eight spaces, we instruct users to set their editor's tab width to
four spaces. Fix this to say eight instead.