### PR TITLE
fetch: pass negotiation data around as a struct

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -32,6 +32,11 @@ typedef enum {
 	GIT_TRANSPORTFLAGS_NONE = 0,
 } git_transport_flags_t;
 
+typedef struct {
+	const git_remote_head * const *refs;
+	size_t count;
+} git_fetch_negotiation;
+
 struct git_transport {
 	unsigned int version; /**< The struct version */
 
@@ -86,8 +91,7 @@ struct git_transport {
 	int GIT_CALLBACK(negotiate_fetch)(
 		git_transport *transport,
 		git_repository *repo,
-		const git_remote_head * const *refs,
-		size_t count);
+		const git_fetch_negotiation *fetch_data);
 
 	/**
 	 * Start downloading the packfile from the remote repository.

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -109,6 +109,7 @@ cleanup:
 int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 {
 	git_transport *t = remote->transport;
+	git_fetch_negotiation nego;
 
 	remote->need_pack = 0;
 
@@ -125,10 +126,11 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 	 * Now we have everything set up so we can start tell the
 	 * server what we want and what we have.
 	 */
+	nego.refs = (const git_remote_head * const *)remote->refs.contents;
+	nego.count = remote->refs.length;
 	return t->negotiate_fetch(t,
 		remote->repo,
-		(const git_remote_head * const *)remote->refs.contents,
-		remote->refs.length);
+		&nego);
 }
 
 int git_fetch_download_pack(git_remote *remote, const git_remote_callbacks *callbacks)

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -268,15 +268,13 @@ static int local_ls(const git_remote_head ***out, size_t *size, git_transport *t
 static int local_negotiate_fetch(
 	git_transport *transport,
 	git_repository *repo,
-	const git_remote_head * const *refs,
-	size_t count)
+	const git_fetch_negotiation *wants)
 {
 	transport_local *t = (transport_local*)transport;
 	git_remote_head *rhead;
 	unsigned int i;
 
-	GIT_UNUSED(refs);
-	GIT_UNUSED(count);
+	GIT_UNUSED(wants);
 
 	/* Fill in the loids */
 	git_vector_foreach(&t->refs, i, rhead) {

--- a/src/transports/smart.h
+++ b/src/transports/smart.h
@@ -171,8 +171,7 @@ int git_smart__push(git_transport *transport, git_push *push, const git_remote_c
 int git_smart__negotiate_fetch(
 	git_transport *transport,
 	git_repository *repo,
-	const git_remote_head * const *refs,
-	size_t count);
+	const git_fetch_negotiation *wants);
 
 int git_smart__download_pack(
 	git_transport *transport,
@@ -192,7 +191,7 @@ int git_pkt_parse_line(git_pkt **head, const char **endptr, const char *line, si
 int git_pkt_buffer_flush(git_buf *buf);
 int git_pkt_send_flush(GIT_SOCKET s);
 int git_pkt_buffer_done(git_buf *buf);
-int git_pkt_buffer_wants(const git_remote_head * const *refs, size_t count, transport_smart_caps *caps, git_buf *buf);
+int git_pkt_buffer_wants(const git_fetch_negotiation *wants, transport_smart_caps *caps, git_buf *buf);
 int git_pkt_buffer_have(git_oid *oid, git_buf *buf);
 void git_pkt_free(git_pkt *pkt);
 

--- a/src/transports/smart_pkt.c
+++ b/src/transports/smart_pkt.c
@@ -583,8 +583,7 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
  */
 
 int git_pkt_buffer_wants(
-	const git_remote_head * const *refs,
-	size_t count,
+	const git_fetch_negotiation *wants,
 	transport_smart_caps *caps,
 	git_buf *buf)
 {
@@ -592,22 +591,22 @@ int git_pkt_buffer_wants(
 	const git_remote_head *head;
 
 	if (caps->common) {
-		for (; i < count; ++i) {
-			head = refs[i];
+		for (; i < wants->count; ++i) {
+			head = wants->refs[i];
 			if (!head->local)
 				break;
 		}
 
-		if (buffer_want_with_caps(refs[i], caps, buf) < 0)
+		if (buffer_want_with_caps(wants->refs[i], caps, buf) < 0)
 			return -1;
 
 		i++;
 	}
 
-	for (; i < count; ++i) {
+	for (; i < wants->count; ++i) {
 		char oid[GIT_OID_HEXSZ];
 
-		head = refs[i];
+		head = wants->refs[i];
 		if (head->local)
 			continue;
 

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -344,7 +344,7 @@ static int wait_while_ack(gitno_buffer *buf)
 	return 0;
 }
 
-int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, const git_remote_head * const *wants, size_t count)
+int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, const git_fetch_negotiation *wants)
 {
 	transport_smart *t = (transport_smart *)transport;
 	gitno_buffer *buf = &t->buffer;
@@ -355,7 +355,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 	unsigned int i;
 	git_oid oid;
 
-	if ((error = git_pkt_buffer_wants(wants, count, &t->caps, &data)) < 0)
+	if ((error = git_pkt_buffer_wants(wants, &t->caps, &data)) < 0)
 		return error;
 
 	if ((error = fetch_setup_walk(&walk, repo)) < 0)
@@ -423,7 +423,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 			git_pkt_ack *pkt;
 			unsigned int j;
 
-			if ((error = git_pkt_buffer_wants(wants, count, &t->caps, &data)) < 0)
+			if ((error = git_pkt_buffer_wants(wants, &t->caps, &data)) < 0)
 				goto on_error;
 
 			git_vector_foreach(&t->common, j, pkt) {
@@ -443,7 +443,7 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 		git_pkt_ack *pkt;
 		unsigned int j;
 
-		if ((error = git_pkt_buffer_wants(wants, count, &t->caps, &data)) < 0)
+		if ((error = git_pkt_buffer_wants(wants, &t->caps, &data)) < 0)
 			goto on_error;
 
 		git_vector_foreach(&t->common, j, pkt) {


### PR DESCRIPTION
This is extracted from the shallow support transport level PR, and since it very clearly has an impact on API compatibility, we should arrange to be ready for anything. For example, shallow clones need to keep negotiated "things" (the list of server-received shallow OIDs, that should technically only be enforced if the fetch actually unpacks or something).

As the public interface changes to support some options to the negotiation step (like depth level for shallow clones), the underlying transport will need to be updated as well, so let's be prepared.