### PR TITLE
Callback type names should be suffixed with `_cb`

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -246,6 +246,21 @@ GIT_EXTERN(void) giterr_set_oom(void);
 
 /**@}*/
 
+/** @name Deprecated Credential Callback Types
+ *
+ * These types are retained for backward compatibility.  The newer
+ * versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+typedef git_cred_sign_cb git_cred_sign_callback;
+typedef git_cred_ssh_interactive_cb git_cred_ssh_interactive_callback;
+
+/**@}*/
+
 /** @name Deprecated Transfer Progress Types
  *
  * These types are retained for backward compatibility.  The newer

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -14,6 +14,7 @@
 #include "object.h"
 #include "refs.h"
 #include "remote.h"
+#include "trace.h"
 
 /*
  * Users can avoid deprecated functions by defining `GIT_DEPRECATE_HARD`.
@@ -258,6 +259,20 @@ GIT_EXTERN(void) giterr_set_oom(void);
 
 typedef git_cred_sign_cb git_cred_sign_callback;
 typedef git_cred_ssh_interactive_cb git_cred_ssh_interactive_callback;
+
+/**@}*/
+
+/** @name Deprecated Trace Callback Types
+ *
+ * These types are retained for backward compatibility.  The newer
+ * versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+typedef git_trace_cb git_trace_callback;
 
 /**@}*/
 

--- a/include/git2/trace.h
+++ b/include/git2/trace.h
@@ -49,7 +49,7 @@ typedef enum {
 /**
  * An instance for a tracing function
  */
-typedef void GIT_CALLBACK(git_trace_callback)(git_trace_level_t level, const char *msg);
+typedef void GIT_CALLBACK(git_trace_cb)(git_trace_level_t level, const char *msg);
 
 /**
  * Sets the system tracing configuration to the specified level with the
@@ -60,7 +60,7 @@ typedef void GIT_CALLBACK(git_trace_callback)(git_trace_level_t level, const cha
  * @param cb Function to call with trace data
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_trace_set(git_trace_level_t level, git_trace_callback cb);
+GIT_EXTERN(int) git_trace_set(git_trace_level_t level, git_trace_cb cb);
 
 /** @} */
 GIT_END_DECL

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -165,8 +165,8 @@ typedef struct _LIBSSH2_USERAUTH_KBDINT_PROMPT LIBSSH2_USERAUTH_KBDINT_PROMPT;
 typedef struct _LIBSSH2_USERAUTH_KBDINT_RESPONSE LIBSSH2_USERAUTH_KBDINT_RESPONSE;
 #endif
 
-typedef int GIT_CALLBACK(git_cred_sign_callback)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract);
-typedef void GIT_CALLBACK(git_cred_ssh_interactive_callback)(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract);
+typedef int GIT_CALLBACK(git_cred_sign_cb)(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract);
+typedef void GIT_CALLBACK(git_cred_ssh_interactive_cb)(const char* name, int name_len, const char* instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses, void **abstract);
 
 /**
  * A ssh key from disk
@@ -185,7 +185,7 @@ typedef struct git_cred_ssh_key {
 typedef struct git_cred_ssh_interactive {
 	git_cred parent;
 	char *username;
-	git_cred_ssh_interactive_callback prompt_callback;
+	git_cred_ssh_interactive_cb prompt_callback;
 	void *payload;
 } git_cred_ssh_interactive;
 
@@ -197,7 +197,7 @@ typedef struct git_cred_ssh_custom {
 	char *username;
 	char *publickey;
 	size_t publickey_len;
-	git_cred_sign_callback sign_callback;
+	git_cred_sign_cb sign_callback;
 	void *payload;
 } git_cred_ssh_custom;
 
@@ -262,7 +262,7 @@ GIT_EXTERN(int) git_cred_ssh_key_new(
 GIT_EXTERN(int) git_cred_ssh_interactive_new(
 	git_cred **out,
 	const char *username,
-	git_cred_ssh_interactive_callback prompt_callback,
+	git_cred_ssh_interactive_cb prompt_callback,
 	void *payload);
 
 /**
@@ -300,7 +300,7 @@ GIT_EXTERN(int) git_cred_ssh_custom_new(
 	const char *username,
 	const char *publickey,
 	size_t publickey_len,
-	git_cred_sign_callback sign_callback,
+	git_cred_sign_cb sign_callback,
 	void *payload);
 
 /**

--- a/src/trace.c
+++ b/src/trace.c
@@ -17,7 +17,7 @@ struct git_trace_data git_trace__data = {0};
 
 #endif
 
-int git_trace_set(git_trace_level_t level, git_trace_callback callback)
+int git_trace_set(git_trace_level_t level, git_trace_cb callback)
 {
 #ifdef GIT_TRACE
 	assert(level == 0 || callback != NULL);

--- a/src/trace.h
+++ b/src/trace.h
@@ -16,7 +16,7 @@
 
 struct git_trace_data {
 	git_trace_level_t level;
-	git_trace_callback callback;
+	git_trace_cb callback;
 };
 
 extern struct git_trace_data git_trace__data;
@@ -25,7 +25,7 @@ GIT_INLINE(void) git_trace__write_fmt(
 	git_trace_level_t level,
 	const char *fmt, ...)
 {
-	git_trace_callback callback = git_trace__data.callback;
+	git_trace_cb callback = git_trace__data.callback;
 	git_buf message = GIT_BUF_INIT;
 	va_list ap;
 

--- a/src/transports/cred.c
+++ b/src/transports/cred.c
@@ -264,7 +264,7 @@ static int git_cred_ssh_key_type_new(
 int git_cred_ssh_interactive_new(
 	git_cred **out,
 	const char *username,
-	git_cred_ssh_interactive_callback prompt_callback,
+	git_cred_ssh_interactive_cb prompt_callback,
 	void *payload)
 {
 	git_cred_ssh_interactive *c;
@@ -312,7 +312,7 @@ int git_cred_ssh_custom_new(
 	const char *username,
 	const char *publickey,
 	size_t publickey_len,
-	git_cred_sign_callback sign_callback,
+	git_cred_sign_cb sign_callback,
 	void *payload)
 {
 	git_cred_ssh_custom *c;


### PR DESCRIPTION
The credential and trace callbacks should match the other callback naming conventions, using the `_cb` suffix instead of a `_callback` suffix.