### PR TITLE
remote: store the connection data in a private struct

### DIFF
--- a/src/push.c
+++ b/src/push.c
@@ -73,7 +73,8 @@ int git_push_set_options(git_push *push, const git_push_options *opts)
 	GITERR_CHECK_VERSION(opts, GIT_PUSH_OPTIONS_VERSION, "git_push_options");
 
 	push->pb_parallelism = opts->pb_parallelism;
-	push->custom_headers = &opts->custom_headers;
+	push->connection.custom_headers = &opts->custom_headers;
+	push->connection.proxy = &opts->proxy_opts;
 
 	return 0;
 }
@@ -475,7 +476,7 @@ int git_push_finish(git_push *push, const git_remote_callbacks *callbacks)
 	int error;
 
 	if (!git_remote_connected(push->remote) &&
-	    (error = git_remote_connect(push->remote, GIT_DIRECTION_PUSH, callbacks, NULL, push->custom_headers)) < 0)
+	    (error = git_remote__connect(push->remote, GIT_DIRECTION_PUSH, callbacks, &push->connection)) < 0)
 		return error;
 
 	if ((error = filter_refs(push->remote)) < 0 ||

--- a/src/push.h
+++ b/src/push.h
@@ -11,6 +11,7 @@
 
 #include "git2.h"
 #include "refspec.h"
+#include "remote.h"
 
 typedef struct push_spec {
 	struct git_refspec refspec;
@@ -40,7 +41,7 @@ struct git_push {
 
 	/* options */
 	unsigned pb_parallelism;
-	const git_strarray *custom_headers;
+	git_remote_connection_opts connection;
 };
 
 /**

--- a/src/remote.h
+++ b/src/remote.h
@@ -36,6 +36,15 @@ struct git_remote {
 	int passed_refspecs;
 };
 
+typedef struct git_remote_connection_opts {
+	const git_strarray *custom_headers;
+	const git_proxy_options *proxy;
+} git_remote_connection_opts;
+
+#define GIT_REMOTE_CONNECTION_OPTIONS_INIT { NULL, NULL }
+
+int git_remote__connect(git_remote *remote, git_direction direction, const git_remote_callbacks *callbacks, const git_remote_connection_opts *conn);
+
 const char* git_remote__urlfordirection(struct git_remote *remote, int direction);
 int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_url);
 


### PR DESCRIPTION
This makes it easier to pass connection-related options around (proxy & custom headers for now).

This fixes a bug in `git_push_finish`, which didn't reuse the provided proxy if the connection closed between the call to `git_remote_push` and the finish step.