### PR TITLE
travis: use new libgit2-owned signing key for Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
  apt:
   sources:
    - sourceline: 'deb https://dl.bintray.com/libgit2/ci-dependencies trusty libgit2deps'
-     key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
+     key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=libgit2'
   packages:
    cmake
    curl


### PR DESCRIPTION
By default, all packages uploaded to our Bintray repositories were
signed by the Bintray-owned private key. As Travis is currently unable
to authenticate the official Bintray-signed packages, it is the perfect
occasion to switch the keypair against our own keypair to try to fix
these problems.