### PR TITLE
cache: fix misnaming of `git_cache_free`

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -101,7 +101,7 @@ void git_cache_clear(git_cache *cache)
 	git_rwlock_wrunlock(&cache->lock);
 }
 
-void git_cache_free(git_cache *cache)
+void git_cache_dispose(git_cache *cache)
 {
 	git_cache_clear(cache);
 	git_oidmap_free(cache->map);

--- a/src/cache.h
+++ b/src/cache.h
@@ -43,7 +43,7 @@ extern git_atomic_ssize git_cache__current_storage;
 int git_cache_set_max_object_size(git_object_t type, size_t size);
 
 int git_cache_init(git_cache *cache);
-void git_cache_free(git_cache *cache);
+void git_cache_dispose(git_cache *cache);
 void git_cache_clear(git_cache *cache);
 
 void *git_cache_store_raw(git_cache *cache, git_odb_object *entry);

--- a/src/odb.c
+++ b/src/odb.c
@@ -448,7 +448,7 @@ int git_odb_new(git_odb **out)
 		return -1;
 	}
 	if (git_vector_init(&db->backends, 4, backend_sort_cmp) < 0) {
-		git_cache_free(&db->own_cache);
+		git_cache_dispose(&db->own_cache);
 		git__free(db);
 		return -1;
 	}
@@ -686,7 +686,7 @@ static void odb_free(git_odb *db)
 	}
 
 	git_vector_free(&db->backends);
-	git_cache_free(&db->own_cache);
+	git_cache_dispose(&db->own_cache);
 
 	git__memzero(db, sizeof(*db));
 	git__free(db);

--- a/src/repository.c
+++ b/src/repository.c
@@ -160,7 +160,7 @@ void git_repository_free(git_repository *repo)
 
 	git_repository__cleanup(repo);
 
-	git_cache_free(&repo->objects);
+	git_cache_dispose(&repo->objects);
 
 	git_diff_driver_registry_free(repo->diff_drivers);
 	repo->diff_drivers = NULL;
@@ -245,7 +245,7 @@ static git_repository *repository_alloc(void)
 
 on_error:
 	if (repo)
-		git_cache_free(&repo->objects);
+		git_cache_dispose(&repo->objects);
 
 	git__free(repo);
 	return NULL;


### PR DESCRIPTION
Functions that free a structure's contents but not the structure
itself shall be named `dispose` in the libgit2 project, but the
function `git_cache_free` does not follow this naming pattern.

Fix this by renaming it to `git_cache_dispose` and adjusting all
callers to make use of the new name.