### PR TITLE
w32: fix unlinking of directory symlinks

### DIFF
--- a/fuzzers/standalone_driver.c
+++ b/fuzzers/standalone_driver.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 #include "git2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "path.h"
 
 extern int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size);

--- a/src/apply.c
+++ b/src/apply.c
@@ -18,7 +18,7 @@
 #include "git2/repository.h"
 #include "array.h"
 #include "patch.h"
-#include "fileops.h"
+#include "futils.h"
 #include "delta.h"
 #include "zstream.h"
 #include "reader.h"

--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -14,7 +14,7 @@
 #include "vector.h"
 #include "pool.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 #define GIT_ATTR_FILE			".gitattributes"
 #define GIT_ATTR_FILE_INREPO	"attributes"

--- a/src/blob.h
+++ b/src/blob.h
@@ -12,7 +12,7 @@
 #include "git2/blob.h"
 #include "repository.h"
 #include "odb.h"
-#include "fileops.h"
+#include "futils.h"
 
 struct git_blob {
 	git_object object;

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1893,11 +1893,18 @@ static int checkout_create_the_new(
 				return error;
 		}
 
-		if (actions[i] & CHECKOUT_ACTION__UPDATE_BLOB) {
-			error = checkout_blob(data, &delta->new_file);
-			if (error < 0)
+		if (actions[i] & CHECKOUT_ACTION__UPDATE_BLOB && !S_ISLNK(delta->new_file.mode)) {
+			if ((error = checkout_blob(data, &delta->new_file)) < 0)
 				return error;
+			data->completed_steps++;
+			report_progress(data, delta->new_file.path);
+		}
+	}
 
+	git_vector_foreach(&data->diff->deltas, i, delta) {
+		if (actions[i] & CHECKOUT_ACTION__UPDATE_BLOB && S_ISLNK(delta->new_file.mode)) {
+			if ((error = checkout_blob(data, &delta->new_file)) < 0)
+				return error;
 			data->completed_steps++;
 			report_progress(data, delta->new_file.path);
 		}

--- a/src/clone.c
+++ b/src/clone.c
@@ -19,7 +19,7 @@
 #include "git2/tree.h"
 
 #include "remote.h"
-#include "fileops.h"
+#include "futils.h"
 #include "refs.h"
 #include "path.h"
 #include "repository.h"

--- a/src/config_cache.c
+++ b/src/config_cache.c
@@ -7,7 +7,7 @@
 
 #include "common.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 #include "config.h"
 #include "git2/config.h"

--- a/src/config_parse.h
+++ b/src/config_parse.h
@@ -10,7 +10,7 @@
 #include "common.h"
 
 #include "array.h"
-#include "fileops.h"
+#include "futils.h"
 #include "oid.h"
 #include "parse.h"
 

--- a/src/crlf.c
+++ b/src/crlf.c
@@ -12,7 +12,7 @@
 #include "git2/index.h"
 #include "git2/sys/filter.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "filter.h"
 #include "buf_text.h"

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -12,7 +12,7 @@
 #include "diff.h"
 #include "diff_generate.h"
 #include "odb.h"
-#include "fileops.h"
+#include "futils.h"
 #include "filter.h"
 
 #define DIFF_MAX_FILESIZE 0x20000000

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -9,7 +9,7 @@
 
 #include "diff.h"
 #include "patch_generate.h"
-#include "fileops.h"
+#include "futils.h"
 #include "config.h"
 #include "attr_file.h"
 #include "filter.h"

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -10,7 +10,7 @@
 #include "diff.h"
 #include "diff_file.h"
 #include "patch_generate.h"
-#include "fileops.h"
+#include "futils.h"
 #include "zstream.h"
 #include "blob.h"
 #include "delta.h"

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -14,7 +14,7 @@
 #include "diff.h"
 #include "diff_generate.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 #include "config.h"
 
 git_diff_delta *git_diff__delta_dup(

--- a/src/fetchhead.c
+++ b/src/fetchhead.c
@@ -11,7 +11,7 @@
 #include "git2/oid.h"
 
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 #include "filebuf.h"
 #include "refs.h"
 #include "repository.h"

--- a/src/filebuf.c
+++ b/src/filebuf.c
@@ -7,7 +7,7 @@
 
 #include "filebuf.h"
 
-#include "fileops.h"
+#include "futils.h"
 
 static const size_t WRITE_BUFFER_SIZE = (4096 * 2);
 

--- a/src/filebuf.h
+++ b/src/filebuf.h
@@ -9,7 +9,7 @@
 
 #include "common.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include <zlib.h>
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -8,7 +8,7 @@
 #include "filter.h"
 
 #include "common.h"
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "repository.h"
 #include "global.h"

--- a/src/futils.c
+++ b/src/futils.c
@@ -5,7 +5,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "fileops.h"
+#include "futils.h"
 
 #include "global.h"
 #include "strmap.h"

--- a/src/futils.h
+++ b/src/futils.h
@@ -4,8 +4,8 @@
  * This file is part of libgit2, distributed under the GNU GPL v2 with
  * a Linking Exception. For full terms see the included COPYING file.
  */
-#ifndef INCLUDE_fileops_h__
-#define INCLUDE_fileops_h__
+#ifndef INCLUDE_futils_h__
+#define INCLUDE_futils_h__
 
 #include "common.h"
 

--- a/src/hashsig.c
+++ b/src/hashsig.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #include "git2/sys/hashsig.h"
-#include "fileops.h"
+#include "futils.h"
 #include "util.h"
 
 typedef uint32_t hashsig_t;

--- a/src/index.h
+++ b/src/index.h
@@ -9,7 +9,7 @@
 
 #include "common.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "filebuf.h"
 #include "vector.h"
 #include "idxmap.h"

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -9,7 +9,7 @@
 
 #include "repository.h"
 #include "posix.h"
-#include "fileops.h"
+#include "futils.h"
 #include "index.h"
 #include "diff_xdiff.h"
 #include "merge.h"

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -8,7 +8,7 @@
 #include "mwindow.h"
 
 #include "vector.h"
-#include "fileops.h"
+#include "futils.h"
 #include "map.h"
 #include "global.h"
 #include "strmap.h"

--- a/src/odb.c
+++ b/src/odb.c
@@ -10,7 +10,7 @@
 #include <zlib.h>
 #include "git2/object.h"
 #include "git2/sys/odb_backend.h"
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "delta.h"
 #include "filter.h"

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -10,7 +10,7 @@
 #include <zlib.h>
 #include "git2/object.h"
 #include "git2/sys/odb_backend.h"
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "odb.h"
 #include "delta.h"

--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -10,7 +10,7 @@
 #include "git2/object.h"
 #include "git2/sys/odb_backend.h"
 #include "git2/sys/mempack.h"
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "odb.h"
 #include "array.h"

--- a/src/odb_pack.c
+++ b/src/odb_pack.c
@@ -11,7 +11,7 @@
 #include "git2/repository.h"
 #include "git2/indexer.h"
 #include "git2/sys/odb_backend.h"
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "odb.h"
 #include "delta.h"

--- a/src/pack.c
+++ b/src/pack.c
@@ -11,7 +11,7 @@
 #include "delta.h"
 #include "sha1_lookup.h"
 #include "mwindow.h"
-#include "fileops.h"
+#include "futils.h"
 #include "oid.h"
 
 #include <zlib.h>

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -15,7 +15,7 @@
 #include "diff_xdiff.h"
 #include "delta.h"
 #include "zstream.h"
-#include "fileops.h"
+#include "futils.h"
 
 static void diff_output_init(
 	git_patch_generated_output *, const git_diff_options *, git_diff_file_cb,

--- a/src/path.c
+++ b/src/path.c
@@ -1924,3 +1924,25 @@ extern int git_path_is_gitfile(const char *path, size_t pathlen, git_path_gitfil
 		return -1;
 	}
 }
+
+bool git_path_supports_symlinks(const char *dir)
+{
+	git_buf path = GIT_BUF_INIT;
+	bool supported = false;
+	struct stat st;
+	int fd;
+
+	if ((fd = git_futils_mktmp(&path, dir, 0666)) < 0 ||
+	    p_close(fd) < 0 ||
+	    p_unlink(path.ptr) < 0 ||
+	    p_symlink("testing", path.ptr) < 0 ||
+	    p_lstat(path.ptr, &st) < 0)
+		goto done;
+
+	supported = (S_ISLNK(st.st_mode) != 0);
+done:
+	if (path.size)
+		(void)p_unlink(path.ptr);
+	git_buf_dispose(&path);
+	return supported;
+}

--- a/src/path.h
+++ b/src/path.h
@@ -647,4 +647,6 @@ extern bool git_path_isvalid(
  */
 int git_path_normalize_slashes(git_buf *out, const char *path);
 
+bool git_path_supports_symlinks(const char *dir);
+
 #endif

--- a/src/reader.c
+++ b/src/reader.c
@@ -7,7 +7,7 @@
 
 #include "reader.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "blob.h"
 
 #include "git2/tree.h"

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -10,7 +10,7 @@
 #include "refs.h"
 #include "hash.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 #include "filebuf.h"
 #include "pack.h"
 #include "reflog.h"

--- a/src/refs.c
+++ b/src/refs.c
@@ -9,7 +9,7 @@
 
 #include "hash.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 #include "filebuf.h"
 #include "pack.h"
 #include "reflog.h"

--- a/src/repository.c
+++ b/src/repository.c
@@ -16,7 +16,7 @@
 #include "commit.h"
 #include "tag.h"
 #include "blob.h"
-#include "fileops.h"
+#include "futils.h"
 #include "sysdir.h"
 #include "filebuf.h"
 #include "index.h"

--- a/src/repository.c
+++ b/src/repository.c
@@ -1419,9 +1419,6 @@ static bool are_symlinks_supported(const char *wd_path)
 	git_buf xdg_buf = GIT_BUF_INIT;
 	git_buf system_buf = GIT_BUF_INIT;
 	git_buf programdata_buf = GIT_BUF_INIT;
-	git_buf path = GIT_BUF_INIT;
-	int fd;
-	struct stat st;
 	int symlinks = 0;
 
 	/*
@@ -1448,23 +1445,14 @@ static bool are_symlinks_supported(const char *wd_path)
 		goto done;
 #endif
 
-	if ((fd = git_futils_mktmp(&path, wd_path, 0666)) < 0 ||
-	    p_close(fd) < 0 ||
-	    p_unlink(path.ptr) < 0 ||
-	    p_symlink("testing", path.ptr) < 0 ||
-	    p_lstat(path.ptr, &st) < 0)
+	if (!(symlinks = git_path_supports_symlinks(wd_path)))
 		goto done;
-
-	symlinks = (S_ISLNK(st.st_mode) != 0);
-
-	(void)p_unlink(path.ptr);
 
 done:
 	git_buf_dispose(&global_buf);
 	git_buf_dispose(&xdg_buf);
 	git_buf_dispose(&system_buf);
 	git_buf_dispose(&programdata_buf);
-	git_buf_dispose(&path);
 	git_config_free(config);
 	return symlinks != 0;
 }

--- a/src/sortedcache.h
+++ b/src/sortedcache.h
@@ -10,7 +10,7 @@
 #include "common.h"
 
 #include "util.h"
-#include "fileops.h"
+#include "futils.h"
 #include "vector.h"
 #include "thread-utils.h"
 #include "pool.h"

--- a/src/status.c
+++ b/src/status.c
@@ -8,7 +8,7 @@
 #include "status.h"
 
 #include "git2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "vector.h"
 #include "tree.h"

--- a/src/submodule.h
+++ b/src/submodule.h
@@ -11,7 +11,7 @@
 
 #include "git2/submodule.h"
 #include "git2/repository.h"
-#include "fileops.h"
+#include "futils.h"
 
 /* Notes:
  *

--- a/src/tree.c
+++ b/src/tree.c
@@ -10,7 +10,7 @@
 #include "commit.h"
 #include "git2/repository.h"
 #include "git2/object.h"
-#include "fileops.h"
+#include "futils.h"
 #include "tree-cache.h"
 #include "index.h"
 

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -8,7 +8,7 @@
 #include "common.h"
 
 #include "../posix.h"
-#include "../fileops.h"
+#include "../futils.h"
 #include "path.h"
 #include "path_w32.h"
 #include "utf-conv.h"

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -414,18 +414,37 @@ int p_readlink(const char *path, char *buf, size_t bufsiz)
 	return (int)bufsiz;
 }
 
+static bool target_is_dir(const char *target, const char *path)
+{
+	git_buf resolved = GIT_BUF_INIT;
+	git_win32_path resolved_w;
+	bool isdir = true;
+
+	if (git_path_is_absolute(target))
+		git_win32_path_from_utf8(resolved_w, target);
+	else if (git_path_dirname_r(&resolved, path) < 0 ||
+		 git_path_apply_relative(&resolved, target) < 0 ||
+		 git_win32_path_from_utf8(resolved_w, resolved.ptr) < 0)
+		goto out;
+
+	isdir = GetFileAttributesW(resolved_w) & FILE_ATTRIBUTE_DIRECTORY;
+
+out:
+	git_buf_dispose(&resolved);
+	return isdir;
+}
+
 int p_symlink(const char *target, const char *path)
 {
 	git_win32_path target_w, path_w;
 	DWORD dwFlags;
 
 	if (git_win32_path_from_utf8(path_w, path) < 0 ||
-		git__utf8_to_16(target_w, MAX_PATH, target) < 0)
+	    git__utf8_to_16(target_w, MAX_PATH, target) < 0)
 		return -1;
 
 	dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
-
-	if (GetFileAttributesW(target_w) & FILE_ATTRIBUTE_DIRECTORY)
+	if (target_is_dir(target, path))
 		dwFlags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
 
 	if (!CreateSymbolicLinkW(path_w, target_w, dwFlags))

--- a/tests/attr/repo.c
+++ b/tests/attr/repo.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/attr.h"
 #include "attr.h"
 #include "sysdir.h"

--- a/tests/checkout/binaryunicode.c
+++ b/tests/checkout/binaryunicode.c
@@ -2,7 +2,7 @@
 #include "refs.h"
 #include "repo/repo_helpers.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo;
 

--- a/tests/checkout/checkout_helpers.c
+++ b/tests/checkout/checkout_helpers.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "checkout_helpers.h"
 #include "refs.h"
-#include "fileops.h"
+#include "futils.h"
 #include "index.h"
 
 void assert_on_branch(git_repository *repo, const char *branch)

--- a/tests/checkout/conflict.c
+++ b/tests/checkout/conflict.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "git2/repository.h"
 #include "git2/sys/index.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 
 static git_repository *g_repo;

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "checkout_helpers.h"
 #include "../filter/crlf.h"
-#include "fileops.h"
+#include "futils.h"
 
 #include "git2/checkout.h"
 #include "repository.h"

--- a/tests/checkout/head.c
+++ b/tests/checkout/head.c
@@ -2,7 +2,7 @@
 #include "refs.h"
 #include "repo/repo_helpers.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo;
 

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -181,7 +181,7 @@ void test_checkout_index__honor_coresymlinks_default_true(void)
 
 	cl_must_pass(p_mkdir("symlink", 0777));
 
-	if (!filesystem_supports_symlinks("symlink/test"))
+	if (!git_path_supports_symlinks("symlink/test"))
 		cl_skip();
 
 #ifdef GIT_WIN32
@@ -214,7 +214,7 @@ void test_checkout_index__honor_coresymlinks_default_false(void)
 	 * supports symlinks.  Bail entirely on POSIX platforms that
 	 * do support symlinks.
 	 */
-	if (filesystem_supports_symlinks("symlink/test"))
+	if (git_path_supports_symlinks("symlink/test"))
 		cl_skip();
 #endif
 
@@ -226,7 +226,7 @@ void test_checkout_index__coresymlinks_set_to_true_fails_when_unsupported(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-	if (filesystem_supports_symlinks("testrepo/test")) {
+	if (git_path_supports_symlinks("testrepo/test")) {
 		cl_skip();
 	}
 
@@ -242,7 +242,7 @@ void test_checkout_index__honor_coresymlinks_setting_set_to_true(void)
 	char link_data[GIT_PATH_MAX];
 	size_t link_size = GIT_PATH_MAX;
 
-	if (!filesystem_supports_symlinks("testrepo/test")) {
+	if (!git_path_supports_symlinks("testrepo/test")) {
 		cl_skip();
 	}
 

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -2,7 +2,7 @@
 #include "checkout_helpers.h"
 
 #include "git2/checkout.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 #include "remote.h"
 #include "repo/repo_helpers.h"

--- a/tests/checkout/nasty.c
+++ b/tests/checkout/nasty.c
@@ -4,7 +4,7 @@
 #include "git2/checkout.h"
 #include "repository.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 static const char *repo_name = "nasty";
 static git_repository *repo;

--- a/tests/checkout/tree.c
+++ b/tests/checkout/tree.c
@@ -4,7 +4,7 @@
 #include "git2/checkout.h"
 #include "repository.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo;
 static git_checkout_options g_opts;

--- a/tests/checkout/typechange.c
+++ b/tests/checkout/typechange.c
@@ -3,7 +3,7 @@
 #include "git2/checkout.h"
 #include "path.h"
 #include "posix.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 

--- a/tests/cherrypick/bare.c
+++ b/tests/cherrypick/bare.c
@@ -2,7 +2,7 @@
 #include "clar_libgit2.h"
 
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/cherrypick.h"
 
 #include "../merge/merge_helpers.h"

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -2,7 +2,7 @@
 #include "clar_libgit2.h"
 
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/cherrypick.h"
 
 #include "../merge/merge_helpers.h"

--- a/tests/clone/local.c
+++ b/tests/clone/local.c
@@ -5,7 +5,7 @@
 #include "buffer.h"
 #include "path.h"
 #include "posix.h"
-#include "fileops.h"
+#include "futils.h"
 
 static int file_url(git_buf *buf, const char *host, const char *path)
 {

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -4,7 +4,7 @@
 #include "git2/sys/commit.h"
 #include "../submodule/submodule_helpers.h"
 #include "remote.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 
 #define LIVE_REPO_URL "git://github.com/libgit2/TestGitRepository"

--- a/tests/clone/transport.c
+++ b/tests/clone/transport.c
@@ -3,7 +3,7 @@
 #include "git2/clone.h"
 #include "git2/transport.h"
 #include "git2/sys/transport.h"
-#include "fileops.h"
+#include "futils.h"
 
 static int custom_transport(
 	git_transport **out,

--- a/tests/config/conditionals.c
+++ b/tests/config/conditionals.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 #ifdef GIT_WIN32
 # define ROOT_PREFIX "C:"

--- a/tests/config/global.c
+++ b/tests/config/global.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 void test_config_global__initialize(void)
 {

--- a/tests/config/include.c
+++ b/tests/config/include.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_config *cfg;
 static git_buf buf;

--- a/tests/config/new.c
+++ b/tests/config/new.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 
 #include "filebuf.h"
-#include "fileops.h"
+#include "futils.h"
 #include "posix.h"
 
 #define TEST_CONFIG "git-new-config"

--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 
 #include "filebuf.h"
-#include "fileops.h"
+#include "futils.h"
 #include "posix.h"
 
 #define TEST_CONFIG "git-test-config"

--- a/tests/config/write.c
+++ b/tests/config/write.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/sys/config.h"
 #include "config.h"
 

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -2,7 +2,7 @@
 #include "buffer.h"
 #include "buf_text.h"
 #include "git2/sys/hashsig.h"
-#include "fileops.h"
+#include "futils.h"
 
 #define TESTSTR "Have you seen that? Have you seeeen that??"
 const char *test_string = TESTSTR;

--- a/tests/core/copy.c
+++ b/tests/core/copy.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "path.h"
 #include "posix.h"
 

--- a/tests/core/dirent.c
+++ b/tests/core/dirent.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 
 typedef struct name_data {
 	int count; /* return count */

--- a/tests/core/env.c
+++ b/tests/core/env.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "sysdir.h"
 #include "path.h"
 

--- a/tests/core/filebuf.c
+++ b/tests/core/filebuf.c
@@ -157,9 +157,8 @@ void test_core_filebuf__symlink_follow(void)
 	git_filebuf file = GIT_FILEBUF_INIT;
 	const char *dir = "linkdir", *source = "linkdir/link";
 
-#ifdef GIT_WIN32
-	cl_skip();
-#endif
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		cl_skip();
 
 	cl_git_pass(p_mkdir(dir, 0777));
 	cl_git_pass(p_symlink("target", source));
@@ -192,9 +191,8 @@ void test_core_filebuf__symlink_follow_absolute_paths(void)
 	git_filebuf file = GIT_FILEBUF_INIT;
 	git_buf source = GIT_BUF_INIT, target = GIT_BUF_INIT;
 
-#ifdef GIT_WIN32
-	cl_skip();
-#endif
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		cl_skip();
 
 	cl_git_pass(git_buf_joinpath(&source, clar_sandbox_path(), "linkdir/link"));
 	cl_git_pass(git_buf_joinpath(&target, clar_sandbox_path(), "linkdir/target"));
@@ -221,9 +219,8 @@ void test_core_filebuf__symlink_depth(void)
 	git_filebuf file = GIT_FILEBUF_INIT;
 	const char *dir = "linkdir", *source = "linkdir/link";
 
-#ifdef GIT_WIN32
-	cl_skip();
-#endif
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		cl_skip();
 
 	cl_git_pass(p_mkdir(dir, 0777));
 	/* Endless loop */

--- a/tests/core/futils.c
+++ b/tests/core/futils.c
@@ -66,3 +66,24 @@ void test_core_futils__write_hidden_file(void)
 #endif
 }
 
+void test_core_futils__recursive_rmdir_keeps_symlink_targets(void)
+{
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		cl_skip();
+
+	cl_git_pass(git_futils_mkdir_r("a/b", 0777));
+	cl_git_pass(git_futils_mkdir_r("dir-target", 0777));
+	cl_git_mkfile("dir-target/file", "Contents");
+	cl_git_mkfile("file-target", "Contents");
+	cl_must_pass(p_symlink("dir-target", "a/symlink"));
+	cl_must_pass(p_symlink("file-target", "a/b/symlink"));
+
+	cl_git_pass(git_futils_rmdir_r("a", NULL, GIT_RMDIR_REMOVE_FILES));
+
+	cl_assert(git_path_exists("dir-target"));
+	cl_assert(git_path_exists("file-target"));
+
+	cl_must_pass(p_unlink("dir-target/file"));
+	cl_must_pass(p_rmdir("dir-target"));
+	cl_must_pass(p_unlink("file-target"));
+}

--- a/tests/core/futils.c
+++ b/tests/core/futils.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 
 /* Fixture setup and teardown */
 void test_core_futils__initialize(void)

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "path.h"
 #include "posix.h"
 

--- a/tests/core/path.c
+++ b/tests/core/path.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 
 static void
 check_dirname(const char *A, const char *B)

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -12,6 +12,7 @@
 #include <locale.h>
 
 #include "clar_libgit2.h"
+#include "futils.h"
 #include "posix.h"
 #include "userdiff.h"
 
@@ -262,4 +263,25 @@ void test_core_posix__p_regcomp_compile_userdiff_regexps(void)
 		p_regfree(&preg);
 		cl_assert(!error);
 	}
+}
+
+void test_core_posix__unlink_removes_symlink(void)
+{
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		clar__skip();
+
+	cl_git_mkfile("file", "Dummy file.");
+	cl_git_pass(git_futils_mkdir("dir", 0777, 0));
+
+	cl_must_pass(p_symlink("file", "file-symlink"));
+	cl_must_pass(p_symlink("dir", "dir-symlink"));
+
+	cl_must_pass(p_unlink("file-symlink"));
+	cl_must_pass(p_unlink("dir-symlink"));
+
+	cl_assert(git_path_exists("file"));
+	cl_assert(git_path_exists("dir"));
+
+	cl_must_pass(p_unlink("file"));
+	cl_must_pass(p_rmdir("dir"));
 }

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -122,7 +122,7 @@ void test_core_posix__utimes(void)
 	cl_git_mkfile("foo", "Dummy file.");
 	cl_must_pass(p_utimes("foo", times));
 
-	p_stat("foo", &st);
+	cl_must_pass(p_stat("foo", &st));
 	cl_assert_equal_i(1234567890, st.st_atime);
 	cl_assert_equal_i(1234567890, st.st_mtime);
 
@@ -135,9 +135,9 @@ void test_core_posix__utimes(void)
 
 	cl_must_pass(fd = p_open("foo", O_RDWR));
 	cl_must_pass(p_futimes(fd, times));
-	p_close(fd);
+	cl_must_pass(p_close(fd));
 
-	p_stat("foo", &st);
+	cl_must_pass(p_stat("foo", &st));
 	cl_assert_equal_i(1414141414, st.st_atime);
 	cl_assert_equal_i(1414141414, st.st_mtime);
 
@@ -148,11 +148,11 @@ void test_core_posix__utimes(void)
 	cl_must_pass(p_utimes("foo", NULL));
 
 	curtime = time(NULL);
-	p_stat("foo", &st);
+	cl_must_pass(p_stat("foo", &st));
 	cl_assert((st.st_atime - curtime) < 5);
 	cl_assert((st.st_mtime - curtime) < 5);
 
-	p_unlink("foo");
+	cl_must_pass(p_unlink("foo"));
 }
 
 static void try_set_locale(int category)

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -285,3 +285,27 @@ void test_core_posix__unlink_removes_symlink(void)
 	cl_must_pass(p_unlink("file"));
 	cl_must_pass(p_rmdir("dir"));
 }
+
+void test_core_posix__symlink_resolves_to_correct_type(void)
+{
+	git_buf contents = GIT_BUF_INIT;
+
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		clar__skip();
+
+	cl_must_pass(git_futils_mkdir("dir", 0777, 0));
+	cl_must_pass(git_futils_mkdir("file", 0777, 0));
+	cl_git_mkfile("dir/file", "symlink target");
+
+	cl_git_pass(p_symlink("file", "dir/link"));
+
+	cl_git_pass(git_futils_readbuffer(&contents, "dir/file"));
+	cl_assert_equal_s(contents.ptr, "symlink target");
+
+	cl_must_pass(p_unlink("dir/link"));
+	cl_must_pass(p_unlink("dir/file"));
+	cl_must_pass(p_rmdir("dir"));
+	cl_must_pass(p_rmdir("file"));
+
+	git_buf_dispose(&contents);
+}

--- a/tests/core/rmdir.c
+++ b/tests/core/rmdir.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 
 static const char *empty_tmp_dir = "test_gitfo_rmdir_recurs_test";
 

--- a/tests/core/stat.c
+++ b/tests/core/stat.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "path.h"
 #include "posix.h"
 

--- a/tests/diff/diff_helpers.h
+++ b/tests/diff/diff_helpers.h
@@ -1,4 +1,4 @@
-#include "fileops.h"
+#include "futils.h"
 #include "git2/diff.h"
 
 extern git_tree *resolve_commit_oid_to_tree(

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "fetchhead.h"
 
 #include "fetchhead_data.h"

--- a/tests/ignore/path.c
+++ b/tests/ignore/path.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "posix.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 

--- a/tests/ignore/status.c
+++ b/tests/ignore/status.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/attr.h"
 #include "ignore.h"
 #include "attr.h"

--- a/tests/index/addall.c
+++ b/tests/index/addall.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "../status/status_helpers.h"
 #include "posix.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 #define TEST_DIR "addall"

--- a/tests/iterator/index.c
+++ b/tests/iterator/index.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "iterator.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 #include "iterator_helpers.h"
 #include "../submodule/submodule_helpers.h"
 #include <stdarg.h>

--- a/tests/iterator/iterator_helpers.c
+++ b/tests/iterator/iterator_helpers.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "iterator.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 #include "iterator_helpers.h"
 #include <stdarg.h>
 

--- a/tests/iterator/tree.c
+++ b/tests/iterator/tree.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "iterator.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 #include "tree.h"
 #include "../submodule/submodule_helpers.h"
 #include "../diff/diff_helpers.h"

--- a/tests/iterator/workdir.c
+++ b/tests/iterator/workdir.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "iterator.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 #include "../submodule/submodule_helpers.h"
 #include "../merge/merge_helpers.h"
 #include "iterator_helpers.h"

--- a/tests/merge/files.c
+++ b/tests/merge/files.c
@@ -6,7 +6,7 @@
 #include "merge_helpers.h"
 #include "conflict_data.h"
 #include "refs.h"
-#include "fileops.h"
+#include "futils.h"
 #include "diff_xdiff.h"
 
 #define TEST_REPO_PATH "merge-resolve"

--- a/tests/merge/merge_helpers.c
+++ b/tests/merge/merge_helpers.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "refs.h"
 #include "tree.h"
 #include "merge_helpers.h"

--- a/tests/merge/trees/automerge.c
+++ b/tests/merge/trees/automerge.c
@@ -3,7 +3,7 @@
 #include "git2/merge.h"
 #include "buffer.h"
 #include "merge.h"
-#include "fileops.h"
+#include "futils.h"
 #include "../merge_helpers.h"
 #include "../conflict_data.h"
 

--- a/tests/merge/trees/modeconflict.c
+++ b/tests/merge/trees/modeconflict.c
@@ -4,7 +4,7 @@
 #include "buffer.h"
 #include "merge.h"
 #include "../merge_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 

--- a/tests/merge/trees/renames.c
+++ b/tests/merge/trees/renames.c
@@ -4,7 +4,7 @@
 #include "buffer.h"
 #include "merge.h"
 #include "../merge_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 

--- a/tests/merge/trees/trivial.c
+++ b/tests/merge/trees/trivial.c
@@ -4,7 +4,7 @@
 #include "merge.h"
 #include "../merge_helpers.h"
 #include "refs.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/sys/index.h"
 
 static git_repository *repo;

--- a/tests/merge/trees/whitespace.c
+++ b/tests/merge/trees/whitespace.c
@@ -4,7 +4,7 @@
 #include "buffer.h"
 #include "merge.h"
 #include "../merge_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 

--- a/tests/merge/workdir/renames.c
+++ b/tests/merge/workdir/renames.c
@@ -4,7 +4,7 @@
 #include "buffer.h"
 #include "merge.h"
 #include "../merge_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 #include "refs.h"
 
 static git_repository *repo;

--- a/tests/merge/workdir/setup.c
+++ b/tests/merge/workdir/setup.c
@@ -3,7 +3,7 @@
 #include "git2/merge.h"
 #include "merge.h"
 #include "refs.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 static git_index *repo_index;

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -6,7 +6,7 @@
 #include "../merge_helpers.h"
 #include "../conflict_data.h"
 #include "refs.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 static git_index *repo_index;

--- a/tests/merge/workdir/trivial.c
+++ b/tests/merge/workdir/trivial.c
@@ -5,7 +5,7 @@
 #include "merge.h"
 #include "../merge_helpers.h"
 #include "refs.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 static git_index *repo_index;

--- a/tests/object/blob/fromstream.c
+++ b/tests/object/blob/fromstream.c
@@ -2,7 +2,7 @@
 #include "buffer.h"
 #include "posix.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 static char textual_content[] = "libgit2\n\r\n\0";

--- a/tests/object/blob/write.c
+++ b/tests/object/blob/write.c
@@ -2,7 +2,7 @@
 #include "buffer.h"
 #include "posix.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 

--- a/tests/object/raw/write.c
+++ b/tests/object/raw/write.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "git2/odb_backend.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "odb.h"
 
 typedef struct object_data {

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -3,7 +3,7 @@
 #include "git2/clone.h"
 #include "git2/cred_helpers.h"
 #include "remote.h"
-#include "fileops.h"
+#include "futils.h"
 #include "refs.h"
 
 #define LIVE_REPO_URL "http://github.com/libgit2/TestGitRepository"

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "fetchhead.h"
 #include "../fetchhead/fetchhead_data.h"
 #include "git2/clone.h"

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 #include <git2.h>
-#include "fileops.h"
+#include "futils.h"
 #include "hash.h"
 #include "iterator.h"
 #include "vector.h"

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "pack.h"
 #include "hash.h"
 #include "iterator.h"

--- a/tests/refs/branches/delete.c
+++ b/tests/refs/branches/delete.c
@@ -2,7 +2,7 @@
 #include "refs.h"
 #include "repo/repo_helpers.h"
 #include "config/config_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 #include "reflog.h"
 
 static git_repository *repo;

--- a/tests/refs/delete.c
+++ b/tests/refs/delete.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "git2/reflog.h"
 #include "git2/refdb.h"
 #include "reflog.h"

--- a/tests/refs/pack.c
+++ b/tests/refs/pack.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "git2/reflog.h"
 #include "git2/refdb.h"
 #include "reflog.h"

--- a/tests/refs/reflog/messages.c
+++ b/tests/refs/reflog/messages.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "git2/reflog.h"
 #include "reflog.h"
 #include "refs.h"

--- a/tests/refs/reflog/reflog.c
+++ b/tests/refs/reflog/reflog.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "git2/reflog.h"
 #include "reflog.h"
 

--- a/tests/refs/rename.c
+++ b/tests/refs/rename.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "git2/reflog.h"
 #include "reflog.h"
 #include "refs.h"

--- a/tests/repo/config.c
+++ b/tests/repo/config.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 #include "sysdir.h"
-#include "fileops.h"
+#include "futils.h"
 #include <ctype.h>
 
 static git_buf path = GIT_BUF_INIT;

--- a/tests/repo/discover.c
+++ b/tests/repo/discover.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 
 #include "odb.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 
 #define TEMP_REPO_FOLDER "temprepo/"

--- a/tests/repo/env.c
+++ b/tests/repo/env.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "sysdir.h"
 #include <ctype.h>
 

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 #include "config.h"
 #include "path.h"

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -253,7 +253,7 @@ void test_repo_init__symlinks_win32_enabled_by_global_config(void)
 	git_config *config, *repo_config;
 	int val;
 
-	if (!filesystem_supports_symlinks("link"))
+	if (!git_path_supports_symlinks("link"))
 		cl_skip();
 
 	create_tmp_global_config("tmp_global_config", "core.symlinks", "true");
@@ -296,7 +296,7 @@ void test_repo_init__symlinks_posix_detected(void)
 	cl_skip();
 #else
 	assert_config_entry_on_init(
-	    "core.symlinks", filesystem_supports_symlinks("link") ? GIT_ENOTFOUND : false);
+	    "core.symlinks", git_path_supports_symlinks("link") ? GIT_ENOTFOUND : false);
 #endif
 }
 

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "sysdir.h"
 #include <ctype.h>
 

--- a/tests/repo/repo_helpers.c
+++ b/tests/repo/repo_helpers.c
@@ -21,21 +21,6 @@ void delete_head(git_repository* repo)
 	git_buf_dispose(&head_path);
 }
 
-int filesystem_supports_symlinks(const char *path)
-{
-	struct stat st;
-	bool support = 0;
-
-	if (p_symlink("target", path) == 0) {
-		if (p_lstat(path, &st) == 0 && S_ISLNK(st.st_mode))
-			support = 1;
-
-		p_unlink(path);
-	}
-
-	return support;
-}
-
 void create_tmp_global_config(const char *dirname, const char *key, const char *val)
 {
 	git_buf path = GIT_BUF_INIT;

--- a/tests/repo/repo_helpers.h
+++ b/tests/repo/repo_helpers.h
@@ -4,5 +4,4 @@
 
 extern void make_head_unborn(git_repository* repo, const char *target);
 extern void delete_head(git_repository* repo);
-extern int filesystem_supports_symlinks(const char *path);
 extern void create_tmp_global_config(const char *path, const char *key, const char *val);

--- a/tests/repo/setters.c
+++ b/tests/repo/setters.c
@@ -5,7 +5,7 @@
 #include "posix.h"
 #include "util.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 

--- a/tests/repo/shallow.c
+++ b/tests/repo/shallow.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo;
 

--- a/tests/repo/state.c
+++ b/tests/repo/state.c
@@ -2,7 +2,7 @@
 #include "buffer.h"
 #include "refs.h"
 #include "posix.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *_repo;
 static git_buf _path;

--- a/tests/repo/template.c
+++ b/tests/repo/template.c
@@ -1,6 +1,6 @@
 #include "clar_libgit2.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "repo/repo_helpers.h"
 
 #define CLEAR_FOR_CORE_FILEMODE(M) ((M) &= ~0177)

--- a/tests/reset/hard.c
+++ b/tests/reset/hard.c
@@ -2,7 +2,7 @@
 #include "posix.h"
 #include "reset_helpers.h"
 #include "path.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *repo;
 static git_object *target;

--- a/tests/revert/bare.c
+++ b/tests/revert/bare.c
@@ -2,7 +2,7 @@
 #include "clar_libgit2.h"
 
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/revert.h"
 
 #include "../merge/merge_helpers.h"

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -2,7 +2,7 @@
 #include "clar_libgit2.h"
 
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 #include "git2/revert.h"
 
 #include "../merge/merge_helpers.h"

--- a/tests/stash/apply.c
+++ b/tests/stash/apply.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "stash_helpers.h"
 
 static git_signature *signature;

--- a/tests/stash/drop.c
+++ b/tests/stash/drop.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "stash_helpers.h"
 #include "refs.h"
 

--- a/tests/stash/foreach.c
+++ b/tests/stash/foreach.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "stash_helpers.h"
 
 struct callback_data

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "stash_helpers.h"
 
 static git_repository *repo;

--- a/tests/stash/stash_helpers.c
+++ b/tests/stash/stash_helpers.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "stash_helpers.h"
 
 void setup_stash(git_repository *repo, git_signature *signature)

--- a/tests/status/submodules.c
+++ b/tests/status/submodules.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "status_helpers.h"
 #include "../submodule/submodule_helpers.h"
 

--- a/tests/status/worktree.c
+++ b/tests/status/worktree.c
@@ -1,5 +1,5 @@
 #include "clar_libgit2.h"
-#include "fileops.h"
+#include "futils.h"
 #include "ignore.h"
 #include "status_data.h"
 #include "posix.h"

--- a/tests/status/worktree_init.c
+++ b/tests/status/worktree_init.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "git2/sys/repository.h"
 
-#include "fileops.h"
+#include "futils.h"
 #include "ignore.h"
 #include "status_helpers.h"
 #include "posix.h"

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -3,7 +3,7 @@
 #include "path.h"
 #include "submodule_helpers.h"
 #include "config/config_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 
 static git_repository *g_repo = NULL;

--- a/tests/submodule/escape.c
+++ b/tests/submodule/escape.c
@@ -2,7 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 
 static git_repository *g_repo = NULL;

--- a/tests/submodule/init.c
+++ b/tests/submodule/init.c
@@ -2,7 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 

--- a/tests/submodule/inject_option.c
+++ b/tests/submodule/inject_option.c
@@ -2,7 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 #include "repository.h"
 
 static git_repository *g_repo = NULL;

--- a/tests/submodule/lookup.c
+++ b/tests/submodule/lookup.c
@@ -2,7 +2,7 @@
 #include "submodule_helpers.h"
 #include "git2/sys/repository.h"
 #include "repository.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 

--- a/tests/submodule/nosubs.c
+++ b/tests/submodule/nosubs.c
@@ -2,7 +2,7 @@
 
 #include "clar_libgit2.h"
 #include "posix.h"
-#include "fileops.h"
+#include "futils.h"
 
 void test_submodule_nosubs__cleanup(void)
 {

--- a/tests/submodule/repository_init.c
+++ b/tests/submodule/repository_init.c
@@ -3,7 +3,7 @@
 #include "path.h"
 #include "submodule_helpers.h"
 #include "config/config_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 

--- a/tests/submodule/status.c
+++ b/tests/submodule/status.c
@@ -2,7 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 #include "iterator.h"
 
 static git_repository *g_repo = NULL;

--- a/tests/submodule/update.c
+++ b/tests/submodule/update.c
@@ -2,7 +2,7 @@
 #include "posix.h"
 #include "path.h"
 #include "submodule_helpers.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_repository *g_repo = NULL;
 

--- a/tests/win32/longpath.c
+++ b/tests/win32/longpath.c
@@ -3,7 +3,7 @@
 #include "git2/clone.h"
 #include "clone.h"
 #include "buffer.h"
-#include "fileops.h"
+#include "futils.h"
 
 static git_buf path = GIT_BUF_INIT;
 


### PR DESCRIPTION
This implements unlinking for directory symlinks on Win32. I've been annoyed by our misnamed "fileops.h" while at it and just renamed it to "futils.h", as it should be named. I hope this doesn't generate too many conflicts, otherwise I'll boot it out of this PR.

Supersedes #5149, fixes #5147