### PR TITLE
tests: 🌀 address two null argument instances

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -312,8 +312,9 @@ static int apply_binary(
 			&patch->binary.old_file)) < 0)
 		goto done;
 
+	/* Verify that the resulting file with the reverse patch applied matches the source file */
 	if (source_len != reverse.size ||
-		memcmp(source, reverse.ptr, source_len) != 0) {
+		(source_len && memcmp(source, reverse.ptr, source_len) != 0)) {
 		error = apply_err("binary patch did not apply cleanly");
 		goto done;
 	}

--- a/tests/apply/fromfile.c
+++ b/tests/apply/fromfile.c
@@ -43,7 +43,8 @@ static int apply_patchfile(
 
 	if (error == 0) {
 		cl_assert_equal_i(new_len, result.size);
-		cl_assert(memcmp(new, result.ptr, new_len) == 0);
+		if (new_len)
+			cl_assert(memcmp(new, result.ptr, new_len) == 0);
 
 		cl_assert_equal_s(filename_expected, filename);
 		cl_assert_equal_i(mode_expected, mode);


### PR DESCRIPTION
Handle two null argument cases that occur in the unit tests.
One is in library code, the other is in test code.

Detected by running unit tests with undefined behavior sanitizer:
```bash
 # build
mkdir build && cd build
cmake -DBUILD_CLAR=ON -DCMAKE_C_FLAGS="-fsanitize=address \
-fsanitize=undefined -fstack-usage -static-libasan" ..
cmake --build .

 # run with asan
ASAN_OPTIONS="allocator_may_return_null=1" ./libgit2_clar
...
............../libgit2/src/apply.c:316:3: runtime error: null pointer \
passed as argument 1, which is declared to never be null
...................../libgit2/tests/apply/fromfile.c:46:3: runtime \
error: null pointer passed as argument 1, which is declared to never be null
```