### PR TITLE
tests: add allocator with limited number of bytes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ ADD_DEFINITIONS(-DGIT_DEPRECATE_HARD)
 
 INCLUDE_DIRECTORIES(${CLAR_PATH} ${libgit2_BINARY_DIR}/src)
 FILE(GLOB_RECURSE SRC_TEST ${CLAR_PATH}/*/*.c ${CLAR_PATH}/*/*.h)
-SET(SRC_CLAR "main.c" "clar_libgit2.c" "clar_libgit2_trace.c" "clar_libgit2_timer.c" "clar.c")
+SET(SRC_CLAR "main.c" "clar_libgit2.c" "clar_libgit2_alloc.c" "clar_libgit2_trace.c" "clar_libgit2_timer.c" "clar.c")
 
 IF(MSVC_IDE)
 	LIST(APPEND SRC_CLAR "precompiled.c")

--- a/tests/clar_libgit2_alloc.c
+++ b/tests/clar_libgit2_alloc.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "clar_libgit2_alloc.h"
+
+static size_t bytes_available;
+
+/*
+ * The clar allocator uses a tagging mechanism for pointers that
+ * prepends the actual pointer's number bytes as `size_t`.
+ *
+ * First, this is required in order to be able to implement
+ * proper bookkeeping of allocated bytes in both `free` and
+ * `realloc`.
+ *
+ * Second, it may also be able to spot bugs that are
+ * otherwise hard to grasp, as the returned pointer cannot be
+ * free'd directly via free(3P). Instead, one is forced to use
+ * the tandem of `cl__malloc` and `cl__free`, as otherwise the
+ * code is going to crash hard. This is considered to be a
+ * feature, as it helps e.g. in finding cases where by accident
+ * malloc(3P) and free(3P) were used instead of git__malloc and
+ * git__free, respectively.
+ *
+ * The downside is obviously that each allocation grows by
+ * sizeof(size_t) bytes. As the allocator is for testing purposes
+ * only, this tradeoff is considered to be perfectly fine,
+ * though.
+ */
+
+static void *cl__malloc(size_t len, const char *file, int line)
+{
+	char *ptr = NULL;
+	size_t alloclen;
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	if (len > bytes_available)
+		goto out;
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, len, sizeof(size_t)) ||
+	    (ptr = malloc(alloclen)) == NULL)
+		goto out;
+	memcpy(ptr, &len, sizeof(size_t));
+
+	bytes_available -= len;
+
+out:
+	if (!ptr)
+		git_error_set_oom();
+	return ptr ? ptr + sizeof(size_t) : NULL;
+}
+
+static void cl__free(void *ptr)
+{
+	if (ptr) {
+		char *p = ptr;
+		size_t len;
+		memcpy(&len, p - sizeof(size_t), sizeof(size_t));
+		free(p - sizeof(size_t));
+		bytes_available += len;
+	}
+}
+
+static void *cl__calloc(size_t nelem, size_t elsize, const char *file, int line)
+{
+	void *ptr = NULL;
+	size_t len;
+
+	if (GIT_MULTIPLY_SIZET_OVERFLOW(&len, nelem, elsize))
+		goto out;
+	if ((ptr = cl__malloc(len, file, line)) == NULL)
+		goto out;
+	memset(ptr, 0, len);
+
+out:
+	if (!ptr) git_error_set_oom();
+	return ptr;
+}
+
+static char *cl__strndup(const char *str, size_t n, const char *file, int line)
+{
+	size_t length = 0, alloclength;
+	char *ptr;
+
+	length = p_strnlen(str, n);
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclength, length, 1) ||
+	    (ptr = cl__malloc(alloclength, file, line)) == NULL)
+		return NULL;
+
+	if (length)
+		memcpy(ptr, str, length);
+
+	ptr[length] = '\0';
+
+	return ptr;
+}
+
+static char *cl__strdup(const char *str, const char *file, int line)
+{
+	return cl__strndup(str, strlen(file), file, line);
+}
+
+static char *cl__substrdup(const char *start, size_t n, const char *file, int line)
+{
+	char *ptr;
+	size_t alloclen;
+
+	if (GIT_ADD_SIZET_OVERFLOW(&alloclen, n, 1) ||
+		!(ptr = cl__malloc(alloclen, file, line)))
+		return NULL;
+
+	memcpy(ptr, start, n);
+	ptr[n] = '\0';
+	return ptr;
+}
+
+static void *cl__realloc(void *ptr, size_t size, const char *file, int line)
+{
+	size_t copybytes = 0;
+	char *p = ptr;
+	void *new;
+
+	if (p)
+		memcpy(&copybytes, p - sizeof(size_t), sizeof(size_t));
+	if (copybytes > size)
+		copybytes = size;
+
+	if ((new = cl__malloc(size, file, line)) == NULL)
+		goto out;
+	memcpy(new, p, copybytes);
+	cl__free(p);
+
+out:
+	if (!new) git_error_set_oom();
+	return new;
+}
+
+static void *cl__reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
+{
+	size_t newsize;
+	if (GIT_MULTIPLY_SIZET_OVERFLOW(&newsize, nelem, elsize))
+		return NULL;
+	return cl__realloc(ptr, newsize, file, line);
+}
+
+static void *cl__mallocarray(size_t nelem, size_t elsize, const char *file, int line)
+{
+	return cl__reallocarray(NULL, nelem, elsize, file, line);
+}
+
+void cl_alloc_limit(size_t bytes)
+{
+	git_allocator alloc;
+
+	alloc.gmalloc = cl__malloc;
+	alloc.gcalloc = cl__calloc;
+	alloc.gstrdup = cl__strdup;
+	alloc.gstrndup = cl__strndup;
+	alloc.gsubstrdup = cl__substrdup;
+	alloc.grealloc = cl__realloc;
+	alloc.greallocarray = cl__reallocarray;
+	alloc.gmallocarray = cl__mallocarray;
+	alloc.gfree = cl__free;
+
+	git_allocator_setup(&alloc);
+
+	bytes_available = bytes;
+}
+
+void cl_alloc_reset(void)
+{
+	git_allocator stdalloc;
+	git_stdalloc_init_allocator(&stdalloc);
+	git_allocator_setup(&stdalloc);
+}

--- a/tests/clar_libgit2_alloc.h
+++ b/tests/clar_libgit2_alloc.h
@@ -1,0 +1,11 @@
+#ifndef __CLAR_LIBGIT2_ALLOC__
+#define __CLAR_LIBGIT2_ALLOC__
+
+#include "clar.h"
+#include "common.h"
+#include "git2/sys/alloc.h"
+
+void cl_alloc_limit(size_t bytes);
+void cl_alloc_reset(void);
+
+#endif

--- a/tests/core/alloc.c
+++ b/tests/core/alloc.c
@@ -1,0 +1,93 @@
+#include "clar_libgit2.h"
+#include "clar_libgit2_alloc.h"
+#include "alloc.h"
+#include "global.h"
+
+void test_core_alloc__initialize(void)
+{
+	/*
+	 * This here is probably not quite obvious. If executing
+	 * libgit2_clar -score::alloc, then the allocation tests
+	 * are the first to get executed. Thus, we do not yet
+	 * have encountered any errors yet, and thus there is no
+	 * global state allocated yet.
+	 *
+	 * Now for the funny thing: if the first error that we
+	 * encounter is an out-of-memory error, then we call
+	 * `git_error_set_oom`. This again calls `GIT_GLOBAL`,
+	 * which requests the current global state. If there is
+	 * none, then we try to allocate one. Guess what? We're
+	 * out of memory, so this fails and we call
+	 * `git_error_set_oom`. Ad infinitum, until we crash
+	 * because of recursion.
+	 *
+	 * This is why we just explicitly request the global
+	 * state now.
+	 */
+	GIT_GLOBAL;
+}
+
+void test_core_alloc__cleanup(void)
+{
+	cl_alloc_reset();
+}
+
+void test_core_alloc__oom(void)
+{
+	void *ptr = NULL;
+
+	cl_alloc_limit(0);
+
+	cl_assert(git__malloc(1) == NULL);
+	cl_assert(git__calloc(1, 1) == NULL);
+	cl_assert(git__realloc(ptr, 1) == NULL);
+	cl_assert(git__strdup("test") == NULL);
+	cl_assert(git__strndup("test", 4) == NULL);
+}
+
+void test_core_alloc__single_byte_is_exhausted(void)
+{
+	void *ptr;
+
+	cl_alloc_limit(1);
+
+	cl_assert(ptr = git__malloc(1));
+	cl_assert(git__malloc(1) == NULL);
+	git__free(ptr);
+}
+
+void test_core_alloc__free_replenishes_byte(void)
+{
+	void *ptr;
+
+	cl_alloc_limit(1);
+
+	cl_assert(ptr = git__malloc(1));
+	cl_assert(git__malloc(1) == NULL);
+	git__free(ptr);
+	cl_assert(ptr = git__malloc(1));
+	git__free(ptr);
+}
+
+void test_core_alloc__realloc(void)
+{
+	char *ptr = NULL;
+
+	cl_alloc_limit(3);
+
+	cl_assert(ptr = git__realloc(ptr, 1));
+	*ptr = 'x';
+
+	cl_assert(ptr = git__realloc(ptr, 1));
+	cl_assert_equal_i(*ptr, 'x');
+
+	cl_assert(ptr = git__realloc(ptr, 2));
+	cl_assert_equal_i(*ptr, 'x');
+
+	cl_assert(git__realloc(ptr, 2) == NULL);
+
+	cl_assert(ptr = git__realloc(ptr, 1));
+	cl_assert_equal_i(*ptr, 'x');
+
+	git__free(ptr);
+}

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "clar_libgit2_alloc.h"
 #include "buffer.h"
 #include "buf_text.h"
 #include "git2/sys/hashsig.h"
@@ -1239,4 +1240,16 @@ void test_core_buffer__avoid_printing_into_oom_buffer(void)
 	 * just print into the `git_buf__oom` array.
 	 */
 	cl_git_fail(git_buf_puts(&buf, "foobar"));
+}
+
+void test_core_buffer__allocation_failure(void)
+{
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_alloc_limit(10);
+
+	cl_git_pass(git_buf_puts(&buf, "foobar"));
+	cl_git_fail(git_buf_puts(&buf, "foobar"));
+
+	cl_alloc_reset();
 }


### PR DESCRIPTION
In several circumstances, we get bug reports about things that happen in
situations where the environment is quite limited with regards to
available memory. While it's expected that functionality will fail if
memory allocations fail, the assumption is that we should do so in a
controlled way. Most importantly, we do not want to crash hard due to
e.g. accessing NULL pointers.

Naturally, it is quite hard to debug such situations. But since our
addition of pluggable allocators, we are able to implement allocators
that fail in deterministic ways, e.g. after a certain amount of bytes
has been allocated. This commit does exactly that.

To be able to properly keep track of the amount of bytes currently
allocated, allocated pointers contain tracking information. This
tracking information is currently limited to the number of bytes
allocated, so that we can correctly replenish them on calling `free` on
the pointer. In the future, it would be feasible to extend the tracked
information even further, e.g. by adding information about file and line
where the allocation has been performed. As this introduced some
overhead to allocations though, only information essential to limited
allocations is currently tracked.