### PR TITLE
mbedtls: remove unused variable "cacert"

### DIFF
--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -86,8 +86,6 @@ int git_mbedtls_stream_global_init(void)
 	char *cipher_string = NULL;
 	char *cipher_string_tmp = NULL;
 
-	mbedtls_x509_crt *cacert = NULL;
-
 	git__ssl_conf = git__malloc(sizeof(mbedtls_ssl_config));
 	GITERR_CHECK_ALLOC(git__ssl_conf);
 
@@ -163,8 +161,6 @@ int git_mbedtls_stream_global_init(void)
 	return 0;
 
 cleanup:
-	mbedtls_x509_crt_free(cacert);
-	git__free(cacert);
 	mbedtls_ctr_drbg_free(ctr_drbg);
 	git__free(ctr_drbg);
 	mbedtls_ssl_config_free(git__ssl_conf);


### PR DESCRIPTION
In commit 382ed1e87 (mbedtls: load default CA certificates, 2018-03-29),
the function `git_mbedtls_stream_global_init` was refactored to call out
to `git_mbedtls__set_cert_location` instead of setting up the
certificates itself. The conversion forgot to remove the now-unused
"cacert" variable, which is now only getting declared to be free'd at
the end of the function. Remove it.