### PR TITLE
Improve deprecation of old enums

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -59,6 +59,7 @@ typedef size_t size_t;
 #if defined(__GNUC__)
 # define GIT_DEPRECATED(func) \
 			 __attribute__((deprecated)) \
+			 __attribute__((used)) \
 			 func
 #elif defined(_MSC_VER)
 # define GIT_DEPRECATED(func) __declspec(deprecated) func

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -762,18 +762,18 @@ GIT_EXTERN(const char *) git_reference_shorthand(const git_reference *ref);
 #define git_ref_t git_reference_t
 #define git_reference_normalize_t git_reference_format_t
 
-GIT_DEPRECATED(static const unsigned int) GIT_REF_INVALID = GIT_REFERENCE_INVALID;
-GIT_DEPRECATED(static const unsigned int) GIT_REF_OID = GIT_REFERENCE_DIRECT;
-GIT_DEPRECATED(static const unsigned int) GIT_REF_SYMBOLIC = GIT_REFERENCE_SYMBOLIC;
-GIT_DEPRECATED(static const unsigned int) GIT_REF_LISTALL = GIT_REFERENCE_ALL;
+GIT_DEPRECATED(static const git_ref_t) GIT_REF_INVALID = GIT_REFERENCE_INVALID;
+GIT_DEPRECATED(static const git_ref_t) GIT_REF_OID = GIT_REFERENCE_DIRECT;
+GIT_DEPRECATED(static const git_ref_t) GIT_REF_SYMBOLIC = GIT_REFERENCE_SYMBOLIC;
+GIT_DEPRECATED(static const git_ref_t) GIT_REF_LISTALL = GIT_REFERENCE_ALL;
 
-GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_NORMAL =
+GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_NORMAL =
 	GIT_REFERENCE_FORMAT_NORMAL;
-GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_ALLOW_ONELEVEL =
+GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_ALLOW_ONELEVEL =
 	GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL;
-GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_REFSPEC_PATTERN =
+GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_REFSPEC_PATTERN =
 	GIT_REFERENCE_FORMAT_REFSPEC_PATTERN;
-GIT_DEPRECATED(static const unsigned int) GIT_REF_FORMAT_REFSPEC_SHORTHAND =
+GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_REFSPEC_SHORTHAND =
 	GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND;
 
 /**@}*/

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -450,18 +450,18 @@ typedef struct git_mailmap git_mailmap;
 
 /**@{*/
 
-GIT_DEPRECATED(static const int) GIT_OBJ_ANY = GIT_OBJECT_ANY;
-GIT_DEPRECATED(static const int) GIT_OBJ_BAD = GIT_OBJECT_INVALID;
-GIT_DEPRECATED(static const int) GIT_OBJ__EXT1 = 0;
-GIT_DEPRECATED(static const int) GIT_OBJ_COMMIT = GIT_OBJECT_COMMIT;
-GIT_DEPRECATED(static const int) GIT_OBJ_TREE = GIT_OBJECT_TREE;
-GIT_DEPRECATED(static const int) GIT_OBJ_BLOB = GIT_OBJECT_BLOB;
-GIT_DEPRECATED(static const int) GIT_OBJ_TAG = GIT_OBJECT_TAG;
-GIT_DEPRECATED(static const int) GIT_OBJ__EXT2 = 5;
-GIT_DEPRECATED(static const int) GIT_OBJ_OFS_DELTA = GIT_OBJECT_OFS_DELTA;
-GIT_DEPRECATED(static const int) GIT_OBJ_REF_DELTA = GIT_OBJECT_REF_DELTA;
-
 #define git_otype git_object_t
+
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_ANY = GIT_OBJECT_ANY;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_BAD = GIT_OBJECT_INVALID;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ__EXT1 = 0;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_COMMIT = GIT_OBJECT_COMMIT;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_TREE = GIT_OBJECT_TREE;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_BLOB = GIT_OBJECT_BLOB;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_TAG = GIT_OBJECT_TAG;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ__EXT2 = 5;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_OFS_DELTA = GIT_OBJECT_OFS_DELTA;
+GIT_DEPRECATED(static const git_otype) GIT_OBJ_REF_DELTA = GIT_OBJECT_REF_DELTA;
 
 /**@}*/
 


### PR DESCRIPTION
Add `__attribute__((used))` to the `GIT_DEPRECATED` macro, otherwise this will be seen as an "unused const variable".

Also, use the enum type in the declaration of deprecated values.  The C standard does not specify whether an enum is a signed or unsigned type.  Obviously, any enum that includes negative values _must_ be signed, but if all values are positive then the compiler is free to choose signed or unsigned.  
Thus, we declare the deprecated values as the enum instead of guessing.