### PR TITLE
Rename options initialization functions

### DIFF
--- a/examples/describe.c
+++ b/examples/describe.c
@@ -63,7 +63,7 @@ static void do_describe_single(git_repository *repo, describe_options *opts, con
 	git_object *commit;
 	git_describe_result *describe_result;
 	git_buf buf = { 0 };
-	
+
 	if (rev) {
 		check_lg2(git_revparse_single(&commit, repo, rev),
 			"Failed to lookup rev", rev);
@@ -148,8 +148,8 @@ static void describe_options_init(describe_options *opts)
 
 	opts->commits = NULL;
 	opts->commit_count = 0;
-	git_describe_init_options(&opts->describe_options, GIT_DESCRIBE_OPTIONS_VERSION);
-	git_describe_init_format_options(&opts->format_options, GIT_DESCRIBE_FORMAT_OPTIONS_VERSION);
+	git_describe_options_init(&opts->describe_options, GIT_DESCRIBE_OPTIONS_VERSION);
+	git_describe_format_options_init(&opts->format_options, GIT_DESCRIBE_FORMAT_OPTIONS_VERSION);
 }
 
 int lg2_describe(git_repository *repo, int argc, char **argv)

--- a/include/git2/apply.h
+++ b/include/git2/apply.h
@@ -57,7 +57,7 @@ typedef int GIT_CALLBACK(git_apply_hunk_cb)(
  * Apply options structure
  *
  * Initialize with `GIT_APPLY_OPTIONS_INIT`. Alternatively, you can
- * use `git_apply_init_options`.
+ * use `git_apply_options_init`.
  *
  * @see git_apply_to_tree, git_apply
  */
@@ -71,6 +71,8 @@ typedef struct {
 
 #define GIT_APPLY_OPTIONS_VERSION 1
 #define GIT_APPLY_OPTIONS_INIT {GIT_APPLY_OPTIONS_VERSION}
+
+GIT_EXTERN(int) git_apply_options_init(git_apply_options *opts, unsigned int version);
 
 /**
  * Apply a `git_diff` to a `git_tree`, and return the resulting image

--- a/include/git2/blame.h
+++ b/include/git2/blame.h
@@ -53,7 +53,7 @@ typedef enum {
  * Blame options structure
  *
  * Initialize with `GIT_BLAME_OPTIONS_INIT`. Alternatively, you can
- * use `git_blame_init_options`.
+ * use `git_blame_options_init`.
  *
  */
 typedef struct git_blame_options {
@@ -100,7 +100,7 @@ typedef struct git_blame_options {
  * @param version The struct version; pass `GIT_BLAME_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_blame_init_options(
+GIT_EXTERN(int) git_blame_options_init(
 	git_blame_options *opts,
 	unsigned int version);
 

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -256,7 +256,7 @@ typedef void GIT_CALLBACK(git_checkout_perfdata_cb)(
  * Checkout options structure
  *
  * Initialize with `GIT_CHECKOUT_OPTIONS_INIT`. Alternatively, you can
- * use `git_checkout_init_options`.
+ * use `git_checkout_options_init`.
  *
  */
 typedef struct git_checkout_options {
@@ -318,7 +318,7 @@ typedef struct git_checkout_options {
  * @param version The struct version; pass `GIT_CHECKOUT_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_checkout_init_options(
+GIT_EXTERN(int) git_checkout_options_init(
 	git_checkout_options *opts,
 	unsigned int version);
 

--- a/include/git2/cherrypick.h
+++ b/include/git2/cherrypick.h
@@ -46,7 +46,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_CHERRYPICK_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_cherrypick_init_options(
+GIT_EXTERN(int) git_cherrypick_options_init(
 	git_cherrypick_options *opts,
 	unsigned int version);
 

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -97,7 +97,7 @@ typedef int GIT_CALLBACK(git_repository_create_cb)(
  * Clone options structure
  *
  * Initialize with `GIT_CLONE_OPTIONS_INIT`. Alternatively, you can
- * use `git_clone_init_options`.
+ * use `git_clone_options_init`.
  *
  */
 typedef struct git_clone_options {
@@ -178,7 +178,7 @@ typedef struct git_clone_options {
  * @param version The struct version; pass `GIT_CLONE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_clone_init_options(
+GIT_EXTERN(int) git_clone_options_init(
 	git_clone_options *opts,
 	unsigned int version);
 

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -8,13 +8,29 @@
 #define INCLUDE_git_deprecated_h__
 
 #include "common.h"
+#include "blame.h"
 #include "buffer.h"
+#include "checkout.h"
+#include "cherrypick.h"
+#include "clone.h"
+#include "describe.h"
+#include "diff.h"
 #include "errors.h"
 #include "index.h"
+#include "indexer.h"
+#include "merge.h"
 #include "object.h"
+#include "proxy.h"
 #include "refs.h"
+#include "rebase.h"
 #include "remote.h"
 #include "trace.h"
+#include "repository.h"
+#include "revert.h"
+#include "stash.h"
+#include "status.h"
+#include "submodule.h"
+#include "worktree.h"
 
 /*
  * Users can avoid deprecated functions by defining `GIT_DEPRECATE_HARD`.
@@ -313,6 +329,45 @@ typedef git_push_transfer_progress_cb git_push_transfer_progress;
 
  /** The type of a remote completion event */
 #define git_remote_completion_type git_remote_completion_t
+
+/**@}*/
+
+/** @name Deprecated Options Initialization Functions
+ *
+ * These functions are retained for backward compatibility.  The newer
+ * versions of these functions should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility functions at
+ * this time.
+ */
+/**@{*/
+
+GIT_EXTERN(int) git_blame_init_options(git_blame_options *opts, unsigned int version);
+GIT_EXTERN(int) git_checkout_init_options(git_checkout_options *opts, unsigned int version);
+GIT_EXTERN(int) git_cherrypick_init_options(git_cherrypick_options *opts, unsigned int version);
+GIT_EXTERN(int) git_clone_init_options(git_clone_options *opts, unsigned int version);
+GIT_EXTERN(int) git_describe_init_options(git_describe_options *opts, unsigned int version);
+GIT_EXTERN(int) git_describe_init_format_options(git_describe_format_options *opts, unsigned int version);
+GIT_EXTERN(int) git_diff_init_options(git_diff_options *opts, unsigned int version);
+GIT_EXTERN(int) git_diff_find_init_options(git_diff_find_options *opts, unsigned int version);
+GIT_EXTERN(int) git_diff_format_email_init_options(git_diff_format_email_options *opts, unsigned int version);
+GIT_EXTERN(int) git_diff_patchid_init_options(git_diff_patchid_options *opts, unsigned int version);
+GIT_EXTERN(int) git_fetch_init_options(git_fetch_options *opts, unsigned int version);
+GIT_EXTERN(int) git_indexer_init_options(git_indexer_options *opts, unsigned int version);
+GIT_EXTERN(int) git_merge_init_options(git_merge_options *opts, unsigned int version);
+GIT_EXTERN(int) git_merge_file_init_input(git_merge_file_input *input, unsigned int version);
+GIT_EXTERN(int) git_merge_file_init_options(git_merge_file_options *opts, unsigned int version);
+GIT_EXTERN(int) git_proxy_init_options(git_proxy_options *opts, unsigned int version);
+GIT_EXTERN(int) git_push_init_options(git_push_options *opts, unsigned int version);
+GIT_EXTERN(int) git_rebase_init_options(git_rebase_options *opts, unsigned int version);
+GIT_EXTERN(int) git_remote_create_init_options(git_remote_create_options *opts, unsigned int version);
+GIT_EXTERN(int) git_repository_init_init_options(git_repository_init_options *opts, unsigned int version);
+GIT_EXTERN(int) git_revert_init_options(git_revert_options *opts, unsigned int version);
+GIT_EXTERN(int) git_stash_apply_init_options(git_stash_apply_options *opts, unsigned int version);
+GIT_EXTERN(int) git_status_init_options(git_status_options *opts, unsigned int version);
+GIT_EXTERN(int) git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version);
+GIT_EXTERN(int) git_worktree_add_init_options(git_worktree_add_options *opts, unsigned int version);
+GIT_EXTERN(int) git_worktree_prune_init_options(git_worktree_prune_options *opts, unsigned int version);
 
 /**@}*/
 

--- a/include/git2/describe.h
+++ b/include/git2/describe.h
@@ -37,7 +37,7 @@ typedef enum {
  * Describe options structure
  *
  * Initialize with `GIT_DESCRIBE_OPTIONS_INIT`. Alternatively, you can
- * use `git_describe_init_options`.
+ * use `git_describe_options_init`.
  *
  */
 typedef struct git_describe_options {
@@ -79,13 +79,13 @@ typedef struct git_describe_options {
  * @param version The struct version; pass `GIT_DESCRIBE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_describe_init_options(git_describe_options *opts, unsigned int version);
+GIT_EXTERN(int) git_describe_options_init(git_describe_options *opts, unsigned int version);
 
 /**
  * Describe format options structure
  *
  * Initialize with `GIT_DESCRIBE_FORMAT_OPTIONS_INIT`. Alternatively, you can
- * use `git_describe_format_init_options`.
+ * use `git_describe_format_options_init`.
  *
  */
 typedef struct {
@@ -126,7 +126,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_DESCRIBE_FORMAT_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_describe_init_format_options(git_describe_format_options *opts, unsigned int version);
+GIT_EXTERN(int) git_describe_format_options_init(git_describe_format_options *opts, unsigned int version);
 
 /**
  * A struct that stores the result of a describe operation.

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -119,7 +119,7 @@ typedef enum {
 
 	/** Include unreadable files in the diff */
 	GIT_DIFF_INCLUDE_UNREADABLE = (1u << 16),
-	
+
 	/** Include unreadable files in the diff */
 	GIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED = (1u << 17),
 
@@ -451,7 +451,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_DIFF_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_diff_init_options(
+GIT_EXTERN(int) git_diff_options_init(
 	git_diff_options *opts,
 	unsigned int version);
 
@@ -784,7 +784,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_DIFF_FIND_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_diff_find_init_options(
+GIT_EXTERN(int) git_diff_find_options_init(
 	git_diff_find_options *opts,
 	unsigned int version);
 
@@ -1448,7 +1448,7 @@ GIT_EXTERN(int) git_diff_commit_as_email(
  * @param version The struct version; pass `GIT_DIFF_FORMAT_EMAIL_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_diff_format_email_init_options(
+GIT_EXTERN(int) git_diff_format_email_options_init(
 	git_diff_format_email_options *opts,
 	unsigned int version);
 
@@ -1456,7 +1456,7 @@ GIT_EXTERN(int) git_diff_format_email_init_options(
  * Patch ID options structure
  *
  * Initialize with `GIT_PATCHID_OPTIONS_INIT`. Alternatively, you can
- * use `git_patchid_init_options`.
+ * use `git_diff_patchid_options_init`.
  *
  */
 typedef struct git_diff_patchid_options {
@@ -1476,7 +1476,7 @@ typedef struct git_diff_patchid_options {
  * @param version The struct version; pass `GIT_DIFF_PATCHID_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_diff_patchid_init_options(
+GIT_EXTERN(int) git_diff_patchid_options_init(
 	git_diff_patchid_options *opts,
 	unsigned int version);
 

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -79,7 +79,7 @@ typedef struct git_indexer_options {
  * @param version Version of struct; pass `GIT_INDEXER_OPTIONS_VERSION`
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_indexer_init_options(
+GIT_EXTERN(int) git_indexer_options_init(
 	git_indexer_options *opts,
 	unsigned int version);
 

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -57,7 +57,7 @@ typedef struct {
  *        `GIT_MERGE_FILE_INPUT_VERSION` here.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_merge_file_init_input(
+GIT_EXTERN(int) git_merge_file_input_init(
 	git_merge_file_input *opts,
 	unsigned int version);
 
@@ -212,9 +212,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_MERGE_FILE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_merge_file_init_options(
-	git_merge_file_options *opts,
-	unsigned int version);
+GIT_EXTERN(int) git_merge_file_options_init(git_merge_file_options *opts, unsigned int version);
 
 /**
  * Information about file-level merging
@@ -310,9 +308,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_MERGE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_merge_init_options(
-	git_merge_options *opts,
-	unsigned int version);
+GIT_EXTERN(int) git_merge_options_init(git_merge_options *opts, unsigned int version);
 
 /**
  * The results of `git_merge_analysis` indicate the merge opportunities.

--- a/include/git2/proxy.h
+++ b/include/git2/proxy.h
@@ -89,7 +89,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_PROXY_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_proxy_init_options(git_proxy_options *opts, unsigned int version);
+GIT_EXTERN(int) git_proxy_options_init(git_proxy_options *opts, unsigned int version);
 
 GIT_END_DECL
 

--- a/include/git2/rebase.h
+++ b/include/git2/rebase.h
@@ -156,7 +156,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_REBASE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_rebase_init_options(
+GIT_EXTERN(int) git_rebase_options_init(
 	git_rebase_options *opts,
 	unsigned int version);
 

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -56,7 +56,7 @@ typedef enum {
  * Remote creation options structure
  *
  * Initialize with `GIT_REMOTE_CREATE_OPTIONS_INIT`. Alternatively, you can
- * use `git_remote_create_init_options`.
+ * use `git_remote_create_options_init`.
  *
  */
 typedef struct git_remote_create_options {
@@ -94,7 +94,7 @@ typedef struct git_remote_create_options {
  * @param version The struct version; pass `GIT_REMOTE_CREATE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_remote_create_init_options(
+GIT_EXTERN(int) git_remote_create_options_init(
 		git_remote_create_options *opts,
 		unsigned int version);
 
@@ -700,7 +700,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_FETCH_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_fetch_init_options(
+GIT_EXTERN(int) git_fetch_options_init(
 	git_fetch_options *opts,
 	unsigned int version);
 
@@ -750,7 +750,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_PUSH_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_push_init_options(
+GIT_EXTERN(int) git_push_options_init(
 	git_push_options *opts,
 	unsigned int version);
 

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -323,7 +323,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_REPOSITORY_INIT_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_repository_init_init_options(
+GIT_EXTERN(int) git_repository_init_options_init(
 	git_repository_init_options *opts,
 	unsigned int version);
 

--- a/include/git2/revert.h
+++ b/include/git2/revert.h
@@ -46,7 +46,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_REVERT_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_revert_init_options(
+GIT_EXTERN(int) git_revert_options_init(
 	git_revert_options *opts,
 	unsigned int version);
 

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -120,7 +120,7 @@ typedef int GIT_CALLBACK(git_stash_apply_progress_cb)(
  * Stash application options structure
  *
  * Initialize with `GIT_STASH_APPLY_OPTIONS_INIT`. Alternatively, you can
- * use `git_stash_apply_init_options`.
+ * use `git_stash_apply_options_init`.
  *
  */
 typedef struct git_stash_apply_options {
@@ -153,7 +153,7 @@ typedef struct git_stash_apply_options {
  * @param version The struct version; pass `GIT_STASH_APPLY_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_stash_apply_init_options(
+GIT_EXTERN(int) git_stash_apply_options_init(
 	git_stash_apply_options *opts, unsigned int version);
 
 /**

--- a/include/git2/status.h
+++ b/include/git2/status.h
@@ -200,7 +200,7 @@ typedef struct {
  * @param version The struct version; pass `GIT_STATUS_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_status_init_options(
+GIT_EXTERN(int) git_status_options_init(
 	git_status_options *opts,
 	unsigned int version);
 

--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -122,7 +122,7 @@ typedef int GIT_CALLBACK(git_submodule_cb)(
  * Submodule update options structure
  *
  * Initialize with `GIT_SUBMODULE_UPDATE_OPTIONS_INIT`. Alternatively, you can
- * use `git_submodule_update_init_options`.
+ * use `git_submodule_update_options_init`.
  *
  */
 typedef struct git_submodule_update_options {
@@ -168,7 +168,7 @@ typedef struct git_submodule_update_options {
  * @param version The struct version; pass `GIT_SUBMODULE_UPDATE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_submodule_update_init_options(
+GIT_EXTERN(int) git_submodule_update_options_init(
 	git_submodule_update_options *opts, unsigned int version);
 
 /**

--- a/include/git2/worktree.h
+++ b/include/git2/worktree.h
@@ -78,7 +78,7 @@ GIT_EXTERN(int) git_worktree_validate(const git_worktree *wt);
  * Worktree add options structure
  *
  * Initialize with `GIT_WORKTREE_ADD_OPTIONS_INIT`. Alternatively, you can
- * use `git_worktree_add_init_options`.
+ * use `git_worktree_add_options_init`.
  *
  */
 typedef struct git_worktree_add_options {
@@ -101,7 +101,7 @@ typedef struct git_worktree_add_options {
  * @param version The struct version; pass `GIT_WORKTREE_ADD_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_worktree_add_init_options(git_worktree_add_options *opts,
+GIT_EXTERN(int) git_worktree_add_options_init(git_worktree_add_options *opts,
 	unsigned int version);
 
 /**
@@ -174,7 +174,7 @@ GIT_EXTERN(const char *) git_worktree_name(const git_worktree *wt);
  *  is valid for the lifetime of the git_worktree.
  */
 GIT_EXTERN(const char *) git_worktree_path(const git_worktree *wt);
- 
+
 /**
  * Flags which can be passed to git_worktree_prune to alter its
  * behavior.
@@ -192,7 +192,7 @@ typedef enum {
  * Worktree prune options structure
  *
  * Initialize with `GIT_WORKTREE_PRUNE_OPTIONS_INIT`. Alternatively, you can
- * use `git_worktree_prune_init_options`.
+ * use `git_worktree_prune_options_init`.
  *
  */
 typedef struct git_worktree_prune_options {
@@ -214,7 +214,7 @@ typedef struct git_worktree_prune_options {
  * @param version The struct version; pass `GIT_WORKTREE_PRUNE_OPTIONS_VERSION`.
  * @return Zero on success; -1 on failure.
  */
-GIT_EXTERN(int) git_worktree_prune_init_options(
+GIT_EXTERN(int) git_worktree_prune_options_init(
 	git_worktree_prune_options *opts,
 	unsigned int version);
 

--- a/src/apply.c
+++ b/src/apply.c
@@ -745,6 +745,13 @@ done:
 	return error;
 }
 
+int git_apply_options_init(git_apply_options *opts, unsigned int version)
+{
+	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
+		opts, version, git_apply_options, GIT_APPLY_OPTIONS_INIT);
+	return 0;
+}
+
 /*
  * Handle the three application options ("locations"):
  *

--- a/src/blame.c
+++ b/src/blame.c
@@ -524,9 +524,14 @@ int git_blame_buffer(
 	return 0;
 }
 
-int git_blame_init_options(git_blame_options *opts, unsigned int version)
+int git_blame_options_init(git_blame_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_blame_options, GIT_BLAME_OPTIONS_INIT);
 	return 0;
+}
+
+int git_blame_init_options(git_blame_options *opts, unsigned int version)
+{
+	return git_blame_options_init(opts, version);
 }

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2791,9 +2791,14 @@ int git_checkout_head(
 	return git_checkout_tree(repo, NULL, opts);
 }
 
-int git_checkout_init_options(git_checkout_options *opts, unsigned int version)
+int git_checkout_options_init(git_checkout_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_checkout_options, GIT_CHECKOUT_OPTIONS_INIT);
 	return 0;
+}
+
+int git_checkout_init_options(git_checkout_options *opts, unsigned int version)
+{
+	return git_checkout_options_init(opts, version);
 }

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -221,10 +221,16 @@ done:
 	return error;
 }
 
-int git_cherrypick_init_options(
+int git_cherrypick_options_init(
 	git_cherrypick_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_cherrypick_options, GIT_CHERRYPICK_OPTIONS_INIT);
 	return 0;
+}
+
+int git_cherrypick_init_options(
+	git_cherrypick_options *opts, unsigned int version)
+{
+	return git_cherrypick_options_init(opts, version);
 }

--- a/src/clone.c
+++ b/src/clone.c
@@ -455,11 +455,16 @@ int git_clone(
 	return error;
 }
 
-int git_clone_init_options(git_clone_options *opts, unsigned int version)
+int git_clone_options_init(git_clone_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_clone_options, GIT_CLONE_OPTIONS_INIT);
 	return 0;
+}
+
+int git_clone_init_options(git_clone_options *opts, unsigned int version)
+{
+	return git_clone_options_init(opts, version);
 }
 
 static bool can_link(const char *src, const char *dst, int link)

--- a/src/describe.c
+++ b/src/describe.c
@@ -759,7 +759,7 @@ static int normalize_format_options(
 	const git_describe_format_options *src)
 {
 	if (!src) {
-		git_describe_init_format_options(dst, GIT_DESCRIBE_FORMAT_OPTIONS_VERSION);
+		git_describe_format_options_init(dst, GIT_DESCRIBE_FORMAT_OPTIONS_VERSION);
 		return 0;
 	}
 
@@ -868,16 +868,26 @@ void git_describe_result_free(git_describe_result *result)
 	git__free(result);
 }
 
-int git_describe_init_options(git_describe_options *opts, unsigned int version)
+int git_describe_options_init(git_describe_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_describe_options, GIT_DESCRIBE_OPTIONS_INIT);
 	return 0;
 }
 
-int git_describe_init_format_options(git_describe_format_options *opts, unsigned int version)
+int git_describe_init_options(git_describe_options *opts, unsigned int version)
+{
+	return git_describe_options_init(opts, version);
+}
+
+int git_describe_format_options_init(git_describe_format_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_describe_format_options, GIT_DESCRIBE_FORMAT_OPTIONS_INIT);
 	return 0;
+}
+
+int git_describe_init_format_options(git_describe_format_options *opts, unsigned int version)
+{
+	return git_describe_format_options_init(opts, version);
 }

--- a/src/diff.c
+++ b/src/diff.c
@@ -350,14 +350,19 @@ int git_diff_commit_as_email(
 	return error;
 }
 
-int git_diff_init_options(git_diff_options *opts, unsigned int version)
+int git_diff_options_init(git_diff_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_diff_options, GIT_DIFF_OPTIONS_INIT);
 	return 0;
 }
 
-int git_diff_find_init_options(
+int git_diff_init_options(git_diff_options *opts, unsigned int version)
+{
+	return git_diff_options_init(opts, version);
+}
+
+int git_diff_find_options_init(
 	git_diff_find_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
@@ -365,13 +370,25 @@ int git_diff_find_init_options(
 	return 0;
 }
 
-int git_diff_format_email_init_options(
+int git_diff_find_init_options(
+	git_diff_find_options *opts, unsigned int version)
+{
+	return git_diff_find_options_init(opts, version);
+}
+
+int git_diff_format_email_options_init(
 	git_diff_format_email_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_diff_format_email_options,
 		GIT_DIFF_FORMAT_EMAIL_OPTIONS_INIT);
 	return 0;
+}
+
+int git_diff_format_email_init_options(
+	git_diff_format_email_options *opts, unsigned int version)
+{
+	return git_diff_format_email_options_init(opts, version);
 }
 
 static int flush_hunk(git_oid *result, git_hash_ctx *ctx)
@@ -481,7 +498,7 @@ out:
 	return error;
 }
 
-int git_diff_patchid_init_options(git_diff_patchid_options *opts, unsigned int version)
+int git_diff_patchid_options_init(git_diff_patchid_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_diff_patchid_options, GIT_DIFF_PATCHID_OPTIONS_INIT);

--- a/src/diff_parse.c
+++ b/src/diff_parse.c
@@ -45,7 +45,7 @@ static git_diff_parsed *diff_parsed_alloc(void)
 	diff->base.patch_fn = git_patch_parsed_from_diff;
 	diff->base.free_fn = diff_parsed_free;
 
-	if (git_diff_init_options(&diff->base.opts, GIT_DIFF_OPTIONS_VERSION) < 0) {
+	if (git_diff_options_init(&diff->base.opts, GIT_DIFF_OPTIONS_VERSION) < 0) {
 		git__free(diff);
 		return NULL;
 	}

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -148,9 +148,14 @@ int git_fetch_download_pack(git_remote *remote, const git_remote_callbacks *call
 	return t->download_pack(t, remote->repo, &remote->stats, progress, payload);
 }
 
-int git_fetch_init_options(git_fetch_options *opts, unsigned int version)
+int git_fetch_options_init(git_fetch_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_fetch_options, GIT_FETCH_OPTIONS_INIT);
 	return 0;
+}
+
+int git_fetch_init_options(git_fetch_options *opts, unsigned int version)
+{
+	return git_fetch_options_init(opts, version);
 }

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -116,11 +116,16 @@ static int objects_cmp(const void *a, const void *b)
 	return git_oid__cmp(&entrya->oid, &entryb->oid);
 }
 
-int git_indexer_init_options(git_indexer_options *opts, unsigned int version)
+int git_indexer_options_init(git_indexer_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_indexer_options, GIT_INDEXER_OPTIONS_INIT);
 	return 0;
+}
+
+int git_indexer_init_options(git_indexer_options *opts, unsigned int version)
+{
+	return git_indexer_options_init(opts, version);
 }
 
 int git_indexer_new(

--- a/src/merge.c
+++ b/src/merge.c
@@ -3322,24 +3322,40 @@ done:
 	return error;
 }
 
-int git_merge_init_options(git_merge_options *opts, unsigned int version)
+int git_merge_options_init(git_merge_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_merge_options, GIT_MERGE_OPTIONS_INIT);
 	return 0;
 }
 
-int git_merge_file_init_input(git_merge_file_input *input, unsigned int version)
+int git_merge_init_options(git_merge_options *opts, unsigned int version)
+{
+	return git_merge_options_init(opts, version);
+}
+
+int git_merge_file_input_init(git_merge_file_input *input, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		input, version, git_merge_file_input, GIT_MERGE_FILE_INPUT_INIT);
 	return 0;
 }
 
-int git_merge_file_init_options(
+int git_merge_file_init_input(git_merge_file_input *input, unsigned int version)
+{
+	return git_merge_file_input_init(input, version);
+}
+
+int git_merge_file_options_init(
 	git_merge_file_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_merge_file_options, GIT_MERGE_FILE_OPTIONS_INIT);
 	return 0;
+}
+
+int git_merge_file_init_options(
+	git_merge_file_options *opts, unsigned int version)
+{
+	return git_merge_file_options_init(opts, version);
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -9,17 +9,22 @@
 
 #include "git2/proxy.h"
 
-int git_proxy_init_options(git_proxy_options *opts, unsigned int version)
+int git_proxy_options_init(git_proxy_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_proxy_options, GIT_PROXY_OPTIONS_INIT);
 	return 0;
 }
 
+int git_proxy_init_options(git_proxy_options *opts, unsigned int version)
+{
+	return git_proxy_options_init(opts, version);
+}
+
 int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src)
 {
 	if (!src) {
-		git_proxy_init_options(tgt, GIT_PROXY_OPTIONS_VERSION);
+		git_proxy_options_init(tgt, GIT_PROXY_OPTIONS_VERSION);
 		return 0;
 	}
 

--- a/src/push.c
+++ b/src/push.c
@@ -547,9 +547,14 @@ void git_push_free(git_push *push)
 	git__free(push);
 }
 
-int git_push_init_options(git_push_options *opts, unsigned int version)
+int git_push_options_init(git_push_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_push_options, GIT_PUSH_OPTIONS_INIT);
 	return 0;
+}
+
+int git_push_init_options(git_push_options *opts, unsigned int version)
+{
+	return git_push_options_init(opts, version);
 }

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -268,7 +268,7 @@ static int rebase_alloc(git_rebase **out, const git_rebase_options *rebase_opts)
 	if (rebase_opts)
 		memcpy(&rebase->options, rebase_opts, sizeof(git_rebase_options));
 	else
-		git_rebase_init_options(&rebase->options, GIT_REBASE_OPTIONS_VERSION);
+		git_rebase_options_init(&rebase->options, GIT_REBASE_OPTIONS_VERSION);
 
 	if (rebase_opts && rebase_opts->rewrite_notes_ref) {
 		rebase->options.rewrite_notes_ref = git__strdup(rebase_opts->rewrite_notes_ref);
@@ -493,11 +493,16 @@ static int rebase_setupfiles(git_rebase *rebase)
 	return rebase_setupfiles_merge(rebase);
 }
 
-int git_rebase_init_options(git_rebase_options *opts, unsigned int version)
+int git_rebase_options_init(git_rebase_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_rebase_options, GIT_REBASE_OPTIONS_INIT);
 	return 0;
+}
+
+int git_rebase_init_options(git_rebase_options *opts, unsigned int version)
+{
+	return git_rebase_options_init(opts, version);
 }
 
 static int rebase_ensure_not_in_progress(git_repository *repo)

--- a/src/remote.c
+++ b/src/remote.c
@@ -217,11 +217,16 @@ static int ensure_remote_doesnot_exist(git_repository *repo, const char *name)
 	return GIT_EEXISTS;
 }
 
-int git_remote_create_init_options(git_remote_create_options *opts, unsigned int version)
+int git_remote_create_options_init(git_remote_create_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_remote_create_options, GIT_REMOTE_CREATE_OPTIONS_INIT);
 	return 0;
+}
+
+int git_remote_create_init_options(git_remote_create_options *opts, unsigned int version)
+{
+	return git_remote_create_options_init(opts, version);
 }
 
 int git_remote_create_with_opts(git_remote **out, const char *url, const git_remote_create_options *opts)

--- a/src/repository.c
+++ b/src/repository.c
@@ -2870,13 +2870,19 @@ int git_repository_is_shallow(git_repository *repo)
 	return st.st_size == 0 ? 0 : 1;
 }
 
-int git_repository_init_init_options(
+int git_repository_init_options_init(
 	git_repository_init_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_repository_init_options,
 		GIT_REPOSITORY_INIT_OPTIONS_INIT);
 	return 0;
+}
+
+int git_repository_init_init_options(
+	git_repository_init_options *opts, unsigned int version)
+{
+	return git_repository_init_options_init(opts, version);
 }
 
 int git_repository_ident(const char **name, const char **email, const git_repository *repo)

--- a/src/revert.c
+++ b/src/revert.c
@@ -224,9 +224,14 @@ done:
 	return error;
 }
 
-int git_revert_init_options(git_revert_options *opts, unsigned int version)
+int git_revert_options_init(git_revert_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_revert_options, GIT_REVERT_OPTIONS_INIT);
 	return 0;
+}
+
+int git_revert_init_options(git_revert_options *opts, unsigned int version)
+{
+	return git_revert_options_init(opts, version);
 }

--- a/src/stash.c
+++ b/src/stash.c
@@ -794,11 +794,16 @@ static void normalize_apply_options(
 		opts->checkout_options.their_label = "Stashed changes";
 }
 
-int git_stash_apply_init_options(git_stash_apply_options *opts, unsigned int version)
+int git_stash_apply_options_init(git_stash_apply_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_stash_apply_options, GIT_STASH_APPLY_OPTIONS_INIT);
 	return 0;
+}
+
+int git_stash_apply_init_options(git_stash_apply_options *opts, unsigned int version)
+{
+	return git_stash_apply_options_init(opts, version);
 }
 
 #define NOTIFY_PROGRESS(opts, progress_type)				\

--- a/src/status.c
+++ b/src/status.c
@@ -280,7 +280,7 @@ int git_status_list_new(
 	if ((error = git_repository__ensure_not_bare(repo, "status")) < 0 ||
 		(error = git_repository_index(&index, repo)) < 0)
 		return error;
-	
+
 	if (opts != NULL && opts->baseline != NULL) {
 		head = opts->baseline;
 	} else {
@@ -540,11 +540,16 @@ int git_status_should_ignore(
 	return git_ignore_path_is_ignored(ignored, repo, path);
 }
 
-int git_status_init_options(git_status_options *opts, unsigned int version)
+int git_status_options_init(git_status_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_status_options, GIT_STATUS_OPTIONS_INIT);
 	return 0;
+}
+
+int git_status_init_options(git_status_options *opts, unsigned int version)
+{
+	return git_status_options_init(opts, version);
 }
 
 int git_status_list_get_perfdata(

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1174,11 +1174,16 @@ static int git_submodule_update_repo_init_cb(
 	return submodule_repo_create(out, sm->repo, path);
 }
 
-int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version)
+int git_submodule_update_options_init(git_submodule_update_options *opts, unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
 		opts, version, git_submodule_update_options, GIT_SUBMODULE_UPDATE_OPTIONS_INIT);
 	return 0;
+}
+
+int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version)
+{
+	return git_submodule_update_options_init(opts, version);
 }
 
 int git_submodule_update(git_submodule *sm, int init, git_submodule_update_options *_update_options)

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -757,7 +757,7 @@ static int load_proxy_config(http_subtransport *t)
 		git__free(t->proxy_url);
 		t->proxy_url = NULL;
 
-		git_proxy_init_options(&t->proxy_opts, GIT_PROXY_OPTIONS_VERSION);
+		git_proxy_options_init(&t->proxy_opts, GIT_PROXY_OPTIONS_VERSION);
 
 		if ((error = git_remote__get_http_proxy(t->owner->owner,
 			!strcmp(t->server.url.scheme, "https"), &t->proxy_url)) < 0)

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -260,12 +260,18 @@ int git_worktree_validate(const git_worktree *wt)
 	return 0;
 }
 
-int git_worktree_add_init_options(git_worktree_add_options *opts,
+int git_worktree_add_options_init(git_worktree_add_options *opts,
 	unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(opts, version,
 		git_worktree_add_options, GIT_WORKTREE_ADD_OPTIONS_INIT);
 	return 0;
+}
+
+int git_worktree_add_init_options(git_worktree_add_options *opts,
+	unsigned int version)
+{
+	return git_worktree_add_options_init(opts, version);
 }
 
 int git_worktree_add(git_worktree **out, git_repository *repo,
@@ -478,13 +484,19 @@ const char *git_worktree_path(const git_worktree *wt)
 	return wt->worktree_path;
 }
 
-int git_worktree_prune_init_options(
+int git_worktree_prune_options_init(
 	git_worktree_prune_options *opts,
 	unsigned int version)
 {
 	GIT_INIT_STRUCTURE_FROM_TEMPLATE(opts, version,
 		git_worktree_prune_options, GIT_WORKTREE_PRUNE_OPTIONS_INIT);
 	return 0;
+}
+
+int git_worktree_pruneinit_options(git_worktree_prune_options *opts,
+	unsigned int version)
+{
+	return git_worktree_prune_options_init(opts, version);
 }
 
 int git_worktree_is_prunable(git_worktree *wt,

--- a/tests/checkout/icase.c
+++ b/tests/checkout/icase.c
@@ -33,7 +33,7 @@ void test_checkout_icase__initialize(void)
 	cl_git_pass(git_reference_name_to_id(&id, repo, "refs/heads/dir"));
 	cl_git_pass(git_object_lookup(&obj, repo, &id, GIT_OBJECT_ANY));
 
-	git_checkout_init_options(&checkout_opts, GIT_CHECKOUT_OPTIONS_VERSION);
+	git_checkout_options_init(&checkout_opts, GIT_CHECKOUT_OPTIONS_VERSION);
 	checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;
 }
 

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -72,6 +72,11 @@ void test_core_structinit__compare(void)
 	clar__skip();
 #endif
 
+	/* apply */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_apply_options, GIT_APPLY_OPTIONS_VERSION, \
+		GIT_APPLY_OPTIONS_INIT, git_apply_options_init);
+
 	/* blame */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_blame_options, GIT_BLAME_OPTIONS_VERSION, \

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -75,27 +75,27 @@ void test_core_structinit__compare(void)
 	/* blame */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_blame_options, GIT_BLAME_OPTIONS_VERSION, \
-		GIT_BLAME_OPTIONS_INIT, git_blame_init_options);
+		GIT_BLAME_OPTIONS_INIT, git_blame_options_init);
 
 	/* checkout */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_checkout_options, GIT_CHECKOUT_OPTIONS_VERSION, \
-		GIT_CHECKOUT_OPTIONS_INIT, git_checkout_init_options);
+		GIT_CHECKOUT_OPTIONS_INIT, git_checkout_options_init);
 
 	/* clone */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_clone_options, GIT_CLONE_OPTIONS_VERSION, \
-		GIT_CLONE_OPTIONS_INIT, git_clone_init_options);
+		GIT_CLONE_OPTIONS_INIT, git_clone_options_init);
 
 	/* diff */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_diff_options, GIT_DIFF_OPTIONS_VERSION, \
-		GIT_DIFF_OPTIONS_INIT, git_diff_init_options);
+		GIT_DIFF_OPTIONS_INIT, git_diff_options_init);
 
 	/* diff_find */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_diff_find_options, GIT_DIFF_FIND_OPTIONS_VERSION, \
-		GIT_DIFF_FIND_OPTIONS_INIT, git_diff_find_init_options);
+		GIT_DIFF_FIND_OPTIONS_INIT, git_diff_find_options_init);
 
 	/* filter */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
@@ -105,22 +105,22 @@ void test_core_structinit__compare(void)
 	/* merge_file_input */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_merge_file_input, GIT_MERGE_FILE_INPUT_VERSION, \
-		GIT_MERGE_FILE_INPUT_INIT, git_merge_file_init_input);
+		GIT_MERGE_FILE_INPUT_INIT, git_merge_file_input_init);
 
 	/* merge_file */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_merge_file_options, GIT_MERGE_FILE_OPTIONS_VERSION, \
-		GIT_MERGE_FILE_OPTIONS_INIT, git_merge_file_init_options);
+		GIT_MERGE_FILE_OPTIONS_INIT, git_merge_file_options_init);
 
 	/* merge_tree */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_merge_options, GIT_MERGE_OPTIONS_VERSION, \
-		GIT_MERGE_OPTIONS_INIT, git_merge_init_options);
+		GIT_MERGE_OPTIONS_INIT, git_merge_options_init);
 
 	/* push */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_push_options, GIT_PUSH_OPTIONS_VERSION, \
-		GIT_PUSH_OPTIONS_INIT, git_push_init_options);
+		GIT_PUSH_OPTIONS_INIT, git_push_options_init);
 
 	/* remote */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
@@ -130,22 +130,22 @@ void test_core_structinit__compare(void)
 	/* repository_init */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_repository_init_options, GIT_REPOSITORY_INIT_OPTIONS_VERSION, \
-		GIT_REPOSITORY_INIT_OPTIONS_INIT, git_repository_init_init_options);
+		GIT_REPOSITORY_INIT_OPTIONS_INIT, git_repository_init_options_init);
 
 	/* revert */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_revert_options, GIT_REVERT_OPTIONS_VERSION, \
-		GIT_REVERT_OPTIONS_INIT, git_revert_init_options);
+		GIT_REVERT_OPTIONS_INIT, git_revert_options_init);
 
 	/* stash apply */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_stash_apply_options, GIT_STASH_APPLY_OPTIONS_VERSION, \
-		GIT_STASH_APPLY_OPTIONS_INIT, git_stash_apply_init_options);
+		GIT_STASH_APPLY_OPTIONS_INIT, git_stash_apply_options_init);
 
 	/* status */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_status_options, GIT_STATUS_OPTIONS_VERSION, \
-		GIT_STATUS_OPTIONS_INIT, git_status_init_options);
+		GIT_STATUS_OPTIONS_INIT, git_status_options_init);
 
 	/* transport */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
@@ -170,14 +170,14 @@ void test_core_structinit__compare(void)
 	/* submodule update */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_submodule_update_options, GIT_SUBMODULE_UPDATE_OPTIONS_VERSION, \
-		GIT_SUBMODULE_UPDATE_OPTIONS_INIT, git_submodule_update_init_options);
+		GIT_SUBMODULE_UPDATE_OPTIONS_INIT, git_submodule_update_options_init);
 
 	/* submodule update */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_proxy_options, GIT_PROXY_OPTIONS_VERSION, \
-		GIT_PROXY_OPTIONS_INIT, git_proxy_init_options);
+		GIT_PROXY_OPTIONS_INIT, git_proxy_options_init);
 
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_diff_patchid_options, GIT_DIFF_PATCHID_OPTIONS_VERSION, \
-		GIT_DIFF_PATCHID_OPTIONS_INIT, git_diff_patchid_init_options);
+		GIT_DIFF_PATCHID_OPTIONS_INIT, git_diff_patchid_options_init);
 }

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -39,7 +39,7 @@ void test_diff_blob__initialize(void)
 
 	g_repo = cl_git_sandbox_init("attr");
 
-	cl_git_pass(git_diff_init_options(&opts, GIT_DIFF_OPTIONS_VERSION));
+	cl_git_pass(git_diff_options_init(&opts, GIT_DIFF_OPTIONS_VERSION));
 	opts.context_lines = 1;
 
 	memset(&expected, 0, sizeof(expected));

--- a/tests/diff/patch.c
+++ b/tests/diff/patch.c
@@ -692,7 +692,7 @@ void test_diff_patch__can_strip_bad_utf8(void)
 	git_patch *patch;
 	git_buf buf = GIT_BUF_INIT;
 
-	cl_git_pass(git_diff_init_options(&opts, GIT_DIFF_OPTIONS_VERSION));
+	cl_git_pass(git_diff_options_init(&opts, GIT_DIFF_OPTIONS_VERSION));
 
 	cl_git_pass(git_patch_from_buffers(&patch, a, strlen(a), NULL, b, strlen(b), NULL, &opts));
 	cl_git_pass(git_patch_to_buf(&buf, patch));

--- a/tests/diff/tree.c
+++ b/tests/diff/tree.c
@@ -9,7 +9,7 @@ static diff_expects expect;
 
 void test_diff_tree__initialize(void)
 {
-	cl_git_pass(git_diff_init_options(&opts, GIT_DIFF_OPTIONS_VERSION));
+	cl_git_pass(git_diff_options_init(&opts, GIT_DIFF_OPTIONS_VERSION));
 
 	memset(&expect, 0, sizeof(expect));
 
@@ -472,7 +472,7 @@ void test_diff_tree__diff_configs(void)
 
 	cl_git_pass(git_diff_tree_to_tree(&diff, g_repo, a, b, NULL));
 
-	cl_git_pass(git_diff_foreach(diff, 
+	cl_git_pass(git_diff_foreach(diff,
 		diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &expect));
 
 	cl_assert_equal_i(2, expect.files);


### PR DESCRIPTION
Rename opt init functions to `options_init`

In libgit2 nomenclature, when we need to verb a direct object, we name a function `git_directobject_verb`.  Thus, if we need to init an options structure named `git_foo_options`, then the name of the function that does that should be `git_foo_options_init`.

The previous names of `git_foo_init_options` is close - it _sounds_ as if it's initializing the options of a `foo`, but in fact `git_foo_options` is its own noun that should be respected.

Deprecate the old names; they'll now call directly to the new ones.

Additionally, add an initializer function for `git_apply_options`.