### PR TITLE
Add some more tests for git_futils_rmdir_r and some cleanup

### DIFF
--- a/tests/core/rmdir.c
+++ b/tests/core/rmdir.c
@@ -27,6 +27,12 @@ void test_core_rmdir__initialize(void)
 	git_buf_dispose(&path);
 }
 
+void test_core_rmdir__cleanup(void)
+{
+	if (git_path_exists(empty_tmp_dir))
+		cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_REMOVE_FILES));
+}
+
 /* make sure empty dir can be deleted recusively */
 void test_core_rmdir__delete_recursive(void)
 {

--- a/tests/core/rmdir.c
+++ b/tests/core/rmdir.c
@@ -30,7 +30,15 @@ void test_core_rmdir__initialize(void)
 /* make sure empty dir can be deleted recusively */
 void test_core_rmdir__delete_recursive(void)
 {
+	git_buf path = GIT_BUF_INIT;
+	cl_git_pass(git_buf_joinpath(&path, empty_tmp_dir, "/one"));
+	cl_assert(git_path_exists(git_buf_cstr(&path)));
+
 	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_EMPTY_HIERARCHY));
+
+	cl_assert(!git_path_exists(git_buf_cstr(&path)));
+
+	git_buf_dispose(&path);
 }
 
 /* make sure non-empty dir cannot be deleted recusively */
@@ -47,7 +55,15 @@ void test_core_rmdir__fail_to_delete_non_empty_dir(void)
 	cl_must_pass(p_unlink(file.ptr));
 	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_EMPTY_HIERARCHY));
 
+	cl_assert(!git_path_exists(empty_tmp_dir));
+
 	git_buf_dispose(&file);
+}
+
+void test_core_rmdir__keep_base(void)
+{
+	cl_git_pass(git_futils_rmdir_r(empty_tmp_dir, NULL, GIT_RMDIR_SKIP_ROOT));
+	cl_assert(git_path_exists(empty_tmp_dir));
 }
 
 void test_core_rmdir__can_skip_non_empty_dir(void)


### PR DESCRIPTION
**Update**: I cannot reproduce the issue any more which was the initial reason for this MR, however, this is a good extension for the test cases now...

**old**: When working on another issue I found that git_futils_rmdir_r does not delete an empty path hierarchy, just the last folder