### PR TITLE
online tests: use gitlab for auth failures

### DIFF
--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -334,7 +334,7 @@ void test_online_clone__cred_callback_called_again_on_auth_failure(void)
 	git__free(_remote_url);
 	git__free(_remote_user);
 
-	_remote_url = git__strdup("https://github.com/libgit2/non-existent");
+	_remote_url = git__strdup("https://gitlab.com/libgit2/non-existent");
 	_remote_user = git__strdup("libgit2test");
 
 	g_options.fetch_opts.callbacks.credentials = cred_count_calls_cb;


### PR DESCRIPTION
GitHub recently changed their behavior from returning 401s for private or nonexistent repositories on a clone to returning 404s.  For our tests that require an auth failure (and 401), move to GitLab to request a missing repository.  This lets us continue to test our auth failure case, at least until they decide to mimic that decision.

I loathe that we're adding a new dependency on _yet another_ provider.  At some point, I would like to spin up our own git server over HTTP (ideally one that could be configured to send a variety of complete garbage responses).  But in the meantime, this will turn our red builds to green.