### PR TITLE
Fix issue #4821 with path canonicalization for Win32 paths

### DIFF
--- a/tests/path/win32.c
+++ b/tests/path/win32.c
@@ -145,6 +145,22 @@ void test_canonicalize(const wchar_t *in, const wchar_t *expected)
 #endif
 }
 
+void test_path_git_win32__canonicalize_path(const wchar_t *in, const wchar_t *expected)
+{
+#ifdef GIT_WIN32
+	git_win32_path canonical;
+
+	cl_assert(wcslen(in) < MAX_PATH);
+	wcscpy(canonical, in);
+
+	cl_must_pass(git_win32__canonicalize_path(canonical, wcslen(in)));
+	cl_assert_equal_wcs(expected, canonical);
+#else
+	GIT_UNUSED(in);
+	GIT_UNUSED(expected);
+#endif
+}
+
 void test_path_win32__canonicalize(void)
 {
 #ifdef GIT_WIN32
@@ -186,6 +202,8 @@ void test_path_win32__canonicalize(void)
 	test_canonicalize(L"\\\\server\\\\share\\\\foo\\\\bar", L"\\\\server\\share\\foo\\bar");
 	test_canonicalize(L"\\\\server\\share\\..\\foo", L"\\\\server\\foo");
 	test_canonicalize(L"\\\\server\\..\\..\\share\\.\\foo", L"\\\\server\\share\\foo");
+
+	test_path_git_win32__canonicalize_path(L"\\\\?\\UNC\\server\\C$\\folder", L"\\\\server\\C$\\folder");
 #endif
 }
 


### PR DESCRIPTION
This pull request fixes issue #4821.

This issue occurs when a user has a reparse point (symbol link) for their global %userprofile%\.gitconfig file the points to a Windows UNC share.

The p_stat function correctly determines that the path is a symbolic link and uses the getfinalpath_w function to Windows file path that can be used with GetFileAttributesEx. The getfinalypath_w ultimately uses git_win32__canonicalize_path to strip any prefixes that may have been returned by GetFinalPathNameByHandleW (for example "\\\\?\\.\\UNC\\). However, when a UNC path is converted, the beginning "\\\\" characters where incorrectly stripped from the path, leaving an incorrect file name.

This libgit to be unable to locate and read the .gitconfig file.