### PR TITLE
Fix segfault in loose_backend__readstream

### DIFF
--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -1028,15 +1028,15 @@ static int loose_backend__readstream(
 
 done:
 	if (error < 0) {
-                if(stream) {
-		        git_futils_mmap_free(&stream->map);
-   		        git_zstream_free(&stream->zstream);
-                        git__free(stream);
-                }
-                if(hash_ctx) {
-   		        git_hash_ctx_cleanup(hash_ctx);
-		        git__free(hash_ctx);
-                }
+		if (stream) {
+			git_futils_mmap_free(&stream->map);
+			git_zstream_free(&stream->zstream);
+			git__free(stream);
+		}
+		if (hash_ctx) {
+			git_hash_ctx_cleanup(hash_ctx);
+			git__free(hash_ctx);
+		}
 	}
 
 	git_buf_dispose(&object_path);

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -1028,11 +1028,16 @@ static int loose_backend__readstream(
 
 done:
 	if (error < 0) {
-		git_futils_mmap_free(&stream->map);
-		git_zstream_free(&stream->zstream);
-		git_hash_ctx_cleanup(hash_ctx);
-		git__free(hash_ctx);
-		git__free(stream);
+                if(stream && stream->map.data)
+		        git_futils_mmap_free(&stream->map);
+                if(stream)
+   		        git_zstream_free(&stream->zstream);
+                if(stream)
+                        git__free(stream);
+                if(hash_ctx) {
+   		        git_hash_ctx_cleanup(hash_ctx);
+		        git__free(hash_ctx);
+                }
 	}
 
 	git_buf_dispose(&object_path);

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -1028,12 +1028,11 @@ static int loose_backend__readstream(
 
 done:
 	if (error < 0) {
-                if(stream && stream->map.data)
+                if(stream) {
 		        git_futils_mmap_free(&stream->map);
-                if(stream)
    		        git_zstream_free(&stream->zstream);
-                if(stream)
                         git__free(stream);
+                }
                 if(hash_ctx) {
    		        git_hash_ctx_cleanup(hash_ctx);
 		        git__free(hash_ctx);


### PR DESCRIPTION
If the routine exits with error before stream or hash_ctx is initialized, the
program will segfault when trying to free them.