### PR TITLE
Resolve static check warnings in example code

### DIFF
--- a/examples/init.c
+++ b/examples/init.c
@@ -244,5 +244,5 @@ static void parse_opts(struct opts *o, int argc, char *argv[])
 	}
 
 	if (!o->dir)
-		usage("must specify directory to init", NULL);
+		usage("must specify directory to init", "");
 }

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -220,6 +220,7 @@ static int create_merge_commit(git_repository *repo, git_index *index, merge_opt
 	check_lg2(git_repository_head(&head_ref, repo), "failed to get repo HEAD", NULL);
 	if (resolve_refish(&merge_commit, repo, opts->heads[0])) {
 		fprintf(stderr, "failed to resolve refish %s", opts->heads[0]);
+		free(parents);
 		return -1;
 	}
 


### PR DESCRIPTION
Using cppcheck on libgit2 sources indicated two warnings in example code.

`merge.c` was reported as having a memory leak. Fix applied was to apply git_commit_free to value of variable `parents`.

`init.c` was reported as having a null pointer dereference on variable `arg`. Function `usage` was being called with a null variable. Changed supplied parameter to empty string.