### PR TITLE
Ignore: only treat one leading slash as a root identifier

### DIFF
--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -604,7 +604,8 @@ int git_attr_fnmatch__parse(
 		if (*scan == '/') {
 			spec->flags = spec->flags | GIT_ATTR_FNMATCH_FULLPATH;
 			slash_count++;
-			if (pattern == scan)
+
+			if (slash_count == 1 && pattern == scan)
 				pattern++;
 		}
 		/* remember if we see an unescaped wildcard in pattern */

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -413,6 +413,30 @@ void test_status_ignore__leading_slash_ignores(void)
 	cl_assert_equal_i(0, counts.wrong_sorted_path);
 }
 
+void test_status_ignore__multiple_leading_slash(void)
+{
+	static const char *test_files[] = {
+		"empty_standard_repo/a.test",
+		"empty_standard_repo/b.test",
+		"empty_standard_repo/c.test",
+		"empty_standard_repo/d.test",
+		NULL
+	};
+
+	make_test_data("empty_standard_repo", test_files);
+	cl_git_mkfile(
+		"empty_standard_repo/.gitignore",
+		"a.test\n"
+		"/b.test\n"
+		"//c.test\n"
+		"///d.test\n");
+
+	assert_is_ignored("a.test");
+	assert_is_ignored("b.test");
+	refute_is_ignored("c.test");
+	refute_is_ignored("d.test");
+}
+
 void test_status_ignore__contained_dir_with_matching_name(void)
 {
 	static const char *test_files[] = {


### PR DESCRIPTION
Per #5070, we should not treat multiple leading slashes as identical to a single leading slash.  One leading slash indicates the directory root, but _only the first_ should indicate that.

Fixes #5070 