### PR TITLE
Use an HTTP scheme that supports the given credentials

### DIFF
--- a/src/transports/auth.c
+++ b/src/transports/auth.c
@@ -70,6 +70,6 @@ int git_http_auth_dummy(
 	GIT_UNUSED(url);
 
 	*out = NULL;
-	return 0;
+	return GIT_PASSTHROUGH;
 }
 


### PR DESCRIPTION
Don't try to select the "best" scheme that the server offers us without taking into account the credentials that the user has selected.  Otherwise, the "best" scheme may not support the given credentials.

eg, many servers use both Negotiate and NTLM as a fallback.  Negotiate _only_ works with default credentials, while our NTLM implementation _only_ works with username/password credentials.  As a result, our caller has given us a particular kind of credentials and we must match those credentials to the schemes offered.

Instead of using the "best" overall scheme, use the "best" scheme (ordered first) that our credentials support.

Fixes #5178 