### PR TITLE
smart protocol: PACK packets are illegal while downloading refs

### DIFF
--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -70,6 +70,12 @@ int git_smart__store_refs(transport_smart *t, int flushes)
 			return -1;
 		}
 
+		if (pkt->type == GIT_PKT_PACK) {
+			giterr_set(GITERR_NET, "Unexpected packfile");
+			git__free(pkt);
+			return -1;
+		}
+
 		if (pkt->type != GIT_PKT_FLUSH && git_vector_insert(refs, pkt) < 0)
 			return -1;
 


### PR DESCRIPTION
I'm not sure this is the best fix, but without this fix we can cause a git2 client to spin forever allocating memory by responding with the four characters "PACK" to a smart protocol client:

```
[nelhage@penguin:~/code/libgit2]$ echo PACK | nc -l -p 9999 -q0 >/dev/null &                                                                      
[1] 22480
[nelhage@penguin:~/code/libgit2]$ build/examples/cgit2 --git-dir .git ls-remote git://localhost:9999/       
# loops until it consumes all available memory and crashes
```

This bug was found by an oss-fuzz integration I'm working on.                                      