### PR TITLE
ci: skip ssh tests on macOS nightly

### DIFF
--- a/azure-pipelines/nightly.yml
+++ b/azure-pipelines/nightly.yml
@@ -73,6 +73,7 @@ jobs:
         LEAK_CHECK: leaks
         CMAKE_OPTIONS: -G Ninja
         RUN_INVASIVE_TESTS: true
+        SKIP_SSH_TESTS: true
 
 - job: windows_vs_amd64
   displayName: 'Windows (amd64; Visual Studio)'


### PR DESCRIPTION
Like 811c1c0f8f80521dccc746a7bff180cd77a783ff, disable the SSH tests on macOS until we can resolve the newly introduced infrastructure issues.