### PR TITLE
ignore unsupported http authentication contexts

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -142,7 +142,7 @@ static int auth_context_match(
 	}
 
 	if (!scheme)
-		return -1;
+		return 0;
 
 	/* See if authentication has already started for this scheme */
 	git_vector_foreach(&t->auth_contexts, i, c) {
@@ -187,6 +187,9 @@ static int apply_credentials(git_buf *buf, http_subtransport *t)
 	/* Get or create a context for the best scheme for this cred type */
 	if (auth_context_match(&context, t, credtype_match, &cred->credtype) < 0)
 		return -1;
+
+	if (!context)
+		return 0;
 
 	return context->next_token(buf, context, cred);
 }


### PR DESCRIPTION
``auth_context_match`` returns -1 when the authentication context is not supported,
but this made ``parse_authenticate_response`` fail in situations where some authentication
contexts are supported and others are not.

``parse_authenticate_response`` will instead ignore authentication contexts where
``auth_context_match`` returns -1

This specifically handles recent changes to visualstudio.com that responds with:

    HTTP/1.1 401 Unauthorized
    WWW-Authenticate: Bearer authorization_uri=https://login.microsoftonline.com/a4c0aef7-6fdd-4c0e-b678-0dd23c73d08a
    WWW-Authenticate: Basic realm=\"https://tfsprodweu2.app.visualstudio.com/\"
    WWW-Authenticate: TFS-Federated

when asking for authentication and the http transport didn't know what to do with ``WWW-Authenticate: Bearer`` returning ``error=-1`` without any further explanation.

I presume the intersection of libgit2 and visualstudio.com users are mostly using the winhttp transport but this change improves behaviour when using the plain http transport.