### PR TITLE
Define SYMBOLIC_LINK_FLAG_DIRECTORY if required

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -33,6 +33,10 @@
 # define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE 0x02
 #endif
 
+#ifndef SYMBOLIC_LINK_FLAG_DIRECTORY
+# define SYMBOLIC_LINK_FLAG_DIRECTORY 0x01
+#endif
+
 /* Allowable mode bits on Win32.  Using mode bits that are not supported on
  * Win32 (eg S_IRWXU) is generally ignored, but Wine warns loudly about it
  * so we simply remove them.


### PR DESCRIPTION
Some older MinGW toolchains may not have it defined:

```
deps/libgit2/src/win32/posix_w32.c: In function 'p_symlink':
deps/libgit2/src/win32/posix_w32.c:409:14: error: 'SYMBOLIC_LINK_FLAG_DIRECTORY' undeclared (first use in this function); did you mean 'SYMLINK_FLAG_RELATIVE'?
   dwFlags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
              SYMLINK_FLAG_RELATIVE
deps/libgit2/src/win32/posix_w32.c:409:14: note: each undeclared identifier is reported only once for each function it appears in
```