### PR TITLE
merge: Return non-const git_repository from accessor method

### DIFF
--- a/include/git2/sys/merge.h
+++ b/include/git2/sys/merge.h
@@ -41,7 +41,7 @@ GIT_EXTERN(git_merge_driver *) git_merge_driver_lookup(const char *name);
 typedef struct git_merge_driver_source git_merge_driver_source;
 
 /** Get the repository that the source data is coming from. */
-GIT_EXTERN(const git_repository *) git_merge_driver_source_repo(
+GIT_EXTERN(git_repository *) git_merge_driver_source_repo(
 	const git_merge_driver_source *src);
 
 /** Gets the ancestor of the file to merge. */

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -32,7 +32,7 @@ static struct merge_driver_registry merge_driver_registry;
 
 static void git_merge_driver_global_shutdown(void);
 
-const git_repository* git_merge_driver_source_repo(const git_merge_driver_source *src)
+git_repository* git_merge_driver_source_repo(const git_merge_driver_source *src)
 {
 	assert(src);
 	return src->repo;


### PR DESCRIPTION
Because this accessor is const, I can't do something like this in the git merge driver without casting away const:

```cpp
int CustomApply(git_merge_driver* self,
                const char** path_out,
                uint32_t* mode_out,
                git_buf* merged_out,
                const char* filter_name,
                const git_merge_driver_source* src) {
    const git_repository* repo = git_merge_driver_source_repo(src);

    git_config* cfg;

    // ERROR! repo is const!
    int errorCode = git_repository_config(&cfg, repo);

    git_config_free(cfg);

    return 0;
}
```

The definition of git_merge_driver_source has git_repository as non-const:

```
struct git_merge_driver_source {
	git_repository *repo;
	const char *default_driver;
	const git_merge_file_options *file_opts;

	const git_index_entry *ancestor;
	const git_index_entry *ours;
	const git_index_entry *theirs;
};
```