### PR TITLE
config_file: implement stat cache to avoid repeated rehashing

### DIFF
--- a/cmake/Modules/FindStatNsec.cmake
+++ b/cmake/Modules/FindStatNsec.cmake
@@ -1,3 +1,5 @@
+INCLUDE(FeatureSummary)
+
 CHECK_STRUCT_HAS_MEMBER ("struct stat" st_mtim "sys/types.h;sys/stat.h"
 	HAVE_STRUCT_STAT_ST_MTIM LANGUAGE C)
 CHECK_STRUCT_HAS_MEMBER ("struct stat" st_mtimespec "sys/types.h;sys/stat.h"
@@ -17,4 +19,8 @@ ENDIF()
 
 IF (HAVE_STRUCT_STAT_NSEC OR WIN32)
 	OPTION( USE_NSEC		"Care about sub-second file mtimes and ctimes"	ON  )
+ELSE()
+	SET(USE_NSEC OFF)
 ENDIF()
+
+ADD_FEATURE_INFO(nanoseconds USE_NSEC "whether to use sub-second file mtimes and ctimes")

--- a/examples/common.h
+++ b/examples/common.h
@@ -39,6 +39,7 @@ extern int lg2_blame(git_repository *repo, int argc, char **argv);
 extern int lg2_cat_file(git_repository *repo, int argc, char **argv);
 extern int lg2_checkout(git_repository *repo, int argc, char **argv);
 extern int lg2_clone(git_repository *repo, int argc, char **argv);
+extern int lg2_config(git_repository *repo, int argc, char **argv);
 extern int lg2_describe(git_repository *repo, int argc, char **argv);
 extern int lg2_diff(git_repository *repo, int argc, char **argv);
 extern int lg2_fetch(git_repository *repo, int argc, char **argv);

--- a/examples/config.c
+++ b/examples/config.c
@@ -1,0 +1,62 @@
+/*
+ * libgit2 "config" example - shows how to use the config API
+ *
+ * Written by the libgit2 contributors
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+#include "common.h"
+
+static int config_get(git_config *cfg, const char *key)
+{
+	git_config_entry *entry;
+	int error;
+
+	if ((error = git_config_get_entry(&entry, cfg, key)) < 0) {
+		if (error != GIT_ENOTFOUND)
+			printf("Unable to get configuration: %s\n", git_error_last()->message);
+		return 1;
+	}
+
+	puts(entry->value);
+	return 0;
+}
+
+static int config_set(git_config *cfg, const char *key, const char *value)
+{
+	if (git_config_set_string(cfg, key, value) < 0) {
+		printf("Unable to set configuration: %s\n", git_error_last()->message);
+		return 1;
+	}
+	return 0;
+}
+
+int lg2_config(git_repository *repo, int argc, char **argv)
+{
+	git_config *cfg;
+	int error;
+
+	if ((error = git_repository_config(&cfg, repo)) < 0) {
+		printf("Unable to obtain repository config: %s\n", git_error_last()->message);
+		goto out;
+	}
+
+	if (argc == 2) {
+		error = config_get(cfg, argv[1]);
+	} else if (argc == 3) {
+		error = config_set(cfg, argv[1], argv[2]);
+	} else {
+		printf("USAGE: %s config <KEY> [<VALUE>]\n", argv[0]);
+		error = 1;
+	}
+
+out:
+	return error;
+}

--- a/examples/lg2.c
+++ b/examples/lg2.c
@@ -15,6 +15,7 @@ struct {
 	{ "cat-file",     lg2_cat_file,     1 },
 	{ "checkout",     lg2_checkout,     1 },
 	{ "clone",        lg2_clone,        0 },
+	{ "config",       lg2_config,       1 },
 	{ "describe",     lg2_describe,     1 },
 	{ "diff",         lg2_diff,         1 },
 	{ "fetch",        lg2_fetch,        1 },

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -44,7 +44,7 @@ typedef struct {
 	git_filebuf locked_buf;
 	git_buf locked_content;
 
-	struct config_file file;
+	git_config_file file;
 } diskfile_backend;
 
 typedef struct {
@@ -95,9 +95,9 @@ static git_config_entries *diskfile_entries_take(diskfile_header *h)
 	return entries;
 }
 
-static void config_file_clear(struct config_file *file)
+static void config_file_clear(git_config_file *file)
 {
-	struct config_file *include;
+	git_config_file *include;
 	uint32_t i;
 
 	if (file == NULL)
@@ -133,7 +133,7 @@ static int config_open(git_config_backend *cfg, git_config_level_t level, const 
 	return res;
 }
 
-static int config_is_modified(int *modified, struct config_file *file)
+static int config_is_modified(int *modified, git_config_file *file)
 {
 	git_config_file *include;
 	git_buf buf = GIT_BUF_INIT;
@@ -659,7 +659,7 @@ static char *escape_value(const char *ptr)
 static int parse_include(git_config_parser *reader,
 	diskfile_parse_state *parse_data, const char *file)
 {
-	struct config_file *include;
+	git_config_file *include;
 	git_buf path = GIT_BUF_INIT;
 	char *dir;
 	int result;

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -22,7 +22,7 @@ typedef struct config_file {
 } git_config_file;
 
 typedef struct {
-	struct config_file *file;
+	git_config_file *file;
 	git_parse_ctx ctx;
 } git_config_parser;
 

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -8,7 +8,9 @@
 #define INCLUDE_config_parse_h__
 
 #include "common.h"
+
 #include "array.h"
+#include "fileops.h"
 #include "oid.h"
 #include "parse.h"
 
@@ -16,6 +18,7 @@ extern const char *git_config_escapes;
 extern const char *git_config_escaped;
 
 typedef struct config_file {
+	git_futils_filestamp stamp;
 	git_oid checksum;
 	char *path;
 	git_array_t(struct config_file) includes;

--- a/tests/clar_libgit2.h
+++ b/tests/clar_libgit2.h
@@ -220,6 +220,12 @@ void cl_fake_home_cleanup(void *);
 void cl_sandbox_set_search_path_defaults(void);
 
 #ifdef GIT_WIN32
+# define cl_msleep(x) Sleep(x)
+#else
+# define cl_msleep(x) usleep(1000 * (x))
+#endif
+
+#ifdef GIT_WIN32
 bool cl_sandbox_supports_8dot3(void);
 #endif
 

--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -123,6 +123,7 @@ void test_config_stress__quick_write(void)
 	for (i = 0; i < 10; i++) {
 		int32_t val;
 		cl_git_pass(git_config_set_int32(config_w, key, i));
+		cl_msleep(1);
 		cl_git_pass(git_config_get_int32(&val, config_r, key));
 		cl_assert_equal_i(i, val);
 	}


### PR DESCRIPTION
To decide whether a config file has changed, we always hash its
complete contents. This is unnecessarily expensive, as
well-behaved filesystems will always update stat information for
files which have changed. So before computing the hash, we should
first check whether the stat info has actually changed for either
the configuration file or any of its includes. This avoids having
to re-read the configuration file and its includes every time
when we check whether it's been modified.

Tracing the for-each-ref example previous to this commit, one can
see that we repeatedly re-open both the repo configuration as
well as the global configuration:

        $ strace lg2 for-each-ref |& grep config
        access("/home/pks/.gitconfig", F_OK)    = -1 ENOENT (No such file or directory)
        access("/home/pks/.config/git/config", F_OK) = 0
        access("/etc/gitconfig", F_OK)          = -1 ENOENT (No such file or directory)
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        access("/tmp/repo/.git/config", F_OK)   = 0
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        open("/tmp/repo/.git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/home/pks/.gitconfig", 0x7ffd15c05290) = -1 ENOENT (No such file or directory)
        access("/home/pks/.gitconfig", F_OK)    = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        access("/home/pks/.config/git/config", F_OK) = 0
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        open("/home/pks/.config/git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        open("/tmp/repo/.git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/home/pks/.gitconfig", 0x7ffd15c051f0) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        open("/home/pks/.config/git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        open("/tmp/repo/.git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/home/pks/.gitconfig", 0x7ffd15c05090) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        open("/home/pks/.config/git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        open("/tmp/repo/.git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/home/pks/.gitconfig", 0x7ffd15c05090) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        open("/home/pks/.config/git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        open("/tmp/repo/.git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/home/pks/.gitconfig", 0x7ffd15c05090) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        open("/home/pks/.config/git/config", O_RDONLY|O_CLOEXEC) = 3

With the change, we only do stats for those files and open them a
single time, only:

        $ strace lg2 for-each-ref |& grep config
        access("/home/pks/.gitconfig", F_OK)    = -1 ENOENT (No such file or directory)
        access("/home/pks/.config/git/config", F_OK) = 0
        access("/etc/gitconfig", F_OK)          = -1 ENOENT (No such file or directory)
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        access("/tmp/repo/.git/config", F_OK)   = 0
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        open("/tmp/repo/.git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/home/pks/.gitconfig", 0x7ffe70540d20) = -1 ENOENT (No such file or directory)
        access("/home/pks/.gitconfig", F_OK)    = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        access("/home/pks/.config/git/config", F_OK) = 0
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        open("/home/pks/.config/git/config", O_RDONLY|O_CLOEXEC) = 3
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        stat("/home/pks/.gitconfig", 0x7ffe70540ca0) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.gitconfig", 0x7ffe70540c80) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        stat("/home/pks/.gitconfig", 0x7ffe70540b40) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.gitconfig", 0x7ffe70540b20) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        stat("/home/pks/.gitconfig", 0x7ffe70540b40) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.gitconfig", 0x7ffe70540b20) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0
        stat("/tmp/repo/.git/config", {st_mode=S_IFREG|0644, st_size=92, ...}) = 0
        stat("/home/pks/.gitconfig", 0x7ffe70540b40) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.gitconfig", 0x7ffe70540b20) = -1 ENOENT (No such file or directory)
        stat("/home/pks/.config/git/config", {st_mode=S_IFREG|0644, st_size=1154, ...}) = 0

The following benchmark has been performed with and without the
stat cache in a best-of-ten run:

```

int lg2_repro(git_repository *repo, int argc, char **argv)
{
        git_config *cfg;
        int32_t dummy;
        int i;

        UNUSED(argc);
        UNUSED(argv);

        check_lg2(git_repository_config(&cfg, repo),
                        "Could not obtain config", NULL);

        for (i = 1; i < 100000; ++i)
                git_config_get_int32(&dummy, cfg, "foo.bar");

        git_config_free(cfg);
        return 0;
}
```

Without stat cache:

        $ time lg2 repro
        real    0m1.528s
        user    0m0.568s
        sys     0m0.944s

With stat cache:

        $ time lg2 repro
        real    0m0.526s
        user    0m0.268s
        sys     0m0.258s

This benchmark shows a nearly three-fold performance improvement.
