### PR TITLE
object: rename git_object__size to git_object_size

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -235,6 +235,8 @@ GIT_EXTERN(void) giterr_set_oom(void);
 #define GIT_OBJ_OFS_DELTA GIT_OBJECT_OFS_DELTA
 #define GIT_OBJ_REF_DELTA GIT_OBJECT_REF_DELTA
 
+GIT_EXTERN(size_t) git_object__size(git_object_t type);
+
 /**@}*/
 
 /** @name Deprecated Reference Constants

--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -197,7 +197,7 @@ GIT_EXTERN(int) git_object_typeisloose(git_object_t type);
  * @param type object type to get its size
  * @return size in bytes of the object
  */
-GIT_EXTERN(size_t) git_object__size(git_object_t type);
+GIT_EXTERN(size_t) git_object_size(git_object_t type);
 
 /**
  * Recursively peel an object until an object of the specified type is met.

--- a/src/object.c
+++ b/src/object.c
@@ -75,7 +75,7 @@ int git_object__from_raw(
 		return GIT_ENOTFOUND;
 	}
 
-	if ((object_size = git_object__size(type)) == 0) {
+	if ((object_size = git_object_size(type)) == 0) {
 		git_error_set(GIT_ERROR_INVALID, "the requested type is invalid");
 		return GIT_ENOTFOUND;
 	}
@@ -123,7 +123,7 @@ int git_object__from_odb_object(
 		return GIT_ENOTFOUND;
 	}
 
-	if ((object_size = git_object__size(odb_obj->cached.type)) == 0) {
+	if ((object_size = git_object_size(odb_obj->cached.type)) == 0) {
 		git_error_set(GIT_ERROR_INVALID, "the requested type is invalid");
 		return GIT_ENOTFOUND;
 	}
@@ -316,7 +316,7 @@ int git_object_typeisloose(git_object_t type)
 	return (git_objects_table[type].size > 0) ? 1 : 0;
 }
 
-size_t git_object__size(git_object_t type)
+size_t git_object_size(git_object_t type)
 {
 	if (type < 0 || ((size_t) type) >= ARRAY_SIZE(git_objects_table))
 		return 0;
@@ -550,3 +550,9 @@ bool git_object__is_valid(
 	return true;
 }
 
+/* Deprecated functions */
+
+size_t git_object__size(git_object_t type)
+{
+	return git_object_size(type);
+}


### PR DESCRIPTION
We don't use double-underscores in the public API.