### PR TITLE
ci: Fix some minor issues

### DIFF
--- a/azure-pipelines/nightly.yml
+++ b/azure-pipelines/nightly.yml
@@ -7,7 +7,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
-  - template: azure-pipelines/docker.yml
+  - template: docker.yml
     parameters:
       imageName: 'libgit2/trusty-amd64:latest'
       environmentVariables: |
@@ -20,7 +20,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
-  - template: azure-pipelines/docker.yml
+  - template: docker.yml
     parameters:
       imageName: 'libgit2/trusty-amd64:latest'
       environmentVariables: |
@@ -33,7 +33,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
-  - template: azure-pipelines/docker.yml
+  - template: docker.yml
     parameters:
       imageName: 'libgit2/trusty-amd64:latest'
       environmentVariables: |
@@ -46,7 +46,7 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
-  - template: azure-pipelines/docker.yml
+  - template: docker.yml
     parameters:
       imageName: 'libgit2/trusty-amd64:latest'
       environmentVariables: |
@@ -61,7 +61,7 @@ jobs:
   steps:
   - bash: . '$(Build.SourcesDirectory)/ci/setup-osx.sh'
     displayName: Setup
-  - template: azure-pipelines/bash.yml
+  - template: bash.yml
     parameters:
       environmentVariables:
         TMPDIR: $(Agent.TempDirectory)
@@ -73,7 +73,7 @@ jobs:
   displayName: 'Windows (amd64; Visual Studio)'
   pool: Hosted
   steps:
-  - template: azure-pipelines/powershell.yml
+  - template: powershell.yml
     parameters:
       environmentVariables:
         CMAKE_OPTIONS: -DMSVC_CRTDBG=ON -G"Visual Studio 12 2013 Win64"
@@ -82,7 +82,7 @@ jobs:
   displayName: 'Windows (x86; Visual Studio)'
   pool: Hosted
   steps:
-  - template: azure-pipelines/powershell.yml
+  - template: powershell.yml
     parameters:
       environmentVariables:
         CMAKE_OPTIONS: -DMSVC_CRTDBG=ON -G"Visual Studio 12 2013"
@@ -96,7 +96,7 @@ jobs:
     env:
       TEMP: $(Agent.TempDirectory)
       ARCH: amd64
-  - template: azure-pipelines/powershell.yml
+  - template: powershell.yml
     parameters:
       environmentVariables:
         CMAKE_OPTIONS: -G"MinGW Makefiles"
@@ -112,7 +112,7 @@ jobs:
     env:
       TEMP: $(Agent.TempDirectory)
       ARCH: x86
-  - template: azure-pipelines/powershell.yml
+  - template: powershell.yml
     parameters:
       environmentVariables:
         CMAKE_OPTIONS: -G"MinGW Makefiles"

--- a/ci/test.ps1
+++ b/ci/test.ps1
@@ -19,12 +19,17 @@ if ($Env:SKIP_TESTS) { exit }
 function run_test {
 	$TestName = $args[0]
 
+	$TestCommand = (ctest -N -V -R "^$TestName$") -join "`n"
+
+	if (-Not ($TestCommand -match "(?ms).*\n^[0-9]*: Test command: ")) {
+		echo "Could not find tests: $TestName"
+		exit
+	}
+
 	$TestCommand = (ctest -N -V -R "^$TestName$") -join "`n" -replace "(?ms).*\n^[0-9]*: Test command: ","" -replace "\n.*",""
 	$TestCommand += " -r${BuildDir}\results_${TestName}.xml"
 
-	Write-Host $TestCommand
 	Invoke-Expression $TestCommand
-
 	if ($LastExitCode -ne 0) { $global:Success = $false }
 }
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -44,6 +44,12 @@ failure() {
 # JUnit-style XML files.
 run_test() {
 	TEST_CMD=$(ctest -N -V -R "^${1}$" | sed -n 's/^[0-9]*: Test command: //p')
+
+	if [ -z "$TEST_CMD" ]; then
+		echo "Could not find tests: $1"
+		exit 1
+	fi
+
 	TEST_CMD="${TEST_CMD} -r${BUILD_DIR}/results_${1}.xml"
 
 	if [ "$LEAK_CHECK" = "valgrind" ]; then


### PR DESCRIPTION
With the recent v0.26 and v0.27 point releases, it became obvious that the `ctest` invocation code in our CI builds was fraught.  Reject invalid / not found test names immediately and clearly.

Additionally, update the nightly build template path.