### PR TITLE
hash: fix missing error return on production builds

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -42,6 +42,7 @@ int git_hash_init(git_hash_ctx *ctx)
 			return git_hash_sha1_init(&ctx->sha1);
 		default:
 			assert(0);
+			return -1;
 	}
 }
 
@@ -52,6 +53,7 @@ int git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)
 			return git_hash_sha1_update(&ctx->sha1, data, len);
 		default:
 			assert(0);
+			return -1;
 	}
 }
 
@@ -62,6 +64,7 @@ int git_hash_final(git_oid *out, git_hash_ctx *ctx)
 			return git_hash_sha1_final(out, &ctx->sha1);
 		default:
 			assert(0);
+			return -1;
 	}
 }
 


### PR DESCRIPTION
When no hash algorithm has been initialized in a given hash context,
then we will simply `assert` and not return a value at all. This works
just fine in debug builds, but on non-debug builds the assert will be
converted to a no-op and thus we do not have a proper return value.

Fix this by returning an error code in addition to the asserts.