### PR TITLE
Optimize string comparisons

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -204,13 +204,6 @@ int git__strntol32(int32_t *result, const char *nptr, size_t nptr_len, const cha
 	return error;
 }
 
-int git__strcmp(const char *a, const char *b)
-{
-	while (*a && *b && *a == *b)
-		++a, ++b;
-	return (int)(*(const unsigned char *)a) - (int)(*(const unsigned char *)b);
-}
-
 int git__strcasecmp(const char *a, const char *b)
 {
 	while (*a && *b && git__tolower(*a) == git__tolower(*b))
@@ -238,15 +231,6 @@ int git__strcasesort_cmp(const char *a, const char *b)
 		return (unsigned char)git__tolower(*a) - (unsigned char)git__tolower(*b);
 
 	return cmp;
-}
-
-int git__strncmp(const char *a, const char *b, size_t sz)
-{
-	while (sz && *a && *b && *a == *b)
-		--sz, ++a, ++b;
-	if (!sz)
-		return 0;
-	return (int)(*(const unsigned char *)a) - (int)(*(const unsigned char *)b);
 }
 
 int git__strncasecmp(const char *a, const char *b, size_t sz)
@@ -301,7 +285,18 @@ GIT_INLINE(int) prefixcmp(const char *str, size_t str_n, const char *prefix, boo
 
 int git__prefixcmp(const char *str, const char *prefix)
 {
-	return prefixcmp(str, SIZE_MAX, prefix, false);
+	unsigned char s, p;
+
+	while (1) {
+		p = *prefix++;
+		s = *str++;
+
+		if (!p)
+			return 0;
+
+		if (s != p)
+			return s - p;
+	}
 }
 
 int git__prefixncmp(const char *str, size_t str_n, const char *prefix)

--- a/src/util.h
+++ b/src/util.h
@@ -150,12 +150,13 @@ extern int git__bsearch_r(
 	void *payload,
 	size_t *position);
 
+#define git__strcmp strcmp
+#define git__strncmp strncmp
+
 extern int git__strcmp_cb(const void *a, const void *b);
 extern int git__strcasecmp_cb(const void *a, const void *b);
 
-extern int git__strcmp(const char *a, const char *b);
 extern int git__strcasecmp(const char *a, const char *b);
-extern int git__strncmp(const char *a, const char *b, size_t sz);
 extern int git__strncasecmp(const char *a, const char *b, size_t sz);
 
 extern int git__strcasesort_cmp(const char *a, const char *b);


### PR DESCRIPTION
See https://github.com/libgit2/libgit2/issues/4230#issuecomment-471710359 for context. This is diff optimization PR 1/3. The smallest of the three both in terms of code delta and impact.

Three hand-rolled string comparison functions -- git__prefixcmp, git__strcmp and git__strncmp -- are showing up on the CPU profile when scanning working directory of chromium repository on Linux. This PR optimizes git__prefixcmp and replaces the other two functions with standard equivalents (unless `GIT_WIN32` is defined).

Test:

```zsh
cd ~/libgit2
mkdir build
cd build
cmake \
  -DUSE_ICONV=OFF           \
  -DBUILD_CLAR=ON           \
  -DUSE_SSH=OFF             \
  -DUSE_HTTPS=OFF           \
  -DTHREADSAFE=OFF          \
  -DBUILD_SHARED_LIBS=OFF   \
  -DUSE_EXT_HTTP_PARSER=OFF \
  -DUSE_BUNDLED_ZLIB=ON     \
  -DBUILD_EXAMPLES=ON       \
  -DCMAKE_BUILD_TYPE=Release ..
make -j 20
./libgit2_clar
```

Benchmark:

```zsh
git clone https://github.com/chromium/chromium.git ~/chromium
cd ~/chromium
~/libgit2/build/examples/lg2 status >/dev/null &&
  time (repeat 100; do ~/libgit2/build/examples/lg2 status >/dev/null; done)
```

  * Baseline: 112.11s user 62.75s system 99% cpu 2:55.15 total
  * With this PR: 104.80s user 62.93s system 99% cpu 2:47.96 total

A modest 4% improvement. Working directory traversal increases more than that. The benchmark spends a lot of time doing other things, so the apparent impact of the PR is diluted.

Note:

  * Built and tested only on Ubuntu 18.04 with gcc 8.2. I didn't even attempt to compile on Windows.
  * Benchmarked only on chromium repository on a single machine running Ubuntu 18.04.
