### PR TITLE
cmake: detect availability of posix_fallocate(3)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,27 @@ IF (HAVE_FUTIMENS)
 	SET(GIT_USE_FUTIMENS 1)
 ENDIF ()
 
+CHECK_SYMBOL_EXISTS(posix_fallocate fcntl.h HAVE_POSIX_FALLOCATE)
+CHECK_SYMBOL_EXISTS(fallocate fcntl.h HAVE_FALLOCATE)
+CHECK_C_SOURCE_COMPILES(
+	"#include <fcntl.h>
+	int main(void) { return F_PREALLOCATE; }"
+	HAVE_F_PREALLOCATE)
+CHECK_C_SOURCE_COMPILES(
+	"#include <fcntl.h>
+	int main(void) { return F_ALLOCSP64; }"
+	HAVE_F_ALLOCSP64)
+IF(HAVE_F_PREALLOCATE)
+	# APPLE OR FREEBSD OR NETBSD
+	SET(GIT_USE_FALLOCATE_BSD 1)
+ELSEIF(HAVE_F_ALLOCSP64)
+	SET(GIT_USE_FALLOCATE_SOLARIS 1)
+ELSEIF(HAVE_FALLOCATE)
+	SET(GIT_USE_FALLOCATE 1)
+ELSEIF (HAVE_POSIX_FALLOCATE)
+	SET(GIT_USE_FALLOCATE_POSIX 1)
+ENDIF ()
+
 CHECK_PROTOTYPE_DEFINITION(qsort_r
 	"void qsort_r(void *base, size_t nmemb, size_t size, void *thunk, int (*compar)(void *, const void *, const void *))"
 	"" "stdlib.h" HAVE_QSORT_R_BSD)

--- a/src/features.h.in
+++ b/src/features.h.in
@@ -15,6 +15,10 @@
 #cmakedefine GIT_USE_STAT_MTIMESPEC 1
 #cmakedefine GIT_USE_STAT_MTIME_NSEC 1
 #cmakedefine GIT_USE_FUTIMENS 1
+#cmakedefine GIT_USE_FALLOCATE 1
+#cmakedefine GIT_USE_FALLOCATE_BSD 1
+#cmakedefine GIT_USE_FALLOCATE_POSIX 1
+#cmakedefine GIT_USE_FALLOCATE_SOLARIS 1
 
 #cmakedefine GIT_REGEX_REGCOMP_L
 #cmakedefine GIT_REGEX_REGCOMP

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -302,5 +302,7 @@ void test_core_posix__fallocate(void)
 	cl_must_pass(p_lseek(fd, 42, SEEK_SET));
 	cl_must_pass(p_fallocate(fd, 0, 200));
 	cl_assert_equal_i(42, p_lseek(fd, 0, SEEK_CUR));
+	cl_must_pass(p_fallocate(fd, 190, 128));
+	cl_assert_equal_i(42, p_lseek(fd, 0, SEEK_CUR));
 	p_close(fd);
 }


### PR DESCRIPTION
Instead of having fragile checks for platform definitions to
guess whether posix_fallocate(3) is available or not, let's just
use CMake's `CHECK_FUNCTION_EXISTS` to detect that. This is both
more accurate and simpler.