### PR TITLE
ci builds: drop macOS leak detection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,6 @@ jobs:
       environmentVariables:
         TMPDIR: $(Agent.TempDirectory)
         PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
-        LEAK_CHECK: leaks
         CMAKE_OPTIONS: -G Ninja
 
 - job: windows_vs_amd64


### PR DESCRIPTION
Memory leak detection using the leaks application on macOS is brittle -
IIRC, it tries to background itself, but keeps a file descriptor open.
I previously got this to the point where it would exit cleanly (instead
of refusing to exit, and causing a build timeout after 60 minutes).  But
apparently these mechanations obscure clar's error code.

Disable leak detection on macOS until we can resolve this problem.