### PR TITLE
attr: rename constants and macros for consistency

### DIFF
--- a/include/git2/attr.h
+++ b/include/git2/attr.h
@@ -30,7 +30,7 @@ GIT_BEGIN_DECL
  * Then for file `xyz.c` looking up attribute "foo" gives a value for
  * which `GIT_ATTR_TRUE(value)` is true.
  */
-#define GIT_ATTR_TRUE(attr)	(git_attr_value(attr) == GIT_ATTR_TRUE_T)
+#define GIT_ATTR_IS_TRUE(attr)	(git_attr_value(attr) == GIT_ATTR_VALUE_TRUE)
 
 /**
  * GIT_ATTR_FALSE checks if an attribute is set off.  In core git
@@ -44,7 +44,7 @@ GIT_BEGIN_DECL
  * Then for file `zyx.h` looking up attribute "foo" gives a value for
  * which `GIT_ATTR_FALSE(value)` is true.
  */
-#define GIT_ATTR_FALSE(attr) (git_attr_value(attr) == GIT_ATTR_FALSE_T)
+#define GIT_ATTR_IS_FALSE(attr) (git_attr_value(attr) == GIT_ATTR_VALUE_FALSE)
 
 /**
  * GIT_ATTR_UNSPECIFIED checks if an attribute is unspecified.  This
@@ -62,7 +62,7 @@ GIT_BEGIN_DECL
  * file `onefile.rb` or looking up "bar" on any file will all give
  * `GIT_ATTR_UNSPECIFIED(value)` of true.
  */
-#define GIT_ATTR_UNSPECIFIED(attr) (git_attr_value(attr) == GIT_ATTR_UNSPECIFIED_T)
+#define GIT_ATTR_IS_UNSPECIFIED(attr) (git_attr_value(attr) == GIT_ATTR_VALUE_UNSPECIFIED)
 
 /**
  * GIT_ATTR_HAS_VALUE checks if an attribute is set to a value (as
@@ -74,17 +74,17 @@ GIT_BEGIN_DECL
  * Given this, looking up "eol" for `onefile.txt` will give back the
  * string "lf" and `GIT_ATTR_SET_TO_VALUE(attr)` will return true.
  */
-#define GIT_ATTR_HAS_VALUE(attr) (git_attr_value(attr) == GIT_ATTR_VALUE_T)
+#define GIT_ATTR_HAS_VALUE(attr) (git_attr_value(attr) == GIT_ATTR_VALUE_STRING)
 
 /**
  * Possible states for an attribute
  */
 typedef enum {
-	GIT_ATTR_UNSPECIFIED_T = 0, /**< The attribute has been left unspecified */
-	GIT_ATTR_TRUE_T,  /**< The attribute has been set */
-	GIT_ATTR_FALSE_T, /**< The attribute has been unset */
-	GIT_ATTR_VALUE_T, /**< This attribute has a value */
-} git_attr_t;
+	GIT_ATTR_VALUE_UNSPECIFIED = 0, /**< The attribute has been left unspecified */
+	GIT_ATTR_VALUE_TRUE,   /**< The attribute has been set */
+	GIT_ATTR_VALUE_FALSE,  /**< The attribute has been unset */
+	GIT_ATTR_VALUE_STRING, /**< This attribute has a value */
+} git_attr_value_t;
 
 /**
  * Return the value type for a given attribute.
@@ -99,7 +99,7 @@ typedef enum {
  * @param attr The attribute
  * @return the value type for the attribute
  */
-GIT_EXTERN(git_attr_t) git_attr_value(const char *attr);
+GIT_EXTERN(git_attr_value_t) git_attr_value(const char *attr);
 
 /**
  * Check attribute flags: Reading values from index and working directory.

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -45,6 +45,28 @@
  */
 GIT_BEGIN_DECL
 
+/** @name Deprecated Attribute Constants
+ *
+ * These enumeration values are retained for backward compatibility.
+ * The newer versions of these functions should be preferred in all
+ * new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+#define GIT_ATTR_UNSPECIFIED_T GIT_ATTR_VALUE_UNSPECIFIED
+#define GIT_ATTR_TRUE_T GIT_ATTR_VALUE_TRUE
+#define GIT_ATTR_FALSE_T GIT_ATTR_VALUE_FALSE
+#define GIT_ATTR_VALUE_T GIT_ATTR_VALUE_STRING
+
+#define GIT_ATTR_TRUE(attr) GIT_ATTR_IS_TRUE(attr)
+#define GIT_ATTR_FALSE(attr) GIT_ATTR_IS_FALSE(attr)
+#define GIT_ATTR_UNSPECIFIED(attr) GIT_ATTR_IS_UNSPECIFIED(attr)
+
+/**@}*/
+
 /** @name Deprecated Blob Functions
  *
  * These functions are retained for backward compatibility.  The newer

--- a/src/attr.c
+++ b/src/attr.c
@@ -19,18 +19,18 @@ const char *git_attr__true  = "[internal]__TRUE__";
 const char *git_attr__false = "[internal]__FALSE__";
 const char *git_attr__unset = "[internal]__UNSET__";
 
-git_attr_t git_attr_value(const char *attr)
+git_attr_value_t git_attr_value(const char *attr)
 {
 	if (attr == NULL || attr == git_attr__unset)
-		return GIT_ATTR_UNSPECIFIED_T;
+		return GIT_ATTR_VALUE_UNSPECIFIED;
 
 	if (attr == git_attr__true)
-		return GIT_ATTR_TRUE_T;
+		return GIT_ATTR_VALUE_TRUE;
 
 	if (attr == git_attr__false)
-		return GIT_ATTR_FALSE_T;
+		return GIT_ATTR_VALUE_FALSE;
 
-	return GIT_ATTR_VALUE_T;
+	return GIT_ATTR_VALUE_STRING;
 }
 
 static int collect_attr_files(

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -44,11 +44,11 @@ struct crlf_filter {
 
 static git_crlf_t check_crlf(const char *value)
 {
-	if (GIT_ATTR_TRUE(value))
+	if (GIT_ATTR_IS_TRUE(value))
 		return GIT_CRLF_TEXT;
-	else if (GIT_ATTR_FALSE(value))
+	else if (GIT_ATTR_IS_FALSE(value))
 		return GIT_CRLF_BINARY;
-	else if (GIT_ATTR_UNSPECIFIED(value))
+	else if (GIT_ATTR_IS_UNSPECIFIED(value))
 		;
 	else if (strcmp(value, "input") == 0)
 		return GIT_CRLF_TEXT_INPUT;
@@ -60,7 +60,7 @@ static git_crlf_t check_crlf(const char *value)
 
 static git_cvar_value check_eol(const char *value)
 {
-	if (GIT_ATTR_UNSPECIFIED(value))
+	if (GIT_ATTR_IS_UNSPECIFIED(value))
 		;
 	else if (strcmp(value, "lf") == 0)
 		return GIT_EOL_LF;

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -371,11 +371,11 @@ int git_diff_driver_lookup(
 			attrsession, 0, path, 1, attrs)) < 0)
 		/* return error below */;
 
-	else if (GIT_ATTR_UNSPECIFIED(values[0]))
+	else if (GIT_ATTR_IS_UNSPECIFIED(values[0]))
 		/* just use the auto value */;
-	else if (GIT_ATTR_FALSE(values[0]))
+	else if (GIT_ATTR_IS_FALSE(values[0]))
 		*out = &global_drivers[DIFF_DRIVER_BINARY];
-	else if (GIT_ATTR_TRUE(values[0]))
+	else if (GIT_ATTR_IS_TRUE(values[0]))
 		*out = &global_drivers[DIFF_DRIVER_TEXT];
 
 	/* otherwise look for driver information in config and build driver */

--- a/src/filter.c
+++ b/src/filter.c
@@ -445,7 +445,7 @@ static int filter_list_check_attributes(
 
 	for (i = 0; !error && i < fdef->nattrs; ++i) {
 		const char *want = fdef->attrs[fdef->nattrs + i];
-		git_attr_t want_type, found_type;
+		git_attr_value_t want_type, found_type;
 
 		if (!want)
 			continue;
@@ -455,7 +455,7 @@ static int filter_list_check_attributes(
 
 		if (want_type != found_type)
 			error = GIT_ENOTFOUND;
-		else if (want_type == GIT_ATTR_VALUE_T &&
+		else if (want_type == GIT_ATTR_VALUE_STRING &&
 				strcmp(want, strs[i]) &&
 				strcmp(want, "*"))
 			error = GIT_ENOTFOUND;

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -371,17 +371,17 @@ static int merge_driver_name_for_path(
 		return error;
 
 	/* set: use the built-in 3-way merge driver ("text") */
-	if (GIT_ATTR_TRUE(value))
+	if (GIT_ATTR_IS_TRUE(value))
 		*out = merge_driver_name__text;
 
 	/* unset: do not merge ("binary") */
-	else if (GIT_ATTR_FALSE(value))
+	else if (GIT_ATTR_IS_FALSE(value))
 		*out = merge_driver_name__binary;
 
-	else if (GIT_ATTR_UNSPECIFIED(value) && default_driver)
+	else if (GIT_ATTR_IS_UNSPECIFIED(value) && default_driver)
 		*out = default_driver;
 
-	else if (GIT_ATTR_UNSPECIFIED(value))
+	else if (GIT_ATTR_IS_UNSPECIFIED(value))
 		*out = merge_driver_name__text;
 
 	else

--- a/tests/attr/attr_expect.h
+++ b/tests/attr/attr_expect.h
@@ -23,15 +23,15 @@ GIT_INLINE(void) attr_check_expected(
 {
 	switch (expected) {
 	case EXPECT_TRUE:
-		cl_assert_(GIT_ATTR_TRUE(value), name);
+		cl_assert_(GIT_ATTR_IS_TRUE(value), name);
 		break;
 
 	case EXPECT_FALSE:
-		cl_assert_(GIT_ATTR_FALSE(value), name);
+		cl_assert_(GIT_ATTR_IS_FALSE(value), name);
 		break;
 
 	case EXPECT_UNDEFINED:
-		cl_assert_(GIT_ATTR_UNSPECIFIED(value), name);
+		cl_assert_(GIT_ATTR_IS_UNSPECIFIED(value), name);
 		break;
 
 	case EXPECT_STRING:

--- a/tests/attr/file.c
+++ b/tests/attr/file.c
@@ -26,7 +26,7 @@ void test_attr_file__simple_read(void)
 	assign = get_assign(rule, 0);
 	cl_assert(assign != NULL);
 	cl_assert_equal_s("binary", assign->name);
-	cl_assert(GIT_ATTR_TRUE(assign->value));
+	cl_assert(GIT_ATTR_IS_TRUE(assign->value));
 
 	git_attr_file__free(file);
 }
@@ -53,7 +53,7 @@ void test_attr_file__match_variants(void)
 	assign = get_assign(rule,0);
 	cl_assert_equal_s("attr0", assign->name);
 	cl_assert(assign->name_hash == git_attr_file__name_hash(assign->name));
-	cl_assert(GIT_ATTR_TRUE(assign->value));
+	cl_assert(GIT_ATTR_IS_TRUE(assign->value));
 
 	rule = get_rule(1);
 	cl_assert_equal_s("pat1", rule->match.pattern);
@@ -83,7 +83,7 @@ void test_attr_file__match_variants(void)
 	cl_assert((rule->match.flags & GIT_ATTR_FNMATCH_HASWILD) != 0);
 	assign = get_assign(rule,0);
 	cl_assert_equal_s("attr7", assign->name);
-	cl_assert(GIT_ATTR_TRUE(assign->value));
+	cl_assert(GIT_ATTR_IS_TRUE(assign->value));
 
 	rule = get_rule(8);
 	cl_assert_equal_s("pat8 with spaces", rule->match.pattern);
@@ -144,11 +144,11 @@ void test_attr_file__assign_variants(void)
 	assign = git_attr_rule__lookup_assignment(rule, "multiple");
 	cl_assert(assign);
 	cl_assert_equal_s("multiple", assign->name);
-	cl_assert(GIT_ATTR_TRUE(assign->value));
+	cl_assert(GIT_ATTR_IS_TRUE(assign->value));
 	assign = git_attr_rule__lookup_assignment(rule, "single");
 	cl_assert(assign);
 	cl_assert_equal_s("single", assign->name);
-	cl_assert(GIT_ATTR_FALSE(assign->value));
+	cl_assert(GIT_ATTR_IS_FALSE(assign->value));
 	assign = git_attr_rule__lookup_assignment(rule, "values");
 	cl_assert(assign);
 	cl_assert_equal_s("values", assign->name);
@@ -170,7 +170,7 @@ void test_attr_file__assign_variants(void)
 	assign = git_attr_rule__lookup_assignment(rule, "again");
 	cl_assert(assign);
 	cl_assert_equal_s("again", assign->name);
-	cl_assert(GIT_ATTR_TRUE(assign->value));
+	cl_assert(GIT_ATTR_IS_TRUE(assign->value));
 	assign = git_attr_rule__lookup_assignment(rule, "another");
 	cl_assert(assign);
 	cl_assert_equal_s("another", assign->name);
@@ -194,10 +194,10 @@ static void assert_examples(git_attr_file *file)
 	cl_assert_equal_s("java", assign->value);
 	assign = git_attr_rule__lookup_assignment(rule, "crlf");
 	cl_assert_equal_s("crlf", assign->name);
-	cl_assert(GIT_ATTR_FALSE(assign->value));
+	cl_assert(GIT_ATTR_IS_FALSE(assign->value));
 	assign = git_attr_rule__lookup_assignment(rule, "myAttr");
 	cl_assert_equal_s("myAttr", assign->name);
-	cl_assert(GIT_ATTR_TRUE(assign->value));
+	cl_assert(GIT_ATTR_IS_TRUE(assign->value));
 	assign = git_attr_rule__lookup_assignment(rule, "missing");
 	cl_assert(assign == NULL);
 
@@ -206,7 +206,7 @@ static void assert_examples(git_attr_file *file)
 	cl_assert(rule->assigns.length == 1);
 	assign = get_assign(rule, 0);
 	cl_assert_equal_s("myAttr", assign->name);
-	cl_assert(GIT_ATTR_UNSPECIFIED(assign->value));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(assign->value));
 
 	rule = get_rule(2);
 	cl_assert_equal_s("README", rule->match.pattern);

--- a/tests/attr/flags.c
+++ b/tests/attr/flags.c
@@ -15,7 +15,7 @@ void test_attr_flags__bare(void)
 
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM, "README.md", "diff"));
-	cl_assert(GIT_ATTR_UNSPECIFIED(value));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(value));
 }
 
 void test_attr_flags__index_vs_workdir(void)
@@ -29,7 +29,7 @@ void test_attr_flags__index_vs_workdir(void)
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_FILE_THEN_INDEX,
 		"README.md", "bar"));
-	cl_assert(GIT_ATTR_FALSE(value));
+	cl_assert(GIT_ATTR_IS_FALSE(value));
 
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_FILE_THEN_INDEX,
@@ -39,13 +39,13 @@ void test_attr_flags__index_vs_workdir(void)
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_FILE_THEN_INDEX,
 		"README.txt", "foo"));
-	cl_assert(GIT_ATTR_FALSE(value));
+	cl_assert(GIT_ATTR_IS_FALSE(value));
 
 	/* index then wd */
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_INDEX_THEN_FILE,
 		"README.md", "bar"));
-	cl_assert(GIT_ATTR_TRUE(value));
+	cl_assert(GIT_ATTR_IS_TRUE(value));
 
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_INDEX_THEN_FILE,
@@ -55,7 +55,7 @@ void test_attr_flags__index_vs_workdir(void)
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_INDEX_THEN_FILE,
 		"README.txt", "foo"));
-	cl_assert(GIT_ATTR_TRUE(value));
+	cl_assert(GIT_ATTR_IS_TRUE(value));
 }
 
 void test_attr_flags__subdir(void)
@@ -77,7 +77,7 @@ void test_attr_flags__subdir(void)
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_FILE_THEN_INDEX,
 		"sub/sub/README.txt", "again"));
-	cl_assert(GIT_ATTR_TRUE(value));
+	cl_assert(GIT_ATTR_IS_TRUE(value));
 
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_FILE_THEN_INDEX,
@@ -98,7 +98,7 @@ void test_attr_flags__subdir(void)
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_INDEX_THEN_FILE,
 		"sub/sub/README.txt", "again"));
-	cl_assert(GIT_ATTR_TRUE(value));
+	cl_assert(GIT_ATTR_IS_TRUE(value));
 
 	cl_git_pass(git_attr_get(
 		&value, repo, GIT_ATTR_CHECK_NO_SYSTEM | GIT_ATTR_CHECK_INDEX_THEN_FILE,

--- a/tests/attr/lookup.c
+++ b/tests/attr/lookup.c
@@ -19,7 +19,7 @@ void test_attr_lookup__simple(void)
 	cl_assert(!path.is_dir);
 
 	cl_git_pass(git_attr_file__lookup_one(file,&path,"binary",&value));
-	cl_assert(GIT_ATTR_TRUE(value));
+	cl_assert(GIT_ATTR_IS_TRUE(value));
 
 	cl_git_pass(git_attr_file__lookup_one(file,&path,"missing",&value));
 	cl_assert(!value);

--- a/tests/attr/repo.c
+++ b/tests/attr/repo.c
@@ -104,23 +104,23 @@ void test_attr_repo__get_many(void)
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "root_test1", 4, names));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
-	cl_assert(GIT_ATTR_TRUE(values[1]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[2]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[3]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[1]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[2]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[3]));
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "root_test2", 4, names));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
-	cl_assert(GIT_ATTR_FALSE(values[1]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[2]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[3]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[1]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[2]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[3]));
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "sub/subdir_test1", 4, names));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
-	cl_assert(GIT_ATTR_TRUE(values[1]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[2]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[1]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[2]));
 	cl_assert_equal_s("yes", values[3]);
 }
 
@@ -134,9 +134,9 @@ void test_attr_repo__get_many_in_place(void)
 
 	cl_git_pass(git_attr_get_many(vals, g_repo, 0, "sub/subdir_test1", 4, vals));
 
-	cl_assert(GIT_ATTR_TRUE(vals[0]));
-	cl_assert(GIT_ATTR_TRUE(vals[1]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(vals[2]));
+	cl_assert(GIT_ATTR_IS_TRUE(vals[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(vals[1]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(vals[2]));
 	cl_assert_equal_s("yes", vals[3]);
 }
 
@@ -202,19 +202,19 @@ void test_attr_repo__manpage_example(void)
 	const char *value;
 
 	cl_git_pass(git_attr_get(&value, g_repo, 0, "sub/abc", "foo"));
-	cl_assert(GIT_ATTR_TRUE(value));
+	cl_assert(GIT_ATTR_IS_TRUE(value));
 
 	cl_git_pass(git_attr_get(&value, g_repo, 0, "sub/abc", "bar"));
-	cl_assert(GIT_ATTR_UNSPECIFIED(value));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(value));
 
 	cl_git_pass(git_attr_get(&value, g_repo, 0, "sub/abc", "baz"));
-	cl_assert(GIT_ATTR_FALSE(value));
+	cl_assert(GIT_ATTR_IS_FALSE(value));
 
 	cl_git_pass(git_attr_get(&value, g_repo, 0, "sub/abc", "merge"));
 	cl_assert_equal_s("filfre", value);
 
 	cl_git_pass(git_attr_get(&value, g_repo, 0, "sub/abc", "frotz"));
-	cl_assert(GIT_ATTR_UNSPECIFIED(value));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(value));
 }
 
 void test_attr_repo__macros(void)
@@ -226,24 +226,24 @@ void test_attr_repo__macros(void)
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "binfile", 5, names));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
-	cl_assert(GIT_ATTR_TRUE(values[1]));
-	cl_assert(GIT_ATTR_FALSE(values[2]));
-	cl_assert(GIT_ATTR_FALSE(values[3]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[4]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[1]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[2]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[3]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[4]));
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "macro_test", 5, names2));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
-	cl_assert(GIT_ATTR_TRUE(values[1]));
-	cl_assert(GIT_ATTR_FALSE(values[2]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[3]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[1]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[2]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[3]));
 	cl_assert_equal_s("77", values[4]);
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "macro_test", 3, names3));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
-	cl_assert(GIT_ATTR_FALSE(values[1]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[1]));
 	cl_assert_equal_s("answer", values[2]);
 }
 
@@ -256,9 +256,9 @@ void test_attr_repo__bad_macros(void)
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "macro_bad", 6, names));
 
 	/* these three just confirm that the "mymacro" rule ran */
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[0]));
-	cl_assert(GIT_ATTR_TRUE(values[1]));
-	cl_assert(GIT_ATTR_FALSE(values[2]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[1]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[2]));
 
 	/* file contains:
 	 *     # let's try some malicious macro defs
@@ -282,9 +282,9 @@ void test_attr_repo__bad_macros(void)
 	 * so summary results should be:
 	 *     -firstmacro secondmacro="hahaha" thirdmacro
 	 */
-	cl_assert(GIT_ATTR_FALSE(values[3]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[3]));
 	cl_assert_equal_s("hahaha", values[4]);
-	cl_assert(GIT_ATTR_TRUE(values[5]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[5]));
 }
 
 #define CONTENT "I'm going to be dynamically processed\r\n" \
@@ -357,22 +357,22 @@ void test_attr_repo__bare_repo_with_index(void)
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "file.txt", 4, names));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
 	cl_assert_equal_s("foobar", values[1]);
-	cl_assert(GIT_ATTR_FALSE(values[2]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[3]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[2]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[3]));
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "trial.txt", 4, names));
 
-	cl_assert(GIT_ATTR_FALSE(values[0]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[0]));
 	cl_assert_equal_s("barfoo", values[1]);
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[2]));
-	cl_assert(GIT_ATTR_TRUE(values[3]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[2]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[3]));
 
 	cl_git_pass(git_attr_get_many(values, g_repo, 0, "sub/sub/subdir.txt", 4, names));
 
-	cl_assert(GIT_ATTR_TRUE(values[0]));
+	cl_assert(GIT_ATTR_IS_TRUE(values[0]));
 	cl_assert_equal_s("foobar", values[1]);
-	cl_assert(GIT_ATTR_FALSE(values[2]));
-	cl_assert(GIT_ATTR_UNSPECIFIED(values[3]));
+	cl_assert(GIT_ATTR_IS_FALSE(values[2]));
+	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[3]));
 }


### PR DESCRIPTION
Our enumeration values are not generally suffixed with `T`.  Further,
our enumeration names are generally more descriptive.