### PR TITLE
ci: only push docs from the libgit2/libgit2 repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,4 +174,4 @@ jobs:
       echo 'password $(GITHUB_PAT)' >> ~/.netrc
       git push origin gh-pages
     displayName: 'Publish Documentation'
-    condition: eq(variables['Build.Reason'], 'IndividualCI')
+    condition: and(eq(variables['Build.Repository.Name'], 'libgit2/libgit2'), eq(variables['Build.Reason'], 'IndividualCI'))


### PR DESCRIPTION
Users may fork libgit2 and run libgit2's CI on that, which is
delightful!  However, if they do, we'll fail the documentation publish
phase, which is correct (because we don't allow them to publish _their_
version of the docs) but regrettable (since it should not fail).

Only run the documentation publish phase when we merge branches into the
libgit2/libgit2 repo.