### PR TITLE
config: fix adding files if their parent directory is a file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -109,7 +109,7 @@ int git_config_add_file_ondisk(
 	assert(cfg && path);
 
 	res = p_stat(path, &st);
-	if (res < 0 && errno != ENOENT) {
+	if (res < 0 && errno != ENOENT && errno != ENOTDIR) {
 		giterr_set(GITERR_CONFIG, "failed to stat '%s'", path);
 		return -1;
 	}

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -534,6 +534,26 @@ void test_config_read__fallback_from_local_to_global_and_from_global_to_system(v
 	git_config_free(cfg);
 }
 
+void test_config_read__parent_dir_is_file(void)
+{
+	git_config *cfg;
+	int count;
+
+	cl_git_pass(git_config_new(&cfg));
+	/*
+	 * Verify we can add non-existing files when the parent directory is not
+	 * a directory.
+	 */
+	cl_git_pass(git_config_add_file_ondisk(cfg, "/dev/null/.gitconfig",
+		GIT_CONFIG_LEVEL_SYSTEM, NULL, 0));
+
+	count = 0;
+	cl_git_pass(git_config_foreach(cfg, count_cfg_entries_and_compare_levels, &count));
+	cl_assert_equal_i(0, count);
+
+	git_config_free(cfg);
+}
+
 /*
  * At the beginning of the test, config18 has:
  *	int32global = 28


### PR DESCRIPTION
When we try to add a configuration file with `git_config_add_file_ondisk`, we
treat nonexisting files as empty. We do this by performing a stat call, ignoring
ENOENT errors. This works just fine in case the file or any of its parents
simply does not exist, but there is also the case where any of the parent
directories is not a directory, but a file. So e.g. trying to add a
configuration file "/dev/null/.gitconfig" will fail, as `errno` will be ENOTDIR
instead of ENOENT.

Catch ENOTDIR in addition to ENOENT to fix the issue. Add a test that verifies
we are able to add configuration files with such an invalid path file just fine.

This should probably fix #4897.