### PR TITLE
patch_parse: handle patches with new empty files

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -406,6 +406,7 @@ static const parse_header_transition transitions[] = {
 	/* Next patch */
 	{ "diff --git "         , STATE_END,        0,                NULL },
 	{ "@@ -"                , STATE_END,        0,                NULL },
+	{ "-- "                 , STATE_INDEX,      0,                NULL },
 	{ "-- "                 , STATE_END,        0,                NULL },
 };
 

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -78,6 +78,26 @@ void test_diff_parse__exact_rename(void)
 	git_diff_free(diff);
 }
 
+void test_diff_parse__empty_file(void)
+{
+	const char *content =
+	    "---\n"
+	    " file | 0\n"
+	    " 1 file changed, 0 insertions(+), 0 deletions(-)\n"
+	    " created mode 100644 file\n"
+	    "\n"
+	    "diff --git a/file b/file\n"
+	    "new file mode 100644\n"
+	    "index 0000000..e69de29\n"
+	    "-- \n"
+	    "2.20.1\n";
+	git_diff *diff;
+
+	cl_git_pass(git_diff_from_buffer(
+		&diff, content, strlen(content)));
+	git_diff_free(diff);
+}
+
 void test_diff_parse__invalid_patches_fails(void)
 {
 	test_parse_invalid_diff(PATCH_CORRUPT_MISSING_NEW_FILE);


### PR DESCRIPTION
Patches containing additions of empty files will not contain diff data
but will end with the index header line followed by the terminating
sequence "-- ". We follow the same logic as in cc4c44a and allow "-- "
to immediately follow the index header.