### PR TITLE
ci: use sh not bash

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Environment variables:
 #
@@ -7,7 +7,7 @@
 
 set -e
 
-SOURCE_DIR=${SOURCE_DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && dirname $( pwd ) )}
+SOURCE_DIR=${SOURCE_DIR:-$( cd "$( dirname -- "${BASH_SOURCE[0]:-0}" )" && dirname $( pwd ) )}
 BUILD_DIR=$(pwd)
 CC=${CC:-cc}
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 
@@ -6,7 +6,7 @@ if [ -n "$SKIP_TESTS" ]; then
 	exit 0
 fi
 
-SOURCE_DIR=${SOURCE_DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && dirname $( pwd ) )}
+SOURCE_DIR=${SOURCE_DIR:-$( cd "$( dirname -- "${BASH_SOURCE[0]:-0}" )" && dirname $( pwd ) )}
 BUILD_DIR=$(pwd)
 TMPDIR=${TMPDIR:-/tmp}
 USER=${USER:-$(whoami)}


### PR DESCRIPTION
There's nothing bash-y about our build and test scripts.  Use sh instead
of bash for bash-deprived systems like FreeBSD.