### PR TITLE
Fix warning 'function': incompatible types - from 'git_cvar_value *' to 'int *' (C4133) on VS

### DIFF
--- a/src/crlf.c
+++ b/src/crlf.c
@@ -35,7 +35,7 @@ struct crlf_attrs {
 
 	int auto_crlf;
 	int safe_crlf;
-	git_cvar_value core_eol;
+	int core_eol;
 };
 
 struct crlf_filter {


### PR DESCRIPTION
All other places don't use git_cvar_value as type.