### PR TITLE
Move `git_ref_t` to `git_reference_t`

### DIFF
--- a/examples/for-each-ref.c
+++ b/examples/for-each-ref.c
@@ -10,7 +10,7 @@ static int show_ref(git_reference *ref, void *data)
         const git_oid *oid;
         git_object *obj;
 
-        if (git_reference_type(ref) == GIT_REF_SYMBOLIC)
+        if (git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC)
                 check_lg2(git_reference_resolve(&resolved, ref),
                           "Unable to resolve symbolic reference",
                           git_reference_name(ref));

--- a/examples/general.c
+++ b/examples/general.c
@@ -692,12 +692,12 @@ static void reference_listing(git_repository *repo)
 		git_reference_lookup(&ref, repo, refname);
 
 		switch (git_reference_type(ref)) {
-			case GIT_REF_OID:
+			case GIT_REFERENCE_DIRECT:
 				git_oid_fmt(oid_hex, git_reference_target(ref));
 				printf("%s [%s]\n", refname, oid_hex);
 				break;
 
-			case GIT_REF_SYMBOLIC:
+			case GIT_REFERENCE_SYMBOLIC:
 				printf("%s => %s\n", refname, git_reference_symbolic_target(ref));
 				break;
 			default:

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -21,6 +21,12 @@
  */
 GIT_BEGIN_DECL
 
+/** @name Reference Functions
+ *
+ * These functions read, write and analyze references.
+ */
+/**@{*/
+
 /**
  * Lookup a reference by name in a repository.
  *
@@ -263,12 +269,12 @@ GIT_EXTERN(const char *) git_reference_symbolic_target(const git_reference *ref)
 /**
  * Get the type of a reference.
  *
- * Either direct (GIT_REF_OID) or symbolic (GIT_REF_SYMBOLIC)
+ * Either direct (GIT_REFERENCE_DIRECT) or symbolic (GIT_REFERENCE_SYMBOLIC)
  *
  * @param ref The reference
  * @return the type
  */
-GIT_EXTERN(git_ref_t) git_reference_type(const git_reference *ref);
+GIT_EXTERN(git_reference_t) git_reference_type(const git_reference *ref);
 
 /**
  * Get the full name of a reference.
@@ -640,7 +646,7 @@ typedef enum {
 	/**
 	 * No particular normalization.
 	 */
-	GIT_REF_FORMAT_NORMAL = 0u,
+	GIT_REFERENCE_FORMAT_NORMAL = 0u,
 
 	/**
 	 * Control whether one-level refnames are accepted
@@ -648,7 +654,7 @@ typedef enum {
 	 * components). Those are expected to be written only using
 	 * uppercase letters and underscore (FETCH_HEAD, ...)
 	 */
-	GIT_REF_FORMAT_ALLOW_ONELEVEL = (1u << 0),
+	GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL = (1u << 0),
 
 	/**
 	 * Interpret the provided name as a reference pattern for a
@@ -657,15 +663,15 @@ typedef enum {
 	 * in place of a one full pathname component
 	 * (e.g., foo/<star>/bar but not foo/bar<star>).
 	 */
-	GIT_REF_FORMAT_REFSPEC_PATTERN = (1u << 1),
+	GIT_REFERENCE_FORMAT_REFSPEC_PATTERN = (1u << 1),
 
 	/**
 	 * Interpret the name as part of a refspec in shorthand form
 	 * so the `ONELEVEL` naming rules aren't enforced and 'master'
 	 * becomes a valid name.
 	 */
-	GIT_REF_FORMAT_REFSPEC_SHORTHAND = (1u << 2),
-} git_reference_normalize_t;
+	GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND = (1u << 2),
+} git_reference_format_t;
 
 /**
  * Normalize reference name and check validity.
@@ -683,7 +689,7 @@ typedef enum {
  * @param buffer_size Size of buffer_out
  * @param name Reference name to be checked.
  * @param flags Flags to constrain name validation rules - see the
- *              GIT_REF_FORMAT constants above.
+ *              GIT_REFERENCE_FORMAT constants above.
  * @return 0 on success, GIT_EBUFS if buffer is too small, GIT_EINVALIDSPEC
  * or an error code.
  */
@@ -743,6 +749,34 @@ GIT_EXTERN(int) git_reference_is_valid_name(const char *refname);
  */
 GIT_EXTERN(const char *) git_reference_shorthand(const git_reference *ref);
 
+/**@}*/
+
+/** @name Deprecated Reference Constants
+ *
+ * These enumeration values are retained for backward compatibility.  The
+ * newer versions of these functions should be preferred in all new code.
+ */
+/**@{*/
+
+ /** Basic type of any Git reference. */
+#define git_ref_t git_reference_t
+#define git_reference_normalize_t git_reference_format_t
+
+GIT_DEPRECATED(static const unsigned int) GIT_REF_INVALID = GIT_REFERENCE_INVALID;
+GIT_DEPRECATED(static const unsigned int) GIT_REF_OID = GIT_REFERENCE_DIRECT;
+GIT_DEPRECATED(static const unsigned int) GIT_REF_SYMBOLIC = GIT_REFERENCE_SYMBOLIC;
+GIT_DEPRECATED(static const unsigned int) GIT_REF_LISTALL = GIT_REFERENCE_ALL;
+
+GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_NORMAL =
+	GIT_REFERENCE_FORMAT_NORMAL;
+GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_ALLOW_ONELEVEL =
+	GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL;
+GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_REFSPEC_PATTERN =
+	GIT_REFERENCE_FORMAT_REFSPEC_PATTERN;
+GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_REFSPEC_SHORTHAND =
+	GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND;
+
+/**@}*/
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -193,11 +193,11 @@ typedef struct git_rebase git_rebase;
 
 /** Basic type of any Git reference. */
 typedef enum {
-	GIT_REF_INVALID = 0, /**< Invalid reference */
-	GIT_REF_OID = 1, /**< A reference which points at an object id */
-	GIT_REF_SYMBOLIC = 2, /**< A reference which points at another reference */
-	GIT_REF_LISTALL = GIT_REF_OID|GIT_REF_SYMBOLIC,
-} git_ref_t;
+	GIT_REFERENCE_INVALID  = 0, /**< Invalid reference */
+	GIT_REFERENCE_DIRECT   = 1, /**< A reference that points at an object id */
+	GIT_REFERENCE_SYMBOLIC = 2, /**< A reference that points at another reference */
+	GIT_REFERENCE_ALL      = GIT_REFERENCE_DIRECT | GIT_REFERENCE_SYMBOLIC,
+} git_reference_t;
 
 /** Basic type of any Git branch. */
 typedef enum {

--- a/src/branch.c
+++ b/src/branch.c
@@ -141,7 +141,7 @@ static int branch_equals(git_repository *repo, const char *path, void *payload)
 	int equal = 0;
 
 	if (git_reference__read_head(&head, repo, path) < 0 ||
-		git_reference_type(head) != GIT_REF_SYMBOLIC)
+		git_reference_type(head) != GIT_REFERENCE_SYMBOLIC)
 		goto done;
 
 	equal = !git__strcmp(head->target.symbolic, branch->name);

--- a/src/refs.c
+++ b/src/refs.c
@@ -59,7 +59,7 @@ git_reference *git_reference__alloc_symbolic(
 	if (!ref)
 		return NULL;
 
-	ref->type = GIT_REF_SYMBOLIC;
+	ref->type = GIT_REFERENCE_SYMBOLIC;
 
 	if ((ref->target.symbolic = git__strdup(target)) == NULL) {
 		git__free(ref);
@@ -82,7 +82,7 @@ git_reference *git_reference__alloc(
 	if (!ref)
 		return NULL;
 
-	ref->type = GIT_REF_OID;
+	ref->type = GIT_REFERENCE_DIRECT;
 	git_oid_cpy(&ref->target.oid, oid);
 
 	if (peel != NULL)
@@ -108,7 +108,7 @@ git_reference *git_reference__set_name(
 
 int git_reference_dup(git_reference **dest, git_reference *source)
 {
-	if (source->type == GIT_REF_SYMBOLIC)
+	if (source->type == GIT_REFERENCE_SYMBOLIC)
 		*dest = git_reference__alloc_symbolic(source->name, source->target.symbolic);
 	else
 		*dest = git_reference__alloc(source->name, &source->target.oid, &source->peel);
@@ -126,7 +126,7 @@ void git_reference_free(git_reference *reference)
 	if (reference == NULL)
 		return;
 
-	if (reference->type == GIT_REF_SYMBOLIC)
+	if (reference->type == GIT_REFERENCE_SYMBOLIC)
 		git__free(reference->target.symbolic);
 
 	if (reference->db)
@@ -140,7 +140,7 @@ int git_reference_delete(git_reference *ref)
 	const git_oid *old_id = NULL;
 	const char *old_target = NULL;
 
-	if (ref->type == GIT_REF_OID)
+	if (ref->type == GIT_REFERENCE_DIRECT)
 		old_id = &ref->target.oid;
 	else
 		old_target = ref->target.symbolic;
@@ -186,14 +186,14 @@ static int reference_normalize_for_repo(
 	bool validate)
 {
 	int precompose;
-	unsigned int flags = GIT_REF_FORMAT_ALLOW_ONELEVEL;
+	unsigned int flags = GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL;
 
 	if (!git_repository__cvar(&precompose, repo, GIT_CVAR_PRECOMPOSE) &&
 		precompose)
-		flags |= GIT_REF_FORMAT__PRECOMPOSE_UNICODE;
+		flags |= GIT_REFERENCE_FORMAT__PRECOMPOSE_UNICODE;
 
 	if (!validate)
-		flags |= GIT_REF_FORMAT__VALIDATION_DISABLE;
+		flags |= GIT_REFERENCE_FORMAT__VALIDATION_DISABLE;
 
 	return git_reference_normalize_name(out, GIT_REFNAME_MAX, name, flags);
 }
@@ -205,7 +205,7 @@ int git_reference_lookup_resolved(
 	int max_nesting)
 {
 	git_refname_t scan_name;
-	git_ref_t scan_type;
+	git_reference_t scan_type;
 	int error = 0, nesting;
 	git_reference *ref = NULL;
 	git_refdb *refdb;
@@ -219,7 +219,7 @@ int git_reference_lookup_resolved(
 	else if (max_nesting < 0)
 		max_nesting = DEFAULT_NESTING_LEVEL;
 
-	scan_type = GIT_REF_SYMBOLIC;
+	scan_type = GIT_REFERENCE_SYMBOLIC;
 
 	if ((error = reference_normalize_for_repo(scan_name, repo, name, true)) < 0)
 		return error;
@@ -228,7 +228,7 @@ int git_reference_lookup_resolved(
 		return error;
 
 	for (nesting = max_nesting;
-		 nesting >= 0 && scan_type == GIT_REF_SYMBOLIC;
+		 nesting >= 0 && scan_type == GIT_REFERENCE_SYMBOLIC;
 		 nesting--)
 	{
 		if (nesting != max_nesting) {
@@ -242,7 +242,7 @@ int git_reference_lookup_resolved(
 		scan_type = ref->type;
 	}
 
-	if (scan_type != GIT_REF_OID && max_nesting != 0) {
+	if (scan_type != GIT_REFERENCE_DIRECT && max_nesting != 0) {
 		giterr_set(GITERR_REFERENCE,
 			"cannot resolve reference (>%u levels deep)", max_nesting);
 		git_reference_free(ref);
@@ -354,7 +354,7 @@ cleanup:
 /**
  * Getters
  */
-git_ref_t git_reference_type(const git_reference *ref)
+git_reference_t git_reference_type(const git_reference *ref)
 {
 	assert(ref);
 	return ref->type;
@@ -376,7 +376,7 @@ const git_oid *git_reference_target(const git_reference *ref)
 {
 	assert(ref);
 
-	if (ref->type != GIT_REF_OID)
+	if (ref->type != GIT_REFERENCE_DIRECT)
 		return NULL;
 
 	return &ref->target.oid;
@@ -386,7 +386,7 @@ const git_oid *git_reference_target_peel(const git_reference *ref)
 {
 	assert(ref);
 
-	if (ref->type != GIT_REF_OID || git_oid_iszero(&ref->peel))
+	if (ref->type != GIT_REFERENCE_DIRECT || git_oid_iszero(&ref->peel))
 		return NULL;
 
 	return &ref->peel;
@@ -396,7 +396,7 @@ const char *git_reference_symbolic_target(const git_reference *ref)
 {
 	assert(ref);
 
-	if (ref->type != GIT_REF_SYMBOLIC)
+	if (ref->type != GIT_REFERENCE_SYMBOLIC)
 		return NULL;
 
 	return ref->target.symbolic;
@@ -566,7 +566,7 @@ int git_reference_symbolic_create(
 
 static int ensure_is_an_updatable_direct_reference(git_reference *ref)
 {
-	if (ref->type == GIT_REF_OID)
+	if (ref->type == GIT_REFERENCE_DIRECT)
 		return 0;
 
 	giterr_set(GITERR_REFERENCE, "cannot set OID on symbolic reference");
@@ -594,7 +594,7 @@ int git_reference_set_target(
 
 static int ensure_is_an_updatable_symbolic_reference(git_reference *ref)
 {
-	if (ref->type == GIT_REF_SYMBOLIC)
+	if (ref->type == GIT_REFERENCE_SYMBOLIC)
 		return 0;
 
 	giterr_set(GITERR_REFERENCE, "cannot set symbolic target on a direct reference");
@@ -640,7 +640,7 @@ static int update_wt_heads(git_repository *repo, const char *path, void *payload
 		goto out;
 	}
 
-	if (git_reference_type(head) != GIT_REF_SYMBOLIC ||
+	if (git_reference_type(head) != GIT_REFERENCE_SYMBOLIC ||
 	    git__strcmp(head->target.symbolic, data->old_name) != 0) {
 		error = 0;
 		goto out;
@@ -723,10 +723,10 @@ int git_reference_rename(
 int git_reference_resolve(git_reference **ref_out, const git_reference *ref)
 {
 	switch (git_reference_type(ref)) {
-	case GIT_REF_OID:
+	case GIT_REFERENCE_DIRECT:
 		return git_reference_lookup(ref_out, ref->db->repo, ref->name);
 
-	case GIT_REF_SYMBOLIC:
+	case GIT_REFERENCE_SYMBOLIC:
 		return git_reference_lookup_resolved(ref_out, ref->db->repo, ref->target.symbolic, -1);
 
 	default:
@@ -970,7 +970,7 @@ int git_reference__normalize_name(
 	int segment_len, segments_count = 0, error = GIT_EINVALIDSPEC;
 	unsigned int process_flags;
 	bool normalize = (buf != NULL);
-	bool validate = (flags & GIT_REF_FORMAT__VALIDATION_DISABLE) == 0;
+	bool validate = (flags & GIT_REFERENCE_FORMAT__VALIDATION_DISABLE) == 0;
 
 #ifdef GIT_USE_ICONV
 	git_path_iconv_t ic = GIT_PATH_ICONV_INIT;
@@ -988,7 +988,7 @@ int git_reference__normalize_name(
 		git_buf_clear(buf);
 
 #ifdef GIT_USE_ICONV
-	if ((flags & GIT_REF_FORMAT__PRECOMPOSE_UNICODE) != 0) {
+	if ((flags & GIT_REFERENCE_FORMAT__PRECOMPOSE_UNICODE) != 0) {
 		size_t namelen = strlen(current);
 		if ((error = git_path_iconv_init_precompose(&ic)) < 0 ||
 			(error = git_path_iconv(&ic, &current, &namelen)) < 0)
@@ -1007,11 +1007,11 @@ int git_reference__normalize_name(
 	while (true) {
 		segment_len = ensure_segment_validity(current);
 		if (segment_len < 0) {
-			if ((process_flags & GIT_REF_FORMAT_REFSPEC_PATTERN) &&
+			if ((process_flags & GIT_REFERENCE_FORMAT_REFSPEC_PATTERN) &&
 					current[0] == '*' &&
 					(current[1] == '\0' || current[1] == '/')) {
 				/* Accept one wildcard as a full refname component. */
-				process_flags &= ~GIT_REF_FORMAT_REFSPEC_PATTERN;
+				process_flags &= ~GIT_REFERENCE_FORMAT_REFSPEC_PATTERN;
 				segment_len = 1;
 			} else
 				goto cleanup;
@@ -1056,13 +1056,13 @@ int git_reference__normalize_name(
 	if (current[segment_len - 1] == '/')
 		goto cleanup;
 
-	if ((segments_count == 1 ) && !(flags & GIT_REF_FORMAT_ALLOW_ONELEVEL))
+	if ((segments_count == 1 ) && !(flags & GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL))
 		goto cleanup;
 
 	if ((segments_count == 1 ) &&
-	    !(flags & GIT_REF_FORMAT_REFSPEC_SHORTHAND) &&
+	    !(flags & GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND) &&
 		!(is_all_caps_and_underscore(name, (size_t)segment_len) ||
-			((flags & GIT_REF_FORMAT_REFSPEC_PATTERN) && !strcmp("*", name))))
+			((flags & GIT_REFERENCE_FORMAT_REFSPEC_PATTERN) && !strcmp("*", name))))
 			goto cleanup;
 
 	if ((segments_count > 1)
@@ -1116,13 +1116,13 @@ cleanup:
 	return error;
 }
 
-#define GIT_REF_TYPEMASK (GIT_REF_OID | GIT_REF_SYMBOLIC)
+#define GIT_REFERENCE_TYPEMASK (GIT_REFERENCE_DIRECT | GIT_REFERENCE_SYMBOLIC)
 
 int git_reference_cmp(
 	const git_reference *ref1,
 	const git_reference *ref2)
 {
-	git_ref_t type1, type2;
+	git_reference_t type1, type2;
 	assert(ref1 && ref2);
 
 	type1 = git_reference_type(ref1);
@@ -1130,9 +1130,9 @@ int git_reference_cmp(
 
 	/* let's put symbolic refs before OIDs */
 	if (type1 != type2)
-		return (type1 == GIT_REF_SYMBOLIC) ? -1 : 1;
+		return (type1 == GIT_REFERENCE_SYMBOLIC) ? -1 : 1;
 
-	if (type1 == GIT_REF_SYMBOLIC)
+	if (type1 == GIT_REFERENCE_SYMBOLIC)
 		return strcmp(ref1->target.symbolic, ref2->target.symbolic);
 
 	return git_oid__cmp(&ref1->target.oid, &ref2->target.oid);
@@ -1158,7 +1158,7 @@ static int get_terminal(git_reference **out, git_repository *repo, const char *r
 		return error;
 	}
 
-	if (git_reference_type(ref) == GIT_REF_OID) {
+	if (git_reference_type(ref) == GIT_REFERENCE_DIRECT) {
 		*out = ref;
 		error = 0;
 	} else {
@@ -1197,7 +1197,7 @@ int git_reference__update_terminal(
 
 	/* found a dangling symref */
 	if (error == GIT_ENOTFOUND && ref) {
-		assert(git_reference_type(ref) == GIT_REF_SYMBOLIC);
+		assert(git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC);
 		giterr_clear();
 		error = reference__create(&ref2, repo, ref->target.symbolic, oid, NULL, 0, to_use,
 					  log_message, NULL, NULL);
@@ -1206,7 +1206,7 @@ int git_reference__update_terminal(
 		error = reference__create(&ref2, repo, ref_name, oid, NULL, 0, to_use,
 					  log_message, NULL, NULL);
 	}  else if (error == 0) {
-		assert(git_reference_type(ref) == GIT_REF_OID);
+		assert(git_reference_type(ref) == GIT_REFERENCE_DIRECT);
 		error = reference__create(&ref2, repo, ref->name, oid, NULL, 1, to_use,
 					  log_message, &ref->target.oid, NULL);
 	}
@@ -1359,7 +1359,7 @@ int git_reference_peel(
 
 	assert(ref);
 
-	if (ref->type == GIT_REF_OID) {
+	if (ref->type == GIT_REFERENCE_DIRECT) {
 		resolved = ref;
 	} else {
 		if ((error = git_reference_resolve(&allocated, ref)) < 0)
@@ -1411,7 +1411,7 @@ int git_reference__is_valid_name(const char *refname, unsigned int flags)
 
 int git_reference_is_valid_name(const char *refname)
 {
-	return git_reference__is_valid_name(refname, GIT_REF_FORMAT_ALLOW_ONELEVEL);
+	return git_reference__is_valid_name(refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
 }
 
 const char *git_reference__shorthand(const char *name)
@@ -1440,7 +1440,7 @@ int git_reference__is_unborn_head(bool *unborn, const git_reference *ref, git_re
 	git_reference *tmp_ref;
 	assert(unborn && ref && repo);
 
-	if (ref->type == GIT_REF_OID) {
+	if (ref->type == GIT_REFERENCE_DIRECT) {
 		*unborn = 0;
 		return 0;
 	}

--- a/src/refs.h
+++ b/src/refs.h
@@ -55,8 +55,8 @@ extern bool git_reference__enable_symbolic_ref_target_validation;
 #define GIT_STASH_FILE "stash"
 #define GIT_REFS_STASH_FILE GIT_REFS_DIR GIT_STASH_FILE
 
-#define GIT_REF_FORMAT__PRECOMPOSE_UNICODE	(1u << 16)
-#define GIT_REF_FORMAT__VALIDATION_DISABLE	(1u << 15)
+#define GIT_REFERENCE_FORMAT__PRECOMPOSE_UNICODE	(1u << 16)
+#define GIT_REFERENCE_FORMAT__VALIDATION_DISABLE	(1u << 15)
 
 #define GIT_REFNAME_MAX 1024
 
@@ -64,7 +64,7 @@ typedef char git_refname_t[GIT_REFNAME_MAX];
 
 struct git_reference {
 	git_refdb *db;
-	git_ref_t type;
+	git_reference_t type;
 
 	union {
 		git_oid oid;

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -69,8 +69,9 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 
 	refspec->pattern = is_glob;
 	refspec->src = git__strndup(lhs, llen);
-	flags = GIT_REF_FORMAT_ALLOW_ONELEVEL | GIT_REF_FORMAT_REFSPEC_SHORTHAND
-		| (is_glob ? GIT_REF_FORMAT_REFSPEC_PATTERN : 0);
+	flags = GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL |
+		GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND |
+		(is_glob ? GIT_REFERENCE_FORMAT_REFSPEC_PATTERN : 0);
 
 	if (is_fetch) {
 		/*

--- a/src/remote.c
+++ b/src/remote.c
@@ -1126,7 +1126,7 @@ static int remote_head_for_ref(git_remote_head **out, git_remote *remote, git_re
 	error = git_reference_resolve(&resolved_ref, ref);
 
 	/* If we're in an unborn branch, let's pretend nothing happened */
-	if (error == GIT_ENOTFOUND && git_reference_type(ref) == GIT_REF_SYMBOLIC) {
+	if (error == GIT_ENOTFOUND && git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC) {
 		ref_name = git_reference_symbolic_target(ref);
 		error = 0;
 	} else {
@@ -1329,7 +1329,7 @@ int git_remote_prune(git_remote *remote, const git_remote_callbacks *callbacks)
 		if (error < 0)
 			goto cleanup;
 
-		if (git_reference_type(ref) == GIT_REF_SYMBOLIC) {
+		if (git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC) {
 			git_reference_free(ref);
 			continue;
 		}
@@ -1450,7 +1450,7 @@ static int update_tips_for_spec(
 			continue;
 
 		/* In autotag mode, don't overwrite any locally-existing tags */
-		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, !autotag, 
+		error = git_reference_create(&ref, remote->repo, refname.ptr, &head->oid, !autotag,
 				log_message);
 
 		if (error == GIT_EEXISTS)
@@ -1919,7 +1919,7 @@ static int rename_one_remote_reference(
 					  git_buf_cstr(&log_message))) < 0)
 		goto cleanup;
 
-	if (git_reference_type(ref) != GIT_REF_SYMBOLIC)
+	if (git_reference_type(ref) != GIT_REFERENCE_SYMBOLIC)
 		goto cleanup;
 
 	/* Handle refs like origin/HEAD -> origin/master */

--- a/src/repository.c
+++ b/src/repository.c
@@ -2119,7 +2119,7 @@ int git_repository_head_detached(git_repository *repo)
 	if (git_reference_lookup(&ref, repo, GIT_HEAD_FILE) < 0)
 		return -1;
 
-	if (git_reference_type(ref) == GIT_REF_SYMBOLIC) {
+	if (git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC) {
 		git_reference_free(ref);
 		return 0;
 	}
@@ -2146,7 +2146,7 @@ int git_repository_head_detached_for_worktree(git_repository *repo, const char *
 	if ((error = git_repository_head_for_worktree(&ref, repo, name)) < 0)
 		goto out;
 
-	error = (git_reference_type(ref) != GIT_REF_SYMBOLIC);
+	error = (git_reference_type(ref) != GIT_REFERENCE_SYMBOLIC);
 out:
 	git_reference_free(ref);
 
@@ -2163,7 +2163,7 @@ int git_repository_head(git_reference **head_out, git_repository *repo)
 	if ((error = git_reference_lookup(&head, repo, GIT_HEAD_FILE)) < 0)
 		return error;
 
-	if (git_reference_type(head) == GIT_REF_OID) {
+	if (git_reference_type(head) == GIT_REFERENCE_DIRECT) {
 		*head_out = head;
 		return 0;
 	}
@@ -2188,7 +2188,7 @@ int git_repository_head_for_worktree(git_reference **out, git_repository *repo, 
 	    (error = git_reference__read_head(&head, repo, path.ptr)) < 0)
 		goto out;
 
-	if (git_reference_type(head) != GIT_REF_OID) {
+	if (git_reference_type(head) != GIT_REFERENCE_DIRECT) {
 		git_reference *resolved;
 
 		error = git_reference_lookup_resolved(&resolved, repo, git_reference_symbolic_target(head), -1);
@@ -2286,7 +2286,7 @@ int git_repository_is_empty(git_repository *repo)
 	if (git_reference_lookup(&head, repo, GIT_HEAD_FILE) < 0)
 		return -1;
 
-	if (git_reference_type(head) == GIT_REF_SYMBOLIC)
+	if (git_reference_type(head) == GIT_REFERENCE_SYMBOLIC)
 		is_empty =
 			(strcmp(git_reference_symbolic_target(head),
 					GIT_REFS_HEADS_DIR "master") == 0) &&
@@ -2594,7 +2594,7 @@ static int checkout_message(git_buf *out, git_reference *old, const char *new)
 {
 	git_buf_puts(out, "checkout: moving from ");
 
-	if (git_reference_type(old) == GIT_REF_SYMBOLIC)
+	if (git_reference_type(old) == GIT_REFERENCE_SYMBOLIC)
 		git_buf_puts(out, git_reference__shorthand(git_reference_symbolic_target(old)));
 	else
 		git_buf_puts(out, git_oid_tostr_s(git_reference_target(old)));
@@ -2669,7 +2669,7 @@ int git_repository_set_head(
 	if (error < 0 && error != GIT_ENOTFOUND)
 		goto cleanup;
 
-	if (ref && current->type == GIT_REF_SYMBOLIC && git__strcmp(current->target.symbolic, ref->name) &&
+	if (ref && current->type == GIT_REFERENCE_SYMBOLIC && git__strcmp(current->target.symbolic, ref->name) &&
 	    git_reference_is_branch(ref) && git_branch_is_checked_out(ref)) {
 		giterr_set(GITERR_REPOSITORY, "cannot set HEAD to reference '%s' as it is the current HEAD "
 			"of a linked repository.", git_reference_name(ref));

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -100,7 +100,7 @@ static int add_ref(transport_local *t, const char *name)
 
 	git_oid_cpy(&head->oid, &obj_id);
 
-	if (git_reference_type(ref) == GIT_REF_SYMBOLIC) {
+	if (git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC) {
 		head->symref_target = git__strdup(git_reference_symbolic_target(ref));
 		GITERR_CHECK_ALLOC(head->symref_target);
 	}
@@ -512,7 +512,7 @@ static int foreach_reference_cb(git_reference *reference, void *payload)
 	git_revwalk *walk = (git_revwalk *)payload;
 	int error;
 
-	if (git_reference_type(reference) != GIT_REF_OID) {
+	if (git_reference_type(reference) != GIT_REFERENCE_DIRECT) {
 		git_reference_free(reference);
 		return 0;
 	}

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -297,7 +297,7 @@ static int fetch_setup_walk(git_revwalk **out, git_repository *repo)
 		if ((error = git_reference_lookup(&ref, repo, refs.strings[i])) < 0)
 			goto on_error;
 
-		if (git_reference_type(ref) == GIT_REF_SYMBOLIC)
+		if (git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC)
 			continue;
 
 		if ((error = git_revwalk_push(walk, git_reference_target(ref))) < 0)

--- a/tests/checkout/checkout_helpers.c
+++ b/tests/checkout/checkout_helpers.c
@@ -10,7 +10,7 @@ void assert_on_branch(git_repository *repo, const char *branch)
 	git_buf bname = GIT_BUF_INIT;
 
 	cl_git_pass(git_reference_lookup(&head, repo, GIT_HEAD_FILE));
-	cl_assert_(git_reference_type(head) == GIT_REF_SYMBOLIC, branch);
+	cl_assert_(git_reference_type(head) == GIT_REFERENCE_SYMBOLIC, branch);
 
 	cl_git_pass(git_buf_joinpath(&bname, "refs/heads", branch));
 	cl_assert_equal_s(bname.ptr, git_reference_symbolic_target(head));

--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -157,7 +157,7 @@ void test_commit_write__root(void)
 
 	/* First we need to update HEAD so it points to our non-existant branch */
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
-	cl_assert(git_reference_type(head) == GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(head) == GIT_REFERENCE_SYMBOLIC);
 	head_old = git__strdup(git_reference_symbolic_target(head));
 	cl_assert(head_old != NULL);
 	git_reference_free(head);

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -369,7 +369,7 @@ void test_network_fetchlocal__clone_into_mirror(void)
 	cl_git_pass(git_clone(&repo, cl_git_fixture_url("testrepo.git"), "./foo.git", &opts));
 
 	cl_git_pass(git_reference_lookup(&ref, repo, "HEAD"));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(ref));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(ref));
 	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(ref));
 
 	git_reference_free(ref);

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -145,7 +145,7 @@ void test_online_clone__empty_repository(void)
 	cl_assert_equal_i(true, git_repository_head_unborn(g_repo));
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, GIT_HEAD_FILE));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(head));
 	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(head));
 
 	git_reference_free(head);
@@ -185,7 +185,7 @@ void test_online_clone__can_checkout_a_cloned_repo(void)
 	cl_assert_equal_i(true, git_path_isfile(git_buf_cstr(&path)));
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(head));
 	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(head));
 
 	cl_assert_equal_i(true, checkout_progress_cb_was_called);
@@ -226,7 +226,7 @@ void test_online_clone__clone_mirror(void)
 	cl_git_pass(git_clone(&g_repo, LIVE_REPO_URL, "./foo.git", &opts));
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(head));
 	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(head));
 
 	cl_assert_equal_i(true, fetch_progress_cb_was_called);

--- a/tests/rebase/merge.c
+++ b/tests/rebase/merge.c
@@ -450,7 +450,7 @@ void test_rebase_merge__finish(void)
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
 	cl_git_pass(git_reference_lookup(&head_ref, repo, "HEAD"));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head_ref));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(head_ref));
 	cl_assert_equal_s("refs/heads/gravy", git_reference_symbolic_target(head_ref));
 
 	/* Make sure the reflogs are updated appropriately */
@@ -512,7 +512,7 @@ void test_rebase_merge__detached_finish(void)
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
 	cl_git_pass(git_reference_lookup(&head_ref, repo, "HEAD"));
-	cl_assert_equal_i(GIT_REF_OID, git_reference_type(head_ref));
+	cl_assert_equal_i(GIT_REFERENCE_DIRECT, git_reference_type(head_ref));
 
 	/* Make sure the reflogs are updated appropriately */
 	cl_git_pass(git_reflog_read(&reflog, repo, "HEAD"));
@@ -561,7 +561,7 @@ void test_rebase_merge__finish_with_ids(void)
 	cl_assert_equal_i(GIT_REPOSITORY_STATE_NONE, git_repository_state(repo));
 
 	cl_git_pass(git_reference_lookup(&head_ref, repo, "HEAD"));
-	cl_assert_equal_i(GIT_REF_OID, git_reference_type(head_ref));
+	cl_assert_equal_i(GIT_REFERENCE_DIRECT, git_reference_type(head_ref));
 	cl_assert_equal_oid(&commit_id, git_reference_target(head_ref));
 
 	/* reflogs are not updated as if we were operating on proper

--- a/tests/refs/branches/delete.c
+++ b/tests/refs/branches/delete.c
@@ -72,7 +72,7 @@ void test_refs_branches_delete__can_delete_a_branch_pointed_at_by_detached_HEAD(
 	git_reference *head, *branch;
 
 	cl_git_pass(git_reference_lookup(&head, repo, GIT_HEAD_FILE));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(head));
 	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(head));
 	git_reference_free(head);
 

--- a/tests/refs/create.c
+++ b/tests/refs/create.c
@@ -41,13 +41,13 @@ void test_refs_create__symbolic(void)
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
-	cl_assert(git_reference_type(looked_up_ref) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(looked_up_ref) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert(reference_is_packed(looked_up_ref) == 0);
 	cl_assert_equal_s(looked_up_ref->name, new_head_tracker);
 
 	/* ...peeled.. */
 	cl_git_pass(git_reference_resolve(&resolved_ref, looked_up_ref));
-	cl_assert(git_reference_type(resolved_ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(resolved_ref) == GIT_REFERENCE_DIRECT);
 
 	/* ...and that it points to the current master tip */
 	cl_assert_equal_oid(&id, git_reference_target(resolved_ref));
@@ -91,7 +91,7 @@ void test_refs_create__symbolic_with_arbitrary_content(void)
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head_tracker));
-	cl_assert(git_reference_type(looked_up_ref) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(looked_up_ref) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert(reference_is_packed(looked_up_ref) == 0);
 	cl_assert_equal_s(looked_up_ref->name, new_head_tracker);
 	git_reference_free(looked_up_ref);
@@ -104,7 +104,7 @@ void test_refs_create__symbolic_with_arbitrary_content(void)
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, repo2, new_head_tracker));
-	cl_assert(git_reference_type(looked_up_ref) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(looked_up_ref) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert(reference_is_packed(looked_up_ref) == 0);
 	cl_assert_equal_s(looked_up_ref->name, new_head_tracker);
 
@@ -152,7 +152,7 @@ void test_refs_create__oid(void)
 
 	/* Ensure the reference can be looked-up... */
 	cl_git_pass(git_reference_lookup(&looked_up_ref, g_repo, new_head));
-	cl_assert(git_reference_type(looked_up_ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(looked_up_ref) & GIT_REFERENCE_DIRECT);
 	cl_assert(reference_is_packed(looked_up_ref) == 0);
 	cl_assert_equal_s(looked_up_ref->name, new_head);
 

--- a/tests/refs/normalize.c
+++ b/tests/refs/normalize.c
@@ -29,83 +29,83 @@ static void ensure_refname_invalid(unsigned int flags, const char *input_refname
 void test_refs_normalize__can_normalize_a_direct_reference_name(void)
 {
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/dummy/a", "refs/dummy/a");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/dummy/a", "refs/dummy/a");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/stash", "refs/stash");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/stash", "refs/stash");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/tags/a", "refs/tags/a");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/tags/a", "refs/tags/a");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/a/b", "refs/heads/a/b");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/a/b", "refs/heads/a/b");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/a./b", "refs/heads/a./b");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/a./b", "refs/heads/a./b");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/v@ation", "refs/heads/v@ation");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/v@ation", "refs/heads/v@ation");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs///heads///a", "refs/heads/a");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs///heads///a", "refs/heads/a");
 }
 
 void test_refs_normalize__cannot_normalize_any_direct_reference_name(void)
 {
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "a");
+		GIT_REFERENCE_FORMAT_NORMAL, "a");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "/a");
+		GIT_REFERENCE_FORMAT_NORMAL, "/a");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "//a");
+		GIT_REFERENCE_FORMAT_NORMAL, "//a");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "");
+		GIT_REFERENCE_FORMAT_NORMAL, "");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "/refs/heads/a/");
+		GIT_REFERENCE_FORMAT_NORMAL, "/refs/heads/a/");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/a/");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/a/");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/a.");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/a.");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/a.lock");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/a.lock");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/foo?bar");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/foo?bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads\foo");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads\foo");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/v@ation", "refs/heads/v@ation");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/v@ation", "refs/heads/v@ation");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "refs///heads///a", "refs/heads/a");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs///heads///a", "refs/heads/a");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/.a/b");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/.a/b");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/foo/../bar");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/foo/../bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/foo..bar");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/foo..bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/./foo");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/./foo");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "refs/heads/v@{ation");
+		GIT_REFERENCE_FORMAT_NORMAL, "refs/heads/v@{ation");
 }
 
 void test_refs_normalize__symbolic(void)
 {
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "heads\foo");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "heads\foo");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "/");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "/");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "///");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "///");
 
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "ALL_CAPS_AND_UNDERSCORES", "ALL_CAPS_AND_UNDERSCORES");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "ALL_CAPS_AND_UNDERSCORES", "ALL_CAPS_AND_UNDERSCORES");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/MixedCasing", "refs/MixedCasing");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/MixedCasing", "refs/MixedCasing");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs///heads///a", "refs/heads/a");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs///heads///a", "refs/heads/a");
 
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "HEAD", "HEAD");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "HEAD", "HEAD");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "MERGE_HEAD", "MERGE_HEAD");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "MERGE_HEAD", "MERGE_HEAD");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "FETCH_HEAD", "FETCH_HEAD");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "FETCH_HEAD", "FETCH_HEAD");
 }
 
 /* Ported from JGit, BSD licence.
@@ -146,47 +146,47 @@ void test_refs_normalize__symbolic(void)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 void test_refs_normalize__jgit_suite(void)
 {
 	/* tests borrowed from JGit */
 
 /* EmptyString */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "/");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "/");
 
 /* MustHaveTwoComponents */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_NORMAL, "master");
+		GIT_REFERENCE_FORMAT_NORMAL, "master");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_NORMAL, "heads/master", "heads/master");
+		GIT_REFERENCE_FORMAT_NORMAL, "heads/master", "heads/master");
 
 /* ValidHead */
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master", "refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master", "refs/heads/master");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/pu", "refs/heads/pu");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/pu", "refs/heads/pu");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/z", "refs/heads/z");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/z", "refs/heads/z");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/FoO", "refs/heads/FoO");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/FoO", "refs/heads/FoO");
 
 /* ValidTag */
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/tags/v1.0", "refs/tags/v1.0");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/tags/v1.0", "refs/tags/v1.0");
 
 /* NoLockSuffix */
-	ensure_refname_invalid(GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master.lock");
+	ensure_refname_invalid(GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master.lock");
 
 /* NoDirectorySuffix */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master/");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master/");
 
 /* NoSpace */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/i haz space");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/i haz space");
 
 /* NoAsciiControlCharacters */
 	{
@@ -194,146 +194,146 @@ void test_refs_normalize__jgit_suite(void)
 		char buffer[GIT_REFNAME_MAX];
 		for (c = '\1'; c < ' '; c++) {
 			p_snprintf(buffer, sizeof(buffer), "refs/heads/mast%cer", c);
-			ensure_refname_invalid(GIT_REF_FORMAT_ALLOW_ONELEVEL, buffer);
+			ensure_refname_invalid(GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, buffer);
 		}
 	}
 
 /* NoBareDot */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/.");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/.");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/..");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/..");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/./master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/./master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/../master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/../master");
 
 /* NoLeadingOrTrailingDot */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, ".");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, ".");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/.bar");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/.bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/..bar");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/..bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/bar.");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/bar.");
 
 /* ContainsDot */
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/m.a.s.t.e.r", "refs/heads/m.a.s.t.e.r");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/m.a.s.t.e.r", "refs/heads/m.a.s.t.e.r");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master..pu");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master..pu");
 
 /* NoMagicRefCharacters */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master^");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master^");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/^master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/^master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "^refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "^refs/heads/master");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master~");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master~");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/~master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/~master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "~refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "~refs/heads/master");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master:");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master:");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/:master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/:master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, ":refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, ":refs/heads/master");
 
 /* ShellGlob */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master?");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master?");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/?master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/?master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "?refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "?refs/heads/master");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master[");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master[");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/[master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/[master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "[refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "[refs/heads/master");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master*");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master*");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/*master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/*master");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "*refs/heads/master");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "*refs/heads/master");
 
 /* ValidSpecialCharacters */
 	ensure_refname_normalized
-		(GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/!", "refs/heads/!");
+		(GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/!", "refs/heads/!");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/\"", "refs/heads/\"");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/\"", "refs/heads/\"");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/#", "refs/heads/#");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/#", "refs/heads/#");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/$", "refs/heads/$");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/$", "refs/heads/$");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/%", "refs/heads/%");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/%", "refs/heads/%");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/&", "refs/heads/&");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/&", "refs/heads/&");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/'", "refs/heads/'");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/'", "refs/heads/'");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/(", "refs/heads/(");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/(", "refs/heads/(");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/)", "refs/heads/)");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/)", "refs/heads/)");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/+", "refs/heads/+");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/+", "refs/heads/+");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/,", "refs/heads/,");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/,", "refs/heads/,");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/-", "refs/heads/-");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/-", "refs/heads/-");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/;", "refs/heads/;");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/;", "refs/heads/;");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/<", "refs/heads/<");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/<", "refs/heads/<");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/=", "refs/heads/=");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/=", "refs/heads/=");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/>", "refs/heads/>");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/>", "refs/heads/>");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/@", "refs/heads/@");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/@", "refs/heads/@");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/]", "refs/heads/]");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/]", "refs/heads/]");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/_", "refs/heads/_");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/_", "refs/heads/_");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/`", "refs/heads/`");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/`", "refs/heads/`");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/{", "refs/heads/{");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/{", "refs/heads/{");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/|", "refs/heads/|");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/|", "refs/heads/|");
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/}", "refs/heads/}");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/}", "refs/heads/}");
 
 	/*
 	 * This is valid on UNIX, but not on Windows
 	 * hence we make in invalid due to non-portability
 	 */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/\\");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/\\");
 
 /* UnicodeNames */
 	/*
 	 * Currently this fails.
-	 * ensure_refname_normalized(GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/\u00e5ngstr\u00f6m", "refs/heads/\u00e5ngstr\u00f6m");
+	 * ensure_refname_normalized(GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/\u00e5ngstr\u00f6m", "refs/heads/\u00e5ngstr\u00f6m");
 	 */
 
 /* RefLogQueryIsValidRef */
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master@{1}");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master@{1}");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_ALLOW_ONELEVEL, "refs/heads/master@{1.hour.ago}");
+		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master@{1.hour.ago}");
 }
 
 void test_refs_normalize__buffer_has_to_be_big_enough_to_hold_the_normalized_version(void)
@@ -341,61 +341,61 @@ void test_refs_normalize__buffer_has_to_be_big_enough_to_hold_the_normalized_ver
 	char buffer_out[21];
 
 	cl_git_pass(git_reference_normalize_name(
-		buffer_out, 21, "refs//heads///long///name", GIT_REF_FORMAT_NORMAL));
+		buffer_out, 21, "refs//heads///long///name", GIT_REFERENCE_FORMAT_NORMAL));
 	cl_git_fail(git_reference_normalize_name(
-		buffer_out, 20, "refs//heads///long///name", GIT_REF_FORMAT_NORMAL));
+		buffer_out, 20, "refs//heads///long///name", GIT_REFERENCE_FORMAT_NORMAL));
 }
 
 #define ONE_LEVEL_AND_REFSPEC \
-	GIT_REF_FORMAT_ALLOW_ONELEVEL \
-	| GIT_REF_FORMAT_REFSPEC_PATTERN
+	GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL \
+	| GIT_REFERENCE_FORMAT_REFSPEC_PATTERN
 
 void test_refs_normalize__refspec_pattern(void)
 {
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "heads/*foo/bar");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/*foo/bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "heads/foo*/bar");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/foo*/bar");
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "heads/f*o/bar");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/f*o/bar");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "foo");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo");
 	ensure_refname_normalized(
 		ONE_LEVEL_AND_REFSPEC, "FOO", "FOO");
 
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "foo/bar", "foo/bar");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo/bar", "foo/bar");
 	ensure_refname_normalized(
 		ONE_LEVEL_AND_REFSPEC, "foo/bar", "foo/bar");
 
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "*/foo", "*/foo");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "*/foo", "*/foo");
 	ensure_refname_normalized(
 		ONE_LEVEL_AND_REFSPEC, "*/foo", "*/foo");
 
 	ensure_refname_normalized(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "foo/*/bar", "foo/*/bar");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo/*/bar", "foo/*/bar");
 	ensure_refname_normalized(
 		ONE_LEVEL_AND_REFSPEC, "foo/*/bar", "foo/*/bar");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "*");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "*");
 	ensure_refname_normalized(
 		ONE_LEVEL_AND_REFSPEC, "*", "*");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "foo/*/*");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo/*/*");
 	ensure_refname_invalid(
 		ONE_LEVEL_AND_REFSPEC, "foo/*/*");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "*/foo/*");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "*/foo/*");
 	ensure_refname_invalid(
 		ONE_LEVEL_AND_REFSPEC, "*/foo/*");
 
 	ensure_refname_invalid(
-		GIT_REF_FORMAT_REFSPEC_PATTERN, "*/*/foo");
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "*/*/foo");
 	ensure_refname_invalid(
 		ONE_LEVEL_AND_REFSPEC, "*/*/foo");
 }

--- a/tests/refs/overwrite.c
+++ b/tests/refs/overwrite.c
@@ -33,7 +33,7 @@ void test_refs_overwrite__symbolic(void)
 
 	/* Ensure it points to the right place*/
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert_equal_s(git_reference_symbolic_target(ref), ref_branch_name);
 	git_reference_free(ref);
 
@@ -44,7 +44,7 @@ void test_refs_overwrite__symbolic(void)
 
 	/* Ensure it points to the right place */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert_equal_s(git_reference_symbolic_target(ref), ref_master_name);
 
 	git_reference_free(ref);
@@ -58,7 +58,7 @@ void test_refs_overwrite__object_id(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
@@ -67,7 +67,7 @@ void test_refs_overwrite__object_id(void)
 	git_reference_free(ref);
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_test_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
@@ -90,7 +90,7 @@ void test_refs_overwrite__object_id_with_symbolic(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
@@ -102,7 +102,7 @@ void test_refs_overwrite__object_id_with_symbolic(void)
 
 	/* Ensure it points to the right place */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert_equal_s(git_reference_symbolic_target(ref), ref_master_name);
 
 	git_reference_free(ref);
@@ -115,7 +115,7 @@ void test_refs_overwrite__symbolic_with_object_id(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
@@ -129,7 +129,7 @@ void test_refs_overwrite__symbolic_with_object_id(void)
 
 	/* Ensure it points to the right place */
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 	cl_assert_equal_oid(&id, git_reference_target(ref));
 
 	git_reference_free(ref);

--- a/tests/refs/read.c
+++ b/tests/refs/read.c
@@ -34,7 +34,7 @@ void test_refs_read__loose_tag(void)
 	git_buf ref_name_from_tag_name = GIT_BUF_INIT;
 
 	cl_git_pass(git_reference_lookup(&reference, g_repo, loose_tag_ref_name));
-	cl_assert(git_reference_type(reference) & GIT_REF_OID);
+	cl_assert(git_reference_type(reference) & GIT_REFERENCE_DIRECT);
 	cl_assert(reference_is_packed(reference) == 0);
 	cl_assert_equal_s(reference->name, loose_tag_ref_name);
 
@@ -71,12 +71,12 @@ void test_refs_read__symbolic(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&reference, g_repo, GIT_HEAD_FILE));
-	cl_assert(git_reference_type(reference) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(reference) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert(reference_is_packed(reference) == 0);
 	cl_assert_equal_s(reference->name, GIT_HEAD_FILE);
 
 	cl_git_pass(git_reference_resolve(&resolved_ref, reference));
-	cl_assert(git_reference_type(resolved_ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(resolved_ref) == GIT_REFERENCE_DIRECT);
 
 	cl_git_pass(git_object_lookup(&object, g_repo, git_reference_target(resolved_ref), GIT_OBJECT_ANY));
 	cl_assert(object != NULL);
@@ -99,12 +99,12 @@ void test_refs_read__nested_symbolic(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&reference, g_repo, head_tracker_sym_ref_name));
-	cl_assert(git_reference_type(reference) & GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(reference) & GIT_REFERENCE_SYMBOLIC);
 	cl_assert(reference_is_packed(reference) == 0);
 	cl_assert_equal_s(reference->name, head_tracker_sym_ref_name);
 
 	cl_git_pass(git_reference_resolve(&resolved_ref, reference));
-	cl_assert(git_reference_type(resolved_ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(resolved_ref) == GIT_REFERENCE_DIRECT);
 
 	cl_git_pass(git_object_lookup(&object, g_repo, git_reference_target(resolved_ref), GIT_OBJECT_ANY));
 	cl_assert(object != NULL);
@@ -167,7 +167,7 @@ void test_refs_read__packed(void)
 	git_object *object;
 
 	cl_git_pass(git_reference_lookup(&reference, g_repo, packed_head_name));
-	cl_assert(git_reference_type(reference) & GIT_REF_OID);
+	cl_assert(git_reference_type(reference) & GIT_REFERENCE_DIRECT);
 	cl_assert(reference_is_packed(reference));
 	cl_assert_equal_s(reference->name, packed_head_name);
 
@@ -188,7 +188,7 @@ void test_refs_read__loose_first(void)
 	cl_git_pass(git_reference_lookup(&reference, g_repo, packed_head_name));
 	git_reference_free(reference);
 	cl_git_pass(git_reference_lookup(&reference, g_repo, packed_test_head_name));
-	cl_assert(git_reference_type(reference) & GIT_REF_OID);
+	cl_assert(git_reference_type(reference) & GIT_REFERENCE_DIRECT);
 	cl_assert(reference_is_packed(reference) == 0);
 	cl_assert_equal_s(reference->name, packed_test_head_name);
 

--- a/tests/refs/rename.c
+++ b/tests/refs/rename.c
@@ -264,7 +264,7 @@ void test_refs_rename__overwrite(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 
 	git_oid_cpy(&id, git_reference_target(ref));
 
@@ -297,7 +297,7 @@ void test_refs_rename__prefix(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 
 	git_oid_cpy(&id, git_reference_target(ref));
 
@@ -330,7 +330,7 @@ void test_refs_rename__move_up(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) & GIT_REF_OID);
+	cl_assert(git_reference_type(ref) & GIT_REFERENCE_DIRECT);
 
 	git_oid_cpy(&id, git_reference_target(ref));
 

--- a/tests/refs/setter.c
+++ b/tests/refs/setter.c
@@ -27,12 +27,12 @@ void test_refs_setter__update_direct(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(ref) == GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 
 	cl_git_pass(git_reference_lookup(&test_ref, g_repo, ref_test_name));
-	cl_assert(git_reference_type(test_ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(test_ref) == GIT_REFERENCE_DIRECT);
 
 	cl_git_pass(git_reference_set_target(&new_ref, test_ref, &id, NULL));
 
@@ -40,7 +40,7 @@ void test_refs_setter__update_direct(void)
 	git_reference_free(new_ref);
 
 	cl_git_pass(git_reference_lookup(&test_ref, g_repo, ref_test_name));
-	cl_assert(git_reference_type(test_ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(test_ref) == GIT_REFERENCE_DIRECT);
 	cl_assert_equal_oid(&id, git_reference_target(test_ref));
 	git_reference_free(test_ref);
 }
@@ -50,7 +50,7 @@ void test_refs_setter__update_symbolic(void)
 	git_reference *head, *new_head;
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
-	cl_assert(git_reference_type(head) == GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(head) == GIT_REFERENCE_SYMBOLIC);
 	cl_assert(strcmp(git_reference_symbolic_target(head), ref_master_name) == 0);
 
 	cl_git_pass(git_reference_symbolic_set_target(&new_head, head, ref_test_name, NULL));
@@ -58,7 +58,7 @@ void test_refs_setter__update_symbolic(void)
 	git_reference_free(head);
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
-	cl_assert(git_reference_type(head) == GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(head) == GIT_REFERENCE_SYMBOLIC);
 	cl_assert(strcmp(git_reference_symbolic_target(head), ref_test_name) == 0);
 	git_reference_free(head);
 }
@@ -70,7 +70,7 @@ void test_refs_setter__cant_update_direct_with_symbolic(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(ref) == GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 
 	cl_git_fail(git_reference_symbolic_set_target(&new, ref, ref_name, NULL));
@@ -85,7 +85,7 @@ void test_refs_setter__cant_update_symbolic_with_direct(void)
 	git_oid id;
 
 	cl_git_pass(git_reference_lookup(&ref, g_repo, ref_master_name));
-	cl_assert(git_reference_type(ref) == GIT_REF_OID);
+	cl_assert(git_reference_type(ref) == GIT_REFERENCE_DIRECT);
 	git_oid_cpy(&id, git_reference_target(ref));
 	git_reference_free(ref);
 

--- a/tests/refs/update.c
+++ b/tests/refs/update.c
@@ -19,7 +19,7 @@ void test_refs_update__updating_the_target_of_a_symref_with_an_invalid_name_retu
 	git_reference *head;
 
 	cl_git_pass(git_reference_lookup(&head, g_repo, GIT_HEAD_FILE));
-	cl_assert_equal_i(GIT_REF_SYMBOLIC, git_reference_type(head));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(head));
 	git_reference_free(head);
 
 	cl_assert_equal_i(GIT_EINVALIDSPEC, git_reference_symbolic_create(&head, g_repo, GIT_HEAD_FILE, "refs/heads/inv@{id", 1, NULL));

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -442,7 +442,7 @@ void test_repo_init__extended_1(void)
 		cl_assert((S_ISGID & st.st_mode) == 0);
 
 	cl_git_pass(git_reference_lookup(&ref, _repo, "HEAD"));
-	cl_assert(git_reference_type(ref) == GIT_REF_SYMBOLIC);
+	cl_assert(git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC);
 	cl_assert_equal_s("refs/heads/development", git_reference_symbolic_target(ref));
 	git_reference_free(ref);
 


### PR DESCRIPTION
Again, for consistency:  our reference function names are all `git_reference_*`.  This PR updates the `git_ref_t` enum to be named `git_reference_t`; its values are now `GIT_REFERENCE_*`.  In addition, `GIT_REF_OID` has been renamed to `GIT_REFERENCE_DIRECT` for standardization with other git and libgit2 terminology.

The old names forward to the new names, but are now marked as deprecated.