### PR TITLE
winhttp: retry erroneously failing requests

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -845,23 +845,27 @@ on_error:
 
 static int do_send_request(winhttp_stream *s, size_t len, int ignore_length)
 {
-	if (ignore_length) {
-		if (!WinHttpSendRequest(s->request,
-			WINHTTP_NO_ADDITIONAL_HEADERS, 0,
-			WINHTTP_NO_REQUEST_DATA, 0,
-			WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH, 0)) {
-			return -1;
+	int attempts;
+	bool success;
+
+	for (attempts = 0; attempts < 5; attempts++) {
+		if (ignore_length) {
+			success = WinHttpSendRequest(s->request,
+				WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+				WINHTTP_NO_REQUEST_DATA, 0,
+				WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH, 0);
+		} else {
+			success = WinHttpSendRequest(s->request,
+				WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+				WINHTTP_NO_REQUEST_DATA, 0,
+				len, 0);
 		}
-	} else {
-		if (!WinHttpSendRequest(s->request,
-			WINHTTP_NO_ADDITIONAL_HEADERS, 0,
-			WINHTTP_NO_REQUEST_DATA, 0,
-			len, 0)) {
-			return -1;
-		}
+
+		if (success || GetLastError() != SEC_E_BUFFER_TOO_SMALL)
+			break;
 	}
 
-	return 0;
+	return success ? 0 : -1;
 }
 
 static int send_request(winhttp_stream *s, size_t len, int ignore_length)


### PR DESCRIPTION
Early Windows TLS 1.2 implementations have an issue during key exchange with OpenSSL implementations that cause negotiation to fail with the error "the buffer supplied to a function was too small."

This is a transient error on the connection, so when that error is received, retry up to 5 times to create a connection to the remote server before actually giving up.

We put [a bandaid on our CI servers](https://github.com/libgit2/libgit2/commit/3a72b0e2569c03ed0bd7ca63572eaf6384a2c81f) by disabling DHE.  This is good for our build servers, but end-users will still see this problem if they are running older versions of Windows.