### PR TITLE
Fix VS warning C4098: 'giterr_set_str' : void function returning a value

### DIFF
--- a/src/errors.c
+++ b/src/errors.c
@@ -226,7 +226,7 @@ void giterr_clear(void)
 
 void giterr_set_str(int error_class, const char *string)
 {
-	return git_error_set_str(error_class, string);
+	git_error_set_str(error_class, string);
 }
 
 void giterr_set_oom(void)


### PR DESCRIPTION
Regression of PR #4917.