### PR TITLE
apply: git_apply_to_tree fails to apply patches that add new files

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -649,9 +649,12 @@ int git_apply_to_tree(
 	for (i = 0; i < git_diff_num_deltas(diff); i++) {
 		delta = git_diff_get_delta(diff, i);
 
-		if ((error = git_index_remove(postimage,
-				delta->old_file.path, 0)) < 0)
-			goto done;
+		if (delta->status == GIT_DELTA_DELETED ||
+			delta->status == GIT_DELTA_RENAMED) {
+			if ((error = git_index_remove(postimage,
+					delta->old_file.path, 0)) < 0)
+				goto done;
+		}
 	}
 
 	if ((error = apply_deltas(repo, pre_reader, NULL, post_reader, postimage, diff, &opts)) < 0)


### PR DESCRIPTION
git_apply_to_tree() cannot be used to apply patches with new files.

An attempt to apply such a patch fails because git_apply_to_tree() tries to
remove a non-existing file from an old index.

The solution is to modify git_apply_to_tree() to git_index_remove() when the
patch states that the modified files is removed.