### PR TITLE
path validation: `char` is not signed by default.

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -1662,7 +1662,7 @@ GIT_INLINE(bool) verify_dotgit_ntfs_generic(const char *name, size_t len, const 
 			saw_tilde = 1;
 		} else if (i >= 6) {
 			return true;
-		} else if (name[i] < 0) {
+		} else if ((unsigned char)name[i] > 127) {
 			return true;
 		} else if (git__tolower(name[i]) != shortname_pfix[i]) {
 			return true;


### PR DESCRIPTION
ARM treats its `char` type as `unsigned type` by default; as a result, testing a `char` value as being `< 0` is always false.  This is a warning on ARM, which is promoted to an error given our use of `-Werror`.

Per ISO 9899:199, section "6.2.5 Types":

> The three types char, signed char, and unsigned char are collectively
> called the character types. The implementation shall define char to
> have the same range, representation, and behavior as either signed
> char or unsigned char.
>
...

> Irrespective of the choice made, char is a separate type from the other
> two and is not compatible with either.