### PR TITLE
ntlm: prevent (spurious) compiler warnings

### DIFF
--- a/deps/ntlmclient/ntlm.c
+++ b/deps/ntlmclient/ntlm.c
@@ -587,7 +587,9 @@ int ntlm_client_negotiate(
 	size_t *out_len,
 	ntlm_client *ntlm)
 {
-	size_t hostname_len, hostname_offset, domain_len, domain_offset;
+	size_t hostname_len, domain_len;
+	size_t domain_offset = 0;
+	size_t hostname_offset = 0;
 	uint32_t flags = 0;
 
 	assert(out && out_len && ntlm);


### PR DESCRIPTION
Pull in commit

https://github.com/ethomson/ntlmclient/commit/e7b2583e1bc28c33c43854e7c318e859b4e83bef

to fix #5353.