### PR TITLE
Fix parsing of IPv6 addresses on Windows PCs

### DIFF
--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -2015,7 +2015,13 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
         break;
 
       case s_http_host_v6:
+#ifdef WIN32
+      case s_http_host_v6_start:
+      case s_http_host_v6_end:
+        if ((s != s_http_host_v6) && (s != s_http_host_v6_start) && (s != s_http_host_v6_end)) {
+#else
         if (s != s_http_host_v6) {
+#endif
           u->field_data[UF_HOST].off = (uint16_t)(p - buf);
         }
         u->field_data[UF_HOST].len++;

--- a/tests/network/urlparse.c
+++ b/tests/network/urlparse.c
@@ -673,6 +673,6 @@ void test_network_urlparse__user_pass_port_ipv6(void)
 
 void test_network_urlparse__fails_ipv6(void)
 {
-	/* Invalid chracter inside address */
+	/* Invalid character inside address */
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata, "http://[fe8o::dcad:beff:fe00:0001]/resource"));
 }

--- a/tests/network/urlparse.c
+++ b/tests/network/urlparse.c
@@ -13,6 +13,10 @@ void test_network_urlparse__cleanup(void)
 	git_net_url_dispose(&conndata);
 }
 
+/*
+ * example.com based tests
+ */
+
 void test_network_urlparse__trivial(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com/resource"));
@@ -165,4 +169,510 @@ void test_network_urlparse__user_pass_port(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+/*
+ * IPv4 based tests
+ */
+
+void test_network_urlparse__trivial_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1/resource"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__root_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1/"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__implied_root_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__implied_root_custom_port_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1:42"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "42");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_network_urlparse__implied_root_empty_port_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1:"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__encoded_password_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user:pass%2fis%40bad@192.168.1.1:1234/"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "1234");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass/is@bad");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_network_urlparse__user_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user@192.168.1.1/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "443");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__user_pass_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user:pass@192.168.1.1/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "443");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__port_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://192.168.1.1:9191/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_network_urlparse__empty_port_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1:/resource"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_network_urlparse__user_port_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user@192.168.1.1:9191/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_network_urlparse__user_pass_port_ipv4(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user:pass@192.168.1.1:9191/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "192.168.1.1");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+/*
+ * IPv6 based tests
+ */
+
+void test_network_urlparse__trivial_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]/resource"));
+	cl_assert_equal_s(conndata.scheme, "http");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001]/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001/resource"));
+#endif
+}
+
+void test_network_urlparse__root_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]/"));
+	cl_assert_equal_s(conndata.scheme, "http");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001]/"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001/"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001/"));
+#endif
+}
+
+void test_network_urlparse__implied_root_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]"));
+	cl_assert_equal_s(conndata.scheme, "http");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001]"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001"));
+#endif
+}
+
+void test_network_urlparse__implied_root_custom_port_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]:42"));
+	cl_assert_equal_s(conndata.scheme, "http");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "42");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001]:42"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001:42"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001:42"));
+#endif
+}
+
+void test_network_urlparse__implied_root_empty_port_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]:"));
+	cl_assert_equal_s(conndata.scheme, "http");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001]:"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001:"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001:"));
+#endif
+}
+
+void test_network_urlparse__encoded_password_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user:pass%2fis%40bad@[fe80::dcad:beff:fe00:0001]:1234/"));
+	cl_assert_equal_s(conndata.scheme, "https");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "1234");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass/is@bad");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass%2fis%40bad@fe80::dcad:beff:fe00:0001]:1234/"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass%2fis%40bad@[fe80::dcad:beff:fe00:0001:1234/"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass%2fis%40bad@fe80::dcad:beff:fe00:0001:1234/"));
+#endif
+}
+
+void test_network_urlparse__user_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user@[fe80::dcad:beff:fe00:0001]/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "443");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user@fe80::dcad:beff:fe00:0001]/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user@[fe80::dcad:beff:fe00:0001/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user@fe80::dcad:beff:fe00:0001/resource"));
+#endif
+}
+
+void test_network_urlparse__user_pass_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user:pass@[fe80::dcad:beff:fe00:0001]/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "443");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass@fe80::dcad:beff:fe00:0001]/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass@[fe80::dcad:beff:fe00:0001/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass@fe80::dcad:beff:fe00:0001/resource"));
+#endif
+}
+
+void test_network_urlparse__port_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://[fe80::dcad:beff:fe00:0001]:9191/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://fe80::dcad:beff:fe00:0001]:9191/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://[fe80::dcad:beff:fe00:0001:9191/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://fe80::dcad:beff:fe00:0001:9191/resource"));
+#endif
+}
+
+void test_network_urlparse__empty_port_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]:/resource"));
+	cl_assert_equal_s(conndata.scheme, "http");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001]:/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001:/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::dcad:beff:fe00:0001:/resource"));
+#endif
+}
+
+void test_network_urlparse__user_port_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user@[fe80::dcad:beff:fe00:0001]:9191/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user@fe80::dcad:beff:fe00:0001]:9191/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user@[fe80::dcad:beff:fe00:0001:9191/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user@fe80::dcad:beff:fe00:0001:9191/resource"));
+#endif
+}
+
+void test_network_urlparse__user_pass_port_ipv6(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata,
+		"https://user:pass@[fe80::dcad:beff:fe00:0001]:9191/resource"));
+	cl_assert_equal_s(conndata.scheme, "https");
+#ifdef WIN32
+	cl_assert_equal_s(conndata.host, "[fe80::dcad:beff:fe00:0001]");
+#else
+	cl_assert_equal_s(conndata.host, "fe80::dcad:beff:fe00:0001");
+#endif
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+
+	/* Opening bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass@fe80::dcad:beff:fe00:0001]:9191/resource"));
+	/* Closing bracket missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass@[fe80::dcad:beff:fe00:0001:9191/resource"));
+#ifdef WIN32
+	/* Both brackets missing */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"https://user:pass@fe80::dcad:beff:fe00:0001:9191/resource"));
+#endif
+}
+
+void test_network_urlparse__fails_ipv6(void)
+{
+	/* Invalid chracter inside address */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata, "http://[fe8o::dcad:beff:fe00:0001]/resource"));
 }


### PR DESCRIPTION
Hello,
We want to use libgit2 on Windows 10 based PCs for managing repositories on PCs and embedded devices. The embedded devices are accessible only via IPv6 addresses, as they only have unique IPv6 addresses but not unique IPv4 ones. Unfortunately, currently it's not possible to use libgit2 on Windows based PCs together with IPv6 addresses.
The purpose of the changes is to keep the opening and closing brackets of IPv6 addresses as part of the URL on Windows based PCs. In order to keep libgit2's behaviour on non Windows PCs as it is, the changes are only valid if WIN32 is defined.
Additional tests check libgits2's URL parser together with IPv4 and IPv6 addresses. All network::urlparse tests run successfully both if WIN32 is defined and if not. I also added IPv4 and IPv6 tests based on the specific tests inside the "maint/v0.28" branch (libgit2 v0.28.2) in my fork together with the changes inside http_parser.c and they also work fine.