### PR TITLE
Enable creation of worktree from bare repo's default branch

### DIFF
--- a/src/branch.c
+++ b/src/branch.c
@@ -153,7 +153,10 @@ done:
 
 int git_branch_is_checked_out(const git_reference *branch)
 {
-	assert(branch && git_reference_is_branch(branch));
+	assert(branch);
+
+	if (!git_reference_is_branch(branch))
+		return 0;
 
 	return git_repository_foreach_head(git_reference_owner(branch),
 		branch_equals, (void *) branch) == 1;

--- a/src/branch.c
+++ b/src/branch.c
@@ -153,13 +153,20 @@ done:
 
 int git_branch_is_checked_out(const git_reference *branch)
 {
+	git_repository *repo;
+	int flags = 0;
+
 	assert(branch);
 
 	if (!git_reference_is_branch(branch))
 		return 0;
 
-	return git_repository_foreach_head(git_reference_owner(branch),
-		branch_equals, 0, (void *) branch) == 1;
+	repo = git_reference_owner(branch);
+
+	if (git_repository_is_bare(repo))
+		flags |= GIT_REPOSITORY_FOREACH_HEAD_SKIP_REPO;
+
+	return git_repository_foreach_head(repo, branch_equals, flags, (void *) branch) == 1;
 }
 
 int git_branch_delete(git_reference *branch)

--- a/src/branch.c
+++ b/src/branch.c
@@ -159,7 +159,7 @@ int git_branch_is_checked_out(const git_reference *branch)
 		return 0;
 
 	return git_repository_foreach_head(git_reference_owner(branch),
-		branch_equals, (void *) branch) == 1;
+		branch_equals, 0, (void *) branch) == 1;
 }
 
 int git_branch_delete(git_reference *branch)

--- a/src/refs.c
+++ b/src/refs.c
@@ -692,7 +692,7 @@ static int reference__rename(git_reference **out, git_reference *ref, const char
 		payload.old_name = ref->name;
 		memcpy(&payload.new_name, &normalized, sizeof(normalized));
 
-		error = git_repository_foreach_head(repo, update_wt_heads, &payload);
+		error = git_repository_foreach_head(repo, update_wt_heads, 0, &payload);
 	}
 
 	return error;

--- a/src/repository.c
+++ b/src/repository.c
@@ -2210,30 +2210,37 @@ out:
 	return error;
 }
 
-int git_repository_foreach_head(git_repository *repo, git_repository_foreach_head_cb cb, void *payload)
+int git_repository_foreach_head(git_repository *repo,
+				git_repository_foreach_head_cb cb,
+				int flags, void *payload)
 {
 	git_strarray worktrees = GIT_VECTOR_INIT;
 	git_buf path = GIT_BUF_INIT;
 	int error;
 	size_t i;
 
-	/* Execute callback for HEAD of commondir */
-	if ((error = git_buf_joinpath(&path, repo->commondir, GIT_HEAD_FILE)) < 0 ||
-	    (error = cb(repo, path.ptr, payload) != 0))
-		goto out;
 
-	if ((error = git_worktree_list(&worktrees, repo)) < 0) {
-		error = 0;
-		goto out;
+	if (!(flags & GIT_REPOSITORY_FOREACH_HEAD_SKIP_REPO)) {
+		/* Gather HEAD of main repository */
+		if ((error = git_buf_joinpath(&path, repo->commondir, GIT_HEAD_FILE)) < 0 ||
+		    (error = cb(repo, path.ptr, payload) != 0))
+			goto out;
 	}
 
-	/* Execute callback for all worktree HEADs */
-	for (i = 0; i < worktrees.count; i++) {
-		if (get_worktree_file_path(&path, repo, worktrees.strings[i], GIT_HEAD_FILE) < 0)
-			continue;
-
-		if ((error = cb(repo, path.ptr, payload)) != 0)
+	if (!(flags & GIT_REPOSITORY_FOREACH_HEAD_SKIP_WORKTREES)) {
+		if ((error = git_worktree_list(&worktrees, repo)) < 0) {
+			error = 0;
 			goto out;
+		}
+
+		/* Gather HEADs of all worktrees */
+		for (i = 0; i < worktrees.count; i++) {
+			if (get_worktree_file_path(&path, repo, worktrees.strings[i], GIT_HEAD_FILE) < 0)
+				continue;
+
+			if ((error = cb(repo, path.ptr, payload)) != 0)
+				goto out;
+		}
 	}
 
 out:

--- a/src/repository.h
+++ b/src/repository.h
@@ -176,6 +176,13 @@ int git_repository_create_head(const char *git_dir, const char *ref_name);
  */
 typedef int (*git_repository_foreach_head_cb)(git_repository *repo, const char *path, void *payload);
 
+enum {
+	/* Skip enumeration of the main repository HEAD */
+	GIT_REPOSITORY_FOREACH_HEAD_SKIP_REPO      = (1u << 0),
+	/* Skip enumeration of worktree HEADs */
+	GIT_REPOSITORY_FOREACH_HEAD_SKIP_WORKTREES = (1u << 1),
+};
+
 /*
  * Iterate over repository and all worktree HEADs.
  *
@@ -184,7 +191,9 @@ typedef int (*git_repository_foreach_head_cb)(git_repository *repo, const char *
  * executed with the given payload. The return value equals the
  * return value of the last executed callback function.
  */
-int git_repository_foreach_head(git_repository *repo, git_repository_foreach_head_cb cb, void *payload);
+int git_repository_foreach_head(git_repository *repo,
+				git_repository_foreach_head_cb cb,
+				int flags, void *payload);
 
 /*
  * Weak pointers to repository internals.

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -290,6 +290,20 @@ int git_worktree_add(git_worktree **out, git_repository *repo,
 
 	*out = NULL;
 
+	if (wtopts.ref) {
+		if (!git_reference_is_branch(wtopts.ref)) {
+			git_error_set(GIT_ERROR_WORKTREE, "reference is not a branch");
+			err = -1;
+			goto out;
+		}
+
+		if (git_branch_is_checked_out(wtopts.ref)) {
+			git_error_set(GIT_ERROR_WORKTREE, "reference is already checked out");
+			err = -1;
+			goto out;
+		}
+	}
+
 	/* Create gitdir directory ".git/worktrees/<name>" */
 	if ((err = git_buf_joinpath(&gitdir, repo->commondir, "worktrees")) < 0)
 		goto out;
@@ -342,18 +356,6 @@ int git_worktree_add(git_worktree **out, git_repository *repo,
 
 	/* Set up worktree reference */
 	if (wtopts.ref) {
-		if (!git_reference_is_branch(wtopts.ref)) {
-			git_error_set(GIT_ERROR_WORKTREE, "reference is not a branch");
-			err = -1;
-			goto out;
-		}
-
-		if (git_branch_is_checked_out(wtopts.ref)) {
-			git_error_set(GIT_ERROR_WORKTREE, "reference is already checked out");
-			err = -1;
-			goto out;
-		}
-
 		if ((err = git_reference_dup(&ref, wtopts.ref)) < 0)
 			goto out;
 	} else {

--- a/tests/refs/branches/checkedout.c
+++ b/tests/refs/branches/checkedout.c
@@ -37,3 +37,10 @@ void test_refs_branches_checkedout__worktree(void)
 
 	cleanup_fixture_worktree(&fixture);
 }
+
+void test_refs_branches_checkedout__head_is_not_checked_out(void)
+{
+	repo = cl_git_sandbox_init("testrepo");
+	assert_checked_out(repo, "HEAD", 0);
+	cl_git_sandbox_cleanup();
+}

--- a/tests/refs/branches/checkedout.c
+++ b/tests/refs/branches/checkedout.c
@@ -44,3 +44,10 @@ void test_refs_branches_checkedout__head_is_not_checked_out(void)
 	assert_checked_out(repo, "HEAD", 0);
 	cl_git_sandbox_cleanup();
 }
+
+void test_refs_branches_checkedout__master_in_bare_repo_is_not_checked_out(void)
+{
+	repo = cl_git_sandbox_init("testrepo.git");
+	assert_checked_out(repo, "refs/heads/master", 0);
+	cl_git_sandbox_cleanup();
+}

--- a/tests/refs/branches/checkedout.c
+++ b/tests/refs/branches/checkedout.c
@@ -1,0 +1,39 @@
+#include "clar_libgit2.h"
+#include "refs.h"
+#include "worktree/worktree_helpers.h"
+
+static git_repository *repo;
+
+static void assert_checked_out(git_repository *repo, const char *branch, int checked_out)
+{
+	git_reference *ref;
+
+	cl_git_pass(git_reference_lookup(&ref, repo, branch));
+	cl_assert(git_branch_is_checked_out(ref) == checked_out);
+
+	git_reference_free(ref);
+}
+
+void test_refs_branches_checkedout__simple_repo(void)
+{
+	repo = cl_git_sandbox_init("testrepo");
+	assert_checked_out(repo, "refs/heads/master", 1);
+	assert_checked_out(repo, "refs/heads/executable", 0);
+	cl_git_sandbox_cleanup();
+}
+
+void test_refs_branches_checkedout__worktree(void)
+{
+	static worktree_fixture fixture =
+	    WORKTREE_FIXTURE_INIT("testrepo", "testrepo-worktree");
+
+	setup_fixture_worktree(&fixture);
+
+	assert_checked_out(fixture.repo, "refs/heads/master", 1);
+	assert_checked_out(fixture.repo, "refs/heads/testrepo-worktree", 1);
+
+	assert_checked_out(fixture.worktree, "refs/heads/master", 1);
+	assert_checked_out(fixture.worktree, "refs/heads/testrepo-worktree", 1);
+
+	cleanup_fixture_worktree(&fixture);
+}

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -604,8 +604,8 @@ void test_worktree_worktree__foreach_head_gives_same_results_in_wt_and_repo(void
 	cl_git_pass(git_reference_lookup(&heads[0], fixture.repo, GIT_HEAD_FILE));
 	cl_git_pass(git_reference_lookup(&heads[1], fixture.worktree, GIT_HEAD_FILE));
 
-	cl_git_pass(git_repository_foreach_head(fixture.repo, read_head_ref, &repo_refs));
-	cl_git_pass(git_repository_foreach_head(fixture.worktree, read_head_ref, &worktree_refs));
+	cl_git_pass(git_repository_foreach_head(fixture.repo, read_head_ref, 0, &repo_refs));
+	cl_git_pass(git_repository_foreach_head(fixture.worktree, read_head_ref, 0, &worktree_refs));
 
 	cl_assert_equal_i(repo_refs.length, ARRAY_SIZE(heads));
 	cl_assert_equal_i(worktree_refs.length, ARRAY_SIZE(heads));


### PR DESCRIPTION
Previously, we have determined whether a branch is checked out or not by simply checking the repo and all its worktree HEADs. This is the wrong thing to do in case where we have a bare repo, as a bare repo's HEAD will not be checked out but only indicate the "default" branch. This is getting fixed by this PR.

Furthermore, we'll now verify a given ref when adding new worktrees before creating the on-disk data structures. In case where the ref is invalid, we'll now stop leaving behind those files.

This fixes #4977