### PR TITLE
refdb_fs: refresh packed refs after loose during iteration

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -333,14 +333,17 @@ static int refdb_fs_backend__exists(
 
 	assert(backend);
 
-	if ((error = packed_reload(backend)) < 0 ||
-		(error = git_buf_joinpath(&ref_path, backend->gitpath, ref_name)) < 0)
+	if ((error = git_buf_joinpath(&ref_path, backend->gitpath, ref_name)) < 0)
 		return error;
-
-	*exists = git_path_isfile(ref_path.ptr) ||
-		(git_sortedcache_lookup(backend->refcache, ref_name) != NULL);
-
+	*exists = git_path_isfile(ref_path.ptr);
 	git_buf_dispose(&ref_path);
+
+	if (!*exists) {
+		if ((error = packed_reload(backend)) < 0)
+		    return error;
+		*exists = git_sortedcache_lookup(backend->refcache, ref_name) != NULL;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
There's a possible race between loose and packed refs when iterating over refs. It works like this:

  0. A loose ref X exists.

  1. libgit2 reads the packed-refs file, which does not mention X.

  2. A simultaneously-running `git pack-refs` commands packs X and prunes the loose version.

  3. libgit2 reads the loose directory, which no longer has X.

At this point, libgit2 claims that X does not exist, even though it does. We can solve this by reading loose refs before packed. This works because refs always migrate from loose to packed, but not the other way around (technically an update to a packed ref creates a new loose file, but it doesn't _delete_ the packed one, so we're guaranteed to always see either the old or the new version).

See also git/git@98eeb09e8acb6cbe0b0da3b1772b6676fe6d167f, which fixed this same race in upstream Git, and discusses the race in more detail.

~~The commit here unfortunately breaks a bunch of tests! The problem seems to be that one cannot naively swap the order of the loose and packed loads. I _think_ the code does not actually understand the precedence between "loose" and "packed", but rather just loads the packed refs and then overlays the loose ones on top in a last-one-wins fashion. By flipping the order, we need a _first-one-wins_ strategy. I don't see a way to easily do that with the `git_sortedcache` data structure.~~

~~So until that is sorted, this PR is garbage; but I wanted to open it to identify the problem and show what the general form of the solution should look like.~~

[I've force-pushed up a non-broken version].
