### PR TITLE
Update VSTS YAML files with the latest syntax

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -5,11 +5,11 @@ trigger:
 - master
 - maint/*
 
-phases:
-- phase: linux_trusty_gcc_openssl
+jobs:
+- job: linux_trusty_gcc_openssl
   displayName: 'Linux (Trusty; GCC; OpenSSL)'
-  queue:
-    name: 'Hosted Linux Preview'
+  pool:
+    vmImage: 'Ubuntu 16.04'
   steps:
   - task: Docker@0
     displayName: Build
@@ -37,10 +37,10 @@ phases:
       containerCommand: '/src/ci/test.sh'
       detached: false
 
-- phase: linux_trusty_gcc_mbedtls
+- job: linux_trusty_gcc_mbedtls
   displayName: 'Linux (Trusty; GCC; mbedTLS)'
-  queue:
-    name: 'Hosted Linux Preview'
+  pool:
+    vmImage: 'Ubuntu 16.04'
   steps:
   - task: Docker@0
     displayName: Build
@@ -70,10 +70,10 @@ phases:
       containerCommand: '/src/ci/test.sh'
       detached: false
 
-- phase: linux_trusty_clang_openssl
+- job: linux_trusty_clang_openssl
   displayName: 'Linux (Trusty; Clang; OpenSSL)'
-  queue:
-    name: 'Hosted Linux Preview'
+  pool:
+    vmImage: 'Ubuntu 16.04'
   steps:
   - task: Docker@0
     displayName: Build
@@ -101,10 +101,10 @@ phases:
       containerCommand: '/src/ci/test.sh'
       detached: false
 
-- phase: linux_trusty_clang_mbedtls
+- job: linux_trusty_clang_mbedtls
   displayName: 'Linux (Trusty; Clang; mbedTLS)'
-  queue:
-    name: 'Hosted Linux Preview'
+  pool:
+    vmImage: 'Ubuntu 16.04'
   steps:
   - task: Docker@0
     displayName: Build
@@ -134,10 +134,10 @@ phases:
       containerCommand: '/src/ci/test.sh'
       detached: false
 
-- phase: macos
+- job: macos
   displayName: 'macOS'
-  queue:
-    name: 'Hosted macOS Preview'
+  pool:
+    vmImage: 'macOS 10.13'
   steps:
   - bash: . '$(Build.SourcesDirectory)/ci/setup-osx.sh'
     displayName: Setup
@@ -151,10 +151,9 @@ phases:
       TMPDIR: $(Agent.TempDirectory)
       LEAK_CHECK: leaks
 
-- phase: windows_vs_amd64
+- job: windows_vs_amd64
   displayName: 'Windows (Visual Studio; amd64)'
-  queue:
-    name: Hosted
+  pool: Hosted
   steps:
   - powershell: . '$(Build.SourcesDirectory)\ci\build.ps1'
     displayName: Build
@@ -163,10 +162,9 @@ phases:
   - powershell: . '$(Build.SourcesDirectory)\ci\test.ps1'
     displayName: Test
 
-- phase: windows_vs_x86
+- job: windows_vs_x86
   displayName: 'Windows (Visual Studio; x86)'
-  queue:
-    name: Hosted
+  pool: Hosted
   steps:
   - powershell: . '$(Build.SourcesDirectory)\ci\build.ps1'
     displayName: Build
@@ -175,10 +173,9 @@ phases:
   - powershell: . '$(Build.SourcesDirectory)\ci\test.ps1'
     displayName: Test
 
-- phase: windows_mingw_amd64
+- job: windows_mingw_amd64
   displayName: 'Windows (MinGW; amd64)'
-  queue:
-    name: Hosted
+  pool: Hosted
   steps:
   - powershell: . '$(Build.SourcesDirectory)\ci\setup-mingw.ps1'
     displayName: Setup
@@ -193,10 +190,9 @@ phases:
   - powershell: . '$(Build.SourcesDirectory)\ci\test.ps1'
     displayName: Test
 
-- phase: windows_mingw_x86
+- job: windows_mingw_x86
   displayName: 'Windows (MinGW; x86)'
-  queue:
-    name: Hosted
+  pool: Hosted
   steps:
   - powershell: . '$(Build.SourcesDirectory)\ci\setup-mingw.ps1'
     displayName: Setup

--- a/.vsts-nightly.yml
+++ b/.vsts-nightly.yml
@@ -1,11 +1,11 @@
 resources:
 - repo: self
 
-phases:
-- phase: coverity
+jobs:
+- job: coverity
   displayName: 'Coverity'
-  queue:
-    name: 'Hosted Linux Preview'
+  pool:
+    vmImage: 'Ubuntu 16.04'
   steps:
   - task: Docker@0
     displayName: Build


### PR DESCRIPTION
The VSTS YAML syntax has evolved to use "pool" instead of "queue" and "job" instead of "phase".  Additionally, this PR adds use of the "Ubuntu 16.04" pool which has performance benefits over "Hosted Linux Preview."