### PR TITLE
Include implicitly used header

### DIFF
--- a/examples/blame.c
+++ b/examples/blame.c
@@ -12,6 +12,7 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
+#include <strings.h>
 #include "common.h"
 
 #ifdef _MSC_VER


### PR DESCRIPTION
When compiling under `clang -std=c11` the following warning is triggered:

```
blame.c:170:13: warning: implicit declaration of function 'strcasecmp' is invalid in C99 [-Wimplicit-function-declaration]
                else if (!strcasecmp(a, "-M"))
                          ^
1 warning generated.
```

Including the header solves the problem.