### PR TITLE
Adjust printf specifiers in examples code

### DIFF
--- a/examples/clone.c
+++ b/examples/clone.c
@@ -23,11 +23,11 @@ static void print_progress(const progress_data *pd)
 
 	if (pd->fetch_progress.total_objects &&
 		pd->fetch_progress.received_objects == pd->fetch_progress.total_objects) {
-		printf("Resolving deltas %d/%d\r",
+		printf("Resolving deltas %u/%u\r",
 		       pd->fetch_progress.indexed_deltas,
 		       pd->fetch_progress.total_deltas);
 	} else {
-		printf("net %3d%% (%4"PRIuZ" kb, %5d/%5d)  /  idx %3d%% (%5d/%5d)  /  chk %3d%% (%4" PRIuZ "/%4" PRIuZ ") %s\n",
+		printf("net %3d%% (%4" PRIuZ " kb, %5u/%5u)  /  idx %3d%% (%5u/%5u)  /  chk %3d%% (%4" PRIuZ "/%4" PRIuZ")%s\n",
 		   network_percent, kbytes,
 		   pd->fetch_progress.received_objects, pd->fetch_progress.total_objects,
 		   index_percent, pd->fetch_progress.indexed_objects, pd->fetch_progress.total_objects,

--- a/examples/fetch.c
+++ b/examples/fetch.c
@@ -43,10 +43,10 @@ static int transfer_progress_cb(const git_indexer_progress *stats, void *payload
 	(void)payload;
 
 	if (stats->received_objects == stats->total_objects) {
-		printf("Resolving deltas %d/%d\r",
+		printf("Resolving deltas %u/%u\r",
 		       stats->indexed_deltas, stats->total_deltas);
 	} else if (stats->total_objects > 0) {
-		printf("Received %d/%d objects (%d) in %" PRIuZ " bytes\r",
+		printf("Received %u/%u objects (%u) in %" PRIuZ " bytes\r",
 		       stats->received_objects, stats->total_objects,
 		       stats->indexed_objects, stats->received_bytes);
 	}
@@ -92,10 +92,10 @@ int lg2_fetch(git_repository *repo, int argc, char **argv)
 	 */
 	stats = git_remote_stats(remote);
 	if (stats->local_objects > 0) {
-		printf("\rReceived %d/%d objects in %" PRIuZ " bytes (used %d local objects)\n",
+		printf("\rReceived %u/%u objects in %" PRIuZ " bytes (used %u local objects)\n",
 		       stats->indexed_objects, stats->total_objects, stats->received_bytes, stats->local_objects);
 	} else{
-		printf("\rReceived %d/%d objects in %" PRIuZ "bytes\n",
+		printf("\rReceived %u/%u objects in %" PRIuZ "bytes\n",
 			stats->indexed_objects, stats->total_objects, stats->received_bytes);
 	}
 

--- a/examples/index-pack.c
+++ b/examples/index-pack.c
@@ -7,7 +7,7 @@
 static int index_cb(const git_indexer_progress *stats, void *data)
 {
 	(void)data;
-	printf("\rProcessing %d of %d", stats->indexed_objects, stats->total_objects);
+	printf("\rProcessing %u of %u", stats->indexed_objects, stats->total_objects);
 
 	return 0;
 }
@@ -59,7 +59,7 @@ int lg2_index_pack(git_repository *repo, int argc, char **argv)
 	if ((error = git_indexer_commit(idx, &stats)) < 0)
 		goto cleanup;
 
-	printf("\rIndexing %d of %d\n", stats.indexed_objects, stats.total_objects);
+	printf("\rIndexing %u of %u\n", stats.indexed_objects, stats.total_objects);
 
 	git_oid_fmt(hash, git_indexer_hash(idx));
 	puts(hash);


### PR DESCRIPTION
Static analysis of example code found multiple findings of `printf` usage
where filling value is members of git_indexer_progress object. Specifier
used was for signed int but git_indexer_progress members are typed as
unsigned int. `printf` specifiers were altered to match type.