### PR TITLE
git_repository_init: stop traversing at windows root

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -489,10 +489,13 @@ int git_futils_mkdir(
 
 		assert(len);
 
-		/* we've walked all the given path's parents and it's either relative
-		 * or rooted.  either way, give up and make the entire path.
+		/*
+		 * We've walked all the given path's parents and it's either relative
+		 * (the parent is simply '.') or rooted (the length is less than or
+		 * equal to length of the root path).  The path may be less than the
+		 * root path length on Windows, where `C:` == `C:/`.
 		 */
-		if ((len == 1 && parent_path.ptr[0] == '.') || len == root_len+1) {
+		if ((len == 1 && parent_path.ptr[0] == '.') || len <= root_len) {
 			relative = make_path.ptr;
 			break;
 		}

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -877,3 +877,15 @@ void test_repo_init__at_filesystem_root(void)
 	git_buf_dispose(&root);
 	git_repository_free(repo);
 }
+
+void test_repo_init__nonexistent_paths(void)
+{
+	git_repository *repo;
+
+#ifdef GIT_WIN32
+	cl_git_fail(git_repository_init(&repo, "Q:/non/existent/path", 0));
+	cl_git_fail(git_repository_init(&repo, "Q:\\non\\existent\\path", 0));
+#else
+	cl_git_fail(git_repository_init(&repo, "/non/existent/path", 0));
+#endif
+}


### PR DESCRIPTION
Stop traversing the filesystem at the Windows directory root.  We were calculating the filesystem root for the given directory to create, and walking up the filesystem hierarchy.  We intended to stop when the traversal path length is equal to the root path length (ie, stopping at the root, since no path may be shorter than the root path).

However, on Windows, the root path may be specified in two different ways, as either `Z:` or `Z:\`, where `Z:` is the current drive letter. `git_path_dirname_r` returns the path _without_ a trailing slash, even for the Windows root.  As a result, during traversal, we need to test that the traversal path is _less than or equal to_ the root path length to determine if we've hit the root to ensure that we stop when our traversal path is `Z:` and our calculated root path was `Z:\`.

Without this change, when we're traversing through a nonexistent directory (eg, `Z:\nonexistent`), we will never detect the filesystem root (`Z:` != `Z:\`) and loop infinitely.

Fixes #5013.