### PR TITLE
Fix warning C4133 incompatible types in MSVC

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -1417,7 +1417,7 @@ static bool are_symlinks_supported(const char *wd_path)
 	git_buf path = GIT_BUF_INIT;
 	int fd;
 	struct stat st;
-	bool symlinks = false;
+	int symlinks = 0;
 
 	/*
 	 * To emulate Git for Windows, symlinks on Windows must be explicitly
@@ -1462,7 +1462,7 @@ static bool are_symlinks_supported(const char *wd_path)
 done:
 	git_buf_dispose(&path);
 	git_config_free(config);
-	return symlinks;
+	return symlinks != 0;
 }
 
 static int create_empty_file(const char *path, mode_t mode)


### PR DESCRIPTION
Introduced in commit b433a22a979ae78c28c8b16f8c3487e2787cb73e.