### PR TITLE
diff: fix OOM on AIX when finding similar deltas in empty diff

### DIFF
--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -822,7 +822,7 @@ int git_diff_find_similar(
 	num_deltas = diff->deltas.length;
 
 	/* TODO: maybe abort if deltas.length > rename_limit ??? */
-	if (!git__is_uint32(num_deltas))
+	if (!num_deltas || !git__is_uint32(num_deltas))
 		goto cleanup;
 
 	/* No flags set; nothing to do */


### PR DESCRIPTION
The function `git_diff_find_similar` keeps a function of cache
similarity metrics signatures, whose size depends on the number of
deltas passed in via the `diff` parameter. In case where the diff is
empty and thus doesn't have any deltas at all, we may end up allocating
this cache via a call to `git__calloc(0, sizeof(void *))`. At least on
AIX, allocating 0 bytes will result in a `NULL` pointer being returned,
which causes us to erroneously return an OOM error.

Fix this situation by simply returning early in case where we are being
passed an empty diff, as we cannot find any similarities in that case
anyway.

---

This should fix #4748