### PR TITLE
smart: implement keepalive

### DIFF
--- a/include/git2/sys/stream.h
+++ b/include/git2/sys/stream.h
@@ -36,6 +36,7 @@ typedef struct git_stream {
 	int GIT_CALLBACK(set_proxy)(struct git_stream *, const git_proxy_options *proxy_opts);
 	ssize_t GIT_CALLBACK(read)(struct git_stream *, void *, size_t);
 	ssize_t GIT_CALLBACK(write)(struct git_stream *, const char *, size_t, int);
+	int GIT_CALLBACK(poll)(struct git_stream *, int);
 	int GIT_CALLBACK(close)(struct git_stream *);
 	void GIT_CALLBACK(free)(struct git_stream *);
 } git_stream;

--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -325,6 +325,17 @@ struct git_smart_subtransport_stream {
 		const char *buffer,
 		size_t len);
 
+	/**
+	 * Poll the transport for data.
+	 *
+	 * The implementation shall return a negative value on
+	 * errors, 0 on timeout and a positive value if there is
+	 * readable data available for the stream.
+	 */
+	int GIT_CALLBACK(poll)(
+		git_smart_subtransport_stream *stream,
+		int timeout);
+
 	/** Free the stream */
 	void GIT_CALLBACK(free)(
 		git_smart_subtransport_stream *stream);

--- a/src/netops.c
+++ b/src/netops.c
@@ -20,17 +20,25 @@ int gitno_recv(gitno_buffer *buf)
 	return buf->recv(buf);
 }
 
+int gitno_poll(gitno_buffer *buf, int timeout)
+{
+	return buf->poll(buf, timeout);
+}
+
 void gitno_buffer_setup_callback(
 	gitno_buffer *buf,
 	char *data,
 	size_t len,
-	int (*recv)(gitno_buffer *buf), void *cb_data)
+	int (*recv)(gitno_buffer *buf),
+	int (*poll)(gitno_buffer *buf, int timeout),
+	void *cb_data)
 {
 	memset(data, 0x0, len);
 	buf->data = data;
 	buf->len = len;
 	buf->offset = 0;
 	buf->recv = recv;
+	buf->poll = poll;
 	buf->cb_data = cb_data;
 }
 
@@ -50,6 +58,12 @@ static int recv_stream(gitno_buffer *buf)
 	return (int)ret;
 }
 
+static int poll_stream(gitno_buffer *buf, int timeout)
+{
+	git_stream *io = (git_stream *) buf->cb_data;
+	return git_stream_poll(io, timeout);
+}
+
 void gitno_buffer_setup_fromstream(git_stream *st, gitno_buffer *buf, char *data, size_t len)
 {
 	memset(data, 0x0, len);
@@ -57,6 +71,7 @@ void gitno_buffer_setup_fromstream(git_stream *st, gitno_buffer *buf, char *data
 	buf->len = len;
 	buf->offset = 0;
 	buf->recv = recv_stream;
+	buf->poll = poll_stream;
 	buf->cb_data = st;
 }
 
@@ -197,4 +212,3 @@ done:
 	git_net_url_dispose(&tmp);
 	return error;
 }
-

--- a/src/netops.h
+++ b/src/netops.h
@@ -36,6 +36,7 @@ typedef struct gitno_buffer {
 	size_t len;
 	size_t offset;
 	int (*recv)(struct gitno_buffer *buffer);
+	int (*poll)(struct gitno_buffer *buffer, int timeout);
 	void *cb_data;
 } gitno_buffer;
 
@@ -59,8 +60,11 @@ enum {
 int gitno__match_host(const char *pattern, const char *host);
 
 void gitno_buffer_setup_fromstream(git_stream *st, gitno_buffer *buf, char *data, size_t len);
-void gitno_buffer_setup_callback(gitno_buffer *buf, char *data, size_t len, int (*recv)(gitno_buffer *buf), void *cb_data);
+void gitno_buffer_setup_callback(gitno_buffer *buf, char *data, size_t len,
+		int (*recv)(gitno_buffer *buf), int (*poll)(gitno_buffer *buf, int timeout),
+		void *cb_data);
 int gitno_recv(gitno_buffer *buf);
+int gitno_poll(gitno_buffer *buf, int timeout);
 
 void gitno_consume(gitno_buffer *buf, const char *ptr);
 void gitno_consume_n(gitno_buffer *buf, size_t cons);

--- a/src/stream.h
+++ b/src/stream.h
@@ -55,6 +55,13 @@ GIT_INLINE(ssize_t) git_stream_write(git_stream *st, const char *data, size_t le
 	return st->write(st, data, len, flags);
 }
 
+GIT_INLINE(int) git_stream_poll(git_stream *st, int timeout)
+{
+	if (!st->poll)
+		return 1;
+	return st->poll(st, timeout);
+}
+
 GIT_INLINE(int) git_stream__write_full(git_stream *st, const char *data, size_t len, int flags)
 {
 	size_t total_written = 0;

--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -332,6 +332,12 @@ static ssize_t mbedtls_stream_read(git_stream *stream, void *data, size_t len)
 	return ret;
 }
 
+static int mbedtls_stream_poll(git_stream *stream, int timeout)
+{
+	mbedtls_stream *st = GIT_CONTAINER_OF(stream, mbedtls_stream, parent);
+	return git_stream_poll(st->io, timeout);
+}
+
 static int mbedtls_stream_close(git_stream *stream)
 {
 	mbedtls_stream *st = (mbedtls_stream *) stream;
@@ -394,6 +400,7 @@ static int mbedtls_stream_wrap(
 	st->parent.set_proxy = mbedtls_set_proxy;
 	st->parent.read = mbedtls_stream_read;
 	st->parent.write = mbedtls_stream_write;
+	st->parent.poll = mbedtls_stream_poll;
 	st->parent.close = mbedtls_stream_close;
 	st->parent.free = mbedtls_stream_free;
 

--- a/src/transports/git.c
+++ b/src/transports/git.c
@@ -130,6 +130,14 @@ static int git_proto_stream_write(
 	return git_stream__write_full(s->io, buffer, len, 0);
 }
 
+static int git_proto_stream_poll(
+	git_smart_subtransport_stream *stream,
+	int timeout)
+{
+	git_proto_stream *s = (git_proto_stream *)stream;
+	return git_stream_poll(s->io, timeout);
+}
+
 static void git_proto_stream_free(git_smart_subtransport_stream *stream)
 {
 	git_proto_stream *s;
@@ -168,6 +176,7 @@ static int git_proto_stream_alloc(
 	s->parent.subtransport = &t->parent;
 	s->parent.read = git_proto_stream_read;
 	s->parent.write = git_proto_stream_write;
+	s->parent.poll = git_proto_stream_poll;
 	s->parent.free = git_proto_stream_free;
 
 	s->cmd = cmd;

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -1400,6 +1400,15 @@ on_error:
 	return -1;
 }
 
+static int http_stream_poll(
+	git_smart_subtransport_stream *stream,
+	int timeout)
+{
+	http_stream *s = GIT_CONTAINER_OF(stream, http_stream, parent);
+	http_subtransport *t = OWNING_SUBTRANSPORT(s);
+	return git_stream_poll(t->server.stream, timeout);
+}
+
 static void http_stream_free(git_smart_subtransport_stream *stream)
 {
 	http_stream *s = GIT_CONTAINER_OF(stream, http_stream, parent);
@@ -1427,6 +1436,7 @@ static int http_stream_alloc(http_subtransport *t,
 	s->parent.subtransport = &t->parent;
 	s->parent.read = http_stream_read;
 	s->parent.write = http_stream_write_single;
+	s->parent.poll = http_stream_poll;
 	s->parent.free = http_stream_free;
 
 	*stream = (git_smart_subtransport_stream *)s;

--- a/src/transports/smart.h
+++ b/src/transports/smart.h
@@ -142,6 +142,7 @@ typedef struct {
 	git_proxy_options proxy;
 	int direction;
 	int flags;
+	int keepalive;
 	git_transport_message_cb progress_cb;
 	git_transport_message_cb error_cb;
 	git_transport_certificate_check_cb certificate_check_cb;

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -246,6 +246,26 @@ static int recv_pkt(git_pkt **out_pkt, git_pkt_type *out_type, gitno_buffer *buf
 	return error;
 }
 
+static ssize_t recv_pkt_keepalive(transport_smart *t, git_pkt **out_pkt, git_pkt_type *out_type, gitno_buffer *buf)
+{
+	int error;
+
+	if (t->keepalive <= 0)
+		goto recv;
+
+	while (t->keepalive) {
+		if ((error = gitno_poll(buf, t->keepalive * 1000)) < 0)
+			return error;
+		if (error > 0)
+			break;
+		if ((error = t->current_stream->write(t->current_stream, "0005\1", 5)) < 0)
+			return error;
+	}
+
+recv:
+	return recv_pkt(out_pkt, out_type, buf);
+}
+
 static int store_common(transport_smart *t)
 {
 	git_pkt *pkt = NULL;
@@ -350,10 +370,16 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 	gitno_buffer *buf = &t->buffer;
 	git_buf data = GIT_BUF_INIT;
 	git_revwalk *walk = NULL;
-	int error = -1;
+	int error = -1, keepalive;
+	git_config *cfg = NULL;
 	git_pkt_type pkt_type;
 	unsigned int i;
 	git_oid oid;
+
+	if (git_repository_config(&cfg, repo) < 0 ||
+	    git_config_get_int32(&keepalive, cfg, "receive.keepAlive") < 0)
+		keepalive = 5;
+	git_config_free(cfg);
 
 	if ((error = git_pkt_buffer_wants(wants, count, &t->caps, &data)) < 0)
 		return error;
@@ -596,7 +622,7 @@ int git_smart__download_pack(
 			goto done;
 		}
 
-		if ((error = recv_pkt(&pkt, NULL, buf)) >= 0) {
+		if ((error = recv_pkt_keepalive(t, &pkt, NULL, buf)) >= 0) {
 			/* Check cancellation after network call */
 			if (t->cancelled.val) {
 				git_error_clear();

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -195,6 +195,14 @@ static int ssh_stream_write(
 	return 0;
 }
 
+static int ssh_stream_poll(
+	git_smart_subtransport_stream *stream,
+	int timeout)
+{
+	ssh_stream *s = GIT_CONTAINER_OF(stream, ssh_stream, parent);
+	return git_stream_poll(s->io, timeout);
+}
+
 static void ssh_stream_free(git_smart_subtransport_stream *stream)
 {
 	ssh_stream *s = GIT_CONTAINER_OF(stream, ssh_stream, parent);
@@ -244,6 +252,7 @@ static int ssh_stream_alloc(
 	s->parent.subtransport = &t->parent;
 	s->parent.read = ssh_stream_read;
 	s->parent.write = ssh_stream_write;
+	s->parent.poll = ssh_stream_poll;
 	s->parent.free = ssh_stream_free;
 
 	s->cmd = cmd;


### PR DESCRIPTION
This is a first proposal on how to implement keepalive for the smart backend as documented in git-config(1), "receive.keepAlive". It was required to change both stream as well as transport backends and extend them with a `poll` function to support timeouts, but in fact it was done in an API-backwards-compatible way: if no `poll` is implemented, we simply assume that there's always data to be read and thus cannot support keepalive for such backends.

Note that this is rather to be seen as an RFC for now. The `poll` function would probably need a `p_poll` wrapper, which I haven't yet done. To make this clearer, I've added `#include <poll.h>` in the middle of the source code.

I think the most important questions I have is: do we want to use `poll`? Or would it be preferred to have a `read_ext` function that accepts a timeout parameter, as well?

Inspired by #5133.