### PR TITLE
Add/multiply with overflow tweaks

### DIFF
--- a/src/integer.h
+++ b/src/integer.h
@@ -42,18 +42,6 @@ GIT_INLINE(int) git__is_int(long long p)
 	return p == (long long)r;
 }
 
-/**
- * Sets `one + two` into `out`, unless the arithmetic would overflow.
- * @return true if the result fits in a `uint64_t`, false on overflow.
- */
-GIT_INLINE(bool) git__add_uint64_overflow(uint64_t *out, uint64_t one, uint64_t two)
-{
-	if (UINT64_MAX - one < two)
-		return true;
-	*out = one + two;
-	return false;
-}
-
 /* Use clang/gcc compiler intrinsics whenever possible */
 #if (__has_builtin(__builtin_add_overflow) || \
      (defined(__GNUC__) && (__GNUC__ >= 5)))

--- a/src/integer.h
+++ b/src/integer.h
@@ -58,32 +58,24 @@ GIT_INLINE(bool) git__add_uint64_overflow(uint64_t *out, uint64_t one, uint64_t 
 #if (__has_builtin(__builtin_add_overflow) || \
      (defined(__GNUC__) && (__GNUC__ >= 5)))
 
-/*
- * Even though __builtin_{add,mul}_overflow should be able to handle all
- * possible cases (since it can accept any type), under some configurations
- * clang would need a dependency on compiler-rt. In order to avoid that, we
- * attempt to choose one of the explicit unsigned long long / unsigned long
- * versions of the intrinsics if possible. Unfortunately, unsigned long long
- * and unsigned long are still different types to the compiler, so we need to
- * still do some additional sniffing to prevent MinGW 64 from choosing the
- * wrong version and triggering compiler warnings.
- */
-#	if (SIZE_MAX == ULLONG_MAX) && (ULONG_MAX == ULLONG_MAX) && defined(_WIN64)
-#		define git__add_sizet_overflow(out, one, two) \
-			__builtin_uaddll_overflow(one, two, out)
-#		define git__multiply_sizet_overflow(out, one, two) \
-			__builtin_umulll_overflow(one, two, out)
-#	elif (SIZE_MAX == ULONG_MAX) && (ULONG_MAX == ULLONG_MAX)
-#		define git__add_sizet_overflow(out, one, two) \
-			__builtin_uaddl_overflow(one, two, out)
-#		define git__multiply_sizet_overflow(out, one, two) \
-			__builtin_umull_overflow(one, two, out)
-#	else
-#		define git__add_sizet_overflow(out, one, two) \
-			__builtin_add_overflow(one, two, out)
-#		define git__multiply_sizet_overflow(out, one, two) \
-			__builtin_mul_overflow(one, two, out)
-#	endif
+# if (SIZE_MAX == UINT_MAX)
+#  define git__add_sizet_overflow(out, one, two) \
+     __builtin_uadd_overflow(one, two, out)
+#  define git__multiply_sizet_overflow(out, one, two) \
+     __builtin_umul_overflow(one, two, out)
+# elif (SIZE_MAX == ULONG_MAX)
+#  define git__add_sizet_overflow(out, one, two) \
+     __builtin_uaddl_overflow(one, two, out)
+#  define git__multiply_sizet_overflow(out, one, two) \
+     __builtin_umull_overflow(one, two, out)
+# elif (SIZE_MAX == ULLONG_MAX)
+#  define git__add_sizet_overflow(out, one, two) \
+     __builtin_uaddll_overflow(one, two, out)
+#  define git__multiply_sizet_overflow(out, one, two) \
+     __builtin_umulll_overflow(one, two, out)
+# else
+#  error compiler has add with overflow intrinsics but SIZE_MAX is unknown
+# endif
 
 #else
 

--- a/src/integer.h
+++ b/src/integer.h
@@ -65,6 +65,16 @@ GIT_INLINE(int) git__is_int(long long p)
 #  error compiler has add with overflow intrinsics but SIZE_MAX is unknown
 # endif
 
+/* Use Microsoft's safe integer handling functions where available */
+#elif defined(_MSC_VER)
+
+# include <intsafe.h>
+
+# define git__add_sizet_overflow(out, one, two) \
+    (SizeTAdd(one, two, out) != S_OK)
+# define git__multiply_sizet_overflow(out, one, two) \
+    (SizeTMult(one, two, out) != S_OK)
+
 #else
 
 /**

--- a/src/integer.h
+++ b/src/integer.h
@@ -55,16 +55,36 @@ GIT_INLINE(bool) git__add_uint64_overflow(uint64_t *out, uint64_t one, uint64_t 
 }
 
 /* Use clang/gcc compiler intrinsics whenever possible */
-#if (SIZE_MAX == ULONG_MAX) && __has_builtin(__builtin_uaddl_overflow)
-# define git__add_sizet_overflow(out, one, two) \
-	__builtin_uaddl_overflow(one, two, out)
-# define git__multiply_sizet_overflow(out, one, two) \
-	__builtin_umull_overflow(one, two, out)
-#elif (SIZE_MAX == UINT_MAX) && __has_builtin(__builtin_uadd_overflow)
-# define git__add_sizet_overflow(out, one, two) \
-	__builtin_uadd_overflow(one, two, out)
-# define git__multiply_sizet_overflow(out, one, two) \
-	__builtin_umul_overflow(one, two, out)
+#if (__has_builtin(__builtin_add_overflow) || \
+     (defined(__GNUC__) && (__GNUC__ >= 5)))
+
+/*
+ * Even though __builtin_{add,mul}_overflow should be able to handle all
+ * possible cases (since it can accept any type), under some configurations
+ * clang would need a dependency on compiler-rt. In order to avoid that, we
+ * attempt to choose one of the explicit unsigned long long / unsigned long
+ * versions of the intrinsics if possible. Unfortunately, unsigned long long
+ * and unsigned long are still different types to the compiler, so we need to
+ * still do some additional sniffing to prevent MinGW 64 from choosing the
+ * wrong version and triggering compiler warnings.
+ */
+#	if (SIZE_MAX == ULLONG_MAX) && (ULONG_MAX == ULLONG_MAX) && defined(_WIN64)
+#		define git__add_sizet_overflow(out, one, two) \
+			__builtin_uaddll_overflow(one, two, out)
+#		define git__multiply_sizet_overflow(out, one, two) \
+			__builtin_umulll_overflow(one, two, out)
+#	elif (SIZE_MAX == ULONG_MAX) && (ULONG_MAX == ULLONG_MAX)
+#		define git__add_sizet_overflow(out, one, two) \
+			__builtin_uaddl_overflow(one, two, out)
+#		define git__multiply_sizet_overflow(out, one, two) \
+			__builtin_umull_overflow(one, two, out)
+#	else
+#		define git__add_sizet_overflow(out, one, two) \
+			__builtin_add_overflow(one, two, out)
+#		define git__multiply_sizet_overflow(out, one, two) \
+			__builtin_mul_overflow(one, two, out)
+#	endif
+
 #else
 
 /**

--- a/src/integer.h
+++ b/src/integer.h
@@ -79,7 +79,7 @@ GIT_INLINE(int) git__is_int(long long p)
 
 /**
  * Sets `one + two` into `out`, unless the arithmetic would overflow.
- * @return true if the result fits in a `size_t`, false on overflow.
+ * @return false if the result fits in a `size_t`, true on overflow.
  */
 GIT_INLINE(bool) git__add_sizet_overflow(size_t *out, size_t one, size_t two)
 {
@@ -91,7 +91,7 @@ GIT_INLINE(bool) git__add_sizet_overflow(size_t *out, size_t one, size_t two)
 
 /**
  * Sets `one * two` into `out`, unless the arithmetic would overflow.
- * @return true if the result fits in a `size_t`, false on overflow.
+ * @return false if the result fits in a `size_t`, true on overflow.
  */
 GIT_INLINE(bool) git__multiply_sizet_overflow(size_t *out, size_t one, size_t two)
 {


### PR DESCRIPTION
This takes #4929 with a few additions:  first, it simplifies the tests a bit on gcc/clang.  Second, it starts using `SizeTAdd` and friends on MSVC, which may be faster than our fallback test.  Third, it corrects an error in the docs for the fallback test.  Finally, it removes an unused function.