### PR TITLE
Config parser separation

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -889,7 +889,7 @@ static int config_read_buffer(
 	}
 
 	/* Initialize the reading position */
-	reader.file = file;
+	reader.path = file->path;
 	git_parse_ctx_init(&reader.ctx, buf, buflen);
 
 	/* If the file is empty, there's nothing for us to do */
@@ -1175,7 +1175,7 @@ static int config_write(diskfile_backend *cfg, const char *orig_key, const char 
 	struct write_data write_data;
 
 	memset(&reader, 0, sizeof(reader));
-	reader.file = &cfg->file;
+	reader.path = cfg->file.path;
 
 	if (cfg->locked) {
 		result = git_buf_puts(&contents, git_buf_cstr(&cfg->locked_content) == NULL ? "" : git_buf_cstr(&cfg->locked_content));

--- a/src/config_mem.c
+++ b/src/config_mem.c
@@ -87,7 +87,7 @@ static int config_memory_open(git_config_backend *backend, git_config_level_t le
 		return 0;
 
 	git_parse_ctx_init(&reader.ctx, memory_backend->cfg.ptr, memory_backend->cfg.size);
-	reader.file = NULL;
+	reader.path = "in-memory";
 	parse_data.entries = memory_backend->entries;
 	parse_data.level = level;
 

--- a/src/config_mem.c
+++ b/src/config_mem.c
@@ -78,20 +78,24 @@ static int read_variable_cb(
 static int config_memory_open(git_config_backend *backend, git_config_level_t level, const git_repository *repo)
 {
 	config_memory_backend *memory_backend = (config_memory_backend *) backend;
+	git_config_parser parser = GIT_PARSE_CTX_INIT;
 	config_memory_parse_data parse_data;
-	git_config_parser reader;
+	int error;
 
 	GIT_UNUSED(repo);
 
-	if (memory_backend->cfg.size == 0)
-		return 0;
-
-	git_parse_ctx_init(&reader.ctx, memory_backend->cfg.ptr, memory_backend->cfg.size);
-	reader.path = "in-memory";
+	if ((error = git_config_parser_init(&parser, "in-memory", memory_backend->cfg.ptr,
+					    memory_backend->cfg.size)) < 0)
+		goto out;
 	parse_data.entries = memory_backend->entries;
 	parse_data.level = level;
 
-	return git_config_parse(&reader, NULL, read_variable_cb, NULL, NULL, &parse_data);
+	if ((error = git_config_parse(&parser, NULL, read_variable_cb, NULL, NULL, &parse_data)) < 0)
+		goto out;
+
+out:
+	git_config_parser_dispose(&parser);
+	return error;
 }
 
 static int config_memory_get(git_config_backend *backend, const char *key, git_config_entry **out)

--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -482,7 +482,7 @@ int git_config_parse(
 	git_config_parser_variable_cb on_variable,
 	git_config_parser_comment_cb on_comment,
 	git_config_parser_eof_cb on_eof,
-	void *data)
+	void *payload)
 {
 	git_parse_ctx *ctx;
 	char *current_section = NULL, *var_name = NULL, *var_value = NULL;
@@ -522,7 +522,7 @@ int git_config_parse(
 			git_parse_advance_chars(ctx, result);
 
 			if (on_section)
-				result = on_section(parser, current_section, line_start, line_len, data);
+				result = on_section(parser, current_section, line_start, line_len, payload);
 			/*
 			 * After we've parsed the section header we may not be
 			 * done with the line. If there's still data in there,
@@ -542,13 +542,13 @@ int git_config_parse(
 		case ';':
 		case '#':
 			if (on_comment) {
-				result = on_comment(parser, line_start, line_len, data);
+				result = on_comment(parser, line_start, line_len, payload);
 			}
 			break;
 
 		default: /* assume variable declaration */
 			if ((result = parse_variable(parser, &var_name, &var_value)) == 0 && on_variable) {
-				result = on_variable(parser, current_section, var_name, var_value, line_start, line_len, data);
+				result = on_variable(parser, current_section, var_name, var_value, line_start, line_len, payload);
 				git__free(var_name);
 				git__free(var_value);
 			}
@@ -561,7 +561,7 @@ int git_config_parse(
 	}
 
 	if (on_eof)
-		result = on_eof(parser, current_section, data);
+		result = on_eof(parser, current_section, payload);
 
 out:
 	git__free(current_section);

--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -474,6 +474,17 @@ out:
 	return error;
 }
 
+int git_config_parser_init(git_config_parser *out, const char *path, const char *data, size_t datalen)
+{
+	out->path = path;
+	return git_parse_ctx_init(&out->ctx, data, datalen);
+}
+
+void git_config_parser_dispose(git_config_parser *parser)
+{
+	git_parse_ctx_clear(&parser->ctx);
+}
+
 int git_config_parse(
 	git_config_parser *parser,
 	git_config_parser_section_cb on_section,

--- a/src/config_parse.c
+++ b/src/config_parse.c
@@ -16,16 +16,14 @@ const char *git_config_escaped = "\n\t\b\"\\";
 
 static void set_parse_error(git_config_parser *reader, int col, const char *error_str)
 {
-	const char *file = reader->file ? reader->file->path : "in-memory";
-
 	if (col)
 		git_error_set(GIT_ERROR_CONFIG,
 		              "failed to parse config file: %s (in %s:%"PRIuZ", column %d)",
-		              error_str, file, reader->ctx.line_num, col);
+		              error_str, reader->path, reader->ctx.line_num, col);
 	else
 		git_error_set(GIT_ERROR_CONFIG,
 		              "failed to parse config file: %s (in %s:%"PRIuZ")",
-		              error_str, file, reader->ctx.line_num);
+		              error_str, reader->path, reader->ctx.line_num);
 }
 
 

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -22,6 +22,8 @@ typedef struct {
 	git_parse_ctx ctx;
 } git_config_parser;
 
+#define GIT_CONFIG_PARSER_INIT { NULL, GIT_PARSE_CTX_INIT }
+
 typedef int (*git_config_parser_section_cb)(
 	git_config_parser *parser,
 	const char *current_section,
@@ -48,6 +50,9 @@ typedef int (*git_config_parser_eof_cb)(
 	git_config_parser *parser,
 	const char *current_section,
 	void *payload);
+
+int git_config_parser_init(git_config_parser *out, const char *path, const char *data, size_t datalen);
+void git_config_parser_dispose(git_config_parser *parser);
 
 int git_config_parse(
 	git_config_parser *parser,

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -25,7 +25,7 @@ typedef struct config_file {
 } git_config_file;
 
 typedef struct {
-	git_config_file *file;
+	const char *path;
 	git_parse_ctx ctx;
 } git_config_parser;
 

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -17,13 +17,6 @@
 extern const char *git_config_escapes;
 extern const char *git_config_escaped;
 
-typedef struct config_file {
-	git_futils_filestamp stamp;
-	git_oid checksum;
-	char *path;
-	git_array_t(struct config_file) includes;
-} git_config_file;
-
 typedef struct {
 	const char *path;
 	git_parse_ctx ctx;

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -34,7 +34,7 @@ typedef int (*git_config_parser_section_cb)(
 	const char *current_section,
 	const char *line,
 	size_t line_len,
-	void *data);
+	void *payload);
 
 typedef int (*git_config_parser_variable_cb)(
 	git_config_parser *parser,
@@ -43,18 +43,18 @@ typedef int (*git_config_parser_variable_cb)(
 	const char *var_value,
 	const char *line,
 	size_t line_len,
-	void *data);
+	void *payload);
 
 typedef int (*git_config_parser_comment_cb)(
 	git_config_parser *parser,
 	const char *line,
 	size_t line_len,
-	void *data);
+	void *payload);
 
 typedef int (*git_config_parser_eof_cb)(
 	git_config_parser *parser,
 	const char *current_section,
-	void *data);
+	void *payload);
 
 int git_config_parse(
 	git_config_parser *parser,
@@ -62,6 +62,6 @@ int git_config_parse(
 	git_config_parser_variable_cb on_variable,
 	git_config_parser_comment_cb on_comment,
 	git_config_parser_eof_cb on_eof,
-	void *data);
+	void *payload);
 
 #endif

--- a/src/parse.h
+++ b/src/parse.h
@@ -23,6 +23,8 @@ typedef struct {
 	size_t line_num;
 } git_parse_ctx;
 
+#define GIT_PARSE_CTX_INIT { 0 }
+
 int git_parse_ctx_init(git_parse_ctx *ctx, const char *content, size_t content_len);
 void git_parse_ctx_clear(git_parse_ctx *ctx);
 


### PR DESCRIPTION
This is the missing piece to really separate the configuration parser and the configuration file backend. Goal is to make the code easier to understand as well as to enable easier refactoring. But I guess the result speaks for itself.

Note: this PR includes the two commits from #5132. I wanted to avoid having to fix conflicts, as I expect that #5132 will land quite fast.