### PR TITLE
travis: remove Coverity cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,12 +65,6 @@ matrix:
        - MBEDTLS=1
          CMAKE_OPTIONS="-DTHREADSAFE=OFF -DBUILD_EXAMPLES=ON -DUSE_HTTPS=mbedTLS -DSHA1_BACKEND=mbedTLS -DMBEDTLS_ROOT_DIR=/tmp/mbedtls"
      os: linux
-   - compiler: gcc
-     if: type = cron
-     env:
-       - CMAKE_OPTIONS="-DBUILD_CLAR=ON -DCMAKE_BUILD_TYPE=Debug"
-         COVERITY=1
-     os: linux
 
 install:
   - if [ -f ./ci/setup-${TRAVIS_OS_NAME}.sh ]; then ./ci/setup-${TRAVIS_OS_NAME}.sh; fi
@@ -79,8 +73,7 @@ install:
 script:
  - mkdir build
  - cd build
- - if [ -n "$COVERITY" ]; then ../ci/coverity.sh; fi
- - if [ -z "$COVERITY" ]; then ../ci/build.sh && ../ci/test.sh; fi
+ - ../ci/build.sh && ../ci/test.sh
 
 # Only watch the development and master branches
 branches:


### PR DESCRIPTION
With the recent addition of VSTS to our CI infrastructure, we now have
two cron jobs running regular Coverity analysis. It doesn't really make
a lot of sense to upload two different analysis on our sources to
Corverity, though:

- in the worst case, Coverity will be repeatedly confused when different
  sets of sources get analyzed and uploaded
- in the best case, nothing is gained because the sources have already
  been analyzed via the other job

Let's just use a single cron job for Coverity. Considering that VSTS
seems to be the more beefy and flexible platform, it is more likely to
be our future target CI platform. Thus, we retain its support for
Coverity and instead remove it from Travis.