### PR TITLE
buffer: fix writes into out-of-memory buffers

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -18,7 +18,8 @@ char git_buf__initbuf[1];
 char git_buf__oom[1];
 
 #define ENSURE_SIZE(b, d) \
-	if ((d) > (b)->asize && git_buf_grow((b), (d)) < 0)\
+	if ((b)->ptr == git_buf__oom || \
+	    ((d) > (b)->asize && git_buf_grow((b), (d)) < 0))\
 		return -1;
 
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -58,13 +58,16 @@ int git_buf_try_grow(
 		new_ptr = NULL;
 	} else {
 		new_size = buf->asize;
+		/*
+		 * Grow the allocated buffer by 1.5 to allow
+		 * re-use of memory holes resulting from the
+		 * realloc. If this is still too small, then just
+		 * use the target size.
+		 */
+		if ((new_size = (new_size << 1) - (new_size >> 1)) < target_size)
+			new_size = target_size;
 		new_ptr = buf->ptr;
 	}
-
-	/* grow the buffer size by 1.5, until it's big enough
-	 * to fit our target size */
-	while (new_size < target_size)
-		new_size = (new_size << 1) - (new_size >> 1);
 
 	/* round allocation up to multiple of 8 */
 	new_size = (new_size + 7) & ~7;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -70,8 +70,11 @@ int git_buf_try_grow(
 	new_size = (new_size + 7) & ~7;
 
 	if (new_size < buf->size) {
-		if (mark_oom)
+		if (mark_oom) {
+			if (buf->ptr && buf->ptr != git_buf__initbuf)
+				git__free(buf->ptr);
 			buf->ptr = git_buf__oom;
+		}
 
 		git_error_set_oom();
 		return -1;


### PR DESCRIPTION
This fixes two issues with `git_buf`:

1. An infinite loop when allocating a huge amount of bytes close to `SIZE_MAX`. While obviously a bogus scenario, I still think the fix is worthwhile.
2. We failed to correctly ensure sizes of OOM'd buffers, which resulted in us writing into the `git_buf__oom` buffer.

Found while investigating #5199 once again. This is probably not the cause for the observed crashes, though, as the stack traces point somewhere else.