### PR TITLE
odb: provide a free function for custom backends

### DIFF
--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -30,8 +30,8 @@ struct git_odb_backend {
 
 	/* read and read_prefix each return to libgit2 a buffer which
 	 * will be freed later. The buffer should be allocated using
-	 * the function git_odb_backend_malloc to ensure that it can
-	 * be safely freed later. */
+	 * the function git_odb_backend_data_alloc to ensure that libgit2
+	 * can safely free it later. */
 	int GIT_CALLBACK(read)(
 		void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *);
 
@@ -117,7 +117,40 @@ GIT_EXTERN(int) git_odb_init_backend(
 	git_odb_backend *backend,
 	unsigned int version);
 
+/**
+ * Allocate data for an ODB object.  Custom ODB backends may use this
+ * to provide data back to the ODB from their read function.  This
+ * memory should not be freed once it is returned to libgit2.  If a
+ * custom ODB uses this function but encounters an error and does not
+ * return this data to libgit2, then they should use the corresponding
+ * git_odb_backend_data_free function.
+ *
+ * @param backend the ODB backend that is allocating this memory
+ * @param len the number of bytes to allocate
+ * @return the allocated buffer on success or NULL if out of memory
+ */
+GIT_EXTERN(void *) git_odb_backend_data_alloc(git_odb_backend *backend, size_t len);
+
+
+/*
+ * Users can avoid deprecated functions by defining `GIT_DEPRECATE_HARD`.
+ */
+#ifndef GIT_DEPRECATE_HARD
+
+/**
+ * Allocate memory for an ODB object from a custom backend.  This is
+ * an alias of `git_odb_backend_data_alloc` and is preserved for
+ * backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @deprecated git_odb_backend_data_alloc
+ * @see git_odb_backend_data_alloc
+ */
 GIT_EXTERN(void *) git_odb_backend_malloc(git_odb_backend *backend, size_t len);
+
+#endif
 
 GIT_END_DECL
 

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -131,6 +131,17 @@ GIT_EXTERN(int) git_odb_init_backend(
  */
 GIT_EXTERN(void *) git_odb_backend_data_alloc(git_odb_backend *backend, size_t len);
 
+/**
+ * Frees custom allocated ODB data.  This should only be called when
+ * memory allocated using git_odb_backend_data_alloc is not returned
+ * to libgit2 because the backend encountered an error in the read
+ * function after allocation and did not return this data to libgit2.
+ *
+ * @param backend the ODB backend that is freeing this memory
+ * @param data the buffer to free
+ */
+GIT_EXTERN(void) git_odb_backend_data_free(git_odb_backend *backend, void *data);
+
 
 /*
  * Users can avoid deprecated functions by defining `GIT_DEPRECATE_HARD`.

--- a/src/odb.c
+++ b/src/odb.c
@@ -1508,6 +1508,12 @@ void *git_odb_backend_malloc(git_odb_backend *backend, size_t len)
 	return git_odb_backend_data_alloc(backend, len);
 }
 
+void git_odb_backend_data_free(git_odb_backend *backend, void *data)
+{
+	GIT_UNUSED(backend);
+	git__free(data);
+}
+
 int git_odb_refresh(struct git_odb *db)
 {
 	size_t i;

--- a/src/odb.c
+++ b/src/odb.c
@@ -1497,10 +1497,15 @@ int git_odb_write_pack(struct git_odb_writepack **out, git_odb *db, git_indexer_
 	return error;
 }
 
-void *git_odb_backend_malloc(git_odb_backend *backend, size_t len)
+void *git_odb_backend_data_alloc(git_odb_backend *backend, size_t len)
 {
 	GIT_UNUSED(backend);
 	return git__malloc(len);
+}
+
+void *git_odb_backend_malloc(git_odb_backend *backend, size_t len)
+{
+	return git_odb_backend_data_alloc(backend, len);
 }
 
 int git_odb_refresh(struct git_odb *db)


### PR DESCRIPTION
The `git_odb_backend_malloc` name is a system function that is provided for custom ODB backends and allows them to allocate memory for an ODB object in the read callback.  This is important so that libgit2 can later free the memory used by an ODB object that was read from the custom backend.

(Simply taking data from the backend that _it_ allocated means that we don't know how to free it, we could be using two different allocators if the library was built "normally" and the app in question has an instrumented allocator for debugging then libgit2 could not `free` the data allocated by the custom backend.)

However, if an error occurs in the custom backend after the memory has been allocated for the custom object but before it's returned to libgit2, the custom backend has no way to free that memory and it must be leaked.

Provide a free function that corresponds to the alloc function so that custom backends have an opportunity to free memory before they return an error.

While creating this `free` function and searching for a name for it, I tweaked the name of the allocation function to avoid sounding like we allocated a _backend_ instead of a bit of backend _data_.  I created a proxy for safe deprecation, but kept the definition in `sys/odb_backend.h` to avoid cluttering `deprecated.h` with data about a function that is only included explicitly (by including `sys/odb_backend.h`).