### PR TITLE
odb: Fix odb foreach to also close on positive error code

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1260,7 +1260,7 @@ int git_odb_foreach(git_odb *db, git_odb_foreach_cb cb, void *payload)
 	git_vector_foreach(&db->backends, i, internal) {
 		git_odb_backend *b = internal->backend;
 		int error = b->foreach(b, cb, payload);
-		if (error < 0)
+		if (error != 0)
 			return error;
 	}
 

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -478,7 +478,7 @@ static int pack_backend__foreach(git_odb_backend *_backend, git_odb_foreach_cb c
 		return error;
 
 	git_vector_foreach(&backend->packs, i, p) {
-		if ((error = git_pack_foreach_entry(p, cb, data)) < 0)
+		if ((error = git_pack_foreach_entry(p, cb, data)) != 0)
 			return error;
 	}
 

--- a/tests/odb/foreach.c
+++ b/tests/odb/foreach.c
@@ -81,6 +81,16 @@ static int foreach_stop_first_cb(const git_oid *oid, void *data)
 	return -123;
 }
 
+static int foreach_stop_cb_positive_ret(const git_oid *oid, void *data)
+{
+	int *nobj = data;
+	(*nobj)++;
+
+	GIT_UNUSED(oid);
+
+	return (*nobj == 1000) ? 321 : 0;
+}
+
 void test_odb_foreach__interrupt_foreach(void)
 {
 	int nobj = 0;
@@ -90,6 +100,11 @@ void test_odb_foreach__interrupt_foreach(void)
 	git_repository_odb(&_odb, _repo);
 
 	cl_assert_equal_i(-321, git_odb_foreach(_odb, foreach_stop_cb, &nobj));
+	cl_assert(nobj == 1000);
+
+	nobj = 0;
+
+	cl_assert_equal_i(321, git_odb_foreach(_odb, foreach_stop_cb_positive_ret, &nobj));
 	cl_assert(nobj == 1000);
 
 	git_odb_free(_odb);


### PR DESCRIPTION
Hi,

This should be fix for #4946 .

I'm not familiar with internals, but all tests pass and I did add one new for this case. I don't like that copy/paste, so I was thinking about using struct (or 2 int array) so that only one callback exists in test. What do you think about that?

Also, should anything else be changed?

Thank you.