### PR TITLE
[WIP] Unborn reference semantics

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -139,7 +139,7 @@ static int git_commit__create_internal(
 	git_array_oid_t parents = GIT_ARRAY_INIT;
 
 	if (update_ref) {
-		error = git_reference_lookup_resolved(&ref, repo, update_ref, 10);
+		error = git_reference_lookup_resolved(&ref, repo, update_ref, 10, 0);
 		if (error < 0 && error != GIT_ENOTFOUND)
 			return error;
 	}
@@ -360,7 +360,7 @@ int git_commit_amend(
 	}
 
 	if (update_ref) {
-		if ((error = git_reference_lookup_resolved(&ref, repo, update_ref, 5)) < 0)
+		if ((error = git_reference_lookup_resolved(&ref, repo, update_ref, 5, 0)) < 0)
 			return error;
 
 		if (git_oid_cmp(git_commit_id(commit_to_amend), git_reference_target(ref))) {

--- a/src/describe.c
+++ b/src/describe.c
@@ -148,7 +148,7 @@ static int retrieve_peeled_tag_or_object_oid(
 	git_object *peeled = NULL;
 	int error;
 
-	if ((error = git_reference_lookup_resolved(&ref, repo, refname, -1)) < 0)
+	if ((error = git_reference_lookup_resolved(&ref, repo, refname, -1, 0)) < 0)
 		return error;
 
 	if ((error = git_reference_peel(&peeled, ref, GIT_OBJ_ANY)) < 0)

--- a/src/refs.c
+++ b/src/refs.c
@@ -1430,3 +1430,28 @@ const char *git_reference_shorthand(const git_reference *ref)
 {
 	return git_reference__shorthand(ref->name);
 }
+
+int git_reference__resolve_unborn(git_reference **out_ref, git_repository *repo, const git_reference *ref)
+{
+	git_reference *tmp_ref = NULL;
+	int error;
+
+	if (ref->type == GIT_REF_OID) {
+		giterr_set(GITERR_REFERENCE, "direct references cannot be unborn");
+		return GIT_EINVALID;
+	}
+
+	if (out_ref == NULL) {
+		out_ref = &tmp_ref;
+	}
+
+	error = git_reference_lookup_resolved(out_ref, repo, git_reference_symbolic_target(ref), -1);
+
+	if (error == GIT_ENOTFOUND) {
+		error = GIT_EUNBORNBRANCH;
+	}
+
+	git_reference_free(tmp_ref);
+
+	return error;
+}

--- a/src/refs.h
+++ b/src/refs.h
@@ -136,4 +136,16 @@ int git_reference__update_for_commit(
 	const git_oid *id,
 	const char *operation);
 
+/**
+ * Lookup a reference, with unborn error semantics.
+ *
+ * @param out_ref Pointer to the resolved reference. Can be null.
+ * @param repo The repository to use for resolution.
+ * @param ref The reference to resolve.
+ * @return 0 on success and out_ref (if provided) will be populated.
+ *         Otherwise, returns GIT_EINVALID if the reference is not symbolic,
+ *         GIT_EUNBORNBRANCH if the reference is unborn, or another error code.
+ */
+int git_reference__resolve_unborn(git_reference **out_ref, git_repository *repo, const git_reference *ref);
+
 #endif

--- a/src/refs.h
+++ b/src/refs.h
@@ -85,6 +85,10 @@ int git_reference__is_remote(const char *ref_name);
 int git_reference__is_tag(const char *ref_name);
 const char *git_reference__shorthand(const char *name);
 
+typedef enum {
+	GIT_REF_LOOKUP_DEFAULT = 0,
+	GIT_REF_LOOKUP_ALLOW_UNBORN = 1,
+} git_reference_lookup_options;
 /**
  * Lookup a reference by name and try to resolve to an OID.
  *
@@ -93,7 +97,7 @@ const char *git_reference__shorthand(const char *name);
  * default.  If you pass 0 for `max_deref`, this will not attempt to resolve
  * the reference.  For any value of `max_deref` other than 0, not
  * successfully resolving the reference will be reported as an error.
-
+ *
  * The generated reference must be freed by the user.
  *
  * @param reference_out Pointer to the looked-up reference
@@ -106,7 +110,8 @@ int git_reference_lookup_resolved(
 	git_reference **reference_out,
 	git_repository *repo,
 	const char *name,
-	int max_deref);
+	int max_deref,
+	unsigned int lookup_options);
 
 /**
  * Read reference from a file.
@@ -135,17 +140,5 @@ int git_reference__update_for_commit(
 	const char *ref_name,
 	const git_oid *id,
 	const char *operation);
-
-/**
- * Lookup a reference, with unborn error semantics.
- *
- * @param out_ref Pointer to the resolved reference. Can be null.
- * @param repo The repository to use for resolution.
- * @param ref The reference to resolve.
- * @return 0 on success and out_ref (if provided) will be populated.
- *         Otherwise, returns GIT_EINVALID if the reference is not symbolic,
- *         GIT_EUNBORNBRANCH if the reference is unborn, or another error code.
- */
-int git_reference__resolve_unborn(git_reference **out_ref, git_repository *repo, const git_reference *ref);
 
 #endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -2131,7 +2131,7 @@ int git_repository_head(git_reference **head_out, git_repository *repo)
 		return 0;
 	}
 
-	error = git_reference__resolve_unborn(head_out, repo, head);
+	error = git_reference_lookup_resolved(head_out, repo, git_reference_symbolic_target(head), -1, GIT_REF_LOOKUP_ALLOW_UNBORN);
 	git_reference_free(head);
 
 	return error;
@@ -2153,8 +2153,7 @@ int git_repository_head_for_worktree(git_reference **out, git_repository *repo, 
 
 	if (git_reference_type(head) != GIT_REF_OID) {
 		git_reference *resolved;
-
-		error = git_reference__resolve_unborn(&resolved, repo, head);
+		error = git_reference_lookup_resolved(&resolved, repo, git_reference_symbolic_target(head), -1, GIT_REF_LOOKUP_ALLOW_UNBORN);
 		git_reference_free(head);
 		head = resolved;
 	}

--- a/src/repository.c
+++ b/src/repository.c
@@ -2131,10 +2131,10 @@ int git_repository_head(git_reference **head_out, git_repository *repo)
 		return 0;
 	}
 
-	error = git_reference_lookup_resolved(head_out, repo, git_reference_symbolic_target(head), -1);
+	error = git_reference__resolve_unborn(head_out, repo, head);
 	git_reference_free(head);
 
-	return error == GIT_ENOTFOUND ? GIT_EUNBORNBRANCH : error;
+	return error;
 }
 
 int git_repository_head_for_worktree(git_reference **out, git_repository *repo, const char *name)
@@ -2154,7 +2154,7 @@ int git_repository_head_for_worktree(git_reference **out, git_repository *repo, 
 	if (git_reference_type(head) != GIT_REF_OID) {
 		git_reference *resolved;
 
-		error = git_reference_lookup_resolved(&resolved, repo, git_reference_symbolic_target(head), -1);
+		error = git_reference__resolve_unborn(&resolved, repo, head);
 		git_reference_free(head);
 		head = resolved;
 	}

--- a/tests/checkout/icase.c
+++ b/tests/checkout/icase.c
@@ -257,13 +257,13 @@ void test_checkout_icase__ignores_unstaged_casechange(void)
 
 	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 
-	cl_git_pass(git_reference_lookup_resolved(&orig_ref, repo, "HEAD", 100));
+	cl_git_pass(git_reference_lookup_resolved(&orig_ref, repo, "HEAD", 100, 0));
 	cl_git_pass(git_commit_lookup(&orig, repo, git_reference_target(orig_ref)));
 	cl_git_pass(git_reset(repo, (git_object *)orig, GIT_RESET_HARD, NULL));
 
 	cl_rename("testrepo/branch_file.txt", "testrepo/Branch_File.txt");
 
-	cl_git_pass(git_reference_lookup_resolved(&br2_ref, repo, "refs/heads/br2", 100));
+	cl_git_pass(git_reference_lookup_resolved(&br2_ref, repo, "refs/heads/br2", 100, 0));
 	cl_git_pass(git_commit_lookup(&br2, repo, git_reference_target(br2_ref)));
 
 	cl_git_pass(git_checkout_tree(repo, (const git_object *)br2, &checkout_opts));
@@ -283,7 +283,7 @@ void test_checkout_icase__conflicts_with_casechanged_subtrees(void)
 
 	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 
-	cl_git_pass(git_reference_lookup_resolved(&orig_ref, repo, "HEAD", 100));
+	cl_git_pass(git_reference_lookup_resolved(&orig_ref, repo, "HEAD", 100, 0));
 	cl_git_pass(git_object_lookup(&orig, repo, git_reference_target(orig_ref), GIT_OBJ_COMMIT));
 	cl_git_pass(git_reset(repo, (git_object *)orig, GIT_RESET_HARD, NULL));
 

--- a/tests/refs/lookup.c
+++ b/tests/refs/lookup.c
@@ -21,11 +21,11 @@ void test_refs_lookup__with_resolve(void)
 	cl_git_pass(git_reference_resolve(&a, temp));
 	git_reference_free(temp);
 
-	cl_git_pass(git_reference_lookup_resolved(&b, g_repo, "HEAD", 5));
+	cl_git_pass(git_reference_lookup_resolved(&b, g_repo, "HEAD", 5, 0));
 	cl_assert(git_reference_cmp(a, b) == 0);
 	git_reference_free(b);
 
-	cl_git_pass(git_reference_lookup_resolved(&b, g_repo, "HEAD_TRACKER", 5));
+	cl_git_pass(git_reference_lookup_resolved(&b, g_repo, "HEAD_TRACKER", 5, 0));
 	cl_assert(git_reference_cmp(a, b) == 0);
 	git_reference_free(b);
 


### PR DESCRIPTION
I've extracted this from #4770 because I don't think it's ready ; some of the points made by @pks-t made me look more closely, and I'm now confused (which is a bad sign). I'm also unclear on what  unbornness means from a technical standpoint, so there's that 😉.

So, this is the initial API I was envisioning in #4770 (DRY-ing that distinction into a shared helper function because I needed it), plus my proposal of folding that special handling in our private lookup function for consistency.

Right now that unborn error is very much HEAD-specific (I came to believe that symbolic references are the lonely kind), as the only code paths that return it are `git_repository_head` and `git_repository_head_for_worktree` ; all the others will return `GIT_ENOTFOUND`. It's not even consistent, because you'll get `GIT_EUNBORNBRANCH` with `git_repository_head` vs. `GIT_ENOTFOUND` with `git_reference_lookup("HEAD")`.

The problem I see is that this error code feels like a hack, because we're overriding `GIT_ENOTFOUND` unconditionally. Looking at my latter `git_reference_lookup_resolve`, it doesn't make any difference if the lookup failed to resolve its initial reference, if one of our symbolic references failed to resolve, or if the final OID wasn't found. To me only the 2nd case is unborn, the others are `GIT_ENOTFOUND` (I'm not sure what a broken direct reference is, so 3 could also be considered unborn, but more broken 😛).

I'd really prefer the API to be consistent, so if the definition above is fine (or if there's a better one), I'd like to fix that consistency issue.