### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Table of Contents
 * [Initialization](#initialization)
 * [Threading](#threading)
 * [Conventions](#conventions)
+* [Building libgit2 - Using vcpkg](#building-libgit2---using-vcpkg)
 * [Building libgit2 - Using CMake](#building-libgit2---using-cmake)
     * [Building](#building)
     * [Installation](#installation)
@@ -179,6 +180,19 @@ Conventions
 
 See [conventions](docs/conventions.md) for an overview of the external
 and internal API/coding conventions we use.
+
+Building libgit2 - Using vcpkg
+==============================
+
+You can download and install libgit2 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install libgit2
+
+The libgit2 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 Building libgit2 - Using CMake
 ==============================


### PR DESCRIPTION
libgit2 is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for libgit2 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libgit2, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libgit2/portfile.cmake). We try to keep the library maintained as close as possible to the original library.