### PR TITLE
Move `git_off_t` to `git_object_size_t`

### DIFF
--- a/examples/blame.c
+++ b/examples/blame.c
@@ -33,7 +33,7 @@ static void parse_opts(struct opts *o, int argc, char *argv[]);
 int lg2_blame(git_repository *repo, int argc, char *argv[])
 {
 	int line, break_on_null_hunk;
-	git_off_t i, rawsize;
+	git_object_size_t i, rawsize;
 	char spec[1024] = {0};
 	struct opts o = {0};
 	const char *rawdata;

--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -94,7 +94,7 @@ GIT_EXTERN(const void *) git_blob_rawcontent(const git_blob *blob);
  * @param blob pointer to the blob
  * @return size on bytes
  */
-GIT_EXTERN(git_off_t) git_blob_rawsize(const git_blob *blob);
+GIT_EXTERN(git_object_size_t) git_blob_rawsize(const git_blob *blob);
 
 /**
  * Flags to control the functionality of `git_blob_filter`.

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -258,12 +258,12 @@ typedef enum {
  * abbreviated to something reasonable, like 7 characters.
  */
 typedef struct {
-	git_oid     id;
-	const char *path;
-	git_off_t   size;
-	uint32_t    flags;
-	uint16_t    mode;
-	uint16_t    id_abbrev;
+	git_oid            id;
+	const char        *path;
+	git_object_size_t  size;
+	uint32_t           flags;
+	uint16_t           mode;
+	uint16_t           id_abbrev;
 } git_diff_file;
 
 /**

--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -21,6 +21,8 @@
  */
 GIT_BEGIN_DECL
 
+#define GIT_OBJECT_SIZE_MAX UINT64_MAX
+
 /**
  * Lookup a reference to one of the objects in a repository.
  *

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -294,7 +294,7 @@ GIT_EXTERN(int) git_odb_write(git_oid *out, git_odb *odb, const void *data, size
  * @param type type of the object that will be written
  * @return 0 if the stream was created; error code otherwise
  */
-GIT_EXTERN(int) git_odb_open_wstream(git_odb_stream **out, git_odb *db, git_off_t size, git_object_t type);
+GIT_EXTERN(int) git_odb_open_wstream(git_odb_stream **out, git_odb *db, git_object_size_t size, git_object_t type);
 
 /**
  * Write to an odb stream

--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -87,8 +87,8 @@ struct git_odb_stream {
 	unsigned int mode;
 	void *hash_ctx;
 
-	git_off_t declared_size;
-	git_off_t received_bytes;
+	git_object_size_t declared_size;
+	git_object_size_t received_bytes;
 
 	/**
 	 * Write at most `len` bytes into `buffer` and advance the stream.

--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -53,7 +53,7 @@ struct git_odb_backend {
 		git_odb_backend *, const git_oid *, const void *, size_t, git_object_t);
 
 	int GIT_CALLBACK(writestream)(
-		git_odb_stream **, git_odb_backend *, git_off_t, git_object_t);
+		git_odb_stream **, git_odb_backend *, git_object_size_t, git_object_t);
 
 	int GIT_CALLBACK(readstream)(
 		git_odb_stream **, size_t *, git_object_t *,

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -63,6 +63,9 @@ typedef int64_t git_time_t; /**< time in seconds from epoch */
 
 #endif
 
+/** The maximum size of an object */
+typedef uint64_t git_object_size_t;
+
 #include "buffer.h"
 #include "oid.h"
 

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -120,7 +120,7 @@ int git_attr_file__load(
 	int bom_offset;
 	git_bom_t bom;
 	git_oid id;
-	git_off_t blobsize;
+	git_object_size_t blobsize;
 
 	*out = NULL;
 

--- a/src/blame.h
+++ b/src/blame.h
@@ -84,7 +84,7 @@ struct git_blame {
 	git_blame__entry *ent;
 	int num_lines;
 	const char *final_buf;
-	git_off_t final_buf_size;
+	size_t final_buf_size;
 };
 
 git_blame *git_blame__alloc(

--- a/src/blob.c
+++ b/src/blob.c
@@ -25,18 +25,18 @@ const void *git_blob_rawcontent(const git_blob *blob)
 		return git_odb_object_data(blob->data.odb);
 }
 
-git_off_t git_blob_rawsize(const git_blob *blob)
+git_object_size_t git_blob_rawsize(const git_blob *blob)
 {
 	assert(blob);
 	if (blob->raw)
 		return blob->data.raw.size;
 	else
-		return (git_off_t)git_odb_object_size(blob->data.odb);
+		return (git_object_size_t)git_odb_object_size(blob->data.odb);
 }
 
 int git_blob__getbuf(git_buf *buffer, git_blob *blob)
 {
-	git_off_t size = git_blob_rawsize(blob);
+	git_object_size_t size = git_blob_rawsize(blob);
 
 	GIT_ERROR_CHECK_BLOBSIZE(size);
 	return git_buf_set(buffer, git_blob_rawcontent(blob), (size_t)size);
@@ -91,13 +91,13 @@ int git_blob_create_from_buffer(
 }
 
 static int write_file_stream(
-	git_oid *id, git_odb *odb, const char *path, git_off_t file_size)
+	git_oid *id, git_odb *odb, const char *path, git_object_size_t file_size)
 {
 	int fd, error;
 	char buffer[FILEIO_BUFSIZE];
 	git_odb_stream *stream = NULL;
 	ssize_t read_len = -1;
-	git_off_t written = 0;
+	git_object_size_t written = 0;
 
 	if ((error = git_odb_open_wstream(
 			&stream, odb, file_size, GIT_OBJECT_BLOB)) < 0)
@@ -129,7 +129,7 @@ static int write_file_stream(
 
 static int write_file_filtered(
 	git_oid *id,
-	git_off_t *size,
+	git_object_size_t *size,
 	git_odb *odb,
 	const char *full_path,
 	git_filter_list *fl)
@@ -184,7 +184,7 @@ int git_blob__create_from_paths(
 	int error;
 	struct stat st;
 	git_odb *odb = NULL;
-	git_off_t size;
+	git_object_size_t size;
 	mode_t mode;
 	git_buf path = GIT_BUF_INIT;
 
@@ -389,7 +389,7 @@ cleanup:
 int git_blob_is_binary(const git_blob *blob)
 {
 	git_buf content = GIT_BUF_INIT;
-	git_off_t size;
+	git_object_size_t size;
 
 	assert(blob);
 

--- a/src/blob.h
+++ b/src/blob.h
@@ -21,7 +21,7 @@ struct git_blob {
 		git_odb_object *odb;
 		struct {
 			const char *data;
-			git_off_t size;
+			git_object_size_t size;
 		} raw;
 	} data;
 	unsigned int raw:1;

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -78,7 +78,7 @@ static int has_cr_in_index(const git_filter_source *src)
 	const git_index_entry *entry;
 	git_blob *blob;
 	const void *blobcontent;
-	git_off_t blobsize;
+	git_object_size_t blobsize;
 	bool found_cr;
 
 	if (!path)

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -330,8 +330,10 @@ static int diff_file_content_load_workdir_file(
 	if (fd < 0)
 		return fd;
 
-	if (!fc->file->size &&
-		!(fc->file->size = git_futils_filesize(fd)))
+	if (!fc->file->size)
+	    error = git_futils_filesize(&fc->file->size, fd);
+
+	if (error < 0 || !fc->file->size)
 		goto cleanup;
 
 	if ((diff_opts->flags & GIT_DIFF_SHOW_BINARY) == 0 &&

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -62,7 +62,7 @@ static int diff_file_content_init_common(
 	git_diff_driver_update_options(&fc->opts_flags, fc->driver);
 
 	/* make sure file is conceivable mmap-able */
-	if ((git_off_t)((size_t)fc->file->size) != fc->file->size)
+	if ((size_t)fc->file->size != fc->file->size)
 		fc->file->flags |= GIT_DIFF_FLAG_BINARY;
 	/* check if user is forcing text diff the file */
 	else if (fc->opts_flags & GIT_DIFF_FORCE_TEXT) {

--- a/src/diff_file.h
+++ b/src/diff_file.h
@@ -20,7 +20,7 @@ typedef struct {
 	git_diff_driver *driver;
 	uint32_t flags;
 	uint32_t opts_flags;
-	git_off_t opts_max_size;
+	git_object_size_t opts_max_size;
 	git_iterator_type_t src;
 	const git_blob *blob;
 	git_map map;

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -560,11 +560,11 @@ int git_diff__oid_for_file(
 	git_diff *diff,
 	const char *path,
 	uint16_t mode,
-	git_off_t size)
+	git_object_size_t size)
 {
 	git_index_entry entry;
 
-	if (size < 0 || size > UINT32_MAX) {
+	if (size > UINT32_MAX) {
 		git_error_set(GIT_ERROR_NOMEMORY, "file size overflow (for 32-bits) on '%s'", path);
 		return -1;
 	}

--- a/src/diff_generate.h
+++ b/src/diff_generate.h
@@ -88,7 +88,7 @@ extern int git_diff__oid_for_file(
 	git_diff *diff,
 	const char *path,
 	uint16_t mode,
-	git_off_t size);
+	git_object_size_t size);
 
 extern int git_diff__oid_for_entry(
 	git_oid *out,
@@ -120,7 +120,7 @@ GIT_INLINE(int) git_diff_file__resolve_zero_size(
 	git_odb_free(odb);
 
 	if (!error)
-		file->size = (git_off_t)len;
+		file->size = (git_object_size_t)len;
 
 	return error;
 }

--- a/src/diff_stats.c
+++ b/src/diff_stats.c
@@ -55,7 +55,7 @@ int git_diff_file_stats__full_to_buf(
 {
 	const char *old_path = NULL, *new_path = NULL;
 	size_t padding;
-	git_off_t old_size, new_size;
+	git_object_size_t old_size, new_size;
 
 	old_path = delta->old_file.path;
 	new_path = delta->new_file.path;

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -510,7 +510,7 @@ static int similarity_sig(
 			if (file->size != git_blob_rawsize(info->blob))
 				file->size = git_blob_rawsize(info->blob);
 
-			sz = (size_t)(git__is_sizet(file->size) ? file->size : -1);
+			sz = git__is_sizet(file->size) ? (size_t)file->size : (size_t)-1;
 
 			error = opts->metric->buffer_signature(
 				&cache[info->idx], info->file,

--- a/src/filter.c
+++ b/src/filter.c
@@ -764,7 +764,7 @@ int git_filter_list_apply_to_file(
 
 static int buf_from_blob(git_buf *out, git_blob *blob)
 {
-	git_off_t rawsize = git_blob_rawsize(blob);
+	git_object_size_t rawsize = git_blob_rawsize(blob);
 
 	if (!git__is_sizet(rawsize)) {
 		git_error_set(GIT_ERROR_OS, "blob is too large to filter");

--- a/src/futils.c
+++ b/src/futils.c
@@ -1110,7 +1110,7 @@ int git_futils_filestamp_check(
 #if defined(GIT_USE_NSEC)
 		stamp->mtime.tv_nsec == st.st_mtime_nsec &&
 #endif
-		stamp->size  == (git_off_t)st.st_size   &&
+		stamp->size  == (uint64_t)st.st_size   &&
 		stamp->ino   == (unsigned int)st.st_ino)
 		return 0;
 
@@ -1118,7 +1118,7 @@ int git_futils_filestamp_check(
 #if defined(GIT_USE_NSEC)
 	stamp->mtime.tv_nsec = st.st_mtime_nsec;
 #endif
-	stamp->size  = (git_off_t)st.st_size;
+	stamp->size  = (uint64_t)st.st_size;
 	stamp->ino   = (unsigned int)st.st_ino;
 
 	return 1;
@@ -1146,7 +1146,7 @@ void git_futils_filestamp_set_from_stat(
 #else
 		stamp->mtime.tv_nsec = 0;
 #endif
-		stamp->size  = (git_off_t)st->st_size;
+		stamp->size  = (uint64_t)st->st_size;
 		stamp->ino   = (unsigned int)st->st_ino;
 	} else {
 		memset(stamp, 0, sizeof(*stamp));

--- a/src/futils.c
+++ b/src/futils.c
@@ -307,7 +307,7 @@ int git_futils_mv_withpath(const char *from, const char *to, const mode_t dirmod
 	return 0;
 }
 
-int git_futils_mmap_ro(git_map *out, git_file fd, git_off_t begin, size_t len)
+int git_futils_mmap_ro(git_map *out, git_file fd, off64_t begin, size_t len)
 {
 	return p_mmap(out, len, GIT_PROT_READ, GIT_MAP_SHARED, fd, begin);
 }

--- a/src/futils.h
+++ b/src/futils.h
@@ -290,7 +290,7 @@ extern mode_t git_futils_canonical_mode(mode_t raw_mode);
 extern int git_futils_mmap_ro(
 	git_map *out,
 	git_file fd,
-	git_off_t begin,
+	off64_t begin,
 	size_t len);
 
 /**

--- a/src/futils.h
+++ b/src/futils.h
@@ -255,7 +255,7 @@ extern int git_futils_truncate(const char *path, int mode);
 /**
  * Get the filesize in bytes of a file
  */
-extern git_off_t git_futils_filesize(git_file fd);
+extern int git_futils_filesize(uint64_t *out, git_file fd);
 
 #define GIT_PERMS_IS_EXEC(MODE)		(((MODE) & 0111) != 0)
 #define GIT_PERMS_CANONICAL(MODE)	(GIT_PERMS_IS_EXEC(MODE) ? 0755 : 0644)

--- a/src/futils.h
+++ b/src/futils.h
@@ -330,7 +330,7 @@ extern int git_futils_fake_symlink(const char *new, const char *old);
  */
 typedef struct {
 	struct timespec mtime;
-	git_off_t  size;
+	uint64_t size;
 	unsigned int ino;
 } git_futils_filestamp;
 

--- a/src/integer.h
+++ b/src/integer.h
@@ -8,10 +8,10 @@
 #define INCLUDE_integer_h__
 
 /** @return true if p fits into the range of a size_t */
-GIT_INLINE(int) git__is_sizet(git_off_t p)
+GIT_INLINE(int) git__is_sizet(int64_t p)
 {
 	size_t r = (size_t)p;
-	return p == (git_off_t)r;
+	return p == (int64_t)r;
 }
 
 /** @return true if p fits into the range of an ssize_t */
@@ -36,10 +36,10 @@ GIT_INLINE(int) git__is_uint32(size_t p)
 }
 
 /** @return true if p fits into the range of an unsigned long */
-GIT_INLINE(int) git__is_ulong(git_off_t p)
+GIT_INLINE(int) git__is_ulong(int64_t p)
 {
 	unsigned long r = (unsigned long)p;
-	return p == (git_off_t)r;
+	return p == (int64_t)r;
 }
 
 /** @return true if p fits into the range of an int */

--- a/src/map.h
+++ b/src/map.h
@@ -40,7 +40,7 @@ typedef struct { /* memory mapped buffer	*/
 	assert((prot & GIT_PROT_WRITE) || (prot & GIT_PROT_READ)); \
 	assert((flags & GIT_MAP_FIXED) == 0); } while (0)
 
-extern int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset);
+extern int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, off64_t offset);
 extern int p_munmap(git_map *map);
 
 #endif

--- a/src/merge.c
+++ b/src/merge.c
@@ -1024,7 +1024,7 @@ static int index_entry_similarity_calc(
 {
 	git_blob *blob;
 	git_diff_file diff_file = {{{0}}};
-	git_off_t blobsize;
+	git_object_size_t blobsize;
 	int error;
 
 	*out = NULL;

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -167,11 +167,11 @@ void git_mwindow_free_all_locked(git_mwindow_file *mwf)
 /*
  * Check if a window 'win' contains the address 'offset'
  */
-int git_mwindow_contains(git_mwindow *win, git_off_t offset)
+int git_mwindow_contains(git_mwindow *win, off64_t offset)
 {
-	git_off_t win_off = win->offset;
+	off64_t win_off = win->offset;
 	return win_off <= offset
-		&& offset <= (git_off_t)(win_off + win->window_map.len);
+		&& offset <= (off64_t)(win_off + win->window_map.len);
 }
 
 /*
@@ -246,12 +246,12 @@ static int git_mwindow_close_lru(git_mwindow_file *mwf)
 static git_mwindow *new_window(
 	git_mwindow_file *mwf,
 	git_file fd,
-	git_off_t size,
-	git_off_t offset)
+	off64_t size,
+	off64_t offset)
 {
 	git_mwindow_ctl *ctl = &mem_ctl;
 	size_t walign = git_mwindow__window_size / 2;
-	git_off_t len;
+	off64_t len;
 	git_mwindow *w;
 
 	w = git__malloc(sizeof(*w));
@@ -263,8 +263,8 @@ static git_mwindow *new_window(
 	w->offset = (offset / walign) * walign;
 
 	len = size - w->offset;
-	if (len > (git_off_t)git_mwindow__window_size)
-		len = (git_off_t)git_mwindow__window_size;
+	if (len > (off64_t)git_mwindow__window_size)
+		len = (off64_t)git_mwindow__window_size;
 
 	ctl->mapped += (size_t)len;
 
@@ -311,7 +311,7 @@ static git_mwindow *new_window(
 unsigned char *git_mwindow_open(
 	git_mwindow_file *mwf,
 	git_mwindow **cursor,
-	git_off_t offset,
+	off64_t offset,
 	size_t extra,
 	unsigned int *left)
 {

--- a/src/mwindow.h
+++ b/src/mwindow.h
@@ -16,7 +16,7 @@
 typedef struct git_mwindow {
 	struct git_mwindow *next;
 	git_map window_map;
-	git_off_t offset;
+	off64_t offset;
 	size_t last_used;
 	size_t inuse_cnt;
 } git_mwindow;
@@ -24,7 +24,7 @@ typedef struct git_mwindow {
 typedef struct git_mwindow_file {
 	git_mwindow *windows;
 	int fd;
-	git_off_t size;
+	off64_t size;
 } git_mwindow_file;
 
 typedef struct git_mwindow_ctl {
@@ -37,10 +37,10 @@ typedef struct git_mwindow_ctl {
 	git_vector windowfiles;
 } git_mwindow_ctl;
 
-int git_mwindow_contains(git_mwindow *win, git_off_t offset);
+int git_mwindow_contains(git_mwindow *win, off64_t offset);
 void git_mwindow_free_all(git_mwindow_file *mwf); /* locks */
 void git_mwindow_free_all_locked(git_mwindow_file *mwf); /* run under lock */
-unsigned char *git_mwindow_open(git_mwindow_file *mwf, git_mwindow **cursor, git_off_t offset, size_t extra, unsigned int *left);
+unsigned char *git_mwindow_open(git_mwindow_file *mwf, git_mwindow **cursor, off64_t offset, size_t extra, unsigned int *left);
 int git_mwindow_file_register(git_mwindow_file *mwf);
 void git_mwindow_file_deregister(git_mwindow_file *mwf);
 void git_mwindow_close(git_mwindow **w_cursor);

--- a/src/notes.c
+++ b/src/notes.c
@@ -320,7 +320,7 @@ static int note_new(
 	git_blob *blob)
 {
 	git_note *note = NULL;
-	git_off_t blobsize;
+	git_object_size_t blobsize;
 
 	note = git__malloc(sizeof(git_note));
 	GIT_ERROR_CHECK_ALLOC(note);

--- a/src/object.h
+++ b/src/object.h
@@ -11,6 +11,8 @@
 
 #include "repository.h"
 
+#define GIT_OBJECT_SIZE_MAX UINT64_MAX
+
 extern bool git_object__strict_input_validation;
 
 /** Base git object for inheritance */

--- a/src/odb.c
+++ b/src/odb.c
@@ -89,7 +89,7 @@ int git_odb__format_object_header(
 	size_t *written,
 	char *hdr,
 	size_t hdr_size,
-	git_off_t obj_len,
+	git_object_size_t obj_len,
 	git_object_t obj_type)
 {
 	const char *type_str = git_object_type2string(obj_type);
@@ -320,7 +320,7 @@ int git_odb__hashlink(git_oid *out, const char *path)
 
 int git_odb_hashfile(git_oid *out, const char *path, git_object_t type)
 {
-	git_off_t size;
+	git_object_size_t size;
 	int result, fd = git_futils_open_ro(path);
 	if (fd < 0)
 		return fd;
@@ -385,7 +385,7 @@ static void fake_wstream__free(git_odb_stream *_stream)
 	git__free(stream);
 }
 
-static int init_fake_wstream(git_odb_stream **stream_p, git_odb_backend *backend, git_off_t size, git_object_t type)
+static int init_fake_wstream(git_odb_stream **stream_p, git_odb_backend *backend, git_object_size_t size, git_object_t type)
 {
 	fake_wstream *stream;
 	size_t blobsize;
@@ -1319,7 +1319,7 @@ int git_odb_write(
 	return error;
 }
 
-static int hash_header(git_hash_ctx *ctx, git_off_t size, git_object_t type)
+static int hash_header(git_hash_ctx *ctx, git_object_size_t size, git_object_t type)
 {
 	char header[64];
 	size_t hdrlen;
@@ -1333,7 +1333,7 @@ static int hash_header(git_hash_ctx *ctx, git_off_t size, git_object_t type)
 }
 
 int git_odb_open_wstream(
-	git_odb_stream **stream, git_odb *db, git_off_t size, git_object_t type)
+	git_odb_stream **stream, git_odb *db, git_object_size_t size, git_object_t type)
 {
 	size_t i, writes = 0;
 	int error = GIT_ERROR;

--- a/src/odb.h
+++ b/src/odb.h
@@ -70,7 +70,7 @@ int git_odb__hashobj(git_oid *id, git_rawobj *obj);
 /*
  * Format the object header such as it would appear in the on-disk object
  */
-int git_odb__format_object_header(size_t *out_len, char *hdr, size_t hdr_size, git_off_t obj_len, git_object_t obj_type);
+int git_odb__format_object_header(size_t *out_len, char *hdr, size_t hdr_size, git_object_size_t obj_len, git_object_t obj_type);
 
 /*
  * Hash an open file descriptor.

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -824,7 +824,7 @@ static int filebuf_flags(loose_backend *backend)
 	return flags;
 }
 
-static int loose_backend__writestream(git_odb_stream **stream_out, git_odb_backend *_backend, git_off_t length, git_object_t type)
+static int loose_backend__writestream(git_odb_stream **stream_out, git_odb_backend *_backend, git_object_size_t length, git_object_t type)
 {
 	loose_backend *backend;
 	loose_writestream *stream = NULL;
@@ -833,7 +833,7 @@ static int loose_backend__writestream(git_odb_stream **stream_out, git_odb_backe
 	size_t hdrlen;
 	int error;
 
-	assert(_backend && length >= 0);
+	assert(_backend);
 
 	backend = (loose_backend *)_backend;
 	*stream_out = NULL;

--- a/src/offmap.c
+++ b/src/offmap.c
@@ -14,9 +14,9 @@
 #define kfree git__free
 #include "khash.h"
 
-__KHASH_TYPE(off, git_off_t, void *)
+__KHASH_TYPE(off, off64_t, void *)
 
-__KHASH_IMPL(off, static kh_inline, git_off_t, void *, 1, kh_int64_hash_func, kh_int64_hash_equal)
+__KHASH_IMPL(off, static kh_inline, off64_t, void *, 1, kh_int64_hash_func, kh_int64_hash_equal)
 
 
 int git_offmap_new(git_offmap **out)
@@ -42,7 +42,7 @@ size_t git_offmap_size(git_offmap *map)
 	return kh_size(map);
 }
 
-void *git_offmap_get(git_offmap *map, const git_off_t key)
+void *git_offmap_get(git_offmap *map, const off64_t key)
 {
 	size_t idx = kh_get(off, map, key);
 	if (idx == kh_end(map) || !kh_exist(map, idx))
@@ -50,7 +50,7 @@ void *git_offmap_get(git_offmap *map, const git_off_t key)
 	return kh_val(map, idx);
 }
 
-int git_offmap_set(git_offmap *map, const git_off_t key, void *value)
+int git_offmap_set(git_offmap *map, const off64_t key, void *value)
 {
 	size_t idx;
 	int rval;
@@ -67,7 +67,7 @@ int git_offmap_set(git_offmap *map, const git_off_t key, void *value)
 	return 0;
 }
 
-int git_offmap_delete(git_offmap *map, const git_off_t key)
+int git_offmap_delete(git_offmap *map, const off64_t key)
 {
 	khiter_t idx = kh_get(off, map, key);
 	if (idx == kh_end(map))
@@ -76,12 +76,12 @@ int git_offmap_delete(git_offmap *map, const git_off_t key)
 	return 0;
 }
 
-int git_offmap_exists(git_offmap *map, const git_off_t key)
+int git_offmap_exists(git_offmap *map, const off64_t key)
 {
 	return kh_get(off, map, key) != kh_end(map);
 }
 
-int git_offmap_iterate(void **value, git_offmap *map, size_t *iter, git_off_t *key)
+int git_offmap_iterate(void **value, git_offmap *map, size_t *iter, off64_t *key)
 {
 	size_t i = *iter;
 

--- a/src/offmap.h
+++ b/src/offmap.h
@@ -11,11 +11,11 @@
 
 #include "git2/types.h"
 
-/** A map with `git_off_t`s as key. */
+/** A map with `off64_t`s as key. */
 typedef struct kh_off_s git_offmap;
 
 /**
- * Allocate a new `git_off_t` map.
+ * Allocate a new `off64_t` map.
  *
  * @param out Pointer to the map that shall be allocated.
  * @return 0 on success, an error code if allocation has failed.
@@ -59,7 +59,7 @@ size_t git_offmap_size(git_offmap *map);
  * @param key key to search for
  * @return value associated with the given key or NULL if the key was not found
  */
-void *git_offmap_get(git_offmap *map, const git_off_t key);
+void *git_offmap_get(git_offmap *map, const off64_t key);
 
 /**
  * Set the entry for key to value.
@@ -74,7 +74,7 @@ void *git_offmap_get(git_offmap *map, const git_off_t key);
  * @return zero if the key was successfully set, a negative error
  *         code otherwise
  */
-int git_offmap_set(git_offmap *map, const git_off_t key, void *value);
+int git_offmap_set(git_offmap *map, const off64_t key, void *value);
 
 /**
  * Delete an entry from the map.
@@ -88,7 +88,7 @@ int git_offmap_set(git_offmap *map, const git_off_t key, void *value);
  *         such key was found, a negative code in case of an
  *         error
  */
-int git_offmap_delete(git_offmap *map, const git_off_t key);
+int git_offmap_delete(git_offmap *map, const off64_t key);
 
 /**
  * Check whether a key exists in the given map.
@@ -97,7 +97,7 @@ int git_offmap_delete(git_offmap *map, const git_off_t key);
  * @param key key to search for
  * @return 0 if the key has not been found, 1 otherwise
  */
-int git_offmap_exists(git_offmap *map, const git_off_t key);
+int git_offmap_exists(git_offmap *map, const off64_t key);
 
 /**
  * Iterate over entries of the map.
@@ -118,7 +118,7 @@ int git_offmap_exists(git_offmap *map, const git_off_t key);
  *        GIT_ITEROVER if no entries are left. A negative error
  *        code otherwise.
  */
-int git_offmap_iterate(void **value, git_offmap *map, size_t *iter, git_off_t *key);
+int git_offmap_iterate(void **value, git_offmap *map, size_t *iter, off64_t *key);
 
 #define git_offmap_foreach(h, kvar, vvar, code) { size_t __i = 0;		\
 	while (git_offmap_iterate((void **) &(vvar), h, &__i, &(kvar)) == 0) {	\

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -30,7 +30,7 @@
 typedef struct git_pobject {
 	git_oid id;
 	git_object_t type;
-	git_off_t offset;
+	off64_t offset;
 
 	size_t size;
 

--- a/src/pack.h
+++ b/src/pack.h
@@ -64,8 +64,8 @@ typedef struct git_pack_cache_entry {
 } git_pack_cache_entry;
 
 struct pack_chain_elem {
-	git_off_t base_key;
-	git_off_t offset;
+	off64_t base_key;
+	off64_t offset;
 	size_t size;
 	git_object_t type;
 };
@@ -108,13 +108,13 @@ struct git_pack_file {
 };
 
 struct git_pack_entry {
-	git_off_t offset;
+	off64_t offset;
 	git_oid sha1;
 	struct git_pack_file *p;
 };
 
 typedef struct git_packfile_stream {
-	git_off_t curpos;
+	off64_t curpos;
 	int done;
 	z_stream zstream;
 	struct git_pack_file *p;
@@ -130,23 +130,23 @@ int git_packfile_unpack_header(
 		git_object_t *type_p,
 		git_mwindow_file *mwf,
 		git_mwindow **w_curs,
-		git_off_t *curpos);
+		off64_t *curpos);
 
 int git_packfile_resolve_header(
 		size_t *size_p,
 		git_object_t *type_p,
 		struct git_pack_file *p,
-		git_off_t offset);
+		off64_t offset);
 
-int git_packfile_unpack(git_rawobj *obj, struct git_pack_file *p, git_off_t *obj_offset);
+int git_packfile_unpack(git_rawobj *obj, struct git_pack_file *p, off64_t *obj_offset);
 
-int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, git_off_t curpos);
+int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, off64_t curpos);
 ssize_t git_packfile_stream_read(git_packfile_stream *obj, void *buffer, size_t len);
 void git_packfile_stream_dispose(git_packfile_stream *obj);
 
-git_off_t get_delta_base(struct git_pack_file *p, git_mwindow **w_curs,
-		git_off_t *curpos, git_object_t type,
-		git_off_t delta_obj_offset);
+off64_t get_delta_base(struct git_pack_file *p, git_mwindow **w_curs,
+		off64_t *curpos, git_object_t type,
+		off64_t delta_obj_offset);
 
 void git_packfile_close(struct git_pack_file *p, bool unlink_packfile);
 void git_packfile_free(struct git_pack_file *p);

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -491,7 +491,7 @@ done:
 
 static int parse_int(int *out, git_patch_parse_ctx *ctx)
 {
-	git_off_t num;
+	int64_t num;
 
 	if (git_parse_advance_digit(&num, &ctx->parse_ctx, 10) < 0 || !git__is_int(num))
 		return -1;
@@ -765,7 +765,7 @@ static int parse_patch_binary_side(
 {
 	git_diff_binary_t type = GIT_DIFF_BINARY_NONE;
 	git_buf base85 = GIT_BUF_INIT, decoded = GIT_BUF_INIT;
-	git_off_t len;
+	int64_t len;
 	int error = 0;
 
 	if (git_parse_ctx_contains_s(&ctx->parse_ctx, "literal ")) {

--- a/src/posix.c
+++ b/src/posix.c
@@ -235,7 +235,7 @@ int git__mmap_alignment(size_t *alignment)
 }
 
 
-int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
+int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, off64_t offset)
 {
 	GIT_MMAP_VALIDATE(out, len, prot, flags);
 

--- a/src/posix.h
+++ b/src/posix.h
@@ -89,6 +89,18 @@
 #define EAFNOSUPPORT (INT_MAX-1)
 #endif
 
+/* Provide a 64-bit size for offsets. */
+
+#if defined(_MSC_VER)
+typedef __int64 off64_t;
+#elif defined(__HAIKU__)
+typedef __haiku_std_int64 off64_t;
+#elif defined(__APPLE__)
+typedef __int64_t off64_t;
+#else
+typedef int64_t off64_t;
+#endif
+
 typedef int git_file;
 
 /**

--- a/src/reader.c
+++ b/src/reader.c
@@ -32,7 +32,7 @@ static int tree_reader_read(
 	tree_reader *reader = (tree_reader *)_reader;
 	git_tree_entry *tree_entry = NULL;
 	git_blob *blob = NULL;
-	git_off_t blobsize;
+	git_object_size_t blobsize;
 	int error;
 
 	if ((error = git_tree_entry_bypath(&tree_entry, reader->tree, filename)) < 0 ||

--- a/src/repository.c
+++ b/src/repository.c
@@ -2545,7 +2545,7 @@ int git_repository_hashfile(
 	int error;
 	git_filter_list *fl = NULL;
 	git_file fd = -1;
-	git_off_t len;
+	uint64_t len;
 	git_buf full_path = GIT_BUF_INIT;
 
 	assert(out && path && repo); /* as_path can be NULL */
@@ -2582,11 +2582,8 @@ int git_repository_hashfile(
 		goto cleanup;
 	}
 
-	len = git_futils_filesize(fd);
-	if (len < 0) {
-		error = (int)len;
+	if ((error = git_futils_filesize(&len, fd)) < 0)
 		goto cleanup;
-	}
 
 	if (!git__is_sizet(len)) {
 		git_error_set(GIT_ERROR_OS, "file size overflow for 32-bit systems");

--- a/src/unix/map.c
+++ b/src/unix/map.c
@@ -32,7 +32,7 @@ int git__mmap_alignment(size_t *alignment)
   return git__page_size(alignment);
 }
 
-int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
+int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, off64_t offset)
 {
 	int mprot = PROT_READ;
 	int mflag = 0;

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -99,8 +99,6 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 		return -1;
 	}
 
-	assert(sizeof(git_off_t) == 8);
-
 	off_low = (DWORD)(page_start);
 	off_hi = (DWORD)(page_start >> 32);
 	out->data = MapViewOfFile(out->fmh, view_prot, off_hi, off_low, len);

--- a/src/win32/map.c
+++ b/src/win32/map.c
@@ -50,7 +50,7 @@ int git__mmap_alignment(size_t *page_size)
 	return 0;
 }
 
-int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offset)
+int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, off64_t offset)
 {
 	HANDLE fh = (HANDLE)_get_osfhandle(fd);
 	DWORD alignment = get_allocation_granularity();
@@ -58,8 +58,8 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, git_off_t offs
 	DWORD view_prot = 0;
 	DWORD off_low = 0;
 	DWORD off_hi = 0;
-	git_off_t page_start;
-	git_off_t page_offset;
+	off64_t page_start;
+	off64_t page_offset;
 
 	GIT_MMAP_VALIDATE(out, len, prot, flags);
 

--- a/src/win32/posix.h
+++ b/src/win32/posix.h
@@ -47,7 +47,7 @@ extern int p_chdir(const char* path);
 extern int p_chmod(const char* path, mode_t mode);
 extern int p_rmdir(const char* path);
 extern int p_access(const char* path, mode_t mode);
-extern int p_ftruncate(int fd, git_off_t size);
+extern int p_ftruncate(int fd, off64_t size);
 
 /* p_lstat is almost but not quite POSIX correct.  Specifically, the use of
  * ENOTDIR is wrong, in that it does not mean precisely that a non-directory

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -210,7 +210,7 @@ on_error:
  * We now take a "git_off_t" rather than "long" because
  * files may be longer than 2Gb.
  */
-int p_ftruncate(int fd, git_off_t size)
+int p_ftruncate(int fd, off64_t size)
 {
 	if (size < 0) {
 		errno = EINVAL;

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -120,7 +120,7 @@ GIT_INLINE(void) git_win32__stat_init(
 	st->st_uid = 0;
 	st->st_nlink = 1;
 	st->st_mode = mode;
-	st->st_size = ((git_off_t)nFileSizeHigh << 32) + nFileSizeLow;
+	st->st_size = ((int64_t)nFileSizeHigh << 32) + nFileSizeLow;
 	st->st_dev = _getdrive() - 1;
 	st->st_rdev = st->st_dev;
 	git_win32__filetime_to_timespec(&ftLastAccessTime, &(st->st_atim));

--- a/tests/core/ftruncate.c
+++ b/tests/core/ftruncate.c
@@ -27,7 +27,7 @@ void test_core_ftruncate__cleanup(void)
 	p_unlink(filename);
 }
 
-static void _extend(git_off_t i64len)
+static void _extend(off64_t i64len)
 {
 	struct stat st;
 	int error;

--- a/tests/index/tests.c
+++ b/tests/index/tests.c
@@ -13,7 +13,7 @@ static const size_t index_entry_count_2 = 1437;
 struct test_entry {
    size_t index;
    char path[128];
-   git_off_t file_size;
+   off64_t file_size;
    git_time_t mtime;
 };
 

--- a/tests/object/blob/filter.c
+++ b/tests/object/blob/filter.c
@@ -19,7 +19,7 @@ static const char *g_crlf_raw[CRLF_NUM_TEST_OBJECTS] = {
 	"\xFE\xFF\x00T\x00h\x00i\x00s\x00!"
 };
 
-static git_off_t g_crlf_raw_len[CRLF_NUM_TEST_OBJECTS] = {
+static off64_t g_crlf_raw_len[CRLF_NUM_TEST_OBJECTS] = {
 	-1, -1, -1, -1, -1, 17, -1, -1, 12
 };
 


### PR DESCRIPTION
`git_off_t` is problematic: first, it's used to represent the size of
a blob, but that's represented in git as an `unsigned long`, meaning
that we've lost a bit (on 64-bit machines).  Second, `git_off_t` is a
poor name, suggesting that it's an offset, not a size (which makes
sense, given that it's a signed type).

Migrate `git_off_t` to `git_object_size_t`, an unsigned 64-bit type.