### PR TITLE
Follow 308 redirect in WinHTTP transport

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -49,6 +49,10 @@
 # define WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2 0x00000800
 #endif
 
+#ifndef HTTP_STATUS_PERMANENT_REDIRECT
+# define HTTP_STATUS_PERMANENT_REDIRECT 308
+#endif
+
 #ifndef DWORD_MAX
 # define DWORD_MAX 0xffffffff
 #endif
@@ -1071,7 +1075,8 @@ replay:
 			 HTTP_STATUS_REDIRECT == status_code ||
 			 (HTTP_STATUS_REDIRECT_METHOD == status_code &&
 			  get_verb == s->verb) ||
-			 HTTP_STATUS_REDIRECT_KEEP_VERB == status_code)) {
+			 HTTP_STATUS_REDIRECT_KEEP_VERB == status_code ||
+			 HTTP_STATUS_PERMANENT_REDIRECT == status_code)) {
 
 			/* Check for Windows 7. This workaround is only necessary on
 			 * Windows Vista and earlier. Windows 7 is version 6.1. */


### PR DESCRIPTION
CC #4675. The issue is closed by #4848 but WinHTTP was forgotten.
The issue caused failures of GitLab repository fetching on Windows.