### PR TITLE
ci: run all the jobs during nightly builds

### DIFF
--- a/azure-pipelines/nightly.yml
+++ b/azure-pipelines/nightly.yml
@@ -2,6 +2,122 @@ resources:
 - repo: self
 
 jobs:
+- job: linux_amd64_trusty_gcc_openssl
+  displayName: 'Linux (amd64; Trusty; GCC; OpenSSL)'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - template: azure-pipelines/docker.yml
+    parameters:
+      imageName: 'libgit2/trusty-amd64:latest'
+      environmentVariables: |
+       CC=gcc
+       CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL
+       LEAK_CHECK=valgrind
+
+- job: linux_amd64_trusty_gcc_mbedtls
+  displayName: 'Linux (amd64; Trusty; GCC; mbedTLS)'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - template: azure-pipelines/docker.yml
+    parameters:
+      imageName: 'libgit2/trusty-amd64:latest'
+      environmentVariables: |
+       CC=gcc
+       CMAKE_OPTIONS=-DUSE_HTTPS=mbedTLS -DSHA1_BACKEND=mbedTLS
+       LEAK_CHECK=valgrind
+
+- job: linux_amd64_trusty_clang_openssl
+  displayName: 'Linux (amd64; Trusty; Clang; OpenSSL)'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - template: azure-pipelines/docker.yml
+    parameters:
+      imageName: 'libgit2/trusty-amd64:latest'
+      environmentVariables: |
+       CC=clang
+       CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL
+       LEAK_CHECK=valgrind
+
+- job: linux_amd64_trusty_clang_mbedtls
+  displayName: 'Linux (amd64; Trusty; Clang; mbedTLS)'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - template: azure-pipelines/docker.yml
+    parameters:
+      imageName: 'libgit2/trusty-amd64:latest'
+      environmentVariables: |
+       CC=clang
+       CMAKE_OPTIONS=-DUSE_HTTPS=mbedTLS -DSHA1_BACKEND=mbedTLS
+       LEAK_CHECK=valgrind
+
+- job: macos
+  displayName: 'macOS'
+  pool:
+    vmImage: 'macOS 10.13'
+  steps:
+  - bash: . '$(Build.SourcesDirectory)/ci/setup-osx.sh'
+    displayName: Setup
+  - template: azure-pipelines/bash.yml
+    parameters:
+      environmentVariables:
+        TMPDIR: $(Agent.TempDirectory)
+        PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
+        LEAK_CHECK: leaks
+        CMAKE_OPTIONS: -G Ninja
+
+- job: windows_vs_amd64
+  displayName: 'Windows (amd64; Visual Studio)'
+  pool: Hosted
+  steps:
+  - template: azure-pipelines/powershell.yml
+    parameters:
+      environmentVariables:
+        CMAKE_OPTIONS: -DMSVC_CRTDBG=ON -G"Visual Studio 12 2013 Win64"
+
+- job: windows_vs_x86
+  displayName: 'Windows (x86; Visual Studio)'
+  pool: Hosted
+  steps:
+  - template: azure-pipelines/powershell.yml
+    parameters:
+      environmentVariables:
+        CMAKE_OPTIONS: -DMSVC_CRTDBG=ON -G"Visual Studio 12 2013"
+
+- job: windows_mingw_amd64
+  displayName: 'Windows (amd64; MinGW)'
+  pool: Hosted
+  steps:
+  - powershell: . '$(Build.SourcesDirectory)\ci\setup-mingw.ps1'
+    displayName: Setup
+    env:
+      TEMP: $(Agent.TempDirectory)
+      ARCH: amd64
+  - template: azure-pipelines/powershell.yml
+    parameters:
+      environmentVariables:
+        CMAKE_OPTIONS: -G"MinGW Makefiles"
+        PATH: $(Agent.TempDirectory)\mingw64\bin;C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files (x86)\CMake\bin
+
+- job: windows_mingw_x86
+  displayName: 'Windows (x86; MinGW)'
+  pool: Hosted
+  steps:
+  - powershell: . '$(Build.SourcesDirectory)\ci\setup-mingw.ps1'
+    displayName: Setup
+    workingDirectory: '$(Build.BinariesDirectory)'
+    env:
+      TEMP: $(Agent.TempDirectory)
+      ARCH: x86
+  - template: azure-pipelines/powershell.yml
+    parameters:
+      environmentVariables:
+        CMAKE_OPTIONS: -G"MinGW Makefiles"
+        PATH: $(Agent.TempDirectory)\mingw32\bin;C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files (x86)\CMake\bin
+
 - job: linux_x86_bionic_gcc_openssl
   displayName: 'Linux (x86; Bionic; GCC; OpenSSL)'
   pool:


### PR DESCRIPTION
Instead of running the oddball builds, run all the builds (the ones
that we always run during PR validation and CI) during a nightly
build for increased coverage.