### PR TITLE
gssapi: delete half-built security context so auth can continue

### DIFF
--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -123,9 +123,9 @@ static int negotiate_next_token(
 		input_token.length = input_buf.size;
 		input_token_ptr = &input_token;
 	} else if (ctx->gss_context != GSS_C_NO_CONTEXT) {
-		git_error_set(GIT_ERROR_NET, "could not restart authentication");
-		error = -1;
-		goto done;
+		/* If we're given a half-built security context, delete it so auth can continue. */
+		gss_delete_sec_context(&status_minor, &ctx->gss_context, GSS_C_NO_BUFFER);
+		ctx->gss_context = GSS_C_NO_CONTEXT;
 	}
 
 	mech = &negotiate_oid_spnego;


### PR DESCRIPTION
Fixes #5233.

As per the [GNU Generic Security Service (GSS) API Reference Manual](https://www.gnu.org/software/gss/reference/gss.pdf) on page 15:

> If the initial call of gss_init_sec_context() fails, the implementation should not create a context object, and should leave the value of the context_handle parameter set to GSS_C_NO_CONTEXT to indicate this. In the event of a failure on a subsequent call, the implementation is permitted to delete the "half-built" security context (in which case it should set the context_handle parameter to GSS_C_NO_CONTEXT), but the preferred behavior is to leave the security context untouched for the application to delete (using gss_delete_sec_context).

I have tested and confirmed that this fixes the issue we were having with our bitbucket + kerberos setup. Running the online tests against our bitbucket setup now succeeds:

```bash
[centos@rhel7 build]$ kinit root/admin
Password for root/admin@KXLABS.COM:
[centos@rhel7 build]$ export GITTEST_REMOTE_URL=https://bitbucket.kxlabs.com:8080/scm/~admin/libgit2_repo.git
[centos@rhel7 build]$ export GITTEST_REMOTE_DEFAULT=ok
[centos@rhel7 build]$ ./libgit2_clar -ionline -sonline
Loaded 381 suites:
Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')

online::badssl...S
online::clone............S.SSSSS...SSS.S.
online::fetch...........
online::fetchhead......
online::push.....................
online::remotes......
```

Note that branched off of e24b8852249716dfc032cdc38f53fbd4a5f12b6e, as recent changes seem to have broken the `-DUSE_GSSAPI=ON` build.