### PR TITLE
Add compat typdef for git_attr_t

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -68,6 +68,21 @@ GIT_BEGIN_DECL
 
 /**@}*/
 
+/** @name Deprecated Attribute type
+ *
+ * These enumeration values are retained for backward compatibility.
+ * The newer versions of these functions should be preferred in all
+ * new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+typedef git_attr_value_t git_attr_t;
+
+/**@}*/
+
 /** @name Deprecated Blob Functions
  *
  * These functions are retained for backward compatibility.  The newer

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -7,6 +7,7 @@
 #ifndef INCLUDE_git_deprecated_h__
 #define INCLUDE_git_deprecated_h__
 
+#include "attr.h"
 #include "config.h"
 #include "common.h"
 #include "blame.h"

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -67,19 +67,6 @@ GIT_BEGIN_DECL
 #define GIT_ATTR_FALSE(attr) GIT_ATTR_IS_FALSE(attr)
 #define GIT_ATTR_UNSPECIFIED(attr) GIT_ATTR_IS_UNSPECIFIED(attr)
 
-/**@}*/
-
-/** @name Deprecated Attribute type
- *
- * These enumeration values are retained for backward compatibility.
- * The newer versions of these functions should be preferred in all
- * new code.
- *
- * There is no plan to remove these backward compatibility values at
- * this time.
- */
-/**@{*/
-
 typedef git_attr_value_t git_attr_t;
 
 /**@}*/


### PR DESCRIPTION
Some libraries haven't updated to git_attr_value_t and break.  Adding
the comapt typedef as suggested.

@pks-t please let me know if there's anything else needed.  I took a brief look but didn't see an obvious place where to add tests.  If required please let me know.