### PR TITLE
cred: add missing private header in GSSAPI block

### DIFF
--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -12,6 +12,7 @@
 #include "git2.h"
 #include "buffer.h"
 #include "auth.h"
+#include "git2/sys/cred.h"
 
 #include <gssapi.h>
 #include <krb5.h>


### PR DESCRIPTION
Should have been part of 8bf0f7eb26c65b2b937b1f40a384b9b269b0b76d, which I missed by having relied too much on Xcode's refactorer (#blameitontheIDE).