### PR TITLE
fuzzer: use futils instead of fileops

### DIFF
--- a/fuzzers/download_refs_fuzzer.c
+++ b/fuzzers/download_refs_fuzzer.c
@@ -13,7 +13,7 @@
 
 #include "git2.h"
 #include "git2/sys/transport.h"
-#include "fileops.h"
+#include "futils.h"
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
Updated after the renamification in #5151 