### PR TITLE
net: remove unused `git_headlist_cb`

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -403,6 +403,11 @@ typedef git_push_transfer_progress_cb git_push_transfer_progress;
  /** The type of a remote completion event */
 #define git_remote_completion_type git_remote_completion_t
 
+/**
+ * Callback for listing the remote heads
+ */
+typedef int GIT_CALLBACK(git_headlist_cb)(git_remote_head *rhead, void *payload);
+
 /**@}*/
 
 /** @name Deprecated Options Initialization Functions

--- a/include/git2/net.h
+++ b/include/git2/net.h
@@ -49,11 +49,6 @@ struct git_remote_head {
 	char *symref_target;
 };
 
-/**
- * Callback for listing the remote heads
- */
-typedef int GIT_CALLBACK(git_headlist_cb)(git_remote_head *rhead, void *payload);
-
 /** @} */
 GIT_END_DECL
 #endif


### PR DESCRIPTION
This callback is never used.  Move it over to `deprecated.h`.