### PR TITLE
fileops: correct error return on p_lstat failures when mkdir

### DIFF
--- a/src/futils.c
+++ b/src/futils.c
@@ -476,6 +476,7 @@ int git_futils_mkdir(
 			break;
 		} else if (errno != ENOENT) {
 			git_error_set(GIT_ERROR_OS, "failed to stat '%s'", parent_path.ptr);
+			error = -1;
 			goto done;
 		}
 


### PR DESCRIPTION
IIRC I got a strange return once from lstat, which translated in a weird
error class/message being reported. As a safety measure, enforce a -1 return in
that case.