### PR TITLE
index: replace map macros with inline functions

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -27,29 +27,6 @@
 #include "git2/config.h"
 #include "git2/sys/index.h"
 
-#define INSERT_IN_MAP_EX(idx, map, e, err) do {				\
-		if ((idx)->ignore_case)					\
-			(err) = git_idxmap_icase_set((git_idxmap_icase *) (map), (e), (e)); \
-		else							\
-			(err) = git_idxmap_set((map), (e), (e));	\
-	} while (0)
-
-#define INSERT_IN_MAP(idx, e, err) INSERT_IN_MAP_EX(idx, (idx)->entries_map, e, err)
-
-#define LOOKUP_IN_MAP(v, idx, k) do {					\
-		if ((idx)->ignore_case)					\
-			(v) = git_idxmap_icase_get((git_idxmap_icase *) index->entries_map, (k)); \
-		else							\
-			(v) = git_idxmap_get(index->entries_map, (k)); \
-	} while (0)
-
-#define DELETE_IN_MAP(idx, e) do {					\
-		if ((idx)->ignore_case)					\
-			git_idxmap_icase_delete((git_idxmap_icase *) (idx)->entries_map, (e)); \
-		else							\
-			git_idxmap_delete((idx)->entries_map, (e));	\
-	} while (0)
-
 static int index_apply_to_wd_diff(git_index *index, int action, const git_strarray *paths,
 				  unsigned int flags,
 				  git_index_matched_path_cb cb, void *payload);
@@ -147,6 +124,22 @@ static int write_index(git_oid *checksum, git_index *index, git_filebuf *file);
 
 static void index_entry_free(git_index_entry *entry);
 static void index_entry_reuc_free(git_index_reuc_entry *reuc);
+
+GIT_INLINE(int) index_map_set(git_idxmap *map, git_index_entry *e, bool ignore_case)
+{
+	if (ignore_case)
+		return git_idxmap_icase_set((git_idxmap_icase *) map, e, e);
+	else
+		return git_idxmap_set(map, e, e);
+}
+
+GIT_INLINE(int) index_map_delete(git_idxmap *map, git_index_entry *e, bool ignore_case)
+{
+	if (ignore_case)
+		return git_idxmap_icase_delete((git_idxmap_icase *) map, e);
+	else
+		return git_idxmap_delete(map, e);
+}
 
 int git_index_entry_srch(const void *key, const void *array_member)
 {
@@ -507,7 +500,7 @@ static int index_remove_entry(git_index *index, size_t pos)
 
 	if (entry != NULL) {
 		git_tree_cache_invalidate_path(index->tree, entry->path);
-		DELETE_IN_MAP(index, entry);
+		index_map_delete(index->entries_map, entry, index->ignore_case);
 	}
 
 	error = git_vector_remove(&index->entries, pos);
@@ -859,7 +852,10 @@ const git_index_entry *git_index_get_bypath(
 	key.path = path;
 	GIT_INDEX_ENTRY_STAGE_SET(&key, stage);
 
-	LOOKUP_IN_MAP(value, index, &key);
+	if (index->ignore_case)
+		value = git_idxmap_icase_get((git_idxmap_icase *) index->entries_map, &key);
+	else
+		value = git_idxmap_get(index->entries_map, &key);
 
 	if (!value) {
 	    git_error_set(GIT_ERROR_INDEX, "index does not contain '%s'", path);
@@ -1399,10 +1395,9 @@ static int index_insert(
 		 * at the sorted position.  (Since we re-sort after each insert to
 		 * check for dups, this is actually cheaper in the long run.)
 		 */
-		if ((error = git_vector_insert_sorted(&index->entries, entry, index_no_dups)) < 0)
+		if ((error = git_vector_insert_sorted(&index->entries, entry, index_no_dups)) < 0 ||
+		    (error = index_map_set(index->entries_map, entry, index->ignore_case)) < 0)
 			goto out;
-
-		INSERT_IN_MAP(index, entry, error);
 	}
 
 	index->dirty = 1;
@@ -1616,8 +1611,8 @@ int git_index_remove_bypath(git_index *index, const char *path)
 int git_index__fill(git_index *index, const git_vector *source_entries)
 {
 	const git_index_entry *source_entry = NULL;
+	int error = 0;
 	size_t i;
-	int ret = 0;
 
 	assert(index);
 
@@ -1631,27 +1626,26 @@ int git_index__fill(git_index *index, const git_vector *source_entries)
 	git_vector_foreach(source_entries, i, source_entry) {
 		git_index_entry *entry = NULL;
 
-		if ((ret = index_entry_dup(&entry, index, source_entry)) < 0)
+		if ((error = index_entry_dup(&entry, index, source_entry)) < 0)
 			break;
 
 		index_entry_adjust_namemask(entry, ((struct entry_internal *)entry)->pathlen);
 		entry->flags_extended |= GIT_INDEX_ENTRY_UPTODATE;
 		entry->mode = git_index__create_mode(entry->mode);
 
-		if ((ret = git_vector_insert(&index->entries, entry)) < 0)
+		if ((error = git_vector_insert(&index->entries, entry)) < 0)
 			break;
 
-		INSERT_IN_MAP(index, entry, ret);
-		if (ret < 0)
+		if ((error = index_map_set(index->entries_map, entry, index->ignore_case)) < 0)
 			break;
 
 		index->dirty = 1;
 	}
 
-	if (!ret)
+	if (!error)
 		git_vector_sort(&index->entries);
 
-	return ret;
+	return error;
 }
 
 
@@ -1684,7 +1678,7 @@ int git_index_remove(git_index *index, const char *path, int stage)
 	remove_key.path = path;
 	GIT_INDEX_ENTRY_STAGE_SET(&remove_key, stage);
 
-	DELETE_IN_MAP(index, &remove_key);
+	index_map_delete(index->entries_map, &remove_key, index->ignore_case);
 
 	if (index_find(&position, index, path, 0, stage) < 0) {
 		git_error_set(
@@ -2636,9 +2630,7 @@ static int parse_index(git_index *index, const char *buffer, size_t buffer_size)
 			goto done;
 		}
 
-		INSERT_IN_MAP(index, entry, error);
-
-		if (error < 0) {
+		if ((error = index_map_set(index->entries_map, entry, index->ignore_case)) < 0) {
 			index_entry_free(entry);
 			goto done;
 		}
@@ -3141,9 +3133,7 @@ int git_index_read_tree(git_index *index, const git_tree *tree)
 		goto cleanup;
 
 	git_vector_foreach(&entries, i, e) {
-		INSERT_IN_MAP_EX(index, entries_map, e, error);
-
-		if (error < 0) {
+		if ((error = index_map_set(entries_map, e, index->ignore_case)) < 0) {
 			git_error_set(GIT_ERROR_INDEX, "failed to insert entry into map");
 			return error;
 		}
@@ -3265,7 +3255,8 @@ static int git_index_read_iterator(
 
 		if (add_entry) {
 			if ((error = git_vector_insert(&new_entries, add_entry)) == 0)
-				INSERT_IN_MAP_EX(index, new_entries_map, add_entry, error);
+				error = index_map_set(new_entries_map, add_entry,
+						      index->ignore_case);
 		}
 
 		if (remove_entry && error >= 0)


### PR DESCRIPTION
Traditionally, our maps were mostly implemented via macros that had
weird call semantics. This shows in our index code, where we have macros
that insert into an index map case-sensitively or insensitively, as they
still return error codes via an error parameter. This is unwieldy and,
most importantly, not necessary anymore, due to the introduction of our
high-level map API and removal of macros.

Replace them with inlined functions to make code easier to read.