### PR TITLE
Address ThreadSanitizer errors

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -188,7 +188,7 @@ static void *cache_store(git_cache *cache, git_cached_obj *entry)
 		return entry;
 
 	/* soften the load on the cache */
-	if (git_cache__current_storage.val > git_cache__max_storage)
+	if (git_atomic_get(&git_cache__current_storage) > git_cache__max_storage)
 		cache_evict_entries(cache);
 
 	pos = git_oidmap_lookup_index(cache->map, &entry->oid);

--- a/src/pool.c
+++ b/src/pool.c
@@ -23,15 +23,24 @@ static void *pool_alloc_page(git_pool *pool, uint32_t size);
 
 uint32_t git_pool__system_page_size(void)
 {
+#ifndef GIT_THREADS
 	static uint32_t size = 0;
 
 	if (!size) {
+#else
+    uint32_t size = 0;
+    do {
+#endif
 		size_t page_size;
 		if (git__page_size(&page_size) < 0)
 			page_size = 4096;
 		/* allow space for malloc overhead */
 		size = page_size - (2 * sizeof(void *)) - sizeof(git_pool_page);
+#ifndef GIT_THREADS
 	}
+#else
+    } while (0);
+#endif
 
 	return size;
 }

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -7,17 +7,25 @@
 #ifndef INCLUDE_thread_utils_h__
 #define INCLUDE_thread_utils_h__
 
-#if defined(__GNUC__) && defined(GIT_THREADS)
-# if (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 1))
-#  error Atomic primitives do not exist on this version of gcc; configure libgit2 with -DTHREADSAFE=OFF
+#if defined(GIT_THREADS)
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+#  define __GIT_THREADS_USE_C11 1
+#  include <stdatomic.h>
+# elif defined(__GNUC__) && __GNUC__ >= 4
+#  define __GIT_THREADS_USE_GNU 1
+# elif defined(GIT_WIN32)
+#  define __GIT_THREADS_USE_WIN32 1
+# else
+#  error Atomic primitives do not exist on this compiler; configure libgit2 with -DGIT_THREADS=0
 # endif
 #endif
 
-/* Common operations even if threading has been disabled */
 typedef struct {
-#if defined(GIT_WIN32)
+#if __GIT_THREADS_USE_C11
+    atomic_int val;
+#elif __GIT_THREADS_USE_WIN32
 	volatile long val;
-#else
+#else // __GIT_THREADS_USE_GNU || true; fallback case
 	volatile int val;
 #endif
 } git_atomic;
@@ -25,10 +33,12 @@ typedef struct {
 #ifdef GIT_ARCH_64
 
 typedef struct {
-#if defined(GIT_WIN32)
-	__int64 val;
-#else
-	int64_t val;
+#if __GIT_THREADS_USE_C11
+    atomic_int_fast64_t val;
+#elif __GIT_THREADS_USE_WIN32
+	volatile __int64 val;
+#else // __GIT_THREADS_USE_GNU || true; fallback case
+	volatile int64_t val;
 #endif
 } git_atomic64;
 
@@ -44,186 +54,123 @@ typedef git_atomic git_atomic_ssize;
 
 #endif
 
-#ifdef GIT_THREADS
-
-#ifdef GIT_WIN32
-#   include "win32/thread.h"
-#else
-#   include "unix/pthread.h"
-#endif
-
 GIT_INLINE(void) git_atomic_set(git_atomic *a, int val)
 {
-#if defined(GIT_WIN32)
+#if __GIT_THREADS_USE_C11
+    atomic_store(&a->val, val);
+#elif __GIT_THREADS_USE_WIN32
 	InterlockedExchange(&a->val, (LONG)val);
-#elif defined(__GNUC__)
+#elif __GIT_THREADS_USE_GNU
 	__sync_lock_test_and_set(&a->val, val);
 #else
-#	error "Unsupported architecture for atomic operations"
+    a->val = val;
+#endif
+}
+
+GIT_INLINE(int) git_atomic_get(git_atomic *a)
+{
+#if __GIT_THREADS_USE_C11
+    return atomic_load(&a->val);
+#else
+    return (int)a->val;
 #endif
 }
 
 GIT_INLINE(int) git_atomic_inc(git_atomic *a)
 {
-#if defined(GIT_WIN32)
-	return InterlockedIncrement(&a->val);
-#elif defined(__GNUC__)
-	return __sync_add_and_fetch(&a->val, 1);
+#if __GIT_THREADS_USE_C11
+    return atomic_fetch_add(&a->val, 1) + 1;
+#elif __GIT_THREADS_USE_WIN32
+    return InterlockedIncrement(&a->val);
+#elif __GIT_THREADS_USE_GNU
+    return __sync_add_and_fetch(&a->val, 1);
 #else
-#	error "Unsupported architecture for atomic operations"
+    return ++a->val;
 #endif
 }
 
 GIT_INLINE(int) git_atomic_add(git_atomic *a, int32_t addend)
 {
-#if defined(GIT_WIN32)
-	return InterlockedExchangeAdd(&a->val, addend);
-#elif defined(__GNUC__)
-	return __sync_add_and_fetch(&a->val, addend);
+#if __GIT_THREADS_USE_C11
+    return atomic_fetch_add(&a->val, addend) + addend;
+#elif __GIT_THREADS_USE_WIN32
+    return InterlockedExchangeAdd(&a->val, addend);
+#elif __GIT_THREADS_USE_GNU
+    return __sync_add_and_fetch(&a->val, addend);
 #else
-#	error "Unsupported architecture for atomic operations"
+    a->val += addend;
+    return a->val;
 #endif
 }
 
 GIT_INLINE(int) git_atomic_dec(git_atomic *a)
 {
-#if defined(GIT_WIN32)
-	return InterlockedDecrement(&a->val);
-#elif defined(__GNUC__)
-	return __sync_sub_and_fetch(&a->val, 1);
+#if __GIT_THREADS_USE_C11
+    return atomic_fetch_sub(&a->val, 1) - 1;
+#elif __GIT_THREADS_USE_WIN32
+    return InterlockedDecrement(&a->val);
+#elif __GIT_THREADS_USE_GNU
+    return __sync_sub_and_fetch(&a->val, 1);
 #else
-#	error "Unsupported architecture for atomic operations"
+    return --a->val;
 #endif
 }
 
 GIT_INLINE(void *) git___compare_and_swap(
 	void * volatile *ptr, void *oldval, void *newval)
 {
-	volatile void *foundval;
-#if defined(GIT_WIN32)
+#if __GIT_THREADS_USE_C11
+    return atomic_compare_exchange_strong((volatile _Atomic(void *) *)ptr, &oldval, newval) ? oldval : newval;
+#elif __GIT_THREADS_USE_WIN32
+    volatile void *foundval;
 	foundval = InterlockedCompareExchangePointer((volatile PVOID *)ptr, newval, oldval);
-#elif defined(__GNUC__)
+    return (foundval == oldval) ? oldval : newval;
+#elif __GIT_THREADS_USE_GNU
+    volatile void *foundval;
 	foundval = __sync_val_compare_and_swap(ptr, oldval, newval);
+    return (foundval == oldval) ? oldval : newval;
 #else
-#	error "Unsupported architecture for atomic operations"
-#endif
-	return (foundval == oldval) ? oldval : newval;
-}
-
-GIT_INLINE(volatile void *) git___swap(
-	void * volatile *ptr, void *newval)
-{
-#if defined(GIT_WIN32)
-	return InterlockedExchangePointer(ptr, newval);
-#else
-	return __sync_lock_test_and_set(ptr, newval);
-#endif
-}
-
-#ifdef GIT_ARCH_64
-
-GIT_INLINE(int64_t) git_atomic64_add(git_atomic64 *a, int64_t addend)
-{
-#if defined(GIT_WIN32)
-	return InterlockedExchangeAdd64(&a->val, addend);
-#elif defined(__GNUC__)
-	return __sync_add_and_fetch(&a->val, addend);
-#else
-#	error "Unsupported architecture for atomic operations"
-#endif
-}
-
-#endif
-
-#else
-
-#define git_thread unsigned int
-#define git_thread_create(thread, start_routine, arg) 0
-#define git_thread_join(id, status) (void)0
-
-/* Pthreads Mutex */
-#define git_mutex unsigned int
-GIT_INLINE(int) git_mutex_init(git_mutex *mutex) \
-	{ GIT_UNUSED(mutex); return 0; }
-GIT_INLINE(int) git_mutex_lock(git_mutex *mutex) \
-	{ GIT_UNUSED(mutex); return 0; }
-#define git_mutex_unlock(a) (void)0
-#define git_mutex_free(a) (void)0
-
-/* Pthreads condition vars */
-#define git_cond unsigned int
-#define git_cond_init(c, a)	(void)0
-#define git_cond_free(c) (void)0
-#define git_cond_wait(c, l)	(void)0
-#define git_cond_signal(c) (void)0
-#define git_cond_broadcast(c) (void)0
-
-/* Pthreads rwlock */
-#define git_rwlock unsigned int
-#define git_rwlock_init(a)		0
-#define git_rwlock_rdlock(a)	0
-#define git_rwlock_rdunlock(a)	(void)0
-#define git_rwlock_wrlock(a)	0
-#define git_rwlock_wrunlock(a)	(void)0
-#define git_rwlock_free(a)		(void)0
-#define GIT_RWLOCK_STATIC_INIT	0
-
-
-GIT_INLINE(void) git_atomic_set(git_atomic *a, int val)
-{
-	a->val = val;
-}
-
-GIT_INLINE(int) git_atomic_inc(git_atomic *a)
-{
-	return ++a->val;
-}
-
-GIT_INLINE(int) git_atomic_add(git_atomic *a, int32_t addend)
-{
-	a->val += addend;
-	return a->val;
-}
-
-GIT_INLINE(int) git_atomic_dec(git_atomic *a)
-{
-	return --a->val;
-}
-
-GIT_INLINE(void *) git___compare_and_swap(
-	void * volatile *ptr, void *oldval, void *newval)
-{
 	if (*ptr == oldval)
 		*ptr = newval;
 	else
 		oldval = newval;
 	return oldval;
+#endif
 }
 
 GIT_INLINE(volatile void *) git___swap(
 	void * volatile *ptr, void *newval)
 {
-	volatile void *old = *ptr;
-	*ptr = newval;
-	return old;
+#if __GIT_THREADS_USE_C11
+    return atomic_exchange((volatile _Atomic(void *) *)ptr, newval);
+#elif __GIT_THREADS_USE_WIN32
+	return InterlockedExchangePointer(ptr, newval);
+#elif __GIT_THREADS_USE_GNU
+	return __sync_lock_test_and_set(ptr, newval);
+#else
+    volatile void *old = *ptr;
+    *ptr = newval;
+    return old;
+#endif
 }
 
 #ifdef GIT_ARCH_64
 
 GIT_INLINE(int64_t) git_atomic64_add(git_atomic64 *a, int64_t addend)
 {
-	a->val += addend;
-	return a->val;
+# if __GIT_THREADS_USE_C11
+    return atomic_fetch_add(&a->val, addend) + addend;
+# elif __GIT_THREADS_USE_WIN32
+    return InterlockedExchangeAdd64(&a->val, addend);
+# elif __GIT_THREADS_USE_GNU
+    return __sync_add_and_fetch(&a->val, addend);
+# else
+    a->val += addend;
+    return a->val;
+# endif
 }
 
 #endif
-
-#endif
-
-GIT_INLINE(int) git_atomic_get(git_atomic *a)
-{
-	return (int)a->val;
-}
 
 /* Atomically replace oldval with newval
  * @return oldval if it was replaced or newval if it was not
@@ -235,12 +182,57 @@ GIT_INLINE(int) git_atomic_get(git_atomic *a)
 
 extern int git_online_cpus(void);
 
-#if defined(GIT_THREADS) && defined(_MSC_VER)
+#if __GIT_THREADS_USE_C11
+#  define GIT_MEMORY_BARRIER atomic_thread_fence(memory_order_seq_cst)
+#elif __GIT_THREADS_USE_WIN32
 # define GIT_MEMORY_BARRIER MemoryBarrier()
-#elif defined(GIT_THREADS)
+#elif __GIT_THREADS_USE_GNU
 # define GIT_MEMORY_BARRIER __sync_synchronize()
 #else
 # define GIT_MEMORY_BARRIER /* noop */
 #endif
 
+#ifdef GIT_THREADS
+
+# ifdef GIT_WIN32
+#  include "win32/thread.h"
+# else
+#  include "unix/pthread.h"
 #endif
+
+#else
+
+# define git_thread unsigned int
+# define git_thread_create(thread, start_routine, arg) 0
+# define git_thread_join(id, status) (void)0
+
+/* Pthreads Mutex */
+# define git_mutex unsigned int
+GIT_INLINE(int) git_mutex_init(git_mutex *mutex) \
+{ GIT_UNUSED(mutex); return 0; }
+GIT_INLINE(int) git_mutex_lock(git_mutex *mutex) \
+{ GIT_UNUSED(mutex); return 0; }
+# define git_mutex_unlock(a) (void)0
+# define git_mutex_free(a) (void)0
+
+/* Pthreads condition vars */
+# define git_cond unsigned int
+# define git_cond_init(c, a)    (void)0
+# define git_cond_free(c) (void)0
+# define git_cond_wait(c, l)    (void)0
+# define git_cond_signal(c) (void)0
+# define git_cond_broadcast(c) (void)0
+
+/* Pthreads rwlock */
+# define git_rwlock unsigned int
+# define git_rwlock_init(a)        0
+# define git_rwlock_rdlock(a)    0
+# define git_rwlock_rdunlock(a)    (void)0
+# define git_rwlock_wrlock(a)    0
+# define git_rwlock_wrunlock(a)    (void)0
+# define git_rwlock_free(a)        (void)0
+# define GIT_RWLOCK_STATIC_INIT    0
+
+#endif
+
+#endif /* INCLUDE_thread_utils_h__ */


### PR DESCRIPTION
* Cleans up and modernizes `thread-utils.h` to use C11 atomics when available, gaining a properly-instrumented use of `atomic_load` in `git_atomic_get`. Replaces the sole use of `.val` in the codebase.
* Disables the caching in `git_pool__system_page_size` under threading. Not caching does not seem to introduce any performance regression and seems similar to other codebases I can find doing the same thing.