### PR TITLE
ignore: handle escaped trailing whitespace

### DIFF
--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -560,13 +560,15 @@ void git_attr_path__free(git_attr_path *info)
  */
 
 /*
- * Determine the length of trailing spaces.
+ * Determine the length of trailing spaces. Escaped spaces do not count as
+ * trailing whitespace.
  */
 static size_t trailing_space_length(const char *p, size_t len)
 {
 	size_t n;
 	for (n = len; n; n--) {
-		if (p[n-1] != ' ' && p[n-1] != '\t')
+		if ((p[n-1] != ' ' && p[n-1] != '\t') ||
+		    (n > 1 && p[n-2] == '\\'))
 			break;
 	}
 	return len - n;

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -560,6 +560,19 @@ void git_attr_path__free(git_attr_path *info)
  */
 
 /*
+ * Determine the length of trailing spaces.
+ */
+static size_t trailing_space_length(const char *p, size_t len)
+{
+	size_t n;
+	for (n = len; n; n--) {
+		if (p[n-1] != ' ' && p[n-1] != '\t')
+			break;
+	}
+	return len - n;
+}
+
+/*
  * This will return 0 if the spec was filled out,
  * GIT_ENOTFOUND if the fnmatch does not require matching, or
  * another error code there was an actual problem.
@@ -646,9 +659,10 @@ int git_attr_fnmatch__parse(
 			return GIT_ENOTFOUND;
 
 	/* Remove trailing spaces. */
-	while (pattern[spec->length - 1] == ' ' || pattern[spec->length - 1] == '\t')
-		if (--spec->length == 0)
-			return GIT_ENOTFOUND;
+	spec->length -= trailing_space_length(pattern, spec->length);
+
+	if (spec->length == 0)
+		return GIT_ENOTFOUND;
 
 	if (pattern[spec->length - 1] == '/') {
 		spec->length--;

--- a/tests/attr/ignore.c
+++ b/tests/attr/ignore.c
@@ -61,6 +61,52 @@ void test_attr_ignore__ignore_space(void)
 	assert_is_ignored(true, "NewFolder/NewFolder/File.txt");
 }
 
+void test_attr_ignore__intermittent_space(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "foo bar\n");
+
+	assert_is_ignored(false, "foo");
+	assert_is_ignored(false, "bar");
+	assert_is_ignored(true, "foo bar");
+}
+
+void test_attr_ignore__trailing_space(void)
+{
+	cl_git_rewritefile(
+		"attr/.gitignore",
+		"foo \n"
+		"bar  \n"
+	);
+
+	assert_is_ignored(true, "foo");
+	assert_is_ignored(false, "foo ");
+	assert_is_ignored(true, "bar");
+	assert_is_ignored(false, "bar ");
+	assert_is_ignored(false, "bar  ");
+}
+
+void test_attr_ignore__escaped_trailing_spaces(void)
+{
+	cl_git_rewritefile(
+		"attr/.gitignore",
+		"foo\\ \n"
+		"bar\\ \\ \n"
+		"baz \\ \n"
+		"qux\\  \n"
+	);
+
+	assert_is_ignored(false, "foo");
+	assert_is_ignored(true, "foo ");
+	assert_is_ignored(false, "bar");
+	assert_is_ignored(false, "bar ");
+	assert_is_ignored(true, "bar  ");
+	assert_is_ignored(true, "baz  ");
+	assert_is_ignored(false, "baz ");
+	assert_is_ignored(true, "qux ");
+	assert_is_ignored(false, "qux");
+	assert_is_ignored(false, "qux  ");
+}
+
 void test_attr_ignore__ignore_dir(void)
 {
 	cl_git_rewritefile("attr/.gitignore", "dir/\n");


### PR DESCRIPTION
The gitignore's pattern format specifies that "Trailing spaces
are ignored unless they are quoted with backslash ("\")". We do
not honor this currently and will treat a pattern "foo\ " as if
it was "foo\" only and a pattern "foo\ \ " as "foo\ \".

The current gitignore format does offer some very special
surprises, though: given a pattern "foo \ ", upstream git will in
fact strip all spaces and treat it as "foo", only.

Fix our code to handle those special cases and add tests to avoid
regressions.