### PR TITLE
git_revwalk_push_range: do not crash if range is missing

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -194,6 +194,12 @@ int git_revwalk_push_range(git_revwalk *walk, const char *range)
 	if ((error = git_revparse(&revspec, walk->repo, range)))
 		return error;
 
+	if (!revspec.to) {
+		git_error_set(GIT_ERROR_INVALID, "invalid revspec. Only range supported.");
+		error = GIT_EINVALIDSPEC;
+		goto out;
+	}
+
 	if (revspec.flags & GIT_REVPARSE_MERGE_BASE) {
 		/* TODO: support "<commit>...<commit>" */
 		git_error_set(GIT_ERROR_INVALID, "symmetric differences not implemented in revwalk");

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -203,7 +203,8 @@ int git_revwalk_push_range(git_revwalk *walk, const char *range)
 	if (revspec.flags & GIT_REVPARSE_MERGE_BASE) {
 		/* TODO: support "<commit>...<commit>" */
 		git_error_set(GIT_ERROR_INVALID, "symmetric differences not implemented in revwalk");
-		return GIT_EINVALIDSPEC;
+		error = GIT_EINVALIDSPEC;
+		goto out;
 	}
 
 	if ((error = push_commit(walk, git_object_id(revspec.from), 1, false)))

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -400,6 +400,15 @@ void test_revwalk_basic__push_range(void)
 	cl_git_pass(test_walk_only(_walk, commit_sorting_segment, 2));
 }
 
+void test_revwalk_basic__push_range_merge_base(void)
+{
+	revwalk_basic_setup_walk(NULL);
+
+	git_revwalk_reset(_walk);
+	git_revwalk_sorting(_walk, 0);
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_revwalk_push_range(_walk, "HEAD...HEAD~2"));
+}
+
 void test_revwalk_basic__push_range_no_range(void)
 {
 	revwalk_basic_setup_walk(NULL);

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -400,6 +400,15 @@ void test_revwalk_basic__push_range(void)
 	cl_git_pass(test_walk_only(_walk, commit_sorting_segment, 2));
 }
 
+void test_revwalk_basic__push_range_no_range(void)
+{
+	revwalk_basic_setup_walk(NULL);
+
+	git_revwalk_reset(_walk);
+	git_revwalk_sorting(_walk, 0);
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_revwalk_push_range(_walk, "HEAD"));
+}
+
 void test_revwalk_basic__push_mixed(void)
 {
 	git_oid oid;


### PR DESCRIPTION
If someone passes just one ref (i.e. "master") and misses passing the
range we should be nice and return an error code instead of crashing.

I am not sure if this is being overly protective, but IMO a library should not crash just because the content in a string is wrong.