### PR TITLE
remote: add callback to resolve URLs before connecting

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -478,7 +478,7 @@ typedef int GIT_CALLBACK(git_push_update_reference_cb)(const char *refname, cons
  * Callback to resolve URLs before connecting to remote
  *
  * @param url_resolved The buffer to write the resolved URL to.
- *                     If GIT_PASSTHROUGH is returned, it is not required to write to the buffer.
+ *                     If GIT_PASSTHROUGH is returned, writing to the buffer it is not required.
  * @param url The URL to resolve
  * @param direction GIT_DIRECTION_FETCH or GIT_DIRECTION_PUSH
  * @param payload The callback payload

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -477,14 +477,14 @@ typedef int GIT_CALLBACK(git_push_update_reference_cb)(const char *refname, cons
 /**
  * Callback to resolve URLs before connecting to remote
  *
- * @param url_resolved The resolved URL. The URL is freed by the caller.
- *                     If GIT_PASSTHROUGH is returned `url_resolved` should not be allocated.
+ * @param url_resolved The buffer to write the resolved URL to.
+ *                     If GIT_PASSTHROUGH is returned, it is not required to write to the buffer.
  * @param url The URL to resolve
  * @param direction GIT_DIRECTION_FETCH or GIT_DIRECTION_PUSH
  * @param payload The callback payload
  * @return 0 on success, GIT_PASSTHROUGH or an error
  */
-typedef int GIT_CALLBACK(git_resolve_url_cb)(char **url_resolved, const char *url, int direction, void *payload);
+typedef int GIT_CALLBACK(git_resolve_url_cb)(git_buf *url_resolved, const char *url, int direction, void *payload);
 
 /**
  * The callback settings structure

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -475,6 +475,17 @@ typedef int GIT_CALLBACK(git_push_negotiation)(const git_push_update **updates, 
 typedef int GIT_CALLBACK(git_push_update_reference_cb)(const char *refname, const char *status, void *data);
 
 /**
+ * Callback to resolve URLs before connecting to remote
+ *
+ * @param url The URL to resolve
+ * @param url_resolved The resolved URL
+ * @param direction GIT_DIRECTION_FETCH or GIT_DIRECTION_PUSH
+ * @param payload The callback payload
+ * @return 0 on success, otherwise an error
+ */
+typedef int GIT_CALLBACK(git_resolve_url_cb)(const char *url, char **url_resolved, int direction, void *payload);
+
+/**
  * The callback settings structure
  *
  * Set the callbacks to be called by the remote when informing the user
@@ -494,6 +505,12 @@ struct git_remote_callbacks {
 	 * process are done (currently unused).
 	 */
 	int GIT_CALLBACK(completion)(git_remote_completion_t type, void *data);
+
+	/**
+	 * Resolve URL before connecting to remote.
+	 * The returned URL will be used to connect to the remote instead.
+	 */
+	git_resolve_url_cb resolve_url;
 
 	/**
 	 * This will be called if the remote host requires

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -477,13 +477,14 @@ typedef int GIT_CALLBACK(git_push_update_reference_cb)(const char *refname, cons
 /**
  * Callback to resolve URLs before connecting to remote
  *
+ * @param url_resolved The resolved URL. The URL is freed by the caller.
+ *                     If GIT_PASSTHROUGH is returned `url_resolved` should not be allocated.
  * @param url The URL to resolve
- * @param url_resolved The resolved URL
  * @param direction GIT_DIRECTION_FETCH or GIT_DIRECTION_PUSH
  * @param payload The callback payload
- * @return 0 on success, otherwise an error
+ * @return 0 on success, GIT_PASSTHROUGH or an error
  */
-typedef int GIT_CALLBACK(git_resolve_url_cb)(const char *url, char **url_resolved, int direction, void *payload);
+typedef int GIT_CALLBACK(git_resolve_url_cb)(char **url_resolved, const char *url, int direction, void *payload);
 
 /**
  * The callback settings structure

--- a/src/remote.c
+++ b/src/remote.c
@@ -686,7 +686,7 @@ static int git_remote__urlresolve(char **resolved_url, const char *url, int dire
 	*resolved_url = git__strdup(url);
 	GIT_ERROR_CHECK_ALLOC(*resolved_url);
 
-	return GIT_OK;
+	return 0;
 }
 
 int git_remote__urlfordirection(char **url_out, struct git_remote *remote, int direction, const git_remote_callbacks *callbacks)

--- a/src/remote.c
+++ b/src/remote.c
@@ -674,6 +674,8 @@ static int git_remote__urlresolve(git_buf *resolved_url, const char *url, int di
 {
 	int status;
 
+	git_buf_clear(resolved_url);
+
 	if (!url)
 		return -1;
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -683,8 +683,7 @@ static int git_remote__urlresolve(char **resolved_url, const char *url, int dire
 			return status;
 	}
 
-	*resolved_url = url ? git__strdup(url) : NULL;
-
+	*resolved_url = git__strdup(url);
 	GIT_ERROR_CHECK_ALLOC(*resolved_url);
 
 	return GIT_OK;

--- a/src/remote.c
+++ b/src/remote.c
@@ -685,9 +685,7 @@ static int git_remote__urlresolve(git_buf *resolved_url, const char *url, int di
 			return status;
 	}
 
-	/* clear again in case user wrote to it */
-	git_buf_clear(resolved_url);
-	git_buf_puts(resolved_url, url);
+	git_buf_sets(resolved_url, url);
 
 	return 0;
 }

--- a/src/remote.c
+++ b/src/remote.c
@@ -685,6 +685,7 @@ static int git_remote__urlresolve(git_buf *resolved_url, const char *url, int di
 			return status;
 	}
 
+	/* clear again in case user wrote to it */
 	git_buf_clear(resolved_url);
 	git_buf_puts(resolved_url, url);
 

--- a/src/remote.h
+++ b/src/remote.h
@@ -45,7 +45,7 @@ typedef struct git_remote_connection_opts {
 
 int git_remote__connect(git_remote *remote, git_direction direction, const git_remote_callbacks *callbacks, const git_remote_connection_opts *conn);
 
-const char* git_remote__urlfordirection(struct git_remote *remote, int direction);
+int git_remote__urlfordirection(struct git_remote *remote, int direction, const git_remote_callbacks *callbacks, char **url_out);
 int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_url);
 
 git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refname);

--- a/src/remote.h
+++ b/src/remote.h
@@ -45,7 +45,7 @@ typedef struct git_remote_connection_opts {
 
 int git_remote__connect(git_remote *remote, git_direction direction, const git_remote_callbacks *callbacks, const git_remote_connection_opts *conn);
 
-int git_remote__urlfordirection(struct git_remote *remote, int direction, const git_remote_callbacks *callbacks, char **url_out);
+int git_remote__urlfordirection(char **url_out, struct git_remote *remote, int direction, const git_remote_callbacks *callbacks);
 int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_url);
 
 git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refname);

--- a/src/remote.h
+++ b/src/remote.h
@@ -45,7 +45,7 @@ typedef struct git_remote_connection_opts {
 
 int git_remote__connect(git_remote *remote, git_direction direction, const git_remote_callbacks *callbacks, const git_remote_connection_opts *conn);
 
-int git_remote__urlfordirection(char **url_out, struct git_remote *remote, int direction, const git_remote_callbacks *callbacks);
+int git_remote__urlfordirection(git_buf *url_out, struct git_remote *remote, int direction, const git_remote_callbacks *callbacks);
 int git_remote__get_http_proxy(git_remote *remote, bool use_ssl, char **proxy_url);
 
 git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refname);

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -58,14 +58,14 @@ void test_network_remote_remotes__parsing(void)
 
 static int urlresolve_callback(git_buf *url_resolved, const char *url, int direction, void *payload)
 {
-	const char *url_out;
-
 	cl_assert(strcmp(url, "git://github.com/libgit2/libgit2") == 0);
 	cl_assert(strcmp(payload, "payload") == 0);
+	cl_assert(url_resolved->size == 0);
 
-	url_out = (direction == GIT_DIRECTION_PUSH) ? "pushresolve" : "fetchresolve";
-
-	git_buf_puts(url_resolved, url_out);
+	if (direction == GIT_DIRECTION_PUSH)
+		git_buf_sets(url_resolved, "pushresolve");
+	if (direction == GIT_DIRECTION_FETCH)
+		git_buf_sets(url_resolved, "fetchresolve");
 
 	return GIT_OK;
 }
@@ -83,10 +83,10 @@ void test_network_remote_remotes__urlresolve(void)
 	cl_assert(git_remote_pushurl(_remote) == NULL);
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote, GIT_DIRECTION_FETCH, &callbacks));
-	cl_assert_equal_s(url, "fetchresolve");
+	cl_assert_equal_s(url.ptr, "fetchresolve");
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote, GIT_DIRECTION_PUSH, &callbacks));
-	cl_assert_equal_s(url, "pushresolve");
+	cl_assert_equal_s(url.ptr, "pushresolve");
 
 	git_buf_dispose(&url);
 }
@@ -113,10 +113,10 @@ void test_network_remote_remotes__urlresolve_passthrough(void)
 	cl_assert(git_remote_pushurl(_remote) == NULL);
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote, GIT_DIRECTION_FETCH, &callbacks));
-	cl_assert_equal_s(url, orig_url);
+	cl_assert_equal_s(url.ptr, orig_url);
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote, GIT_DIRECTION_PUSH, &callbacks));
-	cl_assert_equal_s(url, orig_url);
+	cl_assert_equal_s(url.ptr, orig_url);
 
 	git_buf_dispose(&url);
 }

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -102,10 +102,10 @@ void test_network_remote_remotes__urlresolve(void)
 
 static int test_network_remote_remotes__urlresolve_passthrough_callback(char **url_resolved, const char *url, int direction, void *payload)
 {
-	#pragma unused(url_resolved)
-	#pragma unused(url)
-	#pragma unused(direction)
-	#pragma unused(payload)
+	GIT_UNUSED(url_resolved);
+	GIT_UNUSED(url);
+	GIT_UNUSED(direction);
+	GIT_UNUSED(payload);
 	return GIT_PASSTHROUGH;
 }
 

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -67,12 +67,12 @@ static int urlresolve_callback(char **url_resolved, const char *url, int directi
 {
 	const char *url_out;
 
-	cl_assert(git__strcmp(url, "git://github.com/libgit2/libgit2") == 0);
-	cl_assert(git__strcmp(payload, "payload") == 0);
+	cl_assert(strcmp(url, "git://github.com/libgit2/libgit2") == 0);
+	cl_assert(strcmp(payload, "payload") == 0);
 
 	url_out = (direction == GIT_DIRECTION_PUSH) ? "pushresolve" : "fetchresolve";
 
-	*url_resolved = git__strdup(url_out);
+	*url_resolved = strdup(url_out);
 
 	return GIT_OK;
 }

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -63,7 +63,7 @@ void test_network_remote_remotes__parsing(void)
 	git_remote_free(_remote2);
 }
 
-static int test_network_remote_remotes__urlresolve_callback(char **url_resolved, const char *url, int direction, void *payload)
+static int urlresolve_callback(char **url_resolved, const char *url, int direction, void *payload)
 {
 	const char *url_out;
 
@@ -82,7 +82,7 @@ void test_network_remote_remotes__urlresolve(void)
 	char *url = NULL;
 
 	git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
-	callbacks.resolve_url = test_network_remote_remotes__urlresolve_callback;
+	callbacks.resolve_url = urlresolve_callback;
 	callbacks.payload = "payload";
 
 	cl_assert_equal_s(git_remote_name(_remote), "test");
@@ -100,7 +100,7 @@ void test_network_remote_remotes__urlresolve(void)
 	free(url);
 }
 
-static int test_network_remote_remotes__urlresolve_passthrough_callback(char **url_resolved, const char *url, int direction, void *payload)
+static int urlresolve_passthrough_callback(char **url_resolved, const char *url, int direction, void *payload)
 {
 	GIT_UNUSED(url_resolved);
 	GIT_UNUSED(url);
@@ -115,7 +115,7 @@ void test_network_remote_remotes__urlresolve_passthrough(void)
 	const char *orig_url = "git://github.com/libgit2/libgit2";
 
 	git_remote_callbacks callbacks = GIT_REMOTE_CALLBACKS_INIT;
-	callbacks.resolve_url = test_network_remote_remotes__urlresolve_passthrough_callback;
+	callbacks.resolve_url = urlresolve_passthrough_callback;
 
 	cl_assert_equal_s(git_remote_name(_remote), "test");
 	cl_assert_equal_s(git_remote_url(_remote), orig_url);

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -36,10 +36,10 @@ void test_network_remote_remotes__parsing(void)
 	cl_assert(git_remote_pushurl(_remote) == NULL);
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote, GIT_DIRECTION_FETCH, NULL));
-	cl_assert_equal_s(url, "git://github.com/libgit2/libgit2");
+	cl_assert_equal_s(url.ptr, "git://github.com/libgit2/libgit2");
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote, GIT_DIRECTION_PUSH, NULL));
-	cl_assert_equal_s(url, "git://github.com/libgit2/libgit2");
+	cl_assert_equal_s(url.ptr, "git://github.com/libgit2/libgit2");
 
 	cl_git_pass(git_remote_lookup(&_remote2, _repo, "test_with_pushurl"));
 	cl_assert_equal_s(git_remote_name(_remote2), "test_with_pushurl");
@@ -47,10 +47,10 @@ void test_network_remote_remotes__parsing(void)
 	cl_assert_equal_s(git_remote_pushurl(_remote2), "git://github.com/libgit2/pushlibgit2");
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote2, GIT_DIRECTION_FETCH, NULL));
-	cl_assert_equal_s(url, "git://github.com/libgit2/fetchlibgit2");
+	cl_assert_equal_s(url.ptr, "git://github.com/libgit2/fetchlibgit2");
 
 	cl_git_pass(git_remote__urlfordirection(&url, _remote2, GIT_DIRECTION_PUSH, NULL));
-	cl_assert_equal_s(url, "git://github.com/libgit2/pushlibgit2");
+	cl_assert_equal_s(url.ptr, "git://github.com/libgit2/pushlibgit2");
 
 	git_remote_free(_remote2);
 	git_buf_dispose(&url);

--- a/tests/online/push_util.h
+++ b/tests/online/push_util.h
@@ -12,7 +12,7 @@ extern const git_oid OID_ZERO;
  * @param data pointer to a record_callbacks_data instance
  */
 #define RECORD_CALLBACKS_INIT(data) \
-	{ GIT_REMOTE_CALLBACKS_VERSION, NULL, NULL, cred_acquire_cb, NULL, NULL, record_update_tips_cb, NULL, NULL, NULL, NULL, NULL, data }
+	{ GIT_REMOTE_CALLBACKS_VERSION, NULL, NULL, NULL, cred_acquire_cb, NULL, NULL, record_update_tips_cb, NULL, NULL, NULL, NULL, NULL, data }
 
 typedef struct {
 	char *name;


### PR DESCRIPTION
I tried to move the original PR to another branch on my fork, and Github auto-closed my PR.
This is a new one replacing #5028.
Sorry for the dupe.

----------

Since libssh2 doesn't read host configuration from the config file,
this callback can be used to hand over URL resolving to the client
without touching the SSH implementation itself.

Example:

Remote `origin` has URL

    ssh://myhost/~/repo.git

This would obviously fail with the current libgit2 implementation,
given the following SSH config:

    Host myhost
        User gituser
        HostName my.very.long.host.with.subdomain
        Port 1234

The URL callback allows this to be rewritten to e.g.

    gituser@my.very.long.host.with.subdomain:1234/~/repo.git

by the client without much hassle.