### PR TITLE
Compare buffers in diff example

### DIFF
--- a/examples/common.c
+++ b/examples/common.c
@@ -14,6 +14,14 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifdef _WIN32
+# include <io.h>
+#else
+# include <fcntl.h>
+# include <unistd.h>
+#endif
 #include <string.h>
 #include <errno.h>
 
@@ -391,3 +399,37 @@ out:
 	free(pubkey);
 	return error;
 }
+
+char *read_file(const char *path)
+{
+	ssize_t total = 0;
+	char *buf = NULL;
+	struct stat st;
+	int fd = -1;
+
+	if ((fd = open(path, O_RDONLY)) < 0 || fstat(fd, &st) < 0)
+		goto out;
+
+	if ((buf = malloc(st.st_size + 1)) == NULL)
+		goto out;
+
+	while (total < st.st_size) {
+		ssize_t bytes = read(fd, buf + total, st.st_size - total);
+		if (bytes <= 0) {
+			if (errno == EAGAIN || errno == EINTR)
+				 continue;
+			free(buf);
+			buf = NULL;
+			goto out;
+		}
+		total += bytes;
+	}
+
+	buf[total] = '\0';
+
+out:
+	if (fd >= 0)
+		close(fd);
+	return buf;
+}
+

--- a/examples/common.h
+++ b/examples/common.h
@@ -64,6 +64,14 @@ extern int lg2_tag(git_repository *repo, int argc, char **argv);
 extern void check_lg2(int error, const char *message, const char *extra);
 
 /**
+ * Read a file into a buffer
+ *
+ * @param path The path to the file that shall be read
+ * @return NUL-terminated buffer if the file was successfully read, NULL-pointer otherwise
+ */
+extern char *read_file(const char *path);
+
+/**
  * Exit the program, printing error to stderr
  */
 extern void fatal(const char *message, const char *extra);
@@ -89,7 +97,7 @@ struct args_info {
 /**
  * Check current `args` entry against `opt` string.  If it matches
  * exactly, take the next arg as a string; if it matches as a prefix with
- * an equal sign, take the remainder as a string; if value not supplied, 
+ * an equal sign, take the remainder as a string; if value not supplied,
  * default value `def` will be given. otherwise return 0.
  */
 extern int optional_str_arg(

--- a/examples/common.h
+++ b/examples/common.h
@@ -12,10 +12,25 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <git2.h>
+#include <fcntl.h>
+
+#ifdef _WIN32
+# include <io.h>
+# include <Windows.h>
+# define open _open
+# define read _read
+# define close _close
+# define ssize_t int
+# define sleep(a) Sleep(a * 1000)
+#else
+# include <unistd.h>
+#endif
 
 #ifndef PRIuZ
 /* Define the printf format specifer to use for size_t output */

--- a/examples/for-each-ref.c
+++ b/examples/for-each-ref.c
@@ -1,5 +1,4 @@
 #include <git2.h>
-#include <stdio.h>
 #include "common.h"
 
 static int show_ref(git_reference *ref, void *data)

--- a/examples/general.c
+++ b/examples/general.c
@@ -36,6 +36,8 @@
  * [pg]: https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain
  */
 
+#include "common.h"
+
 /**
  * ### Includes
  *
@@ -43,9 +45,7 @@
  * that you need.  It should be the only thing you need to include in order
  * to compile properly and get all the libgit2 API.
  */
-#include <git2.h>
-#include <stdio.h>
-#include <string.h>
+#include "git2.h"
 
 static void oid_parsing(git_oid *out);
 static void object_database(git_repository *repo, git_oid *oid);

--- a/examples/index-pack.c
+++ b/examples/index-pack.c
@@ -1,21 +1,5 @@
 #include "common.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#ifdef _WIN32
-# include <io.h>
-# include <Windows.h>
-
-# define open _open
-# define read _read
-# define close _close
-
-#define ssize_t int
-#else
-# include <unistd.h>
-#endif
-
 /*
  * This could be run in the main loop whilst the application waits for
  * the indexing to finish in a worker thread

--- a/examples/status.c
+++ b/examples/status.c
@@ -13,12 +13,6 @@
  */
 
 #include "common.h"
-#ifdef _WIN32
-# include <Windows.h>
-# define sleep(a) Sleep(a * 1000)
-#else
-# include <unistd.h>
-#endif
 
 /**
  * This example demonstrates the use of the libgit2 status APIs,


### PR DESCRIPTION
Adding compare buffers feature in diff example

This tries to mimic `git diff --no-index`

```
echo hello > file1
echo bye > file2
git diff --no-index file1 file2
diff --git 1/file1 2/file2
index 5c1b14949..b023018ca 100644
--- 1/file1
+++ 2/file2
@@ -1 +1 @@
-hello
+bye
```

Right now this patch does:

```
$ ./diff --files --text --color
buf: diff --git a/file1 b/file2
index ce01362..b023018 100644
--- a/file1
+++ b/file2
@@ -1 +1 @@
-hello
+bye
diff --git a/file1 b/file2
index ce01362..b023018 100644
--- a/file1
+++ b/file2
@@ -1 +1 @@
-hello
+bye
```

Actual problems:

-  Read real files
- Do not detect buffers as binary files
- Use `--no-index` as parameter
- Check two files are passed and they exists