### PR TITLE
revwalk: remove tautologic condition for hiding a commit

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -426,8 +426,8 @@ static int limit_list(git_commit_list **out, git_revwalk *walk, git_commit_list 
 			break;
 		}
 
-		if (!commit->uninteresting && walk->hide_cb && walk->hide_cb(&commit->oid, walk->hide_cb_payload))
-				continue;
+		if (walk->hide_cb && walk->hide_cb(&commit->oid, walk->hide_cb_payload))
+			continue;
 
 		time = commit->time;
 		p = &git_commit_list_insert(commit, p)->next;


### PR DESCRIPTION
The contition cannot be reached with `commit->uninteresting` being true:
either a `break` or a `continue` statement will be hit in this case.