### PR TITLE
utils: make sure memchr() is not invoked with NULL

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -351,7 +351,13 @@ char *git__strsep(char **end, const char *sep)
 
 size_t git__linenlen(const char *buffer, size_t buffer_len)
 {
-	char *nl = memchr(buffer, '\n', buffer_len);
+	char *nl;
+
+	assert(buffer || buffer_len == 0);
+	if (!buffer)
+		return 0;
+
+	nl = memchr(buffer, '\n', buffer_len);
 	return nl ? (size_t)(nl - buffer) + 1 : buffer_len;
 }
 


### PR DESCRIPTION
Passing a null pointer as first argument to `memchr()` results in
undefined behavior.

In practice, this should not be a problem since, within libgit2,
`git__linenlen()` will be either called with a non-null `buffer` or with
both `buffer` and `buffer_len` being null. Any sane implementation of
`memchr()` should return `NULL` in this case without causing any
malicious or unintended effects.

However, it is still an UB. It will be reported by both dynamic and
static UB checkers. Hence, we add this additional check.

Resolves #4726.