### PR TITLE
alloc: don't overwrite allocator during init if set

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -17,6 +17,13 @@ git_allocator git__allocator;
 
 int git_allocator_global_init(void)
 {
+	/*
+	 * We don't want to overwrite any allocator which has been set before
+	 * the init function is called.
+	 */
+	if (git__allocator.gmalloc != NULL)
+		return 0;
+
 #if defined(GIT_MSVC_CRTDBG)
 	return git_win32_crtdbg_init_allocator(&git__allocator);
 #else


### PR DESCRIPTION
If the allocator has been set before we the library is initialised, we would
replace that setting with the standard allocator contrary to the user's wishes.

---

In the general case the only safe time to set the allocator is before initialising the library as we allocate things there. Did we decide otherwise or this just oversight?

Annoyingly this will work if we init and then set the allocator in CI because by default ruby is built with the standard allocator, but it's not uncommon to have a tcmalloc-using MRI in production which would be upset if we mix allocators.