### PR TITLE
refspec: rename `git_refspec__free` to `git_refspec__dispose`

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -78,7 +78,7 @@ static int filter_wants(git_remote *remote, const git_fetch_options *opts)
 			goto cleanup;
 
 		error = git_refspec__dwim_one(&remote->active_refspecs, &head, &remote->refs);
-		git_refspec__free(&head);
+		git_refspec__dispose(&head);
 
 		if (error < 0)
 			goto cleanup;
@@ -96,7 +96,7 @@ static int filter_wants(git_remote *remote, const git_fetch_options *opts)
 	}
 
 cleanup:
-	git_refspec__free(&tagspec);
+	git_refspec__dispose(&tagspec);
 
 	return error;
 }

--- a/src/push.c
+++ b/src/push.c
@@ -83,7 +83,7 @@ static void free_refspec(push_spec *spec)
 	if (spec == NULL)
 		return;
 
-	git_refspec__free(&spec->refspec);
+	git_refspec__dispose(&spec->refspec);
 	git__free(spec);
 }
 

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -144,11 +144,11 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
         giterr_set(
                 GITERR_INVALID,
                 "'%s' is not a valid refspec.", input);
-        git_refspec__free(refspec);
+        git_refspec__dispose(refspec);
 	return -1;
 }
 
-void git_refspec__free(git_refspec *refspec)
+void git_refspec__dispose(git_refspec *refspec)
 {
 	if (refspec == NULL)
 		return;
@@ -181,7 +181,7 @@ int git_refspec_parse(git_refspec **out_refspec, const char *input, int is_fetch
 
 void git_refspec_free(git_refspec *refspec)
 {
-	git_refspec__free(refspec);
+	git_refspec__dispose(refspec);
 	git__free(refspec);
 }
 

--- a/src/refspec.h
+++ b/src/refspec.h
@@ -30,7 +30,7 @@ int git_refspec__parse(
 	const char *str,
 	bool is_fetch);
 
-void git_refspec__free(git_refspec *refspec);
+void git_refspec__dispose(git_refspec *refspec);
 
 int git_refspec__serialize(git_buf *out, const git_refspec *refspec);
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -44,7 +44,7 @@ static int add_refspec_to(git_vector *vector, const char *string, bool is_fetch)
 
 	spec->push = !is_fetch;
 	if (git_vector_insert(vector, spec) < 0) {
-		git_refspec__free(spec);
+		git_refspec__dispose(spec);
 		git__free(spec);
 		return -1;
 	}
@@ -117,7 +117,7 @@ static int write_add_refspec(git_repository *repo, const char *name, const char 
 		return error;
 	}
 
-	git_refspec__free(&spec);
+	git_refspec__dispose(&spec);
 
 	if ((error = git_buf_printf(&var, fmt, name)) < 0)
 		return error;
@@ -826,7 +826,7 @@ static void free_refspecs(git_vector *vec)
 	git_refspec *spec;
 
 	git_vector_foreach(vec, i, spec) {
-		git_refspec__free(spec);
+		git_refspec__dispose(spec);
 		git__free(spec);
 	}
 
@@ -1416,13 +1416,13 @@ static int update_tips_for_spec(
 		goto on_error;
 
 	git_vector_free(&update_heads);
-	git_refspec__free(&tagspec);
+	git_refspec__dispose(&tagspec);
 	git_buf_dispose(&refname);
 	return 0;
 
 on_error:
 	git_vector_free(&update_heads);
-	git_refspec__free(&tagspec);
+	git_refspec__dispose(&tagspec);
 	git_buf_dispose(&refname);
 	return -1;
 
@@ -1607,7 +1607,7 @@ int git_remote_update_tips(
 
 out:
 	git_vector_free(&refs);
-	git_refspec__free(&tagspec);
+	git_refspec__dispose(&tagspec);
 	return error;
 }
 
@@ -2045,7 +2045,7 @@ int git_remote_is_valid_name(
 	error = git_refspec__parse(&refspec, git_buf_cstr(&buf), true);
 
 	git_buf_dispose(&buf);
-	git_refspec__free(&refspec);
+	git_refspec__dispose(&refspec);
 
 	giterr_clear();
 	return error == 0;

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -192,7 +192,7 @@ static void free_symrefs(git_vector *symrefs)
 	size_t i;
 
 	git_vector_foreach(symrefs, i, spec) {
-		git_refspec__free(spec);
+		git_refspec__dispose(spec);
 		git__free(spec);
 	}
 

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -131,7 +131,7 @@ static int append_symref(const char **out, git_vector *symrefs, const char *ptr)
 
 on_invalid:
 	giterr_set(GITERR_NET, "remote sent invalid symref");
-	git_refspec__free(mapping);
+	git_refspec__dispose(mapping);
 	git__free(mapping);
 	return -1;
 }

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -8,7 +8,7 @@ static void assert_refspec(unsigned int direction, const char *input, bool is_ex
 	int error;
 
 	error = git_refspec__parse(&refspec, input, direction == GIT_DIRECTION_FETCH);
-	git_refspec__free(&refspec);
+	git_refspec__dispose(&refspec);
 
 	if (is_expected_to_be_valid)
 		cl_assert_equal_i(0, error);
@@ -98,7 +98,7 @@ static void assert_valid_transform(const char *refspec, const char *name, const 
 	cl_assert_equal_s(result, buf.ptr);
 
 	git_buf_dispose(&buf);
-	git_refspec__free(&spec);
+	git_refspec__dispose(&spec);
 }
 
 void test_network_refspecs__transform_mid_star(void)
@@ -120,7 +120,7 @@ static void assert_invalid_transform(const char *refspec, const char *name)
 	cl_git_fail(git_refspec_transform(&buf, &spec, name));
 
 	git_buf_dispose(&buf);
-	git_refspec__free(&spec);
+	git_refspec__dispose(&spec);
 }
 
 void test_network_refspecs__invalid(void)
@@ -138,7 +138,7 @@ static void assert_invalid_rtransform(const char *refspec, const char *name)
 	cl_git_fail(git_refspec_rtransform(&buf, &spec, name));
 
 	git_buf_dispose(&buf);
-	git_refspec__free(&spec);
+	git_refspec__dispose(&spec);
 }
 
 void test_network_refspecs__invalid_reverse(void)
@@ -156,7 +156,7 @@ void test_network_refspecs__matching(void)
 	cl_assert_equal_s("", spec.src);
 	cl_assert_equal_s("", spec.dst);
 
-	git_refspec__free(&spec);
+	git_refspec__dispose(&spec);
 }
 
 void test_network_refspecs__parse_free(void)


### PR DESCRIPTION
Since commit 630a67366 (refspec: add public parsing api, 2018-02-07), we
now have two functions `git_refspec_free` and `git_refspec__free`. The
difference is that the first one will free the structure itself, while
the second one will only free the structure's contents. Use our new
`dispose` naming pattern for the latter function to help avoid
confusion.