### PR TITLE
patch_parse.c: Handle CRLF in parse_header_start

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -328,7 +328,8 @@ static int parse_header_start(git_patch_parsed *patch, git_patch_parse_ctx *ctx)
 	 * proceeed here. We then hope for the "---" and "+++" lines to fix that
 	 * for us.
 	 */
-	if (!git_parse_ctx_contains(&ctx->parse_ctx, "\n", 1)) {
+	if (!git_parse_ctx_contains(&ctx->parse_ctx, "\n", 1) &&
+	    !git_parse_ctx_contains(&ctx->parse_ctx, "\r\n", 2)) {
 		git_parse_advance_chars(&ctx->parse_ctx, ctx->parse_ctx.line_len - 1);
 
 		git__free(patch->header_old_path);

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -360,6 +360,7 @@ void test_diff_parse__lineinfo(void)
 	git_diff_free(diff);
 }
 
+
 void test_diff_parse__new_file_with_space(void)
 {
 	const char *content = PATCH_ORIGINAL_NEW_FILE_WITH_SPACE;
@@ -373,6 +374,24 @@ void test_diff_parse__new_file_with_space(void)
 	cl_assert_equal_p(patch->delta->old_file.path, NULL);
 	cl_assert_equal_s(patch->diff_opts.new_prefix, "b/");
 	cl_assert_equal_s(patch->delta->new_file.path, "sp ace.txt");
+
+	git_patch_free(patch);
+	git_diff_free(diff);
+}
+
+void test_diff_parse__crlf(void)
+{
+	const char *text = PATCH_CRLF;
+	git_diff *diff;
+	git_patch *patch;
+	const git_diff_delta *delta;
+
+	cl_git_pass(git_diff_from_buffer(&diff, text, strlen(text)));
+	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
+	delta = git_patch_get_delta(patch);
+
+	cl_assert_equal_s(delta->old_file.path, "test-file");
+	cl_assert_equal_s(delta->new_file.path, "test-file");
 
 	git_patch_free(patch);
 	git_diff_free(diff);

--- a/tests/patch/patch_common.h
+++ b/tests/patch/patch_common.h
@@ -850,3 +850,12 @@
 	"+++ b/sp ace.txt\n" \
 	"@@ -0,0 +1 @@\n" \
 	"+a\n"
+
+#define PATCH_CRLF \
+	"diff --git a/test-file b/test-file\r\n" \
+	"new file mode 100644\r\n" \
+	"index 0000000..af431f2 100644\r\n" \
+	"--- /dev/null\r\n" \
+	"+++ b/test-file\r\n" \
+	"@@ -0,0 +1 @@\r\n" \
+	"+a contents\r\n"


### PR DESCRIPTION
This becomes a segfault later (in `check_prefix`) when parsing patches where a file was added. CRLF seems to be handled fine otherwise. Added test which demonstrates the segfault.

Supporting CRLF is important because patches are often emailed - and emails use CRLF.