### PR TITLE
futils_mktmp: don't use umask.

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -22,6 +22,12 @@ char git_buf__oom[1];
 	    ((d) > (b)->asize && git_buf_grow((b), (d)) < 0))\
 		return -1;
 
+int git_buffer_global_init(void)
+{
+	/* Seed rand for git_buf_put_rand. */
+	srand((unsigned int)time(NULL));
+	return 0;
+}
 
 int git_buf_init(git_buf *buf, size_t initial_size)
 {
@@ -239,6 +245,20 @@ int git_buf_puts(git_buf *buf, const char *string)
 {
 	assert(string);
 	return git_buf_put(buf, string, strlen(string));
+}
+
+static const char rand_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+int git_buf_put_rand(git_buf *buf, size_t chars)
+{
+	size_t i;
+
+	for (i = 0; i < chars; ++i) {
+		if (git_buf_putc(buf, rand_chars[rand() % strlen(rand_chars)]) == -1)
+			return -1;
+	}
+
+	return 0;
 }
 
 static const char base64_encode[] =

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -20,6 +20,8 @@
 extern char git_buf__initbuf[];
 extern char git_buf__oom[];
 
+int git_buffer_global_init(void);
+
 /* Use to initialize buffer structure when git_buf is on stack */
 #define GIT_BUF_INIT { git_buf__initbuf, 0, 0 }
 
@@ -112,6 +114,15 @@ int git_buf_put(git_buf *buf, const char *data, size_t len);
 int git_buf_puts(git_buf *buf, const char *string);
 int git_buf_printf(git_buf *buf, const char *format, ...) GIT_FORMAT_PRINTF(2, 3);
 int git_buf_vprintf(git_buf *buf, const char *format, va_list ap);
+
+/**
+ * Append random characters to this git_buf.
+ *
+ * The entropy source for this is *not* cryptographically secure: do not use it
+ * for applications which require a CSPRNG.
+ */
+int git_buf_put_rand(git_buf *buf, size_t chars);
+
 void git_buf_clear(git_buf *buf);
 void git_buf_consume(git_buf *buf, const char *end);
 void git_buf_truncate(git_buf *buf, size_t len);

--- a/src/global.c
+++ b/src/global.c
@@ -30,6 +30,7 @@ typedef int (*git_global_init_fn)(void);
 
 static git_global_init_fn git__init_callbacks[] = {
 	git_allocator_global_init,
+	git_buffer_global_init,
 	git_hash_global_init,
 	git_sysdir_global_init,
 	git_filter_global_init,


### PR DESCRIPTION
Previously, we were using `umask(mask = umask(0))` to fetch the current
umask in order to apply it to the desired mode, but this is broken in
the presence of threads. There is no portable way to directly fetch
umask without mutating it.

Instead, create the file with 0777 permissions, and fstat it to reverse
engineer what umask was when the file was created, and then apply that
as a mask on the mode.

Fixes: jmgao/pore#46