### PR TITLE
cmake: default NTLM client to off if no HTTPS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,11 @@ OPTION(DEPRECATE_HARD			"Do not include deprecated functions in the library"	OFF
    SET(REGEX_BACKEND			"" CACHE STRING "Regular expression implementation. One of regcomp_l, pcre2, pcre, regcomp, or builtin.")
 
 IF (UNIX)
-	OPTION(USE_NTLMCLIENT		"Enable NTLM support on Unix."				ON )
+	IF (NOT USE_HTTPS)
+	    OPTION(USE_NTLMCLIENT		"Enable NTLM support on Unix."				OFF )
+	ELSE()
+	    OPTION(USE_NTLMCLIENT		"Enable NTLM support on Unix."				ON )
+	ENDIF()
 ENDIF()
 
 IF (UNIX AND NOT APPLE)


### PR DESCRIPTION
If building libgit2 with `-DUSE_HTTPS=NO`, then CMake will
generate an error complaining that there's no usable HTTPS
backend for NTLM. In fact, it doesn't make sense to support NTLM
when we don't support HTTPS. So let's should just have
NTLM default to OFF when HTTPS is disabled to make life easier
and to fix our OSSFuzz builds failing.