### PR TITLE
Fix copy&paste in git_cherrypick_commit docstring

### DIFF
--- a/include/git2/cherrypick.h
+++ b/include/git2/cherrypick.h
@@ -59,8 +59,8 @@ GIT_EXTERN(int) git_cherrypick_options_init(
  * @param out pointer to store the index result in
  * @param repo the repository that contains the given commits
  * @param cherrypick_commit the commit to cherry-pick
- * @param our_commit the commit to revert against (eg, HEAD)
- * @param mainline the parent of the revert commit, if it is a merge
+ * @param our_commit the commit to cherry-pick against (eg, HEAD)
+ * @param mainline the parent of the `cherrypick_commit`, if it is a merge
  * @param merge_options the merge options (or null for defaults)
  * @return zero on success, -1 on failure.
  */


### PR DESCRIPTION
Updates the docstring of `git_cherrypick_commit` to fix some incorrect mentions of reverting