### PR TITLE
Fix Regression: attr: Correctly load system attr file (on Windows)

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -333,6 +333,7 @@ static int attr_setup(git_repository *repo, git_attr_session *attr_session)
 				       NULL, git_repository_attr_cache(repo)->cfg_attr_file)) < 0)
 		goto out;
 
+	git_buf_clear(&path); /* git_repository_item_path expects an empty buffer, because it uses git_buf_set */
 	if ((error = git_repository_item_path(&path, repo, GIT_REPOSITORY_ITEM_INFO)) < 0 ||
 	    (error = preload_attr_file(repo, attr_session, GIT_ATTR_FILE__FROM_FILE,
 				       path.ptr, GIT_ATTR_FILE_INREPO)) < 0) {

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -919,6 +919,7 @@ int git_attr_session__init(git_attr_session *session, git_repository *repo)
 {
 	assert(repo);
 
+	memset(session, 0, sizeof(*session));
 	session->key = git_atomic_inc(&repo->attr_session_key);
 
 	return 0;


### PR DESCRIPTION
Regression introduced in commit 5452e49fce21f726bec19519da7f012e3f19e736 on PR #4967.

I don't know how to provide a test for this.