### PR TITLE
cmake: disable fallthrough warnings for PCRE

### DIFF
--- a/deps/pcre/CMakeLists.txt
+++ b/deps/pcre/CMakeLists.txt
@@ -21,6 +21,7 @@ CHECK_TYPE_SIZE("long long"             LONG_LONG)
 CHECK_TYPE_SIZE("unsigned long long"    UNSIGNED_LONG_LONG)
 
 DISABLE_WARNINGS(unused-function)
+DISABLE_WARNINGS(implicit-fallthrough)
 
 # User-configurable options
 


### PR DESCRIPTION
Our PCRE dependency has uncommented fallthroughs in switch statements.
Turn off warnings for those in the PCRE code.

(These failed in the nightly.)