### PR TITLE
transport/http: Include non-default ports in Host header

### DIFF
--- a/src/netops.c
+++ b/src/netops.c
@@ -119,6 +119,15 @@ int gitno__match_host(const char *pattern, const char *host)
 	return -1;
 }
 
+static const char *default_port_http = "80";
+static const char *default_port_https = "443";
+
+const char *gitno__default_port(
+	gitno_connection_data *data)
+{
+	return data->use_ssl ? default_port_https : default_port_http;
+}
+
 static const char *prefix_http = "http://";
 static const char *prefix_https = "https://";
 
@@ -141,7 +150,7 @@ int gitno_connection_data_from_url(
 
 	if (!git__prefixcmp(url, prefix_http)) {
 		path_search_start = url + strlen(prefix_http);
-		default_port = "80";
+		default_port = default_port_http;
 
 		if (data->use_ssl) {
 			giterr_set(GITERR_NET, "redirect from HTTPS to HTTP is not allowed");
@@ -149,10 +158,10 @@ int gitno_connection_data_from_url(
 		}
 	} else if (!git__prefixcmp(url, prefix_https)) {
 		path_search_start = url + strlen(prefix_https);
-		default_port = "443";
+		default_port = default_port_https;
 		data->use_ssl = true;
 	} else if (url[0] == '/')
-		default_port = data->use_ssl ? "443" : "80";
+		default_port = gitno__default_port(data);
 
 	if (!default_port) {
 		giterr_set(GITERR_NET, "unrecognized URL prefix");

--- a/src/netops.h
+++ b/src/netops.h
@@ -96,4 +96,6 @@ int gitno_extract_url_parts(
 		const char *url,
 		const char *default_port);
 
+const char *gitno__default_port(gitno_connection_data *data);
+
 #endif

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -208,7 +208,11 @@ static int gen_request(
 	git_buf_puts(buf, "User-Agent: ");
 	git_http__user_agent(buf);
 	git_buf_puts(buf, "\r\n");
-	git_buf_printf(buf, "Host: %s\r\n", t->connection_data.host);
+	git_buf_printf(buf, "Host: %s", t->connection_data.host);
+	if (strcmp(t->connection_data.port, gitno__default_port(&t->connection_data)) != 0) {
+		git_buf_printf(buf, ":%s", t->connection_data.port);
+	}
+	git_buf_puts(buf, "\r\n");
 
 	if (s->chunked || content_length > 0) {
 		git_buf_printf(buf, "Accept: application/x-git-%s-result\r\n", s->service);


### PR DESCRIPTION
When the port is omitted, the server assumes the default port for the
service is used (see
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host). In
cases where the client provided a non-default port, it should be passed
along.

This hasn't been an issue so far as the git protocol doesn't include
server-generated URIs. I encountered this when implementing Rust
registry support for Sonatype Nexus. Rust's registry uses a git
repository for the package index. Clients look at a file in the root of
the package index to find the base URL for downloading the packages.
Sonatype Nexus looks at the incoming HTTP request (Host header and URL)
to determine the client-facing URL base as it may be running behind a
load balancer or reverse proxy. This client-facing URL base is then used
to construct the package download base URL. When libgit2 fetches the
index from Nexus on a non-default port, Nexus trusts the incorrect Host
header and generates an incorrect package download base URL.