### PR TITLE
fix check if blob is uninteresting when inserting tree to packbuilder

### DIFF
--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1676,7 +1676,7 @@ int insert_tree(git_packbuilder *pb, git_tree *tree)
 
 			break;
 		case GIT_OBJ_BLOB:
-			if ((error = retrieve_object(&obj, pb, git_tree_id(tree))) < 0)
+			if ((error = retrieve_object(&obj, pb, entry_id)) < 0)
 				return error;
 			if (obj->uninteresting)
 				continue;


### PR DESCRIPTION
Blobs that have been marked as uninteresting should not be inserted into packbuilder
when inserting a tree. The check as to whether a blob was uninteresting looked at
the status for the tree itself instead of the blob.

This could cause significantly larger packfiles.