### PR TITLE
Change API instances of `fromnoun` to `from_noun` (with an underscore)

### DIFF
--- a/examples/blame.c
+++ b/examples/blame.c
@@ -72,7 +72,7 @@ int lg2_blame(git_repository *repo, int argc, char *argv[])
 	 * Get the raw data inside the blob for output. We use the
 	 * `commitish:path/to/file.txt` format to find it.
 	 */
-	if (git_oid_iszero(&blameopts.newest_commit))
+	if (git_oid_is_zero(&blameopts.newest_commit))
 		strcpy(spec, "HEAD");
 	else
 		git_oid_tostr(spec, sizeof(spec), &blameopts.newest_commit);
@@ -101,7 +101,7 @@ int lg2_blame(git_repository *repo, int argc, char *argv[])
 		if (hunk) {
 			char sig[128] = {0};
 			break_on_null_hunk = 1;
-			
+
 			git_oid_tostr(oid, 10, &hunk->final_commit_id);
 			snprintf(sig, 30, "%s <%s>", hunk->final_signature->name, hunk->final_signature->email);
 

--- a/examples/fetch.c
+++ b/examples/fetch.c
@@ -21,7 +21,7 @@ static int update_cb(const char *refname, const git_oid *a, const git_oid *b, vo
 	git_oid_fmt(b_str, b);
 	b_str[GIT_OID_HEXSZ] = '\0';
 
-	if (git_oid_iszero(a)) {
+	if (git_oid_is_zero(a)) {
 		printf("[new]     %.20s %s\n", b_str, refname);
 	} else {
 		git_oid_fmt(a_str, a);

--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -136,7 +136,7 @@ GIT_EXTERN(int) git_blob_filtered_content(
  *	relative to the repository's working dir
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_blob_create_fromworkdir(git_oid *id, git_repository *repo, const char *relative_path);
+GIT_EXTERN(int) git_blob_create_from_workdir(git_oid *id, git_repository *repo, const char *relative_path);
 
 /**
  * Read a file from the filesystem and write its content
@@ -148,7 +148,7 @@ GIT_EXTERN(int) git_blob_create_fromworkdir(git_oid *id, git_repository *repo, c
  * @param path file from which the blob will be created
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_blob_create_fromdisk(git_oid *id, git_repository *repo, const char *path);
+GIT_EXTERN(int) git_blob_create_from_disk(git_oid *id, git_repository *repo, const char *path);
 
 /**
  * Create a stream to write a new blob into the object db
@@ -156,12 +156,12 @@ GIT_EXTERN(int) git_blob_create_fromdisk(git_oid *id, git_repository *repo, cons
  * This function may need to buffer the data on disk and will in
  * general not be the right choice if you know the size of the data
  * to write. If you have data in memory, use
- * `git_blob_create_frombuffer()`. If you do not, but know the size of
+ * `git_blob_create_from_buffer()`. If you do not, but know the size of
  * the contents (and don't want/need to perform filtering), use
  * `git_odb_open_wstream()`.
  *
  * Don't close this stream yourself but pass it to
- * `git_blob_create_fromstream_commit()` to commit the write to the
+ * `git_blob_create_from_stream_commit()` to commit the write to the
  * object db and get the object id.
  *
  * If the `hintpath` parameter is filled, it will be used to determine
@@ -175,7 +175,7 @@ GIT_EXTERN(int) git_blob_create_fromdisk(git_oid *id, git_repository *repo, cons
  *        to apply onto the content of the blob to be created.
  * @return 0 or error code
  */
-GIT_EXTERN(int) git_blob_create_fromstream(
+GIT_EXTERN(int) git_blob_create_from_stream(
 	git_writestream **out,
 	git_repository *repo,
 	const char *hintpath);
@@ -189,7 +189,7 @@ GIT_EXTERN(int) git_blob_create_fromstream(
  * @param stream the stream to close
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_blob_create_fromstream_commit(
+GIT_EXTERN(int) git_blob_create_from_stream_commit(
 	git_oid *out,
 	git_writestream *stream);
 
@@ -202,7 +202,7 @@ GIT_EXTERN(int) git_blob_create_fromstream_commit(
  * @param len length of the data
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_blob_create_frombuffer(
+GIT_EXTERN(int) git_blob_create_from_buffer(
 	git_oid *id, git_repository *repo, const void *buffer, size_t len);
 
 /**

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -291,6 +291,12 @@ GIT_EXTERN(int) git_index_add_frombuffer(
 #define GIT_REF_FORMAT_REFSPEC_PATTERN GIT_REFERENCE_FORMAT_REFSPEC_PATTERN
 #define GIT_REF_FORMAT_REFSPEC_SHORTHAND GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND
 
+GIT_EXTERN(int) git_tag_create_frombuffer(
+	git_oid *oid,
+	git_repository *repo,
+	const char *buffer,
+	int force);
+
 /**@}*/
 
 /** @name Deprecated Credential Callback Types

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -271,7 +271,6 @@ GIT_EXTERN(void) giterr_set_oom(void);
  * There is no plan to remove these backward compatibility values at
  * this time.
  */
-/**@{*/
 
 typedef git_cred_sign_cb git_cred_sign_callback;
 typedef git_cred_ssh_interactive_cb git_cred_ssh_interactive_callback;
@@ -289,6 +288,20 @@ typedef git_cred_ssh_interactive_cb git_cred_ssh_interactive_callback;
 /**@{*/
 
 typedef git_trace_cb git_trace_callback;
+
+/**@}*/
+
+/** @name Deprecated Object ID Types
+ *
+ * These types are retained for backward compatibility.  The newer
+ * versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+GIT_EXTERN(int) git_oid_iszero(const git_oid *id);
 
 /**@}*/
 

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -191,10 +191,11 @@ GIT_EXTERN(void) giterr_set_oom(void);
 
 /**@}*/
 
-/** @name Deprecated Index Constants
+/** @name Deprecated Index Functions and Constants
  *
- * These enumeration values are retained for backward compatibility.
- * The newer versions of these values should be preferred in all new code.
+ * These functions and enumeration values are retained for backward
+ * compatibility.  The newer versions of these values should be
+ * preferred in all new code.
  *
  * There is no plan to remove these backward compatibility values at
  * this time.
@@ -233,6 +234,11 @@ GIT_EXTERN(void) giterr_set_oom(void);
 #define GIT_INDEXCAP_NO_FILEMODE       GIT_INDEX_CAPABILITY_NO_FILEMODE
 #define GIT_INDEXCAP_NO_SYMLINKS       GIT_INDEX_CAPABILITY_NO_SYMLINKS
 #define GIT_INDEXCAP_FROM_OWNER        GIT_INDEX_CAPABILITY_FROM_OWNER
+
+GIT_EXTERN(int) git_index_add_frombuffer(
+	git_index *index,
+	const git_index_entry *entry,
+	const void *buffer, size_t len);
 
 /**@}*/
 

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -45,6 +45,30 @@
  */
 GIT_BEGIN_DECL
 
+/** @name Deprecated Blob Functions
+ *
+ * These functions are retained for backward compatibility.  The newer
+ * versions of these functions should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+GIT_EXTERN(int) git_blob_create_fromworkdir(git_oid *id, git_repository *repo, const char *relative_path);
+GIT_EXTERN(int) git_blob_create_fromdisk(git_oid *id, git_repository *repo, const char *path);
+GIT_EXTERN(int) git_blob_create_fromstream(
+	git_writestream **out,
+	git_repository *repo,
+	const char *hintpath);
+GIT_EXTERN(int) git_blob_create_fromstream_commit(
+	git_oid *out,
+	git_writestream *stream);
+GIT_EXTERN(int) git_blob_create_frombuffer(
+	git_oid *id, git_repository *repo, const void *buffer, size_t len);
+
+/**@}*/
+
 /** @name Deprecated Buffer Functions
  *
  * These functions and enumeration values are retained for backward

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -572,7 +572,7 @@ GIT_EXTERN(int) git_index_add_bypath(git_index *index, const char *path);
  * @param len length of the data
  * @return 0 or an error code
  */
-GIT_EXTERN(int) git_index_add_frombuffer(
+GIT_EXTERN(int) git_index_add_from_buffer(
 	git_index *index,
 	const git_index_entry *entry,
 	const void *buffer, size_t len);

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -207,7 +207,7 @@ GIT_EXTERN(int) git_oid_strcmp(const git_oid *id, const char *str);
  *
  * @return 1 if all zeros, 0 otherwise.
  */
-GIT_EXTERN(int) git_oid_iszero(const git_oid *id);
+GIT_EXTERN(int) git_oid_is_zero(const git_oid *id);
 
 /**
  * OID Shortener object

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -217,7 +217,7 @@ GIT_EXTERN(int) git_tag_annotation_create(
  * @param force Overwrite existing tags
  * @return 0 on success; error code otherwise
  */
-GIT_EXTERN(int) git_tag_create_frombuffer(
+GIT_EXTERN(int) git_tag_create_from_buffer(
 	git_oid *oid,
 	git_repository *repo,
 	const char *buffer,

--- a/src/apply.c
+++ b/src/apply.c
@@ -532,7 +532,7 @@ static int apply_one(
 	if (delta->status != GIT_DELTA_DELETED) {
 		if ((error = git_apply__patch(&post_contents, &filename, &mode,
 				pre_contents.ptr, pre_contents.size, patch, opts)) < 0 ||
-			(error = git_blob_create_frombuffer(&post_id, repo,
+			(error = git_blob_create_from_buffer(&post_id, repo,
 				post_contents.ptr, post_contents.size)) < 0)
 			goto done;
 

--- a/src/blame.c
+++ b/src/blame.c
@@ -204,7 +204,7 @@ static int normalize_options(
 	memcpy(out, in, sizeof(git_blame_options));
 
 	/* No newest_commit => HEAD */
-	if (git_oid_iszero(&out->newest_commit)) {
+	if (git_oid_is_zero(&out->newest_commit)) {
 		if (git_reference_name_to_id(&out->newest_commit, repo, "HEAD") < 0) {
 			return -1;
 		}
@@ -408,7 +408,7 @@ on_error:
 
 static bool hunk_is_bufferblame(git_blame_hunk *hunk)
 {
-	return git_oid_iszero(&hunk->final_commit_id);
+	return git_oid_is_zero(&hunk->final_commit_id);
 }
 
 static int buffer_hunk_cb(

--- a/src/blob.c
+++ b/src/blob.c
@@ -70,7 +70,7 @@ int git_blob__parse(void *_blob, git_odb_object *odb_obj)
 	return 0;
 }
 
-int git_blob_create_frombuffer(
+int git_blob_create_from_buffer(
 	git_oid *id, git_repository *repo, const void *buffer, size_t len)
 {
 	int error;
@@ -263,13 +263,13 @@ done:
 	return error;
 }
 
-int git_blob_create_fromworkdir(
+int git_blob_create_from_workdir(
 	git_oid *id, git_repository *repo, const char *path)
 {
 	return git_blob__create_from_paths(id, NULL, repo, NULL, path, 0, true);
 }
 
-int git_blob_create_fromdisk(
+int git_blob_create_from_disk(
 	git_oid *id, git_repository *repo, const char *path)
 {
 	int error;
@@ -325,7 +325,7 @@ static int blob_writestream_write(git_writestream *_stream, const char *buffer, 
 	return git_filebuf_write(&stream->fbuf, buffer, len);
 }
 
-int git_blob_create_fromstream(git_writestream **out, git_repository *repo, const char *hintpath)
+int git_blob_create_from_stream(git_writestream **out, git_repository *repo, const char *hintpath)
 {
 	int error;
 	git_buf path = GIT_BUF_INIT;
@@ -364,7 +364,7 @@ cleanup:
 	return error;
 }
 
-int git_blob_create_fromstream_commit(git_oid *out, git_writestream *_stream)
+int git_blob_create_from_stream_commit(git_oid *out, git_writestream *_stream)
 {
 	int error;
 	blob_writestream *stream = (blob_writestream *) _stream;
@@ -426,4 +426,37 @@ int git_blob_filtered_content(
 	}
 
 	return error;
+}
+
+/* Deprecated functions */
+
+int git_blob_create_frombuffer(
+	git_oid *id, git_repository *repo, const void *buffer, size_t len)
+{
+	return git_blob_create_from_buffer(id, repo, buffer, len);
+}
+
+int git_blob_create_fromworkdir(git_oid *id, git_repository *repo, const char *relative_path)
+{
+	return git_blob_create_from_workdir(id, repo, relative_path);
+}
+
+int git_blob_create_fromdisk(git_oid *id, git_repository *repo, const char *path)
+{
+	return git_blob_create_from_disk(id, repo, path);
+}
+
+int git_blob_create_fromstream(
+    git_writestream **out,
+    git_repository *repo,
+    const char *hintpath)
+{
+	return  git_blob_create_from_stream(out, repo, hintpath);
+}
+
+int git_blob_create_fromstream_commit(
+	git_oid *out,
+	git_writestream *stream)
+{
+	return git_blob_create_from_stream_commit(out, stream);
 }

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -232,7 +232,7 @@ static int diff_file_content_load_blob(
 	int error = 0;
 	git_odb_object *odb_obj = NULL;
 
-	if (git_oid_iszero(&fc->file->id))
+	if (git_oid_is_zero(&fc->file->id))
 		return 0;
 
 	if (fc->file->mode == GIT_FILEMODE_COMMIT)

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -179,7 +179,7 @@ static int diff_delta__from_one(
 
 	delta->old_file.flags |= GIT_DIFF_FLAG_VALID_ID;
 
-	if (has_old || !git_oid_iszero(&delta->new_file.id))
+	if (has_old || !git_oid_is_zero(&delta->new_file.id))
 		delta->new_file.flags |= GIT_DIFF_FLAG_VALID_ID;
 
 	return diff_insert_delta(diff, delta, matched_pathspec);
@@ -240,7 +240,7 @@ static int diff_delta__from_two(
 		delta->old_file.flags |= GIT_DIFF_FLAG_EXISTS;
 		delta->new_file.flags |= GIT_DIFF_FLAG_EXISTS;
 
-		if (!git_oid_iszero(&new_entry->id))
+		if (!git_oid_is_zero(&new_entry->id))
 			delta->new_file.flags |= GIT_DIFF_FLAG_VALID_ID;
 	}
 
@@ -797,13 +797,13 @@ static int maybe_modified(
 	/* if oids and modes match (and are valid), then file is unmodified */
 	} else if (git_oid_equal(&oitem->id, &nitem->id) &&
 			 omode == nmode &&
-			 !git_oid_iszero(&oitem->id)) {
+			 !git_oid_is_zero(&oitem->id)) {
 		status = GIT_DELTA_UNMODIFIED;
 
 	/* if we have an unknown OID and a workdir iterator, then check some
 	 * circumstances that can accelerate things or need special handling
 	 */
-	} else if (git_oid_iszero(&nitem->id) && new_is_workdir) {
+	} else if (git_oid_is_zero(&nitem->id) && new_is_workdir) {
 		bool use_ctime =
 			((diff->diffcaps & GIT_DIFFCAPS_TRUST_CTIME) != 0);
 		git_index *index = git_iterator_index(info->new_iter);
@@ -843,7 +843,7 @@ static int maybe_modified(
 	/* if we got here and decided that the files are modified, but we
 	 * haven't calculated the OID of the new item, then calculate it now
 	 */
-	if (modified_uncertain && git_oid_iszero(&nitem->id)) {
+	if (modified_uncertain && git_oid_is_zero(&nitem->id)) {
 		const git_oid *update_check =
 			DIFF_FLAG_IS_SET(diff, GIT_DIFF_UPDATE_INDEX) && omode == nmode ?
 			&oitem->id : NULL;
@@ -877,7 +877,7 @@ static int maybe_modified(
 
 	return diff_delta__from_two(
 		diff, status, oitem, omode, nitem, nmode,
-		git_oid_iszero(&noid) ? NULL : &noid, matched_pathspec);
+		git_oid_is_zero(&noid) ? NULL : &noid, matched_pathspec);
 }
 
 static bool entry_is_prefixed(

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -325,10 +325,10 @@ static int diff_delta_format_with_paths(
 	const char *oldpath,
 	const char *newpath)
 {
-	if (git_oid_iszero(&delta->old_file.id))
+	if (git_oid_is_zero(&delta->old_file.id))
 		oldpath = "/dev/null";
 
-	if (git_oid_iszero(&delta->new_file.id))
+	if (git_oid_is_zero(&delta->new_file.id))
 		newpath = "/dev/null";
 
 	return git_buf_printf(out, template, oldpath, newpath);
@@ -381,8 +381,8 @@ done:
 
 static bool delta_is_unchanged(const git_diff_delta *delta)
 {
-	if (git_oid_iszero(&delta->old_file.id) &&
-		git_oid_iszero(&delta->new_file.id))
+	if (git_oid_is_zero(&delta->old_file.id) &&
+		git_oid_is_zero(&delta->new_file.id))
 		return true;
 
 	if (delta->old_file.mode == GIT_FILEMODE_COMMIT ||

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -560,13 +560,13 @@ static int similarity_measure(
 
 	/* if exact match is requested, force calculation of missing OIDs now */
 	if (exact_match) {
-		if (git_oid_iszero(&a_file->id) &&
+		if (git_oid_is_zero(&a_file->id) &&
 			diff->old_src == GIT_ITERATOR_TYPE_WORKDIR &&
 			!git_diff__oid_for_file(&a_file->id,
 				diff, a_file->path, a_file->mode, a_file->size))
 			a_file->flags |= GIT_DIFF_FLAG_VALID_ID;
 
-		if (git_oid_iszero(&b_file->id) &&
+		if (git_oid_is_zero(&b_file->id) &&
 			diff->new_src == GIT_ITERATOR_TYPE_WORKDIR &&
 			!git_diff__oid_for_file(&b_file->id,
 				diff, b_file->path, b_file->mode, b_file->size))

--- a/src/filter.c
+++ b/src/filter.c
@@ -385,7 +385,7 @@ uint16_t git_filter_source_filemode(const git_filter_source *src)
 
 const git_oid *git_filter_source_id(const git_filter_source *src)
 {
-	return git_oid_iszero(&src->oid) ? NULL : &src->oid;
+	return git_oid_is_zero(&src->oid) ? NULL : &src->oid;
 }
 
 git_filter_mode_t git_filter_source_mode(const git_filter_source *src)

--- a/src/index.c
+++ b/src/index.c
@@ -1477,7 +1477,7 @@ int git_index_add_frombuffer(
 	if (index_entry_dup(&entry, index, source_entry) < 0)
 		return -1;
 
-	error = git_blob_create_frombuffer(&id, INDEX_OWNER(index), buffer, len);
+	error = git_blob_create_from_buffer(&id, INDEX_OWNER(index), buffer, len);
 	if (error < 0) {
 		index_entry_free(entry);
 		return error;

--- a/src/index.c
+++ b/src/index.c
@@ -1454,7 +1454,7 @@ GIT_INLINE(bool) valid_filemode(const int filemode)
 	return (is_file_or_link(filemode) || filemode == GIT_FILEMODE_COMMIT);
 }
 
-int git_index_add_frombuffer(
+int git_index_add_from_buffer(
     git_index *index, const git_index_entry *source_entry,
     const void *buffer, size_t len)
 {
@@ -3708,4 +3708,13 @@ void git_indexwriter_cleanup(git_indexwriter *writer)
 
 	git_index_free(writer->index);
 	writer->index = NULL;
+}
+
+/* Deprecated functions */
+
+int git_index_add_frombuffer(
+    git_index *index, const git_index_entry *source_entry,
+    const void *buffer, size_t len)
+{
+	return git_index_add_from_buffer(index, source_entry, buffer, len);
 }

--- a/src/notes.c
+++ b/src/notes.c
@@ -288,7 +288,7 @@ static int note_write(
 
 	/* TODO: should we apply filters? */
 	/* create note object */
-	if ((error = git_blob_create_frombuffer(&oid, repo, note, strlen(note))) < 0)
+	if ((error = git_blob_create_from_buffer(&oid, repo, note, strlen(note))) < 0)
 		goto cleanup;
 
 	if ((error = manipulate_note_in_tree_r(

--- a/src/odb.c
+++ b/src/odb.c
@@ -766,7 +766,7 @@ int git_odb_exists(git_odb *db, const git_oid *id)
 
 	assert(db && id);
 
-	if (git_oid_iszero(id))
+	if (git_oid_is_zero(id))
 		return 0;
 
 	if ((object = git_cache_get_raw(odb_cache(db), id)) != NULL) {
@@ -994,7 +994,7 @@ int git_odb__read_header_or_object(
 
 	*out = NULL;
 
-	if (git_oid_iszero(id))
+	if (git_oid_is_zero(id))
 		return error_null_oid(GIT_ENOTFOUND, "cannot read object");
 
 	if ((object = git_cache_get_raw(odb_cache(db), id)) != NULL) {
@@ -1099,7 +1099,7 @@ int git_odb_read(git_odb_object **out, git_odb *db, const git_oid *id)
 
 	assert(out && db && id);
 
-	if (git_oid_iszero(id))
+	if (git_oid_is_zero(id))
 		return error_null_oid(GIT_ENOTFOUND, "cannot read object");
 
 	*out = git_cache_get_raw(odb_cache(db), id);
@@ -1123,7 +1123,7 @@ static int odb_otype_fast(git_object_t *type_p, git_odb *db, const git_oid *id)
 	size_t _unused;
 	int error;
 
-	if (git_oid_iszero(id))
+	if (git_oid_is_zero(id))
 		return error_null_oid(GIT_ENOTFOUND, "cannot get object type");
 
 	if ((object = git_cache_get_raw(odb_cache(db), id)) != NULL) {
@@ -1283,7 +1283,7 @@ int git_odb_write(
 
 	git_odb_hash(oid, data, len, type);
 
-	if (git_oid_iszero(oid))
+	if (git_oid_is_zero(oid))
 		return error_null_oid(GIT_EINVALID, "cannot write object");
 
 	if (git_odb__freshen(db, oid))

--- a/src/oid.c
+++ b/src/oid.c
@@ -237,7 +237,7 @@ int git_oid_streq(const git_oid *oid_a, const char *str)
 	return git_oid_strcmp(oid_a, str) == 0 ? 0 : -1;
 }
 
-int git_oid_iszero(const git_oid *oid_a)
+int git_oid_is_zero(const git_oid *oid_a)
 {
 	const unsigned char *a = oid_a->id;
 	unsigned int i;
@@ -245,6 +245,11 @@ int git_oid_iszero(const git_oid *oid_a)
 		if (*a != 0)
 			return 0;
 	return 1;
+}
+
+int git_oid_iszero(const git_oid *oid_a)
+{
+	return git_oid_is_zero(oid_a);
 }
 
 typedef short node_index;

--- a/src/push.c
+++ b/src/push.c
@@ -196,7 +196,7 @@ int git_push_update_tips(git_push *push, const git_remote_callbacks *callbacks)
 			continue;
 
 		/* Update the remote ref */
-		if (git_oid_iszero(&push_spec->loid)) {
+		if (git_oid_is_zero(&push_spec->loid)) {
 			error = git_reference_lookup(&remote_ref, push->remote->repo, git_buf_cstr(&remote_ref_name));
 
 			if (error >= 0) {
@@ -281,7 +281,7 @@ static int queue_objects(git_push *push)
 		git_object_t type;
 		size_t size;
 
-		if (git_oid_iszero(&spec->loid))
+		if (git_oid_is_zero(&spec->loid))
 			/*
 			 * Delete reference on remote side;
 			 * nothing to do here.
@@ -319,7 +319,7 @@ static int queue_objects(git_push *push)
 		if (!spec->refspec.force) {
 			git_oid base;
 
-			if (git_oid_iszero(&spec->roid))
+			if (git_oid_is_zero(&spec->roid))
 				continue;
 
 			if (!git_odb_exists(push->repo->_odb, &spec->roid)) {
@@ -346,7 +346,7 @@ static int queue_objects(git_push *push)
 	}
 
 	git_vector_foreach(&push->remote->refs, i, head) {
-		if (git_oid_iszero(&head->oid))
+		if (git_oid_is_zero(&head->oid))
 			continue;
 
 		/* TODO */

--- a/src/refs.c
+++ b/src/refs.c
@@ -386,7 +386,7 @@ const git_oid *git_reference_target_peel(const git_reference *ref)
 {
 	assert(ref);
 
-	if (ref->type != GIT_REFERENCE_DIRECT || git_oid_iszero(&ref->peel))
+	if (ref->type != GIT_REFERENCE_DIRECT || git_oid_is_zero(&ref->peel))
 		return NULL;
 
 	return &ref->peel;
@@ -1380,7 +1380,7 @@ int git_reference_peel(
 	 * to a commit. So we only want to use the peeled value
 	 * if it is not zero and the target is not a tag.
 	 */
-	if (target_type != GIT_OBJECT_TAG && !git_oid_iszero(&resolved->peel)) {
+	if (target_type != GIT_OBJECT_TAG && !git_oid_is_zero(&resolved->peel)) {
 		error = git_object_lookup(&target,
 			git_reference_owner(ref), &resolved->peel, GIT_OBJECT_ANY);
 	} else {

--- a/src/status.c
+++ b/src/status.c
@@ -86,14 +86,14 @@ static unsigned int workdir_delta2status(
 			/* if OIDs don't match, we might need to calculate them now to
 			 * discern between RENAMED vs RENAMED+MODIFED
 			 */
-			if (git_oid_iszero(&idx2wd->old_file.id) &&
+			if (git_oid_is_zero(&idx2wd->old_file.id) &&
 				diff->old_src == GIT_ITERATOR_TYPE_WORKDIR &&
 				!git_diff__oid_for_file(
 					&idx2wd->old_file.id, diff, idx2wd->old_file.path,
 					idx2wd->old_file.mode, idx2wd->old_file.size))
 			idx2wd->old_file.flags |= GIT_DIFF_FLAG_VALID_ID;
 
-			if (git_oid_iszero(&idx2wd->new_file.id) &&
+			if (git_oid_is_zero(&idx2wd->new_file.id) &&
 				diff->new_src == GIT_ITERATOR_TYPE_WORKDIR &&
 				!git_diff__oid_for_file(
 					&idx2wd->new_file.id, diff, idx2wd->new_file.path,

--- a/src/tag.c
+++ b/src/tag.c
@@ -328,7 +328,7 @@ int git_tag_create_lightweight(
 	return git_tag_create__internal(oid, repo, tag_name, target, NULL, NULL, allow_ref_overwrite, 0);
 }
 
-int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *buffer, int allow_ref_overwrite)
+int git_tag_create_from_buffer(git_oid *oid, git_repository *repo, const char *buffer, int allow_ref_overwrite)
 {
 	git_tag tag;
 	int error;
@@ -520,4 +520,11 @@ int git_tag_list(git_strarray *tag_names, git_repository *repo)
 int git_tag_peel(git_object **tag_target, const git_tag *tag)
 {
 	return git_object_peel(tag_target, (const git_object *)tag, GIT_OBJECT_ANY);
+}
+
+/* Deprecated Functions */
+
+int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *buffer, int allow_ref_overwrite)
+{
+	return git_tag_create_from_buffer(oid, repo, buffer, allow_ref_overwrite);
 }

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -309,7 +309,7 @@ static int local_push_update_remote_ref(
 	if (lref[0] != '\0') {
 		/* Create or update a ref */
 		error = git_reference_create(NULL, remote_repo, rref, loid,
-					     !git_oid_iszero(roid), NULL);
+					     !git_oid_is_zero(roid), NULL);
 	} else {
 		/* Delete a ref */
 		if ((error = git_reference_lookup(&remote_ref, remote_repo, rref)) < 0) {

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -286,7 +286,7 @@ static int git_smart__connect(
 	if ((error = git_smart__detect_caps(first, &t->caps, &symrefs)) == 0) {
 		/* If the only ref in the list is capabilities^{} with OID_ZERO, remove it */
 		if (1 == t->refs.length && !strcmp(first->head.name, "capabilities^{}") &&
-			git_oid_iszero(&first->head.oid)) {
+			git_oid_is_zero(&first->head.oid)) {
 			git_vector_clear(&t->refs);
 			git_pkt_free((git_pkt *)first);
 		}

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -963,7 +963,7 @@ static int update_refs_from_report(
 
 	/* Remove any refs which we updated to have a zero OID. */
 	git_vector_rforeach(refs, i, ref) {
-		if (git_oid_iszero(&ref->head.oid)) {
+		if (git_oid_is_zero(&ref->head.oid)) {
 			git_vector_remove(refs, i);
 			git_pkt_free((git_pkt *)ref);
 		}

--- a/src/tree.c
+++ b/src/tree.c
@@ -479,7 +479,7 @@ static int check_entry(git_repository *repo, const char *filename, const git_oid
 	if (!valid_entry_name(repo, filename))
 		return tree_error("failed to insert entry: invalid name for a tree entry", filename);
 
-	if (git_oid_iszero(id))
+	if (git_oid_is_zero(id))
 		return tree_error("failed to insert entry: invalid null OID", filename);
 
 	if (filemode != GIT_FILEMODE_COMMIT &&

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -315,7 +315,7 @@ void test_diff_blob__can_compare_against_null_blobs_with_patch(void)
 	cl_assert_equal_i(GIT_DELTA_DELETED, delta->status);
 	cl_assert_equal_oid(git_blob_id(d), &delta->old_file.id);
 	cl_assert_equal_sz(git_blob_rawsize(d), delta->old_file.size);
-	cl_assert(git_oid_iszero(&delta->new_file.id));
+	cl_assert(git_oid_is_zero(&delta->new_file.id));
 	cl_assert_equal_sz(0, delta->new_file.size);
 
 	cl_assert_equal_i(1, (int)git_patch_num_hunks(p));
@@ -338,7 +338,7 @@ void test_diff_blob__can_compare_against_null_blobs_with_patch(void)
 	delta = git_patch_get_delta(p);
 	cl_assert(delta != NULL);
 	cl_assert_equal_i(GIT_DELTA_ADDED, delta->status);
-	cl_assert(git_oid_iszero(&delta->old_file.id));
+	cl_assert(git_oid_is_zero(&delta->old_file.id));
 	cl_assert_equal_sz(0, delta->old_file.size);
 	cl_assert_equal_oid(git_blob_id(d), &delta->new_file.id);
 	cl_assert_equal_sz(git_blob_rawsize(d), delta->new_file.size);
@@ -445,9 +445,9 @@ void test_diff_blob__can_compare_identical_blobs_with_patch(void)
 	cl_assert(delta != NULL);
 	cl_assert_equal_i(GIT_DELTA_UNMODIFIED, delta->status);
 	cl_assert_equal_sz(0, delta->old_file.size);
-	cl_assert(git_oid_iszero(&delta->old_file.id));
+	cl_assert(git_oid_is_zero(&delta->old_file.id));
 	cl_assert_equal_sz(0, delta->new_file.size);
-	cl_assert(git_oid_iszero(&delta->new_file.id));
+	cl_assert(git_oid_is_zero(&delta->new_file.id));
 
 	cl_assert_equal_i(0, (int)git_patch_num_hunks(p));
 	git_patch_free(p);
@@ -520,19 +520,19 @@ void test_diff_blob__can_compare_a_binary_blob_and_a_text_blob(void)
  * +++ b/a0f7217
  * @@ -1,6 +1,6 @@
  *  Here is some stuff at the start
- * 
+ *
  * -This should go in one hunk
  * +This should go in one hunk (first)
- * 
+ *
  *  Some additional lines
- * 
+ *
  * @@ -8,7 +8,7 @@ Down here below the other lines
- * 
+ *
  *  With even more at the end
- * 
+ *
  * -Followed by a second hunk of stuff
  * +Followed by a second hunk of stuff (second)
- * 
+ *
  *  That happens down here
  */
 void test_diff_blob__comparing_two_text_blobs_honors_interhunkcontext(void)

--- a/tests/filter/blob.c
+++ b/tests/filter/blob.c
@@ -87,14 +87,14 @@ void test_filter_blob__ident(void)
 	git_buf buf = { 0 };
 
 	cl_git_mkfile("crlf/test.ident", "Some text\n$Id$\nGoes there\n");
-	cl_git_pass(git_blob_create_fromworkdir(&id, g_repo, "test.ident"));
+	cl_git_pass(git_blob_create_from_workdir(&id, g_repo, "test.ident"));
 	cl_git_pass(git_blob_lookup(&blob, g_repo, &id));
 	cl_assert_equal_s(
 		"Some text\n$Id$\nGoes there\n", git_blob_rawcontent(blob));
 	git_blob_free(blob);
 
 	cl_git_mkfile("crlf/test.ident", "Some text\n$Id: Any old just you want$\nGoes there\n");
-	cl_git_pass(git_blob_create_fromworkdir(&id, g_repo, "test.ident"));
+	cl_git_pass(git_blob_create_from_workdir(&id, g_repo, "test.ident"));
 	cl_git_pass(git_blob_lookup(&blob, g_repo, &id));
 	cl_assert_equal_s(
 		"Some text\n$Id$\nGoes there\n", git_blob_rawcontent(blob));

--- a/tests/filter/ident.c
+++ b/tests/filter/ident.c
@@ -23,7 +23,7 @@ static void add_blob_and_filter(
 	git_buf out = { 0 };
 
 	cl_git_mkfile("crlf/identtest", data);
-	cl_git_pass(git_blob_create_fromworkdir(&id, g_repo, "identtest"));
+	cl_git_pass(git_blob_create_from_workdir(&id, g_repo, "identtest"));
 	cl_git_pass(git_blob_lookup(&blob, g_repo, &id));
 
 	cl_git_pass(git_filter_list_apply_to_blob(&out, fl, blob));

--- a/tests/index/filemodes.c
+++ b/tests/index/filemodes.c
@@ -164,7 +164,7 @@ static void add_entry_and_check_mode_(
 	git_index_entry new_entry;
 
 	/* If old_filename exists, we copy that to the new file, and test
-	 * git_index_add(), otherwise create a new entry testing git_index_add_frombuffer
+	 * git_index_add(), otherwise create a new entry testing git_index_add_from_buffer
 	 */
 	if (from_file)
 	{
@@ -189,7 +189,7 @@ static void add_entry_and_check_mode_(
 	else
 	{
 		const char *content = "hey there\n";
-		clar__assert(!git_index_add_frombuffer(index, &new_entry, content, strlen(content)),
+		clar__assert(!git_index_add_from_buffer(index, &new_entry, content, strlen(content)),
 			file, line, "Cannot add index entry from buffer", NULL, 1);
 	}
 
@@ -207,7 +207,7 @@ void test_index_filemodes__explicit(void)
 	git_index *index;
 
 	/* These tests should run and work everywhere, as the filemode is
-	 * given explicitly to git_index_add or git_index_add_frombuffer
+	 * given explicitly to git_index_add or git_index_add_from_buffer
 	 */
 	cl_repo_set_bool(g_repo, "core.filemode", false);
 
@@ -271,7 +271,7 @@ void test_index_filemodes__frombuffer_requires_files(void)
 	new_entry.path = "dummy-file.txt";
 	new_entry.mode = GIT_FILEMODE_BLOB;
 
-	cl_git_pass(git_index_add_frombuffer(index,
+	cl_git_pass(git_index_add_from_buffer(index,
 		&new_entry, content, strlen(content)));
 
 	cl_assert((ret_entry = git_index_get_bypath(index, "dummy-file.txt", 0)));
@@ -282,7 +282,7 @@ void test_index_filemodes__frombuffer_requires_files(void)
 	new_entry.path = "dummy-file.txt";
 	new_entry.mode = GIT_FILEMODE_BLOB_EXECUTABLE;
 
-	cl_git_pass(git_index_add_frombuffer(index,
+	cl_git_pass(git_index_add_from_buffer(index,
 		&new_entry, content, strlen(content)));
 
 	cl_assert((ret_entry = git_index_get_bypath(index, "dummy-file.txt", 0)));
@@ -293,7 +293,7 @@ void test_index_filemodes__frombuffer_requires_files(void)
 	new_entry.path = "dummy-link.txt";
 	new_entry.mode = GIT_FILEMODE_LINK;
 
-	cl_git_pass(git_index_add_frombuffer(index,
+	cl_git_pass(git_index_add_from_buffer(index,
 		&new_entry, content, strlen(content)));
 
 	cl_assert((ret_entry = git_index_get_bypath(index, "dummy-link.txt", 0)));
@@ -304,7 +304,7 @@ void test_index_filemodes__frombuffer_requires_files(void)
 	new_entry.path = "invalid_mode.txt";
 	new_entry.mode = GIT_FILEMODE_TREE;
 
-	cl_git_fail(git_index_add_frombuffer(index,
+	cl_git_fail(git_index_add_from_buffer(index,
 		&new_entry, content, strlen(content)));
 	cl_assert_equal_p(NULL, git_index_get_bypath(index, "invalid_mode.txt", 0));
 
@@ -312,7 +312,7 @@ void test_index_filemodes__frombuffer_requires_files(void)
 	new_entry.path = "invalid_mode.txt";
 	new_entry.mode = GIT_FILEMODE_COMMIT;
 
-	cl_git_fail(git_index_add_frombuffer(index,
+	cl_git_fail(git_index_add_from_buffer(index,
 		&new_entry, content, strlen(content)));
 	cl_assert_equal_p(NULL, git_index_get_bypath(index, "invalid_mode.txt", 0));
 

--- a/tests/index/racy.c
+++ b/tests/index/racy.c
@@ -193,7 +193,7 @@ static void setup_uptodate_files(void)
 	/* Put 'C' into the index */
 	new_entry.path = "C";
 	new_entry.mode = GIT_FILEMODE_BLOB;
-	cl_git_pass(git_index_add_frombuffer(index, &new_entry, "hello!\n", 7));
+	cl_git_pass(git_index_add_from_buffer(index, &new_entry, "hello!\n", 7));
 
 	git_index_free(index);
 	git_buf_dispose(&path);

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -310,7 +310,7 @@ void test_index_tests__add_frombuffer(void)
 	memset(&entry, 0x0, sizeof(git_index_entry));
 	entry.mode = GIT_FILEMODE_BLOB;
 	entry.path = "test.txt";
-	cl_git_pass(git_index_add_frombuffer(index, &entry,
+	cl_git_pass(git_index_add_from_buffer(index, &entry,
 		content, strlen(content)));
 
 	/* Wow... it worked! */
@@ -352,7 +352,7 @@ void test_index_tests__dirty_and_clean(void)
 	/* Index is dirty after adding an entry */
 	entry.mode = GIT_FILEMODE_BLOB;
 	entry.path = "test.txt";
-	cl_git_pass(git_index_add_frombuffer(index, &entry, "Hi.\n", 4));
+	cl_git_pass(git_index_add_from_buffer(index, &entry, "Hi.\n", 4));
 	cl_assert(git_index_entrycount(index) == 1);
 	cl_assert(git_index_is_dirty(index));
 
@@ -374,7 +374,7 @@ void test_index_tests__dirty_and_clean(void)
 	cl_assert(!git_index_is_dirty(index));
 
 	/* Index is dirty when we do an unforced read with dirty content */
-	cl_git_pass(git_index_add_frombuffer(index, &entry, "Hi.\n", 4));
+	cl_git_pass(git_index_add_from_buffer(index, &entry, "Hi.\n", 4));
 	cl_assert(git_index_entrycount(index) == 1);
 	cl_assert(git_index_is_dirty(index));
 
@@ -402,7 +402,7 @@ void test_index_tests__dirty_fails_optionally(void)
 	/* Index is dirty after adding an entry */
 	entry.mode = GIT_FILEMODE_BLOB;
 	entry.path = "test.txt";
-	cl_git_pass(git_index_add_frombuffer(index, &entry, "Hi.\n", 4));
+	cl_git_pass(git_index_add_from_buffer(index, &entry, "Hi.\n", 4));
 	cl_assert(git_index_is_dirty(index));
 
 	cl_git_pass(git_checkout_head(repo, NULL));
@@ -410,7 +410,7 @@ void test_index_tests__dirty_fails_optionally(void)
 	/* Index is dirty (again) after adding an entry */
 	entry.mode = GIT_FILEMODE_BLOB;
 	entry.path = "test.txt";
-	cl_git_pass(git_index_add_frombuffer(index, &entry, "Hi.\n", 4));
+	cl_git_pass(git_index_add_from_buffer(index, &entry, "Hi.\n", 4));
 	cl_assert(git_index_is_dirty(index));
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY, 1));
@@ -455,7 +455,7 @@ void test_index_tests__add_frombuffer_reset_entry(void)
 	memset(&entry, 0x0, sizeof(git_index_entry));
 	entry.mode = GIT_FILEMODE_BLOB;
 	entry.path = "test.txt";
-	cl_git_pass(git_index_add_frombuffer(index, &entry,
+	cl_git_pass(git_index_add_from_buffer(index, &entry,
 		content, strlen(content)));
 
 	/* Wow... it worked! */

--- a/tests/index/version.c
+++ b/tests/index/version.c
@@ -55,7 +55,7 @@ void test_index_version__can_write_v4(void)
 		memset(&entry, 0, sizeof(entry));
 		entry.path = paths[i];
 		entry.mode = GIT_FILEMODE_BLOB;
-		cl_git_pass(git_index_add_frombuffer(index, &entry, paths[i],
+		cl_git_pass(git_index_add_from_buffer(index, &entry, paths[i],
 						     strlen(paths[i]) + 1));
 	}
 	cl_assert_equal_sz(git_index_entrycount(index), ARRAY_SIZE(paths));
@@ -100,7 +100,7 @@ void test_index_version__v4_uses_path_compression(void)
 			path[ARRAY_SIZE(path) - 3] = i;
 			path[ARRAY_SIZE(path) - 2] = j;
 			path[ARRAY_SIZE(path) - 1] = '\0';
-			cl_git_pass(git_index_add_frombuffer(index, &entry, buf, sizeof(buf)));
+			cl_git_pass(git_index_add_from_buffer(index, &entry, buf, sizeof(buf)));
 		}
 	}
 

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -352,7 +352,7 @@ int merge_test_workdir(git_repository *repo, const struct merge_index_entry expe
 		return 0;
 
 	for (i = 0; i < expected_len; i++) {
-		git_blob_create_fromworkdir(&actual_oid, repo, expected[i].path);
+		git_blob_create_from_workdir(&actual_oid, repo, expected[i].path);
 		git_oid_fromstr(&expected_oid, expected[i].oid_str);
 
 		if (git_oid_cmp(&actual_oid, &expected_oid) != 0)

--- a/tests/object/blob/filter.c
+++ b/tests/object/blob/filter.c
@@ -59,7 +59,7 @@ void test_object_blob_filter__initialize(void)
 		if (g_crlf_raw_len[i] < 0)
 			g_crlf_raw_len[i] = strlen(g_crlf_raw[i]);
 
-		cl_git_pass(git_blob_create_frombuffer(
+		cl_git_pass(git_blob_create_from_buffer(
 			&g_crlf_oids[i], g_repo, g_crlf_raw[i], (size_t)g_crlf_raw_len[i]));
 	}
 }

--- a/tests/object/blob/fromstream.c
+++ b/tests/object/blob/fromstream.c
@@ -29,12 +29,12 @@ void test_object_blob_fromstream__multiple_write(void)
 	cl_git_fail_with(GIT_ENOTFOUND,
 			 git_object_lookup(&blob, repo, &expected_id, GIT_OBJECT_ANY));
 
-	cl_git_pass(git_blob_create_fromstream(&stream, repo, NULL));
+	cl_git_pass(git_blob_create_from_stream(&stream, repo, NULL));
 
 	for (i = 0; i < howmany; i++)
 		cl_git_pass(stream->write(stream, textual_content, strlen(textual_content)));
 
-	cl_git_pass(git_blob_create_fromstream_commit(&id, stream));
+	cl_git_pass(git_blob_create_from_stream_commit(&id, stream));
 	cl_assert_equal_oid(&expected_id, &id);
 
 	cl_git_pass(git_object_lookup(&blob, repo, &expected_id, GIT_OBJECT_BLOB));
@@ -67,12 +67,12 @@ static void assert_named_chunked_blob(const char *expected_sha, const char *fake
 
 	cl_git_pass(git_oid_fromstr(&expected_id, expected_sha));
 
-	cl_git_pass(git_blob_create_fromstream(&stream, repo, fake_name));
+	cl_git_pass(git_blob_create_from_stream(&stream, repo, fake_name));
 
 	for (i = 0; i < howmany; i++)
 		cl_git_pass(stream->write(stream, textual_content, strlen(textual_content)));
 
-	cl_git_pass(git_blob_create_fromstream_commit(&id, stream));
+	cl_git_pass(git_blob_create_from_stream_commit(&id, stream));
 
 	cl_assert_equal_oid(&expected_id, &id);
 }

--- a/tests/object/blob/write.c
+++ b/tests/object/blob/write.c
@@ -33,7 +33,7 @@ void test_object_blob_write__can_create_a_blob_in_a_standard_repo_from_a_file_lo
 {
 	repo = cl_git_sandbox_init(WORKDIR);
 
-	assert_blob_creation(WORKDIR "/test.txt", "test.txt", &git_blob_create_fromworkdir);
+	assert_blob_creation(WORKDIR "/test.txt", "test.txt", &git_blob_create_from_workdir);
 }
 
 void test_object_blob_write__can_create_a_blob_in_a_standard_repo_from_a_absolute_filepath_pointing_outside_of_the_working_directory(void)
@@ -46,7 +46,7 @@ void test_object_blob_write__can_create_a_blob_in_a_standard_repo_from_a_absolut
 	cl_must_pass(git_path_prettify_dir(&full_path, ELSEWHERE, NULL));
 	cl_must_pass(git_buf_puts(&full_path, "test.txt"));
 
-	assert_blob_creation(ELSEWHERE "/test.txt", git_buf_cstr(&full_path), &git_blob_create_fromdisk);
+	assert_blob_creation(ELSEWHERE "/test.txt", git_buf_cstr(&full_path), &git_blob_create_from_disk);
 
 	git_buf_dispose(&full_path);
 	cl_must_pass(git_futils_rmdir_r(ELSEWHERE, NULL, GIT_RMDIR_REMOVE_FILES));
@@ -62,7 +62,7 @@ void test_object_blob_write__can_create_a_blob_in_a_bare_repo_from_a_absolute_fi
 	cl_must_pass(git_path_prettify_dir(&full_path, ELSEWHERE, NULL));
 	cl_must_pass(git_buf_puts(&full_path, "test.txt"));
 
-	assert_blob_creation(ELSEWHERE "/test.txt", git_buf_cstr(&full_path), &git_blob_create_fromdisk);
+	assert_blob_creation(ELSEWHERE "/test.txt", git_buf_cstr(&full_path), &git_blob_create_from_disk);
 
 	git_buf_dispose(&full_path);
 	cl_must_pass(git_futils_rmdir_r(ELSEWHERE, NULL, GIT_RMDIR_REMOVE_FILES));

--- a/tests/object/tree/read.c
+++ b/tests/object/tree/read.c
@@ -98,7 +98,7 @@ void test_object_tree_read__largefile(void)
 	ie.path = BIGFILE;
 
 	cl_git_pass(git_repository_index(&index, g_repo));
-	cl_git_pass(git_index_add_frombuffer(index, &ie, buf, BIGFILE_SIZE));
+	cl_git_pass(git_index_add_from_buffer(index, &ie, buf, BIGFILE_SIZE));
 	cl_repo_commit_from_index(&oid, g_repo, NULL, 0, BIGFILE);
 
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &oid));

--- a/tests/odb/backend/mempack.c
+++ b/tests/odb/backend/mempack.c
@@ -51,10 +51,10 @@ void test_odb_backend_mempack__exists_with_existing_objects_succeeds(void)
 	cl_assert(git_odb_exists(_odb, &_oid) == 1);
 }
 
-void test_odb_backend_mempack__blob_create_frombuffer_succeeds(void)
+void test_odb_backend_mempack__blob_create_from_buffer_succeeds(void)
 {
 	const char *data = "data";
 
-	cl_git_pass(git_blob_create_frombuffer(&_oid, _repo, data, strlen(data) + 1));
+	cl_git_pass(git_blob_create_from_buffer(&_oid, _repo, data, strlen(data) + 1));
 	cl_assert(git_odb_exists(_odb, &_oid) == 1);
 }

--- a/tests/odb/freshen.c
+++ b/tests/odb/freshen.c
@@ -47,7 +47,7 @@ void test_odb_freshen__loose_blob(void)
 	set_time_wayback(&before, LOOSE_BLOB_FN);
 
 	/* make sure we freshen a blob */
-	cl_git_pass(git_blob_create_frombuffer(&id, repo, LOOSE_STR, CONST_STRLEN(LOOSE_STR)));
+	cl_git_pass(git_blob_create_from_buffer(&id, repo, LOOSE_STR, CONST_STRLEN(LOOSE_STR)));
 	cl_assert_equal_oid(&expected_id, &id);
 	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_BLOB_FN, &after));
 
@@ -66,13 +66,13 @@ void test_odb_freshen__readonly_object(void)
 
 	cl_git_pass(git_oid_fromstr(&expected_id, UNIQUE_BLOB_ID));
 
-	cl_git_pass(git_blob_create_frombuffer(&id, repo, UNIQUE_STR, CONST_STRLEN(UNIQUE_STR)));
+	cl_git_pass(git_blob_create_from_buffer(&id, repo, UNIQUE_STR, CONST_STRLEN(UNIQUE_STR)));
 	cl_assert_equal_oid(&expected_id, &id);
 
 	set_time_wayback(&before, UNIQUE_BLOB_FN);
 	cl_assert((before.st_mode & S_IWUSR) == 0);
 
-	cl_git_pass(git_blob_create_frombuffer(&id, repo, UNIQUE_STR, CONST_STRLEN(UNIQUE_STR)));
+	cl_git_pass(git_blob_create_from_buffer(&id, repo, UNIQUE_STR, CONST_STRLEN(UNIQUE_STR)));
 	cl_assert_equal_oid(&expected_id, &id);
 	cl_must_pass(p_lstat("testrepo.git/objects/" UNIQUE_BLOB_FN, &after));
 


### PR DESCRIPTION
We were inconsistent in our API naming, sometimes using `git_object_fromnoun` and sometimes using `git_object_from_noun`.

The majority of functions are named `from_something` (with an underscore) instead of `fromsomething`.  Update the functions for consistency with the rest of the library.