### PR TITLE
Make type mismatch errors consistent

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -753,7 +753,7 @@ int git_commit_extract_signature(git_buf *signature, git_buf *signed_data, git_r
 		return error;
 
 	if (obj->cached.type != GIT_OBJECT_COMMIT) {
-		git_error_set(GIT_ERROR_INVALID, "the requested type does not match the type in ODB");
+		git_error_set(GIT_ERROR_INVALID, "the requested type does not match the type in the ODB");
 		error = GIT_ENOTFOUND;
 		goto cleanup;
 	}

--- a/src/object.c
+++ b/src/object.c
@@ -201,7 +201,7 @@ int git_object_lookup_prefix(
 				if (type != GIT_OBJECT_ANY && type != object->cached.type) {
 					git_object_free(object);
 					git_error_set(GIT_ERROR_INVALID,
-						"the requested type does not match the type in ODB");
+						"the requested type does not match the type in the ODB");
 					return GIT_ENOTFOUND;
 				}
 


### PR DESCRIPTION
The same error message appears in other places with the word `"the"` included. API consumers in higher-level languages such as JavaScript (via nodegit) might consume these strings, so they should be consistent.