### PR TITLE
Make stdalloc__reallocarray call stdalloc__realloc

### DIFF
--- a/src/stdalloc.c
+++ b/src/stdalloc.c
@@ -88,11 +88,10 @@ static void *stdalloc__reallocarray(void *ptr, size_t nelem, size_t elsize, cons
 {
 	size_t newsize;
 
-	GIT_UNUSED(file);
-	GIT_UNUSED(line);
+	if (GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize))
+		return NULL;
 
-	return GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize) ?
-		NULL : realloc(ptr, newsize);
+	return stdalloc__realloc(ptr, newsize, file, line);
 }
 
 static void *stdalloc__mallocarray(size_t nelem, size_t elsize, const char *file, int line)


### PR DESCRIPTION
This change avoids calling realloc(3) in more than one place.