### PR TITLE
More `git_obj` to `git_object` updates

### DIFF
--- a/examples/cat-file.c
+++ b/examples/cat-file.c
@@ -168,16 +168,16 @@ int main(int argc, char *argv[])
 	case SHOW_PRETTY:
 
 		switch (git_object_type(obj)) {
-		case GIT_OBJ_BLOB:
+		case GIT_OBJECT_BLOB:
 			show_blob((const git_blob *)obj);
 			break;
-		case GIT_OBJ_COMMIT:
+		case GIT_OBJECT_COMMIT:
 			show_commit((const git_commit *)obj);
 			break;
-		case GIT_OBJ_TREE:
+		case GIT_OBJECT_TREE:
 			show_tree((const git_tree *)obj);
 			break;
-		case GIT_OBJ_TAG:
+		case GIT_OBJECT_TAG:
 			show_tag((const git_tag *)obj);
 			break;
 		default:

--- a/examples/common.c
+++ b/examples/common.c
@@ -250,7 +250,7 @@ void treeish_to_tree(
 		"looking up object", treeish);
 
 	check_lg2(
-		git_object_peel((git_object **)out, obj, GIT_OBJ_TREE),
+		git_object_peel((git_object **)out, obj, GIT_OBJECT_TREE),
 		"resolving object to tree", treeish);
 
 	git_object_free(obj);

--- a/examples/for-each-ref.c
+++ b/examples/for-each-ref.c
@@ -18,7 +18,7 @@ static int show_ref(git_reference *ref, void *data)
         oid = git_reference_target(resolved ? resolved : ref);
         git_oid_fmt(hex, oid);
         hex[GIT_OID_HEXSZ] = 0;
-        check_lg2(git_object_lookup(&obj, repo, oid, GIT_OBJ_ANY),
+        check_lg2(git_object_lookup(&obj, repo, oid, GIT_OBJECT_ANY),
                   "Unable to lookup object", hex);
 
         printf("%s %-6s\t%s\n",

--- a/examples/general.c
+++ b/examples/general.c
@@ -241,7 +241,7 @@ static void object_database(git_repository *repo, git_oid *oid)
 	 * we'll write a new blob object that just contains a simple string.
 	 * Notice that we have to specify the object type as the `git_otype` enum.
 	 */
-	git_odb_write(oid, odb, "test data", sizeof("test data") - 1, GIT_OBJ_BLOB);
+	git_odb_write(oid, odb, "test data", sizeof("test data") - 1, GIT_OBJECT_BLOB);
 
 	/**
 	 * Now that we've written the object, we can check out what SHA1 was
@@ -441,7 +441,7 @@ static void tag_parsing(git_repository *repo)
 	 */
 	git_tag_target((git_object **)&commit, tag);
 	name = git_tag_name(tag);		/* "test" */
-	type = git_tag_target_type(tag);	/* GIT_OBJ_COMMIT (otype enum) */
+	type = git_tag_target_type(tag);	/* GIT_OBJECT_COMMIT (object_t enum) */
 	message = git_tag_message(tag);		/* "tag message\n" */
 	printf("Tag Name: %s\nTag Type: %s\nTag Message: %s\n",
 		name, git_object_type2string(type), message);

--- a/examples/log.c
+++ b/examples/log.c
@@ -275,7 +275,7 @@ static int add_revision(struct log_state *s, const char *revstr)
 				git_object_id(revs.from), git_object_id(revs.to)),
 				"Could not find merge base", revstr);
 			check_lg2(
-				git_object_lookup(&revs.to, s->repo, &base, GIT_OBJ_COMMIT),
+				git_object_lookup(&revs.to, s->repo, &base, GIT_OBJECT_COMMIT),
 				"Could not find merge base commit", NULL);
 
 			push_rev(s, revs.to, hide);

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -153,7 +153,7 @@ static int perform_fastforward(git_repository *repo, const git_oid *target_oid, 
 	}
 
 	/* Lookup the target object */
-	err = git_object_lookup(&target, repo, target_oid, GIT_OBJ_COMMIT);
+	err = git_object_lookup(&target, repo, target_oid, GIT_OBJECT_COMMIT);
 	if (err != 0) {
 		fprintf(stderr, "failed to lookup OID %s\n", git_oid_tostr_s(target_oid));
 		return -1;
@@ -251,7 +251,7 @@ static int create_merge_commit(git_repository *repo, git_index *index, merge_opt
 	if (err < 0) goto cleanup;
 
 	/* Setup our parent commits */
-	err = git_reference_peel((git_object **)&parents[0], head_ref, GIT_OBJ_COMMIT);
+	err = git_reference_peel((git_object **)&parents[0], head_ref, GIT_OBJECT_COMMIT);
 	check_lg2(err, "failed to peel head reference", NULL);
 	for (i = 0; i < opts->annotated_count; i++) {
 		git_commit_lookup(&parents[i + 1], repo, git_annotated_commit_id(opts->annotated[i]));

--- a/examples/tag.c
+++ b/examples/tag.c
@@ -135,10 +135,10 @@ static int each_tag(const char *name, tag_state *state)
 			"Failed to lookup rev", name);
 
 	switch (git_object_type(obj)) {
-		case GIT_OBJ_TAG:
+		case GIT_OBJECT_TAG:
 			print_tag((git_tag *) obj, state);
 			break;
-		case GIT_OBJ_COMMIT:
+		case GIT_OBJECT_COMMIT:
 			print_commit((git_commit *) obj, name, state);
 			break;
 		default:

--- a/fuzzers/objects_fuzzer.c
+++ b/fuzzers/objects_fuzzer.c
@@ -26,7 +26,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	const git_otype types[] = {
-		GIT_OBJ_BLOB, GIT_OBJ_TREE, GIT_OBJ_COMMIT, GIT_OBJ_TAG
+		GIT_OBJECT_BLOB, GIT_OBJECT_TREE, GIT_OBJECT_COMMIT, GIT_OBJECT_TAG
 	};
 	git_object *object = NULL;
 	size_t i;

--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -70,7 +70,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	}
 	git_mempack_reset(mempack);
 
-	if (git_odb_write(&id, odb, base_obj, base_obj_len, GIT_OBJ_BLOB) < 0) {
+	if (git_odb_write(&id, odb, base_obj, base_obj_len, GIT_OBJECT_BLOB) < 0) {
 		fprintf(stderr, "Failed to add an object to the odb\n");
 		abort();
 	}
@@ -93,7 +93,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		goto cleanup;
 	if (append_hash) {
 		git_oid oid;
-		if (git_odb_hash(&oid, data, size, GIT_OBJ_BLOB) < 0) {
+		if (git_odb_hash(&oid, data, size, GIT_OBJECT_BLOB) < 0) {
 			fprintf(stderr, "Failed to compute the SHA1 hash\n");
 			abort();
 		}

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -69,7 +69,7 @@ typedef int64_t git_time_t;
 /** Basic type (loose or packed) of any Git object. */
 typedef enum {
 	GIT_OBJECT_ANY =      -2, /**< Object can be any of the following */
-	GIT_OBJECT_BAD =      -1, /**< Object is invalid. */
+	GIT_OBJECT_INVALID =  -1, /**< Object is invalid. */
 	GIT_OBJECT_COMMIT =    1, /**< A commit object. */
 	GIT_OBJECT_TREE =      2, /**< A tree (directory listing) object. */
 	GIT_OBJECT_BLOB =      3, /**< A file revision object. */
@@ -451,7 +451,7 @@ typedef struct git_mailmap git_mailmap;
 /**@{*/
 
 GIT_DEPRECATED(static const int) GIT_OBJ_ANY = GIT_OBJECT_ANY;
-GIT_DEPRECATED(static const int) GIT_OBJ_BAD = GIT_OBJECT_BAD;
+GIT_DEPRECATED(static const int) GIT_OBJ_BAD = GIT_OBJECT_INVALID;
 GIT_DEPRECATED(static const int) GIT_OBJ__EXT1 = 0;
 GIT_DEPRECATED(static const int) GIT_OBJ_COMMIT = GIT_OBJECT_COMMIT;
 GIT_DEPRECATED(static const int) GIT_OBJ_TREE = GIT_OBJECT_TREE;

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -450,16 +450,16 @@ typedef struct git_mailmap git_mailmap;
 
 /**@{*/
 
-#define GIT_OBJ_ANY        GIT_OBJECT_ANY
-#define GIT_OBJ_BAD        GIT_OBJECT_BAD
-#define GIT_OBJ__EXT1      0
-#define GIT_OBJ_COMMIT     GIT_OBJECT_COMMIT
-#define GIT_OBJ_TREE       GIT_OBJECT_TREE
-#define GIT_OBJ_BLOB       GIT_OBJECT_BLOB
-#define GIT_OBJ_TAG        GIT_OBJECT_TAG
-#define GIT_OBJ__EXT2      5
-#define GIT_OBJ_OFS_DELTA  GIT_OBJECT_OFS_DELTA
-#define GIT_OBJ_REF_DELTA  GIT_OBJECT_REF_DELTA
+GIT_DEPRECATED(static const int) GIT_OBJ_ANY = GIT_OBJECT_ANY;
+GIT_DEPRECATED(static const int) GIT_OBJ_BAD = GIT_OBJECT_BAD;
+GIT_DEPRECATED(static const int) GIT_OBJ__EXT1 = 0;
+GIT_DEPRECATED(static const int) GIT_OBJ_COMMIT = GIT_OBJECT_COMMIT;
+GIT_DEPRECATED(static const int) GIT_OBJ_TREE = GIT_OBJECT_TREE;
+GIT_DEPRECATED(static const int) GIT_OBJ_BLOB = GIT_OBJECT_BLOB;
+GIT_DEPRECATED(static const int) GIT_OBJ_TAG = GIT_OBJECT_TAG;
+GIT_DEPRECATED(static const int) GIT_OBJ__EXT2 = 5;
+GIT_DEPRECATED(static const int) GIT_OBJ_OFS_DELTA = GIT_OBJECT_OFS_DELTA;
+GIT_DEPRECATED(static const int) GIT_OBJ_REF_DELTA = GIT_OBJECT_REF_DELTA;
 
 #define git_otype git_object_t
 

--- a/src/annotated_commit.c
+++ b/src/annotated_commit.c
@@ -130,7 +130,7 @@ int git_annotated_commit_from_ref(
 
 	*out = NULL;
 
-	if ((error = git_reference_peel(&peeled, ref, GIT_OBJ_COMMIT)) < 0)
+	if ((error = git_reference_peel(&peeled, ref, GIT_OBJECT_COMMIT)) < 0)
 		return error;
 
 	error = annotated_commit_init_from_id(out,

--- a/src/object.c
+++ b/src/object.c
@@ -288,7 +288,7 @@ const char *git_object_type2string(git_object_t type)
 git_object_t git_object_string2type(const char *str)
 {
 	if (!str)
-		return GIT_OBJECT_BAD;
+		return GIT_OBJECT_INVALID;
 
 	return git_object_stringn2type(str, strlen(str));
 }
@@ -298,14 +298,14 @@ git_object_t git_object_stringn2type(const char *str, size_t len)
 	size_t i;
 
 	if (!str || !len || !*str)
-		return GIT_OBJECT_BAD;
+		return GIT_OBJECT_INVALID;
 
 	for (i = 0; i < ARRAY_SIZE(git_objects_table); i++)
 		if (*git_objects_table[i].str &&
 			!git__prefixncmp(str, len, git_objects_table[i].str))
 			return (git_object_t)i;
 
-	return GIT_OBJECT_BAD;
+	return GIT_OBJECT_INVALID;
 }
 
 int git_object_typeisloose(git_object_t type)

--- a/src/object.h
+++ b/src/object.h
@@ -62,7 +62,7 @@ GIT_INLINE(git_object_t) git_object__type_from_filemode(git_filemode_t mode)
 	case GIT_FILEMODE_LINK:
 		return GIT_OBJECT_BLOB;
 	default:
-		return GIT_OBJECT_BAD;
+		return GIT_OBJECT_INVALID;
 	}
 }
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -63,7 +63,7 @@ static git_object_t odb_hardcoded_type(const git_oid *id)
 	if (!git_oid_cmp(id, &empty_tree))
 		return GIT_OBJECT_TREE;
 
-	return GIT_OBJECT_BAD;
+	return GIT_OBJECT_INVALID;
 }
 
 static int odb_read_hardcoded(bool *found, git_rawobj *raw, const git_oid *id)
@@ -72,7 +72,7 @@ static int odb_read_hardcoded(bool *found, git_rawobj *raw, const git_oid *id)
 
 	*found = false;
 
-	if ((type = odb_hardcoded_type(id)) == GIT_OBJECT_BAD)
+	if ((type = odb_hardcoded_type(id)) == GIT_OBJECT_INVALID)
 		return 0;
 
 	raw->type = type;
@@ -945,7 +945,7 @@ static int odb_read_header_1(
 	bool passthrough = false;
 	int error;
 
-	if (!only_refreshed && (ht = odb_hardcoded_type(id)) != GIT_OBJECT_BAD) {
+	if (!only_refreshed && (ht = odb_hardcoded_type(id)) != GIT_OBJECT_INVALID) {
 		*type_p = ht;
 		*len_p = 0;
 		return 0;

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -351,7 +351,7 @@ static int read_loose(git_rawobj *out, git_buf *loc)
 
 	out->data = NULL;
 	out->len = 0;
-	out->type = GIT_OBJECT_BAD;
+	out->type = GIT_OBJECT_INVALID;
 
 	if ((error = git_futils_readbuffer(&obj, loc->ptr)) < 0)
 		goto done;
@@ -583,7 +583,7 @@ static int loose_backend__read_header(size_t *len_p, git_object_t *type_p, git_o
 	assert(backend && oid);
 
 	raw.len = 0;
-	raw.type = GIT_OBJECT_BAD;
+	raw.type = GIT_OBJECT_INVALID;
 
 	if (locate_object(&object_path, (loose_backend *)backend, oid) < 0) {
 		error = git_odb__error_notfound("no matching loose object",
@@ -989,7 +989,7 @@ static int loose_backend__readstream(
 	backend = (loose_backend *)_backend;
 	*stream_out = NULL;
 	*len_out = 0;
-	*type_out = GIT_OBJECT_BAD;
+	*type_out = GIT_OBJECT_INVALID;
 
 	if (locate_object(&object_path, backend, oid) < 0) {
 		error = git_odb__error_notfound("no matching loose object",

--- a/src/pack.c
+++ b/src/pack.c
@@ -644,7 +644,7 @@ int git_packfile_unpack(
 
 	obj->data = NULL;
 	obj->len = 0;
-	obj->type = GIT_OBJECT_BAD;
+	obj->type = GIT_OBJECT_INVALID;
 
 	/* let's point to the right stack */
 	stack = chain.ptr ? chain.ptr : small_stack;
@@ -726,7 +726,7 @@ int git_packfile_unpack(
 		base = *obj;
 		obj->data = NULL;
 		obj->len = 0;
-		obj->type = GIT_OBJECT_BAD;
+		obj->type = GIT_OBJECT_INVALID;
 
 		error = git_delta_apply(&obj->data, &obj->len, base.data, base.len, delta.data, delta.len);
 		obj->type = base_type;

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -369,7 +369,7 @@ static git_object_t parse_obj_type(const char *str)
 	if (!strcmp(str, "tag"))
 		return GIT_OBJECT_TAG;
 
-	return GIT_OBJECT_BAD;
+	return GIT_OBJECT_INVALID;
 }
 
 static int dereference_to_non_tag(git_object **out, git_object *obj)
@@ -515,7 +515,7 @@ static int handle_caret_curly_syntax(git_object **out, git_object *obj, const ch
 
 	expected_type = parse_obj_type(curly_braces_content);
 
-	if (expected_type == GIT_OBJECT_BAD)
+	if (expected_type == GIT_OBJECT_INVALID)
 		return GIT_EINVALIDSPEC;
 
 	return git_object_peel(out, obj, expected_type);

--- a/src/tag.c
+++ b/src/tag.c
@@ -84,7 +84,7 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 		return tag_error("type field not found");
 	buffer += 5;
 
-	tag->type = GIT_OBJECT_BAD;
+	tag->type = GIT_OBJECT_INVALID;
 
 	for (i = 1; i < ARRAY_SIZE(tag_types); ++i) {
 		size_t type_length = strlen(tag_types[i]);
@@ -99,7 +99,7 @@ static int tag_parse(git_tag *tag, const char *buffer, const char *buffer_end)
 		}
 	}
 
-	if (tag->type == GIT_OBJECT_BAD)
+	if (tag->type == GIT_OBJECT_INVALID)
 		return tag_error("invalid object type");
 
 	if (buffer + 4 >= buffer_end)

--- a/tests/object/raw/data.h
+++ b/tests/object/raw/data.h
@@ -319,5 +319,5 @@ static git_rawobj some_obj = {
 static git_rawobj junk_obj = {
 	NULL,
 	0,
-	GIT_OBJECT_BAD
+	GIT_OBJECT_INVALID
 };

--- a/tests/object/raw/type2string.c
+++ b/tests/object/raw/type2string.c
@@ -6,7 +6,7 @@
 
 void test_object_raw_type2string__convert_type_to_string(void)
 {
-	cl_assert_equal_s(git_object_type2string(GIT_OBJECT_BAD), "");
+	cl_assert_equal_s(git_object_type2string(GIT_OBJECT_INVALID), "");
 	cl_assert_equal_s(git_object_type2string(0), ""); /* EXT1 */
 	cl_assert_equal_s(git_object_type2string(GIT_OBJECT_COMMIT), "commit");
 	cl_assert_equal_s(git_object_type2string(GIT_OBJECT_TREE), "tree");
@@ -23,8 +23,8 @@ void test_object_raw_type2string__convert_type_to_string(void)
 
 void test_object_raw_type2string__convert_string_to_type(void)
 {
-	cl_assert(git_object_string2type(NULL) == GIT_OBJECT_BAD);
-	cl_assert(git_object_string2type("") == GIT_OBJECT_BAD);
+	cl_assert(git_object_string2type(NULL) == GIT_OBJECT_INVALID);
+	cl_assert(git_object_string2type("") == GIT_OBJECT_INVALID);
 	cl_assert(git_object_string2type("commit") == GIT_OBJECT_COMMIT);
 	cl_assert(git_object_string2type("tree") == GIT_OBJECT_TREE);
 	cl_assert(git_object_string2type("blob") == GIT_OBJECT_BLOB);
@@ -32,13 +32,13 @@ void test_object_raw_type2string__convert_string_to_type(void)
 	cl_assert(git_object_string2type("OFS_DELTA") == GIT_OBJECT_OFS_DELTA);
 	cl_assert(git_object_string2type("REF_DELTA") == GIT_OBJECT_REF_DELTA);
 
-	cl_assert(git_object_string2type("CoMmIt") == GIT_OBJECT_BAD);
-	cl_assert(git_object_string2type("hohoho") == GIT_OBJECT_BAD);
+	cl_assert(git_object_string2type("CoMmIt") == GIT_OBJECT_INVALID);
+	cl_assert(git_object_string2type("hohoho") == GIT_OBJECT_INVALID);
 }
 
 void test_object_raw_type2string__check_type_is_loose(void)
 {
-	cl_assert(git_object_typeisloose(GIT_OBJECT_BAD) == 0);
+	cl_assert(git_object_typeisloose(GIT_OBJECT_INVALID) == 0);
 	cl_assert(git_object_typeisloose(0) == 0); /* EXT1 */
 	cl_assert(git_object_typeisloose(GIT_OBJECT_COMMIT) == 1);
 	cl_assert(git_object_typeisloose(GIT_OBJECT_TREE) == 1);


### PR DESCRIPTION
Some further tweaks on moving to `git_object`.  We use the term "invalid" to refer to bad or malformed data, eg `GIT_REF_INVALID` and `GIT_EINVALIDSPEC`.  Since we're changing the names of the `git_object_t`s in this release, update it to be `GIT_OBJECT_INVALID` instead of `BAD`.

Per @tiennou's [note](https://github.com/libgit2/libgit2/pull/4917#discussion_r246396591) in #4917, I've also updated the compatibility declarations to be `static const int`s instead of `#define`s, allowing us to mark them as deprecated using `GIT_DEPRECATED`.

Doing so illustrated some places where we were continuing to use the old names internally; they've also been updated.