### PR TITLE
Refactor packfile code to use zstream abstraction

### DIFF
--- a/src/pack.h
+++ b/src/pack.h
@@ -10,16 +10,15 @@
 
 #include "common.h"
 
-#include <zlib.h>
-
 #include "git2/oid.h"
 
+#include "array.h"
 #include "map.h"
 #include "mwindow.h"
 #include "odb.h"
 #include "offmap.h"
 #include "oidmap.h"
-#include "array.h"
+#include "zstream.h"
 
 #define GIT_PACK_FILE_MODE 0444
 
@@ -116,7 +115,7 @@ struct git_pack_entry {
 typedef struct git_packfile_stream {
 	off64_t curpos;
 	int done;
-	z_stream zstream;
+	git_zstream zstream;
 	struct git_pack_file *p;
 	git_mwindow *mw;
 } git_packfile_stream;

--- a/src/zstream.c
+++ b/src/zstream.c
@@ -77,6 +77,11 @@ bool git_zstream_done(git_zstream *zstream)
 	return (!zstream->in_len && zstream->zerr == Z_STREAM_END);
 }
 
+bool git_zstream_eos(git_zstream *zstream)
+{
+	return zstream->zerr == Z_STREAM_END;
+}
+
 size_t git_zstream_suggest_output_len(git_zstream *zstream)
 {
 	if (zstream->in_len > ZSTREAM_BUFFER_SIZE)

--- a/src/zstream.h
+++ b/src/zstream.h
@@ -44,6 +44,7 @@ int git_zstream_get_output_chunk(
 int git_zstream_get_output(void *out, size_t *out_len, git_zstream *zstream);
 
 bool git_zstream_done(git_zstream *zstream);
+bool git_zstream_eos(git_zstream *zstream);
 
 void git_zstream_reset(git_zstream *zstream);
 

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -145,7 +145,7 @@ void test_pack_packbuilder__get_hash(void)
 
 	seed_packbuilder();
 
-	git_packbuilder_write(_packbuilder, ".", 0, NULL, NULL);
+	cl_git_pass(git_packbuilder_write(_packbuilder, ".", 0, NULL, NULL));
 	git_oid_fmt(hex, git_packbuilder_hash(_packbuilder));
 
 	cl_assert_equal_s(hex, "7f5fa362c664d68ba7221259be1cbd187434b2f0");
@@ -158,7 +158,7 @@ static void test_write_pack_permission(mode_t given, mode_t expected)
 
 	seed_packbuilder();
 
-	git_packbuilder_write(_packbuilder, ".", given, NULL, NULL);
+	cl_git_pass(git_packbuilder_write(_packbuilder, ".", given, NULL, NULL));
 
 	/* Windows does not return group/user bits from stat,
 	* files are never executable.
@@ -197,7 +197,7 @@ void test_pack_packbuilder__permissions_readwrite(void)
 void test_pack_packbuilder__does_not_fsync_by_default(void)
 {
 	seed_packbuilder();
-	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);
+	cl_git_pass(git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL));
 	cl_assert_equal_sz(0, p_fsync__cnt);
 }
 
@@ -215,7 +215,7 @@ void test_pack_packbuilder__fsync_global_setting(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_FSYNC_GITDIR, 1));
 	p_fsync__cnt = 0;
 	seed_packbuilder();
-	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);
+	cl_git_pass(git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL));
 	cl_assert_equal_sz(expected_fsyncs, p_fsync__cnt);
 }
 
@@ -224,7 +224,7 @@ void test_pack_packbuilder__fsync_repo_setting(void)
 	cl_repo_set_bool(_repo, "core.fsyncObjectFiles", true);
 	p_fsync__cnt = 0;
 	seed_packbuilder();
-	git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL);
+	cl_git_pass(git_packbuilder_write(_packbuilder, ".", 0666, NULL, NULL));
 	cl_assert_equal_sz(expected_fsyncs, p_fsync__cnt);
 }
 


### PR DESCRIPTION
While investigating #5324, I noticed that the zlib-related code in packfile looks mighty complicated and could use some love. I thus refactored it to use our own `git_zstream` abstraction, which is a much nicer interface.