### PR TITLE
xdiff: fix typo

### DIFF
--- a/src/xdiff/xdiffi.c
+++ b/src/xdiff/xdiffi.c
@@ -36,7 +36,7 @@
 #elif defined(__GNUC__)
 # define XDL_INLINE(type) static __inline__ type
 #else
-#define XDG_INLINE(type) static type
+# define XDL_INLINE(type) static type
 #endif
 
 typedef struct s_xdpsplit {


### PR DESCRIPTION
Fixes a typo that was introduced in f347a441c81c4e16dd54de07c5070eca8fccd5c8

I found this when the R bindings [git2r](https://github.com/ropensci/git2r) (bundles libgit2) failed to build on Solaris using Oracle Developer Studio 12.6.
