### PR TITLE
config_mem: implement support for snapshots

### DIFF
--- a/src/config_mem.c
+++ b/src/config_mem.c
@@ -170,14 +170,6 @@ static int config_memory_unlock(git_config_backend *backend, int success)
 	return config_error_readonly();
 }
 
-static int config_memory_snapshot(git_config_backend **out, git_config_backend *backend)
-{
-	GIT_UNUSED(out);
-	GIT_UNUSED(backend);
-	git_error_set(GIT_ERROR_CONFIG, "this backend does not support snapshots");
-	return -1;
-}
-
 static void config_memory_free(git_config_backend *_backend)
 {
 	config_memory_backend *backend = (config_memory_backend *)_backend;
@@ -219,7 +211,7 @@ int git_config_backend_from_string(git_config_backend **out, const char *cfg, si
 	backend->parent.iterator = config_memory_iterator;
 	backend->parent.lock = config_memory_lock;
 	backend->parent.unlock = config_memory_unlock;
-	backend->parent.snapshot = config_memory_snapshot;
+	backend->parent.snapshot = git_config_backend_snapshot;
 	backend->parent.free = config_memory_free;
 
 	*out = (git_config_backend *)backend;

--- a/tests/config/snapshot.c
+++ b/tests/config/snapshot.c
@@ -1,5 +1,7 @@
 #include "clar_libgit2.h"
 
+#include "config_backend.h"
+
 static git_config *cfg;
 static git_config *snapshot;
 
@@ -119,4 +121,19 @@ void test_config_snapshot__snapshot(void)
 	git_config_free(snapshot_snapshot);
 
 	cl_git_pass(p_unlink("configfile"));
+}
+
+void test_config_snapshot__snapshot_from_in_memony(void)
+{
+	const char *configuration = "[section]\nkey = 1\n";
+	git_config_backend *backend;
+	int i;
+
+	cl_git_pass(git_config_new(&cfg));
+	cl_git_pass(git_config_backend_from_string(&backend, configuration, strlen(configuration)));
+	cl_git_pass(git_config_add_backend(cfg, backend, 0, NULL, 0));
+
+	cl_git_pass(git_config_snapshot(&snapshot, cfg));
+	cl_git_pass(git_config_get_int32(&i, snapshot, "section.key"));
+	cl_assert_equal_i(i, 1);
 }


### PR DESCRIPTION
Similar as in commit dadbb33b6 (Fix crash if snapshotting a
config_snapshot, 2019-11-01), let's implement snapshots for in-memory
configuration entries. As this deletes more code than it adds, it
doesn't make any sense to not allow for this and allows users to treat
config backends mostly the same.