### PR TITLE
In-memory configuration

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -12,7 +12,7 @@
 #include "git2/sys/config.h"
 #include "vector.h"
 #include "buf_text.h"
-#include "config_file.h"
+#include "config_backend.h"
 #include "transaction.h"
 #if GIT_WIN32
 # include <windows.h>
@@ -114,7 +114,7 @@ int git_config_add_file_ondisk(
 		return -1;
 	}
 
-	if (git_config_file__ondisk(&file, path) < 0)
+	if (git_config_backend_from_file(&file, path) < 0)
 		return -1;
 
 	if ((res = git_config_add_backend(cfg, file, level, repo, force)) < 0) {

--- a/src/config.h
+++ b/src/config.h
@@ -34,19 +34,6 @@ extern int git_config_rename_section(
 	const char *old_section_name,	/* eg "branch.dummy" */
 	const char *new_section_name);	/* NULL to drop the old section */
 
-/**
- * Create a configuration file backend for ondisk files
- *
- * These are the normal `.gitconfig` files that Core Git
- * processes. Note that you first have to add this file to a
- * configuration object before you can query it for configuration
- * variables.
- *
- * @param out the new backend
- * @param path where the config file is located
- */
-extern int git_config_file__ondisk(git_config_backend **out, const char *path);
-
 extern int git_config__normalize_name(const char *in, char **out);
 
 /* internal only: does not normalize key and sets out to NULL if not found */

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,7 @@
 
 struct git_config {
 	git_refcount rc;
-	git_vector files;
+	git_vector backends;
 };
 
 extern int git_config__global_location(git_buf *buf);

--- a/src/config_backend.h
+++ b/src/config_backend.h
@@ -25,6 +25,14 @@
  */
 extern int git_config_backend_from_file(git_config_backend **out, const char *path);
 
+/**
+ * Create an in-memory configuration file backend
+ *
+ * @param out the new backend
+ * @param cfg the configuration that is to be parsed
+ */
+extern int git_config_backend_from_string(git_config_backend **out, const char *cfg);
+
 GIT_INLINE(int) git_config_backend_open(git_config_backend *cfg, unsigned int level, const git_repository *repo)
 {
 	return cfg->open(cfg, level, repo);

--- a/src/config_backend.h
+++ b/src/config_backend.h
@@ -12,36 +12,49 @@
 #include "git2/sys/config.h"
 #include "git2/config.h"
 
-GIT_INLINE(int) git_config_file_open(git_config_backend *cfg, unsigned int level, const git_repository *repo)
+/**
+ * Create a configuration file backend for ondisk files
+ *
+ * These are the normal `.gitconfig` files that Core Git
+ * processes. Note that you first have to add this file to a
+ * configuration object before you can query it for configuration
+ * variables.
+ *
+ * @param out the new backend
+ * @param path where the config file is located
+ */
+extern int git_config_backend_from_file(git_config_backend **out, const char *path);
+
+GIT_INLINE(int) git_config_backend_open(git_config_backend *cfg, unsigned int level, const git_repository *repo)
 {
 	return cfg->open(cfg, level, repo);
 }
 
-GIT_INLINE(void) git_config_file_free(git_config_backend *cfg)
+GIT_INLINE(void) git_config_backend_free(git_config_backend *cfg)
 {
 	if (cfg)
 		cfg->free(cfg);
 }
 
-GIT_INLINE(int) git_config_file_get_string(
+GIT_INLINE(int) git_config_backend_get_string(
 	git_config_entry **out, git_config_backend *cfg, const char *name)
 {
 	return cfg->get(cfg, name, out);
 }
 
-GIT_INLINE(int) git_config_file_set_string(
+GIT_INLINE(int) git_config_backend_set_string(
 	git_config_backend *cfg, const char *name, const char *value)
 {
 	return cfg->set(cfg, name, value);
 }
 
-GIT_INLINE(int) git_config_file_delete(
+GIT_INLINE(int) git_config_backend_delete(
 	git_config_backend *cfg, const char *name)
 {
 	return cfg->del(cfg, name);
 }
 
-GIT_INLINE(int) git_config_file_foreach(
+GIT_INLINE(int) git_config_backend_foreach(
 	git_config_backend *cfg,
 	int (*fn)(const git_config_entry *entry, void *data),
 	void *data)
@@ -49,21 +62,12 @@ GIT_INLINE(int) git_config_file_foreach(
 	return git_config_backend_foreach_match(cfg, NULL, fn, data);
 }
 
-GIT_INLINE(int) git_config_file_foreach_match(
-	git_config_backend *cfg,
-	const char *regexp,
-	int (*fn)(const git_config_entry *entry, void *data),
-	void *data)
-{
-	return git_config_backend_foreach_match(cfg, regexp, fn, data);
-}
-
-GIT_INLINE(int) git_config_file_lock(git_config_backend *cfg)
+GIT_INLINE(int) git_config_backend_lock(git_config_backend *cfg)
 {
 	return cfg->lock(cfg);
 }
 
-GIT_INLINE(int) git_config_file_unlock(git_config_backend *cfg, int success)
+GIT_INLINE(int) git_config_backend_unlock(git_config_backend *cfg, int success)
 {
 	return cfg->unlock(cfg, success);
 }

--- a/src/config_entries.c
+++ b/src/config_entries.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "config_entries.h"
+
+static void config_entry_list_free(config_entry_list *list)
+{
+	config_entry_list *next;
+
+	while (list != NULL) {
+		next = list->next;
+
+		git__free((char*) list->entry->name);
+		git__free((char *) list->entry->value);
+		git__free(list->entry);
+		git__free(list);
+
+		list = next;
+	};
+}
+
+static void config_entry_list_append(config_entry_list **list, config_entry_list *entry)
+{
+	if (*list)
+		(*list)->last->next = entry;
+	else
+		*list = entry;
+	(*list)->last = entry;
+}
+
+int diskfile_entries_alloc(diskfile_entries **out)
+{
+	diskfile_entries *entries;
+	int error;
+
+	entries = git__calloc(1, sizeof(diskfile_entries));
+	GITERR_CHECK_ALLOC(entries);
+
+	git_atomic_set(&entries->refcount, 1);
+
+	if ((error = git_strmap_alloc(&entries->map)) < 0)
+		git__free(entries);
+	else
+		*out = entries;
+
+	return error;
+}
+
+void diskfile_entries_free(diskfile_entries *entries)
+{
+	config_entry_list *list = NULL, *next;
+
+	if (!entries)
+		return;
+
+	if (git_atomic_dec(&entries->refcount) != 0)
+		return;
+
+	git_strmap_foreach_value(entries->map, list, config_entry_list_free(list));
+	git_strmap_free(entries->map);
+
+	list = entries->list;
+	while (list != NULL) {
+		next = list->next;
+		git__free(list);
+		list = next;
+	}
+
+	git__free(entries);
+}
+
+int diskfile_entries_append(diskfile_entries *entries, git_config_entry *entry)
+{
+	git_strmap_iter pos;
+	config_entry_list *existing, *var;
+	int error = 0;
+
+	var = git__calloc(1, sizeof(config_entry_list));
+	GITERR_CHECK_ALLOC(var);
+	var->entry = entry;
+
+	pos = git_strmap_lookup_index(entries->map, entry->name);
+	if (!git_strmap_valid_index(entries->map, pos)) {
+		/*
+		 * We only ever inspect `last` from the first config
+		 * entry in a multivar. In case where this new entry is
+		 * the first one in the entry map, it will also be the
+		 * last one at the time of adding it, which is
+		 * why we set `last` here to itself. Otherwise we
+		 * do not have to set `last` and leave it set to
+		 * `NULL`.
+		 */
+		var->last = var;
+
+		git_strmap_insert(entries->map, entry->name, var, &error);
+
+		if (error > 0)
+			error = 0;
+	} else {
+		existing = git_strmap_value_at(entries->map, pos);
+		config_entry_list_append(&existing, var);
+	}
+
+	var = git__calloc(1, sizeof(config_entry_list));
+	GITERR_CHECK_ALLOC(var);
+	var->entry = entry;
+	config_entry_list_append(&entries->list, var);
+
+	return error;
+}
+
+void config_iterator_free(
+	git_config_iterator* iter)
+{
+	iter->backend->free(iter->backend);
+	git__free(iter);
+}
+
+int config_iterator_next(
+	git_config_entry **entry,
+	git_config_iterator *iter)
+{
+	git_config_file_iter *it = (git_config_file_iter *) iter;
+
+	if (!it->head)
+		return GIT_ITEROVER;
+
+	*entry = it->head->entry;
+	it->head = it->head->next;
+
+	return 0;
+}

--- a/src/config_entries.c
+++ b/src/config_entries.c
@@ -7,10 +7,22 @@
 
 #include "config_entries.h"
 
+typedef struct config_entry_list {
+	struct config_entry_list *next;
+	struct config_entry_list *last;
+	git_config_entry *entry;
+} config_entry_list;
+
 typedef struct config_entries_iterator {
 	git_config_iterator parent;
 	config_entry_list *head;
 } config_entries_iterator;
+
+struct git_config_entries {
+	git_refcount rc;
+	git_strmap *map;
+	config_entry_list *list;
+};
 
 static void config_entry_list_free(config_entry_list *list)
 {

--- a/src/config_entries.c
+++ b/src/config_entries.c
@@ -32,12 +32,12 @@ static void config_entry_list_append(config_entry_list **list, config_entry_list
 	(*list)->last = entry;
 }
 
-int diskfile_entries_alloc(diskfile_entries **out)
+int git_config_entries_new(git_config_entries **out)
 {
-	diskfile_entries *entries;
+	git_config_entries *entries;
 	int error;
 
-	entries = git__calloc(1, sizeof(diskfile_entries));
+	entries = git__calloc(1, sizeof(git_config_entries));
 	GITERR_CHECK_ALLOC(entries);
 
 	git_atomic_set(&entries->refcount, 1);
@@ -50,7 +50,7 @@ int diskfile_entries_alloc(diskfile_entries **out)
 	return error;
 }
 
-void diskfile_entries_free(diskfile_entries *entries)
+void git_config_entries_free(git_config_entries *entries)
 {
 	config_entry_list *list = NULL, *next;
 
@@ -73,7 +73,7 @@ void diskfile_entries_free(diskfile_entries *entries)
 	git__free(entries);
 }
 
-int diskfile_entries_append(diskfile_entries *entries, git_config_entry *entry)
+int git_config_entries_append(git_config_entries *entries, git_config_entry *entry)
 {
 	git_strmap_iter pos;
 	config_entry_list *existing, *var;

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -13,10 +13,11 @@
 typedef struct git_config_entries git_config_entries;
 
 int git_config_entries_new(git_config_entries **out);
+int git_config_entries_dup(git_config_entries **out, git_config_entries *entries);
 void git_config_entries_incref(git_config_entries *entries);
 void git_config_entries_free(git_config_entries *entries);
 /* Add or append the new config option */
 int git_config_entries_append(git_config_entries *entries, git_config_entry *entry);
 int git_config_entries_get(git_config_entry **out, git_config_entries *entries, const char *key);
 int git_config_entries_get_unique(git_config_entry **out, git_config_entries *entries, const char *key);
-int git_config_entries_iterator_new(git_config_iterator **out, git_config_backend *backend, git_config_entries *entries);
+int git_config_entries_iterator_new(git_config_iterator **out, git_config_entries *entries);

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -10,17 +10,7 @@
 #include "git2/sys/config.h"
 #include "config.h"
 
-typedef struct config_entry_list {
-	struct config_entry_list *next;
-	struct config_entry_list *last;
-	git_config_entry *entry;
-} config_entry_list;
-
-typedef struct {
-	git_refcount rc;
-	git_strmap *map;
-	config_entry_list *list;
-} git_config_entries;
+typedef struct git_config_entries git_config_entries;
 
 int git_config_entries_new(git_config_entries **out);
 void git_config_entries_incref(git_config_entries *entries);

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+
+#include "git2/sys/config.h"
+#include "config.h"
+
+typedef struct config_entry_list {
+	struct config_entry_list *next;
+	struct config_entry_list *last;
+	git_config_entry *entry;
+} config_entry_list;
+
+typedef struct {
+	git_atomic refcount;
+	git_strmap *map;
+	config_entry_list *list;
+} diskfile_entries;
+
+typedef struct git_config_file_iter {
+	git_config_iterator parent;
+	config_entry_list *head;
+} git_config_file_iter;
+
+int diskfile_entries_alloc(diskfile_entries **out);
+void diskfile_entries_free(diskfile_entries *entries);
+/* Add or append the new config option */
+int diskfile_entries_append(diskfile_entries *entries, git_config_entry *entry);
+
+void config_iterator_free(git_config_iterator* iter);
+int config_iterator_next(git_config_entry **entry,
+	git_config_iterator *iter);

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -20,17 +20,17 @@ typedef struct {
 	git_atomic refcount;
 	git_strmap *map;
 	config_entry_list *list;
-} diskfile_entries;
+} git_config_entries;
 
 typedef struct git_config_file_iter {
 	git_config_iterator parent;
 	config_entry_list *head;
 } git_config_file_iter;
 
-int diskfile_entries_alloc(diskfile_entries **out);
-void diskfile_entries_free(diskfile_entries *entries);
+int git_config_entries_new(git_config_entries **out);
+void git_config_entries_free(git_config_entries *entries);
 /* Add or append the new config option */
-int diskfile_entries_append(diskfile_entries *entries, git_config_entry *entry);
+int git_config_entries_append(git_config_entries *entries, git_config_entry *entry);
 
 void config_iterator_free(git_config_iterator* iter);
 int config_iterator_next(git_config_entry **entry,

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -17,12 +17,13 @@ typedef struct config_entry_list {
 } config_entry_list;
 
 typedef struct {
-	git_atomic refcount;
+	git_refcount rc;
 	git_strmap *map;
 	config_entry_list *list;
 } git_config_entries;
 
 int git_config_entries_new(git_config_entries **out);
+void git_config_entries_incref(git_config_entries *entries);
 void git_config_entries_free(git_config_entries *entries);
 /* Add or append the new config option */
 int git_config_entries_append(git_config_entries *entries, git_config_entry *entry);

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -31,6 +31,8 @@ int git_config_entries_new(git_config_entries **out);
 void git_config_entries_free(git_config_entries *entries);
 /* Add or append the new config option */
 int git_config_entries_append(git_config_entries *entries, git_config_entry *entry);
+int git_config_entries_get(git_config_entry **out, git_config_entries *entries, const char *key);
+int git_config_entries_get_unique(git_config_entry **out, git_config_entries *entries, const char *key);
 
 void config_iterator_free(git_config_iterator* iter);
 int config_iterator_next(git_config_entry **entry,

--- a/src/config_entries.h
+++ b/src/config_entries.h
@@ -22,18 +22,10 @@ typedef struct {
 	config_entry_list *list;
 } git_config_entries;
 
-typedef struct git_config_file_iter {
-	git_config_iterator parent;
-	config_entry_list *head;
-} git_config_file_iter;
-
 int git_config_entries_new(git_config_entries **out);
 void git_config_entries_free(git_config_entries *entries);
 /* Add or append the new config option */
 int git_config_entries_append(git_config_entries *entries, git_config_entry *entry);
 int git_config_entries_get(git_config_entry **out, git_config_entries *entries, const char *key);
 int git_config_entries_get_unique(git_config_entry **out, git_config_entries *entries, const char *key);
-
-void config_iterator_free(git_config_iterator* iter);
-int config_iterator_next(git_config_entry **entry,
-	git_config_iterator *iter);
+int git_config_entries_iterator_new(git_config_iterator **out, git_config_backend *backend, git_config_entries *entries);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -229,8 +229,6 @@ static int config_iterator_new(
 	git_config_iterator **iter,
 	struct git_config_backend* backend)
 {
-	diskfile_header *h;
-	git_config_file_iter *it;
 	git_config_backend *snapshot;
 	diskfile_header *bh = (diskfile_header *) backend;
 	int error;
@@ -241,19 +239,7 @@ static int config_iterator_new(
 	if ((error = snapshot->open(snapshot, bh->level, bh->repo)) < 0)
 		return error;
 
-	it = git__calloc(1, sizeof(git_config_file_iter));
-	GITERR_CHECK_ALLOC(it);
-
-	h = (diskfile_header *)snapshot;
-
-	it->parent.backend = snapshot;
-	it->head = h->entries->list;
-	it->parent.next = config_iterator_next;
-	it->parent.free = config_iterator_free;
-
-	*iter = (git_config_iterator *) it;
-
-	return 0;
+	return git_config_entries_iterator_new(iter, snapshot, bh->entries);
 }
 
 static int config_set(git_config_backend *cfg, const char *name, const char *value)

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -81,7 +81,6 @@ static int config_read(diskfile_entries *entries, const git_repository *repo, gi
 static int config_write(diskfile_backend *cfg, const char *orig_key, const char *key, const regex_t *preg, const char *value);
 static char *escape_value(const char *ptr);
 
-int git_config_file__snapshot(git_config_backend **out, diskfile_backend *in);
 static int config_snapshot(git_config_backend **out, git_config_backend *in);
 
 static int config_error_readonly(void)
@@ -632,13 +631,6 @@ out:
 	return result;
 }
 
-static int config_snapshot(git_config_backend **out, git_config_backend *in)
-{
-	diskfile_backend *b = (diskfile_backend *) in;
-
-	return git_config_file__snapshot(out, b);
-}
-
 static int config_lock(git_config_backend *_cfg)
 {
 	diskfile_backend *cfg = (diskfile_backend *) _cfg;
@@ -792,7 +784,7 @@ static int config_readonly_open(git_config_backend *cfg, git_config_level_t leve
 	return 0;
 }
 
-int git_config_file__snapshot(git_config_backend **out, diskfile_backend *in)
+static int config_snapshot(git_config_backend **out, git_config_backend *in)
 {
 	diskfile_readonly_backend *backend;
 
@@ -802,7 +794,7 @@ int git_config_file__snapshot(git_config_backend **out, diskfile_backend *in)
 	backend->header.parent.version = GIT_CONFIG_BACKEND_VERSION;
 	git_mutex_init(&backend->header.values_mutex);
 
-	backend->snapshot_from = in;
+	backend->snapshot_from = (diskfile_backend *) in;
 
 	backend->header.parent.readonly = 1;
 	backend->header.parent.version = GIT_CONFIG_BACKEND_VERSION;

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -107,29 +107,6 @@ static void config_entry_list_free(config_entry_list *list)
 	};
 }
 
-int git_config_file_normalize_section(char *start, char *end)
-{
-	char *scan;
-
-	if (start == end)
-		return GIT_EINVALIDSPEC;
-
-	/* Validate and downcase range */
-	for (scan = start; *scan; ++scan) {
-		if (end && scan >= end)
-			break;
-		if (isalnum(*scan))
-			*scan = (char)git__tolower(*scan);
-		else if (*scan != '-' || scan == start)
-			return GIT_EINVALIDSPEC;
-	}
-
-	if (scan == start)
-		return GIT_EINVALIDSPEC;
-
-	return 0;
-}
-
 static void config_entry_list_append(config_entry_list **list, config_entry_list *entry)
 {
 	if (*list)

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -88,7 +88,7 @@ static git_config_entries *diskfile_entries_take(diskfile_header *h)
 	}
 
 	entries = h->entries;
-	git_atomic_inc(&entries->refcount);
+	git_config_entries_incref(entries);
 
 	git_mutex_unlock(&h->values_mutex);
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -5,9 +5,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "config_file.h"
-
 #include "config.h"
+
 #include "filebuf.h"
 #include "sysdir.h"
 #include "buffer.h"
@@ -676,7 +675,7 @@ static int config_unlock(git_config_backend *_cfg, int success)
 	return error;
 }
 
-int git_config_file__ondisk(git_config_backend **out, const char *path)
+int git_config_backend_from_file(git_config_backend **out, const char *path)
 {
 	diskfile_backend *backend;
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -17,30 +17,14 @@
 #include "strmap.h"
 #include "array.h"
 #include "config_parse.h"
+#include "config_entries.h"
 
 #include <ctype.h>
 #include <sys/types.h>
 #include <regex.h>
 
-typedef struct config_entry_list {
-	struct config_entry_list *next;
-	struct config_entry_list *last;
-	git_config_entry *entry;
-} config_entry_list;
-
-typedef struct git_config_file_iter {
-	git_config_iterator parent;
-	config_entry_list *head;
-} git_config_file_iter;
-
 /* Max depth for [include] directives */
 #define MAX_INCLUDE_DEPTH 10
-
-typedef struct {
-	git_atomic refcount;
-	git_strmap *map;
-	config_entry_list *list;
-} diskfile_entries;
 
 typedef struct {
 	git_config_backend parent;
@@ -89,95 +73,6 @@ static int config_error_readonly(void)
 	return -1;
 }
 
-static void config_entry_list_free(config_entry_list *list)
-{
-	config_entry_list *next;
-
-	while (list != NULL) {
-		next = list->next;
-
-		git__free((char*) list->entry->name);
-		git__free((char *) list->entry->value);
-		git__free(list->entry);
-		git__free(list);
-
-		list = next;
-	};
-}
-
-static void config_entry_list_append(config_entry_list **list, config_entry_list *entry)
-{
-	if (*list)
-		(*list)->last->next = entry;
-	else
-		*list = entry;
-	(*list)->last = entry;
-}
-
-/* Add or append the new config option */
-static int diskfile_entries_append(diskfile_entries *entries, git_config_entry *entry)
-{
-	git_strmap_iter pos;
-	config_entry_list *existing, *var;
-	int error = 0;
-
-	var = git__calloc(1, sizeof(config_entry_list));
-	GITERR_CHECK_ALLOC(var);
-	var->entry = entry;
-
-	pos = git_strmap_lookup_index(entries->map, entry->name);
-	if (!git_strmap_valid_index(entries->map, pos)) {
-		/*
-		 * We only ever inspect `last` from the first config
-		 * entry in a multivar. In case where this new entry is
-		 * the first one in the entry map, it will also be the
-		 * last one at the time of adding it, which is
-		 * why we set `last` here to itself. Otherwise we
-		 * do not have to set `last` and leave it set to
-		 * `NULL`.
-		 */
-		var->last = var;
-
-		git_strmap_insert(entries->map, entry->name, var, &error);
-
-		if (error > 0)
-			error = 0;
-	} else {
-		existing = git_strmap_value_at(entries->map, pos);
-		config_entry_list_append(&existing, var);
-	}
-
-	var = git__calloc(1, sizeof(config_entry_list));
-	GITERR_CHECK_ALLOC(var);
-	var->entry = entry;
-	config_entry_list_append(&entries->list, var);
-
-	return error;
-}
-
-static void diskfile_entries_free(diskfile_entries *entries)
-{
-	config_entry_list *list = NULL, *next;
-
-	if (!entries)
-		return;
-
-	if (git_atomic_dec(&entries->refcount) != 0)
-		return;
-
-	git_strmap_foreach_value(entries->map, list, config_entry_list_free(list));
-	git_strmap_free(entries->map);
-
-	list = entries->list;
-	while (list != NULL) {
-		next = list->next;
-		git__free(list);
-		list = next;
-	}
-
-	git__free(entries);
-}
-
 /**
  * Take the current values map from the backend and increase its
  * refcount. This is its own function to make sure we use the mutex to
@@ -198,24 +93,6 @@ static diskfile_entries *diskfile_entries_take(diskfile_header *h)
 	git_mutex_unlock(&h->values_mutex);
 
 	return entries;
-}
-
-static int diskfile_entries_alloc(diskfile_entries **out)
-{
-	diskfile_entries *entries;
-	int error;
-
-	entries = git__calloc(1, sizeof(diskfile_entries));
-	GITERR_CHECK_ALLOC(entries);
-
-	git_atomic_set(&entries->refcount, 1);
-
-	if ((error = git_strmap_alloc(&entries->map)) < 0)
-		git__free(entries);
-	else
-		*out = entries;
-
-	return error;
 }
 
 static void config_file_clear(struct config_file *file)
@@ -346,28 +223,6 @@ static void backend_free(git_config_backend *_backend)
 	diskfile_entries_free(backend->header.entries);
 	git_mutex_free(&backend->header.values_mutex);
 	git__free(backend);
-}
-
-static void config_iterator_free(
-	git_config_iterator* iter)
-{
-	iter->backend->free(iter->backend);
-	git__free(iter);
-}
-
-static int config_iterator_next(
-	git_config_entry **entry,
-	git_config_iterator *iter)
-{
-	git_config_file_iter *it = (git_config_file_iter *) iter;
-
-	if (!it->head)
-		return GIT_ITEROVER;
-
-	*entry = it->head->entry;
-	it->head = it->head->next;
-
-	return 0;
 }
 
 static int config_iterator_new(

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -68,6 +68,4 @@ GIT_INLINE(int) git_config_file_unlock(git_config_backend *cfg, int success)
 	return cfg->unlock(cfg, success);
 }
 
-extern int git_config_file_normalize_section(char *start, char *end);
-
 #endif

--- a/src/config_mem.c
+++ b/src/config_mem.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "config.h"
+
+#include "config_backend.h"
+#include "config_parse.h"
+#include "config_entries.h"
+
+typedef struct {
+	git_config_backend parent;
+	git_config_entries *entries;
+	git_buf cfg;
+} config_memory_backend;
+
+typedef struct {
+	git_config_entries *entries;
+	git_config_level_t level;
+} config_memory_parse_data;
+
+static int config_error_readonly(void)
+{
+	giterr_set(GITERR_CONFIG, "this backend is read-only");
+	return -1;
+}
+
+static int read_variable_cb(
+	git_config_parser *reader,
+	const char *current_section,
+	const char *var_name,
+	const char *var_value,
+	const char *line,
+	size_t line_len,
+	void *payload)
+{
+	config_memory_parse_data *parse_data = (config_memory_parse_data *) payload;
+	git_buf buf = GIT_BUF_INIT;
+	git_config_entry *entry;
+	const char *c;
+	int result;
+
+	GIT_UNUSED(reader);
+	GIT_UNUSED(line);
+	GIT_UNUSED(line_len);
+
+	if (current_section) {
+		/* TODO: Once warnings land, we should likely warn
+		 * here. Git appears to warn in most cases if it sees
+		 * un-namespaced config options.
+		 */
+		git_buf_puts(&buf, current_section);
+		git_buf_putc(&buf, '.');
+	}
+
+	for (c = var_name; *c; c++)
+		git_buf_putc(&buf, git__tolower(*c));
+
+	if (git_buf_oom(&buf))
+		return -1;
+
+	entry = git__calloc(1, sizeof(git_config_entry));
+	GITERR_CHECK_ALLOC(entry);
+	entry->name = git_buf_detach(&buf);
+	entry->value = var_value ? git__strdup(var_value) : NULL;
+	entry->level = parse_data->level;
+	entry->include_depth = 0;
+
+	if ((result = git_config_entries_append(parse_data->entries, entry)) < 0)
+		return result;
+
+	return result;
+}
+
+static int config_memory_open(git_config_backend *backend, git_config_level_t level, const git_repository *repo)
+{
+	config_memory_backend *memory_backend = (config_memory_backend *) backend;
+	config_memory_parse_data parse_data;
+	git_config_parser reader;
+
+	GIT_UNUSED(repo);
+
+	if (memory_backend->cfg.size == 0)
+		return 0;
+
+	git_parse_ctx_init(&reader.ctx, memory_backend->cfg.ptr, memory_backend->cfg.size);
+	reader.file = NULL;
+	parse_data.entries = memory_backend->entries;
+	parse_data.level = level;
+
+	return git_config_parse(&reader, NULL, read_variable_cb, NULL, NULL, &parse_data);
+}
+
+static int config_memory_get(git_config_backend *backend, const char *key, git_config_entry **out)
+{
+	config_memory_backend *memory_backend = (config_memory_backend *) backend;
+	return git_config_entries_get(out, memory_backend->entries, key);
+}
+
+static int config_memory_iterator(
+	git_config_iterator **iter,
+	git_config_backend *backend)
+{
+	config_memory_backend *memory_backend = (config_memory_backend *) backend;
+	git_config_entries *entries;
+	int error;
+
+	if ((error = git_config_entries_dup(&entries, memory_backend->entries)) < 0)
+		goto out;
+
+	if ((error = git_config_entries_iterator_new(iter, entries)) < 0)
+		goto out;
+
+out:
+	/* Let iterator delete duplicated entries when it's done */
+	git_config_entries_free(entries);
+	return error;
+}
+
+static int config_memory_set(git_config_backend *backend, const char *name, const char *value)
+{
+	GIT_UNUSED(backend);
+	GIT_UNUSED(name);
+	GIT_UNUSED(value);
+	return config_error_readonly();
+}
+
+static int config_memory_set_multivar(
+	git_config_backend *backend, const char *name, const char *regexp, const char *value)
+{
+	GIT_UNUSED(backend);
+	GIT_UNUSED(name);
+	GIT_UNUSED(regexp);
+	GIT_UNUSED(value);
+	return config_error_readonly();
+}
+
+static int config_memory_delete(git_config_backend *backend, const char *name)
+{
+	GIT_UNUSED(backend);
+	GIT_UNUSED(name);
+	return config_error_readonly();
+}
+
+static int config_memory_delete_multivar(git_config_backend *backend, const char *name, const char *regexp)
+{
+	GIT_UNUSED(backend);
+	GIT_UNUSED(name);
+	GIT_UNUSED(regexp);
+	return config_error_readonly();
+}
+
+static int config_memory_lock(git_config_backend *backend)
+{
+	GIT_UNUSED(backend);
+	return config_error_readonly();
+}
+
+static int config_memory_unlock(git_config_backend *backend, int success)
+{
+	GIT_UNUSED(backend);
+	GIT_UNUSED(success);
+	return config_error_readonly();
+}
+
+static int config_memory_snapshot(git_config_backend **out, git_config_backend *backend)
+{
+	GIT_UNUSED(out);
+	GIT_UNUSED(backend);
+	giterr_set(GITERR_CONFIG, "this backend does not support snapshots");
+	return -1;
+}
+
+static void config_memory_free(git_config_backend *_backend)
+{
+	config_memory_backend *backend = (config_memory_backend *)_backend;
+
+	if (backend == NULL)
+		return;
+
+	git_config_entries_free(backend->entries);
+	git_buf_dispose(&backend->cfg);
+	git__free(backend);
+}
+
+int git_config_backend_from_string(git_config_backend **out, const char *cfg)
+{
+	config_memory_backend *backend;
+
+	backend = git__calloc(1, sizeof(config_memory_backend));
+	GITERR_CHECK_ALLOC(backend);
+
+	if (git_config_entries_new(&backend->entries) < 0) {
+		git__free(backend);
+		return -1;
+	}
+
+	if (git_buf_sets(&backend->cfg, cfg) < 0) {
+		git_config_entries_free(backend->entries);
+		git__free(backend);
+		return -1;
+	}
+
+	backend->parent.version = GIT_CONFIG_BACKEND_VERSION;
+	backend->parent.readonly = 1;
+	backend->parent.open = config_memory_open;
+	backend->parent.get = config_memory_get;
+	backend->parent.set = config_memory_set;
+	backend->parent.set_multivar = config_memory_set_multivar;
+	backend->parent.del = config_memory_delete;
+	backend->parent.del_multivar = config_memory_delete_multivar;
+	backend->parent.iterator = config_memory_iterator;
+	backend->parent.lock = config_memory_lock;
+	backend->parent.unlock = config_memory_unlock;
+	backend->parent.snapshot = config_memory_snapshot;
+	backend->parent.free = config_memory_free;
+
+	*out = (git_config_backend *)backend;
+
+	return 0;
+}

--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -16,8 +16,9 @@ const char *git_config_escaped = "\n\t\b\"\\";
 
 static void set_parse_error(git_config_parser *reader, int col, const char *error_str)
 {
+	const char *file = reader->file ? reader->file->path : "in-memory";
 	giterr_set(GITERR_CONFIG, "failed to parse config file: %s (in %s:%"PRIuZ", column %d)",
-		error_str, reader->file->path, reader->ctx.line_num, col);
+		error_str, file, reader->ctx.line_num, col);
 }
 
 

--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -11,6 +11,9 @@
 
 #include <ctype.h>
 
+const char *git_config_escapes = "ntb\"\\";
+const char *git_config_escaped = "\n\t\b\"\\";
+
 static void set_parse_error(git_config_parser *reader, int col, const char *error_str)
 {
 	giterr_set(GITERR_CONFIG, "failed to parse config file: %s (in %s:%"PRIuZ", column %d)",

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -12,8 +12,8 @@
 #include "oid.h"
 #include "parse.h"
 
-static const char *git_config_escapes = "ntb\"\\";
-static const char *git_config_escaped = "\n\t\b\"\\";
+extern const char *git_config_escapes;
+extern const char *git_config_escaped;
 
 typedef struct config_file {
 	git_oid checksum;

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -199,13 +199,15 @@ out:
  */
 static void free_submodule_names(git_strmap *names)
 {
-	git_buf *name;
+	const char *key;
+	char *value;
 
 	if (names == NULL)
 		return;
 
-	git_strmap_foreach_value(names, name, {
-		git__free(name);
+	git_strmap_foreach(names, key, value, {
+		git__free((char *) key);
+		git__free(value);
 	});
 	git_strmap_free(names);
 
@@ -257,7 +259,7 @@ static int load_submodule_names(git_strmap **out, git_repository *repo, git_conf
 		if (!isvalid)
 			continue;
 
-		git_strmap_insert(names, entry->value, git_buf_detach(&buf), &rval);
+		git_strmap_insert(names, git__strdup(entry->value), git_buf_detach(&buf), &rval);
 		if (rval < 0) {
 			giterr_set(GITERR_NOMEMORY, "error inserting submodule into hash table");
 			error = -1;

--- a/tests/config/memory.c
+++ b/tests/config/memory.c
@@ -1,0 +1,138 @@
+#include "clar_libgit2.h"
+
+#include "config_backend.h"
+
+static git_config_backend *backend;
+
+void test_config_memory__initialize(void)
+{
+	backend = NULL;
+}
+
+void test_config_memory__cleanup(void)
+{
+	git_config_backend_free(backend);
+}
+
+static void assert_config_contains(git_config_backend *backend,
+	const char *name, const char *value)
+{
+	git_config_entry *entry;
+	cl_git_pass(git_config_backend_get_string(&entry, backend, name));
+	cl_assert_equal_s(entry->value, value);
+}
+
+struct expected_entry {
+	const char *name;
+	const char *value;
+	int seen;
+};
+
+static int contains_all_cb(const git_config_entry *entry, void *payload)
+{
+	struct expected_entry *entries = (struct expected_entry *) payload;
+	int i;
+
+	for (i = 0; entries[i].name; i++) {
+		if (strcmp(entries[i].name, entry->name) ||
+		    strcmp(entries[i].value , entry->value))
+			continue;
+
+		if (entries[i].seen)
+			cl_fail("Entry seen more than once");
+		entries[i].seen = 1;
+		return 0;
+	}
+
+	cl_fail("Unexpected entry");
+	return -1;
+}
+
+static void assert_config_contains_all(git_config_backend *backend,
+	struct expected_entry *entries)
+{
+	int i;
+
+	cl_git_pass(git_config_backend_foreach(backend, contains_all_cb, entries));
+
+	for (i = 0; entries[i].name; i++)
+		cl_assert(entries[i].seen);
+}
+
+static void setup_backend(const char *cfg)
+{
+	cl_git_pass(git_config_backend_from_string(&backend, cfg));
+	cl_git_pass(git_config_backend_open(backend, 0, NULL));
+}
+
+void test_config_memory__write_operations_fail(void)
+{
+	setup_backend("");
+	cl_git_fail(git_config_backend_set_string(backend, "general.foo", "var"));
+	cl_git_fail(git_config_backend_delete(backend, "general.foo"));
+	cl_git_fail(git_config_backend_lock(backend));
+	cl_git_fail(git_config_backend_unlock(backend, 0));
+}
+
+void test_config_memory__simple(void)
+{
+	setup_backend(
+		"[general]\n"
+		"foo=bar\n");
+
+	assert_config_contains(backend, "general.foo", "bar");
+}
+
+void test_config_memory__malformed_fails_to_open(void)
+{
+	cl_git_pass(git_config_backend_from_string(&backend,
+		"[general\n"
+		"foo=bar\n"));
+	cl_git_fail(git_config_backend_open(backend, 0, NULL));
+}
+
+void test_config_memory__multiple_vars(void)
+{
+	setup_backend(
+		"[general]\n"
+		"foo=bar\n"
+		"key=value\n");
+	assert_config_contains(backend, "general.foo", "bar");
+	assert_config_contains(backend, "general.key", "value");
+}
+
+void test_config_memory__multiple_sections(void)
+{
+	setup_backend(
+		"[general]\n"
+		"foo=bar\n"
+		"\n"
+		"[other]\n"
+		"key=value\n");
+	assert_config_contains(backend, "general.foo", "bar");
+	assert_config_contains(backend, "other.key", "value");
+}
+
+void test_config_memory__multivar_gets_correct_string(void)
+{
+	setup_backend(
+		"[general]\n"
+		"foo=bar1\n"
+		"foo=bar2\n");
+	assert_config_contains(backend, "general.foo", "bar2");
+}
+
+void test_config_memory__foreach_sees_multivar(void)
+{
+	struct expected_entry entries[] = {
+		{ "general.foo", "bar1", 0 },
+		{ "general.foo", "bar2", 0 },
+		{ NULL, NULL, 0 },
+	};
+
+	setup_backend(
+		"[general]\n"
+		"foo=bar1\n"
+		"foo=bar2\n");
+	assert_config_contains_all(backend, entries);
+}

--- a/tests/config/readonly.c
+++ b/tests/config/readonly.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "config_file.h"
+#include "config_backend.h"
 #include "config.h"
 #include "path.h"
 
@@ -20,7 +20,7 @@ void test_config_readonly__writing_to_readonly_fails(void)
 {
 	git_config_backend *backend;
 
-	cl_git_pass(git_config_file__ondisk(&backend, "global"));
+	cl_git_pass(git_config_backend_from_file(&backend, "global"));
 	backend->readonly = 1;
 	cl_git_pass(git_config_add_backend(cfg, backend, GIT_CONFIG_LEVEL_GLOBAL, NULL, 0));
 
@@ -32,11 +32,11 @@ void test_config_readonly__writing_to_cfg_with_rw_precedence_succeeds(void)
 {
 	git_config_backend *backend;
 
-	cl_git_pass(git_config_file__ondisk(&backend, "global"));
+	cl_git_pass(git_config_backend_from_file(&backend, "global"));
 	backend->readonly = 1;
 	cl_git_pass(git_config_add_backend(cfg, backend, GIT_CONFIG_LEVEL_GLOBAL, NULL, 0));
 
-	cl_git_pass(git_config_file__ondisk(&backend, "local"));
+	cl_git_pass(git_config_backend_from_file(&backend, "local"));
 	cl_git_pass(git_config_add_backend(cfg, backend, GIT_CONFIG_LEVEL_LOCAL, NULL, 0));
 
 	cl_git_pass(git_config_set_string(cfg, "foo.bar", "baz"));
@@ -50,11 +50,11 @@ void test_config_readonly__writing_to_cfg_with_ro_precedence_succeeds(void)
 {
 	git_config_backend *backend;
 
-	cl_git_pass(git_config_file__ondisk(&backend, "local"));
+	cl_git_pass(git_config_backend_from_file(&backend, "local"));
 	backend->readonly = 1;
 	cl_git_pass(git_config_add_backend(cfg, backend, GIT_CONFIG_LEVEL_LOCAL, NULL, 0));
 
-	cl_git_pass(git_config_file__ondisk(&backend, "global"));
+	cl_git_pass(git_config_backend_from_file(&backend, "global"));
 	cl_git_pass(git_config_add_backend(cfg, backend, GIT_CONFIG_LEVEL_GLOBAL, NULL, 0));
 
 	cl_git_pass(git_config_set_string(cfg, "foo.bar", "baz"));

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -2,7 +2,6 @@
 #include "buffer.h"
 #include "fileops.h"
 #include "git2/sys/config.h"
-#include "config_file.h"
 #include "config.h"
 
 void test_config_write__initialize(void)


### PR DESCRIPTION
So finally I hold true to my promise to refactor our config code (once again) and create an in-memory configuration backend. I think the result is quite pleasant due to the refactorings, and in fact the in-memory backend implementation is only a bit more than a hundred lines of code (excluding the stubs).

This series has three phases:

1. Refactorings to make our config file more generic with regards to names. Most importantly, many things are renamed from "git_config_file_*" to "git_config_backend_*" to express that they are actually backend-agnostic.
2. I pull out the "config_entries" store from the "git_config_file" backend that abstracts iteration order and memory management for config entries.
3. I create the "git_config_mem" backend based on that store, which is rather trivial to do as everything is in place already.

There are a few more things I'd like to do after this PR is merged. First, I think that we can get rid of the file read-only snapshot implementation and simply use an in-memory backend instead. Second, I'll implement writing to and snapshotting of the in-memory config backend. Both things should be easy to implement, but the series is already long enough and thus I refrained from doing so now.

As always, I tried to make sure that the series "develops" to make a pleasant read. So I highly recommend to read it commit-wise instead of all at once.