### PR TITLE
Ignore VS2017 specific files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ tags
 mkmf.log
 *.profdata
 *.profraw
+CMakeSettings.json
+.vs


### PR DESCRIPTION
When using VS2017 there are some files in the libgit2 folder which should be ignored.