### PR TITLE
patch_parse: fix segfault when header path contains whitespace only

### DIFF
--- a/tests/patch/parse.c
+++ b/tests/patch/parse.c
@@ -156,6 +156,20 @@ void test_patch_parse__binary_file_with_missing_paths(void)
 					  strlen(PATCH_BINARY_FILE_WITH_MISSING_PATHS), NULL));
 }
 
+void test_patch_parse__binary_file_with_whitespace_paths(void)
+{
+	git_patch *patch;
+	cl_git_fail(git_patch_from_buffer(&patch, PATCH_BINARY_FILE_WITH_WHITESPACE_PATHS,
+					  strlen(PATCH_BINARY_FILE_WITH_WHITESPACE_PATHS), NULL));
+}
+
+void test_patch_parse__binary_file_with_empty_quoted_paths(void)
+{
+	git_patch *patch;
+	cl_git_fail(git_patch_from_buffer(&patch, PATCH_BINARY_FILE_WITH_QUOTED_EMPTY_PATHS,
+					  strlen(PATCH_BINARY_FILE_WITH_QUOTED_EMPTY_PATHS), NULL));
+}
+
 void test_patch_parse__memory_leak_on_multiple_paths(void)
 {
 	git_patch *patch;

--- a/tests/patch/patch_common.h
+++ b/tests/patch/patch_common.h
@@ -912,6 +912,18 @@
 	"+++ \n" \
 	"Binary files "
 
+#define PATCH_BINARY_FILE_WITH_WHITESPACE_PATHS \
+	"diff --git a/file b/file\n" \
+	"---  \n" \
+	"+++  \n" \
+	"Binary files "
+
+#define PATCH_BINARY_FILE_WITH_QUOTED_EMPTY_PATHS \
+	"diff --git a/file b/file\n" \
+	"--- \"\"\n" \
+	"+++ \"\"\n" \
+	"Binary files "
+
 #define PATCH_MULTIPLE_OLD_PATHS \
 	"diff --git  \n" \
 	"---  \n" \


### PR DESCRIPTION
When parsing header paths from a patch, we reject any patches with empty
paths as malformed patches. We perform the check whether a path is empty
before sanitizing it, though, which may lead to a path becoming empty
after the check, e.g. if we have trimmed whitespace. This may lead to a
segfault later when any part of our patching logic actually references
such a path, which may then be a `NULL` pointer.

Fix the issue by performing the check after sanitizing. Add tests to
catch the issue as they would have produced a segfault previosuly.