### PR TITLE
tests: config: only test parsing huge file with GITTEST_INVASIVE_SPEED

### DIFF
--- a/tests/config/stress.c
+++ b/tests/config/stress.c
@@ -181,6 +181,9 @@ void test_config_stress__huge_section_with_many_values(void)
 {
 	git_config *config;
 
+	if (!cl_is_env_set("GITTEST_INVASIVE_SPEED"))
+		cl_skip();
+
 	/*
 	 * The config file is structured in such a way that is
 	 * has a section header that is approximately 500kb of


### PR DESCRIPTION
The test in config::stress::huge_section_with_many_values takes quite a
long time to execute. Hide it behind the GITTEST_INVASIVE_SPEED
environment varibale to not needlessly blow up execution time of tests.
As this environment variable is being set by the continuous integration,
we will execute it regularly anyway.