### PR TITLE
Some CI enhancements

### DIFF
--- a/azure-pipelines/coverity.yml
+++ b/azure-pipelines/coverity.yml
@@ -1,0 +1,21 @@
+resources:
+- repo: self
+
+- job: coverity
+  displayName: 'Coverity'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - task: Docker@0
+    displayName: Build
+    inputs:
+      action: 'Run an image'
+      imageName: 'libgit2/trusty-openssl:latest'
+      volumes: |
+       $(Build.SourcesDirectory):/src
+       $(Build.BinariesDirectory):/build
+      envVars: |
+       COVERITY_TOKEN=$(COVERITY_TOKEN)
+      workDir: '/build'
+      containerCommand: '/src/ci/coverity.sh'
+      detached: false

--- a/azure-pipelines/nightly.yml
+++ b/azure-pipelines/nightly.yml
@@ -173,22 +173,3 @@ jobs:
        CC=gcc
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL
        SKIP_PROXY_TESTS=true
-
-- job: coverity
-  displayName: 'Coverity'
-  pool:
-    vmImage: 'Ubuntu 16.04'
-  steps:
-  - task: Docker@0
-    displayName: Build
-    inputs:
-      action: 'Run an image'
-      imageName: 'libgit2/trusty-openssl:latest'
-      volumes: |
-       $(Build.SourcesDirectory):/src
-       $(Build.BinariesDirectory):/build
-      envVars: |
-       COVERITY_TOKEN=$(COVERITY_TOKEN)
-      workDir: '/build'
-      containerCommand: '/src/ci/coverity.sh'
-      detached: false

--- a/ci/test.ps1
+++ b/ci/test.ps1
@@ -51,6 +51,16 @@ Write-Host "####################################################################
 
 run_test offline
 
+if (-not $Env:SKIP_INVASIVE_TESTS) {
+	Write-Host ""
+	Write-Host "##############################################################################"
+	Write-Host "## Running (invasive) tests"
+	Write-Host "##############################################################################"
+
+	$Env:GITTEST_INVASIVE_FS_SIZE=1
+	run_test invasive
+}
+
 if (-not $Env:SKIP_ONLINE_TESTS) {
 	Write-Host ""
 	Write-Host "##############################################################################"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -136,6 +136,20 @@ if [ -z "$SKIP_OFFLINE_TESTS" ]; then
 	run_test offline
 fi
 
+if [ -z "$SKIP_INVASIVE_TESTS" ]; then
+	echo ""
+	echo "Running invasive tests"
+	echo ""
+
+	export GITTEST_INVASIVE_FS_SIZE=1
+	export GITTEST_INVASIVE_MEMORY=1
+	export GITTEST_INVASIVE_SPEED=1
+	run_test invasive
+	unset GITTEST_INVASIVE_FS_SIZE
+	unset GITTEST_INVASIVE_MEMORY
+	unset GITTEST_INVASIVE_SPEED
+fi
+
 if [ -z "$SKIP_ONLINE_TESTS" ]; then
 	# Run the various online tests.  The "online" test suite only includes the
 	# default online tests that do not require additional configuration.  The

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ IF (MSVC_IDE)
 ENDIF ()
 
 ADD_TEST(offline   "${libgit2_BINARY_DIR}/libgit2_clar" -v -xonline)
+ADD_TEST(invasive  "${libgit2_BINARY_DIR}/libgit2_clar" -v -score::ftruncate -sfilter::stream -sodb::largefiles -siterator::workdir -srepo::init)
 ADD_TEST(online    "${libgit2_BINARY_DIR}/libgit2_clar" -v -sonline)
 ADD_TEST(gitdaemon "${libgit2_BINARY_DIR}/libgit2_clar" -v -sonline::push)
 ADD_TEST(ssh       "${libgit2_BINARY_DIR}/libgit2_clar" -v -sonline::push -sonline::clone::ssh_cert -sonline::clone::ssh_with_paths)

--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -661,10 +661,10 @@ void test_iterator_workdir__filesystem_gunk(void)
 
 	cl_git_pass(git_iterator_for_filesystem(&i, "testrepo/.git/refs", NULL));
 
-	/* should only have 13 items, since we're not asking for trees to be
+	/* should only have 16 items, since we're not asking for trees to be
 	 * returned.  the goal of this test is simply to not crash.
 	 */
-	expect_iterator_items(i, 15, NULL, 15, NULL);
+	expect_iterator_items(i, 16, NULL, 15, NULL);
 	git_iterator_free(i);
 	git_buf_dispose(&parent);
 }


### PR DESCRIPTION
Since Coverity is down at the moment with no timeframe, isolate it from the nightly run. I think it also makes sense from a concern-separation POV, as it insulates the Azure "hosted" pipelines from flakyness.

This also attempts to enable the few `GITTEST_INVASIVE_FS_SIZE` (though I'm not sure how Azure will react, or if my `run_test` invocation is valid 🤞).