### PR TITLE
Variadic macros

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -24,9 +24,6 @@
 #include "reader.h"
 #include "index.h"
 
-#define apply_err(...) \
-	( git_error_set(GIT_ERROR_PATCH, __VA_ARGS__), GIT_EAPPLYFAIL )
-
 typedef struct {
 	/* The lines that we allocate ourself are allocated out of the pool.
 	 * (Lines may have been allocated out of the diff.)
@@ -34,6 +31,18 @@ typedef struct {
 	git_pool pool;
 	git_vector lines;
 } patch_image;
+
+static int apply_err(const char *fmt, ...) GIT_FORMAT_PRINTF(1, 2);
+static int apply_err(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	git_error_vset(GIT_ERROR_PATCH, fmt, ap);
+	va_end(ap);
+
+	return GIT_EAPPLYFAIL;
+}
 
 static void patch_line_init(
 	git_diff_line *out,

--- a/src/errors.c
+++ b/src/errors.c
@@ -49,9 +49,17 @@ void git_error_set_oom(void)
 	GIT_GLOBAL->last_error = &g_git_oom_error;
 }
 
-void git_error_set(int error_class, const char *string, ...)
+void git_error_set(int error_class, const char *fmt, ...)
 {
-	va_list arglist;
+	va_list ap;
+
+	va_start(ap, fmt);
+	git_error_vset(error_class, fmt, ap);
+	va_end(ap);
+}
+
+void git_error_vset(int error_class, const char *fmt, va_list ap)
+{
 #ifdef GIT_WIN32
 	DWORD win32_error_code = (error_class == GIT_ERROR_OS) ? GetLastError() : 0;
 #endif
@@ -59,11 +67,8 @@ void git_error_set(int error_class, const char *string, ...)
 	git_buf *buf = &GIT_GLOBAL->error_buf;
 
 	git_buf_clear(buf);
-	if (string) {
-		va_start(arglist, string);
-		git_buf_vprintf(buf, string, arglist);
-		va_end(arglist);
-
+	if (fmt) {
+		git_buf_vprintf(buf, fmt, ap);
 		if (error_class == GIT_ERROR_OS)
 			git_buf_PUTS(buf, ": ");
 	}

--- a/src/errors.h
+++ b/src/errors.h
@@ -14,8 +14,8 @@
 /*
  * Set the error message for this thread, formatting as needed.
  */
-
-void git_error_set(int error_class, const char *string, ...) GIT_FORMAT_PRINTF(2, 3);
+void git_error_set(int error_class, const char *fmt, ...) GIT_FORMAT_PRINTF(2, 3);
+void git_error_vset(int error_class, const char *fmt, va_list ap);
 
 /**
  * Set the error message for a regex failure, using the internal regex

--- a/src/parse.h
+++ b/src/parse.h
@@ -28,9 +28,6 @@ typedef struct {
 int git_parse_ctx_init(git_parse_ctx *ctx, const char *content, size_t content_len);
 void git_parse_ctx_clear(git_parse_ctx *ctx);
 
-#define git_parse_err(...) \
-	( git_error_set(GIT_ERROR_PATCH, __VA_ARGS__), -1 )
-
 #define git_parse_ctx_contains_s(ctx, str) \
 	git_parse_ctx_contains(ctx, str, sizeof(str) - 1)
 

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -33,6 +33,18 @@ typedef struct {
 	char *old_prefix, *new_prefix;
 } git_patch_parsed;
 
+static int git_parse_err(const char *fmt, ...) GIT_FORMAT_PRINTF(1, 2);
+static int git_parse_err(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	git_error_vset(GIT_ERROR_PATCH, fmt, ap);
+	va_end(ap);
+
+	return -1;
+}
+
 static size_t header_path_len(git_patch_parse_ctx *ctx)
 {
 	bool inquote = 0;

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -59,7 +59,7 @@ GIT_INLINE(int) p_fsync(int fd)
 #define p_strcasecmp(s1, s2) strcasecmp(s1, s2)
 #define p_strncasecmp(s1, s2, c) strncasecmp(s1, s2, c)
 #define p_vsnprintf(b, c, f, a) vsnprintf(b, c, f, a)
-#define p_snprintf(b, c, ...) snprintf(b, c, __VA_ARGS__)
+#define p_snprintf snprintf
 #define p_mkstemp(p) mkstemp(p)
 #define p_chdir(p) chdir(p)
 #define p_chmod(p,m) chmod(p, m)


### PR DESCRIPTION
The macro `git_parse_error` is implemented in a variadic way so
that it's possible to pass printf-style parameters.
Unfortunately, variadic macros are not defined by C89 and thus we
cannot use that functionality. But as we have implemented
`git_error_vset` in the previous commit, we can now just use that
instead.

Convert `git_parse_error` to a variadic function and use
`git_error_vset` to fix the compliance violation.

---

Edit: fixed more locations to be compliant