### PR TITLE
Allow revwalk to traverse shallow clones

### DIFF
--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -441,6 +441,11 @@ static int still_interesting(git_commit_list *list, int64_t time, int slop)
 	return slop - 1;
 }
 
+static int expected_fail(git_commit *commit) {
+	//TODO: Check commit is in $GIT_DIR/.git/shallow
+	return 1;
+}
+
 static int limit_list(git_commit_list **out, git_revwalk *walk, git_commit_list *commits)
 {
 	int error, slop = SLOP;
@@ -452,8 +457,10 @@ static int limit_list(git_commit_list **out, git_revwalk *walk, git_commit_list 
 	while (list) {
 		git_commit_list_node *commit = git_commit_list_pop(&list);
 
-		if ((error = add_parents_to_list(walk, commit, &list)) < 0)
-			return error;
+		if ((error = add_parents_to_list(walk, commit, &list)) < 0) {
+			if (!expected_fail(commit))
+				return error;
+		}
 
 		if (commit->uninteresting) {
 			mark_parents_uninteresting(commit);


### PR DESCRIPTION
This patch allow to traverse shallow clones.
```
mkdir build
cmake -DBUILD_EXAMPLES=ON -DBUILD_SHARED_LIBS=ON -DTHREADSAFE=ON ..
make
cd build/examples
git clone --depth 5 https://github.com/libgit2/libgit2 shallow-clone
cd shallow-clone
../lg2 log
commit ef5a3851fdece852569ffebf3537883223744a7a
Merge: 1f9b497 3335a03
Author: Patrick Steinhardt <ps@pks.im>
Date:   Fri Oct 11 07:47:17 2019 +0200

    Merge pull request #5257 from henkesn/master
    
    Fix file locking on POSIX OS

commit 1f9b4970c5227909aedd79249eae16585712343f
Merge: 6716e2f ebabb88
Author: Patrick Steinhardt <ps@pks.im>
Date:   Fri Oct 11 07:44:10 2019 +0200

    Merge pull request #5260 from pks-t/pks/cmake3
    
    cmake: update minimum CMake version to v3.5.1
...
```

That will show 5 commits from master and a bunch of parents from them (not showed all to avoid noise). That match with

```
git log --graph --oneline --decorate --all
*   ef5a385 (HEAD -> master, origin/master, origin/HEAD) Merge pull request #5257 from henkesn/master
|\  
* \   1f9b497 Merge pull request #5260 from pks-t/pks/cmake3
|\ \  
| | * 3335a03 refs: fix locks getting forcibly removed
* | |   6716e2f Merge pull request #5248 from dlax/parse-patch-empty-files
|\ \ \  
| |_|/  
|/| |   
| | * ebabb88 cmake: update minimum CMake version to v3.5.1
| |/  
|/|   
* |   f04a58b Merge pull request #4445 from tiennou/shallow/dry-commit-parsing
|\ \  
| * | 5cf17e0 commit_list: store in/out-degrees as uint16_t
| * | 5988cf3 (grafted) commit_list: unify commit information parsing
|  /  
* |   0ec0b2b Merge pull request #5239 from pks-t/pks/docker-non-root-builds
|\ \  
* | | 63307cb (grafted) Merge pull request #5226 from pks-t/pks/regexp-api
 / /  
| * b61810b patch_parse: handle patches with new empty files
| * 7032537 (grafted) Merge pull request #5106 from tiennou/fix/ref-api-fixes
* 3c884cc (grafted) azure: avoid building and testing in Docker as root
```

Basically implement the @arthurschreiber comment https://github.com/libgit2/libgit2/issues/3058#issuecomment-94212516

TODO:

- [ ] parse <GIT_DIR>/.git/shallow and confirm that parents not finded are expected

I'm not sure if there're corner cases as don't know much about .git/shallow structure.

seems it basically grafted all parents from 5 last comments   (or something like that)

```
$ cat .git/shallow 
3c884cc31a13f63f3d4095e1c7fcf11e003fb019
5988cf34f0c77a426510c3bff665fd8a1e8cceb9
63307cbad7408b38693e73b74560a063da21f530
70325370667370159d5b85690c6dd5db17be3b20
```

Relates to #3058 