### PR TITLE
Fix include casing for case-sensitive filesystems.

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -14,7 +14,7 @@
 #include "win32/w32_buffer.h"
 #include "win32/w32_util.h"
 #include "win32/version.h"
-#include <AclAPI.h>
+#include <aclapi.h>
 #else
 #include <dirent.h>
 #endif


### PR DESCRIPTION
This recently added include broke compilation on mingw32 with case-sensitive filesystems. Lowercasing here fixes compilation for me and mingw32 standardizes on lowercase include paths, so this seems like the right thing to do.