### PR TITLE
cmake: correct comment from libssh to libssh2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ OPTION(LIBGIT2_FILENAME			"Name of the produced binary"				OFF)
 
    SET(SHA1_BACKEND 			"CollisionDetection"			       CACHE STRING
        "Backend to use for SHA1. One of Generic, OpenSSL, Win32, CommonCrypto, mbedTLS, CollisionDetection.")
-OPTION(USE_SSH				"Link with libssh to enable SSH support"		 ON)
+OPTION(USE_SSH				"Link with libssh2 to enable SSH support"		 ON)
 OPTION(USE_HTTPS			"Enable HTTPS support. Can be set to a specific backend" ON)
 OPTION(USE_GSSAPI			"Link with libgssapi for SPNEGO auth"			OFF)
 OPTION(USE_STANDALONE_FUZZERS		"Enable standalone fuzzers (compatible with gcc)"	OFF)


### PR DESCRIPTION
We use libssh2.  We do not use libssh.  Make sure to disambiguate them correctly.