### PR TITLE
path: preserve SSH prefixes when resolving relative paths

### DIFF
--- a/tests/submodule/resolve.c
+++ b/tests/submodule/resolve.c
@@ -1,0 +1,115 @@
+#include "clar_libgit2.h"
+
+#include "path.h"
+
+static git_repository *g_repo;
+static git_buf g_buf;
+
+void test_submodule_resolve__initialize(void)
+{
+	cl_git_pass(git_buf_init(&g_buf, 0));
+	g_repo = cl_git_sandbox_init("testrepo");
+}
+
+void test_submodule_resolve__cleanup(void)
+{
+	git_buf_dispose(&g_buf);
+	cl_git_sandbox_cleanup();
+}
+
+static void assert_resolves(const char *remote_url, const char *url, const char *expected)
+{
+	git_buf resolved = GIT_BUF_INIT;
+	git_remote *remote = NULL;
+
+	if (remote_url)
+		cl_git_pass(git_remote_create(&remote, g_repo, "origin", remote_url));
+	cl_git_pass(git_submodule_resolve_url(&resolved, g_repo, url));
+	cl_assert_equal_s(resolved.ptr, expected);
+
+	git_remote_free(remote);
+	git_buf_dispose(&resolved);
+}
+
+void test_submodule_resolve__absolute_path(void)
+{
+	assert_resolves(NULL, "/foo/bar", "/foo/bar");
+}
+
+void test_submodule_resolve__relative_dot(void)
+{
+	assert_resolves(NULL, "./", git_repository_workdir(g_repo));
+}
+
+void test_submodule_resolve__relative_child(void)
+{
+	cl_git_pass(git_buf_printf(&g_buf, "%schild", git_repository_workdir(g_repo)));
+	assert_resolves(NULL, "./child", g_buf.ptr);
+}
+
+void test_submodule_resolve__relative_sibling(void)
+{
+	cl_assert(git_path_dirname_r(&g_buf, git_repository_workdir(g_repo)) > 0);
+	cl_git_pass(git_buf_puts(&g_buf, "/sibling"));
+	assert_resolves(NULL, "../sibling", g_buf.ptr);
+}
+
+void test_submodule_resolve__absolute_path_with_http_remote(void)
+{
+	assert_resolves("https://example.com/foobar", "/foo/bar", "/foo/bar");
+}
+
+void test_submodule_resolve__relative_dot_with_http_remote(void)
+{
+	assert_resolves("https://example.com/foobar", "./", "https://example.com/foobar/");
+}
+
+void test_submodule_resolve__relative_child_with_http_remote(void)
+{
+	assert_resolves("https://example.com/foobar", "./child", "https://example.com/foobar/child");
+}
+
+void test_submodule_resolve__relative_sibling_with_http_remote(void)
+{
+	assert_resolves("https://example.com/foobar", "../sibling", "https://example.com/sibling");
+}
+
+void test_submodule_resolve__absolute_path_with_ssh_remote(void)
+{
+	assert_resolves("git@example.com:foobar", "/foo/bar", "/foo/bar");
+}
+
+void test_submodule_resolve__relative_dot_with_ssh_remote(void)
+{
+	assert_resolves("git@example.com:foobar", "./", "git@example.com:foobar/");
+}
+
+void test_submodule_resolve__relative_child_with_ssh_remote(void)
+{
+	assert_resolves("git@example.com:foobar", "./child", "git@example.com:foobar/child");
+}
+
+void test_submodule_resolve__relative_sibling_with_ssh_remote(void)
+{
+	assert_resolves("git@example.com:foobar", "../sibling", "git@example.com:sibling");
+}
+
+void test_submodule_resolve__absolute_path_with_ssh_schema_remote(void)
+{
+	assert_resolves("ssh://git@example.com:foobar", "/foo/bar", "/foo/bar");
+}
+
+void test_submodule_resolve__relative_dot_with_ssh_schema_remote(void)
+{
+	assert_resolves("ssh://git@example.com:foobar", "./", "ssh://git@example.com:foobar/");
+}
+
+void test_submodule_resolve__relative_child_with_ssh_schema_remote(void)
+{
+	assert_resolves("ssh://git@example.com:foobar", "./child", "ssh://git@example.com:foobar/child");
+}
+
+void test_submodule_resolve__relative_sibling_with_ssh_schema_remote(void)
+{
+	assert_resolves("ssh://git@example.com:foobar", "../sibling", "ssh://git@example.com:sibling");
+}


### PR DESCRIPTION
The function `git_path_resolve_relative` is not only used for paths, but
also for URLs. As a result, it needs to detect certain URL prefixes like
for example schemata ("http://") which are not to be removed during any
directory traversals.

We already handle the schemata part correctly, but we are missing the
special case of SSH. In contrast to most other protocols, SSH uses a
colon instead of a slash after the host part, like for example in
"git@example.com:foo". As a result, `git_path_resolve_relative` would've
treated the complete "git@example.com:foo" part as a single directory
part and thus remove it during upwards-traversal.

This problem is relatively easy to hit when having submodules with a
relative URL. As `git_submodule_resolve_url` calls out to
`git_path_resolve_relative`, it mis-treated SSH URLs and thus didn't
compute them correctly.

Fix the issue by special-casing the SSH protocol. Detection makes use
either of the "ssh://" prefix or with a heuristic that tries to detect
whether there's a colon before a slash. Note that especially the second
heuristic is error prone, but it is in fact what git uses right now.

Add some tests to verify behaviour.

---

Fixes #5346 