### PR TITLE
Fix type confusion in git_smart__connect

### DIFF
--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -266,7 +266,12 @@ static int git_smart__connect(
 	/* We now have loaded the refs. */
 	t->have_refs = 1;
 
-	first = (git_pkt_ref *)git_vector_get(&t->refs, 0);
+	pkt = (git_pkt *)git_vector_get(&t->refs, 0);
+	if (pkt && GIT_PKT_REF != pkt->type) {
+		giterr_set(GITERR_NET, "invalid response");
+		return -1;
+	}
+	first = (git_pkt_ref *)pkt;
 
 	if ((error = git_vector_init(&symrefs, 1, NULL)) < 0)
 		return error;


### PR DESCRIPTION
Nothing verifies that t->refs[0] is a GIT_PKT_REF. A remote can send
another packet type, ultimately resulting in a type confusion in
`git_smart__detect_caps`.

This was found by an oss-fuzz integration I'm working on.