### PR TITLE
Disable SSL/TLS client certificate handling in WinHTTP.

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -404,6 +404,14 @@ static int winhttp_stream_connect(winhttp_stream *s)
 		goto on_error;
 	}
 
+	/* Currently there is no method for providing client certificates, so disable
+	   the option instead, to allow connecting to servers that ask for a certificate
+	   but don't require one. */
+	if (!WinHttpSetOption(s->request, WINHTTP_OPTION_CLIENT_CERT_CONTEXT, WINHTTP_NO_CLIENT_CERT_CONTEXT, 0)) {
+		giterr_set(GITERR_OS, "failed to disable TLS client certificates");
+		goto on_error;		
+	}	
+
 	proxy_opts = &t->owner->proxy;
 	if (proxy_opts->type == GIT_PROXY_AUTO) {
 		/* Set proxy if necessary */


### PR DESCRIPTION
I can see there is currently a feature request #4204 for actually being able to supply a client certificate, however this change is still an incremental improvement over the current situation where there is no possible way to connect to a server that asks for an optional client certificate.

Code is basically straight from Microsoft docs: https://docs.microsoft.com/en-us/windows/desktop/winhttp/ssl-in-winhttp#optional-client-ssl-certificates 