### PR TITLE
revwalk: Allow changing hide_cb

### DIFF
--- a/include/git2/revwalk.h
+++ b/include/git2/revwalk.h
@@ -279,7 +279,7 @@ typedef int(*git_revwalk_hide_cb)(
 	void *payload);
 
 /**
- * Adds a callback function to hide a commit and its parents
+ * Adds, changes or removes a callback function to hide a commit and its parents
  *
  * @param walk the revision walker
  * @param hide_cb  callback function to hide a commit and its parents

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -756,15 +756,11 @@ int git_revwalk_add_hide_cb(
 	if (walk->walking)
 		git_revwalk_reset(walk);
 
-	if (walk->hide_cb) {
-		/* There is already a callback added */
-		giterr_set(GITERR_INVALID, "there is already a callback added to hide commits in revwalk");
-		return -1;
-	}
-
 	walk->hide_cb = hide_cb;
 	walk->hide_cb_payload = payload;
-	walk->limited = 1;
+
+	if (hide_cb)
+		walk->limited = 1;
 
 	return 0;
 }


### PR DESCRIPTION
Remove the check for existing `hide_cb` and conditionally set the `limited` flag.

Fixes https://github.com/libgit2/libgit2/issues/4887