### PR TITLE
Fix a memory leak in odb_otype_fast()

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1128,6 +1128,7 @@ static int odb_otype_fast(git_object_t *type_p, git_odb *db, const git_oid *id)
 
 	if ((object = git_cache_get_raw(odb_cache(db), id)) != NULL) {
 		*type_p = object->cached.type;
+		git_odb_object_free(object);
 		return 0;
 	}
 

--- a/tests/odb/mixed.c
+++ b/tests/odb/mixed.c
@@ -263,3 +263,24 @@ void test_odb_mixed__expand_ids(void)
 	git__free(ids);
 }
 
+void test_odb_mixed__expand_ids_cached(void)
+{
+	git_odb_expand_id *ids;
+	size_t i, num;
+
+	/* test looking for the actual (correct) types after accessing the object */
+
+	setup_prefix_query(&ids, &num);
+
+	for (i = 0; i < num; i++) {
+		git_odb_object *obj;
+		if (ids[i].type == GIT_OBJECT_ANY)
+			continue;
+		cl_git_pass(git_odb_read_prefix(&obj, _odb, &ids[i].id, ids[i].length));
+		git_odb_object_free(obj);
+	}
+
+	cl_git_pass(git_odb_expand_ids(_odb, ids, num));
+	assert_found_objects(ids);
+	git__free(ids);
+}


### PR DESCRIPTION
This change frees a copy of a cached object in odb_otype_fast().