### PR TITLE
config_file: check result of git_array_alloc

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -678,6 +678,7 @@ static int parse_include(git_config_parser *reader,
 		return result;
 
 	include = git_array_alloc(reader->file->includes);
+	GIT_ERROR_CHECK_ALLOC(include);
 	memset(include, 0, sizeof(*include));
 	git_array_init(include->includes);
 	include->path = git_buf_detach(&path);


### PR DESCRIPTION
`git_array_alloc` can return `NULL` if no memory is available, causing a segmentation fault in memset. This adds `GIT_ERROR_CHECK_ALLOC` similar to how other parts of the code base deal with the return value of `git_array_alloc`.

This is my first contribution to libgit2, please let me know if I made a mistake.