### PR TITLE
Removal of `p_fallocate`

### DIFF
--- a/src/posix.h
+++ b/src/posix.h
@@ -115,7 +115,6 @@ extern int p_open(const char *path, int flags, ...);
 extern int p_creat(const char *path, mode_t mode);
 extern int p_getcwd(char *buffer_out, size_t size);
 extern int p_rename(const char *from, const char *to);
-extern int p_fallocate(int fd, off_t offset, off_t len);
 
 extern int git__page_size(size_t *page_size);
 extern int git__mmap_alignment(size_t *page_size);

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -525,58 +525,6 @@ int p_creat(const char *path, mode_t mode)
 	return p_open(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
 }
 
-int p_fallocate(int fd, off_t offset, off_t len)
-{
-	HANDLE fh = (HANDLE)_get_osfhandle(fd);
-	LARGE_INTEGER zero, position, oldsize, newsize;
-	size_t size;
-
-	if (fh == INVALID_HANDLE_VALUE) {
-		errno = EBADF;
-		return -1;
-	}
-
-	if (offset < 0 || len <= 0) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (git__add_sizet_overflow(&size, offset, len)) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	zero.u.LowPart = 0;
-	zero.u.HighPart = 0;
-
-	newsize.u.LowPart = (size & 0xffffffff);
-
-#if (SIZE_MAX > UINT32_MAX)
-	newsize.u.HighPart = size >> 32;
-#else
-	newsize.u.HighPart = 0;
-#endif
-
-	if (!GetFileSizeEx(fh, &oldsize)) {
-		set_errno();
-		return -1;
-	}
-
-	/* POSIX emulation: attempting to shrink the file is ignored */
-	if (oldsize.QuadPart >= newsize.QuadPart)
-		return 0;
-
-	if (!SetFilePointerEx(fh, zero, &position, FILE_CURRENT) ||
-	    !SetFilePointerEx(fh, newsize, NULL, FILE_BEGIN) ||
-	    !SetEndOfFile(fh) ||
-	    !SetFilePointerEx(fh, position, 0, FILE_BEGIN)) {
-		set_errno();
-		return -1;
-	}
-
-	return 0;
-}
-
 int p_utimes(const char *path, const struct p_timeval times[2])
 {
 	git_win32_path wpath;

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -35,11 +35,6 @@ void test_core_posix__initialize(void)
 #endif
 }
 
-void test_core_posix__cleanup(void)
-{
-    p_unlink("fallocate_test");
-}
-
 static bool supports_ipv6(void)
 {
 #ifdef GIT_WIN32
@@ -267,40 +262,4 @@ void test_core_posix__p_regcomp_compile_userdiff_regexps(void)
 		p_regfree(&preg);
 		cl_assert(!error);
 	}
-}
-
-void test_core_posix__fallocate(void)
-{
-	int fd;
-	struct stat st;
-
-	/* fallocate a new file succeeds */
-	cl_must_pass(fd = p_open("fallocate_test", O_RDWR|O_CREAT, 0666));
-	cl_must_pass(p_fallocate(fd, 0, 42));
-	cl_must_pass(p_fstat(fd, &st));
-	cl_assert_equal_i(42, st.st_size);
-	p_close(fd);
-
-	/* fallocate an existing file succeeds */
-	cl_must_pass(fd = p_open("fallocate_test", O_RDWR, 0666));
-	cl_must_pass(p_fallocate(fd, 90, 9));
-	cl_must_pass(p_fstat(fd, &st));
-	cl_assert_equal_i(99, st.st_size);
-	p_close(fd);
-
-	/* fallocate doesn't shrink */
-	cl_must_pass(fd = p_open("fallocate_test", O_RDWR, 0666));
-	cl_must_pass(p_fallocate(fd, 0, 14));
-	cl_must_pass(p_fstat(fd, &st));
-	cl_assert_equal_i(99, st.st_size);
-	p_close(fd);
-
-	/* fallocate doesn't move the cursor */
-	cl_must_pass(fd = p_open("fallocate_test", O_RDWR, 0666));
-	cl_must_pass(p_fallocate(fd, 0, 100));
-	cl_assert_equal_i(0, p_lseek(fd, 0, SEEK_CUR));
-	cl_must_pass(p_lseek(fd, 42, SEEK_SET));
-	cl_must_pass(p_fallocate(fd, 0, 200));
-	cl_assert_equal_i(42, p_lseek(fd, 0, SEEK_CUR));
-	p_close(fd);
 }

--- a/tests/object/tree/read.c
+++ b/tests/object/tree/read.c
@@ -79,46 +79,36 @@ void test_object_tree_read__two(void)
 
 void test_object_tree_read__largefile(void)
 {
-	git_reference *ref;
+	const git_tree_entry *entry;
+	git_index_entry ie;
 	git_commit *commit;
+	git_object *object;
+	git_index *index;
 	git_tree *tree;
 	git_oid oid;
-	const git_tree_entry *entry;
-	git_object *object;
-	git_buf file = GIT_BUF_INIT;
-	int fd;
-	git_index *idx;
+	char *buf;
 
 	if (!cl_is_env_set("GITTEST_INVASIVE_FS_SIZE"))
 		cl_skip();
 
-	cl_git_pass(git_reference_lookup(&ref, g_repo, "refs/heads/master"));
-	cl_git_pass(git_repository_index(&idx, g_repo));
+	cl_assert(buf = git__calloc(1, BIGFILE_SIZE));
 
-	cl_git_pass(git_buf_puts(&file, git_repository_workdir(g_repo)));
-	cl_git_pass(git_buf_joinpath(&file, file.ptr, BIGFILE));
+	memset(&ie, 0, sizeof(ie));
+	ie.mode = GIT_FILEMODE_BLOB;
+	ie.path = BIGFILE;
 
-	fd = p_open(git_buf_cstr(&file), O_CREAT|O_RDWR, 0644);
-	cl_assert_(fd >= 0, "invalid file descriptor");
-
-	cl_must_pass(p_fallocate(fd, 0, BIGFILE_SIZE));
-	cl_must_pass(p_close(fd));
-
-	cl_git_pass(git_index_add_bypath(idx, BIGFILE));
-	cl_repo_commit_from_index(&oid, g_repo, NULL, 0, "bigfile");
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_frombuffer(index, &ie, buf, BIGFILE_SIZE));
+	cl_repo_commit_from_index(&oid, g_repo, NULL, 0, BIGFILE);
 
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &oid));
 	cl_git_pass(git_commit_tree(&tree, commit));
-
-	entry = git_tree_entry_byname(tree, BIGFILE);
-	cl_assert_(entry, "entry was NULL");
-
+	cl_assert(entry = git_tree_entry_byname(tree, BIGFILE));
 	cl_git_pass(git_tree_entry_to_object(&object, g_repo, entry));
 
-	git_buf_dispose(&file);
 	git_object_free(object);
 	git_tree_free(tree);
-	git_index_free(idx);
+	git_index_free(index);
 	git_commit_free(commit);
-	git_reference_free(ref);
+	git__free(buf);
 }


### PR DESCRIPTION
The `p_fallocate` platform is currently in use in our tests,
only, but it proved to be quite burdensome to get it implemented
in a cross-platform way. The only "real" user is the test
object::tree::read::largefile, where it's used to allocate a
large file in the filesystem only to commit it to the repo and
read its object back again. We can simplify this quite a bit by
just using an in-memory buffer of 4GB. Sure, this cannot be used
on platforms with low resources. But creating 4GB files is not
any better, and we already skip the test if the environment
variable "GITTEST_INVASIVE_FS_SIZE" is not set. So we're arguably
not worse off than before.

Supersedes #5087