### PR TITLE
Do not return free'd git_repository object on error

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -865,8 +865,7 @@ cleanup:
 
 	if (error < 0)
 		git_repository_free(repo);
-
-	if (repo_ptr)
+	else if (repo_ptr)
 		*repo_ptr = repo;
 
 	return error;

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -277,7 +277,9 @@ void test_repo_open__bad_gitlinks(void)
 
 	for (scan = bad_links; *scan != NULL; scan++) {
 		make_gitlink_dir("alternate", *scan);
+		repo = NULL;
 		cl_git_fail(git_repository_open_ext(&repo, "alternate", 0, NULL));
+		cl_assert(repo == NULL);
 	}
 
 	git_futils_rmdir_r("invalid", NULL, GIT_RMDIR_REMOVE_FILES);


### PR DESCRIPTION
Regression introduced in commit dde6d9c706bf1ecab545da55ab874a016587af1f.

This issue causes lots of crashes in TortoiseGit.