### PR TITLE
travis: do not execute Coverity analysis for all cron jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,12 @@ matrix:
        - MBEDTLS=1
          CMAKE_OPTIONS="-DTHREADSAFE=OFF -DBUILD_EXAMPLES=ON -DUSE_HTTPS=mbedTLS -DSHA1_BACKEND=mbedTLS -DMBEDTLS_ROOT_DIR=/tmp/mbedtls"
      os: linux
- allow_failures:
-   - env: COVERITY=1
+   - compiler: gcc
+     if: type = cron
+     env:
+       - CMAKE_OPTIONS="-DBUILD_CLAR=ON -DCMAKE_BUILD_TYPE=Debug"
+         COVERITY=1
+     os: linux
 
 install:
   - if [ -f ./ci/setup-${TRAVIS_OS_NAME}.sh ]; then ./ci/setup-${TRAVIS_OS_NAME}.sh; fi
@@ -75,8 +79,8 @@ install:
 script:
  - mkdir build
  - cd build
- - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then ../ci/coverity.sh; fi
- - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then ../ci/build.sh && ../ci/test.sh; fi
+ - if [ -n "$COVERITY" ]; then ../ci/coverity.sh; fi
+ - if [ -z "$COVERITY" ]; then ../ci/build.sh && ../ci/test.sh; fi
 
 # Only watch the development and master branches
 branches:


### PR DESCRIPTION
The new Travis cron job gets executed daily, but our current
configuration will cause each job to execute our Coverity script instead
of the default build and testing scripts. This cannot work, as Coverity
is heavily rate-limiting its API, so our cron builds are doomed to
always fail. What we want to do instead is execute our normal builds,
but add an additional Coverity jobs.

This can easily be done by adding another Coverity-specific job with a
conditional "type = cron", which sets the "COVERITY" environment
variable. Instead of checking the build type, we then simply check
whether "COVERITY" is set or not.