### PR TITLE
revwalk: refer the sorting modes more to git's options

### DIFF
--- a/include/git2/revwalk.h
+++ b/include/git2/revwalk.h
@@ -25,15 +25,15 @@ GIT_BEGIN_DECL
  */
 typedef enum {
 	/**
-	 * Sort the output with the same default time-order method from git.
-	 * This is the default sorting for new walkers.
+	 * Sort the output with the same default method from `git`: reverse
+	 * chronological order. This is the default sorting for new walkers.
 	 */
 	GIT_SORT_NONE = 0,
 
 	/**
-	 * Sort the repository contents in topological order (parents before
-	 * children); this sorting mode can be combined with time sorting to
-	 * produce git's "time-order".
+	 * Sort the repository contents in topological order (no parents before
+	 * all of its children are shown); this sorting mode can be combined
+	 * with time sorting to produce `git`'s `--date-order``.
 	 */
 	GIT_SORT_TOPOLOGICAL = 1 << 0,
 


### PR DESCRIPTION
Show more directly what the sorting modes correspond to in git's `rev-list` as
that's the reference implementation for what the possible sorting orders are.