### PR TITLE
config_file: fix race when creating an iterator

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -250,17 +250,19 @@ static int config_file_iterator(
 	struct git_config_backend *backend)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(backend, config_file_backend, parent);
-	git_config_entries *entries = NULL;
+	git_config_entries *dupped = NULL, *entries = NULL;
 	int error;
 
 	if ((error = config_file_refresh(backend)) < 0 ||
-	    (error = git_config_entries_dup(&entries, b->entries)) < 0 ||
-	    (error = git_config_entries_iterator_new(iter, entries)) < 0)
+	    (error = config_file_entries_take(&entries, b)) < 0 ||
+	    (error = git_config_entries_dup(&dupped, entries)) < 0 ||
+	    (error = git_config_entries_iterator_new(iter, dupped)) < 0)
 		goto out;
 
 out:
 	/* Let iterator delete duplicated entries when it's done */
 	git_config_entries_free(entries);
+	git_config_entries_free(dupped);
 	return error;
 }
 

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -9,22 +9,16 @@
 
 #include "git2/config.h"
 #include "git2/sys/config.h"
-#include "git2/types.h"
 
 #include "array.h"
-#include "buf_text.h"
 #include "buffer.h"
 #include "config_backend.h"
 #include "config_entries.h"
 #include "config_parse.h"
 #include "filebuf.h"
 #include "regexp.h"
-#include "strmap.h"
 #include "sysdir.h"
 #include "wildmatch.h"
-
-#include <ctype.h>
-#include <sys/types.h>
 
 /* Max depth for [include] directives */
 #define MAX_INCLUDE_DEPTH 10

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -60,9 +60,9 @@ typedef struct {
 	unsigned int depth;
 } config_file_parse_data;
 
-static int config_read(git_config_entries *entries, const git_repository *repo, config_file *file, git_config_level_t level, int depth);
-static int config_read_buffer(git_config_entries *entries, const git_repository *repo, config_file *file, git_config_level_t level, int depth, const char *buf, size_t buflen);
-static int config_write(config_file_backend *cfg, const char *orig_key, const char *key, const git_regexp *preg, const char *value);
+static int config_file_read(git_config_entries *entries, const git_repository *repo, config_file *file, git_config_level_t level, int depth);
+static int config_file_read_buffer(git_config_entries *entries, const git_repository *repo, config_file *file, git_config_level_t level, int depth, const char *buf, size_t buflen);
+static int config_file_write(config_file_backend *cfg, const char *orig_key, const char *key, const git_regexp *preg, const char *value);
 static char *escape_value(const char *ptr);
 
 /**
@@ -70,7 +70,7 @@ static char *escape_value(const char *ptr);
  * refcount. This is its own function to make sure we use the mutex to
  * avoid the map pointer from changing under us.
  */
-static git_config_entries *diskfile_entries_take(config_file_backend *b)
+static git_config_entries *config_file_entries_take(config_file_backend *b)
 {
 	git_config_entries *entries;
 
@@ -103,7 +103,7 @@ static void config_file_clear(config_file *file)
 	git__free(file->path);
 }
 
-static int config_open(git_config_backend *cfg, git_config_level_t level, const git_repository *repo)
+static int config_file_open(git_config_backend *cfg, git_config_level_t level, const git_repository *repo)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	int res;
@@ -117,7 +117,7 @@ static int config_open(git_config_backend *cfg, git_config_level_t level, const 
 	if (!git_path_exists(b->file.path))
 		return 0;
 
-	if (res < 0 || (res = config_read(b->entries, repo, &b->file, level, 0)) < 0) {
+	if (res < 0 || (res = config_file_read(b->entries, repo, &b->file, level, 0)) < 0) {
 		git_config_entries_free(b->entries);
 		b->entries = NULL;
 	}
@@ -125,7 +125,7 @@ static int config_open(git_config_backend *cfg, git_config_level_t level, const 
 	return res;
 }
 
-static int config_is_modified(int *modified, config_file *file)
+static int config_file_is_modified(int *modified, config_file *file)
 {
 	config_file *include;
 	git_buf buf = GIT_BUF_INIT;
@@ -151,7 +151,7 @@ static int config_is_modified(int *modified, config_file *file)
 
 check_includes:
 	git_array_foreach(file->includes, i, include) {
-		if ((error = config_is_modified(modified, include)) < 0 || *modified)
+		if ((error = config_file_is_modified(modified, include)) < 0 || *modified)
 			goto out;
 	}
 
@@ -161,7 +161,7 @@ out:
 	return error;
 }
 
-static int config_set_entries(git_config_backend *cfg, git_config_entries *entries)
+static int config_file_set_entries(git_config_backend *cfg, git_config_entries *entries)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *old = NULL;
@@ -193,16 +193,16 @@ out:
 	return error;
 }
 
-static int config_refresh_from_buffer(git_config_backend *cfg, const char *buf, size_t buflen)
+static int config_file_refresh_from_buffer(git_config_backend *cfg, const char *buf, size_t buflen)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries = NULL;
 	int error;
 
 	if ((error = git_config_entries_new(&entries)) < 0 ||
-	    (error = config_read_buffer(entries, b->repo, &b->file,
-					b->level, 0, buf, buflen)) < 0 ||
-	    (error = config_set_entries(cfg, entries)) < 0)
+	    (error = config_file_read_buffer(entries, b->repo, &b->file,
+					     b->level, 0, buf, buflen)) < 0 ||
+	    (error = config_file_set_entries(cfg, entries)) < 0)
 		goto out;
 
 	entries = NULL;
@@ -211,7 +211,7 @@ out:
 	return error;
 }
 
-static int config_refresh(git_config_backend *cfg)
+static int config_file_refresh(git_config_backend *cfg)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries = NULL;
@@ -220,15 +220,15 @@ static int config_refresh(git_config_backend *cfg)
 	if (cfg->readonly)
 		return 0;
 
-	if ((error = config_is_modified(&modified, &b->file)) < 0 && error != GIT_ENOTFOUND)
+	if ((error = config_file_is_modified(&modified, &b->file)) < 0 && error != GIT_ENOTFOUND)
 		goto out;
 
 	if (!modified)
 		return 0;
 
 	if ((error = git_config_entries_new(&entries)) < 0 ||
-	    (error = config_read(entries, b->repo, &b->file, b->level, 0)) < 0 ||
-	    (error = config_set_entries(cfg, entries)) < 0)
+	    (error = config_file_read(entries, b->repo, &b->file, b->level, 0)) < 0 ||
+	    (error = config_file_set_entries(cfg, entries)) < 0)
 		goto out;
 
 	entries = NULL;
@@ -238,7 +238,7 @@ out:
 	return (error == GIT_ENOTFOUND) ? 0 : error;
 }
 
-static void backend_free(git_config_backend *_backend)
+static void config_file_free(git_config_backend *_backend)
 {
 	config_file_backend *backend = GIT_CONTAINER_OF(_backend, config_file_backend, parent);
 
@@ -251,7 +251,7 @@ static void backend_free(git_config_backend *_backend)
 	git__free(backend);
 }
 
-static int config_iterator_new(
+static int config_file_iterator(
 	git_config_iterator **iter,
 	struct git_config_backend *backend)
 {
@@ -259,7 +259,7 @@ static int config_iterator_new(
 	git_config_entries *entries = NULL;
 	int error;
 
-	if ((error = config_refresh(backend)) < 0 ||
+	if ((error = config_file_refresh(backend)) < 0 ||
 	    (error = git_config_entries_dup(&entries, b->entries)) < 0 ||
 	    (error = git_config_entries_iterator_new(iter, entries)) < 0)
 		goto out;
@@ -270,7 +270,12 @@ out:
 	return error;
 }
 
-static int config_set(git_config_backend *cfg, const char *name, const char *value)
+static int config_file_snapshot(git_config_backend **out, git_config_backend *backend)
+{
+	return git_config_backend_snapshot(out, backend);
+}
+
+static int config_file_set(git_config_backend *cfg, const char *name, const char *value)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries;
@@ -281,7 +286,7 @@ static int config_set(git_config_backend *cfg, const char *name, const char *val
 	if ((error = git_config__normalize_name(name, &key)) < 0)
 		return error;
 
-	if ((entries = diskfile_entries_take(b)) == NULL)
+	if ((entries = config_file_entries_take(b)) == NULL)
 		return -1;
 
 	/* Check whether we'd be modifying an included or multivar key */
@@ -302,7 +307,7 @@ static int config_set(git_config_backend *cfg, const char *name, const char *val
 		GIT_ERROR_CHECK_ALLOC(esc_value);
 	}
 
-	if ((error = config_write(b, name, key, NULL, esc_value)) < 0)
+	if ((error = config_file_write(b, name, key, NULL, esc_value)) < 0)
 		goto out;
 
 out:
@@ -313,7 +318,7 @@ out:
 }
 
 /* release the map containing the entry as an equivalent to freeing it */
-static void free_diskfile_entry(git_config_entry *entry)
+static void config_file_entry_free(git_config_entry *entry)
 {
 	git_config_entries *entries = (git_config_entries *) entry->payload;
 	git_config_entries_free(entries);
@@ -322,17 +327,17 @@ static void free_diskfile_entry(git_config_entry *entry)
 /*
  * Internal function that actually gets the value in string form
  */
-static int config_get(git_config_backend *cfg, const char *key, git_config_entry **out)
+static int config_file_get(git_config_backend *cfg, const char *key, git_config_entry **out)
 {
 	config_file_backend *h = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries = NULL;
 	git_config_entry *entry;
 	int error = 0;
 
-	if (!h->parent.readonly && ((error = config_refresh(cfg)) < 0))
+	if (!h->parent.readonly && ((error = config_file_refresh(cfg)) < 0))
 		return error;
 
-	if ((entries = diskfile_entries_take(h)) == NULL)
+	if ((entries = config_file_entries_take(h)) == NULL)
 		return -1;
 
 	if ((error = (git_config_entries_get(&entry, entries, key))) < 0) {
@@ -340,14 +345,14 @@ static int config_get(git_config_backend *cfg, const char *key, git_config_entry
 		return error;
 	}
 
-	entry->free = free_diskfile_entry;
+	entry->free = config_file_entry_free;
 	entry->payload = entries;
 	*out = entry;
 
 	return 0;
 }
 
-static int config_set_multivar(
+static int config_file_set_multivar(
 	git_config_backend *cfg, const char *name, const char *regexp, const char *value)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
@@ -363,8 +368,8 @@ static int config_set_multivar(
 	if ((result = git_regexp_compile(&preg, regexp, 0)) < 0)
 		goto out;
 
-	/* If we do have it, set call config_write() and reload */
-	if ((result = config_write(b, name, key, &preg, value)) < 0)
+	/* If we do have it, set call config_file_write() and reload */
+	if ((result = config_file_write(b, name, key, &preg, value)) < 0)
 		goto out;
 
 out:
@@ -374,7 +379,7 @@ out:
 	return result;
 }
 
-static int config_delete(git_config_backend *cfg, const char *name)
+static int config_file_delete(git_config_backend *cfg, const char *name)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries = NULL;
@@ -385,7 +390,7 @@ static int config_delete(git_config_backend *cfg, const char *name)
 	if ((error = git_config__normalize_name(name, &key)) < 0)
 		goto out;
 
-	if ((entries = diskfile_entries_take(b)) == NULL)
+	if ((entries = config_file_entries_take(b)) == NULL)
 		goto out;
 
 	/* Check whether we'd be modifying an included or multivar key */
@@ -395,7 +400,7 @@ static int config_delete(git_config_backend *cfg, const char *name)
 		goto out;
 	}
 
-	if ((error = config_write(b, name, entry->name, NULL, NULL)) < 0)
+	if ((error = config_file_write(b, name, entry->name, NULL, NULL)) < 0)
 		goto out;
 
 out:
@@ -404,7 +409,7 @@ out:
 	return error;
 }
 
-static int config_delete_multivar(git_config_backend *cfg, const char *name, const char *regexp)
+static int config_file_delete_multivar(git_config_backend *cfg, const char *name, const char *regexp)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries = NULL;
@@ -416,7 +421,7 @@ static int config_delete_multivar(git_config_backend *cfg, const char *name, con
 	if ((result = git_config__normalize_name(name, &key)) < 0)
 		goto out;
 
-	if ((entries = diskfile_entries_take(b)) == NULL) {
+	if ((entries = config_file_entries_take(b)) == NULL) {
 		result = -1;
 		goto out;
 	}
@@ -430,7 +435,7 @@ static int config_delete_multivar(git_config_backend *cfg, const char *name, con
 	if ((result = git_regexp_compile(&preg, regexp, 0)) < 0)
 		goto out;
 
-	if ((result = config_write(b, name, key, &preg, NULL)) < 0)
+	if ((result = config_file_write(b, name, key, &preg, NULL)) < 0)
 		goto out;
 
 out:
@@ -440,7 +445,7 @@ out:
 	return result;
 }
 
-static int config_lock(git_config_backend *_cfg)
+static int config_file_lock(git_config_backend *_cfg)
 {
 	config_file_backend *cfg = GIT_CONTAINER_OF(_cfg, config_file_backend, parent);
 	int error;
@@ -459,7 +464,7 @@ static int config_lock(git_config_backend *_cfg)
 
 }
 
-static int config_unlock(git_config_backend *_cfg, int success)
+static int config_file_unlock(git_config_backend *_cfg, int success)
 {
 	config_file_backend *cfg = GIT_CONTAINER_OF(_cfg, config_file_backend, parent);
 	int error = 0;
@@ -490,17 +495,17 @@ int git_config_backend_from_file(git_config_backend **out, const char *path)
 	GIT_ERROR_CHECK_ALLOC(backend->file.path);
 	git_array_init(backend->file.includes);
 
-	backend->parent.open = config_open;
-	backend->parent.get = config_get;
-	backend->parent.set = config_set;
-	backend->parent.set_multivar = config_set_multivar;
-	backend->parent.del = config_delete;
-	backend->parent.del_multivar = config_delete_multivar;
-	backend->parent.iterator = config_iterator_new;
-	backend->parent.snapshot = git_config_backend_snapshot;
-	backend->parent.lock = config_lock;
-	backend->parent.unlock = config_unlock;
-	backend->parent.free = backend_free;
+	backend->parent.open = config_file_open;
+	backend->parent.get = config_file_get;
+	backend->parent.set = config_file_set;
+	backend->parent.set_multivar = config_file_set_multivar;
+	backend->parent.del = config_file_delete;
+	backend->parent.del_multivar = config_file_delete_multivar;
+	backend->parent.iterator = config_file_iterator;
+	backend->parent.snapshot = config_file_snapshot;
+	backend->parent.lock = config_file_lock;
+	backend->parent.unlock = config_file_unlock;
+	backend->parent.free = config_file_free;
 
 	*out = (git_config_backend *)backend;
 
@@ -574,8 +579,8 @@ static int parse_include(config_file_parse_data *parse_data, const char *file)
 	git_array_init(include->includes);
 	include->path = git_buf_detach(&path);
 
-	result = config_read(parse_data->entries, parse_data->repo,
-		include, parse_data->level, parse_data->depth+1);
+	result = config_file_read(parse_data->entries, parse_data->repo, include,
+				  parse_data->level, parse_data->depth+1);
 
 	if (result == GIT_ENOTFOUND) {
 		git_error_clear();
@@ -793,7 +798,7 @@ static int read_on_variable(
 	return result;
 }
 
-static int config_read_buffer(
+static int config_file_read_buffer(
 	git_config_entries *entries,
 	const git_repository *repo,
 	config_file *file,
@@ -833,7 +838,7 @@ out:
 	return error;
 }
 
-static int config_read(
+static int config_file_read(
 	git_config_entries *entries,
 	const git_repository *repo,
 	config_file *file,
@@ -856,8 +861,8 @@ static int config_read(
 	if ((error = git_hash_buf(&file->checksum, contents.ptr, contents.size)) < 0)
 		goto out;
 
-	if ((error = config_read_buffer(entries, repo, file, level, depth,
-					contents.ptr, contents.size)) < 0)
+	if ((error = config_file_read_buffer(entries, repo, file, level, depth,
+					     contents.ptr, contents.size)) < 0)
 		goto out;
 
 out:
@@ -1088,7 +1093,7 @@ static int write_on_eof(
 /*
  * This is pretty much the parsing, except we write out anything we don't have
  */
-static int config_write(config_file_backend *cfg, const char *orig_key, const char *key, const git_regexp *preg, const char* value)
+static int config_file_write(config_file_backend *cfg, const char *orig_key, const char *key, const git_regexp *preg, const char* value)
 
 {
 	char *orig_section = NULL, *section = NULL, *orig_name, *name, *ldot;
@@ -1149,7 +1154,7 @@ static int config_write(config_file_backend *cfg, const char *orig_key, const ch
 		if ((error = git_filebuf_commit(&file)) < 0)
 			goto done;
 
-		if ((error = config_refresh_from_buffer(&cfg->parent, buf.ptr, buf.size)) < 0)
+		if ((error = config_file_refresh_from_buffer(&cfg->parent, buf.ptr, buf.size)) < 0)
 			goto done;
 	}
 


### PR DESCRIPTION
When creating a configuration file iterator, then we first refresh the
backend and then afterwards duplicate all refreshed configuration
entries into the iterator in order to avoid seeing any concurrent
modifications of the entries while iterating. The duplication of entries
is not guarded, though, as we do not increase the refcount of the
entries that we duplicate right now. This opens us up for a race, as
another thread may concurrently refresh the repository configuration and
thus swap out the current set of entries. As we didn't increase the
refcount, this may lead to the entries being free'd while we iterate
over them in the first thread.

Fix the issue by properly handling the lifecycle of the backend's
entries via `config_file_entries_take` and `git_config_entries_free`,
respectively.

---

I think this may be the likely cause of #5281, as it fixes a severe race condition in exactly the code path that #5281 shows.