### PR TITLE
Rename git_transfer_progress to git_indexer_progress

### DIFF
--- a/examples/clone.c
+++ b/examples/clone.c
@@ -1,7 +1,7 @@
 #include "common.h"
 
 typedef struct progress_data {
-	git_transfer_progress fetch_progress;
+	git_indexer_progress fetch_progress;
 	size_t completed_steps;
 	size_t total_steps;
 	const char *path;
@@ -46,7 +46,7 @@ static int sideband_progress(const char *str, int len, void *payload)
 	return 0;
 }
 
-static int fetch_progress(const git_transfer_progress *stats, void *payload)
+static int fetch_progress(const git_indexer_progress *stats, void *payload)
 {
 	progress_data *pd = (progress_data*)payload;
 	pd->fetch_progress = *stats;

--- a/examples/fetch.c
+++ b/examples/fetch.c
@@ -38,7 +38,7 @@ static int update_cb(const char *refname, const git_oid *a, const git_oid *b, vo
  * data. Most frontends will probably want to show a percentage and
  * the download rate.
  */
-static int transfer_progress_cb(const git_transfer_progress *stats, void *payload)
+static int transfer_progress_cb(const git_indexer_progress *stats, void *payload)
 {
 	(void)payload;
 
@@ -57,7 +57,7 @@ static int transfer_progress_cb(const git_transfer_progress *stats, void *payloa
 int lg2_fetch(git_repository *repo, int argc, char **argv)
 {
 	git_remote *remote = NULL;
-	const git_transfer_progress *stats;
+	const git_indexer_progress *stats;
 	git_fetch_options fetch_opts = GIT_FETCH_OPTIONS_INIT;
 
 	if (argc < 2) {

--- a/examples/index-pack.c
+++ b/examples/index-pack.c
@@ -20,7 +20,7 @@
  * This could be run in the main loop whilst the application waits for
  * the indexing to finish in a worker thread
  */
-static int index_cb(const git_transfer_progress *stats, void *data)
+static int index_cb(const git_indexer_progress *stats, void *data)
 {
 	(void)data;
 	printf("\rProcessing %d of %d", stats->indexed_objects, stats->total_objects);
@@ -31,7 +31,7 @@ static int index_cb(const git_transfer_progress *stats, void *data)
 int lg2_index_pack(git_repository *repo, int argc, char **argv)
 {
 	git_indexer *idx;
-	git_transfer_progress stats = {0, 0};
+	git_indexer_progress stats = {0, 0};
 	int error;
 	char hash[GIT_OID_HEXSZ + 1] = {0};
 	int fd;

--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -55,7 +55,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	git_indexer *indexer = NULL;
-	git_transfer_progress stats = {0, 0};
+	git_indexer_progress stats = {0, 0};
 	bool append_hash = false;
 	git_oid id;
 	char hash[GIT_OID_HEXSZ + 1] = {0};

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -245,6 +245,35 @@ GIT_EXTERN(void) giterr_set_oom(void);
 
 /**@}*/
 
+/** @name Deprecated Transfer Progress Types
+ *
+ * These types are retained for backward compatibility.  The newer
+ * versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+/**
+ * This structure is used to provide callers information about the
+ * progress of indexing a packfile.
+ *
+ * This type is deprecated, but there is no plan to remove this
+ * type definition at this time.
+ */
+typedef git_indexer_progress git_transfer_progress;
+
+/**
+ * Type definition for progress callbacks during indexing.
+ *
+ * This type is deprecated, but there is no plan to remove this
+ * type definition at this time.
+ */
+typedef git_indexer_progress_cb git_transfer_progress_cb;
+
+/**@}*/
+
 /** @} */
 GIT_END_DECL
 

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -13,6 +13,7 @@
 #include "index.h"
 #include "object.h"
 #include "refs.h"
+#include "remote.h"
 
 /*
  * Users can avoid deprecated functions by defining `GIT_DEPRECATE_HARD`.
@@ -271,6 +272,14 @@ typedef git_indexer_progress git_transfer_progress;
  * type definition at this time.
  */
 typedef git_indexer_progress_cb git_transfer_progress_cb;
+
+/**
+ * Type definition for push transfer progress callbacks.
+ *
+ * This type is deprecated, but there is no plan to remove this
+ * type definition at this time.
+ */
+typedef git_push_transfer_progress_cb git_push_transfer_progress;
 
 /**@}*/
 

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -15,6 +15,51 @@ GIT_BEGIN_DECL
 
 typedef struct git_indexer git_indexer;
 
+/**
+ * This structure is used to provide callers information about the
+ * progress of indexing a packfile, either directly or part of a
+ * fetch or clone that downloads a packfile.
+ */
+typedef struct git_indexer_progress {
+	/** number of objects in the packfile being indexed */
+	unsigned int total_objects;
+
+	/** received objects that have been hashed */
+	unsigned int indexed_objects;
+
+	/** received_objects: objects which have been downloaded */
+	unsigned int received_objects;
+
+	/**
+	 * locally-available objects that have been injected in order
+	 * to fix a thin pack
+	 */
+	unsigned int local_objects;
+
+	/** number of deltas in the packfile being indexed */
+	unsigned int total_deltas;
+
+	/** received deltas that have been indexed */
+	unsigned int indexed_deltas;
+
+	/** size of the packfile received up to now */
+	size_t received_bytes;
+} git_indexer_progress;
+
+typedef git_indexer_progress git_transfer_progress;
+
+/**
+ * Type for progress callbacks during indexing.  Return a value less
+ * than zero to cancel the indexing or download.
+ *
+ * @param stats Structure containing information about the state of the tran    sfer
+ * @param payload Payload provided by caller
+ */
+typedef int GIT_CALLBACK(git_indexer_progress_cb)(const git_indexer_progress *stats, void *payload);
+
+typedef git_indexer_progress_cb git_transfer_progress_cb;
+
+
 typedef struct git_indexer_options {
 	unsigned int version;
 

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -64,7 +64,7 @@ typedef struct git_indexer_options {
 	unsigned int version;
 
 	/** progress_cb function to call with progress information */
-	git_transfer_progress_cb progress_cb;
+	git_indexer_progress_cb progress_cb;
 	/** progress_cb_payload payload for the progress callback */
 	void *progress_cb_payload;
 
@@ -114,7 +114,7 @@ GIT_EXTERN(int) git_indexer_new(
  * @param size the size of the data in bytes
  * @param stats stat storage
  */
-GIT_EXTERN(int) git_indexer_append(git_indexer *idx, const void *data, size_t size, git_transfer_progress *stats);
+GIT_EXTERN(int) git_indexer_append(git_indexer *idx, const void *data, size_t size, git_indexer_progress *stats);
 
 /**
  * Finalize the pack and index
@@ -123,7 +123,7 @@ GIT_EXTERN(int) git_indexer_append(git_indexer *idx, const void *data, size_t si
  *
  * @param idx the indexer
  */
-GIT_EXTERN(int) git_indexer_commit(git_indexer *idx, git_transfer_progress *stats);
+GIT_EXTERN(int) git_indexer_commit(git_indexer *idx, git_indexer_progress *stats);
 
 /**
  * Get the packfile's hash

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -46,8 +46,6 @@ typedef struct git_indexer_progress {
 	size_t received_bytes;
 } git_indexer_progress;
 
-typedef git_indexer_progress git_transfer_progress;
-
 /**
  * Type for progress callbacks during indexing.  Return a value less
  * than zero to cancel the indexing or download.
@@ -56,8 +54,6 @@ typedef git_indexer_progress git_transfer_progress;
  * @param payload Payload provided by caller
  */
 typedef int GIT_CALLBACK(git_indexer_progress_cb)(const git_indexer_progress *stats, void *payload);
-
-typedef git_indexer_progress_cb git_transfer_progress_cb;
 
 
 typedef struct git_indexer_options {

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -391,7 +391,7 @@ GIT_EXTERN(int) git_odb_open_rstream(
 GIT_EXTERN(int) git_odb_write_pack(
 	git_odb_writepack **out,
 	git_odb *db,
-	git_transfer_progress_cb progress_cb,
+	git_indexer_progress_cb progress_cb,
 	void *progress_payload);
 
 /**

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -124,8 +124,8 @@ struct git_odb_stream {
 struct git_odb_writepack {
 	git_odb_backend *backend;
 
-	int GIT_CALLBACK(append)(git_odb_writepack *writepack, const void *data, size_t size, git_transfer_progress *stats);
-	int GIT_CALLBACK(commit)(git_odb_writepack *writepack, git_transfer_progress *stats);
+	int GIT_CALLBACK(append)(git_odb_writepack *writepack, const void *data, size_t size, git_indexer_progress *stats);
+	int GIT_CALLBACK(commit)(git_odb_writepack *writepack, git_indexer_progress *stats);
 	void GIT_CALLBACK(free)(git_odb_writepack *writepack);
 };
 

--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -165,7 +165,7 @@ GIT_EXTERN(int) git_packbuilder_write(
 	git_packbuilder *pb,
 	const char *path,
 	unsigned int mode,
-	git_transfer_progress_cb progress_cb,
+	git_indexer_progress_cb progress_cb,
 	void *progress_cb_payload);
 
 /**

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -422,11 +422,12 @@ typedef enum git_remote_completion_type {
 } git_remote_completion_type;
 
 /** Push network progress notification function */
-typedef int GIT_CALLBACK(git_push_transfer_progress)(
+typedef int GIT_CALLBACK(git_push_transfer_progress_cb)(
 	unsigned int current,
 	unsigned int total,
 	size_t bytes,
 	void* payload);
+
 /**
  * Represents an update which will be performed on the remote during push
  */
@@ -537,7 +538,7 @@ struct git_remote_callbacks {
 	 * inline with pack building operations, so performance may be
 	 * affected.
 	 */
-	git_push_transfer_progress push_transfer_progress;
+	git_push_transfer_progress_cb push_transfer_progress;
 
 	/**
 	 * See documentation of git_push_update_reference_cb

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -516,7 +516,7 @@ struct git_remote_callbacks {
 	 * called with the current count of progress done by the
 	 * indexer.
 	 */
-	git_transfer_progress_cb transfer_progress;
+	git_indexer_progress_cb transfer_progress;
 
 	/**
 	 * Each time a reference is updated locally, this function
@@ -832,7 +832,7 @@ GIT_EXTERN(int) git_remote_push(git_remote *remote,
 /**
  * Get the statistics structure that is filled in by the fetch operation.
  */
-GIT_EXTERN(const git_transfer_progress *) git_remote_stats(git_remote *remote);
+GIT_EXTERN(const git_indexer_progress *) git_remote_stats(git_remote *remote);
 
 /**
  * Retrieve the tag auto-follow setting

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -82,7 +82,7 @@ struct git_odb_backend {
 
 	int GIT_CALLBACK(writepack)(
 		git_odb_writepack **, git_odb_backend *, git_odb *odb,
-		git_transfer_progress_cb progress_cb, void *progress_payload);
+		git_indexer_progress_cb progress_cb, void *progress_payload);
 
 	/**
 	 * "Freshens" an already existing object, updating its last-used

--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -98,8 +98,8 @@ struct git_transport {
 	int GIT_CALLBACK(download_pack)(
 		git_transport *transport,
 		git_repository *repo,
-		git_transfer_progress *stats,
-		git_transfer_progress_cb progress_cb,
+		git_indexer_progress *stats,
+		git_indexer_progress_cb progress_cb,
 		void *progress_payload);
 
 	/** Checks to see if the transport is connected */

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -245,36 +245,6 @@ typedef struct git_remote_head git_remote_head;
 typedef struct git_remote_callbacks git_remote_callbacks;
 
 /**
- * This is passed as the first argument to the callback to allow the
- * user to see the progress.
- *
- * - total_objects: number of objects in the packfile being downloaded
- * - indexed_objects: received objects that have been hashed
- * - received_objects: objects which have been downloaded
- * - local_objects: locally-available objects that have been injected
- *    in order to fix a thin pack.
- * - received-bytes: size of the packfile received up to now
- */
-typedef struct git_transfer_progress {
-	unsigned int total_objects;
-	unsigned int indexed_objects;
-	unsigned int received_objects;
-	unsigned int local_objects;
-	unsigned int total_deltas;
-	unsigned int indexed_deltas;
-	size_t received_bytes;
-} git_transfer_progress;
-
-/**
- * Type for progress callbacks during indexing.  Return a value less than zero
- * to cancel the transfer.
- *
- * @param stats Structure containing information about the state of the transfer
- * @param payload Payload provided by caller
- */
-typedef int GIT_CALLBACK(git_transfer_progress_cb)(const git_transfer_progress *stats, void *payload);
-
-/**
  * Type for messages delivered by the transport.  Return a negative value
  * to cancel the network operation.
  *

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -134,7 +134,7 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 int git_fetch_download_pack(git_remote *remote, const git_remote_callbacks *callbacks)
 {
 	git_transport *t = remote->transport;
-	git_transfer_progress_cb progress = NULL;
+	git_indexer_progress_cb progress = NULL;
 	void *payload = NULL;
 
 	if (!remote->need_pack)

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -58,7 +58,7 @@ struct git_indexer {
 	unsigned int fanout[256];
 	git_hash_ctx hash_ctx;
 	git_oid hash;
-	git_transfer_progress_cb progress_cb;
+	git_indexer_progress_cb progress_cb;
 	void *progress_payload;
 	char objbuf[8*1024];
 
@@ -544,7 +544,7 @@ on_error:
 	return -1;
 }
 
-static int do_progress_callback(git_indexer *idx, git_transfer_progress *stats)
+static int do_progress_callback(git_indexer *idx, git_indexer_progress *stats)
 {
 	if (idx->progress_cb)
 		return git_error_set_after_callback_function(
@@ -652,7 +652,7 @@ static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 	return write_at(idx, data, idx->pack->mwf.size, size);
 }
 
-static int read_stream_object(git_indexer *idx, git_transfer_progress *stats)
+static int read_stream_object(git_indexer *idx, git_indexer_progress *stats)
 {
 	git_packfile_stream *stream = &idx->stream;
 	git_off_t entry_start = idx->off;
@@ -741,7 +741,7 @@ static int read_stream_object(git_indexer *idx, git_transfer_progress *stats)
 	return 0;
 }
 
-int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_transfer_progress *stats)
+int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_indexer_progress *stats)
 {
 	int error = -1;
 	struct git_pack_header *hdr = &idx->hdr;
@@ -925,7 +925,7 @@ cleanup:
 	return error;
 }
 
-static int fix_thin_pack(git_indexer *idx, git_transfer_progress *stats)
+static int fix_thin_pack(git_indexer *idx, git_indexer_progress *stats)
 {
 	int error, found_ref_delta = 0;
 	unsigned int i;
@@ -987,7 +987,7 @@ static int fix_thin_pack(git_indexer *idx, git_transfer_progress *stats)
 	return 0;
 }
 
-static int resolve_deltas(git_indexer *idx, git_transfer_progress *stats)
+static int resolve_deltas(git_indexer *idx, git_indexer_progress *stats)
 {
 	unsigned int i;
 	int error;
@@ -1044,7 +1044,7 @@ static int resolve_deltas(git_indexer *idx, git_transfer_progress *stats)
 	return 0;
 }
 
-static int update_header_and_rehash(git_indexer *idx, git_transfer_progress *stats)
+static int update_header_and_rehash(git_indexer *idx, git_indexer_progress *stats)
 {
 	void *ptr;
 	size_t chunk = 1024*1024;
@@ -1085,7 +1085,7 @@ static int update_header_and_rehash(git_indexer *idx, git_transfer_progress *sta
 	return 0;
 }
 
-int git_indexer_commit(git_indexer *idx, git_transfer_progress *stats)
+int git_indexer_commit(git_indexer *idx, git_indexer_progress *stats)
 {
 	git_mwindow *w = NULL;
 	unsigned int i, long_offsets = 0, left;

--- a/src/odb.c
+++ b/src/odb.c
@@ -1468,7 +1468,7 @@ int git_odb_open_rstream(
 	return error;
 }
 
-int git_odb_write_pack(struct git_odb_writepack **out, git_odb *db, git_transfer_progress_cb progress_cb, void *progress_payload)
+int git_odb_write_pack(struct git_odb_writepack **out, git_odb *db, git_indexer_progress_cb progress_cb, void *progress_payload)
 {
 	size_t i, writes = 0;
 	int error = GIT_ERROR;

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -485,7 +485,7 @@ static int pack_backend__foreach(git_odb_backend *_backend, git_odb_foreach_cb c
 	return 0;
 }
 
-static int pack_backend__writepack_append(struct git_odb_writepack *_writepack, const void *data, size_t size, git_transfer_progress *stats)
+static int pack_backend__writepack_append(struct git_odb_writepack *_writepack, const void *data, size_t size, git_indexer_progress *stats)
 {
 	struct pack_writepack *writepack = (struct pack_writepack *)_writepack;
 
@@ -494,7 +494,7 @@ static int pack_backend__writepack_append(struct git_odb_writepack *_writepack, 
 	return git_indexer_append(writepack->indexer, data, size, stats);
 }
 
-static int pack_backend__writepack_commit(struct git_odb_writepack *_writepack, git_transfer_progress *stats)
+static int pack_backend__writepack_commit(struct git_odb_writepack *_writepack, git_indexer_progress *stats)
 {
 	struct pack_writepack *writepack = (struct pack_writepack *)_writepack;
 
@@ -516,7 +516,7 @@ static void pack_backend__writepack_free(struct git_odb_writepack *_writepack)
 static int pack_backend__writepack(struct git_odb_writepack **out,
 	git_odb_backend *_backend,
         git_odb *odb,
-	git_transfer_progress_cb progress_cb,
+	git_indexer_progress_cb progress_cb,
 	void *progress_payload)
 {
 	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -38,7 +38,7 @@ struct tree_walk_context {
 
 struct pack_write_context {
 	git_indexer *indexer;
-	git_transfer_progress *stats;
+	git_indexer_progress *stats;
 };
 
 struct walk_object {
@@ -1379,12 +1379,12 @@ int git_packbuilder_write(
 	git_packbuilder *pb,
 	const char *path,
 	unsigned int mode,
-	git_transfer_progress_cb progress_cb,
+	git_indexer_progress_cb progress_cb,
 	void *progress_cb_payload)
 {
 	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
 	git_indexer *indexer;
-	git_transfer_progress stats;
+	git_indexer_progress stats;
 	struct pack_write_context ctx;
 	int t;
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -1770,7 +1770,7 @@ int git_remote_list(git_strarray *remotes_list, git_repository *repo)
 	return 0;
 }
 
-const git_transfer_progress* git_remote_stats(git_remote *remote)
+const git_indexer_progress *git_remote_stats(git_remote *remote)
 {
 	assert(remote);
 	return &remote->stats;

--- a/src/remote.h
+++ b/src/remote.h
@@ -29,7 +29,7 @@ struct git_remote {
 	git_transport *transport;
 	git_repository *repo;
 	git_push *push;
-	git_transfer_progress stats;
+	git_indexer_progress stats;
 	unsigned int need_pack;
 	git_remote_autotag_option_t download_tags;
 	int prune_refs;

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -325,7 +325,7 @@ static int local_push_update_remote_ref(
 	return error;
 }
 
-static int transfer_to_push_transfer(const git_transfer_progress *stats, void *payload)
+static int transfer_to_push_transfer(const git_indexer_progress *stats, void *payload)
 {
 	const git_remote_callbacks *cbs = payload;
 
@@ -460,8 +460,8 @@ on_error:
 }
 
 typedef struct foreach_data {
-	git_transfer_progress *stats;
-	git_transfer_progress_cb progress_cb;
+	git_indexer_progress *stats;
+	git_indexer_progress_cb progress_cb;
 	void *progress_payload;
 	git_odb_writepack *writepack;
 } foreach_data;
@@ -533,8 +533,8 @@ static int foreach_reference_cb(git_reference *reference, void *payload)
 static int local_download_pack(
 		git_transport *transport,
 		git_repository *repo,
-		git_transfer_progress *stats,
-		git_transfer_progress_cb progress_cb,
+		git_indexer_progress *stats,
+		git_indexer_progress_cb progress_cb,
 		void *progress_payload)
 {
 	transport_local *t = (transport_local*)transport;

--- a/src/transports/smart.h
+++ b/src/transports/smart.h
@@ -177,8 +177,8 @@ int git_smart__negotiate_fetch(
 int git_smart__download_pack(
 	git_transport *transport,
 	git_repository *repo,
-	git_transfer_progress *stats,
-	git_transfer_progress_cb progress_cb,
+	git_indexer_progress *stats,
+	git_indexer_progress_cb progress_cb,
 	void *progress_payload);
 
 /* smart.c */

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -978,7 +978,7 @@ struct push_packbuilder_payload
 {
 	git_smart_subtransport_stream *stream;
 	git_packbuilder *pb;
-	git_push_transfer_progress cb;
+	git_push_transfer_progress_cb cb;
 	void *cb_payload;
 	size_t last_bytes;
 	double last_progress_report_time;

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -492,7 +492,7 @@ on_error:
 	return error;
 }
 
-static int no_sideband(transport_smart *t, struct git_odb_writepack *writepack, gitno_buffer *buf, git_transfer_progress *stats)
+static int no_sideband(transport_smart *t, struct git_odb_writepack *writepack, gitno_buffer *buf, git_indexer_progress *stats)
 {
 	int recvd;
 
@@ -519,9 +519,9 @@ static int no_sideband(transport_smart *t, struct git_odb_writepack *writepack, 
 
 struct network_packetsize_payload
 {
-	git_transfer_progress_cb callback;
+	git_indexer_progress_cb callback;
 	void *payload;
-	git_transfer_progress *stats;
+	git_indexer_progress *stats;
 	size_t last_fired_bytes;
 };
 
@@ -546,8 +546,8 @@ static int network_packetsize(size_t received, void *payload)
 int git_smart__download_pack(
 	git_transport *transport,
 	git_repository *repo,
-	git_transfer_progress *stats,
-	git_transfer_progress_cb transfer_progress_cb,
+	git_indexer_progress *stats,
+	git_indexer_progress_cb progress_cb,
 	void *progress_payload)
 {
 	transport_smart *t = (transport_smart *)transport;
@@ -557,10 +557,10 @@ int git_smart__download_pack(
 	int error = 0;
 	struct network_packetsize_payload npp = {0};
 
-	memset(stats, 0, sizeof(git_transfer_progress));
+	memset(stats, 0, sizeof(git_indexer_progress));
 
-	if (transfer_progress_cb) {
-		npp.callback = transfer_progress_cb;
+	if (progress_cb) {
+		npp.callback = progress_cb;
 		npp.payload = progress_payload;
 		npp.stats = stats;
 		t->packetsize_cb = &network_packetsize;
@@ -573,7 +573,7 @@ int git_smart__download_pack(
 	}
 
 	if ((error = git_repository_odb__weakptr(&odb, repo)) < 0 ||
-		((error = git_odb_write_pack(&writepack, odb, transfer_progress_cb, progress_payload)) != 0))
+		((error = git_odb_write_pack(&writepack, odb, progress_cb, progress_payload)) != 0))
 		goto done;
 
 	/*
@@ -626,7 +626,7 @@ int git_smart__download_pack(
 	} while (1);
 
 	/*
-	 * Trailing execution of transfer_progress_cb, if necessary...
+	 * Trailing execution of progress_cb, if necessary...
 	 * Only the callback through the npp datastructure currently
 	 * updates the last_fired_bytes value. It is possible that
 	 * progress has already been reported with the correct
@@ -645,7 +645,7 @@ int git_smart__download_pack(
 done:
 	if (writepack)
 		writepack->free(writepack);
-	if (transfer_progress_cb) {
+	if (progress_cb) {
 		t->packetsize_cb = NULL;
 		t->packetsize_payload = NULL;
 	}

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -171,7 +171,7 @@ void test_clone_nonetwork__can_checkout_given_branch(void)
 }
 
 static int clone_cancel_fetch_transfer_progress_cb(
-	const git_transfer_progress *stats, void *data)
+	const git_indexer_progress *stats, void *data)
 {
 	GIT_UNUSED(stats); GIT_UNUSED(data);
 	return -54321;

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -8,7 +8,7 @@ static const char* tagger_name = "Vicent Marti";
 static const char* tagger_email = "vicent@github.com";
 static const char* tagger_message = "This is my tag.\n\nThere are many tags, but this one is mine\n";
 
-static int transfer_cb(const git_transfer_progress *stats, void *payload)
+static int transfer_cb(const git_indexer_progress *stats, void *payload)
 {
 	int *callcount = (int*)payload;
 	GIT_UNUSED(stats);

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -158,7 +158,7 @@ static void checkout_progress(const char *path, size_t cur, size_t tot, void *pa
 	(*was_called) = true;
 }
 
-static int fetch_progress(const git_transfer_progress *stats, void *payload)
+static int fetch_progress(const git_indexer_progress *stats, void *payload)
 {
 	bool *was_called = (bool*)payload;
 	GIT_UNUSED(stats);
@@ -442,7 +442,7 @@ void test_online_clone__bitbucket_falls_back_to_specified_creds(void)
 	cl_fixture_cleanup("./foo");
 }
 
-static int cancel_at_half(const git_transfer_progress *stats, void *payload)
+static int cancel_at_half(const git_indexer_progress *stats, void *payload)
 {
 	GIT_UNUSED(payload);
 

--- a/tests/online/fetch.c
+++ b/tests/online/fetch.c
@@ -25,7 +25,7 @@ static int update_tips(const char *refname, const git_oid *a, const git_oid *b, 
 	return 0;
 }
 
-static int progress(const git_transfer_progress *stats, void *payload)
+static int progress(const git_indexer_progress *stats, void *payload)
 {
 	size_t *bytes_received = (size_t *)payload;
 	*bytes_received = stats->received_bytes;
@@ -84,15 +84,15 @@ void test_online_fetch__fetch_twice(void)
 	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH, NULL, NULL, NULL));
 	cl_git_pass(git_remote_download(remote, NULL, NULL));
     	git_remote_disconnect(remote);
-    	
+
 	git_remote_connect(remote, GIT_DIRECTION_FETCH, NULL, NULL, NULL);
 	cl_git_pass(git_remote_download(remote, NULL, NULL));
 	git_remote_disconnect(remote);
-	
+
 	git_remote_free(remote);
 }
 
-static int transferProgressCallback(const git_transfer_progress *stats, void *payload)
+static int transferProgressCallback(const git_indexer_progress *stats, void *payload)
 {
 	bool *invoked = (bool *)payload;
 
@@ -134,7 +134,7 @@ void test_online_fetch__doesnt_retrieve_a_pack_when_the_repository_is_up_to_date
 	git_repository_free(_repository);
 }
 
-static int cancel_at_half(const git_transfer_progress *stats, void *payload)
+static int cancel_at_half(const git_indexer_progress *stats, void *payload)
 {
 	GIT_UNUSED(payload);
 

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -98,7 +98,7 @@ static const unsigned int base_obj_len = 2;
 void test_pack_indexer__out_of_order(void)
 {
 	git_indexer *idx = 0;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 
 	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_indexer_append(
@@ -115,7 +115,7 @@ void test_pack_indexer__out_of_order(void)
 void test_pack_indexer__missing_trailer(void)
 {
 	git_indexer *idx = 0;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 
 	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_indexer_append(
@@ -131,7 +131,7 @@ void test_pack_indexer__missing_trailer(void)
 void test_pack_indexer__leaky(void)
 {
 	git_indexer *idx = 0;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 
 	cl_git_pass(git_indexer_new(&idx, ".", 0, NULL, NULL));
 	cl_git_pass(git_indexer_append(
@@ -147,7 +147,7 @@ void test_pack_indexer__leaky(void)
 void test_pack_indexer__fix_thin(void)
 {
 	git_indexer *idx = NULL;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 	git_repository *repo;
 	git_odb *odb;
 	git_oid id, should_id;
@@ -213,7 +213,7 @@ void test_pack_indexer__fix_thin(void)
 void test_pack_indexer__corrupt_length(void)
 {
 	git_indexer *idx = NULL;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 	git_repository *repo;
 	git_odb *odb;
 	git_oid id, should_id;
@@ -243,7 +243,7 @@ void test_pack_indexer__incomplete_pack_fails_with_strict(void)
 {
 	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
 	git_indexer *idx = 0;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 
 	opts.verify = 1;
 
@@ -263,7 +263,7 @@ void test_pack_indexer__out_of_order_with_connectivity_checks(void)
 {
 	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
 	git_indexer *idx = 0;
-	git_transfer_progress stats = { 0 };
+	git_indexer_progress stats = { 0 };
 
 	opts.verify = 1;
 

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -12,7 +12,7 @@ static git_packbuilder *_packbuilder;
 static git_indexer *_indexer;
 static git_vector _commits;
 static int _commits_is_initialized;
-static git_transfer_progress _stats;
+static git_indexer_progress _stats;
 
 extern bool git_disable_pack_keep_file_checks;
 
@@ -88,14 +88,14 @@ static void seed_packbuilder(void)
 
 static int feed_indexer(void *ptr, size_t len, void *payload)
 {
-	git_transfer_progress *stats = (git_transfer_progress *)payload;
+	git_indexer_progress *stats = (git_indexer_progress *)payload;
 
 	return git_indexer_append(_indexer, ptr, len, stats);
 }
 
 void test_pack_packbuilder__create_pack(void)
 {
-	git_transfer_progress stats;
+	git_indexer_progress stats;
 	git_buf buf = GIT_BUF_INIT, path = GIT_BUF_INIT;
 	git_hash_ctx ctx;
 	git_oid hash;


### PR DESCRIPTION
While going through the API, I found it strange that object database functions took a "transfer progress" callback.  In fact, this is a callback for _indexer_ progress that happened to start life as reporting for transfers.

Rename it as such, updating the internal usages and creating a typedef for the old names for backward compatibility.