### PR TITLE
Fix interaction between limited flag and sorting over resets

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -455,7 +455,7 @@ static int get_revision(git_commit_list_node **out, git_revwalk *walk, git_commi
 	 */
 	if (!walk->limited) {
 		if ((error = add_parents_to_list(walk, commit, list)) < 0)
-		return error;
+			return error;
 	}
 
 	*out = commit;
@@ -678,7 +678,7 @@ void git_revwalk_sorting(git_revwalk *walk, unsigned int sort_mode)
 		walk->enqueue = &revwalk_enqueue_unsorted;
 	}
 
-	if (sort_mode != GIT_SORT_NONE)
+	if (walk->sorting != GIT_SORT_NONE)
 		walk->limited = 1;
 }
 
@@ -737,6 +737,7 @@ void git_revwalk_reset(git_revwalk *walk)
 	walk->walking = 0;
 	walk->limited = 0;
 	walk->did_push = walk->did_hide = 0;
+	walk->sorting = GIT_SORT_NONE;
 }
 
 int git_revwalk_add_hide_cb(

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -197,6 +197,31 @@ void test_revwalk_basic__push_head(void)
 	cl_assert_equal_i(i, 7);
 }
 
+void test_revwalk_basic__sorted_after_reset(void)
+{
+	int i = 0;
+	git_oid oid;
+
+	revwalk_basic_setup_walk(NULL);
+
+	git_oid_fromstr(&oid, commit_head);
+
+	/* push, sort, and test the walk */
+	cl_git_pass(git_revwalk_push(_walk, &oid));
+	git_revwalk_sorting(_walk, GIT_SORT_TIME);
+
+	cl_git_pass(test_walk_only(_walk, commit_sorting_time, 2));
+
+	/* reset, push, and test again - we should see all entries */
+	git_revwalk_reset(_walk);
+	cl_git_pass(git_revwalk_push(_walk, &oid));
+
+	while (git_revwalk_next(&oid, _walk) == 0)
+		i++;
+
+	cl_assert_equal_i(i, commit_count);
+}
+
 void test_revwalk_basic__push_head_hide_ref(void)
 {
 	int i = 0;


### PR DESCRIPTION
Sorted revwalks have their limited flag set because lazy revwalks, which are used when `limited` is not set since #4606, currently only handle `GIT_SORT_NONE`.

Revwalks persist their sorting over calls to `git_revwalk_reset`. However, the `limited` flag was unconditionally cleared during `git_revwalk_reset`, which would cause breakage.

This patch sets the limited flag for non-`GIT_SORT_NONE` revwalks in reset, and adds a test for the failing case.

I ran into this bug while making a version of `pygit2` with the mailmap changes from #4586, as pygit2 tests started failing. 