### PR TITLE
int-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ ELSE ()
 	DISABLE_WARNINGS(unused-function)
 	ENABLE_WARNINGS(format)
 	ENABLE_WARNINGS(format-security)
+	ENABLE_WARNINGS(int-conversion)
 
 	IF (APPLE) # Apple deprecated OpenSSL
 	    DISABLE_WARNINGS(deprecated-declarations)

--- a/tests/core/vector.c
+++ b/tests/core/vector.c
@@ -412,7 +412,7 @@ void test_core_vector__dup_empty_vector(void)
 {
 	git_vector v = GIT_VECTOR_INIT;
 	git_vector dup = GIT_VECTOR_INIT;
-	void *dummy = 0xDEAFBEEB;
+	int dummy;
 
 	cl_assert_equal_i(0, v.length);
 
@@ -420,7 +420,7 @@ void test_core_vector__dup_empty_vector(void)
 	cl_assert_equal_i(0, dup._alloc_size);
 	cl_assert_equal_i(0, dup.length);
 
-	cl_git_pass(git_vector_insert(&dup, dummy));
+	cl_git_pass(git_vector_insert(&dup, &dummy));
 	cl_assert_equal_i(8, dup._alloc_size);
 	cl_assert_equal_i(1, dup.length);
 


### PR DESCRIPTION
This fixes a newly introduced warning with regards to int-conversion. To avoid such warnings in the future, this PR also introduces an explicit call `ENABLE_WARNINGS(int-conversion)`, such that passing "-DENABLE_WERROR=ON" to CMake will now trigger int-conversion errors instead of warnings.