### PR TITLE
Support symlinks for directories in win32

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -402,8 +402,12 @@ int p_symlink(const char *target, const char *path)
 		git__utf8_to_16(target_w, MAX_PATH, target) < 0)
 		return -1;
 
-	if (!CreateSymbolicLinkW(path_w, target_w,
-	    SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE))
+	DWORD dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+
+	if (GetFileAttributesW(target_w) & FILE_ATTRIBUTE_DIRECTORY)
+		dwFlags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+
+	if (!CreateSymbolicLinkW(path_w, target_w, dwFlags))
 		return -1;
 
 	return 0;

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -397,12 +397,13 @@ int p_readlink(const char *path, char *buf, size_t bufsiz)
 int p_symlink(const char *target, const char *path)
 {
 	git_win32_path target_w, path_w;
+	DWORD dwFlags;
 
 	if (git_win32_path_from_utf8(path_w, path) < 0 ||
 		git__utf8_to_16(target_w, MAX_PATH, target) < 0)
 		return -1;
 
-	DWORD dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+	dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
 
 	if (GetFileAttributesW(target_w) & FILE_ATTRIBUTE_DIRECTORY)
 		dwFlags |= SYMBOLIC_LINK_FLAG_DIRECTORY;


### PR DESCRIPTION
PR #4713 had one thing missing, which is correctly setting the `SYMBOLIC_LINK_FLAG_DIRECTORY` for directories, as Windows weirdly handles symlinks differently than unix-like systems.

This issue is discussed with @ethomson in #4713.