### PR TITLE
Nightlies: use `latest` docker images

### DIFF
--- a/azure-pipelines/nightly.yml
+++ b/azure-pipelines/nightly.yml
@@ -135,7 +135,7 @@ jobs:
   - template: docker.yml
     parameters:
       qemu: 'true'
-      imageName: 'libgit2/bionic-x86:test'
+      imageName: 'libgit2/bionic-x86:latest'
       environmentVariables: |
        CC=gcc
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL
@@ -150,7 +150,7 @@ jobs:
   - template: docker.yml
     parameters:
       qemu: 'true'
-      imageName: 'libgit2/bionic-x86:test'
+      imageName: 'libgit2/bionic-x86:latest'
       environmentVariables: |
        CC=clang
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL
@@ -165,7 +165,7 @@ jobs:
   - template: docker.yml
     parameters:
       qemu: 'true'
-      imageName: 'libgit2/bionic-arm32:test'
+      imageName: 'libgit2/bionic-arm32:latest'
       environmentVariables: |
        CC=gcc
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL
@@ -180,7 +180,7 @@ jobs:
   - template: docker.yml
     parameters:
       qemu: 'true'
-      imageName: 'libgit2/bionic-arm64:test'
+      imageName: 'libgit2/bionic-arm64:latest'
       environmentVariables: |
        CC=gcc
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL


### PR DESCRIPTION
I was originally trying to get the ppc64 builds working, but the emulator seems to not love emulating that platform.  I'm abandoning that but taking the update to use the `latest` images.