### PR TITLE
While fuzzing, limit number objects a pack can contain

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -563,6 +563,11 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_tran
 			total_objects = (unsigned int)idx->nr_objects;
 		else
 			total_objects = UINT_MAX;
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+		if (total_objects > 4096) {
+			total_objects = 4096;
+		}
+#endif
 
 		idx->pack->idx_cache = git_oidmap_alloc();
 		GITERR_CHECK_ALLOC(idx->pack->idx_cache);


### PR DESCRIPTION
This is needed in order for https://github.com/google/oss-fuzz/pull/1604 to not [immediately OOM](https://github.com/google/oss-fuzz/pull/1604#issuecomment-403991802) with a ~32GB allocation.

The existing code enforces a hard limit of 2³² objects, which may be acceptable as a general default, but is too large for the fuzzer's memory limits.

I'm very open to other approaches (should there be a configurable limit that the fuzzer configures?) but I'm throwing up a PR with the simplest fix I could find in order to start a discussion.