### PR TITLE
Allow merge analysis against any reference

### DIFF
--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -389,6 +389,25 @@ GIT_EXTERN(int) git_merge_analysis(
 	size_t their_heads_len);
 
 /**
+ * Analyzes the given branch(es) and determines the opportunities for
+ * merging them into a reference.
+ *
+ * @param analysis_out analysis enumeration that the result is written into
+ * @param repo the repository to merge
+ * @param our_ref the reference to perform the analysis from
+ * @param their_heads the heads to merge into
+ * @param their_heads_len the number of heads to merge
+ * @return 0 on success or error code
+ */
+GIT_EXTERN(int) git_merge_analysis_for_ref(
+	git_merge_analysis_t *analysis_out,
+	git_merge_preference_t *preference_out,
+	git_repository *repo,
+	git_reference *our_ref,
+	const git_annotated_commit **their_heads,
+	size_t their_heads_len);
+
+/**
  * Find a merge base between two commits
  *
  * @param out the OID of a merge base between 'one' and 'two'

--- a/src/merge.c
+++ b/src/merge.c
@@ -3191,7 +3191,7 @@ int git_merge_analysis_for_ref(
 	int error = 0;
 	bool unborn;
 
-	assert(analysis_out && preference_out && repo && their_heads);
+	assert(analysis_out && preference_out && repo && their_heads && their_heads_len > 0);
 
 	if (their_heads_len != 1) {
 		giterr_set(GITERR_MERGE, "can only merge a single branch");
@@ -3273,7 +3273,7 @@ int git_merge(
 	unsigned int checkout_strategy;
 	int error = 0;
 
-	assert(repo && their_heads);
+	assert(repo && their_heads && their_heads_len > 0);
 
 	if (their_heads_len != 1) {
 		giterr_set(GITERR_MERGE, "can only merge a single branch");

--- a/src/merge.c
+++ b/src/merge.c
@@ -3110,11 +3110,11 @@ static int merge_heads(
 	git_annotated_commit **ancestor_head_out,
 	git_annotated_commit **our_head_out,
 	git_repository *repo,
+	git_reference *our_ref,
 	const git_annotated_commit **their_heads,
 	size_t their_heads_len)
 {
 	git_annotated_commit *ancestor_head = NULL, *our_head = NULL;
-	git_reference *our_ref = NULL;
 	int error = 0;
 
 	*ancestor_head_out = NULL;
@@ -3123,8 +3123,7 @@ static int merge_heads(
 	if ((error = git_repository__ensure_not_bare(repo, "merge")) < 0)
 		goto done;
 
-	if ((error = git_reference_lookup(&our_ref, repo, GIT_HEAD_FILE)) < 0 ||
-		(error = git_annotated_commit_from_ref(&our_head, repo, our_ref)) < 0)
+	if ((error = git_annotated_commit_from_ref(&our_head, repo, our_ref)) < 0)
 		goto done;
 
 	if ((error = merge_ancestor_head(&ancestor_head, repo, our_head, their_heads, their_heads_len)) < 0) {
@@ -3143,8 +3142,6 @@ done:
 		git_annotated_commit_free(ancestor_head);
 		git_annotated_commit_free(our_head);
 	}
-
-	git_reference_free(our_ref);
 
 	return error;
 }
@@ -3182,15 +3179,17 @@ done:
 	return error;
 }
 
-int git_merge_analysis(
+int git_merge_analysis_for_ref(
 	git_merge_analysis_t *analysis_out,
 	git_merge_preference_t *preference_out,
 	git_repository *repo,
+	git_reference *our_ref,
 	const git_annotated_commit **their_heads,
 	size_t their_heads_len)
 {
 	git_annotated_commit *ancestor_head = NULL, *our_head = NULL;
 	int error = 0;
+	bool unborn;
 
 	assert(analysis_out && preference_out && repo && their_heads);
 
@@ -3205,12 +3204,16 @@ int git_merge_analysis(
 	if ((error = merge_preference(preference_out, repo)) < 0)
 		goto done;
 
-	if (git_repository_head_unborn(repo)) {
+	if ((error = git_reference__is_unborn_head(&unborn, our_ref, repo)) < 0)
+		goto done;
+
+	if (unborn) {
 		*analysis_out |= GIT_MERGE_ANALYSIS_FASTFORWARD | GIT_MERGE_ANALYSIS_UNBORN;
+		error = 0;
 		goto done;
 	}
 
-	if ((error = merge_heads(&ancestor_head, &our_head, repo, their_heads, their_heads_len)) < 0)
+	if ((error = merge_heads(&ancestor_head, &our_head, repo, our_ref, their_heads, their_heads_len)) < 0)
 		goto done;
 
 	/* We're up-to-date if we're trying to merge our own common ancestor. */
@@ -3230,6 +3233,28 @@ int git_merge_analysis(
 done:
 	git_annotated_commit_free(ancestor_head);
 	git_annotated_commit_free(our_head);
+	return error;
+}
+
+int git_merge_analysis(
+	git_merge_analysis_t *analysis_out,
+	git_merge_preference_t *preference_out,
+	git_repository *repo,
+	const git_annotated_commit **their_heads,
+	size_t their_heads_len)
+{
+	git_reference *head_ref = NULL;
+	int error = 0;
+
+	if ((error = git_reference_lookup(&head_ref, repo, GIT_HEAD_FILE)) < 0) {
+		giterr_set(GITERR_MERGE, "failed to lookup HEAD reference");
+		return error;
+	}
+
+	error = git_merge_analysis_for_ref(analysis_out, preference_out, repo, head_ref, their_heads, their_heads_len);
+
+	git_reference_free(head_ref);
+
 	return error;
 }
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -1430,3 +1430,27 @@ const char *git_reference_shorthand(const git_reference *ref)
 {
 	return git_reference__shorthand(ref->name);
 }
+
+int git_reference__is_unborn_head(bool *unborn, const git_reference *ref, git_repository *repo)
+{
+	int error;
+	git_reference *tmp_ref;
+	assert(unborn && ref && repo);
+
+	if (ref->type == GIT_REF_OID) {
+		*unborn = 0;
+		return 0;
+	}
+
+	error = git_reference_lookup_resolved(&tmp_ref, repo, ref->name, -1);
+	git_reference_free(tmp_ref);
+
+	if (error != 0 && error != GIT_ENOTFOUND)
+		return error;
+	else if (error == GIT_ENOTFOUND && git__strcmp(ref->name, GIT_HEAD_FILE) == 0)
+		*unborn = true;
+	else
+		*unborn = false;
+
+	return 0;
+}

--- a/src/refs.h
+++ b/src/refs.h
@@ -136,4 +136,6 @@ int git_reference__update_for_commit(
 	const git_oid *id,
 	const char *operation);
 
+int git_reference__is_unborn_head(bool *unborn, const git_reference *ref, git_repository *repo);
+
 #endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -2123,6 +2123,8 @@ int git_repository_head(git_reference **head_out, git_repository *repo)
 	git_reference *head;
 	int error;
 
+	assert(head_out);
+
 	if ((error = git_reference_lookup(&head, repo, GIT_HEAD_FILE)) < 0)
 		return error;
 


### PR DESCRIPTION
This adds a new `git_merge_analysis_any` function that can be used to check a merge against any given reference, as right now we only support checking `HEAD`.

Inspired by https://github.com/libgit2/objective-git/pull/629.