### PR TITLE
ci: build with ENABLE_WERROR on Windows

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -18,7 +18,7 @@ Write-Host "####################################################################
 Write-Host "## Configuring build environment"
 Write-Host "##############################################################################"
 
-Invoke-Expression "cmake ${SourceDirectory} -DBUILD_EXAMPLES=ON ${Env:CMAKE_OPTIONS}"
+Invoke-Expression "cmake ${SourceDirectory} -DBUILD_EXAMPLES=ON -DENABLE_WERROR=ON ${Env:CMAKE_OPTIONS}"
 if ($LastExitCode -ne 0) { [Environment]::Exit($LastExitCode) }
 
 Write-Host ""

--- a/examples/blame.c
+++ b/examples/blame.c
@@ -91,7 +91,7 @@ int lg2_blame(git_repository *repo, int argc, char *argv[])
 	i = 0;
 	break_on_null_hunk = 0;
 	while (i < rawsize) {
-		const char *eol = memchr(rawdata + i, '\n', rawsize - i);
+		const char *eol = memchr(rawdata + i, '\n', (size_t)(rawsize - i));
 		char oid[10] = {0};
 		const git_blame_hunk *hunk = git_blame_get_hunk_byline(blame, line);
 

--- a/examples/blame.c
+++ b/examples/blame.c
@@ -33,7 +33,7 @@ static void parse_opts(struct opts *o, int argc, char *argv[]);
 int lg2_blame(git_repository *repo, int argc, char *argv[])
 {
 	int line, break_on_null_hunk;
-	size_t i, rawsize;
+	git_off_t i, rawsize;
 	char spec[1024] = {0};
 	struct opts o = {0};
 	const char *rawdata;

--- a/examples/clone.c
+++ b/examples/clone.c
@@ -17,9 +17,9 @@ static void print_progress(const progress_data *pd)
 		0;
 
 	int checkout_percent = pd->total_steps > 0
-		? (100 * pd->completed_steps) / pd->total_steps
+		? (int)((100 * pd->completed_steps) / pd->total_steps)
 		: 0;
-	int kbytes = pd->fetch_progress.received_bytes / 1024;
+	size_t kbytes = pd->fetch_progress.received_bytes / 1024;
 
 	if (pd->fetch_progress.total_objects &&
 		pd->fetch_progress.received_objects == pd->fetch_progress.total_objects) {
@@ -27,7 +27,7 @@ static void print_progress(const progress_data *pd)
 		       pd->fetch_progress.indexed_deltas,
 		       pd->fetch_progress.total_deltas);
 	} else {
-		printf("net %3d%% (%4d kb, %5d/%5d)  /  idx %3d%% (%5d/%5d)  /  chk %3d%% (%4" PRIuZ "/%4" PRIuZ ") %s\n",
+		printf("net %3d%% (%4"PRIuZ" kb, %5d/%5d)  /  idx %3d%% (%5d/%5d)  /  chk %3d%% (%4" PRIuZ "/%4" PRIuZ ") %s\n",
 		   network_percent, kbytes,
 		   pd->fetch_progress.received_objects, pd->fetch_progress.total_objects,
 		   index_percent, pd->fetch_progress.indexed_objects, pd->fetch_progress.total_objects,

--- a/examples/describe.c
+++ b/examples/describe.c
@@ -54,7 +54,7 @@ static void opts_add_commit(describe_options *opts, const char *commit)
 	assert(opts != NULL);
 
 	sz = ++opts->commit_count * sizeof(opts->commits[0]);
-	opts->commits = xrealloc(opts->commits, sz);
+	opts->commits = (const char **)xrealloc(opts->commits, sz);
 	opts->commits[opts->commit_count - 1] = commit;
 }
 

--- a/examples/describe.c
+++ b/examples/describe.c
@@ -54,7 +54,7 @@ static void opts_add_commit(describe_options *opts, const char *commit)
 	assert(opts != NULL);
 
 	sz = ++opts->commit_count * sizeof(opts->commits[0]);
-	opts->commits = (const char **)xrealloc(opts->commits, sz);
+	opts->commits = xrealloc((void *) opts->commits, sz);
 	opts->commits[opts->commit_count - 1] = commit;
 }
 

--- a/examples/general.c
+++ b/examples/general.c
@@ -624,7 +624,7 @@ static void revwalking(git_repository *repo)
 static void index_walking(git_repository *repo)
 {
 	git_index *index;
-	unsigned int i, ecount;
+	size_t i, ecount;
 
 	printf("\n*Index Walking*\n");
 

--- a/examples/index-pack.c
+++ b/examples/index-pack.c
@@ -11,7 +11,7 @@
 # define read _read
 # define close _close
 
-#define ssize_t unsigned int
+#define ssize_t int
 #else
 # include <unistd.h>
 #endif

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -57,7 +57,7 @@ static void opts_add_refish(merge_options *opts, const char *refish)
 	assert(opts != NULL);
 
 	sz = ++opts->heads_count * sizeof(opts->heads[0]);
-	opts->heads = (const char **)xrealloc(opts->heads, sz);
+	opts->heads = xrealloc((void *) opts->heads, sz);
 	opts->heads[opts->heads_count - 1] = refish;
 }
 

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -57,7 +57,7 @@ static void opts_add_refish(merge_options *opts, const char *refish)
 	assert(opts != NULL);
 
 	sz = ++opts->heads_count * sizeof(opts->heads[0]);
-	opts->heads = xrealloc(opts->heads, sz);
+	opts->heads = (const char **)xrealloc(opts->heads, sz);
 	opts->heads[opts->heads_count - 1] = refish;
 }
 
@@ -354,7 +354,7 @@ int lg2_merge(git_repository *repo, int argc, char **argv)
 	}
 
 cleanup:
-	free(opts.heads);
+	free((char **)opts.heads);
 	free(opts.annotated);
 
 	return 0;

--- a/examples/show-index.c
+++ b/examples/show-index.c
@@ -17,7 +17,7 @@
 int lg2_show_index(git_repository *repo, int argc, char** argv)
 {
 	git_index *index;
-	unsigned int i, ecount;
+	size_t i, ecount;
 	char *dir = ".";
 	size_t dirlen;
 	char out[GIT_OID_HEXSZ+1];

--- a/src/win32/w32_stack.c
+++ b/src/win32/w32_stack.c
@@ -91,10 +91,10 @@ int git_win32__stack_format(
 	} s;
 
 	IMAGEHLP_LINE64 line;
-	int buf_used = 0;
+	size_t buf_used = 0;
 	unsigned int k;
 	char detail[MY_MAX_FILENAME * 2]; /* filename plus space for function name and formatting */
-	int detail_len;
+	size_t detail_len;
 
 	if (!g_win32_stack_initialized) {
 		git_error_set(GIT_ERROR_INVALID, "git_win32_stack not initialized.");

--- a/src/win32/w32_stack.c
+++ b/src/win32/w32_stack.c
@@ -76,7 +76,7 @@ int git_win32__stack_compare(
 }
 
 int git_win32__stack_format(
-	char *pbuf, int buf_len,
+	char *pbuf, size_t buf_len,
 	const git_win32__stack__raw_data *pdata,
 	const char *prefix, const char *suffix)
 {
@@ -171,7 +171,7 @@ int git_win32__stack_format(
 }
 
 int git_win32__stack(
-	char * pbuf, int buf_len,
+	char * pbuf, size_t buf_len,
 	int skip,
 	const char *prefix, const char *suffix)
 {

--- a/src/win32/w32_stack.h
+++ b/src/win32/w32_stack.h
@@ -116,7 +116,7 @@ int git_win32__stack_compare(
  * @param suffix String written after each frame; defaults to "\n".
  */
 int git_win32__stack_format(
-	char *pbuf, int buf_len,
+	char *pbuf, size_t buf_len,
 	const git_win32__stack__raw_data *pdata,
 	const char *prefix, const char *suffix);
 
@@ -132,7 +132,7 @@ int git_win32__stack_format(
  * @param suffix String written after each frame; defaults to "\n".
  */
 int git_win32__stack(
-	char * pbuf, int buf_len,
+	char * pbuf, size_t buf_len,
 	int skip,
 	const char *prefix, const char *suffix);
 

--- a/src/win32/w32_stack.h
+++ b/src/win32/w32_stack.h
@@ -38,7 +38,7 @@ typedef void (*git_win32__stack__aux_cb_alloc)(unsigned int *aux_id);
  * @param aux_msg A buffer where a formatted message should be written.
  * @param aux_msg_len The size of the buffer.
  */
-typedef void (*git_win32__stack__aux_cb_lookup)(unsigned int aux_id, char *aux_msg, unsigned int aux_msg_len);
+typedef void (*git_win32__stack__aux_cb_lookup)(unsigned int aux_id, char *aux_msg, size_t aux_msg_len);
 
 /**
  * Register an "aux" data provider to augment our C stacktrace data.

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -96,7 +96,7 @@ fixture_path(const char *base, const char *fixture_name);
 
 struct clar_error {
 	const char *file;
-	int line_number;
+	size_t line_number;
 	const char *error_msg;
 	char *description;
 
@@ -589,7 +589,7 @@ void clar__skip(void)
 
 void clar__fail(
 	const char *file,
-	int line,
+	size_t line,
 	const char *error_msg,
 	const char *description,
 	int should_abort)
@@ -621,7 +621,7 @@ void clar__fail(
 void clar__assert(
 	int condition,
 	const char *file,
-	int line,
+	size_t line,
 	const char *error_msg,
 	const char *description,
 	int should_abort)
@@ -634,7 +634,7 @@ void clar__assert(
 
 void clar__assert_equal(
 	const char *file,
-	int line,
+	size_t line,
 	const char *err,
 	int should_abort,
 	const char *fmt,

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -141,7 +141,7 @@ void clar__skip(void);
 
 void clar__fail(
 	const char *file,
-	int line,
+	size_t line,
 	const char *error,
 	const char *description,
 	int should_abort);
@@ -149,14 +149,14 @@ void clar__fail(
 void clar__assert(
 	int condition,
 	const char *file,
-	int line,
+	size_t line,
 	const char *error,
 	const char *description,
 	int should_abort);
 
 void clar__assert_equal(
 	const char *file,
-	int line,
+	size_t line,
 	const char *err,
 	int should_abort,
 	const char *fmt,

--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -20,7 +20,7 @@ static void clar_print_error(int num, const struct clar_report *report, const st
 {
 	printf("  %d) Failure:\n", num);
 
-	printf("%s::%s [%s:%d]\n",
+	printf("%s::%s [%s:%"PRIuZ"]\n",
 		report->suite,
 		report->test,
 		error->file,

--- a/tests/trace/windows/stacktrace.c
+++ b/tests/trace/windows/stacktrace.c
@@ -132,7 +132,7 @@ static void aux_cb_alloc__1(unsigned int *aux_id)
 	*aux_id = aux_counter++;
 }
 
-static void aux_cb_lookup__1(unsigned int aux_id, char *aux_msg, unsigned int aux_msg_len)
+static void aux_cb_lookup__1(unsigned int aux_id, char *aux_msg, size_t aux_msg_len)
 {
 	p_snprintf(aux_msg, aux_msg_len, "\tQQ%08x\n", aux_id);
 }


### PR DESCRIPTION
Build with -Werror's equivalent (/WX) on MSVC.

I neglected to do this in the previous warnings PR, oops.  I think that there are also some lingering issues in things like examples that I didn't build locally with `/WX` and missed since I didn't add this in the CI setup.