### PR TITLE
index: failing more thorough test for adding colliding path

### DIFF
--- a/tests/index/collision.c
+++ b/tests/index/collision.c
@@ -26,6 +26,7 @@ void test_index_collision__cleanup(void)
 void test_index_collision__add(void)
 {
 	git_index_entry entry;
+	git_tree_entry *tentry;
 	git_oid tree_id;
 	git_tree *tree;
 
@@ -39,12 +40,21 @@ void test_index_collision__add(void)
 	entry.path = "a/b";
 	cl_git_pass(git_index_add(g_index, &entry));
 
+	/* Check a/b exists here */
+	cl_git_pass(git_index_write_tree(&tree_id, g_index));
+	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
+	cl_git_pass(git_tree_entry_bypath(&tentry, tree, "a/b"));
+	git_tree_entry_free(tentry);
+
 	/* create a tree/blob collision */
 	entry.path = "a/b/c";
 	cl_git_fail(git_index_add(g_index, &entry));
 
+	/* a/b should still exist here */
 	cl_git_pass(git_index_write_tree(&tree_id, g_index));
 	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
+	cl_git_pass(git_tree_entry_bypath(&tentry, tree, "a/b"));
+	git_tree_entry_free(tentry);
 
 	git_tree_free(tree);
 }


### PR DESCRIPTION
We've had tests since v0.21 that we error out when trying to add a colliding
path to the index, but it turns out that right now we remove the
already-existing path from the index instead of leaving it alone.

I was looking at #4077 again and it looks like all we do right now is test that we return an error, but (at least) the tree we write out does not include the original path we inserted. I realise now that it would probably be a better test to look at the index instead of the tree it creates, but if someone wants to tackle this, they can do that I guess.