### PR TITLE
largefile tests: only write 2GB on 32-bit platforms

### DIFF
--- a/tests/object/tree/read.c
+++ b/tests/object/tree/read.c
@@ -75,7 +75,11 @@ void test_object_tree_read__two(void)
 }
 
 #define BIGFILE "bigfile"
-#define BIGFILE_SIZE (off_t)4 * 1024 * 1024 * 1024 /* 4 GiB */
+#ifdef GIT_ARCH_64
+# define BIGFILE_SIZE (size_t)4 * 1024 * 1024 * 1024 /* 4 GiB */
+#else
+# define BIGFILE_SIZE SIZE_MAX
+#endif
 
 void test_object_tree_read__largefile(void)
 {


### PR DESCRIPTION
Don't try to feed 4 GB of data to APIs that only take a `size_t` on 32-bit platforms.