### PR TITLE
azure: avoid building and testing in Docker as root

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ jobs:
       git config user.name 'Documentation Generation'
       git config user.email 'libgit2@users.noreply.github.com'
       git branch gh-pages origin/gh-pages
-      docker run --rm -v $(Build.SourcesDirectory):/src -w /src libgit2/docurium:latest cm doc api.docurium
+      docker run --rm -v $(Build.SourcesDirectory):/home/libgit2/source -w /home/libgit2/source libgit2/docurium:latest cm doc api.docurium
       git checkout gh-pages
       cp -R * '$(Build.BinariesDirectory)'
     displayName: 'Generate Documentation'

--- a/azure-pipelines/coverity.yml
+++ b/azure-pipelines/coverity.yml
@@ -15,12 +15,12 @@ jobs:
         image: xenial
         base: xenial
       volumes: |
-       $(Build.SourcesDirectory):/src
-       $(Build.BinariesDirectory):/build
+       $(Build.SourcesDirectory):/home/libgit2/source
+       $(Build.BinariesDirectory):/home/libgit2/build
       envVars: |
        COVERITY_TOKEN=$(COVERITY_TOKEN)
-      workDir: '/build'
-      containerCommand: '/src/azure-pipelines/coverity-build.sh'
+      workDir: '/home/libgit2/build'
+      containerCommand: '/home/libgit2/source/azure-pipelines/coverity-build.sh'
       detached: false
   - task: Docker@0
     displayName: Publish
@@ -28,11 +28,11 @@ jobs:
       action: 'Run an image'
       imageName: 'libgit2/trusty-openssl:latest'
       volumes: |
-       $(Build.SourcesDirectory):/src
-       $(Build.BinariesDirectory):/build
+       $(Build.SourcesDirectory):/home/libgit2/source
+       $(Build.BinariesDirectory):/home/libgit2/build
       envVars: |
        COVERITY_TOKEN=$(COVERITY_TOKEN)
-      workDir: '/build'
-      containerCommand: '/src/azure-pipelines/coverity-publish.sh'
+      workDir: '/home/libgit2/build'
+      containerCommand: '/home/libgit2/source/azure-pipelines/coverity-publish.sh'
       detached: false
     continueOnError: true

--- a/azure-pipelines/docker.yml
+++ b/azure-pipelines/docker.yml
@@ -14,11 +14,11 @@ steps:
     action: 'Run an image'
     imageName: libgit2/${{ parameters.docker.image }}
     volumes: |
-     $(Build.SourcesDirectory):/src
-     $(Build.BinariesDirectory):/build
+     $(Build.SourcesDirectory):/home/libgit2/source
+     $(Build.BinariesDirectory):/home/libgit2/build
     envVars: ${{ parameters.environmentVariables }}
-    workDir: '/build'
-    containerCommand: '/src/azure-pipelines/build.sh'
+    workDir: '/home/libgit2/build'
+    containerCommand: '/home/libgit2/source/azure-pipelines/build.sh'
     detached: false
 - task: docker@0
   displayName: Test
@@ -26,11 +26,11 @@ steps:
     action: 'Run an image'
     imageName: libgit2/${{ parameters.docker.image }}
     volumes: |
-     $(Build.SourcesDirectory):/src
-     $(Build.BinariesDirectory):/build
+     $(Build.SourcesDirectory):/home/libgit2/source
+     $(Build.BinariesDirectory):/home/libgit2/build
     envVars: ${{ parameters.environmentVariables }}
-    workDir: '/build'
-    containerCommand: '/src/azure-pipelines/test.sh'
+    workDir: '/home/libgit2/build'
+    containerCommand: '/home/libgit2/source/azure-pipelines/test.sh'
     detached: false
 - task: publishtestresults@2
   displayName: Publish Test Results

--- a/azure-pipelines/docker/bionic
+++ b/azure-pipelines/docker/bionic
@@ -7,6 +7,7 @@ RUN apt-get update && \
         curl \
         gcc \
         git \
+        gosu \
         libcurl4-openssl-dev \
         libpcre3-dev \
         libssh2-1-dev \
@@ -33,3 +34,8 @@ RUN cd /tmp && \
     ninja install && \
     cd .. && \
     rm -rf mbedtls-2.16.2
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/azure-pipelines/docker/entrypoint.sh
+++ b/azure-pipelines/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+useradd --shell /bin/bash --create-home libgit2
+chown -R $(id -u libgit2) /home/libgit2
+exec gosu libgit2 "$@"

--- a/azure-pipelines/docker/xenial
+++ b/azure-pipelines/docker/xenial
@@ -9,6 +9,7 @@ RUN echo 'deb http://ppa.launchpad.net/hola-launchpad/valgrind/ubuntu xenial mai
         curl \
         gcc \
         git \
+        gosu \
         libcurl4-gnutls-dev \
         libpcre3-dev \
         libssh2-1-dev \
@@ -45,3 +46,8 @@ RUN cd /tmp && \
     ninja install && \
     cd .. && \
     rm -rf libssh2-1.8.2
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod a+x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Right now, all tests in libgit2's CI are being executed as root
user. As libgit2 will usually not run as a root user in "normal"
usecases and furthermore as there are tests that rely on the
ability to _not_ be able to create certain paths, let's instead
create an unprivileged user "libgit2" and use that across all
docker images.