### PR TITLE
refdb_fs: fix loose/packed refs lookup racing with repacks

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -694,10 +694,10 @@ static int refdb_fs_backend__iterator(
 		goto out;
 	}
 
-	if ((error = packed_reload(backend)) < 0)
+	if ((error = iter_load_loose_paths(backend, iter)) < 0)
 		goto out;
 
-	if ((error = iter_load_loose_paths(backend, iter)) < 0)
+	if ((error = packed_reload(backend)) < 0)
 		goto out;
 
 	if ((error = git_sortedcache_copy(&iter->cache, backend->refcache, 1, NULL, NULL)) < 0)


### PR DESCRIPTION
This is a different approach to #4981 that should correctly fix the issues described by @peff. 

There had been an ordering dependency between loading loose and packed refs in that loading loose refs set the PACKREF_SHADOWED flag in already loaded packed refs. Upon reloading packed refs, this flag gets reset. Due to that, we always had to load loose and packed refs in the wrong order. This PR fixes this dependency and thus allows us to first load the loose refs and only afterwards load the packed refs, effectively mitigating the race.

It also fixes the same race condition in the `exists` callback that has been pointed out by @peff, too.