### PR TITLE
Shutdown callback count

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -26,9 +26,23 @@
 
 git_mutex git__mwindow_mutex;
 
-#define MAX_SHUTDOWN_CB 10
+typedef int (*git_global_init_fn)(void);
 
-static git_global_shutdown_fn git__shutdown_callbacks[MAX_SHUTDOWN_CB];
+static git_global_init_fn git__init_callbacks[] = {
+	git_allocator_global_init,
+	git_hash_global_init,
+	git_sysdir_global_init,
+	git_filter_global_init,
+	git_merge_driver_global_init,
+	git_transport_ssh_global_init,
+	git_stream_registry_global_init,
+	git_openssl_stream_global_init,
+	git_mbedtls_stream_global_init,
+	git_mwindow_global_init
+};
+
+static git_global_shutdown_fn git__shutdown_callbacks[ARRAY_SIZE(git__init_callbacks)];
+
 static git_atomic git__n_shutdown_callbacks;
 static git_atomic git__n_inits;
 char *git__user_agent;
@@ -37,7 +51,7 @@ char *git__ssl_ciphers;
 void git__on_shutdown(git_global_shutdown_fn callback)
 {
 	int count = git_atomic_inc(&git__n_shutdown_callbacks);
-	assert(count <= MAX_SHUTDOWN_CB && count > 0);
+	assert(count <= (int) ARRAY_SIZE(git__shutdown_callbacks) && count > 0);
 	git__shutdown_callbacks[count - 1] = callback;
 }
 
@@ -52,6 +66,7 @@ static void git__global_state_cleanup(git_global_st *st)
 
 static int init_common(void)
 {
+	size_t i;
 	int ret;
 
 	/* Initialize the CRT debug allocator first, before our first malloc */
@@ -60,17 +75,10 @@ static int init_common(void)
 	git_win32__stack_init();
 #endif
 
-	/* Initialize any other subsystems that have global state */
-	if ((ret = git_allocator_global_init()) == 0 &&
-		(ret = git_hash_global_init()) == 0 &&
-		(ret = git_sysdir_global_init()) == 0 &&
-		(ret = git_filter_global_init()) == 0 &&
-		(ret = git_merge_driver_global_init()) == 0 &&
-		(ret = git_transport_ssh_global_init()) == 0 &&
-		(ret = git_stream_registry_global_init()) == 0 &&
-		(ret = git_openssl_stream_global_init()) == 0 &&
-		(ret = git_mbedtls_stream_global_init()) == 0)
-		ret = git_mwindow_global_init();
+	/* Initialize subsystems that have global state */
+	for (i = 0; i < ARRAY_SIZE(git__init_callbacks); i++)
+		if ((ret = git__init_callbacks[i]()) != 0)
+			break;
 
 	GIT_MEMORY_BARRIER;
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -14,7 +14,6 @@
 typedef struct git_hash_prov git_hash_prov;
 typedef struct git_hash_ctx git_hash_ctx;
 
-int git_hash_global_init(void);
 int git_hash_ctx_init(git_hash_ctx *ctx);
 void git_hash_ctx_cleanup(git_hash_ctx *ctx);
 
@@ -31,6 +30,8 @@ void git_hash_ctx_cleanup(git_hash_ctx *ctx);
 #else
 # include "hash/hash_generic.h"
 #endif
+
+int git_hash_global_init(void);
 
 typedef struct {
 	void *data;

--- a/src/hash/hash_collisiondetect.h
+++ b/src/hash/hash_collisiondetect.h
@@ -15,9 +15,13 @@ struct git_hash_ctx {
 	SHA1_CTX c;
 };
 
-#define git_hash_global_init() 0
 #define git_hash_ctx_init(ctx) git_hash_init(ctx)
 #define git_hash_ctx_cleanup(ctx)
+
+GIT_INLINE(int) git_hash_global_init(void)
+{
+	return 0;
+}
 
 GIT_INLINE(int) git_hash_init(git_hash_ctx *ctx)
 {

--- a/src/hash/hash_common_crypto.h
+++ b/src/hash/hash_common_crypto.h
@@ -18,9 +18,13 @@ struct git_hash_ctx {
 
 #define CC_LONG_MAX ((CC_LONG)-1)
 
-#define git_hash_global_init() 0
 #define git_hash_ctx_init(ctx) git_hash_init(ctx)
 #define git_hash_ctx_cleanup(ctx)
+
+GIT_INLINE(int) git_hash_global_init(void)
+{
+	return 0;
+}
 
 GIT_INLINE(int) git_hash_init(git_hash_ctx *ctx)
 {

--- a/src/hash/hash_generic.h
+++ b/src/hash/hash_generic.h
@@ -18,8 +18,12 @@ struct git_hash_ctx {
 	unsigned int W[16];
 };
 
-#define git_hash_global_init() 0
 #define git_hash_ctx_init(ctx) git_hash_init(ctx)
 #define git_hash_ctx_cleanup(ctx)
+
+GIT_INLINE(int) git_hash_global_init(void)
+{
+	return 0;
+}
 
 #endif

--- a/src/hash/hash_mbedtls.h
+++ b/src/hash/hash_mbedtls.h
@@ -14,7 +14,11 @@ struct git_hash_ctx {
     mbedtls_sha1_context c;
 };
 
-#define git_hash_global_init() 0
 #define git_hash_ctx_init(ctx) git_hash_init(ctx)
+
+GIT_INLINE(int) git_hash_global_init(void)
+{
+	return 0;
+}
 
 #endif /* INCLUDE_hash_mbedtld_h__ */

--- a/src/hash/hash_openssl.h
+++ b/src/hash/hash_openssl.h
@@ -16,9 +16,13 @@ struct git_hash_ctx {
 	SHA_CTX c;
 };
 
-#define git_hash_global_init() 0
 #define git_hash_ctx_init(ctx) git_hash_init(ctx)
 #define git_hash_ctx_cleanup(ctx)
+
+GIT_INLINE(int) git_hash_global_init(void)
+{
+	return 0;
+}
 
 GIT_INLINE(int) git_hash_init(git_hash_ctx *ctx)
 {


### PR DESCRIPTION
It randomly occurred to me that we can avoid manually updating the `MAX_SHUTDOWN_CB` macro whenever we add a new global initializer by just declaring the initializers as an array and then using the initializer array's size to declare the shutdown array. This PR does exactly that as a small cleanup.