### PR TITLE
rebase: orig_head and onto accessors

### DIFF
--- a/include/git2/rebase.h
+++ b/include/git2/rebase.h
@@ -200,6 +200,34 @@ GIT_EXTERN(int) git_rebase_open(
 	const git_rebase_options *opts);
 
 /**
+ * Gets the original `HEAD` ref name for merge rebases.
+ *
+ * @return The original `HEAD` ref name
+ */
+GIT_EXTERN(const char *) git_rebase_orig_head_name(git_rebase *rebase);
+
+/**
+ * Gets the original `HEAD` id for merge rebases.
+ *
+ * @return The original `HEAD` id
+ */
+GIT_EXTERN(const git_oid *) git_rebase_orig_head_id(git_rebase *rebase);
+
+/**
+ * Gets the `onto` ref name for merge rebases.
+ *
+ * @return The `onto` ref name
+ */
+GIT_EXTERN(const char *) git_rebase_onto_name(git_rebase *rebase);
+
+/**
+ * Gets the `onto` id for merge rebases.
+ *
+ * @return The `onto` id
+ */
+GIT_EXTERN(const git_oid *) git_rebase_onto_id(git_rebase *rebase);
+
+/**
  * Gets the count of rebase operations that are to be applied.
  *
  * @param rebase The in-progress rebase

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -1327,6 +1327,22 @@ int git_rebase_finish(
 	return error;
 }
 
+const char *git_rebase_orig_head_name(git_rebase *rebase) {
+	return rebase->orig_head_name;
+}
+
+const git_oid *git_rebase_orig_head_id(git_rebase *rebase) {
+	return &rebase->orig_head_id;
+}
+
+const char *git_rebase_onto_name(git_rebase *rebase) {
+	return rebase->onto_name;
+}
+
+const git_oid *git_rebase_onto_id(git_rebase *rebase) {
+	return &rebase->onto_id;
+}
+
 size_t git_rebase_operation_entrycount(git_rebase *rebase)
 {
 	assert(rebase);

--- a/tests/rebase/merge.c
+++ b/tests/rebase/merge.c
@@ -44,6 +44,10 @@ void test_rebase_merge__next(void)
 	git_status_list *status_list;
 	const git_status_entry *status_entry;
 	git_oid pick_id, file1_id;
+	git_oid master_id, beef_id;
+
+	git_oid_fromstr(&master_id, "efad0b11c47cb2f0220cbd6f5b0f93bb99064b00");
+	git_oid_fromstr(&beef_id, "b146bd7608eac53d9bf9e1a6963543588b555c64");
 
 	cl_git_pass(git_reference_lookup(&branch_ref, repo, "refs/heads/beef"));
 	cl_git_pass(git_reference_lookup(&upstream_ref, repo, "refs/heads/master"));
@@ -52,6 +56,12 @@ void test_rebase_merge__next(void)
 	cl_git_pass(git_annotated_commit_from_ref(&upstream_head, repo, upstream_ref));
 
 	cl_git_pass(git_rebase_init(&rebase, repo, branch_head, upstream_head, NULL, NULL));
+
+	cl_assert_equal_s("refs/heads/beef", git_rebase_orig_head_name(rebase));
+	cl_assert_equal_oid(&beef_id, git_rebase_orig_head_id(rebase));
+
+	cl_assert_equal_s("master", git_rebase_onto_name(rebase));
+	cl_assert_equal_oid(&master_id, git_rebase_onto_id(rebase));
 
 	cl_git_pass(git_rebase_next(&rebase_operation, rebase));
 


### PR DESCRIPTION
The rebase struct stores fields with information about the current
rebase process, which were not accessible via a public interface.

Accessors for getting the `orig_head` and `onto` branch
names and object ids have been added.