### PR TITLE
Verify ref_pkt's are long enough

### DIFF
--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -216,6 +216,11 @@ static int ref_pkt(git_pkt **out, const char *line, size_t len)
 	git_pkt_ref *pkt;
 	size_t alloclen;
 
+	if (len < GIT_OID_HEXSZ + 1) {
+		giterr_set(GITERR_NET, "error parsing pkt-line");
+		return -1;
+	}
+
 	pkt = git__malloc(sizeof(git_pkt_ref));
 	GITERR_CHECK_ALLOC(pkt);
 


### PR DESCRIPTION
If the remote sends a too-short packet, we'll allow `len` to go
negative and eventually issue a malloc for <= 0 bytes on

```
pkt->head.name = git__malloc(alloclen);
```

This was found by an oss-fuzz integration I'm working on.