### PR TITLE
object: deprecate git_object__size for removal

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -301,6 +301,18 @@ GIT_EXTERN(int) git_index_add_frombuffer(
 #define GIT_OBJ_OFS_DELTA GIT_OBJECT_OFS_DELTA
 #define GIT_OBJ_REF_DELTA GIT_OBJECT_REF_DELTA
 
+/**
+ * Get the size in bytes for the structure which
+ * acts as an in-memory representation of any given
+ * object type.
+ *
+ * For all the core types, this would the equivalent
+ * of calling `sizeof(git_commit)` if the core types
+ * were not opaque on the external API.
+ *
+ * @param type object type to get its size
+ * @return size in bytes of the object
+ */
 GIT_EXTERN(size_t) git_object__size(git_object_t type);
 
 /**@}*/

--- a/include/git2/object.h
+++ b/include/git2/object.h
@@ -186,20 +186,6 @@ GIT_EXTERN(git_object_t) git_object_string2type(const char *str);
 GIT_EXTERN(int) git_object_typeisloose(git_object_t type);
 
 /**
- * Get the size in bytes for the structure which
- * acts as an in-memory representation of any given
- * object type.
- *
- * For all the core types, this would the equivalent
- * of calling `sizeof(git_commit)` if the core types
- * were not opaque on the external API.
- *
- * @param type object type to get its size
- * @return size in bytes of the object
- */
-GIT_EXTERN(size_t) git_object_size(git_object_t type);
-
-/**
  * Recursively peel an object until an object of the specified type is met.
  *
  * If the query cannot be satisfied due to the object model,

--- a/src/object.c
+++ b/src/object.c
@@ -21,6 +21,7 @@
 bool git_object__strict_input_validation = true;
 
 extern int git_odb_hash(git_oid *out, const void *data, size_t len, git_object_t type);
+size_t git_object__size(git_object_t type);
 
 typedef struct {
 	const char	*str;	/* type name string */
@@ -75,7 +76,7 @@ int git_object__from_raw(
 		return GIT_ENOTFOUND;
 	}
 
-	if ((object_size = git_object_size(type)) == 0) {
+	if ((object_size = git_object__size(type)) == 0) {
 		git_error_set(GIT_ERROR_INVALID, "the requested type is invalid");
 		return GIT_ENOTFOUND;
 	}
@@ -123,7 +124,7 @@ int git_object__from_odb_object(
 		return GIT_ENOTFOUND;
 	}
 
-	if ((object_size = git_object_size(odb_obj->cached.type)) == 0) {
+	if ((object_size = git_object__size(odb_obj->cached.type)) == 0) {
 		git_error_set(GIT_ERROR_INVALID, "the requested type is invalid");
 		return GIT_ENOTFOUND;
 	}
@@ -316,7 +317,7 @@ int git_object_typeisloose(git_object_t type)
 	return (git_objects_table[type].size > 0) ? 1 : 0;
 }
 
-size_t git_object_size(git_object_t type)
+size_t git_object__size(git_object_t type)
 {
 	if (type < 0 || ((size_t) type) >= ARRAY_SIZE(git_objects_table))
 		return 0;
@@ -548,11 +549,4 @@ bool git_object__is_valid(
 	}
 
 	return true;
-}
-
-/* Deprecated functions */
-
-size_t git_object__size(git_object_t type)
-{
-	return git_object_size(type);
 }


### PR DESCRIPTION
In #5118 we remove the double-underscore to make it a normally-named public
function. However, this is not an interesting function outside of the library
and it takes up a name for something that could be more useful.

Remove the single-underscore version as we have not done any releases with it.