### PR TITLE
ssh: include sha256 host key hash when supported

### DIFF
--- a/include/git2/cert.h
+++ b/include/git2/cert.h
@@ -78,6 +78,8 @@ typedef enum {
 	GIT_CERT_SSH_MD5 = (1 << 0),
 	/** SHA-1 is available */
 	GIT_CERT_SSH_SHA1 = (1 << 1),
+	/** SHA-256 is available */
+	GIT_CERT_SSH_SHA256 = (1 << 2),
 } git_cert_ssh_t;
 
 /**
@@ -103,6 +105,12 @@ typedef struct {
 	 * have the SHA-1 hash of the hostkey.
 	 */
 	unsigned char hash_sha1[20];
+
+	/**
+	 * Hostkey hash. If type has `GIT_CERT_SSH_SHA256` set, this will
+	 * have the SHA-256 hash of the hostkey.
+	 */
+	unsigned char hash_sha256[32];
 } git_cert_hostkey;
 
 /**

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -566,6 +566,14 @@ post_extract:
 
 		cert.parent.cert_type = GIT_CERT_HOSTKEY_LIBSSH2;
 
+#ifdef LIBSSH2_HOSTKEY_HASH_SHA256
+		key = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA256);
+		if (key != NULL) {
+			cert.type |= GIT_CERT_SSH_SHA256;
+			memcpy(&cert.hash_sha256, key, 32);
+		}
+#endif
+
 		key = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA1);
 		if (key != NULL) {
 			cert.type |= GIT_CERT_SSH_SHA1;


### PR DESCRIPTION
libssh2 1.9.0 supports SHA-256 host key fingerprints and by checking if LIBSSH2_HOSTKEY_HASH_SHA256 is defined this can be included in git_cert_hostkey when libssh2 supports this without breaking builds when older versions of libssh2 does not.