### PR TITLE
deps: fix implicit fallthrough warning in http-parser

### DIFF
--- a/deps/http-parser/CMakeLists.txt
+++ b/deps/http-parser/CMakeLists.txt
@@ -1,3 +1,5 @@
 FILE(GLOB SRC_HTTP "*.c" "*.h")
 
 ADD_LIBRARY(http-parser OBJECT ${SRC_HTTP})
+
+ENABLE_WARNINGS(implicit-fallthrough=1)


### PR DESCRIPTION
GCC 7 has introduced new warnings for implicit fallthrough in switch
statements. Whenever there is no branch in a case block, GCC will watch
out for some heuristics which indicate that the implicit fallthrough is
intended, like a "fallthrough" comment. The third-party http-parser code
manages to trick this heuristic in one case, even though there is a
"FALLTHROUGH" comment. Fortunately, GCC has also added a strictness
level to the -Wimplicit-fallthrough diagnostic, such that we can loosen
this heuristic and make it more lax.

Set -Wimplicit-fallthrough=1 in http-parser's CMake build instructions,
which is the strictest level that gets rid of the warning. This level
will treat any kind of comment as a "fallthrough" comment, which
silences the warning.