### PR TITLE
Provide flags to limit config file lookup when open a repository

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -142,6 +142,26 @@ typedef enum {
 	 * $GIT_WORK_TREE or $GIT_COMMON_DIR is set.
 	 */
 	GIT_REPOSITORY_OPEN_FROM_ENV  = (1 << 4),
+
+	/**
+	 * Bypass lookup for GIT_CONFIG_FILENAME_GLOBAL
+	 */
+	GIT_REPOSITORY_OPEN_NO_GLOBAL_CONFIG = (1 << 5),
+
+	/**
+	 * Bypass lookup for GIT_CONFIG_FILENAME_SYSTEM
+	 */
+	GIT_REPOSITORY_OPEN_NO_SYSTEM_CONFIG = (1 << 6),
+
+	/**
+	 * Bypass lookup for GIT_CONFIG_FILENAME_XDG
+	 */
+	GIT_REPOSITORY_OPEN_NO_XDG_CONFIG = (1 << 7),
+
+	/**
+	 * Bypass lookup for GIT_CONFIG_FILENAME_PROGRAMDATA
+	 */
+	GIT_REPOSITORY_OPEN_NO_PROGRAMDATA_CONFIG = (1 << 8),
 } git_repository_open_flag_t;
 
 /**

--- a/src/repository.h
+++ b/src/repository.h
@@ -150,6 +150,8 @@ struct git_repository {
 	unsigned is_bare:1;
 	unsigned is_worktree:1;
 
+	uint32_t open_flags;
+
 	unsigned int lru_counter;
 
 	git_atomic attr_session_key;


### PR DESCRIPTION
By supporting specifiying config file locations, we minimize filesystem
calls to check if config file exists. This optimization helps when
repositories reside on network storage.