### PR TITLE
tests: checkout: fix symlink.git being created outside of sandbox

### DIFF
--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -148,13 +148,15 @@ void test_checkout_index__honor_coreautocrlf_setting_set_to_true(void)
 
 static void populate_symlink_workdir(void)
 {
+	git_buf path = GIT_BUF_INIT;
 	git_repository *repo;
 	git_remote *origin;
 	git_object *target;
 
 	const char *url = git_repository_path(g_repo);
 
-	cl_git_pass(git_repository_init(&repo, "../symlink.git", true));
+	cl_git_pass(git_buf_joinpath(&path, clar_sandbox_path(), "symlink.git"));
+	cl_git_pass(git_repository_init(&repo, path.ptr, true));
 	cl_git_pass(git_repository_set_workdir(repo, "symlink", 1));
 
 	/* Delete the `origin` repo (if it exists) so we can recreate it. */
@@ -166,8 +168,10 @@ static void populate_symlink_workdir(void)
 
 	cl_git_pass(git_revparse_single(&target, repo, "remotes/origin/master"));
 	cl_git_pass(git_reset(repo, target, GIT_RESET_HARD, NULL));
+
 	git_object_free(target);
 	git_repository_free(repo);
+	git_buf_dispose(&path);
 }
 
 void test_checkout_index__honor_coresymlinks_default_true(void)


### PR DESCRIPTION
The function `populate_symlink_workdir` creates a new
"symlink.git" repository with a relative path "../symlink.git".
As the current working directory is the sandbox, the new
repository will be created just outside of the sandbox.

Fix this by using `clar_sandbox_path`.