### PR TITLE
Clean up some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,9 @@ IF (MSVC)
 	# /O1 - Optimize for size
 	SET(CMAKE_C_FLAGS_MINSIZEREL "/DNDEBUG /O1 /Oy /GL /Gy ${CRT_FLAG_RELEASE}")
 
+	# /IGNORE:4221 - Ignore empty compilation units
+	SET(CMAKE_STATIC_LINKER_FLAGS "/IGNORE:4221")
+
 	# /DYNAMICBASE - Address space load randomization (ASLR)
 	# /NXCOMPAT - Data execution prevention (DEP)
 	# /LARGEADDRESSAWARE - >2GB user address space on x86

--- a/src/apply.c
+++ b/src/apply.c
@@ -138,7 +138,7 @@ static bool find_hunk_linenum(
 
 static int update_hunk(
 	patch_image *image,
-	unsigned int linenum,
+	size_t linenum,
 	patch_image *preimage,
 	patch_image *postimage)
 {

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -12,6 +12,7 @@
 #include "attrcache.h"
 #include "git2/blob.h"
 #include "git2/tree.h"
+#include "blob.h"
 #include "index.h"
 #include <ctype.h>
 
@@ -119,6 +120,7 @@ int git_attr_file__load(
 		break;
 	case GIT_ATTR_FILE__FROM_INDEX: {
 		git_oid id;
+		git_off_t blobsize;
 
 		if ((error = attr_file_oid_from_index(&id, repo, entry->path)) < 0 ||
 			(error = git_blob_lookup(&blob, repo, &id)) < 0)
@@ -126,7 +128,10 @@ int git_attr_file__load(
 
 		/* Do not assume that data straight from the ODB is NULL-terminated;
 		 * copy the contents of a file to a buffer to work on */
-		git_buf_put(&content, git_blob_rawcontent(blob), git_blob_rawsize(blob));
+		blobsize = git_blob_rawsize(blob);
+
+		GIT_ERROR_CHECK_BLOBSIZE(blobsize);
+		git_buf_put(&content, git_blob_rawcontent(blob), (size_t)blobsize);
 		break;
 	}
 	case GIT_ATTR_FILE__FROM_FILE: {

--- a/src/blame.c
+++ b/src/blame.c
@@ -41,7 +41,12 @@ static int hunk_cmp(const void *_a, const void *_b)
 	git_blame_hunk *a = (git_blame_hunk*)_a,
 						*b = (git_blame_hunk*)_b;
 
-	return a->final_start_line_number - b->final_start_line_number;
+	if (a->final_start_line_number > b->final_start_line_number)
+		return 1;
+	else if (a->final_start_line_number < b->final_start_line_number)
+		return -1;
+	else
+		return 0;
 }
 
 static bool hunk_ends_at_or_before_line(git_blame_hunk *hunk, size_t line)

--- a/src/blob.c
+++ b/src/blob.c
@@ -36,10 +36,10 @@ git_off_t git_blob_rawsize(const git_blob *blob)
 
 int git_blob__getbuf(git_buf *buffer, git_blob *blob)
 {
-	return git_buf_set(
-		buffer,
-		git_blob_rawcontent(blob),
-		git_blob_rawsize(blob));
+	git_off_t size = git_blob_rawsize(blob);
+
+	GIT_ERROR_CHECK_BLOBSIZE(size);
+	return git_buf_set(buffer, git_blob_rawcontent(blob), (size_t)size);
 }
 
 void git_blob__free(void *_blob)
@@ -389,12 +389,14 @@ cleanup:
 int git_blob_is_binary(const git_blob *blob)
 {
 	git_buf content = GIT_BUF_INIT;
+	git_off_t size;
 
 	assert(blob);
 
+	size = git_blob_rawsize(blob);
+
 	git_buf_attach_notowned(&content, git_blob_rawcontent(blob),
-		min(git_blob_rawsize(blob),
-		GIT_FILTER_BYTES_TO_CHECK_NUL));
+		(size_t)min(size, GIT_FILTER_BYTES_TO_CHECK_NUL));
 	return git_buf_text_is_binary(&content);
 }
 

--- a/src/blob.h
+++ b/src/blob.h
@@ -27,6 +27,14 @@ struct git_blob {
 	unsigned int raw:1;
 };
 
+#define GIT_ERROR_CHECK_BLOBSIZE(n) \
+	do { \
+		if (!git__is_sizet(n)) { \
+			git_error_set(GIT_ERROR_NOMEMORY, "blob contents too large to fit in memory"); \
+			return -1; \
+		} \
+	} while(0)
+
 void git_blob__free(void *blob);
 int git_blob__parse(void *blob, git_odb_object *obj);
 int git_blob__parse_raw(void *blob, const char *data, size_t size);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -440,7 +440,7 @@ int git_buf_decode_base85(
 
 		acc += de;
 
-		cnt = (output_len < 4) ? output_len : 4;
+		cnt = (output_len < 4) ? (int)output_len : 4;
 		output_len -= cnt;
 		do {
 			acc = (acc << 8) | (acc >> 24);

--- a/src/describe.c
+++ b/src/describe.c
@@ -366,7 +366,7 @@ static int find_unique_abbrev_size(
 	int *out,
 	git_repository *repo,
 	const git_oid *oid_in,
-	int abbreviated_size)
+	unsigned int abbreviated_size)
 {
 	size_t size = abbreviated_size;
 	git_odb *odb;
@@ -401,7 +401,7 @@ static int show_suffix(
 	int depth,
 	git_repository *repo,
 	const git_oid* id,
-	size_t abbrev_size)
+	unsigned int abbrev_size)
 {
 	int error, size = 0;
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -386,7 +386,7 @@ static int flush_hunk(git_oid *result, git_hash_ctx *ctx)
 
 	for (i = 0; i < GIT_OID_RAWSZ; i++) {
 		carry += result->id[i] + hash.id[i];
-		result->id[i] = carry;
+		result->id[i] = (unsigned char)carry;
 		carry >>= 8;
 	}
 

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -564,9 +564,14 @@ int git_diff__oid_for_file(
 {
 	git_index_entry entry;
 
+	if (!git__is_sizet(size)) {
+		git_error_set(GIT_ERROR_NOMEMORY, "file size overflow (for 32-bits) on '%s'", path);
+		return -1;
+	}
+
 	memset(&entry, 0, sizeof(entry));
 	entry.mode = mode;
-	entry.file_size = size;
+	entry.file_size = (size_t)size;
 	entry.path = (char *)path;
 
 	return git_diff__oid_for_entry(out, diff, &entry, mode, NULL);
@@ -628,7 +633,7 @@ int git_diff__oid_for_entry(
 		error = git_odb__hashlink(out, full_path.ptr);
 		diff->base.perf.oid_calculations++;
 	} else if (!git__is_sizet(entry.file_size)) {
-		git_error_set(GIT_ERROR_OS, "file size overflow (for 32-bits) on '%s'",
+		git_error_set(GIT_ERROR_NOMEMORY, "file size overflow (for 32-bits) on '%s'",
 			entry.path);
 		error = -1;
 	} else if (!(error = git_filter_list_load(&fl,

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -564,14 +564,14 @@ int git_diff__oid_for_file(
 {
 	git_index_entry entry;
 
-	if (!git__is_sizet(size)) {
+	if (size < 0 || size > UINT32_MAX) {
 		git_error_set(GIT_ERROR_NOMEMORY, "file size overflow (for 32-bits) on '%s'", path);
 		return -1;
 	}
 
 	memset(&entry, 0, sizeof(entry));
 	entry.mode = mode;
-	entry.file_size = (size_t)size;
+	entry.file_size = (uint32_t)size;
 	entry.path = (char *)path;
 
 	return git_diff__oid_for_entry(out, diff, &entry, mode, NULL);

--- a/src/diff_stats.c
+++ b/src/diff_stats.c
@@ -54,7 +54,8 @@ int git_diff_file_stats__full_to_buf(
 	size_t width)
 {
 	const char *old_path = NULL, *new_path = NULL;
-	size_t padding, old_size, new_size;
+	size_t padding;
+	git_off_t old_size, new_size;
 
 	old_path = delta->old_file.path;
 	new_path = delta->new_file.path;
@@ -96,7 +97,7 @@ int git_diff_file_stats__full_to_buf(
 
 	if (delta->flags & GIT_DIFF_FLAG_BINARY) {
 		if (git_buf_printf(out,
-				"Bin %" PRIuZ " -> %" PRIuZ " bytes", old_size, new_size) < 0)
+				"Bin %" PRId64 " -> %" PRId64 " bytes", old_size, new_size) < 0)
 			goto on_error;
 	}
 	else {

--- a/src/filter.c
+++ b/src/filter.c
@@ -974,7 +974,7 @@ int git_filter_list_stream_file(
 	}
 
 	if (readlen < 0)
-		error = readlen;
+		error = -1;
 
 done:
 	if (initialized)

--- a/src/index.c
+++ b/src/index.c
@@ -2475,7 +2475,7 @@ static int read_entry(
 		if (varint_len == 0 || last_len < strip_len)
 			return index_error_invalid("incorrect prefix length");
 
-		prefix_len = last_len - strip_len;
+		prefix_len = last_len - (size_t)strip_len;
 		suffix_len = strlen(path_ptr + varint_len);
 
 		GIT_ERROR_CHECK_ALLOC_ADD(&path_len, prefix_len, suffix_len);

--- a/src/notes.c
+++ b/src/notes.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #include "iterator.h"
 #include "signature.h"
+#include "blob.h"
 
 static int note_error_notfound(void)
 {
@@ -319,6 +320,7 @@ static int note_new(
 	git_blob *blob)
 {
 	git_note *note = NULL;
+	git_off_t blobsize;
 
 	note = git__malloc(sizeof(git_note));
 	GIT_ERROR_CHECK_ALLOC(note);
@@ -329,7 +331,10 @@ static int note_new(
 		git_signature_dup(&note->committer, git_commit_committer(commit)) < 0)
 		return -1;
 
-	note->message = git__strndup(git_blob_rawcontent(blob), git_blob_rawsize(blob));
+	blobsize = git_blob_rawsize(blob);
+	GIT_ERROR_CHECK_BLOBSIZE(blobsize);
+
+	note->message = git__strndup(git_blob_rawcontent(blob), (size_t)blobsize);
 	GIT_ERROR_CHECK_ALLOC(note->message);
 
 	*out = note;

--- a/src/odb.c
+++ b/src/odb.c
@@ -15,6 +15,7 @@
 #include "delta.h"
 #include "filter.h"
 #include "repository.h"
+#include "blob.h"
 
 #include "git2/odb_backend.h"
 #include "git2/oid.h"
@@ -387,18 +388,17 @@ static void fake_wstream__free(git_odb_stream *_stream)
 static int init_fake_wstream(git_odb_stream **stream_p, git_odb_backend *backend, git_off_t size, git_object_t type)
 {
 	fake_wstream *stream;
+	size_t blobsize;
 
-	if (!git__is_ssizet(size)) {
-		git_error_set(GIT_ERROR_ODB, "object size too large to keep in memory");
-		return -1;
-	}
+	GIT_ERROR_CHECK_BLOBSIZE(size);
+	blobsize = (size_t)size;
 
 	stream = git__calloc(1, sizeof(fake_wstream));
 	GIT_ERROR_CHECK_ALLOC(stream);
 
-	stream->size = size;
+	stream->size = blobsize;
 	stream->type = type;
-	stream->buffer = git__malloc(size);
+	stream->buffer = git__malloc(blobsize);
 	if (stream->buffer == NULL) {
 		git__free(stream);
 		return -1;

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -183,7 +183,7 @@ static int parse_header(
 		return -1;
 	}
 
-	out->size = size;
+	out->size = (size_t)size;
 
 	if (GIT_ADD_SIZET_OVERFLOW(out_len, i, 1))
 		goto on_error;

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -282,7 +282,7 @@ static int parse_header_percent(uint16_t *out, git_patch_parse_ctx *ctx)
 	if (val < 0 || val > 100)
 		return -1;
 
-	*out = val;
+	*out = (uint16_t)val;
 	return 0;
 }
 

--- a/src/reader.c
+++ b/src/reader.c
@@ -32,11 +32,17 @@ static int tree_reader_read(
 	tree_reader *reader = (tree_reader *)_reader;
 	git_tree_entry *tree_entry = NULL;
 	git_blob *blob = NULL;
+	git_off_t blobsize;
 	int error;
 
 	if ((error = git_tree_entry_bypath(&tree_entry, reader->tree, filename)) < 0 ||
-	    (error = git_blob_lookup(&blob, git_tree_owner(reader->tree), git_tree_entry_id(tree_entry))) < 0 ||
-	    (error = git_buf_set(out, git_blob_rawcontent(blob), git_blob_rawsize(blob))) < 0)
+	    (error = git_blob_lookup(&blob, git_tree_owner(reader->tree), git_tree_entry_id(tree_entry))) < 0)
+		goto done;
+
+	blobsize = git_blob_rawsize(blob);
+	GIT_ERROR_CHECK_BLOBSIZE(blobsize);
+
+	if ((error = git_buf_set(out, git_blob_rawcontent(blob), (size_t)blobsize)) < 0)
 		goto done;
 
 	if (out_id)

--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -303,22 +303,22 @@ static int mbedtls_set_proxy(git_stream *stream, const git_proxy_options *proxy_
 	return git_stream_set_proxy(st->io, proxy_options);
 }
 
-ssize_t mbedtls_stream_write(git_stream *stream, const char *data, size_t len, int flags)
+ssize_t mbedtls_stream_write(git_stream *stream, const char *data, size_t data_len, int flags)
 {
-	size_t read = 0;
+	ssize_t written = 0, len = min(data_len, SSIZE_MAX);
 	mbedtls_stream *st = (mbedtls_stream *) stream;
 
 	GIT_UNUSED(flags);
 
 	do {
-		int error = mbedtls_ssl_write(st->ssl, (const unsigned char *)data + read, len - read);
+		int error = mbedtls_ssl_write(st->ssl, (const unsigned char *)data + written, len - written);
 		if (error <= 0) {
 			return ssl_set_error(st->ssl, error);
 		}
-		read += error;
-	} while (read < len);
+		written += error;
+	} while (written < len);
 
-	return read;
+	return written;
 }
 
 ssize_t mbedtls_stream_read(git_stream *stream, void *data, size_t len)

--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -644,10 +644,10 @@ static int openssl_set_proxy(git_stream *stream, const git_proxy_options *proxy_
 	return git_stream_set_proxy(st->io, proxy_opts);
 }
 
-ssize_t openssl_write(git_stream *stream, const char *data, size_t len, int flags)
+ssize_t openssl_write(git_stream *stream, const char *data, size_t data_len, int flags)
 {
 	openssl_stream *st = (openssl_stream *) stream;
-	int ret;
+	int ret, len = min(data_len, INT_MAX);
 
 	GIT_UNUSED(flags);
 

--- a/src/streams/socket.c
+++ b/src/streams/socket.c
@@ -130,10 +130,9 @@ int socket_connect(git_stream *stream)
 	return 0;
 }
 
-ssize_t socket_write(git_stream *stream, const char *data, size_t len, int flags)
+ssize_t socket_write(git_stream *stream, const char *data, size_t data_len, int flags)
 {
-	ssize_t ret;
-	size_t off = 0;
+	ssize_t ret, off = 0, len = min(data_len, SSIZE_MAX);
 	git_socket_stream *st = (git_socket_stream *) stream;
 
 	while (off < len) {

--- a/src/streams/stransport.c
+++ b/src/streams/stransport.c
@@ -164,11 +164,12 @@ static ssize_t stransport_write(git_stream *stream, const char *data, size_t len
 
 	GIT_UNUSED(flags);
 
-	data_len = len;
+	data_len = min(len, SSIZE_MAX);
 	if ((ret = SSLWrite(st->ctx, data, data_len, &processed)) != noErr)
 		return stransport_error(ret);
 
-	return processed;
+	assert(processed < SSIZE_MAX);
+	return (ssize_t)processed;
 }
 
 /*

--- a/src/tree.c
+++ b/src/tree.c
@@ -403,7 +403,7 @@ int git_tree__parse_raw(void *_tree, const char *data, size_t size)
 		if ((nul = memchr(buffer, 0, buffer_end - buffer)) == NULL)
 			return tree_error("failed to parse tree: object is corrupted", NULL);
 
-		if ((filename_len = nul - buffer) == 0)
+		if ((filename_len = nul - buffer) == 0 || filename_len > UINT16_MAX)
 			return tree_error("failed to parse tree: can't parse filename", NULL);
 
 		if ((buffer_end - (nul + 1)) < GIT_OID_RAWSZ)
@@ -415,7 +415,7 @@ int git_tree__parse_raw(void *_tree, const char *data, size_t size)
 			GIT_ERROR_CHECK_ALLOC(entry);
 
 			entry->attr = attr;
-			entry->filename_len = filename_len;
+			entry->filename_len = (uint16_t)filename_len;
 			entry->filename = buffer;
 			entry->oid = (git_oid *) ((char *) buffer + filename_len + 1);
 		}

--- a/src/win32/msvc-compat.h
+++ b/src/win32/msvc-compat.h
@@ -12,6 +12,12 @@
 typedef unsigned short mode_t;
 typedef SSIZE_T ssize_t;
 
+#ifdef _WIN64
+# define SSIZE_MAX _I64_MAX
+#else
+# define SSIZE_MAX LONG_MAX
+#endif
+
 #define strcasecmp(s1, s2) _stricmp(s1, s2)
 #define strncasecmp(s1, s2, c) _strnicmp(s1, s2, c)
 

--- a/tests/core/zstream.c
+++ b/tests/core/zstream.c
@@ -61,7 +61,7 @@ void test_core_zstream__basic(void)
 void test_core_zstream__fails_on_trailing_garbage(void)
 {
 	git_buf deflated = GIT_BUF_INIT, inflated = GIT_BUF_INIT;
-	size_t i = 0;
+	char i = 0;
 
 	/* compress a simple string */
 	git_zstream_deflatebuf(&deflated, "foobar!!", 8);

--- a/tests/index/racy.c
+++ b/tests/index/racy.c
@@ -126,8 +126,8 @@ static void setup_race(void)
 	cl_assert(entry = (git_index_entry *)git_index_get_bypath(index, "A", 0));
 
 	/* force a race */
-	entry->mtime.seconds = st.st_mtime;
-	entry->mtime.nanoseconds = st.st_mtime_nsec;
+	entry->mtime.seconds = (int32_t)st.st_mtime;
+	entry->mtime.nanoseconds = (int32_t)st.st_mtime_nsec;
 
 	git_buf_dispose(&path);
 }


### PR DESCRIPTION
This cleans up some warnings encountered building on Win32 with MSVC.  This PR attacks all the x86 warnings.  (Some remain on amd64.)