### PR TITLE
cmake: enable -Wformat and -Wformat-security

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,8 @@ ELSE ()
 	ENABLE_WARNINGS(shift-count-overflow)
 	DISABLE_WARNINGS(unused-const-variable)
 	DISABLE_WARNINGS(unused-function)
+	ENABLE_WARNINGS(format)
+	ENABLE_WARNINGS(format-security)
 
 	IF (APPLE) # Apple deprecated OpenSSL
 	    DISABLE_WARNINGS(deprecated-declarations)


### PR DESCRIPTION
We do not currently have any warnings in this regard, but it's good practice to
have them on in case we introduce something.

Ideally we would also have `-Wformat-nonliteral` but we actually use it a lot and at least GCC cannot differentiate between static strings and stuff we've accepted from users, unfortunately.