### PR TITLE
checkout: make sure we remove files we are told to remove

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2550,6 +2550,7 @@ int git_checkout_iterator(
 		workdir_opts = GIT_ITERATOR_OPTIONS_INIT;
 	checkout_data data = {0};
 	git_diff_options diff_opts = GIT_DIFF_OPTIONS_INIT;
+	int needs_expand;
 	uint32_t *actions = NULL;
 	size_t *counts = NULL;
 
@@ -2574,10 +2575,14 @@ int git_checkout_iterator(
 		diff_opts.pathspec = data.opts.paths;
 
 	/* set up iterators */
-
 	workdir_opts.flags = git_iterator_ignore_case(target) ?
 		GIT_ITERATOR_IGNORE_CASE : GIT_ITERATOR_DONT_IGNORE_CASE;
-	workdir_opts.flags |= GIT_ITERATOR_DONT_AUTOEXPAND;
+	needs_expand = (data.opts.checkout_strategy & (
+		GIT_CHECKOUT_REMOVE_UNTRACKED |
+		GIT_CHECKOUT_REMOVE_IGNORED
+	));
+	if (!needs_expand)
+		workdir_opts.flags |= GIT_ITERATOR_DONT_AUTOEXPAND;
 	workdir_opts.start = data.pfx;
 	workdir_opts.end = data.pfx;
 

--- a/tests/checkout/head.c
+++ b/tests/checkout/head.c
@@ -264,3 +264,36 @@ void test_checkout_head__obeys_filemode_false(void)
 	git_object_free(branch);
 	git_object_free(target);
 }
+
+void test_checkout_head__do_remove_untracked_paths(void)
+{
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_index *index;
+	char *paths[] = {"tracked/untracked", "tracked/ignored"};
+
+	cl_git_pass(p_mkdir("testrepo/tracked", 0755));
+	cl_git_pass(p_mkdir("testrepo/tracked/subdir", 0755));
+	cl_git_mkfile("testrepo/tracked/tracked", "tracked\n");
+	cl_git_mkfile("testrepo/tracked/untracked", "untracked\n");
+	cl_git_mkfile("testrepo/tracked/ignored", "ignored\n");
+	cl_git_rewritefile("testrepo/.gitignore", "tracked/ignored");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, ".gitignore"));
+	cl_git_pass(git_index_add_bypath(index, "tracked/tracked"));
+	cl_git_pass(git_index_write(index));
+	git_index_free(index);
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE |
+		GIT_CHECKOUT_REMOVE_UNTRACKED |
+		GIT_CHECKOUT_REMOVE_IGNORED;
+	opts.paths.strings = paths;
+	opts.paths.count = ARRAY_SIZE(paths);
+
+	cl_git_pass(git_checkout_head(g_repo, &opts));
+
+	cl_assert(git_path_isfile("testrepo/tracked/tracked"));
+	cl_assert(!git_path_isfile("testrepo/tracked/untracked"));
+	cl_assert(!git_path_isfile("testrepo/tracked/ignored"));
+}
+


### PR DESCRIPTION
Fixes #5089.

It turns out checkout fails to remove files, even in cases the user is being pretty specific: a correctly-setup pathspec + `GIT_CHECKOUT_FORCE`). Though the OP was about untracked files, I think ignored files should be handled the same.

I don't really understand the fix, am not comfortable around the iterators, and I'm not sure the fix shouldn't actually be an unconditional removal of that option, so the commit message is obviously bikesheddable.