### PR TITLE
config: Port config_file_fuzzer to the new in-memory backend.

### DIFF
--- a/fuzzers/config_file_fuzzer.c
+++ b/fuzzers/config_file_fuzzer.c
@@ -8,6 +8,7 @@
  */
 
 #include <git2.h>
+#include "config_backend.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -25,9 +26,6 @@ int foreach_cb(const git_config_entry *entry, void *payload)
 	return 0;
 }
 
-static char path[] = "/tmp/git.XXXXXX";
-static int fd = -1;
-
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
 	UNUSED(argc);
@@ -35,10 +33,6 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 
 	if (git_libgit2_init() < 0)
 		abort();
-	fd = mkstemp(path);
-	if (fd < 0) {
-		abort();
-	}
 
 	return 0;
 }
@@ -46,30 +40,29 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	git_config *cfg = NULL;
+	git_config_backend *backend = NULL;
 	int err = 0;
-	size_t total = 0;
 
-	if (ftruncate(fd, 0) !=0 ) {
-		abort();
-	}
-	if (lseek(fd, 0, SEEK_SET) != 0) {
-		abort();
+	err = git_config_new(&cfg);
+	if (err != 0) {
+		goto out;
 	}
 
-	while (total < size) {
-		ssize_t written = write(fd, data, size);
-		if (written < 0 && errno != EINTR)
-			abort();
-		if (written < 0)
-			continue;
-		total += written;
+	err = git_config_backend_from_string(&backend, (const char*)data, size);
+	if (err != 0) {
+		goto out;
 	}
+	err = git_config_add_backend(cfg, backend, 0, NULL, 0);
+	if (err != 0) {
+		goto out;
+	}
+	// Now owned by the config
+	backend = NULL;
 
-	err = git_config_open_ondisk(&cfg, path);
-	if (err == 0) {
-		git_config_foreach(cfg, foreach_cb, NULL);
-		git_config_free(cfg);
-	}
+	git_config_foreach(cfg, foreach_cb, NULL);
+ out:
+	git_config_backend_free(backend);
+	git_config_free(cfg);
 
 	return 0;
 }

--- a/fuzzers/config_file_fuzzer.c
+++ b/fuzzers/config_file_fuzzer.c
@@ -43,20 +43,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	git_config_backend *backend = NULL;
 	int err = 0;
 
-	err = git_config_new(&cfg);
-	if (err != 0) {
+	if ((err = git_config_new(&cfg)) != 0) {
 		goto out;
 	}
 
-	err = git_config_backend_from_string(&backend, (const char*)data, size);
-	if (err != 0) {
+	if ((err = git_config_backend_from_string(&backend, (const char*)data, size)) != 0) {
 		goto out;
 	}
-	err = git_config_add_backend(cfg, backend, 0, NULL, 0);
-	if (err != 0) {
+	if ((err = git_config_add_backend(cfg, backend, 0, NULL, 0)) != 0) {
 		goto out;
 	}
-	// Now owned by the config
+	/* Now owned by the config */
 	backend = NULL;
 
 	git_config_foreach(cfg, foreach_cb, NULL);

--- a/src/config_backend.h
+++ b/src/config_backend.h
@@ -30,8 +30,9 @@ extern int git_config_backend_from_file(git_config_backend **out, const char *pa
  *
  * @param out the new backend
  * @param cfg the configuration that is to be parsed
+ * @param len the length of the string pointed to by `cfg`
  */
-extern int git_config_backend_from_string(git_config_backend **out, const char *cfg);
+extern int git_config_backend_from_string(git_config_backend **out, const char *cfg, size_t len);
 
 GIT_INLINE(int) git_config_backend_open(git_config_backend *cfg, unsigned int level, const git_repository *repo)
 {

--- a/src/config_mem.c
+++ b/src/config_mem.c
@@ -186,7 +186,7 @@ static void config_memory_free(git_config_backend *_backend)
 	git__free(backend);
 }
 
-int git_config_backend_from_string(git_config_backend **out, const char *cfg)
+int git_config_backend_from_string(git_config_backend **out, const char *cfg, size_t len)
 {
 	config_memory_backend *backend;
 
@@ -198,7 +198,7 @@ int git_config_backend_from_string(git_config_backend **out, const char *cfg)
 		return -1;
 	}
 
-	if (git_buf_sets(&backend->cfg, cfg) < 0) {
+	if (git_buf_put(&backend->cfg, cfg, len) < 0) {
 		git_config_entries_free(backend->entries);
 		git__free(backend);
 		return -1;

--- a/src/config_mem.c
+++ b/src/config_mem.c
@@ -198,7 +198,7 @@ int git_config_backend_from_string(git_config_backend **out, const char *cfg, si
 		return -1;
 	}
 
-	if (git_buf_put(&backend->cfg, cfg, len) < 0) {
+	if (git_buf_set(&backend->cfg, cfg, len) < 0) {
 		git_config_entries_free(backend->entries);
 		git__free(backend);
 		return -1;

--- a/tests/config/memory.c
+++ b/tests/config/memory.c
@@ -61,7 +61,7 @@ static void assert_config_contains_all(git_config_backend *backend,
 
 static void setup_backend(const char *cfg)
 {
-	cl_git_pass(git_config_backend_from_string(&backend, cfg));
+	cl_git_pass(git_config_backend_from_string(&backend, cfg, strlen(cfg)));
 	cl_git_pass(git_config_backend_open(backend, 0, NULL));
 }
 
@@ -85,9 +85,10 @@ void test_config_memory__simple(void)
 
 void test_config_memory__malformed_fails_to_open(void)
 {
-	cl_git_pass(git_config_backend_from_string(&backend,
+	const char *cfg =
 		"[general\n"
-		"foo=bar\n"));
+		"foo=bar\n";
+	cl_git_pass(git_config_backend_from_string(&backend, cfg, strlen(cfg)));
 	cl_git_fail(git_config_backend_open(backend, 0, NULL));
 }
 


### PR DESCRIPTION
In quick testing, I see this hitting up to about 10k exec/s starting with an empty corpus on one core of my laptop, versus about 1500 for the old one.