### PR TITLE
ci: Correct the status code check so Coverity doesn't force-fail Travis

### DIFF
--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -59,7 +59,7 @@ STATUS_CODE="$(echo "$HTML" | tail -n1)"
 
 echo "${BODY}"
 
-if [ "${STATUS_CODE}" != "200" -o "${STATUS_CODE}" != "201" ]; then
+if [ "${STATUS_CODE}" != "200" -a "${STATUS_CODE}" != "201" ]; then
 	echo "Received error code ${STATUS_CODE} from Coverity"
 	exit 1
 fi


### PR DESCRIPTION
As per https://travis-ci.org/libgit2/libgit2/jobs/415921269, which is the cron job.

```
Emitted 525 C/C++ compilation units (100%) successfully

525 C/C++ compilation units (100%) are ready for analysis
The cov-build utility completed successfully.
Build successfully submitted.
Received error code 200 from Coverity

travis_time:end:14cf6373:start=1534254309066933889,finish=1534254728190974302,duration=419124040413
The command "if [ -n "$COVERITY" ]; then ../ci/coverity.sh; fi" exited with 1.
travis_time:start:01ed61d4
$ if [ -z "$COVERITY" ]; then ../ci/build.sh && ../ci/test.sh; fi

travis_time:end:01ed61d4:start=1534254728197560961,finish=1534254728202711214,duration=5150253
The command "if [ -z "$COVERITY" ]; then ../ci/build.sh && ../ci/test.sh; fi" exited with 0.

Done. Your build exited with 1.
```