### PR TITLE
Ignore files: don't ignore whitespace

### DIFF
--- a/tests/attr/file.c
+++ b/tests/attr/file.c
@@ -181,15 +181,10 @@ void test_attr_file__assign_variants(void)
 	git_attr_file__free(file);
 }
 
-void test_attr_file__check_attr_examples(void)
+static void assert_examples(git_attr_file *file)
 {
-	git_attr_file *file;
 	git_attr_rule *rule;
 	git_attr_assignment *assign;
-
-	cl_git_pass(git_attr_file__load_standalone(&file, cl_fixture("attr/attr3")));
-	cl_assert_equal_s(cl_fixture("attr/attr3"), file->entry->path);
-	cl_assert(file->rules.length == 3);
 
 	rule = get_rule(0);
 	cl_assert_equal_s("*.java", rule->match.pattern);
@@ -219,6 +214,30 @@ void test_attr_file__check_attr_examples(void)
 	assign = get_assign(rule, 0);
 	cl_assert_equal_s("caveat", assign->name);
 	cl_assert_equal_s("unspecified", assign->value);
+}
+
+void test_attr_file__check_attr_examples(void)
+{
+	git_attr_file *file;
+
+	cl_git_pass(git_attr_file__load_standalone(&file, cl_fixture("attr/attr3")));
+	cl_assert_equal_s(cl_fixture("attr/attr3"), file->entry->path);
+	cl_assert(file->rules.length == 3);
+
+	assert_examples(file);
+
+	git_attr_file__free(file);
+}
+
+void test_attr_file__whitespace(void)
+{
+	git_attr_file *file;
+
+	cl_git_pass(git_attr_file__load_standalone(&file, cl_fixture("attr/attr4")));
+	cl_assert_equal_s(cl_fixture("attr/attr4"), file->entry->path);
+	cl_assert(file->rules.length == 3);
+
+	assert_examples(file);
 
 	git_attr_file__free(file);
 }

--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -100,7 +100,7 @@ static void workdir_iterator_test(
 
 void test_iterator_workdir__0(void)
 {
-	workdir_iterator_test("attr", NULL, NULL, 23, 5, NULL, "ign");
+	workdir_iterator_test("attr", NULL, NULL, 24, 5, NULL, "ign");
 }
 
 static const char *status_paths[] = {

--- a/tests/resources/attr/attr4
+++ b/tests/resources/attr/attr4
@@ -1,0 +1,7 @@
+# This is a comment
+  # This is also a comment
+*.java diff=java -crlf myAttr
+
+  NoMyAttr.java !myAttr
+
+	README caveat=unspecified

--- a/tests/status/ignore.c
+++ b/tests/status/ignore.c
@@ -1251,14 +1251,18 @@ void test_status_ignore__leading_spaces_are_significant(void)
 	cl_git_mkfile(
 		"empty_standard_repo/.gitignore",
 		" a.test\n"
+		"# this is a comment\n"
 		"b.test\n"
 		"\tc.test\n"
+		" # not a comment\n"
 		"d.test\n");
 
 	refute_is_ignored("a.test");
 	assert_is_ignored(" a.test");
+	refute_is_ignored("# this is a comment");
 	assert_is_ignored("b.test");
 	refute_is_ignored("c.test");
 	assert_is_ignored("\tc.test");
+	assert_is_ignored(" # not a comment");
 	assert_is_ignored("d.test");
 }

--- a/tests/status/ignore.c.bak
+++ b/tests/status/ignore.c.bak
@@ -1251,14 +1251,18 @@ void test_status_ignore__leading_spaces_are_significant(void)
 	cl_git_mkfile(
 		"empty_standard_repo/.gitignore",
 		" a.test\n"
+		"# this is a comment\n"
 		"b.test\n"
 		"\tc.test\n"
+		" # not a comment\n"
 		"d.test\n");
 
 	refute_is_ignored("a.test");
 	assert_is_ignored(" a.test");
+	refute_is_ignored("# this is a comment");
 	assert_is_ignored("b.test");
 	refute_is_ignored("c.test");
 	assert_is_ignored("\tc.test");
+	assert_is_ignored(" # not a comment");
 	assert_is_ignored("d.test");
 }


### PR DESCRIPTION
Whitespace is significant in ignore files.  Per the documentation, "trailing spaces are ignored".  But leading spaces are not.  Ensure that we do _not_ skip leading spaces in ignore files.

(However, in a cruel yet typical joke, for _attribute_ files, "leading and trailing whitespaces are ignored".  So I've added a test to ensure that we didn't break _that_.)

Fixes #5069 