### PR TITLE
patch_parse: populate line numbers while parsing diffs

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -563,6 +563,8 @@ static int parse_hunk_body(
 		char c;
 		int origin;
 		int prefix = 1;
+		int old_lineno = hunk->hunk.old_start + (hunk->hunk.old_lines - oldlines);
+		int new_lineno = hunk->hunk.new_start + (hunk->hunk.new_lines - newlines);
 
 		if (ctx->parse_ctx.line_len == 0 || ctx->parse_ctx.line[ctx->parse_ctx.line_len - 1] != '\n') {
 			error = git_parse_err("invalid patch instruction at line %"PRIuZ,
@@ -586,11 +588,13 @@ static int parse_hunk_body(
 		case '-':
 			origin = GIT_DIFF_LINE_DELETION;
 			oldlines--;
+			new_lineno = -1;
 			break;
 
 		case '+':
 			origin = GIT_DIFF_LINE_ADDITION;
 			newlines--;
+			old_lineno = -1;
 			break;
 
 		default:
@@ -607,6 +611,9 @@ static int parse_hunk_body(
 		line->content_len = ctx->parse_ctx.line_len - prefix;
 		line->content_offset = ctx->parse_ctx.content_len - ctx->parse_ctx.remain_len;
 		line->origin = origin;
+		line->num_lines = 1;
+		line->old_lineno = old_lineno;
+		line->new_lineno = new_lineno;
 
 		hunk->line_count++;
 	}


### PR DESCRIPTION
This should fix #4672. Looks like providing the "parsed" line numbers in the line struct was never actually wired (!).