### PR TITLE
win32: fix fuzzers and have CI build them

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -18,7 +18,7 @@ Write-Host "####################################################################
 Write-Host "## Configuring build environment"
 Write-Host "##############################################################################"
 
-Invoke-Expression "cmake ${SourceDirectory} -DBUILD_EXAMPLES=ON -DENABLE_WERROR=ON ${Env:CMAKE_OPTIONS}"
+Invoke-Expression "cmake ${SourceDirectory} -DBUILD_EXAMPLES=ON -DBUILD_FUZZERS=ON -DUSE_STANDALONE_FUZZERS=ON -DENABLE_WERROR=ON ${Env:CMAKE_OPTIONS}"
 if ($LastExitCode -ne 0) { [Environment]::Exit($LastExitCode) }
 
 Write-Host ""

--- a/fuzzers/config_file_fuzzer.c
+++ b/fuzzers/config_file_fuzzer.c
@@ -7,14 +7,8 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include <git2.h>
+#include "git2.h"
 #include "config_backend.h"
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <limits.h>
-#include <errno.h>
 
 #define UNUSED(x) (void)(x)
 

--- a/fuzzers/download_refs_fuzzer.c
+++ b/fuzzers/download_refs_fuzzer.c
@@ -7,11 +7,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include <string.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <unistd.h>
 
 #include "git2.h"
 #include "git2/sys/transport.h"

--- a/fuzzers/download_refs_fuzzer.c
+++ b/fuzzers/download_refs_fuzzer.c
@@ -15,6 +15,7 @@
 
 #include "git2.h"
 #include "git2/sys/transport.h"
+#include "fileops.h"
 
 #define UNUSED(x) (void)(x)
 
@@ -166,10 +167,23 @@ void fuzzer_git_abort(const char *op)
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-	char tmp[] = "/tmp/git2.XXXXXX";
+#if defined(_WIN32)
+	char tmpdir[MAX_PATH], path[MAX_PATH];
 
-	UNUSED(argc);
-	UNUSED(argv);
+	if (GetTempPath((DWORD)sizeof(tmpdir), tmpdir) == 0)
+		abort();
+
+	if (GetTempFileName(tmpdir, "lg2", 1, path) == 0)
+		abort();
+
+	if (git_futils_mkdir(path, 0700, 0) < 0)
+		abort();
+#else
+	char path[] = "/tmp/git2.XXXXXX";
+
+	if (mkdtemp(path) != path)
+		abort();
+#endif
 
 	if (git_libgit2_init() < 0)
 		abort();
@@ -177,10 +191,10 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 	if (git_libgit2_opts(GIT_OPT_SET_PACK_MAX_OBJECTS, 10000000) < 0)
 		abort();
 
-	if (mkdtemp(tmp) != tmp)
-		abort();
+	UNUSED(argc);
+	UNUSED(argv);
 
-	if (git_repository_init(&repo, tmp, 1) < 0)
+	if (git_repository_init(&repo, path, 1) < 0)
 		fuzzer_git_abort("git_repository_init");
 
 	return 0;

--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -16,6 +16,7 @@
 #include "git2.h"
 #include "git2/sys/mempack.h"
 #include "common.h"
+#include "buffer.h"
 
 static git_odb *odb = NULL;
 static git_odb_backend *mempack = NULL;
@@ -54,12 +55,11 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-	git_indexer *indexer = NULL;
 	git_indexer_progress stats = {0, 0};
+	git_indexer *indexer = NULL;
+	git_buf path = GIT_BUF_INIT;
+	git_oid oid;
 	bool append_hash = false;
-	git_oid id;
-	char hash[GIT_OID_HEXSZ + 1] = {0};
-	char path[GIT_PATH_MAX];
 
 	if (size == 0)
 		return 0;
@@ -70,7 +70,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	}
 	git_mempack_reset(mempack);
 
-	if (git_odb_write(&id, odb, base_obj, base_obj_len, GIT_OBJECT_BLOB) < 0) {
+	if (git_odb_write(&oid, odb, base_obj, base_obj_len, GIT_OBJECT_BLOB) < 0) {
 		fprintf(stderr, "Failed to add an object to the odb\n");
 		abort();
 	}
@@ -92,7 +92,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if (git_indexer_append(indexer, data, size, &stats) < 0)
 		goto cleanup;
 	if (append_hash) {
-		git_oid oid;
 		if (git_odb_hash(&oid, data, size, GIT_OBJECT_BLOB) < 0) {
 			fprintf(stderr, "Failed to compute the SHA1 hash\n");
 			abort();
@@ -104,19 +103,19 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if (git_indexer_commit(indexer, &stats) < 0)
 		goto cleanup;
 
-	/*
-	 * We made it! We managed to produce a valid packfile.
-	 * Let's clean it up.
-	 */
-	git_oid_fmt(hash, git_indexer_hash(indexer));
-	printf("Generated packfile %s\n", hash);
-	snprintf(path, sizeof(path), "pack-%s.idx", hash);
-	p_unlink(path);
-	snprintf(path, sizeof(path), "pack-%s.pack", hash);
-	p_unlink(path);
+	if (git_buf_printf(&path, "pack-%s.idx", git_oid_tostr_s(git_indexer_hash(indexer))) < 0)
+		goto cleanup;
+	p_unlink(git_buf_cstr(&path));
+
+	git_buf_clear(&path);
+
+	if (git_buf_printf(&path, "pack-%s.pack", git_oid_tostr_s(git_indexer_hash(indexer))) < 0)
+		goto cleanup;
+	p_unlink(git_buf_cstr(&path));
 
 cleanup:
 	git_mempack_reset(mempack);
 	git_indexer_free(indexer);
+	git_buf_dispose(&path);
 	return 0;
 }

--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -15,8 +15,7 @@
 
 #include "git2.h"
 #include "git2/sys/mempack.h"
-
-#define UNUSED(x) (void)(x)
+#include "common.h"
 
 static git_odb *odb = NULL;
 static git_odb_backend *mempack = NULL;
@@ -27,8 +26,9 @@ static const unsigned int base_obj_len = 2;
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-	UNUSED(argc);
-	UNUSED(argv);
+	GIT_UNUSED(argc);
+	GIT_UNUSED(argv);
+
 	if (git_libgit2_init() < 0) {
 		fprintf(stderr, "Failed to initialize libgit2\n");
 		abort();
@@ -59,7 +59,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	bool append_hash = false;
 	git_oid id;
 	char hash[GIT_OID_HEXSZ + 1] = {0};
-	char path[PATH_MAX];
+	char path[GIT_PATH_MAX];
 
 	if (size == 0)
 		return 0;
@@ -111,9 +111,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	git_oid_fmt(hash, git_indexer_hash(indexer));
 	printf("Generated packfile %s\n", hash);
 	snprintf(path, sizeof(path), "pack-%s.idx", hash);
-	unlink(path);
+	p_unlink(path);
 	snprintf(path, sizeof(path), "pack-%s.pack", hash);
-	unlink(path);
+	p_unlink(path);
 
 cleanup:
 	git_mempack_reset(mempack);

--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -7,11 +7,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <limits.h>
-#include <unistd.h>
 
 #include "git2.h"
 #include "git2/sys/mempack.h"

--- a/fuzzers/standalone_driver.c
+++ b/fuzzers/standalone_driver.c
@@ -24,7 +24,7 @@ static int run_one_file(const char *filename)
 	int error = 0;
 
 	if (git_futils_readbuffer(&buf, filename) < 0) {
-		fprintf(stderr, "Failed to read %s: %m\n", filename);
+		fprintf(stderr, "Failed to read %s: %s\n", filename, git_error_last()->message);
 		error = -1;
 		goto exit;
 	}
@@ -57,7 +57,8 @@ int main(int argc, char **argv)
 	LLVMFuzzerInitialize(&argc, &argv);
 
 	if (git_path_dirload(&corpus_files, argv[1], 0, 0x0) < 0) {
-		fprintf(stderr, "Failed to scan corpus directory: %m\n");
+		fprintf(stderr, "Failed to scan corpus directory '%s': %s\n",
+			argv[1], git_error_last()->message);
 		error = -1;
 		goto exit;
 	}

--- a/fuzzers/standalone_driver.c
+++ b/fuzzers/standalone_driver.c
@@ -5,11 +5,7 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include <assert.h>
-#include <dirent.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <sys/types.h>
 
 #include "git2.h"
 #include "fileops.h"


### PR DESCRIPTION
This fixes our fuzzers so that they build on Win32 platforms and enables fuzzer building in our CI.