### PR TITLE
Windows: default credentials / fallback credential handling

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -219,6 +219,7 @@ static int fallback_cred_acquire_cb(
 	 * as an authentication mechanism */
 	if (GIT_CREDTYPE_DEFAULT & allowed_types) {
 		wchar_t *wide_url;
+		HRESULT hCoInitResult;
 
 		/* Convert URL to wide characters */
 		if (git__utf8_to_16_alloc(&wide_url, url) < 0) {
@@ -226,7 +227,9 @@ static int fallback_cred_acquire_cb(
 			return -1;
 		}
 
-		if (SUCCEEDED(CoInitializeEx(NULL, COINIT_MULTITHREADED))) {
+		hCoInitResult = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+			
+		if (SUCCEEDED(hCoInitResult) || hCoInitResult == RPC_E_CHANGED_MODE) {
 			IInternetSecurityManager* pISM;
 
 			/* And if the target URI is in the My Computer, Intranet, or Trusted zones */

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -253,7 +253,9 @@ static int fallback_cred_acquire_cb(
 				pISM->lpVtbl->Release(pISM);
 			}
 
-			CoUninitialize();
+            if (SUCCEEDED(hCoInitResult))
+                /* Only unitialize if the call to CoInitializeEx was successful. */
+                CoUninitialize();
 		}
 
 		git__free(wide_url);

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -184,10 +184,10 @@ static int apply_default_credentials(HINTERNET request, int mechanisms)
 	DWORD native_scheme = 0;
 
 	if ((mechanisms & GIT_WINHTTP_AUTH_NTLM) != 0)
-		native_scheme |= WINHTTP_AUTH_SCHEME_NTLM;
+		native_scheme = WINHTTP_AUTH_SCHEME_NTLM;
 
 	if ((mechanisms & GIT_WINHTTP_AUTH_NEGOTIATE) != 0)
-		native_scheme |= WINHTTP_AUTH_SCHEME_NEGOTIATE;
+		native_scheme = WINHTTP_AUTH_SCHEME_NEGOTIATE;
 
 	if (!native_scheme) {
 		giterr_set(GITERR_NET, "invalid authentication scheme");


### PR DESCRIPTION
While trying to use pygit2 with my TFS Git I stumbled accross two problems.

Whenever the server reports that it supports the NTLM and Negotiate authentication schemes both of the enum values are combined with the bitwise or assignment and the subsequent call to WinHttpSetCredentials fails.

The second problem was due to the fact that I had the python code running in PythonWin and it seems that PythonWin is setting the apartment state of the thread to single threaded. In this case the call to CoInitializeEx in the fallback credential function fails with the RPC_E_CHANGED_MODE and the fallback default credentials are never set.