### PR TITLE
smart subtransport: don't free the url when resetting the stream

### DIFF
--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -46,9 +46,6 @@ GIT_INLINE(int) git_smart__reset_stream(transport_smart *t, bool close_subtransp
 	}
 
 	if (close_subtransport) {
-		git__free(t->url);
-		t->url = NULL;
-
 		if (t->wrapped->close(t->wrapped) < 0)
 			return -1;
 	}
@@ -223,6 +220,7 @@ static int git_smart__connect(
 	if (git_smart__reset_stream(t, true) < 0)
 		return -1;
 
+	git__free(t->url);
 	t->url = git__strdup(url);
 	GITERR_CHECK_ALLOC(t->url);
 


### PR DESCRIPTION
We reset the stream in the RPC (HTTP) case constantly and then pass the url
field to the action method for the transport to perform their action.

A transport would thus get `NULL` for the url and if it does use it, it might
crash or at least return an error making it impossible for it to work.

The transports that come with libgit2 keep their own copy of the url and thus
this issue was not noticed.

---

This should resolve the issue that cargo is experiencing with the changes in #4732 while still plugging the leak by freeing the URL before we set it anew when connecting.

/cc @grahamc @alexcrichton rust-lang/cargo#6365