### PR TITLE
Support creating annotated commits from annotated tags

### DIFF
--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -710,7 +710,7 @@ GIT_EXTERN(int) git_reference_normalize_name(
  */
 GIT_EXTERN(int) git_reference_peel(
 	git_object **out,
-	git_reference *ref,
+	const git_reference *ref,
 	git_object_t type);
 
 /**

--- a/src/annotated_commit.c
+++ b/src/annotated_commit.c
@@ -123,19 +123,19 @@ int git_annotated_commit_from_ref(
 	git_repository *repo,
 	const git_reference *ref)
 {
-	git_reference *resolved;
+	git_object *peeled;
 	int error = 0;
 
 	assert(out && repo && ref);
 
 	*out = NULL;
 
-	if ((error = git_reference_resolve(&resolved, ref)) < 0)
+	if ((error = git_reference_peel(&peeled, ref, GIT_OBJ_COMMIT)) < 0)
 		return error;
 
 	error = annotated_commit_init_from_id(out,
 		repo,
-		git_reference_target(resolved),
+		git_object_id(peeled),
 		git_reference_name(ref));
 
 	if (!error) {
@@ -143,7 +143,7 @@ int git_annotated_commit_from_ref(
 		GITERR_CHECK_ALLOC((*out)->ref_name);
 	}
 
-	git_reference_free(resolved);
+	git_object_free(peeled);
 	return error;
 }
 

--- a/tests/merge/annotated_commit.c
+++ b/tests/merge/annotated_commit.c
@@ -1,0 +1,26 @@
+#include "clar_libgit2.h"
+
+
+static git_repository *g_repo;
+
+void test_merge_annotated_commit__initialize(void)
+{
+	g_repo = cl_git_sandbox_init("testrepo");
+}
+
+void test_merge_annotated_commit__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_merge_annotated_commit__lookup_annotated_tag(void)
+{
+	git_annotated_commit *commit;
+	git_reference *ref;
+
+	cl_git_pass(git_reference_lookup(&ref, g_repo, "refs/tags/test"));
+	cl_git_pass(git_annotated_commit_from_ref(&commit, g_repo, ref));
+
+	git_annotated_commit_free(commit);
+	git_reference_free(ref);
+}


### PR DESCRIPTION
This got a bit messy with the `const`ness of `git_reference_peel` and I'm happy to move that to its own PR if y'all want.

The crux of this is to use `git_reference_peel` instead of `git_reference_resolve` so we get the id of the commit regardless of how much wrapping there is around it.

This fixes #4909 