### PR TITLE
Remove unconditional -Wno-deprecated-declaration on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,9 +235,6 @@ ELSE ()
 	ENABLE_WARNINGS(int-conversion)
 	DISABLE_WARNINGS(documentation-deprecated-sync)
 
-	IF (APPLE) # Apple deprecated OpenSSL
-	    DISABLE_WARNINGS(deprecated-declarations)
-	ENDIF()
 
 	IF (PROFILE)
 		SET(CMAKE_C_FLAGS "-pg ${CMAKE_C_FLAGS}")


### PR DESCRIPTION
Just noticed that while investigating #4924.

After taking into consideration the following, I think this should be removed :
- OpenSSL isn't the default on Apple platforms
- you have to jump through hoops to get CMake to use OpenSSL on macOS (headers aren't in `/usr/include`, so you have to provide `-DOPENSSL_*` overrides)
- users are likely (as getting anywhere near the installed 0.9.8 version is insanity IMHO) to package a "modern" version, which wouldn't be marked as deprecated

There might be a way to detect which version is getting used, or maybe `#pragma` the deprecation warnings out of `openssl.c` instead.