### PR TITLE
Clar JUnit XML Support

### DIFF
--- a/tests/clar.c
+++ b/tests/clar.c
@@ -132,6 +132,7 @@ static struct {
 	int report_errors_only;
 	int exit_on_error;
 	int report_suite_names;
+	int write_summary;
 
 	struct clar_report *reports;
 	struct clar_report *last_report;
@@ -344,6 +345,7 @@ clar_usage(const char *arg)
 	printf("  -q    \tOnly report tests that had an error\n");
 	printf("  -Q    \tQuit as soon as a test fails\n");
 	printf("  -l    \tPrint suite names\n");
+	printf("  -r    \tWrite summary file\n");
 	exit(-1);
 }
 
@@ -357,7 +359,7 @@ clar_parse_args(int argc, char **argv)
 		char *argument = argv[i];
 
 		if (argument[0] != '-' || argument[1] == '\0'
-		    || strchr("sixvqQl", argument[1]) == NULL) {
+		    || strchr("sixvqQlr", argument[1]) == NULL) {
 			clar_usage(argv[0]);
 		}
 	}
@@ -436,6 +438,10 @@ clar_parse_args(int argc, char **argv)
 			_clar.report_suite_names = 1;
 			break;
 
+		case 'r':
+			_clar.write_summary = 1;
+			break;
+
 		default:
 			assert(!"Unexpected commandline argument!");
 		}
@@ -475,6 +481,8 @@ clar_test_run(void)
 	return _clar.total_errors;
 }
 
+static void clar_summary_write(void);
+
 void
 clar_test_shutdown(void)
 {
@@ -485,6 +493,9 @@ clar_test_shutdown(void)
 	);
 
 	clar_unsandbox();
+
+	if (_clar.write_summary)
+		clar_summary_write();
 }
 
 int
@@ -689,3 +700,4 @@ void cl_set_cleanup(void (*cleanup)(void *), void *opaque)
 #include "clar/fixtures.h"
 #include "clar/fs.h"
 #include "clar/print.h"
+#include "clar/summary.h"

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -95,9 +95,6 @@ static const char *
 fixture_path(const char *base, const char *fixture_name);
 
 struct clar_error {
-	const char *test;
-	int test_number;
-	const char *suite;
 	const char *file;
 	int line_number;
 	const char *error_msg;
@@ -106,11 +103,23 @@ struct clar_error {
 	struct clar_error *next;
 };
 
+struct clar_report {
+	const char *test;
+	int test_number;
+	const char *suite;
+
+	enum cl_test_status status;
+
+	struct clar_error *errors;
+	struct clar_error *last_error;
+
+	struct clar_report *next;
+};
+
 static struct {
 	int argc;
 	char **argv;
 
-	enum cl_test_status test_status;
 	const char *active_test;
 	const char *active_suite;
 
@@ -124,8 +133,8 @@ static struct {
 	int exit_on_error;
 	int report_suite_names;
 
-	struct clar_error *errors;
-	struct clar_error *last_error;
+	struct clar_report *reports;
+	struct clar_report *last_report;
 
 	void (*local_cleanup)(void *);
 	void *local_cleanup_payload;
@@ -155,7 +164,7 @@ struct clar_suite {
 /* From clar_print_*.c */
 static void clar_print_init(int test_count, int suite_count, const char *suite_names);
 static void clar_print_shutdown(int test_count, int suite_count, int error_count);
-static void clar_print_error(int num, const struct clar_error *error);
+static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error);
 static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status failed);
 static void clar_print_onsuite(const char *suite_name, int suite_index);
 static void clar_print_onabort(const char *msg, ...);
@@ -186,21 +195,33 @@ void cl_trace_register(cl_trace_cb *cb, void *payload)
 
 /* Core test functions */
 static void
-clar_report_errors(void)
+clar_report(int *i, struct clar_error *error)
+{
+	while (error != NULL) {
+		clar_print_error((*i)++, _clar.last_report, error);
+		error = error->next;
+	}
+}
+
+static void
+clar_report_errors(struct clar_error *error)
 {
 	int i = 1;
-	struct clar_error *error, *next;
+	clar_report(&i, error);
+}
 
-	error = _clar.errors;
-	while (error != NULL) {
-		next = error->next;
-		clar_print_error(i++, error);
-		free(error->description);
-		free(error);
-		error = next;
+static void
+clar_report_all(void)
+{
+	int i = 1;
+	struct clar_report *report;
+
+	report = _clar.reports;
+	while (report != NULL) {
+		if (report->status == CL_TEST_FAILURE)
+			clar_report(&i, report->errors);
+		report = report->next;
 	}
-
-	_clar.errors = _clar.last_error = NULL;
 }
 
 static void
@@ -209,7 +230,6 @@ clar_run_test(
 	const struct clar_func *initialize,
 	const struct clar_func *cleanup)
 {
-	_clar.test_status = CL_TEST_OK;
 	_clar.trampoline_enabled = 1;
 
 	CL_TRACE(CL_TRACE__TEST__BEGIN);
@@ -224,6 +244,9 @@ clar_run_test(
 	}
 
 	_clar.trampoline_enabled = 0;
+
+	if (_clar.last_report->status == CL_TEST_NOTRUN)
+		_clar.last_report->status = CL_TEST_OK;
 
 	if (_clar.local_cleanup != NULL)
 		_clar.local_cleanup(_clar.local_cleanup_payload);
@@ -240,9 +263,9 @@ clar_run_test(
 	_clar.local_cleanup_payload = NULL;
 
 	if (_clar.report_errors_only) {
-		clar_report_errors();
+		clar_report_errors(_clar.last_report->errors);
 	} else {
-		clar_print_ontest(test->name, _clar.tests_ran, _clar.test_status);
+		clar_print_ontest(test->name, _clar.tests_ran, _clar.last_report->status);
 	}
 }
 
@@ -250,6 +273,7 @@ static void
 clar_run_suite(const struct clar_suite *suite, const char *filter)
 {
 	const struct clar_func *test = suite->tests;
+	struct clar_report *report;
 	size_t i, matchlen = 0;
 
 	if (!suite->enabled)
@@ -283,6 +307,21 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 			continue;
 
 		_clar.active_test = test[i].name;
+
+		report = calloc(1, sizeof(struct clar_report));
+		report->suite = _clar.active_suite;
+		report->test = _clar.active_test;
+		report->test_number = _clar.tests_ran;
+		report->status = CL_TEST_NOTRUN;
+
+		if (_clar.reports == NULL)
+			_clar.reports = report;
+
+		if (_clar.last_report != NULL)
+			_clar.last_report->next = report;
+
+		_clar.last_report = report;
+
 		clar_run_test(&test[i], &suite->initialize, &suite->cleanup);
 
 		if (_clar.exit_on_error && _clar.total_errors)
@@ -465,7 +504,7 @@ static void abort_test(void)
 	if (!_clar.trampoline_enabled) {
 		clar_print_onabort(
 				"Fatal error: a cleanup method raised an exception.");
-		clar_report_errors();
+		clar_report_errors(_clar.last_report->errors);
 		exit(-1);
 	}
 
@@ -475,7 +514,7 @@ static void abort_test(void)
 
 void clar__skip(void)
 {
-	_clar.test_status = CL_TEST_SKIP;
+	_clar.last_report->status = CL_TEST_SKIP;
 	_clar.total_skipped++;
 	abort_test();
 }
@@ -489,17 +528,14 @@ void clar__fail(
 {
 	struct clar_error *error = calloc(1, sizeof(struct clar_error));
 
-	if (_clar.errors == NULL)
-		_clar.errors = error;
+	if (_clar.last_report->errors == NULL)
+		_clar.last_report->errors = error;
 
-	if (_clar.last_error != NULL)
-		_clar.last_error->next = error;
+	if (_clar.last_report->last_error != NULL)
+		_clar.last_report->last_error->next = error;
 
-	_clar.last_error = error;
+	_clar.last_report->last_error = error;
 
-	error->test = _clar.active_test;
-	error->test_number = _clar.tests_ran;
-	error->suite = _clar.active_suite;
 	error->file = file;
 	error->line_number = line;
 	error->error_msg = error_msg;
@@ -508,7 +544,7 @@ void clar__fail(
 		error->description = strdup(description);
 
 	_clar.total_errors++;
-	_clar.test_status = CL_TEST_FAILURE;
+	_clar.last_report->status = CL_TEST_FAILURE;
 
 	if (should_abort)
 		abort_test();

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -250,7 +250,7 @@ static void
 clar_run_suite(const struct clar_suite *suite, const char *filter)
 {
 	const struct clar_func *test = suite->tests;
-	size_t i, matchlen;
+	size_t i, matchlen = 0;
 
 	if (!suite->enabled)
 		return;

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -16,10 +16,12 @@ enum cl_test_status {
 	CL_TEST_NOTRUN,
 };
 
+/** Setup clar environment */
 void clar_test_init(int argc, char *argv[]);
 int clar_test_run(void);
 void clar_test_shutdown(void);
 
+/** One shot setup & run */
 int clar_test(int argc, char *argv[]);
 
 const char *clar_sandbox_path(void);

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -12,7 +12,8 @@
 enum cl_test_status {
 	CL_TEST_OK,
 	CL_TEST_FAILURE,
-	CL_TEST_SKIP
+	CL_TEST_SKIP,
+	CL_TEST_NOTRUN,
 };
 
 void clar_test_init(int argc, char *argv[]);

--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -13,16 +13,16 @@ static void clar_print_shutdown(int test_count, int suite_count, int error_count
 	(void)error_count;
 
 	printf("\n\n");
-	clar_report_errors();
+	clar_report_all();
 }
 
-static void clar_print_error(int num, const struct clar_error *error)
+static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
 
 	printf("%s::%s [%s:%d]\n",
-		error->suite,
-		error->test,
+		report->suite,
+		report->test,
 		error->file,
 		error->line_number);
 
@@ -44,6 +44,7 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	case CL_TEST_OK: printf("."); break;
 	case CL_TEST_FAILURE: printf("F"); break;
 	case CL_TEST_SKIP: printf("S"); break;
+	case CL_TEST_NOTRUN: printf("N"); break;
 	}
 
 	fflush(stdout);

--- a/tests/clar/summary.h
+++ b/tests/clar/summary.h
@@ -1,0 +1,98 @@
+
+#include <stdio.h>
+#include <time.h>
+
+static FILE *summary;
+
+int clar_summary_close_tag(const char *tag, int indent)
+{
+	const char *indt;
+
+	if (indent == 0) indt = "";
+	else if (indent == 1) indt = "\t";
+	else indt = "\t\t";
+
+	return fprintf(summary, "%s</%s>\n", indt, tag);
+}
+
+int clar_summary_testsuites(void)
+{
+	return fprintf(summary, "<testsuites>\n");
+}
+
+int clar_summary_testsuite(int idn, const char *name, const char *pkg, time_t timestamp, double time, int test_count, int fail_count, int error_count)
+{
+	struct tm *tm = localtime(&timestamp);
+	char iso_dt[20];
+
+	if (strftime(iso_dt, sizeof(iso_dt), "%FT%T", tm) == 0)
+		return -1;
+
+	return fprintf(summary, "\t<testsuite "
+		       " id=\"%d\""
+		       " name=\"%s\""
+		       " package=\"%s\""
+		       " hostname=\"localhost\""
+		       " timestamp=\"%s\""
+		       " time=\"%.2f\""
+		       " tests=\"%d\""
+		       " failures=\"%d\""
+		       " errors=\"%d\">\n",
+		       idn, name, pkg, iso_dt, time, test_count, fail_count, error_count);
+}
+
+int clar_summary_testcase(const char *name, const char *classname, double time)
+{
+	return fprintf(summary, "\t\t<testcase name=\"%s\" classname=\"%s\" time=\"%.2f\">\n", name, classname, time);
+}
+
+int clar_summary_failure(const char *type, const char *message, const char *desc)
+{
+	return fprintf(summary, "\t\t\t<failure type=\"%s\"><![CDATA[%s\n%s]]></failure>\n", type, message, desc);
+}
+
+void clar_summary_write(void)
+{
+	struct clar_report *report;
+	const char *last_suite = NULL;
+	char wd[1024];
+
+	summary = fopen("summary.xml", "w");
+	if (!summary) {
+		printf("failed to open summary.xml for writing\n");
+		return;
+	}
+
+	clar_summary_testsuites();
+
+	report = _clar.reports;
+	while (report != NULL) {
+		struct clar_error *error = report->errors;
+
+		if (last_suite == NULL || strcmp(last_suite, report->suite) != 0) {
+			clar_summary_testsuite(0, report->suite, "", time(NULL), 0, _clar.tests_ran, _clar.total_errors, 0);
+		}
+
+		last_suite = report->suite;
+
+		clar_summary_testcase(report->test, "what", 0);
+
+		while (error != NULL) {
+			clar_summary_failure("assert", error->error_msg, error->description);
+			error = error->next;
+		}
+
+		clar_summary_close_tag("testcase", 2);
+
+		report = report->next;
+
+		if (!report || strcmp(last_suite, report->suite) != 0)
+			clar_summary_close_tag("testsuite", 1);
+	}
+
+	clar_summary_close_tag("testsuites", 0);
+
+	fclose(summary);
+
+	printf("written summary file to %s\n", getcwd((char *)&wd, sizeof(wd)));
+}


### PR DESCRIPTION
As per https://github.com/libgit2/libgit2/pull/4723#discussion_r205529535, here's a (shoddy) JUnit XML writer for Clar.

It's completely untested, I've only checked the XML against this [XSD](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd) but that's all. Reporting is also quite spotty (a few accounting knobs are missing from clar, but they should be simple). I'll keep my fingers crossed that nothing will put unescaped names because there's no escaping done.

You should be able to pass `-r` and get a summary.xml file in the working directory. Unless clar crashes.