### PR TITLE
Always build a cdecl library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,14 +74,6 @@ IF (APPLE)
 ENDIF()
 
 IF(MSVC)
-	# This option is only available when building with MSVC. By default, libgit2
-	# is build using the cdecl calling convention, which is useful if you're
-	# writing C. However, the CLR and Win32 API both expect stdcall.
-	#
-	# If you are writing a CLR program and want to link to libgit2, you'll want
-	# to turn this on by invoking CMake with the "-DSTDCALL=ON" argument.
-	OPTION(STDCALL			"Build libgit2 with the __stdcall convention"		OFF)
-
 	# This option must match the settings used in your program, in particular if you
 	# are linking statically
 	OPTION(STATIC_CRT		"Link the static CRT libraries"		 		 ON)
@@ -125,10 +117,8 @@ IF (MSVC)
 	# /MP - Parallel build
 	SET(CMAKE_C_FLAGS "/GF /MP /nologo ${CMAKE_C_FLAGS}")
 
-	IF (STDCALL)
-		# /Gz - stdcall calling convention
-		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gz")
-	ENDIF ()
+	# /Gd - explicitly set cdecl calling convention
+	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gd")
 
 	IF (STATIC_CRT)
 		SET(CRT_FLAG_DEBUG "/MTd")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,10 @@ STRING(REGEX REPLACE "^.*LIBGIT2_SOVERSION ([0-9]+)$" "\\1" LIBGIT2_SOVERSION "$
 
 # Platform specific compilation flags
 IF (MSVC)
+	IF (STDCALL)
+		MESSAGE(FATAL_ERROR "The STDCALL option is no longer supported; libgit2 is now always built as a cdecl library.  If you're using PInvoke, please add the CallingConventions.Cdecl attribute for support.")
+	ENDIF()
+
 	ADD_DEFINITIONS(-D_SCL_SECURE_NO_WARNINGS)
 	ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE)
 	ADD_DEFINITIONS(-D_CRT_NONSTDC_NO_DEPRECATE)

--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ The following CMake variables are declared:
 - `BUILD_SHARED_LIBS`: Build libgit2 as a Shared Library (defaults to ON)
 - `BUILD_CLAR`: Build [Clar](https://github.com/vmg/clar)-based test suite (defaults to ON)
 - `THREADSAFE`: Build libgit2 with threading support (defaults to ON)
-- `STDCALL`: Build libgit2 as `stdcall`. Turn off for `cdecl` (Windows; defaults to ON)
 
 To list all build options and their current value, you can do the
 following:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@ v0.27 + 1
 
 ### Changes or improvements
 
+* The library is now always built with cdecl calling conventions on
+  Windows; the ability to build a stdcall library has been removed.
+
 * Reference log creation now honors `core.logallrefupdates=always`.
 
 * Fix some issues with the error-reporting in the OpenSSL backend.

--- a/include/git2/apply.h
+++ b/include/git2/apply.h
@@ -33,7 +33,7 @@ GIT_BEGIN_DECL
  * @param delta The delta to be applied
  * @param payload User-specified payload
  */
-typedef int (*git_apply_delta_cb)(
+typedef int GIT_CALLBACK(git_apply_delta_cb)(
 	const git_diff_delta *delta,
 	void *payload);
 
@@ -49,7 +49,7 @@ typedef int (*git_apply_delta_cb)(
  * @param hunk The hunk to be applied
  * @param payload User-specified payload
  */
-typedef int (*git_apply_hunk_cb)(
+typedef int GIT_CALLBACK(git_apply_hunk_cb)(
 	const git_diff_hunk *hunk,
 	void *payload);
 

--- a/include/git2/attr.h
+++ b/include/git2/attr.h
@@ -202,7 +202,7 @@ GIT_EXTERN(int) git_attr_get_many(
  * @return 0 to continue looping, non-zero to stop. This value will be returned
  *         from git_attr_foreach.
  */
-typedef int (*git_attr_foreach_cb)(const char *name, const char *value, void *payload);
+typedef int GIT_CALLBACK(git_attr_foreach_cb)(const char *name, const char *value, void *payload);
 
 /**
  * Loop over all the git attributes for a path.

--- a/include/git2/buffer.h
+++ b/include/git2/buffer.h
@@ -81,7 +81,7 @@ GIT_EXTERN(void) git_buf_dispose(git_buf *buffer);
  *
  * This function is going to be removed in v0.30.0.
  */
-GIT_EXTERN(void) GIT_DEPRECATED(git_buf_free)(git_buf *buffer);
+GIT_DEPRECATED(GIT_EXTERN(void)) git_buf_free(git_buf *buffer);
 
 /**
  * Resize the buffer allocation to make more space.

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -220,7 +220,7 @@ typedef struct {
 } git_checkout_perfdata;
 
 /** Checkout notification callback function */
-typedef int (*git_checkout_notify_cb)(
+typedef int GIT_CALLBACK(git_checkout_notify_cb)(
 	git_checkout_notify_t why,
 	const char *path,
 	const git_diff_file *baseline,
@@ -229,14 +229,14 @@ typedef int (*git_checkout_notify_cb)(
 	void *payload);
 
 /** Checkout progress notification function */
-typedef void (*git_checkout_progress_cb)(
+typedef void GIT_CALLBACK(git_checkout_progress_cb)(
 	const char *path,
 	size_t completed_steps,
 	size_t total_steps,
 	void *payload);
 
 /** Checkout perfdata notification function */
-typedef void (*git_checkout_perfdata_cb)(
+typedef void GIT_CALLBACK(git_checkout_perfdata_cb)(
 	const git_checkout_perfdata *perfdata,
 	void *payload);
 

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -66,7 +66,7 @@ typedef enum {
  * @param payload an opaque payload
  * @return 0, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code
  */
-typedef int (*git_remote_create_cb)(
+typedef int GIT_CALLBACK(git_remote_create_cb)(
 	git_remote **out,
 	git_repository *repo,
 	const char *name,
@@ -87,7 +87,7 @@ typedef int (*git_remote_create_cb)(
  * @param payload payload specified by the options
  * @return 0, or a negative value to indicate error
  */
-typedef int (*git_repository_create_cb)(
+typedef int GIT_CALLBACK(git_repository_create_cb)(
 	git_repository **out,
 	const char *path,
 	int bare,

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -48,6 +48,13 @@ typedef size_t size_t;
 # define GIT_EXTERN(type) extern type
 #endif
 
+/** Declare a callback function for application use. */
+#if defined(_MSC_VER)
+# define GIT_CALLBACK(name) (__cdecl *name)
+#else
+# define GIT_CALLBACK(name) (*name)
+#endif
+
 /** Declare a function as deprecated. */
 #if defined(__GNUC__)
 # define GIT_DEPRECATED(func) \

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -43,7 +43,7 @@ typedef size_t size_t;
 			 __attribute__((visibility("default"))) \
 			 type
 #elif defined(_MSC_VER)
-# define GIT_EXTERN(type) __declspec(dllexport) type
+# define GIT_EXTERN(type) __declspec(dllexport) type __cdecl
 #else
 # define GIT_EXTERN(type) extern type
 #endif

--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -66,7 +66,7 @@ typedef struct git_config_entry {
 	const char *value; /**< String value of the entry */
 	unsigned int include_depth; /**< Depth of includes where this variable was found */
 	git_config_level_t level; /**< Which config file this was found in */
-	void (*free)(struct git_config_entry *entry); /**< Free function for this entry */
+	void GIT_CALLBACK(free)(struct git_config_entry *entry); /**< Free function for this entry */
 	void *payload; /**< Opaque value for the free function. Do not read or write */
 } git_config_entry;
 
@@ -81,7 +81,7 @@ GIT_EXTERN(void) git_config_entry_free(git_config_entry *);
  * @param entry the entry currently being enumerated
  * @param payload a user-specified pointer
  */
-typedef int  (*git_config_foreach_cb)(const git_config_entry *entry, void *payload);
+typedef int GIT_CALLBACK(git_config_foreach_cb)(const git_config_entry *entry, void *payload);
 
 /**
  * An opaque structure for a configuration iterator

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -328,7 +328,7 @@ typedef struct {
  * - returns 0, the delta is inserted into the diff, and the diff process
  *		continues.
  */
-typedef int (*git_diff_notify_cb)(
+typedef int GIT_CALLBACK(git_diff_notify_cb)(
 	const git_diff *diff_so_far,
 	const git_diff_delta *delta_to_add,
 	const char *matched_pathspec,
@@ -344,7 +344,7 @@ typedef int (*git_diff_notify_cb)(
  * @param new_path The path to the new file or NULL.
  * @return Non-zero to abort the diff.
  */
-typedef int (*git_diff_progress_cb)(
+typedef int GIT_CALLBACK(git_diff_progress_cb)(
 	const git_diff *diff_so_far,
 	const char *old_path,
 	const char *new_path,
@@ -462,7 +462,7 @@ GIT_EXTERN(int) git_diff_init_options(
  * @param progress Goes from 0 to 1 over the diff
  * @param payload User-specified pointer from foreach function
  */
-typedef int (*git_diff_file_cb)(
+typedef int GIT_CALLBACK(git_diff_file_cb)(
 	const git_diff_delta *delta,
 	float progress,
 	void *payload);
@@ -528,7 +528,7 @@ typedef struct {
  * When iterating over a diff, callback that will be made for
  * binary content within the diff.
  */
-typedef int(*git_diff_binary_cb)(
+typedef int GIT_CALLBACK(git_diff_binary_cb)(
 	const git_diff_delta *delta,
 	const git_diff_binary *binary,
 	void *payload);
@@ -554,7 +554,7 @@ typedef struct {
 /**
  * When iterating over a diff, callback that will be made per hunk.
  */
-typedef int (*git_diff_hunk_cb)(
+typedef int GIT_CALLBACK(git_diff_hunk_cb)(
 	const git_diff_delta *delta,
 	const git_diff_hunk *hunk,
 	void *payload);
@@ -615,7 +615,7 @@ typedef struct {
  * of text.  This uses some extra GIT_DIFF_LINE_... constants for output
  * of lines of file and hunk headers.
  */
-typedef int (*git_diff_line_cb)(
+typedef int GIT_CALLBACK(git_diff_line_cb)(
 	const git_diff_delta *delta, /**< delta that contains this data */
 	const git_diff_hunk *hunk,   /**< hunk containing this data */
 	const git_diff_line *line,   /**< line data */
@@ -699,14 +699,14 @@ typedef enum {
  * Pluggable similarity metric
  */
 typedef struct {
-	int (*file_signature)(
+	int GIT_CALLBACK(file_signature)(
 		void **out, const git_diff_file *file,
 		const char *fullpath, void *payload);
-	int (*buffer_signature)(
+	int GIT_CALLBACK(buffer_signature)(
 		void **out, const git_diff_file *file,
 		const char *buf, size_t buflen, void *payload);
-	void (*free_signature)(void *sig, void *payload);
-	int (*similarity)(int *score, void *siga, void *sigb, void *payload);
+	void GIT_CALLBACK(free_signature)(void *sig, void *payload);
+	int GIT_CALLBACK(similarity)(int *score, void *siga, void *sigb, void *payload);
 	void *payload;
 } git_diff_similarity_metric;
 

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -132,7 +132,7 @@ typedef enum {
 
 
 /** Callback for APIs that add/remove/update files matching pathspec */
-typedef int (*git_index_matched_path_cb)(
+typedef int GIT_CALLBACK(git_index_matched_path_cb)(
 	const char *path, const char *matched_pathspec, void *payload);
 
 /** Flags for APIs that add files matching pathspec */

--- a/include/git2/net.h
+++ b/include/git2/net.h
@@ -52,7 +52,7 @@ struct git_remote_head {
 /**
  * Callback for listing the remote heads
  */
-typedef int (*git_headlist_cb)(git_remote_head *rhead, void *payload);
+typedef int GIT_CALLBACK(git_headlist_cb)(git_remote_head *rhead, void *payload);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -26,7 +26,7 @@ GIT_BEGIN_DECL
  * - annotated_object_id: Oid of the git object being annotated
  * - payload: Payload data passed to `git_note_foreach`
  */
-typedef int (*git_note_foreach_cb)(
+typedef int GIT_CALLBACK(git_note_foreach_cb)(
 	const git_oid *blob_id, const git_oid *annotated_object_id, void *payload);
 
 /**

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -24,7 +24,7 @@ GIT_BEGIN_DECL
 /**
  * Function type for callbacks from git_odb_foreach.
  */
-typedef int (*git_odb_foreach_cb)(const git_oid *id, void *payload);
+typedef int GIT_CALLBACK(git_odb_foreach_cb)(const git_oid *id, void *payload);
 
 /**
  * Create a new object database with no backends.

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -92,12 +92,12 @@ struct git_odb_stream {
 	/**
 	 * Write at most `len` bytes into `buffer` and advance the stream.
 	 */
-	int (*read)(git_odb_stream *stream, char *buffer, size_t len);
+	int GIT_CALLBACK(read)(git_odb_stream *stream, char *buffer, size_t len);
 
 	/**
 	 * Write `len` bytes from `buffer` into the stream.
 	 */
-	int (*write)(git_odb_stream *stream, const char *buffer, size_t len);
+	int GIT_CALLBACK(write)(git_odb_stream *stream, const char *buffer, size_t len);
 
 	/**
 	 * Store the contents of the stream as an object with the id
@@ -109,7 +109,7 @@ struct git_odb_stream {
 	 * - the final number of received bytes differs from the size declared
 	 *   with `git_odb_open_wstream()`
 	 */
-	int (*finalize_write)(git_odb_stream *stream, const git_oid *oid);
+	int GIT_CALLBACK(finalize_write)(git_odb_stream *stream, const git_oid *oid);
 
 	/**
 	 * Free the stream's memory.
@@ -117,16 +117,16 @@ struct git_odb_stream {
 	 * This method might be called without a call to `finalize_write` if
 	 * an error occurs or if the object is already present in the ODB.
 	 */
-	void (*free)(git_odb_stream *stream);
+	void GIT_CALLBACK(free)(git_odb_stream *stream);
 };
 
 /** A stream to write a pack file to the ODB */
 struct git_odb_writepack {
 	git_odb_backend *backend;
 
-	int (*append)(git_odb_writepack *writepack, const void *data, size_t size, git_transfer_progress *stats);
-	int (*commit)(git_odb_writepack *writepack, git_transfer_progress *stats);
-	void (*free)(git_odb_writepack *writepack);
+	int GIT_CALLBACK(append)(git_odb_writepack *writepack, const void *data, size_t size, git_transfer_progress *stats);
+	int GIT_CALLBACK(commit)(git_odb_writepack *writepack, git_transfer_progress *stats);
+	void GIT_CALLBACK(free)(git_odb_writepack *writepack);
 };
 
 GIT_END_DECL

--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -178,7 +178,7 @@ GIT_EXTERN(int) git_packbuilder_write(
 */
 GIT_EXTERN(const git_oid *) git_packbuilder_hash(git_packbuilder *pb);
 
-typedef int (*git_packbuilder_foreach_cb)(void *buf, size_t size, void *payload);
+typedef int GIT_CALLBACK(git_packbuilder_foreach_cb)(void *buf, size_t size, void *payload);
 
 /**
  * Create the new pack and pass each object to the callback
@@ -207,7 +207,7 @@ GIT_EXTERN(size_t) git_packbuilder_object_count(git_packbuilder *pb);
 GIT_EXTERN(size_t) git_packbuilder_written(git_packbuilder *pb);
 
 /** Packbuilder progress notification function */
-typedef int (*git_packbuilder_progress)(
+typedef int GIT_CALLBACK(git_packbuilder_progress)(
 	int stage,
 	uint32_t current,
 	uint32_t total,

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -422,8 +422,8 @@ GIT_EXTERN(int) git_reference_remove(git_repository *repo, const char *name);
  */
 GIT_EXTERN(int) git_reference_list(git_strarray *array, git_repository *repo);
 
-typedef int (*git_reference_foreach_cb)(git_reference *reference, void *payload);
-typedef int (*git_reference_foreach_name_cb)(const char *name, void *payload);
+typedef int GIT_CALLBACK(git_reference_foreach_cb)(git_reference *reference, void *payload);
+typedef int GIT_CALLBACK(git_reference_foreach_name_cb)(const char *name, void *payload);
 
 /**
  * Perform a callback on each reference in the repository.

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -422,7 +422,7 @@ typedef enum git_remote_completion_type {
 } git_remote_completion_type;
 
 /** Push network progress notification function */
-typedef int (*git_push_transfer_progress)(
+typedef int GIT_CALLBACK(git_push_transfer_progress)(
 	unsigned int current,
 	unsigned int total,
 	size_t bytes,
@@ -457,7 +457,7 @@ typedef struct {
  * @param len number of elements in `updates`
  * @param payload Payload provided by the caller
  */
-typedef int (*git_push_negotiation)(const git_push_update **updates, size_t len, void *payload);
+typedef int GIT_CALLBACK(git_push_negotiation)(const git_push_update **updates, size_t len, void *payload);
 
 /**
  * Callback used to inform of the update status from the remote.
@@ -471,7 +471,7 @@ typedef int (*git_push_negotiation)(const git_push_update **updates, size_t len,
  * @param data data provided by the caller
  * @return 0 on success, otherwise an error
  */
-typedef int (*git_push_update_reference_cb)(const char *refname, const char *status, void *data);
+typedef int GIT_CALLBACK(git_push_update_reference_cb)(const char *refname, const char *status, void *data);
 
 /**
  * The callback settings structure
@@ -492,7 +492,7 @@ struct git_remote_callbacks {
 	 * Completion is called when different parts of the download
 	 * process are done (currently unused).
 	 */
-	int (*completion)(git_remote_completion_type type, void *data);
+	int GIT_CALLBACK(completion)(git_remote_completion_type type, void *data);
 
 	/**
 	 * This will be called if the remote host requires
@@ -522,7 +522,7 @@ struct git_remote_callbacks {
 	 * Each time a reference is updated locally, this function
 	 * will be called with information about it.
 	 */
-	int (*update_tips)(const char *refname, const git_oid *a, const git_oid *b, void *data);
+	int GIT_CALLBACK(update_tips)(const char *refname, const git_oid *a, const git_oid *b, void *data);
 
 	/**
 	 * Function to call with progress information during pack

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -627,7 +627,7 @@ GIT_EXTERN(int) git_repository_message_remove(git_repository *repo);
  */
 GIT_EXTERN(int) git_repository_state_cleanup(git_repository *repo);
 
-typedef int (*git_repository_fetchhead_foreach_cb)(const char *ref_name,
+typedef int GIT_CALLBACK(git_repository_fetchhead_foreach_cb)(const char *ref_name,
 	const char *remote_url,
 	const git_oid *oid,
 	unsigned int is_merge,
@@ -649,7 +649,7 @@ GIT_EXTERN(int) git_repository_fetchhead_foreach(
 	git_repository_fetchhead_foreach_cb callback,
 	void *payload);
 
-typedef int (*git_repository_mergehead_foreach_cb)(const git_oid *oid,
+typedef int GIT_CALLBACK(git_repository_mergehead_foreach_cb)(const git_oid *oid,
 	void *payload);
 
 /**

--- a/include/git2/revwalk.h
+++ b/include/git2/revwalk.h
@@ -274,7 +274,7 @@ GIT_EXTERN(git_repository *) git_revwalk_repository(git_revwalk *walk);
  * @param commit_id oid of Commit
  * @param payload User-specified pointer to data to be passed as data payload
  */
-typedef int(*git_revwalk_hide_cb)(
+typedef int GIT_CALLBACK(git_revwalk_hide_cb)(
 	const git_oid *commit_id,
 	void *payload);
 

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -112,7 +112,7 @@ typedef enum {
  * Return 0 to continue processing, or a negative value to
  * abort the stash application.
  */
-typedef int (*git_stash_apply_progress_cb)(
+typedef int GIT_CALLBACK(git_stash_apply_progress_cb)(
 	git_stash_apply_progress_t progress,
 	void *payload);
 
@@ -198,7 +198,7 @@ GIT_EXTERN(int) git_stash_apply(
  * @param payload Extra parameter to callback function.
  * @return 0 to continue iterating or non-zero to stop.
  */
-typedef int (*git_stash_cb)(
+typedef int GIT_CALLBACK(git_stash_cb)(
 	size_t index,
 	const char* message,
 	const git_oid *stash_id,

--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -60,7 +60,7 @@ typedef enum {
  *
  * `payload` is the value you passed to the foreach function as payload.
  */
-typedef int (*git_status_cb)(
+typedef int GIT_CALLBACK(git_status_cb)(
 	const char *path, unsigned int status_flags, void *payload);
 
 /**

--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -115,7 +115,7 @@ typedef enum {
  * @param payload value you passed to the foreach function as payload
  * @return 0 on success or error code
  */
-typedef int (*git_submodule_cb)(
+typedef int GIT_CALLBACK(git_submodule_cb)(
 	git_submodule *sm, const char *name, void *payload);
 
 /**

--- a/include/git2/sys/alloc.h
+++ b/include/git2/sys/alloc.h
@@ -22,54 +22,54 @@ GIT_BEGIN_DECL
  */
 typedef struct {
 	/* Allocate `n` bytes of memory */
-	void *(*gmalloc)(size_t n, const char *file, int line);
+	void * GIT_CALLBACK(gmalloc)(size_t n, const char *file, int line);
 
 	/*
 	 * Allocate memory for an array of `nelem` elements, where each element
 	 * has a size of `elsize`. Returned memory shall be initialized to
 	 * all-zeroes
 	 */
-	void *(*gcalloc)(size_t nelem, size_t elsize, const char *file, int line);
+	void * GIT_CALLBACK(gcalloc)(size_t nelem, size_t elsize, const char *file, int line);
 
 	/* Allocate memory for the string `str` and duplicate its contents. */
-	char *(*gstrdup)(const char *str, const char *file, int line);
+	char * GIT_CALLBACK(gstrdup)(const char *str, const char *file, int line);
 
 	/*
 	 * Equivalent to the `gstrdup` function, but only duplicating at most
 	 * `n + 1` bytes
 	 */
-	char *(*gstrndup)(const char *str, size_t n, const char *file, int line);
+	char * GIT_CALLBACK(gstrndup)(const char *str, size_t n, const char *file, int line);
 
 	/*
 	 * Equivalent to `gstrndup`, but will always duplicate exactly `n` bytes
 	 * of `str`. Thus, out of bounds reads at `str` may happen.
 	 */
-	char *(*gsubstrdup)(const char *str, size_t n, const char *file, int line);
+	char * GIT_CALLBACK(gsubstrdup)(const char *str, size_t n, const char *file, int line);
 
 	/*
 	 * This function shall deallocate the old object `ptr` and return a
 	 * pointer to a new object that has the size specified by `size`. In
 	 * case `ptr` is `NULL`, a new array shall be allocated.
 	 */
-	void *(*grealloc)(void *ptr, size_t size, const char *file, int line);
+	void * GIT_CALLBACK(grealloc)(void *ptr, size_t size, const char *file, int line);
 
 	/*
 	 * This function shall be equivalent to `grealloc`, but allocating
 	 * `neleme * elsize` bytes.
 	 */
-	void *(*greallocarray)(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
+	void * GIT_CALLBACK(greallocarray)(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
 
 	/*
 	 * This function shall allocate a new array of `nelem` elements, where
 	 * each element has a size of `elsize` bytes.
 	 */
-	void *(*gmallocarray)(size_t nelem, size_t elsize, const char *file, int line);
+	void * GIT_CALLBACK(gmallocarray)(size_t nelem, size_t elsize, const char *file, int line);
 
 	/*
 	 * This function shall free the memory pointed to by `ptr`. In case
 	 * `ptr` is `NULL`, this shall be a no-op.
 	 */
-	void (*gfree)(void *ptr);
+	void GIT_CALLBACK(gfree)(void *ptr);
 } git_allocator;
 
 /**

--- a/include/git2/sys/commit.h
+++ b/include/git2/sys/commit.h
@@ -50,7 +50,7 @@ GIT_EXTERN(int) git_commit_create_from_ids(
  * along with the user supplied payload.  This should return a git_oid of
  * the next parent or NULL if all parents have been provided.
  */
-typedef const git_oid *(*git_commit_parent_callback)(size_t idx, void *payload);
+typedef const git_oid * GIT_CALLBACK(git_commit_parent_callback)(size_t idx, void *payload);
 
 /**
  * Create a new commit in the repository with an callback to supply parents.

--- a/include/git2/sys/config.h
+++ b/include/git2/sys/config.h
@@ -39,12 +39,12 @@ struct git_config_iterator {
 	 * Return the current entry and advance the iterator. The
 	 * memory belongs to the library.
 	 */
-	int (*next)(git_config_entry **entry, git_config_iterator *iter);
+	int GIT_CALLBACK(next)(git_config_entry **entry, git_config_iterator *iter);
 
 	/**
 	 * Free the iterator
 	 */
-	void (*free)(git_config_iterator *iter);
+	void GIT_CALLBACK(free)(git_config_iterator *iter);
 };
 
 /**
@@ -58,15 +58,15 @@ struct git_config_backend {
 	struct git_config *cfg;
 
 	/* Open means open the file/database and parse if necessary */
-	int (*open)(struct git_config_backend *, git_config_level_t level, const git_repository *repo);
-	int (*get)(struct git_config_backend *, const char *key, git_config_entry **entry);
-	int (*set)(struct git_config_backend *, const char *key, const char *value);
-	int (*set_multivar)(git_config_backend *cfg, const char *name, const char *regexp, const char *value);
-	int (*del)(struct git_config_backend *, const char *key);
-	int (*del_multivar)(struct git_config_backend *, const char *key, const char *regexp);
-	int (*iterator)(git_config_iterator **, struct git_config_backend *);
+	int GIT_CALLBACK(open)(struct git_config_backend *, git_config_level_t level, const git_repository *repo);
+	int GIT_CALLBACK(get)(struct git_config_backend *, const char *key, git_config_entry **entry);
+	int GIT_CALLBACK(set)(struct git_config_backend *, const char *key, const char *value);
+	int GIT_CALLBACK(set_multivar)(git_config_backend *cfg, const char *name, const char *regexp, const char *value);
+	int GIT_CALLBACK(del)(struct git_config_backend *, const char *key);
+	int GIT_CALLBACK(del_multivar)(struct git_config_backend *, const char *key, const char *regexp);
+	int GIT_CALLBACK(iterator)(git_config_iterator **, struct git_config_backend *);
 	/** Produce a read-only version of this backend */
-	int (*snapshot)(struct git_config_backend **, struct git_config_backend *);
+	int GIT_CALLBACK(snapshot)(struct git_config_backend **, struct git_config_backend *);
 	/**
 	 * Lock this backend.
 	 *
@@ -74,14 +74,14 @@ struct git_config_backend {
 	 * backend. Any updates must not be visible to any other
 	 * readers.
 	 */
-	int (*lock)(struct git_config_backend *);
+	int GIT_CALLBACK(lock)(struct git_config_backend *);
 	/**
 	 * Unlock the data store backing this backend. If success is
 	 * true, the changes should be committed, otherwise rolled
 	 * back.
 	 */
-	int (*unlock)(struct git_config_backend *, int success);
-	void (*free)(struct git_config_backend *);
+	int GIT_CALLBACK(unlock)(struct git_config_backend *, int success);
+	void GIT_CALLBACK(free)(struct git_config_backend *);
 };
 #define GIT_CONFIG_BACKEND_VERSION 1
 #define GIT_CONFIG_BACKEND_INIT {GIT_CONFIG_BACKEND_VERSION}

--- a/include/git2/sys/filter.h
+++ b/include/git2/sys/filter.h
@@ -138,7 +138,7 @@ GIT_EXTERN(uint32_t) git_filter_source_flags(const git_filter_source *src);
  * initialization operations (in case libgit2 is being used in a way that
  * doesn't need the filter).
  */
-typedef int (*git_filter_init_fn)(git_filter *self);
+typedef int GIT_CALLBACK(git_filter_init_fn)(git_filter *self);
 
 /**
  * Shutdown callback on filter
@@ -150,7 +150,7 @@ typedef int (*git_filter_init_fn)(git_filter *self);
  *
  * Typically this function will free the `git_filter` object itself.
  */
-typedef void (*git_filter_shutdown_fn)(git_filter *self);
+typedef void GIT_CALLBACK(git_filter_shutdown_fn)(git_filter *self);
 
 /**
  * Callback to decide if a given source needs this filter
@@ -172,7 +172,7 @@ typedef void (*git_filter_shutdown_fn)(git_filter *self);
  * callback can use it.  If a filter allocates and assigns a value to the
  * `payload`, it will need a `cleanup` callback to free the payload.
  */
-typedef int (*git_filter_check_fn)(
+typedef int GIT_CALLBACK(git_filter_check_fn)(
 	git_filter  *self,
 	void       **payload, /* points to NULL ptr on entry, may be set */
 	const git_filter_source *src,
@@ -190,14 +190,14 @@ typedef int (*git_filter_check_fn)(
  * The `payload` value will refer to any payload that was set by the
  * `check` callback.  It may be read from or written to as needed.
  */
-typedef int (*git_filter_apply_fn)(
+typedef int GIT_CALLBACK(git_filter_apply_fn)(
 	git_filter    *self,
 	void         **payload, /* may be read and/or set */
 	git_buf       *to,
 	const git_buf *from,
 	const git_filter_source *src);
 
-typedef int (*git_filter_stream_fn)(
+typedef int GIT_CALLBACK(git_filter_stream_fn)(
 	git_writestream **out,
 	git_filter *self,
 	void **payload,
@@ -212,7 +212,7 @@ typedef int (*git_filter_stream_fn)(
  * allocated a `payload` to keep per-source filter state, use this
  * callback to free that payload and release resources as required.
  */
-typedef void (*git_filter_cleanup_fn)(
+typedef void GIT_CALLBACK(git_filter_cleanup_fn)(
 	git_filter *self,
 	void       *payload);
 

--- a/include/git2/sys/merge.h
+++ b/include/git2/sys/merge.h
@@ -73,7 +73,7 @@ GIT_EXTERN(const git_merge_file_options *) git_merge_driver_source_file_options(
  * initialization operations (in case libgit2 is being used in a way that
  * doesn't need the merge driver).
  */
-typedef int (*git_merge_driver_init_fn)(git_merge_driver *self);
+typedef int GIT_CALLBACK(git_merge_driver_init_fn)(git_merge_driver *self);
 
 /**
  * Shutdown callback on merge driver
@@ -85,7 +85,7 @@ typedef int (*git_merge_driver_init_fn)(git_merge_driver *self);
  *
  * Typically this function will free the `git_merge_driver` object itself.
  */
-typedef void (*git_merge_driver_shutdown_fn)(git_merge_driver *self);
+typedef void GIT_CALLBACK(git_merge_driver_shutdown_fn)(git_merge_driver *self);
 
 /**
  * Callback to perform the merge.
@@ -105,7 +105,7 @@ typedef void (*git_merge_driver_shutdown_fn)(git_merge_driver *self);
  *
  * The `src` contains the data about the file to be merged.
  */
-typedef int (*git_merge_driver_apply_fn)(
+typedef int GIT_CALLBACK(git_merge_driver_apply_fn)(
 	git_merge_driver *self,
 	const char **path_out,
 	uint32_t *mode_out,

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -32,37 +32,37 @@ struct git_odb_backend {
 	 * will be freed later. The buffer should be allocated using
 	 * the function git_odb_backend_malloc to ensure that it can
 	 * be safely freed later. */
-	int (* read)(
+	int GIT_CALLBACK(read)(
 		void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *);
 
 	/* To find a unique object given a prefix of its oid.  The oid given
 	 * must be so that the remaining (GIT_OID_HEXSZ - len)*4 bits are 0s.
 	 */
-	int (* read_prefix)(
+	int GIT_CALLBACK(read_prefix)(
 		git_oid *, void **, size_t *, git_object_t *,
 		git_odb_backend *, const git_oid *, size_t);
 
-	int (* read_header)(
+	int GIT_CALLBACK(read_header)(
 		size_t *, git_object_t *, git_odb_backend *, const git_oid *);
 
 	/**
 	 * Write an object into the backend. The id of the object has
 	 * already been calculated and is passed in.
 	 */
-	int (* write)(
+	int GIT_CALLBACK(write)(
 		git_odb_backend *, const git_oid *, const void *, size_t, git_object_t);
 
-	int (* writestream)(
+	int GIT_CALLBACK(writestream)(
 		git_odb_stream **, git_odb_backend *, git_off_t, git_object_t);
 
-	int (* readstream)(
+	int GIT_CALLBACK(readstream)(
 		git_odb_stream **, size_t *, git_object_t *,
 		git_odb_backend *, const git_oid *);
 
-	int (* exists)(
+	int GIT_CALLBACK(exists)(
 		git_odb_backend *, const git_oid *);
 
-	int (* exists_prefix)(
+	int GIT_CALLBACK(exists_prefix)(
 		git_oid *, git_odb_backend *, const git_oid *, size_t);
 
 	/**
@@ -75,12 +75,12 @@ struct git_odb_backend {
 	 * implementation to achieve this could be to internally invoke this
 	 * endpoint on failed lookups (ie. `exists()`, `read()`, `read_header()`).
 	 */
-	int (* refresh)(git_odb_backend *);
+	int GIT_CALLBACK(refresh)(git_odb_backend *);
 
-	int (* foreach)(
+	int GIT_CALLBACK(foreach)(
 		git_odb_backend *, git_odb_foreach_cb cb, void *payload);
 
-	int (* writepack)(
+	int GIT_CALLBACK(writepack)(
 		git_odb_writepack **, git_odb_backend *, git_odb *odb,
 		git_transfer_progress_cb progress_cb, void *progress_payload);
 
@@ -93,13 +93,13 @@ struct git_odb_backend {
 	 * If callers implement this, they should return `0` if the object
 	 * exists and was freshened, and non-zero otherwise.
 	 */
-	int (* freshen)(git_odb_backend *, const git_oid *);
+	int GIT_CALLBACK(freshen)(git_odb_backend *, const git_oid *);
 
 	/**
 	 * Frees any resources held by the odb (including the `git_odb_backend`
 	 * itself). An odb backend implementation must provide this function.
 	 */
-	void (* free)(git_odb_backend *);
+	void GIT_CALLBACK(free)(git_odb_backend *);
 };
 
 #define GIT_ODB_BACKEND_VERSION 1

--- a/include/git2/sys/refdb_backend.h
+++ b/include/git2/sys/refdb_backend.h
@@ -38,21 +38,21 @@ struct git_reference_iterator {
 	/**
 	 * Return the current reference and advance the iterator.
 	 */
-	int (*next)(
+	int GIT_CALLBACK(next)(
 		git_reference **ref,
 		git_reference_iterator *iter);
 
 	/**
 	 * Return the name of the current reference and advance the iterator
 	 */
-	int (*next_name)(
+	int GIT_CALLBACK(next_name)(
 		const char **ref_name,
 		git_reference_iterator *iter);
 
 	/**
 	 * Free the iterator
 	 */
-	void (*free)(
+	void GIT_CALLBACK(free)(
 		git_reference_iterator *iter);
 };
 
@@ -64,7 +64,7 @@ struct git_refdb_backend {
 	 * Queries the refdb backend to determine if the given ref_name
 	 * exists.  A refdb implementation must provide this function.
 	 */
-	int (*exists)(
+	int GIT_CALLBACK(exists)(
 		int *exists,
 		git_refdb_backend *backend,
 		const char *ref_name);
@@ -73,7 +73,7 @@ struct git_refdb_backend {
 	 * Queries the refdb backend for a given reference.  A refdb
 	 * implementation must provide this function.
 	 */
-	int (*lookup)(
+	int GIT_CALLBACK(lookup)(
 		git_reference **out,
 		git_refdb_backend *backend,
 		const char *ref_name);
@@ -83,7 +83,7 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 */
-	int (*iterator)(
+	int GIT_CALLBACK(iterator)(
 		git_reference_iterator **iter,
 		struct git_refdb_backend *backend,
 		const char *glob);
@@ -92,12 +92,12 @@ struct git_refdb_backend {
 	 * Writes the given reference to the refdb.  A refdb implementation
 	 * must provide this function.
 	 */
-	int (*write)(git_refdb_backend *backend,
+	int GIT_CALLBACK(write)(git_refdb_backend *backend,
 		     const git_reference *ref, int force,
 		     const git_signature *who, const char *message,
 		     const git_oid *old, const char *old_target);
 
-	int (*rename)(
+	int GIT_CALLBACK(rename)(
 		git_reference **out, git_refdb_backend *backend,
 		const char *old_name, const char *new_name, int force,
 		const git_signature *who, const char *message);
@@ -107,7 +107,7 @@ struct git_refdb_backend {
 	 * from the refdb.  A refdb implementation must provide this
 	 * function.
 	 */
-	int (*del)(git_refdb_backend *backend, const char *ref_name, const git_oid *old_id, const char *old_target);
+	int GIT_CALLBACK(del)(git_refdb_backend *backend, const char *ref_name, const git_oid *old_id, const char *old_target);
 
 	/**
 	 * Suggests that the given refdb compress or optimize its references.
@@ -116,56 +116,56 @@ struct git_refdb_backend {
 	 * implementation may provide this function; if it is not provided,
 	 * nothing will be done.
 	 */
-	int (*compress)(git_refdb_backend *backend);
+	int GIT_CALLBACK(compress)(git_refdb_backend *backend);
 
 	/**
 	 * Query whether a particular reference has a log (may be empty)
 	 */
-	int (*has_log)(git_refdb_backend *backend, const char *refname);
+	int GIT_CALLBACK(has_log)(git_refdb_backend *backend, const char *refname);
 
 	/**
 	 * Make sure a particular reference will have a reflog which
 	 * will be appended to on writes.
 	 */
-	int (*ensure_log)(git_refdb_backend *backend, const char *refname);
+	int GIT_CALLBACK(ensure_log)(git_refdb_backend *backend, const char *refname);
 
 	/**
 	 * Frees any resources held by the refdb (including the `git_refdb_backend`
 	 * itself). A refdb backend implementation must provide this function.
 	 */
-	void (*free)(git_refdb_backend *backend);
+	void GIT_CALLBACK(free)(git_refdb_backend *backend);
 
 	/**
 	 * Read the reflog for the given reference name.
 	 */
-	int (*reflog_read)(git_reflog **out, git_refdb_backend *backend, const char *name);
+	int GIT_CALLBACK(reflog_read)(git_reflog **out, git_refdb_backend *backend, const char *name);
 
 	/**
 	 * Write a reflog to disk.
 	 */
-	int (*reflog_write)(git_refdb_backend *backend, git_reflog *reflog);
+	int GIT_CALLBACK(reflog_write)(git_refdb_backend *backend, git_reflog *reflog);
 
 	/**
 	 * Rename a reflog
 	 */
-	int (*reflog_rename)(git_refdb_backend *_backend, const char *old_name, const char *new_name);
+	int GIT_CALLBACK(reflog_rename)(git_refdb_backend *_backend, const char *old_name, const char *new_name);
 
 	/**
 	 * Remove a reflog.
 	 */
-	int (*reflog_delete)(git_refdb_backend *backend, const char *name);
+	int GIT_CALLBACK(reflog_delete)(git_refdb_backend *backend, const char *name);
 
 	/**
 	 * Lock a reference. The opaque parameter will be passed to the unlock function
 	 */
-	int (*lock)(void **payload_out, git_refdb_backend *backend, const char *refname);
+	int GIT_CALLBACK(lock)(void **payload_out, git_refdb_backend *backend, const char *refname);
 
 	/**
 	 * Unlock a reference. Only one of target or symbolic_target
 	 * will be set. success indicates whether to update the
 	 * reference or discard the lock (if it's false)
 	 */
-	int (*unlock)(git_refdb_backend *backend, void *payload, int success, int update_reflog,
+	int GIT_CALLBACK(unlock)(git_refdb_backend *backend, void *payload, int success, int update_reflog,
 		      const git_reference *ref, const git_signature *sig, const char *message);
 };
 

--- a/include/git2/sys/stream.h
+++ b/include/git2/sys/stream.h
@@ -31,13 +31,13 @@ typedef struct git_stream {
 
 	int encrypted;
 	int proxy_support;
-	int (*connect)(struct git_stream *);
-	int (*certificate)(git_cert **, struct git_stream *);
-	int (*set_proxy)(struct git_stream *, const git_proxy_options *proxy_opts);
-	ssize_t (*read)(struct git_stream *, void *, size_t);
-	ssize_t (*write)(struct git_stream *, const char *, size_t, int);
-	int (*close)(struct git_stream *);
-	void (*free)(struct git_stream *);
+	int GIT_CALLBACK(connect)(struct git_stream *);
+	int GIT_CALLBACK(certificate)(git_cert **, struct git_stream *);
+	int GIT_CALLBACK(set_proxy)(struct git_stream *, const git_proxy_options *proxy_opts);
+	ssize_t GIT_CALLBACK(read)(struct git_stream *, void *, size_t);
+	ssize_t GIT_CALLBACK(write)(struct git_stream *, const char *, size_t, int);
+	int GIT_CALLBACK(close)(struct git_stream *);
+	void GIT_CALLBACK(free)(struct git_stream *);
 } git_stream;
 
 typedef struct {
@@ -54,7 +54,7 @@ typedef struct {
 	 *             service name
 	 * @return 0 or an error code
 	 */
-	int (*init)(git_stream **out, const char *host, const char *port);
+	int GIT_CALLBACK(init)(git_stream **out, const char *host, const char *port);
 
 	/**
 	 * Called to create a new connection on top of the given stream.  If
@@ -68,7 +68,7 @@ typedef struct {
 	 *             for certificate validation
 	 * @return 0 or an error code
 	 */
-	int (*wrap)(git_stream **out, git_stream *in, const char *host);
+	int GIT_CALLBACK(wrap)(git_stream **out, git_stream *in, const char *host);
 } git_stream_registration;
 
 /**
@@ -111,7 +111,7 @@ GIT_EXTERN(int) git_stream_register(
  * @deprecated Provide a git_stream_registration to git_stream_register
  * @see git_stream_registration
  */
-typedef int (*git_stream_cb)(git_stream **out, const char *host, const char *port);
+typedef int GIT_CALLBACK(git_stream_cb)(git_stream **out, const char *host, const char *port);
 
 /**
  * Register a TLS stream constructor for the library to use.  This stream

--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -35,7 +35,7 @@ typedef enum {
 struct git_transport {
 	unsigned int version;
 	/* Set progress and error callbacks */
-	int (*set_callbacks)(
+	int GIT_CALLBACK(set_callbacks)(
 		git_transport *transport,
 		git_transport_message_cb progress_cb,
 		git_transport_message_cb error_cb,
@@ -43,13 +43,13 @@ struct git_transport {
 		void *payload);
 
 	/* Set custom headers for HTTP requests */
-	int (*set_custom_headers)(
+	int GIT_CALLBACK(set_custom_headers)(
 		git_transport *transport,
 		const git_strarray *custom_headers);
 
 	/* Connect the transport to the remote repository, using the given
 	 * direction. */
-	int (*connect)(
+	int GIT_CALLBACK(connect)(
 		git_transport *transport,
 		const char *url,
 		git_cred_acquire_cb cred_acquire_cb,
@@ -61,18 +61,18 @@ struct git_transport {
 	/* This function may be called after a successful call to
 	 * connect(). The array returned is owned by the transport and
 	 * is guaranteed until the next call of a transport function. */
-	int (*ls)(
+	int GIT_CALLBACK(ls)(
 		const git_remote_head ***out,
 		size_t *size,
 		git_transport *transport);
 
 	/* Executes the push whose context is in the git_push object. */
-	int(*push)(git_transport *transport, git_push *push, const git_remote_callbacks *callbacks);
+	int GIT_CALLBACK(push)(git_transport *transport, git_push *push, const git_remote_callbacks *callbacks);
 
 	/* This function may be called after a successful call to connect(), when
 	 * the direction is FETCH. The function performs a negotiation to calculate
 	 * the wants list for the fetch. */
-	int (*negotiate_fetch)(
+	int GIT_CALLBACK(negotiate_fetch)(
 		git_transport *transport,
 		git_repository *repo,
 		const git_remote_head * const *refs,
@@ -81,7 +81,7 @@ struct git_transport {
 	/* This function may be called after a successful call to negotiate_fetch(),
 	 * when the direction is FETCH. This function retrieves the pack file for
 	 * the fetch from the remote end. */
-	int (*download_pack)(
+	int GIT_CALLBACK(download_pack)(
 		git_transport *transport,
 		git_repository *repo,
 		git_transfer_progress *stats,
@@ -89,20 +89,20 @@ struct git_transport {
 		void *progress_payload);
 
 	/* Checks to see if the transport is connected */
-	int (*is_connected)(git_transport *transport);
+	int GIT_CALLBACK(is_connected)(git_transport *transport);
 
 	/* Reads the flags value previously passed into connect() */
-	int (*read_flags)(git_transport *transport, int *flags);
+	int GIT_CALLBACK(read_flags)(git_transport *transport, int *flags);
 
 	/* Cancels any outstanding transport operation */
-	void (*cancel)(git_transport *transport);
+	void GIT_CALLBACK(cancel)(git_transport *transport);
 
 	/* This function is the reverse of connect() -- it terminates the
 	 * connection to the remote end. */
-	int (*close)(git_transport *transport);
+	int GIT_CALLBACK(close)(git_transport *transport);
 
 	/* Frees/destructs the git_transport object. */
-	void (*free)(git_transport *transport);
+	void GIT_CALLBACK(free)(git_transport *transport);
 };
 
 #define GIT_TRANSPORT_VERSION 1
@@ -292,25 +292,25 @@ struct git_smart_subtransport_stream {
 	/* The owning subtransport */
 	git_smart_subtransport *subtransport;
 
-	int (*read)(
+	int GIT_CALLBACK(read)(
 		git_smart_subtransport_stream *stream,
 		char *buffer,
 		size_t buf_size,
 		size_t *bytes_read);
 
-	int (*write)(
+	int GIT_CALLBACK(write)(
 		git_smart_subtransport_stream *stream,
 		const char *buffer,
 		size_t len);
 
-	void (*free)(
+	void GIT_CALLBACK(free)(
 		git_smart_subtransport_stream *stream);
 };
 
 /* An implementation of a subtransport which carries data for the
  * smart transport */
 struct git_smart_subtransport {
-	int (* action)(
+	int GIT_CALLBACK(action)(
 			git_smart_subtransport_stream **out,
 			git_smart_subtransport *transport,
 			const char *url,
@@ -322,13 +322,13 @@ struct git_smart_subtransport {
 	 *
 	 * 1. UPLOADPACK_LS -> UPLOADPACK
 	 * 2. RECEIVEPACK_LS -> RECEIVEPACK */
-	int (*close)(git_smart_subtransport *transport);
+	int GIT_CALLBACK(close)(git_smart_subtransport *transport);
 
-	void (*free)(git_smart_subtransport *transport);
+	void GIT_CALLBACK(free)(git_smart_subtransport *transport);
 };
 
 /* A function which creates a new subtransport for the smart transport */
-typedef int (*git_smart_subtransport_cb)(
+typedef int GIT_CALLBACK(git_smart_subtransport_cb)(
 	git_smart_subtransport **out,
 	git_transport* owner,
 	void* param);

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -318,7 +318,7 @@ GIT_EXTERN(int) git_tag_list_match(
 	git_repository *repo);
 
 
-typedef int (*git_tag_foreach_cb)(const char *name, git_oid *oid, void *payload);
+typedef int GIT_CALLBACK(git_tag_foreach_cb)(const char *name, git_oid *oid, void *payload);
 
 /**
  * Call callback `cb' for each tag in the repository

--- a/include/git2/trace.h
+++ b/include/git2/trace.h
@@ -49,7 +49,7 @@ typedef enum {
 /**
  * An instance for a tracing function
  */
-typedef void (*git_trace_callback)(git_trace_level_t level, const char *msg);
+typedef void GIT_CALLBACK(git_trace_callback)(git_trace_level_t level, const char *msg);
 
 /**
  * Sets the system tracing configuration to the specified level with the

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -21,7 +21,7 @@
 GIT_BEGIN_DECL
 
 /** Signature of a function which creates a transport */
-typedef int (*git_transport_cb)(git_transport **out, git_remote *owner, void *param);
+typedef int GIT_CALLBACK(git_transport_cb)(git_transport **out, git_remote *owner, void *param);
 
 /**
  * Type of SSH host fingerprint
@@ -144,7 +144,7 @@ typedef struct git_cred git_cred;
  */
 struct git_cred {
 	git_credtype_t credtype; /**< A type of credential */
-	void (*free)(git_cred *cred);
+	void GIT_CALLBACK(free)(git_cred *cred);
 };
 
 /** A plaintext username and password */
@@ -165,8 +165,8 @@ typedef struct _LIBSSH2_USERAUTH_KBDINT_PROMPT LIBSSH2_USERAUTH_KBDINT_PROMPT;
 typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE LIBSSH2_USERAUTH_KBDINT_RESPONSE;
 #endif
 
-typedef int (*git_cred_sign_callback)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract);
-typedef void (*git_cred_ssh_interactive_callback)(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract);
+typedef int GIT_CALLBACK(git_cred_sign_callback)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract);
+typedef void GIT_CALLBACK(git_cred_ssh_interactive_callback)(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract);
 
 /**
  * A ssh key from disk
@@ -359,7 +359,7 @@ GIT_EXTERN(void) git_cred_free(git_cred *cred);
  * @return 0 for success, < 0 to indicate an error, > 0 to indicate
  *       no credential was acquired
  */
-typedef int (*git_cred_acquire_cb)(
+typedef int GIT_CALLBACK(git_cred_acquire_cb)(
 	git_cred **cred,
 	const char *url,
 	const char *username_from_url,

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -344,7 +344,7 @@ GIT_EXTERN(int) git_treebuilder_remove(
  * entry should be left alone and any non-zero value meaning that the
  * entry should be removed from the treebuilder list (i.e. filtered out).
  */
-typedef int (*git_treebuilder_filter_cb)(
+typedef int GIT_CALLBACK(git_treebuilder_filter_cb)(
 	const git_tree_entry *entry, void *payload);
 
 /**
@@ -391,7 +391,7 @@ GIT_EXTERN(int) git_treebuilder_write_with_buffer(
 	git_oid *oid, git_treebuilder *bld, git_buf *tree);
 
 /** Callback for the tree traversal method */
-typedef int (*git_treewalk_cb)(
+typedef int GIT_CALLBACK(git_treewalk_cb)(
 	const char *root, const git_tree_entry *entry, void *payload);
 
 /** Tree traversal modes */

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -272,7 +272,7 @@ typedef struct git_transfer_progress {
  * @param stats Structure containing information about the state of the transfer
  * @param payload Payload provided by caller
  */
-typedef int (*git_transfer_progress_cb)(const git_transfer_progress *stats, void *payload);
+typedef int GIT_CALLBACK(git_transfer_progress_cb)(const git_transfer_progress *stats, void *payload);
 
 /**
  * Type for messages delivered by the transport.  Return a negative value
@@ -282,7 +282,7 @@ typedef int (*git_transfer_progress_cb)(const git_transfer_progress *stats, void
  * @param len The length of the message
  * @param payload Payload provided by the caller
  */
-typedef int (*git_transport_message_cb)(const char *str, int len, void *payload);
+typedef int GIT_CALLBACK(git_transport_message_cb)(const char *str, int len, void *payload);
 
 
 /**
@@ -335,7 +335,7 @@ typedef struct {
  *         or > 0 to indicate that the callback refused to act and that
  *         the existing validity determination should be honored
  */
-typedef int (*git_transport_certificate_check_cb)(git_cert *cert, int valid, const char *host, void *payload);
+typedef int GIT_CALLBACK(git_transport_certificate_check_cb)(git_cert *cert, int valid, const char *host, void *payload);
 
 /**
  * Opaque structure representing a submodule.
@@ -433,9 +433,9 @@ typedef struct git_writestream git_writestream;
 
 /** A type to write in a streaming fashion, for example, for filters. */
 struct git_writestream {
-	int (*write)(git_writestream *stream, const char *buffer, size_t len);
-	int (*close)(git_writestream *stream);
-	void (*free)(git_writestream *stream);
+	int GIT_CALLBACK(write)(git_writestream *stream, const char *buffer, size_t len);
+	int GIT_CALLBACK(close)(git_writestream *stream);
+	void GIT_CALLBACK(free)(git_writestream *stream);
 };
 
 /** Representation of .mailmap file state. */


### PR DESCRIPTION
On Windows, we currently offer end-users the ability to compile the library with cdecl calling conventions (the default) or stdcall calling conventions (an option enabled by `-DSTDCALL=ON` to cmake).

The recommendation from engineers within Microsoft is that libraries should have a calling convention specified in the public API, and that calling convention should be cdecl unless there are strong reasons to use a different calling convention.

We offered stdcall for the LibGit2Sharp project, since by default, PInvoke (the .NET FFI) uses stdcall.  This is because PInvoke is usually used to call standard library functions, and Win32 is stdcall for historic reasons.  But the defaults for all new projects is to use cdecl, and most other modern libraries are using it.

(In either case, we _should_ pick one and declare it in our API.  Without having done so, the end user must match our calling conventions in order to even operate.  This is onerous, and we should allow interop to programs from any calling convention.)

This PR removes the `STDCALL` option from cmake, and adds the necessary `cdecl` attributes to `GIT_EXTERN`.  In addition, we need to identify the calling conventions for our callbacks, so I've introduced the `GIT_CALLBACK` macro to do so and updated our public callbacks to have that attribute.

Note that this _is_ a breaking change for anybody who was building with `STDCALL=ON`.  _However_ I suspect that LibGit2Sharp is the only consumer who's done that, since it made their bindings somewhat easier.  But it's not impossible that there's somebody building with stdcall who will need to update their callbacks to be cdecl (one simply needs to add the attribute).

So this is a breaking API change, but I suspect it will not affect too many end users.  But @csware and @implausible are probably the most likely to be affected and I'd like their input.

I have a PR for LibGit2Sharp ready to go to move over to cdecl, to ensure that it will work (it does).