### PR TITLE
fileops: fix creation of directory in filesystem root

### DIFF
--- a/src/fileops.c
+++ b/src/fileops.c
@@ -495,7 +495,9 @@ int git_futils_mkdir(
 		 * equal to length of the root path).  The path may be less than the
 		 * root path length on Windows, where `C:` == `C:/`.
 		 */
-		if ((len == 1 && parent_path.ptr[0] == '.') || len <= root_len) {
+		if ((len == 1 && parent_path.ptr[0] == '.') ||
+		    (len == 1 && parent_path.ptr[0] == '/') ||
+		    len <= root_len) {
 			relative = make_path.ptr;
 			break;
 		}


### PR DESCRIPTION
In commit 45f24e787 (git_repository_init: stop traversing at
windows root, 2019-04-12), we have fixed `git_futils_mkdir` to
correctly handle the case where we create a directory in
Windows-style filesystem roots like "C:\repo".

The problem here is an off-by-one: previously, to that commit,
we've been checking wether the parent directory's length is equal
to the root directory's length incremented by one. When we call
the function with "/example", then the parent directory's length
("/") is 1, but the root directory offset is 0 as the path is
directly rooted without a drive prefix. This resulted in `1 == 0 +
1`, which was true. With the change, we've stopped incrementing
the root directory length, and thus now compare `1 <= 0`, which
is false.

The previous way of doing it was kind of finicky any non-obvious,
which is also why the error was introduced. So instead of just
re-adding the increment, let's explicitly add a condition that
aborts finding the parent if the current parent path is "/".

---

Fixes #5130 