### PR TITLE
ci: run docurium to create documentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,3 +121,26 @@ jobs:
       environmentVariables:
         CMAKE_OPTIONS: -G"MinGW Makefiles"
         PATH: $(Agent.TempDirectory)\mingw32\bin;C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files (x86)\CMake\bin
+
+- job: documentation
+  displayName: 'Generate Documentation'
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  steps:
+  - script: |
+      git config user.name 'Documentation Generation'
+      git config user.email 'noreply@libgit2.org'
+      docker run --rm -v /home/vsts/work/1/s:/src -w /src libgit2/docurium:test cm doc api.docurium
+      git checkout gh-pages
+      cp -R * '$(Build.BinariesDirectory)'
+  - task: archivefiles@2
+    displayName: 'Archive Documentation'
+    inputs:
+      rootFolderOrFile: '$(Build.BinariesDirectory)'
+      includeRootFolder: false
+      archiveFile: '$(Build.ArtifactStagingDirectory)/api-documentation.zip'
+  - task: publishbuildartifacts@1
+    displayName: 'Upload Documentation'
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'docs'


### PR DESCRIPTION
Run docurium as part of the build.  The goal of this is to be able to evaluate the documentation in a given pull request; as such, this does not implement any sort of deployment pipeline.

This will allow us to download a snapshot of the documentation from the CI build and evaluate the docs for a particular pull request; before it's been merged.