### PR TITLE
online::clone: free url and username before resetting

### DIFF
--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -276,6 +276,9 @@ static int cred_failure_cb(
 
 void test_online_clone__cred_callback_failure_return_code_is_tunnelled(void)
 {
+	git__free(_remote_url);
+	git__free(_remote_user);
+
 	_remote_url = git__strdup("https://github.com/libgit2/non-existent");
 	_remote_user = git__strdup("libgit2test");
 
@@ -305,6 +308,9 @@ static int cred_count_calls_cb(git_cred **cred, const char *url, const char *use
 void test_online_clone__cred_callback_called_again_on_auth_failure(void)
 {
 	size_t counter = 0;
+
+	git__free(_remote_url);
+	git__free(_remote_user);
 
 	_remote_url = git__strdup("https://github.com/libgit2/non-existent");
 	_remote_user = git__strdup("libgit2test");


### PR DESCRIPTION
Before resetting the url and username, ensure that we free them in case they were set by environment variables.  (This is definitely a bit ugly, but since the callbacks make use of the globals, this was the most straightforward way to keep that consistent without leaking.)