### PR TITLE
Deprecate functions and constants more gently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,9 @@ SET(LIBGIT2_VERSION_STRING "${LIBGIT2_VERSION_MAJOR}.${LIBGIT2_VERSION_MINOR}.${
 FILE(STRINGS "${libgit2_SOURCE_DIR}/include/git2/version.h" GIT2_HEADER_SOVERSION REGEX "^#define LIBGIT2_SOVERSION [0-9]+$")
 STRING(REGEX REPLACE "^.*LIBGIT2_SOVERSION ([0-9]+)$" "\\1" LIBGIT2_SOVERSION "${GIT2_HEADER_SOVERSION}")
 
+# Ensure that we do not use deprecated functions internally
+ADD_DEFINITIONS(-DGIT_DEPRECATE_HARD)
+
 # Platform specific compilation flags
 IF (MSVC)
 	IF (STDCALL)
@@ -228,7 +231,6 @@ ELSE ()
 	ENABLE_WARNINGS(format-security)
 	ENABLE_WARNINGS(int-conversion)
 	DISABLE_WARNINGS(documentation-deprecated-sync)
-
 
 	IF (PROFILE)
 		SET(CMAKE_C_FLAGS "-pg ${CMAKE_C_FLAGS}")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -112,22 +112,30 @@ v0.27 + 1
 
 ### API removals
 
-### Breaking API changes
-
 * The `git_buf_free` API is deprecated; it has been renamed to
   `git_buf_dispose` for consistency.  The `git_buf_free` API will be
-  removed in a future release.
+  retained for backward compatibility for the foreseeable future.
 
 * The `git_otype` enumeration and its members are deprecated and have
   been renamed for consistency.  The `GIT_OBJ_` enumeration values are
-  now prefixed with `GIT_OBJECT_`.  The `git_otype` enumeration will
-  be removed in a future release.
+  now prefixed with `GIT_OBJECT_`.  The old enumerations and macros
+  will be retained for backward compatibility for the foreseeable future.
 
 * Several index-related APIs have been renamed for consistency.  The
   `GIT_IDXENTRY_` enumeration values and macros have been renamed to
   be prefixed with `GIT_INDEX_ENTRY_`.  The `GIT_INDEXCAP` enumeration
   values are now prefixed with `GIT_INDEX_CAPABILITY_`.  The old
-  enumerations and macros will be removed in a future release.
+  enumerations and macros will be retained for backward compatibility
+  for the foreseeable future.
+
+* The error functions and enumeration values have been renamed for
+  consistency.  The `giterr_` functions and values prefix have been
+  renamed to be prefixed with `git_error_`; similarly, the `GITERR_`
+  constants have been renamed to be prefixed with `GIT_ERROR_`.
+  The old enumerations and macros will be retained for backward
+  compatibility for the foreseeable future.
+
+### Breaking API changes
 
 * The default checkout strategy changed from `DRY_RUN` to `SAFE` (#4531).
 

--- a/examples/general.c
+++ b/examples/general.c
@@ -185,7 +185,7 @@ static void object_database(git_repository *repo, git_oid *oid)
 	int error;
 	git_odb_object *obj;
 	git_odb *odb;
-	git_otype otype;
+	git_object_t otype;
 
 	git_repository_odb(&odb, repo);
 
@@ -416,7 +416,7 @@ static void commit_parsing(git_repository *repo)
 static void tag_parsing(git_repository *repo)
 {
 	git_commit *commit;
-	git_otype type;
+	git_object_t type;
 	git_tag *tag;
 	git_oid oid;
 	const char *name, *message;

--- a/fuzzers/objects_fuzzer.c
+++ b/fuzzers/objects_fuzzer.c
@@ -25,7 +25,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-	const git_otype types[] = {
+	const git_object_t types[] = {
 		GIT_OBJECT_BLOB, GIT_OBJECT_TREE, GIT_OBJECT_COMMIT, GIT_OBJECT_TAG
 	};
 	git_object *object = NULL;

--- a/include/git2.h
+++ b/include/git2.h
@@ -21,6 +21,7 @@
 #include "git2/commit.h"
 #include "git2/common.h"
 #include "git2/config.h"
+#include "git2/deprecated.h"
 #include "git2/describe.h"
 #include "git2/diff.h"
 #include "git2/errors.h"

--- a/include/git2/buffer.h
+++ b/include/git2/buffer.h
@@ -72,18 +72,6 @@ typedef struct {
 GIT_EXTERN(void) git_buf_dispose(git_buf *buffer);
 
 /**
- * Alias of `git_buf_dispose`.
- *
- * This function is directly calls `git_buf_dispose` now and is deprecated.
- * Going forward, we refer to functions freeing the internal state of a
- * structure a `dispose` function, while functions freeing the structure
- * themselves will be called a `free` function.
- *
- * This function is going to be removed in v0.30.0.
- */
-GIT_DEPRECATED(GIT_EXTERN(void)) git_buf_free(git_buf *buffer);
-
-/**
  * Resize the buffer allocation to make more space.
  *
  * This will attempt to grow the buffer to accommodate the target size.

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_git_deprecated_h__
+#define INCLUDE_git_deprecated_h__
+
+#include "common.h"
+#include "buffer.h"
+#include "errors.h"
+#include "index.h"
+#include "object.h"
+#include "refs.h"
+
+/**
+ * @file git2/deprecated.h
+ * @brief libgit2 deprecated functions and values
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/** @name Deprecated Buffer Functions
+ *
+ * These functions and enumeration values are retained for backward
+ * compatibility.  The newer versions of these functions should be
+ * preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+/**
+ * Free the memory referred to by the git_buf.  This is an alias of
+ * `git_buf_dispose` and is preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @see git_buf_dispose
+ */
+GIT_EXTERN(void) git_buf_free(git_buf *buffer);
+
+/**@}*/
+
+/** @name Deprecated Error Functions and Constants
+ *
+ * These functions and enumeration values are retained for backward
+ * compatibility.  The newer versions of these functions and values
+ * should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+#define GITERR_NONE GIT_ERROR_NONE
+#define GITERR_NOMEMORY GIT_ERROR_NOMEMORY
+#define GITERR_OS GIT_ERROR_OS
+#define GITERR_INVALID GIT_ERROR_INVALID
+#define GITERR_REFERENCE GIT_ERROR_REFERENCE
+#define GITERR_ZLIB GIT_ERROR_ZLIB
+#define GITERR_REPOSITORY GIT_ERROR_REPOSITORY
+#define GITERR_CONFIG GIT_ERROR_CONFIG
+#define GITERR_REGEX GIT_ERROR_REGEX
+#define GITERR_ODB GIT_ERROR_ODB
+#define GITERR_INDEX GIT_ERROR_INDEX
+#define GITERR_OBJECT GIT_ERROR_OBJECT
+#define GITERR_NET GIT_ERROR_NET
+#define GITERR_TAG GIT_ERROR_TAG
+#define GITERR_TREE GIT_ERROR_TREE
+#define GITERR_INDEXER GIT_ERROR_INDEXER
+#define GITERR_SSL GIT_ERROR_SSL
+#define GITERR_SUBMODULE GIT_ERROR_SUBMODULE
+#define GITERR_THREAD GIT_ERROR_THREAD
+#define GITERR_STASH GIT_ERROR_STASH
+#define GITERR_CHECKOUT GIT_ERROR_CHECKOUT
+#define GITERR_FETCHHEAD GIT_ERROR_FETCHHEAD
+#define GITERR_MERGE GIT_ERROR_MERGE
+#define GITERR_SSH GIT_ERROR_SSH
+#define GITERR_FILTER GIT_ERROR_FILTER
+#define GITERR_REVERT GIT_ERROR_REVERT
+#define GITERR_CALLBACK GIT_ERROR_CALLBACK
+#define GITERR_CHERRYPICK GIT_ERROR_CHERRYPICK
+#define GITERR_DESCRIBE GIT_ERROR_DESCRIBE
+#define GITERR_REBASE GIT_ERROR_REBASE
+#define GITERR_FILESYSTEM GIT_ERROR_FILESYSTEM
+#define GITERR_PATCH GIT_ERROR_PATCH
+#define GITERR_WORKTREE GIT_ERROR_WORKTREE
+#define GITERR_SHA1 GIT_ERROR_SHA1
+
+/**
+ * Return the last `git_error` object that was generated for the
+ * current thread.  This is an alias of `git_error_last` and is
+ * preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @see git_error_last
+ */
+GIT_EXTERN(const git_error *) giterr_last(void);
+
+/**
+ * Clear the last error.  This is an alias of `git_error_last` and is
+ * preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @see git_error_clear
+ */
+GIT_EXTERN(void) giterr_clear(void);
+
+/**
+ * Sets the error message to the given string.  This is an alias of
+ * `git_error_set_str` and is preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @see git_error_set_str
+ */
+GIT_EXTERN(void) giterr_set_str(int error_class, const char *string);
+
+/**
+ * Indicates that an out-of-memory situation occured.  This is an alias
+ * of `git_error_set_oom` and is preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @see git_error_set_oom
+ */
+GIT_EXTERN(void) giterr_set_oom(void);
+
+/**@}*/
+
+/** @name Deprecated Index Constants
+ *
+ * These enumeration values are retained for backward compatibility.
+ * The newer versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+#define GIT_IDXENTRY_NAMEMASK          GIT_INDEX_ENTRY_NAMEMASK
+#define GIT_IDXENTRY_STAGEMASK         GIT_INDEX_ENTRY_STAGEMASK
+#define GIT_IDXENTRY_STAGESHIFT        GIT_INDEX_ENTRY_STAGESHIFT
+
+/* The git_indxentry_flag_t enum */
+#define GIT_IDXENTRY_EXTENDED          GIT_INDEX_ENTRY_EXTENDED
+#define GIT_IDXENTRY_VALID             GIT_INDEX_ENTRY_VALID
+
+#define GIT_IDXENTRY_STAGE(E)          GIT_INDEX_ENTRY_STAGE(E)
+#define GIT_IDXENTRY_STAGE_SET(E,S)    GIT_INDEX_ENTRY_STAGE_SET(E,S)
+
+/* The git_idxentry_extended_flag_t enum */
+#define GIT_IDXENTRY_INTENT_TO_ADD     GIT_INDEX_ENTRY_INTENT_TO_ADD
+#define GIT_IDXENTRY_SKIP_WORKTREE     GIT_INDEX_ENTRY_SKIP_WORKTREE
+#define GIT_IDXENTRY_EXTENDED_FLAGS    (GIT_INDEX_ENTRY_INTENT_TO_ADD | GIT_INDEX_ENTRY_SKIP_WORKTREE)
+#define GIT_IDXENTRY_EXTENDED2         (1 << 15)
+#define GIT_IDXENTRY_UPDATE            (1 << 0)
+#define GIT_IDXENTRY_REMOVE            (1 << 1)
+#define GIT_IDXENTRY_UPTODATE          (1 << 2)
+#define GIT_IDXENTRY_ADDED             (1 << 3)
+#define GIT_IDXENTRY_HASHED            (1 << 4)
+#define GIT_IDXENTRY_UNHASHED          (1 << 5)
+#define GIT_IDXENTRY_WT_REMOVE         (1 << 6)
+#define GIT_IDXENTRY_CONFLICTED        (1 << 7)
+#define GIT_IDXENTRY_UNPACKED          (1 << 8)
+#define GIT_IDXENTRY_NEW_SKIP_WORKTREE (1 << 9)
+
+/* The git_index_capability_t enum */
+#define GIT_INDEXCAP_IGNORE_CASE       GIT_INDEX_CAPABILITY_IGNORE_CASE
+#define GIT_INDEXCAP_NO_FILEMODE       GIT_INDEX_CAPABILITY_NO_FILEMODE
+#define GIT_INDEXCAP_NO_SYMLINKS       GIT_INDEX_CAPABILITY_NO_SYMLINKS
+#define GIT_INDEXCAP_FROM_OWNER        GIT_INDEX_CAPABILITY_FROM_OWNER
+
+/**@}*/
+
+/** @name Deprecated Object Constants
+ *
+ * These enumeration values are retained for backward compatibility.  The
+ * newer versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+#define git_otype git_object_t
+
+#define GIT_OBJ_ANY GIT_OBJECT_ANY
+#define GIT_OBJ_BAD GIT_OBJECT_INVALID
+#define GIT_OBJ__EXT1 0
+#define GIT_OBJ_COMMIT GIT_OBJECT_COMMIT
+#define GIT_OBJ_TREE GIT_OBJECT_TREE
+#define GIT_OBJ_BLOB GIT_OBJECT_BLOB
+#define GIT_OBJ_TAG GIT_OBJECT_TAG
+#define GIT_OBJ__EXT2 5
+#define GIT_OBJ_OFS_DELTA GIT_OBJECT_OFS_DELTA
+#define GIT_OBJ_REF_DELTA GIT_OBJECT_REF_DELTA
+
+/**@}*/
+
+/** @name Deprecated Reference Constants
+ *
+ * These enumeration values are retained for backward compatibility.  The
+ * newer versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+ /** Basic type of any Git reference. */
+#define git_ref_t git_reference_t
+#define git_reference_normalize_t git_reference_format_t
+
+#define GIT_REF_INVALID GIT_REFERENCE_INVALID
+#define GIT_REF_OID GIT_REFERENCE_DIRECT
+#define GIT_REF_SYMBOLIC GIT_REFERENCE_SYMBOLIC
+#define GIT_REF_LISTALL GIT_REFERENCE_ALL
+
+#define GIT_REF_FORMAT_NORMAL GIT_REFERENCE_FORMAT_NORMAL
+#define GIT_REF_FORMAT_ALLOW_ONELEVEL GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL
+#define GIT_REF_FORMAT_REFSPEC_PATTERN GIT_REFERENCE_FORMAT_REFSPEC_PATTERN
+#define GIT_REF_FORMAT_REFSPEC_SHORTHAND GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND
+
+/**@}*/
+
+/** @} */
+GIT_END_DECL
+
+#endif

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -14,6 +14,11 @@
 #include "object.h"
 #include "refs.h"
 
+/*
+ * Users can avoid deprecated functions by defining `GIT_DEPRECATE_HARD`.
+ */
+#ifndef GIT_DEPRECATE_HARD
+
 /**
  * @file git2/deprecated.h
  * @brief libgit2 deprecated functions and values
@@ -242,5 +247,7 @@ GIT_EXTERN(void) giterr_set_oom(void);
 
 /** @} */
 GIT_END_DECL
+
+#endif
 
 #endif

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -40,6 +40,7 @@ GIT_BEGIN_DECL
  * This function is deprecated, but there is no plan to remove this
  * function at this time.
  *
+ * @deprecated Use git_buf_dispose
  * @see git_buf_dispose
  */
 GIT_EXTERN(void) git_buf_free(git_buf *buffer);
@@ -100,6 +101,7 @@ GIT_EXTERN(void) git_buf_free(git_buf *buffer);
  * This function is deprecated, but there is no plan to remove this
  * function at this time.
  *
+ * @deprecated Use git_error_last
  * @see git_error_last
  */
 GIT_EXTERN(const git_error *) giterr_last(void);
@@ -111,6 +113,7 @@ GIT_EXTERN(const git_error *) giterr_last(void);
  * This function is deprecated, but there is no plan to remove this
  * function at this time.
  *
+ * @deprecated Use git_error_clear
  * @see git_error_clear
  */
 GIT_EXTERN(void) giterr_clear(void);
@@ -122,6 +125,7 @@ GIT_EXTERN(void) giterr_clear(void);
  * This function is deprecated, but there is no plan to remove this
  * function at this time.
  *
+ * @deprecated Use git_error_set_str
  * @see git_error_set_str
  */
 GIT_EXTERN(void) giterr_set_str(int error_class, const char *string);
@@ -133,6 +137,7 @@ GIT_EXTERN(void) giterr_set_str(int error_class, const char *string);
  * This function is deprecated, but there is no plan to remove this
  * function at this time.
  *
+ * @deprecated Use git_error_set_oom
  * @see git_error_set_oom
  */
 GIT_EXTERN(void) giterr_set_oom(void);

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -109,12 +109,6 @@ typedef enum {
 	GIT_ERROR_SHA1
 } git_error_t;
 
-/** @name Error Functions
- *
- * These functions report or set error information.
- */
-/**@{*/
-
 /**
  * Return the last `git_error` object that was generated for the
  * current thread.
@@ -161,88 +155,6 @@ GIT_EXTERN(void) git_error_set_str(int error_class, const char *string);
  * statically allocated internal value.
  */
 GIT_EXTERN(void) git_error_set_oom(void);
-
-/**@}*/
-
-/** @name Deprecated Error Functions
- *
- * These functions and enumeration values are retained for backward
- * compatibility.  The newer versions of these functions should be
- * preferred in all new code.
- */
-/**@{*/
-
-GIT_DEPRECATED(static const int) GITERR_NONE = GIT_ERROR_NONE;
-GIT_DEPRECATED(static const int) GITERR_NOMEMORY = GIT_ERROR_NOMEMORY;
-GIT_DEPRECATED(static const int) GITERR_OS = GIT_ERROR_OS;
-GIT_DEPRECATED(static const int) GITERR_INVALID = GIT_ERROR_INVALID;
-GIT_DEPRECATED(static const int) GITERR_REFERENCE = GIT_ERROR_REFERENCE;
-GIT_DEPRECATED(static const int) GITERR_ZLIB = GIT_ERROR_ZLIB;
-GIT_DEPRECATED(static const int) GITERR_REPOSITORY = GIT_ERROR_REPOSITORY;
-GIT_DEPRECATED(static const int) GITERR_CONFIG = GIT_ERROR_CONFIG;
-GIT_DEPRECATED(static const int) GITERR_REGEX = GIT_ERROR_REGEX;
-GIT_DEPRECATED(static const int) GITERR_ODB = GIT_ERROR_ODB;
-GIT_DEPRECATED(static const int) GITERR_INDEX = GIT_ERROR_INDEX;
-GIT_DEPRECATED(static const int) GITERR_OBJECT = GIT_ERROR_OBJECT;
-GIT_DEPRECATED(static const int) GITERR_NET = GIT_ERROR_NET;
-GIT_DEPRECATED(static const int) GITERR_TAG = GIT_ERROR_TAG;
-GIT_DEPRECATED(static const int) GITERR_TREE = GIT_ERROR_TREE;
-GIT_DEPRECATED(static const int) GITERR_INDEXER = GIT_ERROR_INDEXER;
-GIT_DEPRECATED(static const int) GITERR_SSL = GIT_ERROR_SSL;
-GIT_DEPRECATED(static const int) GITERR_SUBMODULE = GIT_ERROR_SUBMODULE;
-GIT_DEPRECATED(static const int) GITERR_THREAD = GIT_ERROR_THREAD;
-GIT_DEPRECATED(static const int) GITERR_STASH = GIT_ERROR_STASH;
-GIT_DEPRECATED(static const int) GITERR_CHECKOUT = GIT_ERROR_CHECKOUT;
-GIT_DEPRECATED(static const int) GITERR_FETCHHEAD = GIT_ERROR_FETCHHEAD;
-GIT_DEPRECATED(static const int) GITERR_MERGE = GIT_ERROR_MERGE;
-GIT_DEPRECATED(static const int) GITERR_SSH = GIT_ERROR_SSH;
-GIT_DEPRECATED(static const int) GITERR_FILTER = GIT_ERROR_FILTER;
-GIT_DEPRECATED(static const int) GITERR_REVERT = GIT_ERROR_REVERT;
-GIT_DEPRECATED(static const int) GITERR_CALLBACK = GIT_ERROR_CALLBACK;
-GIT_DEPRECATED(static const int) GITERR_CHERRYPICK = GIT_ERROR_CHERRYPICK;
-GIT_DEPRECATED(static const int) GITERR_DESCRIBE = GIT_ERROR_DESCRIBE;
-GIT_DEPRECATED(static const int) GITERR_REBASE = GIT_ERROR_REBASE;
-GIT_DEPRECATED(static const int) GITERR_FILESYSTEM = GIT_ERROR_FILESYSTEM;
-GIT_DEPRECATED(static const int) GITERR_PATCH = GIT_ERROR_PATCH;
-GIT_DEPRECATED(static const int) GITERR_WORKTREE = GIT_ERROR_WORKTREE;
-GIT_DEPRECATED(static const int) GITERR_SHA1 = GIT_ERROR_SHA1;
-
-/**
- * Return the last `git_error` object that was generated for the
- * current thread.  This function is deprecated and will be removed
- * in a future release; `git_error_last` should be used instead.
- *
- * @see git_error_last
- */
-GIT_DEPRECATED(GIT_EXTERN(const git_error *)) giterr_last(void);
-
-/**
- * Clear the last error.  This function is deprecated and will be
- * removed in a future release; `giterr_clear` should be used instead.
- *
- * @see git_error_last
- */
-GIT_DEPRECATED(GIT_EXTERN(void)) giterr_clear(void);
-
-/**
- * Sets the error message to the given string.  This function is
- * deprecated and will be removed in a future release; `giterr_clear`
- * should be used instead.
- *
- * @see git_error_set_str
- */
-GIT_DEPRECATED(GIT_EXTERN(void)) giterr_set_str(int error_class, const char *string);
-
-/**
- * Indicates that an out-of-memory situation occured.  This function
- * is deprecated and will be removed in a future release; `giterr_clear`
- * should be used instead.
- *
- * @see git_error_set_oom
- */
-GIT_DEPRECATED(GIT_EXTERN(void)) giterr_set_oom(void);
-
-/**@}*/
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -165,12 +165,6 @@ typedef enum {
 	GIT_INDEX_STAGE_THEIRS = 3,
 } git_index_stage_t;
 
-/** @name Index File Functions
- *
- * These functions work on the index file itself.
- */
-/**@{*/
-
 /**
  * Create a new bare Git index object as a memory representation
  * of the Git index file in 'index_path', without a repository
@@ -833,51 +827,6 @@ GIT_EXTERN(int) git_index_conflict_next(
  */
 GIT_EXTERN(void) git_index_conflict_iterator_free(
 	git_index_conflict_iterator *iterator);
-
-/**@}*/
-
-/** @name Deprecated Index Structures
- *
- * These macros, structures and enumerations are retained for backward
- * compatibility.  The newer versions of these functions and structures
- * should be preferred in all new code.
- */
-/**@{*/
-
-#define GIT_IDXENTRY_NAMEMASK          GIT_INDEX_ENTRY_NAMEMASK
-#define GIT_IDXENTRY_STAGEMASK         GIT_INDEX_ENTRY_STAGEMASK
-#define GIT_IDXENTRY_STAGESHIFT        GIT_INDEX_ENTRY_STAGESHIFT
-
-/* The git_indxentry_flag_t enum */
-#define GIT_IDXENTRY_EXTENDED          GIT_INDEX_ENTRY_EXTENDED
-#define GIT_IDXENTRY_VALID             GIT_INDEX_ENTRY_VALID
-
-#define GIT_IDXENTRY_STAGE(E)          GIT_INDEX_ENTRY_STAGE(E)
-#define GIT_IDXENTRY_STAGE_SET(E,S)    GIT_INDEX_ENTRY_STAGE_SET(E,S)
-
-/* The git_idxentry_extended_flag_t enum */
-#define GIT_IDXENTRY_INTENT_TO_ADD     GIT_INDEX_ENTRY_INTENT_TO_ADD
-#define GIT_IDXENTRY_SKIP_WORKTREE     GIT_INDEX_ENTRY_SKIP_WORKTREE
-#define GIT_IDXENTRY_EXTENDED_FLAGS    (GIT_INDEX_ENTRY_INTENT_TO_ADD | GIT_INDEX_ENTRY_SKIP_WORKTREE)
-#define GIT_IDXENTRY_EXTENDED2         (1 << 15)
-#define GIT_IDXENTRY_UPDATE            (1 << 0)
-#define GIT_IDXENTRY_REMOVE            (1 << 1)
-#define GIT_IDXENTRY_UPTODATE          (1 << 2)
-#define GIT_IDXENTRY_ADDED             (1 << 3)
-#define GIT_IDXENTRY_HASHED            (1 << 4)
-#define GIT_IDXENTRY_UNHASHED          (1 << 5)
-#define GIT_IDXENTRY_WT_REMOVE         (1 << 6)
-#define GIT_IDXENTRY_CONFLICTED        (1 << 7)
-#define GIT_IDXENTRY_UNPACKED          (1 << 8)
-#define GIT_IDXENTRY_NEW_SKIP_WORKTREE (1 << 9)
-
-/* The git_index_capability_t enum */
-#define GIT_INDEXCAP_IGNORE_CASE       GIT_INDEX_CAPABILITY_IGNORE_CASE
-#define GIT_INDEXCAP_NO_FILEMODE       GIT_INDEX_CAPABILITY_NO_FILEMODE
-#define GIT_INDEXCAP_NO_SYMLINKS       GIT_INDEX_CAPABILITY_NO_SYMLINKS
-#define GIT_INDEXCAP_FROM_OWNER        GIT_INDEX_CAPABILITY_FROM_OWNER
-
-/**@}*/
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -21,12 +21,6 @@
  */
 GIT_BEGIN_DECL
 
-/** @name Reference Functions
- *
- * These functions read, write and analyze references.
- */
-/**@{*/
-
 /**
  * Lookup a reference by name in a repository.
  *
@@ -748,35 +742,6 @@ GIT_EXTERN(int) git_reference_is_valid_name(const char *refname);
  * @return the human-readable version of the name
  */
 GIT_EXTERN(const char *) git_reference_shorthand(const git_reference *ref);
-
-/**@}*/
-
-/** @name Deprecated Reference Constants
- *
- * These enumeration values are retained for backward compatibility.  The
- * newer versions of these functions should be preferred in all new code.
- */
-/**@{*/
-
- /** Basic type of any Git reference. */
-#define git_ref_t git_reference_t
-#define git_reference_normalize_t git_reference_format_t
-
-GIT_DEPRECATED(static const git_ref_t) GIT_REF_INVALID = GIT_REFERENCE_INVALID;
-GIT_DEPRECATED(static const git_ref_t) GIT_REF_OID = GIT_REFERENCE_DIRECT;
-GIT_DEPRECATED(static const git_ref_t) GIT_REF_SYMBOLIC = GIT_REFERENCE_SYMBOLIC;
-GIT_DEPRECATED(static const git_ref_t) GIT_REF_LISTALL = GIT_REFERENCE_ALL;
-
-GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_NORMAL =
-	GIT_REFERENCE_FORMAT_NORMAL;
-GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_ALLOW_ONELEVEL =
-	GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL;
-GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_REFSPEC_PATTERN =
-	GIT_REFERENCE_FORMAT_REFSPEC_PATTERN;
-GIT_DEPRECATED(static const git_reference_normalize_t) GIT_REF_FORMAT_REFSPEC_SHORTHAND =
-	GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND;
-
-/**@}*/
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/sys/stream.h
+++ b/include/git2/sys/stream.h
@@ -98,13 +98,16 @@ typedef enum {
 GIT_EXTERN(int) git_stream_register(
 	git_stream_t type, git_stream_registration *registration);
 
+#ifndef GIT_DEPRECATE_HARD
+
 /** @name Deprecated TLS Stream Registration Functions
  *
- * These typedefs and functions are retained for backward compatibility.
- * The newer versions of these functions and structures should be preferred
- * in all new code.
+ * These functions are retained for backward compatibility.  The newer
+ * versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
  */
-
 /**@{*/
 
 /**
@@ -115,14 +118,20 @@ typedef int GIT_CALLBACK(git_stream_cb)(git_stream **out, const char *host, cons
 
 /**
  * Register a TLS stream constructor for the library to use.  This stream
- * will not support HTTP CONNECT proxies.
+ * will not support HTTP CONNECT proxies.  This internally calls
+ * `git_stream_register` and is preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
  *
  * @deprecated Provide a git_stream_registration to git_stream_register
  * @see git_stream_register
  */
 GIT_EXTERN(int) git_stream_register_tls(git_stream_cb ctor);
 
- /**@}*/
+/**@}*/
+
+#endif
 
 GIT_END_DECL
 

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -441,30 +441,6 @@ struct git_writestream {
 /** Representation of .mailmap file state. */
 typedef struct git_mailmap git_mailmap;
 
-/** @name Deprecated Index Structures
- *
- * These macros, structures and enumerations are retained for backward
- * compatibility.  The newer versions of these functions and structures
- * should be preferred in all new code.
- */
-
-/**@{*/
-
-#define git_otype git_object_t
-
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_ANY = GIT_OBJECT_ANY;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_BAD = GIT_OBJECT_INVALID;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ__EXT1 = 0;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_COMMIT = GIT_OBJECT_COMMIT;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_TREE = GIT_OBJECT_TREE;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_BLOB = GIT_OBJECT_BLOB;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_TAG = GIT_OBJECT_TAG;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ__EXT2 = 5;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_OFS_DELTA = GIT_OBJECT_OFS_DELTA;
-GIT_DEPRECATED(static const git_otype) GIT_OBJ_REF_DELTA = GIT_OBJECT_REF_DELTA;
-
-/**@}*/
-
 /** @} */
 GIT_END_DECL
 

--- a/src/streams/registry.c
+++ b/src/streams/registry.c
@@ -100,7 +100,9 @@ int git_stream_register(git_stream_t type, git_stream_registration *registration
 	return 0;
 }
 
-int git_stream_register_tls(git_stream_cb ctor)
+
+int git_stream_register_tls(
+	int GIT_CALLBACK(ctor)(git_stream **out, const char *host, const char *port))
 {
 	git_stream_registration registration = {0};
 

--- a/tests/stream/deprecated.c
+++ b/tests/stream/deprecated.c
@@ -1,3 +1,5 @@
+#undef GIT_DEPRECATE_HARD
+
 #include "clar_libgit2.h"
 #include "git2/sys/stream.h"
 #include "streams/tls.h"

--- a/tests/stream/deprecated.c
+++ b/tests/stream/deprecated.c
@@ -1,0 +1,56 @@
+#include "clar_libgit2.h"
+#include "git2/sys/stream.h"
+#include "streams/tls.h"
+#include "streams/socket.h"
+#include "stream.h"
+
+static git_stream test_stream;
+static int ctor_called;
+
+void test_stream_deprecated__cleanup(void)
+{
+	cl_git_pass(git_stream_register(GIT_STREAM_TLS | GIT_STREAM_STANDARD, NULL));
+}
+
+static int test_stream_init(git_stream **out, const char *host, const char *port)
+{
+	GIT_UNUSED(host);
+	GIT_UNUSED(port);
+
+	ctor_called = 1;
+	*out = &test_stream;
+
+	return 0;
+}
+
+void test_stream_deprecated__register_tls(void)
+{
+	git_stream *stream;
+	int error;
+
+	ctor_called = 0;
+	cl_git_pass(git_stream_register_tls(test_stream_init));
+	cl_git_pass(git_tls_stream_new(&stream, "localhost", "443"));
+	cl_assert_equal_i(1, ctor_called);
+	cl_assert_equal_p(&test_stream, stream);
+
+	ctor_called = 0;
+	stream = NULL;
+	cl_git_pass(git_stream_register_tls(NULL));
+	error = git_tls_stream_new(&stream, "localhost", "443");
+
+	/*
+	 * We don't have TLS support enabled, or we're on Windows,
+	 * which has no arbitrary TLS stream support.
+	 */
+#if defined(GIT_WIN32) || !defined(GIT_HTTPS)
+	cl_git_fail_with(-1, error);
+#else
+	cl_git_pass(error);
+#endif
+
+	cl_assert_equal_i(0, ctor_called);
+	cl_assert(&test_stream != stream);
+
+	git_stream_free(stream);
+}

--- a/tests/stream/registration.c
+++ b/tests/stream/registration.c
@@ -7,7 +7,7 @@
 static git_stream test_stream;
 static int ctor_called;
 
-void test_core_stream__cleanup(void)
+void test_stream_registration__cleanup(void)
 {
 	cl_git_pass(git_stream_register(GIT_STREAM_TLS | GIT_STREAM_STANDARD, NULL));
 }
@@ -34,7 +34,7 @@ static int test_stream_wrap(git_stream **out, git_stream *in, const char *host)
 	return 0;
 }
 
-void test_core_stream__register_insecure(void)
+void test_stream_registration__insecure(void)
 {
 	git_stream *stream;
 	git_stream_registration registration = {0};
@@ -60,7 +60,7 @@ void test_core_stream__register_insecure(void)
 	git_stream_free(stream);
 }
 
-void test_core_stream__register_tls(void)
+void test_stream_registration__tls(void)
 {
 	git_stream *stream;
 	git_stream_registration registration = {0};
@@ -96,7 +96,7 @@ void test_core_stream__register_tls(void)
 	git_stream_free(stream);
 }
 
-void test_core_stream__register_both(void)
+void test_stream_registration__both(void)
 {
 	git_stream *stream;
 	git_stream_registration registration = {0};
@@ -116,36 +116,4 @@ void test_core_stream__register_both(void)
 	cl_git_pass(git_socket_stream_new(&stream, "localhost", "80"));
 	cl_assert_equal_i(1, ctor_called);
 	cl_assert_equal_p(&test_stream, stream);
-}
-
-void test_core_stream__register_tls_deprecated(void)
-{
-	git_stream *stream;
-	int error;
-
-	ctor_called = 0;
-	cl_git_pass(git_stream_register_tls(test_stream_init));
-	cl_git_pass(git_tls_stream_new(&stream, "localhost", "443"));
-	cl_assert_equal_i(1, ctor_called);
-	cl_assert_equal_p(&test_stream, stream);
-
-	ctor_called = 0;
-	stream = NULL;
-	cl_git_pass(git_stream_register_tls(NULL));
-	error = git_tls_stream_new(&stream, "localhost", "443");
-
-	/*
-	 * We don't have TLS support enabled, or we're on Windows,
-	 * which has no arbitrary TLS stream support.
-	 */
-#if defined(GIT_WIN32) || !defined(GIT_HTTPS)
-	cl_git_fail_with(-1, error);
-#else
-	cl_git_pass(error);
-#endif
-
-	cl_assert_equal_i(0, ctor_called);
-	cl_assert(&test_stream != stream);
-
-	git_stream_free(stream);
 }


### PR DESCRIPTION
Provide a new kindler, gentler deprecation policy for the upcoming release.

1. Move deprecated bits into their own header file `deprecated.h`.
2. Remove the `GIT_DEPRECATED` attribute from the deprecated bits.  This will allow users to more gently move into the new functions at their leisure.  We have no hurry in removing the old functions or values, so let's not rush things.
3. Allow users to opt-in to a harder deprecation, by defining `GIT_DEPRECATE_HARD` to completely remove the deprecated functions.
4. Enable `GIT_DEPRECATE_HARD` ourselves to ensure that we don't use them in the library code, tests, or examples.

I've kept the `GIT_DEPRECATED` macro so that we can mark something as properly deprecated, using the compiler attributes, in the future if we desire.