### PR TITLE
worktree: mimic 'git worktree add' behavior.

### DIFF
--- a/include/git2/worktree.h
+++ b/include/git2/worktree.h
@@ -84,12 +84,13 @@ GIT_EXTERN(int) git_worktree_validate(const git_worktree *wt);
 typedef struct git_worktree_add_options {
 	unsigned int version;
 
-	int lock; /**< lock newly created worktree */
-	git_reference *ref; /**< reference to use for the new worktree HEAD */
+	int lock;		/**< lock newly created worktree */
+	int checkout_existing;	/**< allow checkout of existing branch matching worktree name */
+	git_reference *ref;	/**< reference to use for the new worktree HEAD */
 } git_worktree_add_options;
 
-#define GIT_WORKTREE_ADD_OPTIONS_VERSION 1
-#define GIT_WORKTREE_ADD_OPTIONS_INIT {GIT_WORKTREE_ADD_OPTIONS_VERSION,0,NULL}
+#define GIT_WORKTREE_ADD_OPTIONS_VERSION 2
+#define GIT_WORKTREE_ADD_OPTIONS_INIT {GIT_WORKTREE_ADD_OPTIONS_VERSION,0,0,NULL}
 
 /**
  * Initialize git_worktree_add_options structure

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -218,12 +218,12 @@ void test_worktree_worktree__init(void)
 
 void test_worktree_worktree__add_remove_add(void)
 {
-	git_worktree *wt;
-	git_repository *repo;
-	git_reference *branch;
-	git_buf path = GIT_BUF_INIT;
-
+	git_worktree_add_options add_opts = GIT_WORKTREE_ADD_OPTIONS_INIT;
 	git_worktree_prune_options opts = GIT_WORKTREE_PRUNE_OPTIONS_INIT;
+	git_buf path = GIT_BUF_INIT;
+	git_reference *branch;
+	git_repository *repo;
+	git_worktree *wt;
 
 	/* Add the worktree */
 	cl_git_pass(git_buf_joinpath(&path, fixture.repo->workdir, "../worktree-add-remove-add"));
@@ -233,6 +233,7 @@ void test_worktree_worktree__add_remove_add(void)
 	cl_git_pass(git_repository_open(&repo, path.ptr));
 	cl_assert(git__suffixcmp(git_repository_workdir(repo), "worktree-add-remove-add/") == 0);
 	cl_git_pass(git_branch_lookup(&branch, repo, "worktree-add-remove-add", GIT_BRANCH_LOCAL));
+	git_reference_free(branch);
 	git_repository_free(repo);
 
 	/* Prune the worktree */
@@ -242,18 +243,21 @@ void test_worktree_worktree__add_remove_add(void)
 	cl_assert(!git_path_exists(wt->gitlink_path));
 	git_worktree_free(wt);
 
-	/* Add the worktree back */
-	cl_git_pass(git_worktree_add(&wt, fixture.repo, "worktree-add-remove-add", path.ptr, NULL));
+	/* Add the worktree back with default options should fail. */
+	cl_git_fail(git_worktree_add(&wt, fixture.repo, "worktree-add-remove-add", path.ptr, &add_opts));
+	/* If allowing checkout of existing branches, it should succeed. */
+	add_opts.checkout_existing = 1;
+	cl_git_pass(git_worktree_add(&wt, fixture.repo, "worktree-add-remove-add", path.ptr, &add_opts));
 
 	/* Open and verify created repo */
 	cl_git_pass(git_repository_open(&repo, path.ptr));
 	cl_assert(git__suffixcmp(git_repository_workdir(repo), "worktree-add-remove-add/") == 0);
 	cl_git_pass(git_branch_lookup(&branch, repo, "worktree-add-remove-add", GIT_BRANCH_LOCAL));
+	git_reference_free(branch);
+	git_repository_free(repo);
 
 	git_buf_dispose(&path);
 	git_worktree_free(wt);
-	git_reference_free(branch);
-	git_repository_free(repo);
 }
 
 void test_worktree_worktree__add_locked(void)
@@ -283,6 +287,7 @@ void test_worktree_worktree__add_locked(void)
 
 void test_worktree_worktree__init_existing_branch(void)
 {
+	git_worktree_add_options opts = GIT_WORKTREE_ADD_OPTIONS_INIT;
 	git_reference *head, *branch;
 	git_commit *commit;
 	git_worktree *wt;
@@ -293,7 +298,12 @@ void test_worktree_worktree__init_existing_branch(void)
 	cl_git_pass(git_branch_create(&branch, fixture.repo, "worktree-new-exist", commit, false));
 
 	cl_git_pass(git_buf_joinpath(&path, fixture.repo->workdir, "../worktree-new-exist"));
-	cl_git_pass(git_worktree_add(&wt, fixture.repo, "worktree-new-exist", path.ptr, NULL));
+
+	/* Add the worktree back with default options should fail. */
+	cl_git_fail(git_worktree_add(&wt, fixture.repo, "worktree-new-exist", path.ptr, NULL));
+	/* If allowing checkout of existing branches, it should succeed. */
+	opts.checkout_existing = 1;
+	cl_git_pass(git_worktree_add(&wt, fixture.repo, "worktree-new-exist", path.ptr, &opts));
 
 	git_buf_dispose(&path);
 	git_worktree_free(wt);
@@ -421,7 +431,7 @@ void test_worktree_worktree__name(void)
 
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_assert_equal_s(git_worktree_name(wt), "testrepo-worktree");
-	
+
 	git_worktree_free(wt);
 }
 


### PR DESCRIPTION
When adding a worktree using `git worktree add <path>`, if a reference
named `refs/heads/$(basename <path>)` already exist, it is checkouted in
the worktree.
Mimic this behavior in libgit2.