### PR TITLE
Restore NetBSD support

### DIFF
--- a/src/posix.c
+++ b/src/posix.c
@@ -157,7 +157,7 @@ int p_rename(const char *from, const char *to)
 
 int p_fallocate(int fd, off_t offset, off_t len)
 {
-#ifdef __APPLE__
+#if defined (__APPLE__) || (defined (__NetBSD__) && __NetBSD_Version__ < 700000000)
 	fstore_t prealloc;
 	struct stat st;
 	size_t newsize;


### PR DESCRIPTION
NetBSD 7 added support for ```posix_fallocate```.

See:
https://www.netbsd.org/changes/changes-7.0.html
http://www.cpantesters.org/cpan/report/ca7e64c8-7d3a-11e9-9ccb-b1ae95f66eb9