### PR TITLE
Correct typo in name of referenced parameter

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -211,7 +211,7 @@ GIT_EXTERN(int) git_branch_upstream(
 /**
  * Set a branch's upstream branch
  *
- * This will update the configuration to set the branch named `name` as the upstream of `branch`.
+ * This will update the configuration to set the branch named `branch_name` as the upstream of `branch`.
  * Pass a NULL name to unset the upstream information.
  *
  * @note the actual tracking reference must have been already created for the


### PR DESCRIPTION
The name of the parameter in the `git_branch_set_upstream` function is `branch_name` and not `name`.