### PR TITLE
tree: reset spurious errors while walking entries

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -947,6 +947,7 @@ static int tree_walk(
 
 	git_array_foreach(tree->entries, i, entry) {
 		if (preorder) {
+			giterr_clear();
 			error = callback(path->ptr, entry, payload);
 			if (error < 0) { /* negative value stops iteration */
 				giterr_set_after_callback_function(error, "git_tree_walk");
@@ -983,6 +984,7 @@ static int tree_walk(
 		}
 
 		if (!preorder) {
+			giterr_clear();
 			error = callback(path->ptr, entry, payload);
 			if (error < 0) { /* negative value stops iteration */
 				giterr_set_after_callback_function(error, "git_tree_walk");


### PR DESCRIPTION
Fixes #4693.

Note that I choose to be paranoid here, in case the callback sets an error but doesn't report it. Maybe it's too paranoid 😉.