### PR TITLE
Make cred structure more private

### DIFF
--- a/include/git2/sys/cred.h
+++ b/include/git2/sys/cred.h
@@ -30,7 +30,7 @@ typedef struct git_cred_username {
 } git_cred_username;
 
 /** A key for NTLM/Kerberos "default" credentials */
-typedef struct git_cred git_cred_default;
+typedef struct git_cred git_cred_negotiate;
 
 /**
  * A ssh key from disk

--- a/include/git2/sys/cred.h
+++ b/include/git2/sys/cred.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_sys_git_cred_h__
+#define INCLUDE_sys_git_cred_h__
+
+#include "common.h"
+
+#include "git2/transport.h"
+
+struct git_cred {
+	git_credtype_t credtype; /**< A type of credential */
+	void (*free)(git_cred *cred);
+};
+
+/** A plaintext username and password */
+typedef struct {
+	git_cred parent;
+	char *username;
+	char *password;
+} git_cred_userpass_plaintext;
+
+/** Username-only credential information */
+typedef struct git_cred_username {
+	git_cred parent;
+	char username[1];
+} git_cred_username;
+
+/** A key for NTLM/Kerberos "default" credentials */
+typedef struct git_cred git_cred_default;
+
+/**
+ * A ssh key from disk
+ */
+typedef struct git_cred_ssh_key {
+	git_cred parent;
+	char *username;
+	char *publickey;
+	char *privatekey;
+	char *passphrase;
+} git_cred_ssh_key;
+
+/**
+ * Keyboard-interactive based ssh authentication
+ */
+typedef struct git_cred_ssh_interactive {
+	git_cred parent;
+	char *username;
+	git_cred_ssh_interactive_callback prompt_callback;
+	void *payload;
+} git_cred_ssh_interactive;
+
+/**
+ * A key with a custom signature function
+ */
+typedef struct git_cred_ssh_custom {
+	git_cred parent;
+	char *username;
+	char *publickey;
+	size_t publickey_len;
+	git_cred_sign_callback sign_callback;
+	void *payload;
+} git_cred_ssh_custom;
+
+#endif

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -104,9 +104,9 @@ typedef enum {
 
 	/**
 	 * An NTLM/Negotiate-based authentication request.
-	 * @see git_cred_default
+	 * @see git_cred_negotiate
 	 */
-	GIT_CREDTYPE_DEFAULT = (1u << 3),
+	GIT_CREDTYPE_NEGOTIATE = (1u << 3),
 
 	/**
 	 * An SSH interactive authentication request
@@ -249,12 +249,12 @@ GIT_EXTERN(int) git_cred_ssh_custom_new(
 	void *payload);
 
 /**
- * Create a "default" credential usable for Negotiate mechanisms like NTLM
+ * Create a credential object usable for Negotiate mechanisms like NTLM
  * or Kerberos authentication.
  *
  * @return 0 for success or an error code for failure
  */
-GIT_EXTERN(int) git_cred_default_new(git_cred **out);
+GIT_EXTERN(int) git_cred_negotiate_new(git_cred **out);
 
 /**
  * Create a credential to specify a username.

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -137,23 +137,10 @@ typedef enum {
 	GIT_CREDTYPE_SSH_MEMORY = (1u << 6),
 } git_credtype_t;
 
-typedef struct git_cred git_cred;
-
 /**
  * The base structure for all credential types
  */
-struct git_cred {
-	git_credtype_t credtype; /**< A type of credential */
-	void (*free)(git_cred *cred);
-};
-
-/** A plaintext username and password */
-typedef struct {
-	git_cred parent;
-	char *username;
-	char *password;
-} git_cred_userpass_plaintext;
-
+typedef struct git_cred git_cred;
 
 /*
  * If the user hasn't included libssh2.h before git2.h, we need to
@@ -167,48 +154,6 @@ typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE LIBSSH2_USERAUTH_KBDINT_RESPONS
 
 typedef int (*git_cred_sign_callback)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract);
 typedef void (*git_cred_ssh_interactive_callback)(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract);
-
-/**
- * A ssh key from disk
- */
-typedef struct git_cred_ssh_key {
-	git_cred parent;
-	char *username;
-	char *publickey;
-	char *privatekey;
-	char *passphrase;
-} git_cred_ssh_key;
-
-/**
- * Keyboard-interactive based ssh authentication
- */
-typedef struct git_cred_ssh_interactive {
-	git_cred parent;
-	char *username;
-	git_cred_ssh_interactive_callback prompt_callback;
-	void *payload;
-} git_cred_ssh_interactive;
-
-/**
- * A key with a custom signature function
- */
-typedef struct git_cred_ssh_custom {
-	git_cred parent;
-	char *username;
-	char *publickey;
-	size_t publickey_len;
-	git_cred_sign_callback sign_callback;
-	void *payload;
-} git_cred_ssh_custom;
-
-/** A key for NTLM/Kerberos "default" credentials */
-typedef struct git_cred git_cred_default;
-
-/** Username-only credential information */
-typedef struct git_cred_username {
-	git_cred parent;
-	char username[1];
-} git_cred_username;
 
 /**
  * Check whether a credential object contains username information.

--- a/src/streams/curl.c
+++ b/src/streams/curl.c
@@ -13,6 +13,7 @@
 
 #include "stream.h"
 #include "git2/transport.h"
+#include "git2/sys/cred.h"
 #include "buffer.h"
 #include "global.h"
 #include "vector.h"

--- a/src/transports/auth.c
+++ b/src/transports/auth.c
@@ -9,6 +9,7 @@
 
 #include "git2.h"
 #include "buffer.h"
+#include "git2/sys/cred.h"
 
 static int basic_next_token(
 	git_buf *out, git_http_auth_context *ctx, git_cred *c)

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -22,7 +22,7 @@ static int git_cred_ssh_key_type_new(
 
 int git_cred_has_username(git_cred *cred)
 {
-	if (cred->credtype == GIT_CREDTYPE_DEFAULT)
+	if (cred->credtype == GIT_CREDTYPE_NEGOTIATE)
 		return 0;
 
 	return 1;
@@ -168,9 +168,9 @@ static void ssh_custom_free(struct git_cred *cred)
 	git__free(c);
 }
 
-static void default_free(struct git_cred *cred)
+static void negotiate_free(struct git_cred *cred)
 {
-	git_cred_default *c = (git_cred_default *)cred;
+	git_cred_negotiate *c = (git_cred_negotiate *)cred;
 
 	git__free(c);
 }
@@ -344,17 +344,17 @@ int git_cred_ssh_custom_new(
 	return 0;
 }
 
-int git_cred_default_new(git_cred **cred)
+int git_cred_negotiate_new(git_cred **cred)
 {
-	git_cred_default *c;
+	git_cred_negotiate *c;
 
 	assert(cred);
 
-	c = git__calloc(1, sizeof(git_cred_default));
+	c = git__calloc(1, sizeof(git_cred_negotiate));
 	GITERR_CHECK_ALLOC(c);
 
-	c->credtype = GIT_CREDTYPE_DEFAULT;
-	c->free = default_free;
+	c->credtype = GIT_CREDTYPE_NEGOTIATE;
+	c->free = negotiate_free;
 
 	*cred = c;
 	return 0;

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -9,6 +9,7 @@
 
 #include "git2.h"
 #include "smart.h"
+#include "git2/sys/cred.h"
 #include "git2/cred_helpers.h"
 
 static int git_cred_ssh_key_type_new(

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -25,7 +25,7 @@
 #include "streams/curl.h"
 
 git_http_auth_scheme auth_schemes[] = {
-	{ GIT_AUTHTYPE_NEGOTIATE, "Negotiate", GIT_CREDTYPE_DEFAULT, git_http_auth_negotiate },
+	{ GIT_AUTHTYPE_NEGOTIATE, "Negotiate", GIT_CREDTYPE_NEGOTIATE, git_http_auth_negotiate },
 	{ GIT_AUTHTYPE_BASIC, "Basic", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_basic },
 };
 

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -15,6 +15,7 @@
 #include "netops.h"
 #include "global.h"
 #include "remote.h"
+#include "git2/sys/cred.h"
 #include "smart.h"
 #include "auth.h"
 #include "http.h"

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -17,6 +17,7 @@
 #include "netops.h"
 #include "smart.h"
 #include "cred.h"
+#include "git2/sys/cred.h"
 #include "streams/socket.h"
 
 #ifdef GIT_SSH

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -19,6 +19,7 @@
 #include "repository.h"
 #include "global.h"
 #include "http.h"
+#include "git2/sys/cred.h"
 
 #include <wincrypt.h>
 #include <winhttp.h>

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -218,7 +218,7 @@ static int fallback_cred_acquire_cb(
 
 	/* If the target URI supports integrated Windows authentication
 	 * as an authentication mechanism */
-	if (GIT_CREDTYPE_DEFAULT & allowed_types) {
+	if (GIT_CREDTYPE_NEGOTIATE & allowed_types) {
 		wchar_t *wide_url;
 		HRESULT hCoInitResult;
 
@@ -582,7 +582,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 		apply_userpass_credential(s->request, t->auth_mechanisms, t->cred) < 0)
 		goto on_error;
 	else if (t->cred &&
-		t->cred->credtype == GIT_CREDTYPE_DEFAULT &&
+		t->cred->credtype == GIT_CREDTYPE_NEGOTIATE &&
 		apply_default_credentials(s->request, t->auth_mechanisms) < 0)
 		goto on_error;
 
@@ -629,12 +629,12 @@ static int parse_unauthorized_response(
 
 	if (WINHTTP_AUTH_SCHEME_NTLM & supported) {
 		*allowed_types |= GIT_CREDTYPE_USERPASS_PLAINTEXT;
-		*allowed_types |= GIT_CREDTYPE_DEFAULT;
+		*allowed_types |= GIT_CREDTYPE_NEGOTIATE;
 		*allowed_mechanisms |= GIT_WINHTTP_AUTH_NTLM;
 	}
 
 	if (WINHTTP_AUTH_SCHEME_NEGOTIATE & supported) {
-		*allowed_types |= GIT_CREDTYPE_DEFAULT;
+		*allowed_types |= GIT_CREDTYPE_NEGOTIATE;
 		*allowed_mechanisms |= GIT_WINHTTP_AUTH_NEGOTIATE;
 	}
 

--- a/tests/network/cred.c
+++ b/tests/network/cred.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "git2/sys/cred.h"
 
 #include "git2/cred_helpers.h"
 

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -322,7 +322,7 @@ void test_online_clone__cred_callback_called_again_on_auth_failure(void)
 	cl_assert_equal_i(3, counter);
 }
 
-int cred_default(
+int cred_negotiate(
 	git_cred **cred,
 	const char *url,
 	const char *user_from_url,
@@ -333,10 +333,10 @@ int cred_default(
 	GIT_UNUSED(user_from_url);
 	GIT_UNUSED(payload);
 
-	if (!(allowed_types & GIT_CREDTYPE_DEFAULT))
+	if (!(allowed_types & GIT_CREDTYPE_NEGOTIATE))
 		return 0;
 
-	return git_cred_default_new(cred);
+	return git_cred_negotiate_new(cred);
 }
 
 void test_online_clone__credentials(void)
@@ -353,7 +353,7 @@ void test_online_clone__credentials(void)
 		clar__skip();
 
 	if (cl_is_env_set("GITTEST_REMOTE_DEFAULT")) {
-		g_options.fetch_opts.callbacks.credentials = cred_default;
+		g_options.fetch_opts.callbacks.credentials = cred_negotiate;
 	} else {
 		g_options.fetch_opts.callbacks.credentials = git_cred_userpass;
 		g_options.fetch_opts.callbacks.payload = &user_pass;

--- a/tests/online/push.c
+++ b/tests/online/push.c
@@ -59,13 +59,13 @@ static int cred_acquire_cb(
 		return git_cred_username_new(cred, _remote_user);
 	}
 
-	if (GIT_CREDTYPE_DEFAULT & allowed_types) {
+	if (GIT_CREDTYPE_NEGOTIATE & allowed_types) {
 		if (!_remote_default) {
 			printf("GITTEST_REMOTE_DEFAULT must be set to use NTLM/Negotiate credentials\n");
 			return -1;
 		}
 
-		return git_cred_default_new(cred);
+		return git_cred_negotiate_new(cred);
 	}
 
 	if (GIT_CREDTYPE_SSH_KEY & allowed_types) {


### PR DESCRIPTION
I don't think we want those structs to be "open", as they're only useful for code that has to perform authentication (ie. custom transport). Hence, let's move them in a `sys` header so they're less likely to be depended upon. As I don't expect anyone to have used those structs internal details, I think it's okay from a BC standpoint.

Additionally, rename the `GIT_CREDTYPE_DEFAULT` to `GIT_CREDTYPE_NEGOTIATE`, so it's less confusing. This one's breaking, but I'm really not fond of having "default" mean something specific, since at a glance it looks like the default authentication mechanism to use (which it is not).