### PR TITLE
Coverity fixes

### DIFF
--- a/script/user_model.c
+++ b/script/user_model.c
@@ -73,3 +73,26 @@ int git_buf_set(git_buf *buf, const void *data, size_t len)
     buf->size = len + 1;
     return 0;
 }
+
+void clar__fail(
+	const char *file,
+	int line,
+	const char *error,
+	const char *description,
+	int should_abort)
+{
+	if (should_abort)
+		__coverity_panic__();
+}
+
+void clar__assert(
+	int condition,
+	const char *file,
+	int line,
+	const char *error,
+	const char *description,
+	int should_abort)
+{
+	if (!condition && should_abort)
+		__coverity_panic__();
+}

--- a/src/config.c
+++ b/src/config.c
@@ -513,6 +513,8 @@ int git_config_backend_foreach_match(
 	regex_t regex;
 	int error = 0;
 
+	assert(backend && cb);
+
 	if (regexp != NULL) {
 		if ((error = p_regcomp(&regex, regexp, REG_EXTENDED)) != 0) {
 			giterr_set_regex(&regex, error);

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -816,6 +816,8 @@ int git_diff_find_similar(
 	diff_find_match *best_match;
 	git_diff_file swap;
 
+	assert(diff);
+
 	if ((error = normalize_find_opts(diff, &opts, given_opts)) < 0)
 		return error;
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -709,6 +709,8 @@ int git_reference_rename(
 	git_signature *who;
 	int error;
 
+	assert(out && ref);
+
 	if ((error = git_reference__log_signature(&who, ref->db->repo)) < 0)
 		return error;
 

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -208,7 +208,7 @@ static int load_submodule_names(git_strmap **out, git_repository *repo, git_conf
 	if ((error = git_config_iterator_glob_new(&iter, cfg, key)) < 0)
 		goto out;
 
-	while (git_config_next(&entry, iter) == 0) {
+	while ((error = git_config_next(&entry, iter)) == 0) {
 		const char *fdot, *ldot;
 		fdot = strchr(entry->name, '.');
 		ldot = strrchr(entry->name, '.');

--- a/tests/index/crlf.c
+++ b/tests/index/crlf.c
@@ -353,6 +353,7 @@ void test_index_crlf__safecrlf_true_autocrlf_input_text_auto_attr(void)
 
 	cl_git_pass(git_index_add_bypath(g_index, "newfile.txt"));
 	entry = git_index_get_bypath(g_index, "newfile.txt", 0);
+	cl_assert(entry);
 
 	cl_git_pass(git_oid_fromstr(&oid, FILE_OID_LF));
 	cl_assert_equal_oid(&oid, &entry->id);
@@ -373,6 +374,7 @@ void test_index_crlf__safecrlf_true_autocrlf_input_text__no_attr(void)
 
 	cl_git_pass(git_index_add_bypath(g_index, "newfile.txt"));
 	entry = git_index_get_bypath(g_index, "newfile.txt", 0);
+	cl_assert(entry);
 
 	cl_git_pass(git_oid_fromstr(&oid, FILE_OID_LF));
 	cl_assert_equal_oid(&oid, &entry->id);


### PR DESCRIPTION
Again, this fixes some of the latest Coverity reports.

Do note that the last commit attempts to make Coverity realize that clar's assertions are not dependent on `DEBUG`/`NDEBUG`, but it's (almost) a complete shot in the dark.

Ref: https://community.synopsys.com/s/question/0D534000046Yuzb/suppressing-assertsideeffect-for-functions-that-allow-for-sideeffects