### PR TITLE
valgrind: suppress memory leaks in libssh2_session_handshake

### DIFF
--- a/script/valgrind.supp
+++ b/script/valgrind.supp
@@ -56,6 +56,15 @@
 }
 
 {
+	ignore-libssh2-init
+	Memcheck:Leak
+	...
+	fun:gcry_control
+	fun:libssh2_init
+	...
+}
+
+{
 	ignore-libssh2-gcrypt-control-leak
 	Memcheck:Leak
 	...
@@ -101,6 +110,17 @@
 	...
 	fun:gcry_pk_sign
 	obj:*libssh2.so*
+}
+
+{
+	ignore-libssh2-gcrypt-session-handshake
+	Memcheck:Leak
+	...
+	obj:*libgcrypt.so*
+	obj:*libssh2.so*
+	obj:*libssh2.so*
+	fun:libssh2_session_handshake
+	...
 }
 
 {


### PR DESCRIPTION
On Ubuntu, the combination of libgcrypt and libssh2 is quite old and
known to contain memory leaks. We thus have several functions listed in
our suppressions file that are known to leak. Due to a recent update of
libssh2 or libgcrypt, there now is a new memory leak caused by
libssh2_session_handshake that causes the CI to fail.

Add a new suppression to fix the issue.