### PR TITLE
ci: publish documentation on merge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,10 +130,12 @@ jobs:
   steps:
   - script: |
       git config user.name 'Documentation Generation'
-      git config user.email 'noreply@libgit2.org'
-      docker run --rm -v /home/vsts/work/1/s:/src -w /src libgit2/docurium:test cm doc api.docurium
+      git config user.email 'libgit2@users.noreply.github.com'
+      git branch gh-pages origin/gh-pages
+      docker run --rm -v $(Build.SourcesDirectory):/src -w /src libgit2/docurium:latest cm doc api.docurium
       git checkout gh-pages
       cp -R * '$(Build.BinariesDirectory)'
+    displayName: 'Generate Documentation'
   - task: archivefiles@2
     displayName: 'Archive Documentation'
     inputs:
@@ -141,7 +143,15 @@ jobs:
       includeRootFolder: false
       archiveFile: '$(Build.ArtifactStagingDirectory)/api-documentation.zip'
   - task: publishbuildartifacts@1
-    displayName: 'Upload Documentation'
+    displayName: 'Upload Documentation Artifact'
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'docs'
+  - script: |
+      git remote -v
+      echo 'machine github.com' > ~/.netrc
+      echo 'login $(GITHUB_USERNAME)' >> ~/.netrc
+      echo 'password $(GITHUB_PAT)' >> ~/.netrc
+      git push origin gh-pages
+    displayName: 'Publish Documentation'
+    condition: eq(variables['Build.Reason'], 'IndividualCI')


### PR DESCRIPTION
When a commit is pushed or merged into one of the release branches (`master`, `maint/*`) then push the documentation update to gh-pages.