### PR TITLE
Fix crash on remote connection when GIT_PROXY_AUTO is set but no proxy is detected

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -679,6 +679,9 @@ static int load_proxy_config(http_subtransport *t)
 		    !!t->server.url.use_ssl, &t->proxy_url)) < 0)
 			return error;
 
+		if (!t->proxy_url)
+			return 0;
+
 		t->proxy_opts.type = GIT_PROXY_SPECIFIED;
 		t->proxy_opts.url = t->proxy_url;
 		t->proxy_opts.credentials = t->owner->proxy.credentials;

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -840,3 +840,10 @@ void test_online_clone__proxy_credentials_in_environment(void)
 
 	git_buf_dispose(&url);
 }
+
+void test_online_clone__proxy_auto_not_detected(void)
+{
+	g_options.fetch_opts.proxy_opts.type = GIT_PROXY_AUTO;
+
+	cl_git_pass(git_clone(&g_repo, "http://github.com/libgit2/TestGitRepository", "./foo", &g_options));
+}


### PR DESCRIPTION
This broke recently. If no proxy is detected, the URL remains unset but it still gets into `gitno_connection_data_from_url` which has `assert(url)`.