### PR TITLE
apply: Fix a patch corruption related to EOFNL handling

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -219,7 +219,7 @@ static int apply_hunk(
 			case GIT_DIFF_LINE_CONTEXT_EOFNL:
 			case GIT_DIFF_LINE_DEL_EOFNL:
 			case GIT_DIFF_LINE_ADD_EOFNL:
-				prev = i ? git_array_get(patch->lines, i - 1) : NULL;
+				prev = i ? git_array_get(patch->lines, linenum - 1) : NULL;
 				if (prev && prev->content[prev->content_len - 1] == '\n')
 					prev->content_len -= 1;
 				break;

--- a/tests/apply/fromdiff.c
+++ b/tests/apply/fromdiff.c
@@ -131,6 +131,17 @@ void test_apply_fromdiff__lastline(void)
 		PATCH_ORIGINAL_TO_CHANGE_LASTLINE, NULL));
 }
 
+void test_apply_fromdiff__change_middle_and_lastline_nocontext(void)
+{
+	git_diff_options diff_opts = GIT_DIFF_OPTIONS_INIT;
+	diff_opts.context_lines = 0;
+
+	cl_git_pass(apply_buf(
+		FILE_ORIGINAL, "file.txt",
+		FILE_CHANGE_MIDDLE_AND_LASTLINE, "file.txt",
+		PATCH_ORIGINAL_TO_CHANGE_MIDDLE_AND_LASTLINE_NOCONTEXT, &diff_opts));
+}
+
 void test_apply_fromdiff__prepend(void)
 {
 	cl_git_pass(apply_buf(

--- a/tests/patch/patch_common.h
+++ b/tests/patch/patch_common.h
@@ -263,6 +263,32 @@
 	"-(this line is changed)\n" \
 	"+(THIS line is changed!)\n"
 
+/* A change in the middle and a deletion of the newline at the end of the file */
+
+#define FILE_CHANGE_MIDDLE_AND_LASTLINE \
+	"hey!\n" \
+	"this is some context!\n" \
+	"around some lines\n" \
+	"that will change\n" \
+	"yes it is!\n" \
+	"(THIS line is changed!)\n" \
+	"and this\n" \
+	"is additional context\n" \
+	"BELOW it! - (THIS line is changed!)"
+
+#define PATCH_ORIGINAL_TO_CHANGE_MIDDLE_AND_LASTLINE_NOCONTEXT \
+	"diff --git a/file.txt b/file.txt\n" \
+	"index 9432026..e05d36c 100644\n" \
+	"--- a/file.txt\n" \
+	"+++ b/file.txt\n" \
+	"@@ -6 +6 @@ yes it is!\n" \
+	"-(this line is changed)\n" \
+	"+(THIS line is changed!)\n" \
+	"@@ -9 +9 @@ is additional context\n" \
+	"-below it!\n" \
+	"+BELOW it! - (THIS line is changed!)\n" \
+	"\\ No newline at end of file\n"
+
 /* A deletion at the beginning of the file and a change in the middle */
 
 #define FILE_DELETE_AND_CHANGE \


### PR DESCRIPTION
Use of apply's API can lead to an improper patch application and a corruption
of the modified file.

The issue is caused by mishandling of the end of file changes if there are
several hunks to apply. The new line character is added to a line from a wrong
hunk.

The solution is to modify apply_hunk() to add the newline character at the end
of a line from a right hunk.