### PR TITLE
Don't use enum for flags

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -122,8 +122,8 @@ typedef enum {
 typedef struct {
 	int version;
 
-	/** Flags to control the filtering process */
-	git_blob_filter_flag_t flags;
+	/** Flags to control the filtering process, see `git_blob_filter_flag_t` above */
+	uint32_t flags;
 } git_blob_filter_options;
 
 #define GIT_BLOB_FILTER_OPTIONS_VERSION 1

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -1378,7 +1378,8 @@ typedef enum {
 typedef struct {
 	unsigned int version;
 
-	git_diff_format_email_flags_t flags;
+	/** see `git_diff_format_email_flags_t` above */
+	uint32_t flags;
 
 	/** This patch number */
 	size_t patch_no;
@@ -1435,7 +1436,7 @@ GIT_EXTERN(int) git_diff_commit_as_email(
 	git_commit *commit,
 	size_t patch_no,
 	size_t total_patches,
-	git_diff_format_email_flags_t flags,
+	uint32_t flags,
 	const git_diff_options *diff_opts);
 
 /**

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -192,7 +192,7 @@ typedef struct {
 	git_merge_file_favor_t favor;
 
 	/** see `git_merge_file_flag_t` above */
-	git_merge_file_flag_t flags;
+	uint32_t flags;
 
 	/** The size of conflict markers (eg, "<<<<<<<").  Default is
 	 * GIT_MERGE_CONFLICT_MARKER_SIZE. */
@@ -247,7 +247,7 @@ typedef struct {
 	unsigned int version;
 
 	/** See `git_merge_flag_t` above */
-	git_merge_flag_t flags;
+	uint32_t flags;
 
 	/**
 	 * Similarity to consider a file renamed (default 50).  If
@@ -291,7 +291,7 @@ typedef struct {
 	git_merge_file_favor_t file_favor;
 
 	/** see `git_merge_file_flag_t` above */
-	git_merge_file_flag_t file_flags;
+	uint32_t file_flags;
 } git_merge_options;
 
 #define GIT_MERGE_OPTIONS_VERSION 1

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -127,7 +127,7 @@ typedef struct git_stash_apply_options {
 	unsigned int version;
 
 	/** See `git_stash_apply_flags_t`, above. */
-	git_stash_apply_flags flags;
+	uint32_t flags;
 
 	/** Options to use when writing files to the working directory. */
 	git_checkout_options checkout_options;

--- a/src/diff.c
+++ b/src/diff.c
@@ -323,7 +323,7 @@ int git_diff_commit_as_email(
 	git_commit *commit,
 	size_t patch_no,
 	size_t total_patches,
-	git_diff_format_email_flags_t flags,
+	uint32_t flags,
 	const git_diff_options *diff_opts)
 {
 	git_diff *diff = NULL;


### PR DESCRIPTION
Using an `enum` causes trouble when used with C++ as bitwise operations are not possible w/o casting (e.g., `opts.flags &= ~GIT_BLOB_FILTER_CHECK_FOR_BINARY;` is invalid as there is no `&=` operator for `enum`).

I'm unsure whether `uint32_t` is a good way, because then I get "signed/unsigned" warnings in the case above - no warnigns would be generated with a plain `int` (cf. the following is needed with `uint32_t`: `opts.flags &= ~static_cast<uint32_t>(GIT_BLOB_FILTER_CHECK_FOR_BINARY);`).