### PR TITLE
Fix attribute lookup without common dir

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -336,8 +336,10 @@ static int attr_setup(git_repository *repo, git_attr_session *attr_session)
 
 	if ((error = git_repository_item_path(&path, repo, GIT_REPOSITORY_ITEM_INFO)) < 0 ||
 	    (error = preload_attr_file(repo, attr_session, GIT_ATTR_FILE__FROM_FILE,
-				       path.ptr, GIT_ATTR_FILE_INREPO)) < 0)
-		goto out;
+				       path.ptr, GIT_ATTR_FILE_INREPO)) < 0) {
+		if (error != GIT_ENOTFOUND)
+			goto out;
+	}
 
 	if ((workdir = git_repository_workdir(repo)) != NULL &&
 	    (error = preload_attr_file(repo, attr_session, GIT_ATTR_FILE__FROM_FILE,
@@ -511,15 +513,12 @@ static int collect_attr_files(
 	 * - $GIT_PREFIX/etc/gitattributes
 	 */
 
-	error = git_repository_item_path(&attrfile, repo, GIT_REPOSITORY_ITEM_INFO);
-	if (error < 0)
-		goto cleanup;
-
-	error = push_attr_file(
-		repo, attr_session, files, GIT_ATTR_FILE__FROM_FILE,
-		attrfile.ptr, GIT_ATTR_FILE_INREPO);
-	if (error < 0)
-		goto cleanup;
+	if ((error = git_repository_item_path(&attrfile, repo, GIT_REPOSITORY_ITEM_INFO)) < 0 ||
+	    (error = push_attr_file(repo, attr_session, files, GIT_ATTR_FILE__FROM_FILE,
+				    attrfile.ptr, GIT_ATTR_FILE_INREPO)) < 0) {
+		if (error != GIT_ENOTFOUND)
+			goto cleanup;
+	}
 
 	info.repo = repo;
 	info.attr_session = attr_session;

--- a/tests/attr/macro.c
+++ b/tests/attr/macro.c
@@ -1,0 +1,58 @@
+#include "clar_libgit2.h"
+
+#include "attr_file.h"
+#include "git2/sys/repository.h"
+
+static git_repository *repo;
+
+void test_attr_macro__initialize(void)
+{
+	cl_git_pass(git_repository_new(&repo));
+}
+
+void test_attr_macro__cleanup(void)
+{
+	git_repository_free(repo);
+}
+
+static void assert_attr_expands(const char *attr, const char *expected)
+{
+	git_attr_file_entry entry = { { NULL }, ".gitattributes" };
+	git_buf attrbuf = GIT_BUF_INIT;
+	git_attr_file *attrs;
+	const char *value;
+
+	cl_git_pass(git_buf_printf(&attrbuf, "example.txt %s\n", attr));
+	cl_git_pass(git_attr_file__new(&attrs, &entry, GIT_ATTR_FILE__IN_MEMORY));
+	cl_git_pass(git_attr_file__parse_buffer(repo, attrs, attrbuf.ptr));
+
+	cl_git_pass(git_attr_get(&value, repo, 0, "example.txt", attr));
+	cl_assert_equal_s(value, expected);
+
+	git_attr_file__free(attrs);
+	git_buf_dispose(&attrbuf);
+}
+
+void test_attr_macro__adding_macro_succeeds(void)
+{
+	cl_git_pass(git_attr_add_macro(repo, "foo", "test"));
+	assert_attr_expands("foo", "test");
+}
+
+void test_attr_macro__adding_negative_macro_succeeds(void)
+{
+	cl_git_pass(git_attr_add_macro(repo, "foo", "-test"));
+	assert_attr_expands("foo", "-text");
+}
+
+void test_attr_macro__redefining_macro_succeeds(void)
+{
+	cl_git_pass(git_attr_add_macro(repo, "foo", "foo"));
+	cl_git_pass(git_attr_add_macro(repo, "foo", "bar"));
+}
+
+void test_attr_macro__recursive_macro_resolves(void)
+{
+	cl_git_pass(git_attr_add_macro(repo, "foo", "bar"));
+	cl_git_pass(git_attr_add_macro(repo, "bar", "-text"));
+}


### PR DESCRIPTION
So this is the fix I came up while I didn't yet see that there's #4967 already. The fixes are mostly the same, even though I did some refactoring up front to make the code a bit more readable (at least in my opinion).

What's been itching me is to write tests for this. While it's quite easy to write one with `git_attr_get`, I noticed that we didn't have any tests for our attribute macros at all. As that code path implicitly also verified that we're able to look up attributes without commondir, I thought I'd just write one like that.

But the crux is: with `git_repository_new`, I don't see any way of adding attributes files to a `git_repository`. While we supposedly have in-memory support for gitattributes files, we have no way of adding them to a repo. The same holds for adding real files: there is no way of adding a gitattributes file that lives at a non-standard path to a repo. So maybe I'm dumb and not seeing the obvious way to do so, but I was not able to make gitattributes work with in-memory repos.

So this PR is rather a plea for help: is there anything that makes this work already? Otherwise I think we should definitely fix this API shortcoming and introduce proper in-memory gitattributes support.