### PR TITLE
patch_parse: handle patches without extended headers

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -389,6 +389,7 @@ static const parse_header_transition transitions[] = {
 	{ "index "              , STATE_DIFF,       STATE_INDEX,      parse_header_git_index },
 	{ "index "              , STATE_END,        STATE_INDEX,      parse_header_git_index },
 
+	{ "--- "                , STATE_DIFF,       STATE_PATH,       parse_header_git_oldpath },
 	{ "--- "                , STATE_INDEX,      STATE_PATH,       parse_header_git_oldpath },
 	{ "+++ "                , STATE_PATH,       STATE_END,        parse_header_git_newpath },
 	{ "GIT binary patch"    , STATE_INDEX,      STATE_END,        NULL },

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -98,6 +98,16 @@ void test_diff_parse__empty_file(void)
 	git_diff_free(diff);
 }
 
+void test_diff_parse__no_extended_headers(void)
+{
+	const char *content = PATCH_NO_EXTENDED_HEADERS;
+	git_diff *diff;
+
+	cl_git_pass(git_diff_from_buffer(
+		&diff, content, strlen(content)));
+	git_diff_free(diff);
+}
+
 void test_diff_parse__invalid_patches_fails(void)
 {
 	test_parse_invalid_diff(PATCH_CORRUPT_MISSING_NEW_FILE);

--- a/tests/patch/patch_common.h
+++ b/tests/patch/patch_common.h
@@ -895,3 +895,13 @@
 	"+++ b/test-file\r\n" \
 	"@@ -0,0 +1 @@\r\n" \
 	"+a contents\r\n"
+
+#define PATCH_NO_EXTENDED_HEADERS \
+	"diff --git a/file b/file\n" \
+	"--- a/file\n" \
+	"+++ b/file\n" \
+	"@@ -1,3 +1,3 @@\n" \
+	" a\n" \
+	"-b\n" \
+	"+bb\n" \
+	" c\n"


### PR DESCRIPTION
Extended header lines (especially the "index <hash>..<hash> <mode>") are
not required by "git apply" so it import patches. So we allow the
from-file/to-file lines (--- a/file\n+++ b/file) to directly follow the
git diff header.

This fixes #5267.