### PR TITLE
Loosen restriction on wildcard "*" refspecs

### DIFF
--- a/src/refspec.c
+++ b/src/refspec.c
@@ -228,7 +228,6 @@ static int refspec_transform(
 	git_buf *out, const char *from, const char *to, const char *name)
 {
 	const char *from_star, *to_star;
-	const char *name_slash, *from_slash;
 	size_t replacement_len, star_offset;
 
 	git_buf_sanitize(out);
@@ -251,17 +250,11 @@ static int refspec_transform(
 	/* the first half is copied over */
 	git_buf_put(out, to, to_star - to);
 
-	/* then we copy over the replacement, from the star's offset to the next slash in 'name' */
-	name_slash = strchr(name + star_offset, '/');
-	if (!name_slash)
-		name_slash = strrchr(name, '\0');
-
-	/* if there is no slash after the star in 'from', we want to copy everything over */
-	from_slash = strchr(from + star_offset, '/');
-	if (!from_slash)
-		name_slash = strrchr(name, '\0');
-
-	replacement_len = (name_slash - name) - star_offset;
+	/*
+	 * Copy over the name, but exclude the trailing part in "from" starting
+	 * after the glob
+	 */
+	replacement_len = strlen(name + star_offset) - strlen(from_star + 1);
 	git_buf_put(out, name + star_offset, replacement_len);
 
 	return git_buf_puts(out, to_star + 1);

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -120,6 +120,11 @@ void test_network_refspecs__transform_loosened_star(void)
 	assert_valid_transform("refs/heads/branch-*/head:refs/remotes/origin/branch-*/head", "refs/heads/branch-a/head", "refs/remotes/origin/branch-a/head");
 }
 
+void test_network_refspecs__transform_nested_star(void)
+{
+	assert_valid_transform("refs/heads/x*x/for-linus:refs/remotes/mine/*", "refs/heads/xbranchx/for-linus", "refs/remotes/mine/branch");
+}
+
 void test_network_refspecs__no_dst(void)
 {
 	assert_valid_transform("refs/heads/master:", "refs/heads/master", "");

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -70,14 +70,17 @@ void test_network_refspecs__parsing(void)
 	assert_refspec(GIT_DIRECTION_PUSH, ":refs/remotes/frotz/delete me", false);
 	assert_refspec(GIT_DIRECTION_FETCH, ":refs/remotes/frotz/HEAD to me", false);
 
-	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads/*/for-linus:refs/remotes/mine/*-blah", false);
-	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads/*/for-linus:refs/remotes/mine/*-blah", false);
+	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads/*/for-linus:refs/remotes/mine/*-blah", true);
+	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads/*/for-linus:refs/remotes/mine/*-blah", true);
 
-	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads*/for-linus:refs/remotes/mine/*", false);
-	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads*/for-linus:refs/remotes/mine/*", false);
+	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads*/for-linus:refs/remotes/mine/*", true);
+	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads*/for-linus:refs/remotes/mine/*", true);
 
 	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads/*/*/for-linus:refs/remotes/mine/*", false);
 	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads/*/*/for-linus:refs/remotes/mine/*", false);
+
+	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads/*g*/for-linus:refs/remotes/mine/*", false);
+	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads/*g*/for-linus:refs/remotes/mine/*", false);
 
 	assert_refspec(GIT_DIRECTION_FETCH, "refs/heads/*/for-linus:refs/remotes/mine/*", true);
 	assert_refspec(GIT_DIRECTION_PUSH, "refs/heads/*/for-linus:refs/remotes/mine/*", true);
@@ -109,6 +112,12 @@ void test_network_refspecs__transform_mid_star(void)
 	assert_valid_transform("refs/heads/*:refs/heads/*", "refs/heads/master", "refs/heads/master");
 	assert_valid_transform("refs/heads/*:refs/heads/*", "refs/heads/user/feature", "refs/heads/user/feature");
 	assert_valid_transform("refs/*:refs/*", "refs/heads/master", "refs/heads/master");
+}
+
+void test_network_refspecs__transform_loosened_star(void)
+{
+	assert_valid_transform("refs/heads/branch-*:refs/remotes/origin/branch-*", "refs/heads/branch-a", "refs/remotes/origin/branch-a");
+	assert_valid_transform("refs/heads/branch-*/head:refs/remotes/origin/branch-*/head", "refs/heads/branch-a/head", "refs/remotes/origin/branch-a/head");
 }
 
 void test_network_refspecs__no_dst(void)

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -93,7 +93,7 @@ static void assert_valid_transform(const char *refspec, const char *name, const 
 	git_refspec spec;
 	git_buf buf = GIT_BUF_INIT;
 
-	git_refspec__parse(&spec, refspec, true);
+	cl_git_pass(git_refspec__parse(&spec, refspec, true));
 	cl_git_pass(git_refspec_transform(&buf, &spec, name));
 	cl_assert_equal_s(result, buf.ptr);
 

--- a/tests/refs/normalize.c
+++ b/tests/refs/normalize.c
@@ -352,12 +352,12 @@ void test_refs_normalize__buffer_has_to_be_big_enough_to_hold_the_normalized_ver
 
 void test_refs_normalize__refspec_pattern(void)
 {
-	ensure_refname_invalid(
-		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/*foo/bar");
-	ensure_refname_invalid(
-		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/foo*/bar");
-	ensure_refname_invalid(
-		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/f*o/bar");
+	ensure_refname_normalized(
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/*foo/bar", "heads/*foo/bar");
+	ensure_refname_normalized(
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/foo*/bar", "heads/foo*/bar");
+	ensure_refname_normalized(
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "heads/f*o/bar", "heads/f*o/bar");
 
 	ensure_refname_invalid(
 		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo");


### PR DESCRIPTION
Upstream has changed the restrictions on wildcard "*" refspecs. Previously, a wildcard in a refspec was only allowed if it was the only character in a component. This restriction has been lifted to allow wildcards to be nested between other characters in that component with cd377f45c9 (refs: loosen restriction on wildcard "*" refspecs, 2015-07-22).

More details in the commits.

Fixes #5058