### PR TITLE
ci: enable compilation with "-Werror"

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -29,7 +29,7 @@ echo "## Configuring build environment"
 echo "##############################################################################"
 
 echo cmake ${SOURCE_DIR} -DBUILD_EXAMPLES=ON ${CMAKE_OPTIONS}
-cmake ${SOURCE_DIR} -DBUILD_EXAMPLES=ON -DBUILD_FUZZERS=ON -DUSE_STANDALONE_FUZZERS=ON ${CMAKE_OPTIONS}
+cmake ${SOURCE_DIR} -DENABLE_WERROR=ON -DBUILD_EXAMPLES=ON -DBUILD_FUZZERS=ON -DUSE_STANDALONE_FUZZERS=ON ${CMAKE_OPTIONS}
 
 echo ""
 echo "##############################################################################"

--- a/src/odb.c
+++ b/src/odb.c
@@ -1384,8 +1384,8 @@ static int git_odb_stream__invalid_length(
 {
 	giterr_set(GITERR_ODB,
 		"cannot %s - "
-		"Invalid length. %"PRIdZ" was expected. The "
-		"total size of the received chunks amounts to %"PRIdZ".",
+		"Invalid length. %"PRId64" was expected. The "
+		"total size of the received chunks amounts to %"PRId64".",
 		action, stream->declared_size, stream->received_bytes);
 
 	return -1;


### PR DESCRIPTION
During the conversion of our CI scripts in bf418f09c (ci: refactor unix
ci build/test scripts, 2018-07-14), we accidentally dropped the
"-DENABLE_WERROR=ON" switch in our cmake invocation. Re-add it to help
us catch compiler warnings early.