### PR TITLE
Commit creation API streamlining

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,23 @@ v0.28 + 1
 * libgit2 can now correctly cope with URLs where the host contains a colon
   but a port is not specified.  (eg `http://example.com:/repo.git`).
 
+### API additions
+
+* `git_commit_create_on_ex()` takes on the role which
+  `git_commit_create()` had when provided a reference name to
+  update. `git_commit_create_on_head()` always updates the current
+  branch.
+
+* `git_commit_create_fromstate()` is a variant of the commit creation
+  function which behaves closer to `git-commit` by taking the parents
+  and tree from the current branch and the index.
+
+### API removals
+
+* `git_commit_create()` has been deprecated. Its replacement,
+  `git_commit_create_on()`, forgoes the `update_ref` parameter.
+  Callers will have to perform the reference manipulation themselves.
+
 v0.28
 -----
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,7 @@ v0.28 + 1
 
 ### API additions
 
-* `git_commit_create_on_ex()` takes on the role which
+* `git_commit_create_on()` takes on the role which
   `git_commit_create()` had when provided a reference name to
   update. `git_commit_create_on_head()` always updates the current
   branch.

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -258,12 +258,12 @@ static int create_merge_commit(git_repository *repo, git_index *index, merge_opt
 	check_lg2(git_tree_lookup(&tree, repo, &tree_oid), "failed to lookup tree", NULL);
 
 	/* Commit time ! */
-	err = git_commit_create_ext(&commit_oid,
-	                        repo, git_reference_name(head_ref),
-	                        sign, sign,
-	                        NULL, msg,
-	                        tree,
-	                        opts->annotated_count + 1, (const git_commit **)parents);
+	err = git_commit_create_on(&commit_oid,
+	                           repo, git_reference_name(head_ref),
+	                           sign, sign,
+	                           NULL, msg,
+	                           tree,
+	                           opts->annotated_count + 1, (const git_commit **)parents);
 	check_lg2(err, "failed to create commit", NULL);
 
 	/* We're done merging, cleanup the repository state */

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -258,7 +258,7 @@ static int create_merge_commit(git_repository *repo, git_index *index, merge_opt
 	check_lg2(git_tree_lookup(&tree, repo, &tree_oid), "failed to lookup tree", NULL);
 
 	/* Commit time ! */
-	err = git_commit_create(&commit_oid,
+	err = git_commit_create_ext(&commit_oid,
 	                        repo, git_reference_name(head_ref),
 	                        sign, sign,
 	                        NULL, msg,

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -313,6 +313,23 @@ GIT_EXTERN(int) git_commit_header_field(git_buf *out, const git_commit *commit, 
 GIT_EXTERN(int) git_commit_extract_signature(git_buf *signature, git_buf *signed_data, git_repository *repo, git_oid *commit_id, const char *field);
 
 /**
+ * Deprecated commit creation function.
+ *
+ * @see git_commit_create_on for the modern version.
+ */
+GIT_EXTERN(int) GIT_DEPRECATED(git_commit_create)(
+	git_oid *id,
+	git_repository *repo,
+	const char *update_ref,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[]);
+
+/**
  * Create new commit in the repository from a list of `git_object` pointers
  *
  * The message will **not** be cleaned up automatically. You can do that
@@ -321,14 +338,6 @@ GIT_EXTERN(int) git_commit_extract_signature(git_buf *signature, git_buf *signed
  * @param id Pointer in which to store the OID of the newly created commit
  *
  * @param repo Repository where to store the commit
- *
- * @param update_ref If not NULL, name of the reference that
- *	will be updated to point to this commit. If the reference
- *	is not direct, it will be resolved to a direct reference.
- *	Use "HEAD" to update the HEAD of the current branch and
- *	make it point to this commit. If the reference doesn't
- *	exist yet, it will be created. If it does exist, the first
- *	parent must be the tip of this branch.
  *
  * @param author Signature with author and author time of commit
  *
@@ -356,10 +365,46 @@ GIT_EXTERN(int) git_commit_extract_signature(git_buf *signature, git_buf *signed
  *	The created commit will be written to the Object Database and
  *	the given reference will be updated to point to it
  */
-GIT_EXTERN(int) git_commit_create(
+GIT_EXTERN(int) git_commit_create_ext(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[]);
+
+/**
+ * Create a commit and update a reference
+ *
+ * @param update_ref reference to update with the new commit. The
+ * current tip of the reference must be the first commit in the parent
+ * list.
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_on(
 	git_oid *id,
 	git_repository *repo,
 	const char *update_ref,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[]);
+
+/**
+ * Create a commit and update the current branch
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_on_head(
+	git_oid *id,
+	git_repository *repo,
 	const git_signature *author,
 	const git_signature *committer,
 	const char *message_encoding,

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -398,20 +398,20 @@ GIT_EXTERN(int) git_commit_create_on(
 	const git_commit *parents[]);
 
 /**
- * Create a commit and update the current branch
+ * Create a commit from the current state and update the current branch
  *
- * @see git_commit_create
+ * Like `git_commit_create_fromstate`; additionally the current branch will be
+ * updated.
+ *
+ * @see git_commit_create_fromstate
  */
-GIT_EXTERN(int) git_commit_create_on_head(
+GIT_EXTERN(int) git_commit_create_fromstate_on_head(
 	git_oid *id,
 	git_repository *repo,
 	const git_signature *author,
 	const git_signature *committer,
 	const char *message_encoding,
-	const char *message,
-	const git_tree *tree,
-	size_t parent_count,
-	const git_commit *parents[]);
+	const char *message);
 
 /**
  * Create new commit in the repository using a variable argument list.
@@ -523,9 +523,8 @@ GIT_EXTERN(int) git_commit_create_buffer(
  * variant takes the current state of the repository instead of
  * arguments.
  *
- * The current branch will be updated. The tree will be created from
- * the repository's index. The parents will be taken from HEAD and
- * MERGE_HEAD, if applicable.
+ * The tree will be created from the repository's index. The parents will be
+ * taken from HEAD and MERGE_HEAD, if applicable.
  *
  * @see git_commit_create
  */

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -471,6 +471,27 @@ GIT_EXTERN(int) git_commit_create_buffer(
 	size_t parent_count,
 	const git_commit *parents[]);
 
+/*
+ * Create a new commit from the current state and update the current branch
+ *
+ * Creates a new commit, similarly to the other functions. This
+ * variant takes the current state of the repository instead of
+ * arguments.
+ *
+ * The current branch will be updated. The tree will be created from
+ * the repository's index. The parents will be taken from HEAD and
+ * MERGE_HEAD, if applicable.
+ *
+ * @see git_commit_create
+ */
+GIT_EXTERN(int) git_commit_create_fromstate(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message);
+
 /**
  * Create a commit object from the given buffer and signature
  *

--- a/include/git2/sys/commit.h
+++ b/include/git2/sys/commit.h
@@ -75,6 +75,52 @@ GIT_EXTERN(int) git_commit_create_from_callback(
 	git_commit_parent_callback parent_cb,
 	void *parent_payload);
 
+typedef struct git_commit_descriptor {
+	unsigned int version;
+
+	const git_oid *tree; /**< The commit's underlying tree */
+
+	/**
+	 * The commit's author.
+	 *
+	 * Set to NULL to resolve using the repository's configuration.
+	 */
+	const git_signature *author;
+
+	/**
+	 * The commit's committer.
+	 *
+	 * Set to NULL to default to the author, if provided, or resolve using
+	 * the repository.
+	 */
+	const git_signature *committer;
+
+	/**
+	 * The commit's message.
+	 *
+	 * Mandatory.
+	 */
+	const char *message;
+
+	/**
+	 * The commit's message encoding
+	 *
+	 * NULL will default to UTF-8.
+	 */
+	const char *message_encoding;
+
+	/**
+	 * The commit's parents
+	 */
+	git_oidarray parents;
+} git_commit_descriptor;
+
+#define GIT_COMMIT_DESCRIPTOR_VERSION 1
+#define GIT_COMMIT_DESCRIPTOR_INIT { GIT_COMMIT_DESCRIPTOR_VERSION }
+
+GIT_EXTERN(int) git_commit_desc_write_buffer(git_buf *buffer,
+	const git_commit_descriptor *desc);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/sys/commit.h
+++ b/include/git2/sys/commit.h
@@ -121,6 +121,34 @@ typedef struct git_commit_descriptor {
 GIT_EXTERN(int) git_commit_desc_write_buffer(git_buf *buffer,
 	const git_commit_descriptor *desc);
 
+typedef enum {
+	GIT_COMMIT_BUILDER_VALIDATE = 1,
+} git_commit_builder_flags;
+
+typedef struct git_commit_desc_options {
+	unsigned int version;
+
+	uint32_t flags;
+
+	git_commit_parent_callback parent_cb;
+	void *parent_payload;
+
+	/**
+	 * The name of a reference on which to make the commit.
+	 *
+	 * NULL means that the commit will be left dangling.
+	 */
+	const char *update_ref;
+} git_commit_desc_options;
+
+#define GIT_COMMIT_DESC_OPTIONS_VERSION 1
+#define GIT_COMMIT_DESC_OPTIONS_INIT { GIT_COMMIT_DESC_OPTIONS_VERSION }
+
+GIT_EXTERN(int) git_commit_desc_write_object(git_oid *oid,
+	git_repository *repository,
+	const git_commit_descriptor *desc,
+	const git_commit_desc_options *opts);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/commit.c
+++ b/src/commit.c
@@ -466,9 +466,10 @@ int gather_commit_ids(const git_oid *id, void *payload)
 	return insert_commit(data->commits, data->repo, id);
 }
 
-int git_commit_create_fromstate(
+static int commit_fromstate(
 	git_oid *id,
 	git_repository *repo,
+	const char *update_ref,
 	const git_signature *author,
 	const git_signature *committer,
 	const char *message_encoding,
@@ -509,7 +510,7 @@ int git_commit_create_fromstate(
 	if ((error = git_tree_lookup(&tree, repo, &tree_id)) < 0)
 		goto cleanup;
 
-	error = git_commit_create_on(id, repo, GIT_HEAD_FILE,
+	error = git_commit_create_on(id, repo, update_ref,
 				     author, committer, message_encoding, message,
 				     tree, commits.length, (const git_commit **) commits.contents);
 
@@ -520,6 +521,28 @@ cleanup:
 	}
 	git_vector_free(&commits);
 	return 0;
+}
+
+int git_commit_create_fromstate(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message)
+{
+	return commit_fromstate(id, repo, NULL, author, committer, message_encoding, message);
+}
+
+int git_commit_create_fromstate_on_head(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message)
+{
+	return commit_fromstate(id, repo, GIT_HEAD_FILE, author, committer, message_encoding, message);
 }
 
 int git_commit__parse_raw(void *_commit, const char *data, size_t size)

--- a/src/commit.c
+++ b/src/commit.c
@@ -314,6 +314,60 @@ int git_commit_create(
 		commit_parent_from_array, &data, false);
 }
 
+int git_commit_create_on(
+	git_oid *id,
+	git_repository *repo,
+	const char *update_ref,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[])
+{
+	commit_parent_data data = { parent_count, parents, repo };
+
+	assert(tree && git_tree_owner(tree) == repo);
+
+	return git_commit__create_internal(
+		id, repo, update_ref, author, committer,
+		message_encoding, message, git_tree_id(tree),
+		commit_parent_from_array, &data, false);
+}
+
+int git_commit_create_on_head(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[])
+{
+	return git_commit_create_on(id, repo, GIT_HEAD_FILE,
+				    author, committer, message_encoding, message,
+				    tree, parent_count, parents);
+}
+
+int git_commit_create_ext(
+	git_oid *id,
+	git_repository *repo,
+	const git_signature *author,
+	const git_signature *committer,
+	const char *message_encoding,
+	const char *message,
+	const git_tree *tree,
+	size_t parent_count,
+	const git_commit *parents[])
+{
+	return git_commit_create_on(id, repo, NULL,
+				    author, committer, message_encoding, message,
+				    tree, parent_count, parents);
+}
+
 static const git_oid *commit_parent_for_amend(size_t curr, void *payload)
 {
 	const git_commit *commit_to_amend = payload;
@@ -455,9 +509,9 @@ int git_commit_create_fromstate(
 	if ((error = git_tree_lookup(&tree, repo, &tree_id)) < 0)
 		goto cleanup;
 
-	error = git_commit_create(id, repo, GIT_HEAD_FILE,
-				  author, committer, message_encoding, message,
-				  tree, commits.length, (const git_commit **) commits.contents);
+	error = git_commit_create_on(id, repo, GIT_HEAD_FILE,
+				     author, committer, message_encoding, message,
+				     tree, commits.length, (const git_commit **) commits.contents);
 
 cleanup:
 	git_tree_free(tree);

--- a/src/notes.c
+++ b/src/notes.c
@@ -301,9 +301,9 @@ static int note_write(
 		git_oid_cpy(notes_blob_out, &oid);
 
 
-	error = git_commit_create(&oid, repo, notes_ref, author, committer,
-				  NULL, GIT_NOTES_DEFAULT_MSG_ADD,
-				  tree, *parents == NULL ? 0 : 1, (const git_commit **) parents);
+	error = git_commit_create_on(&oid, repo, notes_ref, author, committer,
+				     NULL, GIT_NOTES_DEFAULT_MSG_ADD,
+				     tree, *parents == NULL ? 0 : 1, (const git_commit **) parents);
 
 	if (notes_commit_out)
 		git_oid_cpy(notes_commit_out, &oid);
@@ -390,7 +390,7 @@ static int note_remove(
 		remove_note_in_tree_eexists_cb, remove_note_in_tree_enotfound_cb)) < 0)
 		goto cleanup;
 
-	error = git_commit_create(&oid, repo, notes_ref, author, committer,
+	error = git_commit_create_on(&oid, repo, notes_ref, author, committer,
 	  NULL, GIT_NOTES_DEFAULT_MSG_RM,
 	  tree_after_removal,
 	  *parents == NULL ? 0 : 1,

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -980,7 +980,7 @@ static int rebase_commit__create(
 		message = git_commit_message(current_commit);
 	}
 
-	if ((error = git_commit_create(&commit_id, rebase->repo, NULL, author,
+	if ((error = git_commit_create_ext(&commit_id, rebase->repo, author,
 		committer, message_encoding, message, tree, 1,
 		(const git_commit **)&parent_commit)) < 0 ||
 		(error = git_commit_lookup(&commit, rebase->repo, &commit_id)) < 0)

--- a/src/stash.c
+++ b/src/stash.c
@@ -137,10 +137,9 @@ static int commit_index(
 	if ((error = git_buf_printf(&msg, "index on %s\n", message)) < 0)
 		goto cleanup;
 
-	if ((error = git_commit_create(
+	if ((error = git_commit_create_ext(
 		&i_commit_oid,
 		git_index_owner(index),
-		NULL,
 		stasher,
 		stasher,
 		NULL,
@@ -312,10 +311,9 @@ static int commit_untracked(
 	if ((error = git_buf_printf(&msg, "untracked files on %s\n", message)) < 0)
 		goto cleanup;
 
-	if ((error = git_commit_create(
+	if ((error = git_commit_create_ext(
 		&u_commit_oid,
 		repo,
-		NULL,
 		stasher,
 		stasher,
 		NULL,
@@ -423,10 +421,9 @@ static int commit_worktree(
 	if ((error = build_workdir_tree(&w_tree, repo, i_index, b_commit)) < 0)
 		goto cleanup;
 
-	error = git_commit_create(
+	error = git_commit_create_ext(
 		w_commit_oid,
 		repo,
-		NULL,
 		stasher,
 		stasher,
 		NULL,

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -1234,7 +1234,7 @@ void test_checkout_tree__case_changing_rename(void)
 
 	cl_git_pass(git_signature_new(&signature, "Renamer", "rename@contoso.com", time(NULL), 0));
 
-	cl_git_pass(git_commit_create(&commit_id, g_repo, "refs/heads/dir", signature, signature, NULL, "case-changing rename", tree, 1, (const git_commit **)&dir_commit));
+	cl_git_pass(git_commit_create_on(&commit_id, g_repo, "refs/heads/dir", signature, signature, NULL, "case-changing rename", tree, 1, (const git_commit **)&dir_commit));
 
 	cl_assert(git_path_isfile("testrepo/readme"));
 	if (case_sensitive)

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -77,7 +77,7 @@ void test_cherrypick_workdir__automerge(void)
 
 		cl_git_pass(git_index_write_tree(&cherrypicked_tree_oid, repo_index));
 		cl_git_pass(git_tree_lookup(&cherrypicked_tree, repo, &cherrypicked_tree_oid));
-		cl_git_pass(git_commit_create(&cherrypicked_oid, repo, "HEAD", signature, signature, NULL,
+		cl_git_pass(git_commit_create_on(&cherrypicked_oid, repo, "HEAD", signature, signature, NULL,
 			"Cherry picked!", cherrypicked_tree, 1, (const git_commit **)&head));
 
 		cl_assert(merge_test_index(repo_index, merge_index_entries + i * 3, 3));

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -35,12 +35,12 @@ void test_commit_commit__create_unexisting_update_ref(void)
 	cl_git_pass(git_signature_now(&s, "alice", "alice@example.com"));
 
 	cl_git_fail(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
-	cl_git_pass(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
-				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+	cl_git_pass(git_commit_create_on(&oid, _repo, "refs/heads/foo/bar", s, s,
+					 NULL, "some msg", tree, 1, (const git_commit **) &commit));
 
 	/* fail because the parent isn't the tip of the branch anymore */
-	cl_git_fail(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
-				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+	cl_git_fail(git_commit_create_on(&oid, _repo, "refs/heads/foo/bar", s, s,
+					 NULL, "some msg", tree, 1, (const git_commit **) &commit));
 
 	cl_git_pass(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
 	cl_assert_equal_oid(&oid, git_reference_target(ref));
@@ -68,7 +68,7 @@ void test_commit_commit__create_initial_commit(void)
 	cl_git_pass(git_signature_now(&s, "alice", "alice@example.com"));
 
 	cl_git_fail(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
-	cl_git_pass(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
+	cl_git_pass(git_commit_create_on(&oid, _repo, "refs/heads/foo/bar", s, s,
 				      NULL, "initial commit", tree, 0, NULL));
 
 	cl_git_pass(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
@@ -99,7 +99,7 @@ void test_commit_commit__create_initial_commit_parent_not_current(void)
 
 	cl_git_pass(git_reference_name_to_id(&original_oid, _repo, "HEAD"));
 
-	cl_git_fail(git_commit_create(&oid, _repo, "HEAD", s, s,
+	cl_git_fail(git_commit_create_on(&oid, _repo, "HEAD", s, s,
 				      NULL, "initial commit", tree, 0, NULL));
 
 	cl_git_pass(git_reference_name_to_id(&oid, _repo, "HEAD"));

--- a/tests/diff/rename.c
+++ b/tests/diff/rename.c
@@ -423,7 +423,7 @@ void test_diff_rename__test_small_files(void)
 	cl_git_pass(git_index_write_tree(&oid, index));
 	cl_git_pass(git_tree_lookup(&commit_tree, g_repo, &oid));
 	cl_git_pass(git_signature_new(&signature, "Rename", "rename@example.com", 1404157834, 0));
-	cl_git_pass(git_commit_create(&oid, g_repo, "HEAD", signature, signature, NULL, "Test commit", commit_tree, 1, (const git_commit**)&head_commit));
+	cl_git_pass(git_commit_create_on(&oid, g_repo, "HEAD", signature, signature, NULL, "Test commit", commit_tree, 1, (const git_commit**)&head_commit));
 
 	cl_git_mkfile("renames/copy.txt", "Hello World!\n");
 	cl_git_rmfile("renames/small.txt");

--- a/tests/odb/freshen.c
+++ b/tests/odb/freshen.c
@@ -123,7 +123,7 @@ void test_odb_freshen__tree_during_commit(void)
 	cl_git_pass(git_signature_new(&signature,
 		"Refresher", "refresher@example.com", 1488547083, 0));
 
-	cl_git_pass(git_commit_create(&commit_id, repo, NULL,
+	cl_git_pass(git_commit_create_ext(&commit_id, repo,
 		signature, signature, NULL, "New commit pointing to old tree",
 		tree, 1, (const git_commit **)&parent));
 

--- a/tests/refs/reflog/messages.c
+++ b/tests/refs/reflog/messages.c
@@ -164,7 +164,7 @@ void test_refs_reflog_messages__branch_birth(void)
 	cl_assert_equal_i(nentries, nentries_after);
 
 	msg = "message 2";
-	cl_git_pass(git_commit_create(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
+	cl_git_pass(git_commit_create_on(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
 
 	cl_assert_equal_i(1, reflog_entrycount(g_repo, "refs/heads/orphan"));
 
@@ -203,7 +203,7 @@ void test_refs_reflog_messages__commit_on_symbolic_ref_updates_head_reflog(void)
 	cl_assert_equal_i(nentries_master, reflog_entrycount(g_repo, "refs/heads/master"));
 
 	msg = "message 2";
-	cl_git_pass(git_commit_create(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
+	cl_git_pass(git_commit_create_on(&id, g_repo, "HEAD", sig, sig, NULL, msg, tree, 0, NULL));
 
 	cl_assert_equal_i(1, reflog_entrycount(g_repo, "refs/heads/foo"));
 	cl_assert_equal_i(nentries_head + 1, reflog_entrycount(g_repo, GIT_HEAD_FILE));
@@ -239,7 +239,7 @@ void test_refs_reflog_messages__show_merge_for_merge_commits(void)
 
 	cl_git_pass(git_commit_tree(&tree, b1_commit));
 
-	cl_git_pass(git_commit_create(&merge_commit_oid,
+	cl_git_pass(git_commit_create_on(&merge_commit_oid,
 		g_repo, "HEAD", s, s, NULL,
 		"Merge commit", tree,
 		2, (const struct git_commit **) parent_commits));

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -265,7 +265,7 @@ void test_reset_hard__switch_file_to_dir(void)
 	cl_git_pass(git_index_clear(idx));
 
 	cl_git_pass(git_tree_lookup(&tree, repo, &src_tree_id));
-	cl_git_pass(git_commit_create(&src_id, repo, NULL, sig, sig, NULL, "foo", tree, 0, NULL));
+	cl_git_pass(git_commit_create_ext(&src_id, repo, sig, sig, NULL, "foo", tree, 0, NULL));
 	git_tree_free(tree);
 
 	/* Create the new tree */
@@ -276,7 +276,7 @@ void test_reset_hard__switch_file_to_dir(void)
 
 	cl_git_pass(git_index_write_tree_to(&tgt_tree_id, idx, repo));
 	cl_git_pass(git_tree_lookup(&tree, repo, &tgt_tree_id));
-	cl_git_pass(git_commit_create(&tgt_id, repo, NULL, sig, sig, NULL, "foo", tree, 0, NULL));
+	cl_git_pass(git_commit_create_ext(&tgt_id, repo, sig, sig, NULL, "foo", tree, 0, NULL));
 	git_tree_free(tree);
 	git_index_free(idx);
 	git_signature_free(sig);

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -189,7 +189,7 @@ void test_revert_workdir__again(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
+	cl_git_pass(git_commit_create_on(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
 
 	cl_git_pass(git_revert(repo, orig_head, NULL));
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));
@@ -239,7 +239,7 @@ void test_revert_workdir__again_after_automerge(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&head));
+	cl_git_pass(git_commit_create_on(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&head));
 
 	cl_git_pass(git_revert(repo, commit, NULL));
 	cl_assert(merge_test_index(repo_index, second_revert_entries, 6));
@@ -288,7 +288,7 @@ void test_revert_workdir__again_after_edit(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
+	cl_git_pass(git_commit_create_on(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
 
 	cl_git_pass(git_revert(repo, commit, NULL));
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));

--- a/tests/revwalk/basic.c
+++ b/tests/revwalk/basic.c
@@ -533,7 +533,7 @@ void test_revwalk_basic__big_timestamp(void)
 	cl_git_pass(git_signature_new(&sig, "Joe", "joe@example.com", 2399662595ll, 0));
 	cl_git_pass(git_commit_tree(&tree, tip));
 
-	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1,
+	cl_git_pass(git_commit_create_on(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1,
 		(const git_commit **)&tip));
 
 	cl_git_pass(git_revwalk_push_head(_walk));

--- a/tests/status/submodules.c
+++ b/tests/status/submodules.c
@@ -502,7 +502,7 @@ void test_status_submodules__entry_but_dir_tracked(void)
 		cl_git_pass(git_index_write_tree(&tree_id, index));
 		cl_git_pass(git_signature_now(&sig, "Sloppy Submoduler", "sloppy@example.com"));
 		cl_git_pass(git_tree_lookup(&tree, repo, &tree_id));
-		cl_git_pass(git_commit_create(&commit_id, repo, NULL, sig, sig, NULL, "message", tree, 0, NULL));
+		cl_git_pass(git_commit_create_ext(&commit_id, repo, sig, sig, NULL, "message", tree, 0, NULL));
 		cl_git_pass(git_reference_create(&ref, repo, "refs/heads/master", &commit_id, 1, "commit: foo"));
 		git_reference_free(ref);
 		git_signature_free(sig);


### PR DESCRIPTION
This is a rebase of #3075, with the attempt at a more general low-level API I've envisioned for #4913 ([comment](https://github.com/libgit2/libgit2/pull/4913#discussion_r247658573)).

It's slightly different in that I (should) have taken care of not changing anything with old API, and only implement new things on top on newly added functions.

And then I'm adding low-level methods to manipulate a `git_commit_desc`, which serves to keep track of "the parts of a commit", via the following way.
- prepare a buffer given a `git_commit_desc`
- write a commit object to a repository, given a `git_commit_desc`, and some options.

This is still very much in flux, as I'm still trying to see how much things I can delegate to the low-level helpers (stuff like `fromstate` becomes an option when object-writing). Ideally in the end it should be possible to reimplement all the new "helpers" from #3075 using those two, but I wanted the "cleaner API" first. Thus, any design insights would be welcome.