### PR TITLE
patch_parse: properly parse EOFNL comment lines

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -474,17 +474,20 @@ static int line_cb(
 	GIT_UNUSED(hunk);
 
 	switch (line->origin) {
-	    case GIT_DIFF_LINE_ADDITION:
-		git_buf_putc(&buf, '+');
-		break;
-	    case GIT_DIFF_LINE_DELETION:
-		git_buf_putc(&buf, '-');
-		break;
-	    case GIT_DIFF_LINE_CONTEXT:
-		break;
-	    default:
-		git_error_set(GIT_ERROR_PATCH, "invalid line origin for patch");
-		return -1;
+		case GIT_DIFF_LINE_ADDITION:
+			git_buf_putc(&buf, '+');
+			break;
+		case GIT_DIFF_LINE_DELETION:
+			git_buf_putc(&buf, '-');
+			break;
+		case GIT_DIFF_LINE_CONTEXT:
+		case GIT_DIFF_LINE_CONTEXT_EOFNL:
+		case GIT_DIFF_LINE_ADD_EOFNL:
+		case GIT_DIFF_LINE_DEL_EOFNL:
+			break;
+		default:
+			git_error_set(GIT_ERROR_PATCH, "invalid line origin for patch");
+			return -1;
 	}
 
 	git_buf_put(&buf, line->content, line->content_len);

--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -836,7 +836,7 @@ static int patch_generated_line_cb(
 {
 	git_patch_generated  *patch = payload;
 	git_patch_hunk *hunk;
-	git_diff_line   *line;
+	git_diff_line *line;
 
 	GIT_UNUSED(delta);
 	GIT_UNUSED(hunk_);

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -578,6 +578,16 @@ static int parse_hunk_body(
 			old_lineno = -1;
 			break;
 
+		case '\\':
+			/*
+			 * If there are no oldlines left, then this is probably
+			 * the "\ No newline at end of file" marker. Do not
+			 * verify its format, as it may be localized.
+			 */
+			if (!oldlines)
+				continue;
+			/* fall through */
+
 		default:
 			error = git_parse_err("invalid patch hunk at line %"PRIuZ, ctx->parse_ctx.line_num);
 			goto done;
@@ -606,7 +616,8 @@ static int parse_hunk_body(
 		goto done;
 	}
 
-	/* Handle "\ No newline at end of file".  Only expect the leading
+	/*
+	 * Handle "\ No newline at end of file".  Only expect the leading
 	 * backslash, though, because the rest of the string could be
 	 * localized.  Because `diff` optimizes for the case where you
 	 * want to apply the patch by hand.

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -524,6 +524,14 @@ fail:
 	return -1;
 }
 
+static int eof_for_origin(int origin) {
+	if (origin == GIT_DIFF_LINE_ADDITION)
+		return GIT_DIFF_LINE_ADD_EOFNL;
+	if (origin == GIT_DIFF_LINE_DELETION)
+		return GIT_DIFF_LINE_DEL_EOFNL;
+	return GIT_DIFF_LINE_CONTEXT_EOFNL;
+}
+
 static int parse_hunk_body(
 	git_patch_parsed *patch,
 	git_patch_hunk *hunk,
@@ -534,6 +542,7 @@ static int parse_hunk_body(
 
 	int oldlines = hunk->hunk.old_lines;
 	int newlines = hunk->hunk.new_lines;
+	int last_origin = 0;
 
 	for (;
 		ctx->parse_ctx.remain_len > 1 &&
@@ -579,14 +588,11 @@ static int parse_hunk_body(
 			break;
 
 		case '\\':
-			/*
-			 * If there are no oldlines left, then this is probably
-			 * the "\ No newline at end of file" marker. Do not
-			 * verify its format, as it may be localized.
-			 */
-			if (!oldlines)
-				continue;
-			/* fall through */
+			prefix = 0;
+			origin = eof_for_origin(last_origin);
+			old_lineno = -1;
+			new_lineno = -1;
+			break;
 
 		default:
 			error = git_parse_err("invalid patch hunk at line %"PRIuZ, ctx->parse_ctx.line_num);
@@ -607,6 +613,8 @@ static int parse_hunk_body(
 		line->new_lineno = new_lineno;
 
 		hunk->line_count++;
+
+		last_origin = origin;
 	}
 
 	if (oldlines || newlines) {
@@ -617,7 +625,7 @@ static int parse_hunk_body(
 	}
 
 	/*
-	 * Handle "\ No newline at end of file".  Only expect the leading
+	 * Handle "\ No newline at end of file". Only expect the leading
 	 * backslash, though, because the rest of the string could be
 	 * localized.  Because `diff` optimizes for the case where you
 	 * want to apply the patch by hand.
@@ -628,11 +636,24 @@ static int parse_hunk_body(
 		line = git_array_get(patch->base.lines, git_array_size(patch->base.lines) - 1);
 
 		if (line->content_len < 1) {
-			error = git_parse_err("cannot trim trailing newline of empty line");
+			error = git_parse_err("last line has no trailing newline");
 			goto done;
 		}
 
-		line->content_len--;
+		line = git_array_alloc(patch->base.lines);
+		GIT_ERROR_CHECK_ALLOC(line);
+
+		memset(line, 0x0, sizeof(git_diff_line));
+
+		line->content = ctx->parse_ctx.line;
+		line->content_len = ctx->parse_ctx.line_len;
+		line->content_offset = ctx->parse_ctx.content_len - ctx->parse_ctx.remain_len;
+		line->origin = eof_for_origin(last_origin);
+		line->num_lines = 1;
+		line->old_lineno = -1;
+		line->new_lineno = -1;
+
+		hunk->line_count++;
 
 		git_parse_advance_line(&ctx->parse_ctx);
 	}

--- a/tests/diff/patchid.c
+++ b/tests/diff/patchid.c
@@ -22,7 +22,7 @@ void test_diff_patchid__simple_commit(void)
 
 void test_diff_patchid__filename_with_spaces(void)
 {
-	verify_patch_id(PATCH_APPEND_NO_NL, "f0ba05413beaef743b630e796153839462ee477a");
+	verify_patch_id(PATCH_APPEND_NO_NL, "cc0d67fc516f3378baa8a72b248da6e26c5dbf4a");
 }
 
 void test_diff_patchid__multiple_hunks(void)

--- a/tests/patch/parse.c
+++ b/tests/patch/parse.c
@@ -27,6 +27,18 @@ static void ensure_patch_validity(git_patch *patch)
 	cl_assert_equal_i(0, delta->new_file.size);
 }
 
+static void ensure_identical_patch_inout(const char *content) {
+	git_buf buf = GIT_BUF_INIT;
+	git_patch *patch;
+
+	cl_git_pass(git_patch_from_buffer(&patch, content, strlen(content), NULL));
+	cl_git_pass(git_patch_to_buf(&buf, patch));
+	cl_assert_equal_strn(git_buf_cstr(&buf), content, strlen(content));
+
+	git_patch_free(patch);
+	git_buf_dispose(&buf);
+}
+
 void test_patch_parse__original_to_change_middle(void)
 {
 	git_patch *patch;
@@ -104,21 +116,15 @@ void test_patch_parse__invalid_patches_fails(void)
 
 void test_patch_parse__no_newline_at_end_of_new_file(void)
 {
-	git_patch *patch;
-	cl_git_pass(git_patch_from_buffer(&patch, PATCH_APPEND_NO_NL, strlen(PATCH_APPEND_NO_NL), NULL));
-	git_patch_free(patch);
+	ensure_identical_patch_inout(PATCH_APPEND_NO_NL);
 }
 
 void test_patch_parse__no_newline_at_end_of_old_file(void)
 {
-	git_patch *patch;
-	cl_git_pass(git_patch_from_buffer(&patch, PATCH_APPEND_NO_NL_IN_OLD_FILE, strlen(PATCH_APPEND_NO_NL_IN_OLD_FILE), NULL));
-	git_patch_free(patch);
+	ensure_identical_patch_inout(PATCH_APPEND_NO_NL_IN_OLD_FILE);
 }
 
 void test_patch_parse__files_with_whitespaces_succeeds(void)
 {
-	git_patch *patch;
-	cl_git_pass(git_patch_from_buffer(&patch, PATCH_NAME_WHITESPACE, strlen(PATCH_NAME_WHITESPACE), NULL));
-	git_patch_free(patch);
+	ensure_identical_patch_inout(PATCH_NAME_WHITESPACE);
 }

--- a/tests/patch/parse.c
+++ b/tests/patch/parse.c
@@ -102,6 +102,20 @@ void test_patch_parse__invalid_patches_fails(void)
 		strlen(PATCH_CORRUPT_MISSING_HUNK_HEADER), NULL));
 }
 
+void test_patch_parse__no_newline_at_end_of_new_file(void)
+{
+	git_patch *patch;
+	cl_git_pass(git_patch_from_buffer(&patch, PATCH_APPEND_NO_NL, strlen(PATCH_APPEND_NO_NL), NULL));
+	git_patch_free(patch);
+}
+
+void test_patch_parse__no_newline_at_end_of_old_file(void)
+{
+	git_patch *patch;
+	cl_git_pass(git_patch_from_buffer(&patch, PATCH_APPEND_NO_NL_IN_OLD_FILE, strlen(PATCH_APPEND_NO_NL_IN_OLD_FILE), NULL));
+	git_patch_free(patch);
+}
+
 void test_patch_parse__files_with_whitespaces_succeeds(void)
 {
 	git_patch *patch;

--- a/tests/patch/patch_common.h
+++ b/tests/patch/patch_common.h
@@ -681,6 +681,16 @@
 	"+added line with no nl\n" \
 	"\\ No newline at end of file\n"
 
+#define PATCH_APPEND_NO_NL_IN_OLD_FILE \
+	"diff --git a/file.txt b/file.txt\n" \
+	"index 9432026..83759c0 100644\n" \
+	"--- a/file.txt\n" \
+	"+++ b/file.txt\n" \
+	"@@ -1,1 +1,1 @@\n" \
+	"-foo\n" \
+	"\\ No newline at end of file\n" \
+	"+foo\n"
+
 #define PATCH_NAME_WHITESPACE \
 	"diff --git a/file with spaces.txt b/file with spaces.txt\n" \
 	"index 9432026..83759c0 100644\n" \


### PR DESCRIPTION
The patch output of #5159 did not produce a valid EOF comment