### PR TITLE
sha1: don't inline `git_hash_global_init` for win32

### DIFF
--- a/src/hash/hash_win32.c
+++ b/src/hash/hash_win32.c
@@ -109,6 +109,21 @@ static void git_hash_global_shutdown(void)
 		hash_cryptoapi_prov_shutdown();
 }
 
+int git_hash_global_init(void)
+{
+	int error = 0;
+
+	if (hash_prov.type != INVALID)
+		return 0;
+
+	if ((error = hash_cng_prov_init()) < 0)
+		error = hash_cryptoapi_prov_init();
+
+	git__on_shutdown(git_hash_global_shutdown);
+
+	return error;
+}
+
 /* CryptoAPI: available in Windows XP and newer */
 
 GIT_INLINE(int) hash_ctx_cryptoapi_init(git_hash_ctx *ctx)

--- a/src/hash/hash_win32.h
+++ b/src/hash/hash_win32.h
@@ -138,19 +138,6 @@ struct git_hash_ctx {
 	} ctx;
 };
 
-GIT_INLINE(int) git_hash_global_init(void)
-{
-	int error = 0;
-
-	if (hash_prov.type != INVALID)
-		return 0;
-
-	if ((error = hash_cng_prov_init()) < 0)
-		error = hash_cryptoapi_prov_init();
-
-	git__on_shutdown(git_hash_global_shutdown);
-
-	return error;
-}
+extern int git_hash_global_init(void);
 
 #endif


### PR DESCRIPTION
Users of the Win32 hash cannot be inlined, as it uses a static struct.
Don't inline it, but continue to declare the function in the header.

/cc @csware 