### PR TITLE
commit: verify objects exist in git_commit_with_signature

### DIFF
--- a/tests/commit/write.c
+++ b/tests/commit/write.c
@@ -299,19 +299,43 @@ void test_commit_write__can_validate_objects(void)
 	cl_git_fail(create_commit_from_ids(&commit_id, &tree_id, &parent_id));
 }
 
+void test_commit_write__attach_signature_checks_objects(void)
+{
+	const char *sig = "magic word: pretty please";
+	const char *badtree =  "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n\
+parent 34734e478d6cf50c27c9d69026d93974d052c454\n\
+author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
+committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
+\n\
+a simple commit which does not work\n";
+
+	const char *badparent =  "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+parent 34734e478d6cf50c27c9d69026d93974d052c454\n\
+author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
+committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
+\n\
+a simple commit which does not work\n";
+
+	git_oid id;
+
+	cl_git_fail_with(-1, git_commit_create_with_signature(&id, g_repo, badtree, sig, "magicsig"));
+	cl_git_fail_with(-1, git_commit_create_with_signature(&id, g_repo, badparent, sig, "magicsig"));
+
+}
+
 void test_commit_write__attach_singleline_signature(void)
 {
 	const char *sig = "magic word: pretty please";
 
-	const char *data =  "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n\
-parent 34734e478d6cf50c27c9d69026d93974d052c454\n\
+	const char *data =  "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+parent 8496071c1b46c854b31185ea97743be6a8774479\n\
 author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 \n\
 a simple commit which works\n";
 
-	const char *complete =  "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n\
-parent 34734e478d6cf50c27c9d69026d93974d052c454\n\
+	const char *complete =  "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+parent 8496071c1b46c854b31185ea97743be6a8774479\n\
 author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 magicsig magic word: pretty please\n\
@@ -352,15 +376,15 @@ cpxtDQQMGYFpXK/71stq\n\
 =ozeK\n\
 -----END PGP SIGNATURE-----";
 
-	const char *data =  "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n\
-parent 34734e478d6cf50c27c9d69026d93974d052c454\n\
+	const char *data =  "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+parent 8496071c1b46c854b31185ea97743be6a8774479\n\
 author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 \n\
 a simple commit which works\n";
 
-const char *complete = "tree 6b79e22d69bf46e289df0345a14ca059dfc9bdf6\n\
-parent 34734e478d6cf50c27c9d69026d93974d052c454\n\
+const char *complete = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+parent 8496071c1b46c854b31185ea97743be6a8774479\n\
 author Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 committer Ben Burkert <ben@benburkert.com> 1358451456 -0800\n\
 gpgsig -----BEGIN PGP SIGNATURE-----\n\


### PR DESCRIPTION
There can be a significant difference between the system where we created the                                                                              
buffer (if at all) and when the caller provides us with the contents of a                                                                                  
commit.

Verify that the commit we are being asked to create references objects which do
exist in the target repository.

This is not terribly efficient since we allocate a commit, but AFAICT it's what we have available. Obviously our test suite fails with these changes because we were creating commits that referenced non-existent trees and commits.

Fixes #5288 