### PR TITLE
make proxy_stream_close close target stream even on errors

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -809,6 +809,7 @@ static int proxy_stream_close(git_writestream *s)
 {
 	struct proxy_stream *proxy_stream = (struct proxy_stream *)s;
 	git_buf *writebuf;
+	git_error_state error_state = {0};
 	int error;
 
 	assert(proxy_stream);
@@ -826,6 +827,11 @@ static int proxy_stream_close(git_writestream *s)
 		git_buf_sanitize(proxy_stream->output);
 		writebuf = proxy_stream->output;
 	} else {
+		/* close stream before erroring out taking care
+		 * to preserve the original error */
+		giterr_state_capture(&error_state, error);
+		proxy_stream->target->close(proxy_stream->target);
+		giterr_state_restore(&error_state);
 		return error;
 	}
 


### PR DESCRIPTION
When a `git_filter_apply_fn` callback returns a error while smudging `proxy_stream_close`
ends up [returning](https://github.com/libgit2/libgit2/blob/master/src/filter.c#L829) without closing the stream. This is turn makes `blob_content_to_file`
crash as it [asserts](https://github.com/libgit2/libgit2/blob/master/src/checkout.c#L1555) the stream being closed whether there are errors or not.

Closing the target stream on error fixes this problem, with the downside being that
error strings set by `proxy_stream->target->close()` will override ones set by `git_filter_apply_fn`
callback.