### PR TITLE
worktree: unlock should return 1 when the worktree isn't locked

### DIFF
--- a/src/worktree.c
+++ b/src/worktree.c
@@ -426,7 +426,7 @@ int git_worktree_unlock(git_worktree *wt)
 	assert(wt);
 
 	if (!git_worktree_is_locked(NULL, wt))
-		return 0;
+		return 1;
 
 	if (git_buf_joinpath(&path, wt->gitdir_path, "locked") < 0)
 		return -1;

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -477,7 +477,7 @@ void test_worktree_worktree__unlock_unlocked_worktree(void)
 
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_assert(!git_worktree_is_locked(NULL, wt));
-	cl_assert(git_worktree_unlock(wt) == 0);
+	cl_assert_equal_i(1, git_worktree_unlock(wt));
 	cl_assert(!wt->locked);
 
 	git_worktree_free(wt);
@@ -490,7 +490,7 @@ void test_worktree_worktree__unlock_locked_worktree(void)
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_git_pass(git_worktree_lock(wt, NULL));
 	cl_assert(git_worktree_is_locked(NULL, wt));
-	cl_git_pass(git_worktree_unlock(wt));
+	cl_assert_equal_i(0, git_worktree_unlock(wt));
 	cl_assert(!wt->locked);
 
 	git_worktree_free(wt);


### PR DESCRIPTION
The documentation states that git_worktree_unlock returns 0 on success,
and 1 on success if the worktree wasn't locked. Turns out we were
returning 0 in any of those cases.

Found it while writing test cases for Objective-Git.