### PR TITLE
Adds support for multiple SSH auth mechanisms being used sequentially

### DIFF
--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -518,6 +518,7 @@ static int _git_ssh_setup_conn(
 {
 	git_net_url urldata = GIT_NET_URL_INIT;
 	int auth_methods, error = 0;
+	int sub_error;
 	size_t i;
 	ssh_stream *s;
 	git_cred *cred = NULL;
@@ -638,6 +639,15 @@ post_extract:
 		}
 
 		error = _git_ssh_authenticate_session(session, cred);
+
+		if (error == GIT_EAUTH) {
+			/* refresh auth methods */
+			sub_error = list_auth_methods(&auth_methods, session, urldata.username);
+			if (sub_error < 0) {
+				error = sub_error;
+				goto done;
+			}
+		}
 	}
 
 	if (error < 0)

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -518,7 +518,6 @@ static int _git_ssh_setup_conn(
 {
 	git_net_url urldata = GIT_NET_URL_INIT;
 	int auth_methods, error = 0;
-	int sub_error;
 	size_t i;
 	ssh_stream *s;
 	git_cred *cred = NULL;
@@ -642,11 +641,10 @@ post_extract:
 
 		if (error == GIT_EAUTH) {
 			/* refresh auth methods */
-			sub_error = list_auth_methods(&auth_methods, session, urldata.username);
-			if (sub_error < 0) {
-				error = sub_error;
+			if ((error = list_auth_methods(&auth_methods, session, urldata.username)) < 0)
 				goto done;
-			}
+			else
+				error = GIT_EAUTH;
 		}
 	}
 


### PR DESCRIPTION
Needed to make eg. 2FA work

Fixes the following problem:
- An SSH server has multiple authentication mechanisms configured (`pubkey` and `keyboard-interactive`, both are required).
1. When connecting to the server it responds sends only `pubkey` as an available mechanism
2. libgit correctly invokes `cred_acquire_cb` with `GIT_CREDTYPE_SSH_KEY` set and `GIT_CREDTYPE_SSH_INTERACTIVE` unset.
3. The `pubkey` authentication is completed successfully, but the server responds with a failure code since not all mechanisms have successfully completed.
4. The connection's available mechanisms are updated to only include `keyboard-interactive` on the server side.
5. libgit incorrectly invokes `cred_acquire_cb` with `GIT_CREDTYPE_SSH_KEY` set and `GIT_CREDTYPE_SSH_INTERACTIVE` unset.
- This repeats until the process is terminated by the server or `cred_acquire_cb`