### PR TITLE
SECURITY.md: split out security-relevant bits from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,7 @@ We ask that you not open a GitHub Issue for help, only for bug reports.
 
 **Reporting Security Issues**
 
-In case you think to have found a security issue with libgit2, please do not
-open a public issue.  Instead, you can report the issue to the private mailing
-list [security@libgit2.com](mailto:security@libgit2.com).
+Please have a look at SECURITY.md.
 
 What It Can Do
 ==============

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+This project will always provide security fixes for the latest two released
+versions. E.g. if the latest version is v0.28.x, then we will provide security
+fixes for both v0.28.x and v0.27.y, but no later versions.
+
+## Reporting a Vulnerability
+
+In case you think to have found a security issue with libgit2, please do not
+open a public issue.  Instead, you can report the issue to the private mailing
+list [security@libgit2.com](mailto:security@libgit2.com). We will acknowledge
+receipt of your message in at most three days and try to clarify further steps.


### PR DESCRIPTION
GitHub has recently introduced a new set of tools that aims to
ease the process around vulnerability reports and security fixes.
Part of those tools is a new security tab for projects that will
display contents from a new SECURITY.md file.

Move relevant parts from README.md to this new file to make use
of this feature.