### PR TITLE
deps: ntlmclient: disable implicit fallthrough warnings

### DIFF
--- a/deps/ntlmclient/CMakeLists.txt
+++ b/deps/ntlmclient/CMakeLists.txt
@@ -2,6 +2,8 @@ FILE(GLOB SRC_NTLMCLIENT "ntlm.c" "unicode_builtin.c" "util.c")
 
 ADD_DEFINITIONS(-DNTLM_STATIC=1)
 
+DISABLE_WARNINGS(implicit-fallthrough)
+
 IF (HTTPS_BACKEND STREQUAL "SecureTransport")
 	ADD_DEFINITIONS(-DCRYPT_COMMONCRYPTO)
 	SET(SRC_NTLMCLIENT_CRYPTO "crypt_commoncrypto.c")


### PR DESCRIPTION
The ntlmclient dependency has quite a lot of places with implicit
fallthroughs. As at least modern GCC has enabled warnings on
implicit fallthroughs by default, the developer is greeted with a
wall of warnings when compiling that dependency.

Disable implicit fallthrough warnings for ntlmclient to fix this
issue.