### PR TITLE
git_refspec_transform: Handle NULL dst

### DIFF
--- a/src/refspec.c
+++ b/src/refspec.c
@@ -252,7 +252,7 @@ int git_refspec_transform(git_buf *out, const git_refspec *spec, const char *nam
 	}
 
 	if (!spec->pattern)
-		return git_buf_puts(out, spec->dst);
+		return git_buf_puts(out, spec->dst ? spec->dst : "");
 
 	return refspec_transform(out, spec->src, spec->dst, name);
 }

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -111,7 +111,8 @@ void test_network_refspecs__transform_mid_star(void)
 	assert_valid_transform("refs/*:refs/*", "refs/heads/master", "refs/heads/master");
 }
 
-void test_network_refspecs__no_dst(void) {
+void test_network_refspecs__no_dst(void)
+{
 	assert_valid_transform("refs/heads/master:", "refs/heads/master", "");
 }
 

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -111,6 +111,10 @@ void test_network_refspecs__transform_mid_star(void)
 	assert_valid_transform("refs/*:refs/*", "refs/heads/master", "refs/heads/master");
 }
 
+void test_network_refspecs__no_dst(void) {
+	assert_valid_transform("refs/heads/master:", "refs/heads/master", "");
+}
+
 static void assert_invalid_transform(const char *refspec, const char *name)
 {
 	git_refspec spec;


### PR DESCRIPTION
per https://github.com/libgit2/libgit2/blob/b121b7ac972156cdc67b25be075fd62450b57f29/src/refspec.c#L85-L90 this is considered valid, so we should handle it downstream.

Found via triggering the assertion failure in  `git_buf_puts` in my work-in-progress fuzzer.