### PR TITLE
Allow bypassing check for '.keep' file

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -205,7 +205,8 @@ typedef enum {
 	GIT_OPT_SET_ALLOCATOR,
 	GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY,
 	GIT_OPT_GET_PACK_MAX_OBJECTS,
-	GIT_OPT_SET_PACK_MAX_OBJECTS
+	GIT_OPT_SET_PACK_MAX_OBJECTS,
+	GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS
 } git_libgit2_opt_t;
 
 /**
@@ -394,6 +395,10 @@ typedef enum {
  *
  *		> Set the maximum number of objects libgit2 will allow in a pack
  *		> file when downloading a pack file from a remote.
+ *
+ *	 opts(GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS, int enabled)
+ *		> This will cause .keep file existence checks to be skipped when
+ *		> accessing packfiles, which can help performance with remote filesystems.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/src/pack.c
+++ b/src/pack.c
@@ -16,6 +16,9 @@
 
 #include <zlib.h>
 
+/* Option to bypass checking existence of '.keep' files */
+bool git_disable_pack_keep_file_checks = false;
+
 static int packfile_open(struct git_pack_file *p);
 static git_off_t nth_packed_object_offset(const struct git_pack_file *p, uint32_t n);
 static int packfile_unpack_compressed(
@@ -1141,9 +1144,11 @@ int git_packfile_alloc(struct git_pack_file **pack_out, const char *path)
 	if (git__suffixcmp(path, ".idx") == 0) {
 		size_t root_len = path_len - strlen(".idx");
 
-		memcpy(p->pack_name + root_len, ".keep", sizeof(".keep"));
-		if (git_path_exists(p->pack_name) == true)
-			p->pack_keep = 1;
+		if (!git_disable_pack_keep_file_checks) {
+			memcpy(p->pack_name + root_len, ".keep", sizeof(".keep"));
+			if (git_path_exists(p->pack_name) == true)
+				p->pack_keep = 1;
+		}
 
 		memcpy(p->pack_name + root_len, ".pack", sizeof(".pack"));
 	}

--- a/src/settings.c
+++ b/src/settings.c
@@ -57,6 +57,7 @@ int git_libgit2_features(void)
 extern size_t git_mwindow__window_size;
 extern size_t git_mwindow__mapped_limit;
 extern size_t git_indexer__max_objects;
+extern bool git_disable_pack_keep_file_checks;
 
 static int config_level_to_sysdir(int config_level)
 {
@@ -277,6 +278,10 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_GET_PACK_MAX_OBJECTS:
 		*(va_arg(ap, size_t *)) = git_indexer__max_objects;
+		break;
+
+	case GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS:
+		git_disable_pack_keep_file_checks = (va_arg(ap, int) != 0);
 		break;
 
 	default:

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -14,6 +14,8 @@ static git_vector _commits;
 static int _commits_is_initialized;
 static git_transfer_progress _stats;
 
+extern bool git_disable_pack_keep_file_checks;
+
 void test_pack_packbuilder__initialize(void)
 {
 	_repo = cl_git_sandbox_init("testrepo.git");
@@ -32,6 +34,7 @@ void test_pack_packbuilder__cleanup(void)
 	unsigned int i;
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 0));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS, false));
 
 	if (_commits_is_initialized) {
 		_commits_is_initialized = 0;
@@ -259,4 +262,11 @@ void test_pack_packbuilder__foreach_with_cancel(void)
 	cl_git_fail_with(
 		git_packbuilder_foreach(_packbuilder, foreach_cancel_cb, idx), -1111);
 	git_indexer_free(idx);
+}
+
+void test_pack_packbuilder__keep_file_check(void)
+{
+	assert(!git_disable_pack_keep_file_checks);
+	cl_git_pass(git_libgit2_opts(GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS, true));
+	assert(git_disable_pack_keep_file_checks);
 }


### PR DESCRIPTION
Retrieving commits involving looking for pack files. Any file operation for git repositories accessed over NAS has a huge performance impact.
For repositories which do not require retaining pack files, we can avoid a call to check for existence of '.keep' file and reduce the overall latency.