### PR TITLE
win32: fix relative symlinks pointing into dirs

### DIFF
--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -439,8 +439,16 @@ int p_symlink(const char *target, const char *path)
 	git_win32_path target_w, path_w;
 	DWORD dwFlags;
 
+	/*
+	 * Convert both target and path to Windows-style paths. Note that we do
+	 * not want to use `git_win32_path_from_utf8` for converting the target,
+	 * as that function will automatically pre-pend the current working
+	 * directory in case the path is not absolute. As Git will instead use
+	 * relative symlinks, this is not someting we want.
+	 */
 	if (git_win32_path_from_utf8(path_w, path) < 0 ||
-	    git__utf8_to_16(target_w, MAX_PATH, target) < 0)
+	    git__utf8_to_16(target_w, MAX_PATH, target) < 0 ||
+	    git_win32_path_canonicalize(target_w) < 0)
 		return -1;
 
 	dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;


### PR DESCRIPTION
On Windows platforms, we need some logic to emulate symlink(3P) defined
by POSIX. As unprivileged symlinks on Windows are a rather new feature,
our current implementation is comparatively new and still has some
rough edges in special cases.

One such case is relative symlinks. While relative symlinks to files in
the same directory work as expected, libgit2 currently fails to create
reltaive symlinks pointing into other directories. This is due to the
fact that we forgot to translate the Unix-style target path to
Windows-style. Most importantly, we are currently not converting
directory separators from "/" to "\".

Fix the issue by calling `git_win32_path_canonicalize` on the target.
Add a test that verifies our ability to create such relative links
across directories.

Fixes #5252.