### PR TITLE
Fix revwalk limiting regression

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -388,10 +388,16 @@ static int still_interesting(git_commit_list *list, int64_t time, int slop)
 	if (!list)
 		return 0;
 
+	/*
+	 * If the destination list has commits with an earlier date than our
+	 * source, we want to reset the slop counter as we're not done.
+	 */
+	if (time <= list->item->time)
+		return SLOP;
+
 	for (; list; list = list->next) {
 		/*
-		 * If the destination list has commits with an earlier date than
-		 * our source or if it still contains interesting commits we
+		 * If the destination list still contains interesting commits we
 		 * want to continue looking.
 		 */
 		if (!list->item->uninteresting || list->item->time > time)

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -405,7 +405,7 @@ static int still_interesting(git_commit_list *list, int64_t time, int slop)
 static int limit_list(git_commit_list **out, git_revwalk *walk, git_commit_list *commits)
 {
 	int error, slop = SLOP;
-	int64_t time = ~0ll;
+	int64_t time = INT64_MAX;
 	git_commit_list *list = commits;
 	git_commit_list *newlist = NULL;
 	git_commit_list **p = &newlist;


### PR DESCRIPTION
When porting, we overlooked that the difference between git's and our's time
representation and copied their way of getting the max value.
    
Unfortunately git was using unsigned integers, so `~0ll` does correspond to
their max value, whereas for us it corresponds to `-1`. This means that we
always consider the last date to be smaller than the current commit's and always
think commits are interesting.
    
Change the initial value to the macro that gives us the maximum value on each
platform so we can accurately consider commits interesting or not.

The second commit is mostly just to reduce the drift from git, the actual perf difference should be negligible.

This fixes #4740 and we should backport it as it fixes a regression.