### PR TITLE
Direct path negation of files under ignored directories are ignored

### DIFF
--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -1213,3 +1213,21 @@ void test_status_ignore__unignored_subdirs(void)
 	assert_is_ignored("dir/a.test");
 	refute_is_ignored("dir/subdir/a.test");
 }
+
+void test_status_ignore__unignored_subdirfiles(void)
+{
+	static const char *test_files[] = {
+		"empty_standard_repo/dir/a.test",
+		"empty_standard_repo/dir/subdir/a.test",
+		NULL
+	};
+
+	make_test_data("empty_standard_repo", test_files);
+	cl_git_mkfile(
+		"empty_standard_repo/.gitignore",
+		"dir/\n"
+		"!dir/subdir/a.test\n");
+
+	assert_is_ignored("dir/a.test");
+	refute_is_ignored("dir/subdir/a.test");
+}


### PR DESCRIPTION
.gitignore seems to break in odd ways with negation patterns. Currently, I know for sure that this pattern is good:
```
dir/
!dir/subdir/*
```
Where `dir/*` is ignored, but `dir/subdir/specific-file.test` is not ignored.

However this pattern is bad:
```
dir/
!dir/subdir/specific-file.test
```
`dir/subdir/specific-file.test` is ignored, even though it's very explicitly not ignored.

This may be related to https://github.com/libgit2/libgit2/issues/4963.