### PR TITLE
Each hash implementation should define `git_hash_global_init`

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -31,8 +31,6 @@ void git_hash_ctx_cleanup(git_hash_ctx *ctx);
 # include "hash/hash_generic.h"
 #endif
 
-int git_hash_global_init(void);
-
 typedef struct {
 	void *data;
 	size_t len;

--- a/src/hash/hash_win32.c
+++ b/src/hash/hash_win32.c
@@ -109,21 +109,6 @@ static void git_hash_global_shutdown(void)
 		hash_cryptoapi_prov_shutdown();
 }
 
-int git_hash_global_init(void)
-{
-	int error = 0;
-
-	if (hash_prov.type != INVALID)
-		return 0;
-
-	if ((error = hash_cng_prov_init()) < 0)
-		error = hash_cryptoapi_prov_init();
-
-	git__on_shutdown(git_hash_global_shutdown);
-
-	return error;
-}
-
 /* CryptoAPI: available in Windows XP and newer */
 
 GIT_INLINE(int) hash_ctx_cryptoapi_init(git_hash_ctx *ctx)

--- a/src/hash/hash_win32.h
+++ b/src/hash/hash_win32.h
@@ -138,4 +138,19 @@ struct git_hash_ctx {
 	} ctx;
 };
 
+GIT_INLINE(int) git_hash_global_init(void)
+{
+	int error = 0;
+
+	if (hash_prov.type != INVALID)
+		return 0;
+
+	if ((error = hash_cng_prov_init()) < 0)
+		error = hash_cryptoapi_prov_init();
+
+	git__on_shutdown(git_hash_global_shutdown);
+
+	return error;
+}
+
 #endif


### PR DESCRIPTION
This means the forward declaration isn't necessary.  The forward
declaration can cause compilation errors as it conflicts with the
`GIT_INLINE` declaration (the signatures are different).

/cc @rafeca 