### PR TITLE
open:fix memory leak when passing NULL to git_repository_open_ext

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -800,7 +800,7 @@ int git_repository_open_ext(
 	unsigned is_worktree;
 	git_buf gitdir = GIT_BUF_INIT, workdir = GIT_BUF_INIT,
 		gitlink = GIT_BUF_INIT, commondir = GIT_BUF_INIT;
-	git_repository *repo;
+	git_repository *repo = NULL;
 	git_config *config = NULL;
 
 	if (flags & GIT_REPOSITORY_OPEN_FROM_ENV)
@@ -812,13 +812,8 @@ int git_repository_open_ext(
 	error = find_repo(
 		&gitdir, &workdir, &gitlink, &commondir, start_path, flags, ceiling_dirs);
 
-	if (error < 0 || !repo_ptr) {
-		git_buf_dispose(&gitdir);
-		git_buf_dispose(&workdir);
-		git_buf_dispose(&gitlink);
-		git_buf_dispose(&commondir);
-		return error;
-	}
+	if (error < 0 || !repo_ptr)
+		goto cleanup;
 
 	repo = repository_alloc();
 	GIT_ERROR_CHECK_ALLOC(repo);
@@ -864,11 +859,14 @@ int git_repository_open_ext(
 cleanup:
 	git_buf_dispose(&gitdir);
 	git_buf_dispose(&workdir);
+	git_buf_dispose(&gitlink);
+	git_buf_dispose(&commondir);
 	git_config_free(config);
 
 	if (error < 0)
 		git_repository_free(repo);
-	else
+
+	if (repo_ptr)
 		*repo_ptr = repo;
 
 	return error;

--- a/src/repository.c
+++ b/src/repository.c
@@ -812,8 +812,13 @@ int git_repository_open_ext(
 	error = find_repo(
 		&gitdir, &workdir, &gitlink, &commondir, start_path, flags, ceiling_dirs);
 
-	if (error < 0 || !repo_ptr)
+	if (error < 0 || !repo_ptr) {
+		git_buf_dispose(&gitdir);
+		git_buf_dispose(&workdir);
+		git_buf_dispose(&gitlink);
+		git_buf_dispose(&commondir);
 		return error;
+	}
 
 	repo = repository_alloc();
 	GIT_ERROR_CHECK_ALLOC(repo);

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -88,6 +88,17 @@ void test_repo_open__open_with_discover(void)
 	cl_fixture_cleanup("attr");
 }
 
+void test_repo_open__check_if_repository(void)
+{
+	cl_git_sandbox_init("empty_standard_repo");
+
+	/* Pass NULL for the output parameter to check for but not open the repo */
+	cl_git_pass(git_repository_open_ext(NULL, "empty_standard_repo", 0, NULL));
+	cl_git_fail(git_repository_open_ext(NULL, "repo_does_not_exist", 0, NULL));
+
+	cl_fixture_cleanup("empty_standard_repo");
+}
+
 static void make_gitlink_dir(const char *dir, const char *linktext)
 {
 	git_buf path = GIT_BUF_INIT;


### PR DESCRIPTION
There is an example on the website for checking if a directory looks like a repository:

https://libgit2.org/docs/guides/101-samples/#repositories_openable

This example leaks memory. This pull request includes a test point which leaks memory and is caught by valgrind, plus a fix in git_repository_open_ext to dispose of buffers on the early return.