### PR TITLE
internal types: change enums from `type_t` to `_t`

### DIFF
--- a/src/diff.h
+++ b/src/diff.h
@@ -39,8 +39,8 @@ struct git_diff {
 	git_diff_options opts;
 	git_vector       deltas;    /* vector of git_diff_delta */
 	git_pool pool;
-	git_iterator_type_t old_src;
-	git_iterator_type_t new_src;
+	git_iterator_t old_src;
+	git_iterator_t new_src;
 	git_diff_perfdata perf;
 
 	int (*strcomp)(const char *, const char *);

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -50,8 +50,8 @@ static int diff_file_content_init_common(
 		fc->opts_max_size = opts->max_size ?
 			opts->max_size : DIFF_MAX_FILESIZE;
 
-	if (fc->src == GIT_ITERATOR_TYPE_EMPTY)
-		fc->src = GIT_ITERATOR_TYPE_TREE;
+	if (fc->src == GIT_ITERATOR_EMPTY)
+		fc->src = GIT_ITERATOR_TREE;
 
 	if (!fc->driver &&
 		git_diff_driver_lookup(&fc->driver, fc->repo,
@@ -425,7 +425,7 @@ int git_diff_file_content__load(
 		(diff_opts->flags & GIT_DIFF_SHOW_BINARY) == 0)
 		return 0;
 
-	if (fc->src == GIT_ITERATOR_TYPE_WORKDIR)
+	if (fc->src == GIT_ITERATOR_WORKDIR)
 		error = diff_file_content_load_workdir(fc, diff_opts);
 	else
 		error = diff_file_content_load_blob(fc, diff_opts);

--- a/src/diff_file.h
+++ b/src/diff_file.h
@@ -21,7 +21,7 @@ typedef struct {
 	uint32_t flags;
 	uint32_t opts_flags;
 	git_object_size_t opts_max_size;
-	git_iterator_type_t src;
+	git_iterator_t src;
 	const git_blob *blob;
 	git_map map;
 } git_diff_file_content;

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -341,16 +341,16 @@ bool git_diff_delta__should_skip(
 
 
 static const char *diff_mnemonic_prefix(
-	git_iterator_type_t type, bool left_side)
+	git_iterator_t type, bool left_side)
 {
 	const char *pfx = "";
 
 	switch (type) {
-	case GIT_ITERATOR_TYPE_EMPTY:   pfx = "c"; break;
-	case GIT_ITERATOR_TYPE_TREE:    pfx = "c"; break;
-	case GIT_ITERATOR_TYPE_INDEX:   pfx = "i"; break;
-	case GIT_ITERATOR_TYPE_WORKDIR: pfx = "w"; break;
-	case GIT_ITERATOR_TYPE_FS:      pfx = left_side ? "1" : "2"; break;
+	case GIT_ITERATOR_EMPTY:   pfx = "c"; break;
+	case GIT_ITERATOR_TREE:    pfx = "c"; break;
+	case GIT_ITERATOR_INDEX:   pfx = "i"; break;
+	case GIT_ITERATOR_WORKDIR: pfx = "w"; break;
+	case GIT_ITERATOR_FS:      pfx = left_side ? "1" : "2"; break;
 	default: break;
 	}
 
@@ -497,17 +497,17 @@ static int diff_generated_apply_options(
 
 	/* Reverse src info if diff is reversed */
 	if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_REVERSE)) {
-		git_iterator_type_t tmp_src = diff->base.old_src;
+		git_iterator_t tmp_src = diff->base.old_src;
 		diff->base.old_src = diff->base.new_src;
 		diff->base.new_src = tmp_src;
 	}
 
 	/* Unset UPDATE_INDEX unless diffing workdir and index */
 	if (DIFF_FLAG_IS_SET(diff, GIT_DIFF_UPDATE_INDEX) &&
-		(!(diff->base.old_src == GIT_ITERATOR_TYPE_WORKDIR ||
-		   diff->base.new_src == GIT_ITERATOR_TYPE_WORKDIR) ||
-		 !(diff->base.old_src == GIT_ITERATOR_TYPE_INDEX ||
-		   diff->base.new_src == GIT_ITERATOR_TYPE_INDEX)))
+		(!(diff->base.old_src == GIT_ITERATOR_WORKDIR ||
+		   diff->base.new_src == GIT_ITERATOR_WORKDIR) ||
+		 !(diff->base.old_src == GIT_ITERATOR_INDEX ||
+		   diff->base.new_src == GIT_ITERATOR_INDEX)))
 		diff->base.opts.flags &= ~GIT_DIFF_UPDATE_INDEX;
 
 	/* if ignore_submodules not explicitly set, check diff config */
@@ -742,7 +742,7 @@ static int maybe_modified(
 	const git_index_entry *nitem = info->nitem;
 	unsigned int omode = oitem->mode;
 	unsigned int nmode = nitem->mode;
-	bool new_is_workdir = (info->new_iter->type == GIT_ITERATOR_TYPE_WORKDIR);
+	bool new_is_workdir = (info->new_iter->type == GIT_ITERATOR_WORKDIR);
 	bool modified_uncertain = false;
 	const char *matched_pathspec;
 	int error = 0;
@@ -1079,7 +1079,7 @@ static int handle_unmatched_new_item(
 		/* item contained in ignored directory, so skip over it */
 		return iterator_advance(&info->nitem, info->new_iter);
 
-	else if (info->new_iter->type != GIT_ITERATOR_TYPE_WORKDIR) {
+	else if (info->new_iter->type != GIT_ITERATOR_WORKDIR) {
 		if (delta_type != GIT_DELTA_CONFLICTED)
 			delta_type = GIT_DELTA_ADDED;
 	}

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -389,7 +389,7 @@ static int apply_splits_and_deletes(
 			if (insert_delete_side_of_split(diff, &onto, delta) < 0)
 				goto on_error;
 
-			if (diff->new_src == GIT_ITERATOR_TYPE_WORKDIR)
+			if (diff->new_src == GIT_ITERATOR_WORKDIR)
 				delta->status = GIT_DELTA_UNTRACKED;
 			else
 				delta->status = GIT_DELTA_ADDED;
@@ -441,7 +441,7 @@ GIT_INLINE(git_diff_file *) similarity_get_file(git_diff *diff, size_t idx)
 
 typedef struct {
 	size_t idx;
-	git_iterator_type_t src;
+	git_iterator_t src;
 	git_repository *repo;
 	git_diff_file *file;
 	git_buf data;
@@ -460,7 +460,7 @@ static int similarity_init(
 	info->blob = NULL;
 	git_buf_init(&info->data, 0);
 
-	if (info->file->size > 0 || info->src == GIT_ITERATOR_TYPE_WORKDIR)
+	if (info->file->size > 0 || info->src == GIT_ITERATOR_WORKDIR)
 		return 0;
 
 	return git_diff_file__resolve_zero_size(
@@ -475,7 +475,7 @@ static int similarity_sig(
 	int error = 0;
 	git_diff_file *file = info->file;
 
-	if (info->src == GIT_ITERATOR_TYPE_WORKDIR) {
+	if (info->src == GIT_ITERATOR_WORKDIR) {
 		if ((error = git_buf_joinpath(
 			&info->data, git_repository_workdir(info->repo), file->path)) < 0)
 			return error;
@@ -561,13 +561,13 @@ static int similarity_measure(
 	/* if exact match is requested, force calculation of missing OIDs now */
 	if (exact_match) {
 		if (git_oid_is_zero(&a_file->id) &&
-			diff->old_src == GIT_ITERATOR_TYPE_WORKDIR &&
+			diff->old_src == GIT_ITERATOR_WORKDIR &&
 			!git_diff__oid_for_file(&a_file->id,
 				diff, a_file->path, a_file->mode, a_file->size))
 			a_file->flags |= GIT_DIFF_FLAG_VALID_ID;
 
 		if (git_oid_is_zero(&b_file->id) &&
-			diff->new_src == GIT_ITERATOR_TYPE_WORKDIR &&
+			diff->new_src == GIT_ITERATOR_WORKDIR &&
 			!git_diff__oid_for_file(&b_file->id,
 				diff, b_file->path, b_file->mode, b_file->size))
 			b_file->flags |= GIT_DIFF_FLAG_VALID_ID;
@@ -1013,7 +1013,7 @@ find_best_matches:
 
 				delta_make_rename(tgt, src, best_match->similarity);
 
-				src->status = (diff->new_src == GIT_ITERATOR_TYPE_WORKDIR) ?
+				src->status = (diff->new_src == GIT_ITERATOR_WORKDIR) ?
 					GIT_DELTA_UNTRACKED : GIT_DELTA_ADDED;
 				src->nfiles = 1;
 				memset(&src->old_file, 0, sizeof(src->old_file));

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -405,7 +405,7 @@ int git_iterator_for_nothing(
 	iter = git__calloc(1, sizeof(empty_iterator));
 	GIT_ERROR_CHECK_ALLOC(iter);
 
-	iter->base.type = GIT_ITERATOR_TYPE_EMPTY;
+	iter->base.type = GIT_ITERATOR_EMPTY;
 	iter->base.cb = &callbacks;
 	iter->base.flags = options->flags;
 
@@ -950,7 +950,7 @@ int git_iterator_for_tree(
 	iter = git__calloc(1, sizeof(tree_iterator));
 	GIT_ERROR_CHECK_ALLOC(iter);
 
-	iter->base.type = GIT_ITERATOR_TYPE_TREE;
+	iter->base.type = GIT_ITERATOR_TREE;
 	iter->base.cb = &callbacks;
 
 	if ((error = iterator_init_common(&iter->base,
@@ -974,7 +974,7 @@ int git_iterator_current_tree_entry(
 	tree_iterator_frame *frame;
 	tree_iterator_entry *entry;
 
-	assert(i->type == GIT_ITERATOR_TYPE_TREE);
+	assert(i->type == GIT_ITERATOR_TREE);
 
 	iter = (tree_iterator *)i;
 
@@ -991,7 +991,7 @@ int git_iterator_current_parent_tree(
 	tree_iterator *iter;
 	tree_iterator_frame *frame;
 
-	assert(i->type == GIT_ITERATOR_TYPE_TREE);
+	assert(i->type == GIT_ITERATOR_TREE);
 
 	iter = (tree_iterator *)i;
 
@@ -1271,7 +1271,7 @@ static int filesystem_iterator_entry_hash(
 		return 0;
 	}
 
-	if (iter->base.type == GIT_ITERATOR_TYPE_WORKDIR)
+	if (iter->base.type == GIT_ITERATOR_WORKDIR)
 		return git_repository_hashfile(&entry->id,
 			iter->base.repo, entry->path, GIT_OBJECT_BLOB, NULL);
 
@@ -1668,8 +1668,8 @@ int git_iterator_current_workdir_path(git_buf **out, git_iterator *i)
 	filesystem_iterator *iter = GIT_CONTAINER_OF(i, filesystem_iterator, base);
 	const git_index_entry *entry;
 
-	if (i->type != GIT_ITERATOR_TYPE_FS &&
-		i->type != GIT_ITERATOR_TYPE_WORKDIR) {
+	if (i->type != GIT_ITERATOR_FS &&
+		i->type != GIT_ITERATOR_WORKDIR) {
 		*out = NULL;
 		return 0;
 	}
@@ -1727,7 +1727,7 @@ bool git_iterator_current_is_ignored(git_iterator *i)
 {
 	filesystem_iterator *iter = NULL;
 
-	if (i->type != GIT_ITERATOR_TYPE_WORKDIR)
+	if (i->type != GIT_ITERATOR_WORKDIR)
 		return false;
 
 	iter = GIT_CONTAINER_OF(i, filesystem_iterator, base);
@@ -1740,7 +1740,7 @@ bool git_iterator_current_tree_is_ignored(git_iterator *i)
 	filesystem_iterator *iter = GIT_CONTAINER_OF(i, filesystem_iterator, base);
 	filesystem_iterator_frame *frame;
 
-	if (i->type != GIT_ITERATOR_TYPE_WORKDIR)
+	if (i->type != GIT_ITERATOR_WORKDIR)
 		return false;
 
 	frame = filesystem_iterator_current_frame(iter);
@@ -1894,7 +1894,7 @@ static int iterator_for_filesystem(
 	const char *root,
 	git_index *index,
 	git_tree *tree,
-	git_iterator_type_t type,
+	git_iterator_t type,
 	git_iterator_options *options)
 {
 	filesystem_iterator *iter;
@@ -1971,7 +1971,7 @@ int git_iterator_for_filesystem(
 	git_iterator_options *options)
 {
 	return iterator_for_filesystem(out,
-		NULL, root, NULL, NULL, GIT_ITERATOR_TYPE_FS, options);
+		NULL, root, NULL, NULL, GIT_ITERATOR_FS, options);
 }
 
 int git_iterator_for_workdir_ext(
@@ -1999,7 +1999,7 @@ int git_iterator_for_workdir_ext(
 		GIT_ITERATOR_IGNORE_DOT_GIT;
 
 	return iterator_for_filesystem(out,
-		repo, repo_workdir, index, tree, GIT_ITERATOR_TYPE_WORKDIR, &options);
+		repo, repo_workdir, index, tree, GIT_ITERATOR_WORKDIR, &options);
 }
 
 
@@ -2248,7 +2248,7 @@ int git_iterator_for_index(
 	iter = git__calloc(1, sizeof(index_iterator));
 	GIT_ERROR_CHECK_ALLOC(iter);
 
-	iter->base.type = GIT_ITERATOR_TYPE_INDEX;
+	iter->base.type = GIT_ITERATOR_INDEX;
 	iter->base.cb = &callbacks;
 
 	if ((error = iterator_init_common(&iter->base, repo, index, options)) < 0 ||

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -17,12 +17,12 @@
 typedef struct git_iterator git_iterator;
 
 typedef enum {
-	GIT_ITERATOR_TYPE_EMPTY = 0,
-	GIT_ITERATOR_TYPE_TREE = 1,
-	GIT_ITERATOR_TYPE_INDEX = 2,
-	GIT_ITERATOR_TYPE_WORKDIR = 3,
-	GIT_ITERATOR_TYPE_FS = 4,
-} git_iterator_type_t;
+	GIT_ITERATOR_EMPTY = 0,
+	GIT_ITERATOR_TREE = 1,
+	GIT_ITERATOR_INDEX = 2,
+	GIT_ITERATOR_WORKDIR = 3,
+	GIT_ITERATOR_FS = 4,
+} git_iterator_t;
 
 typedef enum {
 	/** ignore case for entry sort order */
@@ -78,7 +78,7 @@ typedef struct {
 } git_iterator_callbacks;
 
 struct git_iterator {
-	git_iterator_type_t type;
+	git_iterator_t type;
 	git_iterator_callbacks *cb;
 
 	git_repository *repo;
@@ -238,7 +238,7 @@ GIT_INLINE(int) git_iterator_reset(git_iterator *iter)
 extern int git_iterator_reset_range(
 	git_iterator *iter, const char *start, const char *end);
 
-GIT_INLINE(git_iterator_type_t) git_iterator_type(git_iterator *iter)
+GIT_INLINE(git_iterator_t) git_iterator_type(git_iterator *iter)
 {
 	return iter->type;
 }

--- a/src/merge.h
+++ b/src/merge.h
@@ -84,7 +84,7 @@ typedef enum {
 
 	/* The child of a folder that is in a directory/file conflict. */
 	GIT_MERGE_DIFF_DF_CHILD = (1 << 11),
-} git_merge_diff_type_t;
+} git_merge_diff_t;
 
 typedef struct {
 	git_repository *repo;
@@ -113,7 +113,7 @@ typedef struct {
  * Description of changes to one file across three trees.
  */
 typedef struct {
-	git_merge_diff_type_t type;
+	git_merge_diff_t type;
 
 	git_index_entry ancestor_entry;
 

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -422,7 +422,7 @@ static int pathspec_match_from_iterator(
 	if ((error = git_iterator_reset_range(iter, ps->prefix, ps->prefix)) < 0)
 		goto done;
 
-	if (git_iterator_type(iter) == GIT_ITERATOR_TYPE_WORKDIR &&
+	if (git_iterator_type(iter) == GIT_ITERATOR_WORKDIR &&
 		(error = git_repository_index__weakptr(
 			&index, git_iterator_owner(iter))) < 0)
 		goto done;

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -49,18 +49,18 @@
 #define REBASE_FILE_MODE    0666
 
 typedef enum {
-	GIT_REBASE_TYPE_NONE = 0,
-	GIT_REBASE_TYPE_APPLY = 1,
-	GIT_REBASE_TYPE_MERGE = 2,
-	GIT_REBASE_TYPE_INTERACTIVE = 3,
-} git_rebase_type_t;
+	GIT_REBASE_NONE = 0,
+	GIT_REBASE_APPLY = 1,
+	GIT_REBASE_MERGE = 2,
+	GIT_REBASE_INTERACTIVE = 3,
+} git_rebase_t;
 
 struct git_rebase {
 	git_repository *repo;
 
 	git_rebase_options options;
 
-	git_rebase_type_t type;
+	git_rebase_t type;
 	char *state_path;
 
 	int head_detached : 1,
@@ -86,18 +86,18 @@ struct git_rebase {
 #define GIT_REBASE_STATE_INIT {0}
 
 static int rebase_state_type(
-	git_rebase_type_t *type_out,
+	git_rebase_t *type_out,
 	char **path_out,
 	git_repository *repo)
 {
 	git_buf path = GIT_BUF_INIT;
-	git_rebase_type_t type = GIT_REBASE_TYPE_NONE;
+	git_rebase_t type = GIT_REBASE_NONE;
 
 	if (git_buf_joinpath(&path, repo->gitdir, REBASE_APPLY_DIR) < 0)
 		return -1;
 
 	if (git_path_isdir(git_buf_cstr(&path))) {
-		type = GIT_REBASE_TYPE_APPLY;
+		type = GIT_REBASE_APPLY;
 		goto done;
 	}
 
@@ -106,14 +106,14 @@ static int rebase_state_type(
 		return -1;
 
 	if (git_path_isdir(git_buf_cstr(&path))) {
-		type = GIT_REBASE_TYPE_MERGE;
+		type = GIT_REBASE_MERGE;
 		goto done;
 	}
 
 done:
 	*type_out = type;
 
-	if (type != GIT_REBASE_TYPE_NONE && path_out)
+	if (type != GIT_REBASE_NONE && path_out)
 		*path_out = git_buf_detach(&path);
 
 	git_buf_dispose(&path);
@@ -314,7 +314,7 @@ int git_rebase_open(
 	if ((error = rebase_state_type(&rebase->type, &rebase->state_path, repo)) < 0)
 		goto done;
 
-	if (rebase->type == GIT_REBASE_TYPE_NONE) {
+	if (rebase->type == GIT_REBASE_NONE) {
 		git_error_set(GIT_ERROR_REBASE, "there is no rebase in progress");
 		error = GIT_ENOTFOUND;
 		goto done;
@@ -370,14 +370,14 @@ int git_rebase_open(
 		rebase->orig_head_name = git_buf_detach(&orig_head_name);
 
 	switch (rebase->type) {
-	case GIT_REBASE_TYPE_INTERACTIVE:
+	case GIT_REBASE_INTERACTIVE:
 		git_error_set(GIT_ERROR_REBASE, "interactive rebase is not supported");
 		error = -1;
 		break;
-	case GIT_REBASE_TYPE_MERGE:
+	case GIT_REBASE_MERGE:
 		error = rebase_open_merge(rebase);
 		break;
-	case GIT_REBASE_TYPE_APPLY:
+	case GIT_REBASE_APPLY:
 		git_error_set(GIT_ERROR_REBASE, "patch application rebase is not supported");
 		error = -1;
 		break;
@@ -509,12 +509,12 @@ int git_rebase_init_options(git_rebase_options *opts, unsigned int version)
 static int rebase_ensure_not_in_progress(git_repository *repo)
 {
 	int error;
-	git_rebase_type_t type;
+	git_rebase_t type;
 
 	if ((error = rebase_state_type(&type, NULL, repo)) < 0)
 		return error;
 
-	if (type != GIT_REBASE_TYPE_NONE) {
+	if (type != GIT_REBASE_NONE) {
 		git_error_set(GIT_ERROR_REBASE, "there is an existing rebase in progress");
 		return -1;
 	}
@@ -729,7 +729,7 @@ int git_rebase_init(
 
 	rebase->repo = repo;
 	rebase->inmemory = inmemory;
-	rebase->type = GIT_REBASE_TYPE_MERGE;
+	rebase->type = GIT_REBASE_MERGE;
 
 	if ((error = rebase_init_operations(rebase, repo, branch, upstream, onto)) < 0)
 		goto done;
@@ -764,7 +764,7 @@ static void normalize_checkout_options_for_apply(
 	if (!checkout_opts->ancestor_label)
 		checkout_opts->ancestor_label = "ancestor";
 
-	if (rebase->type == GIT_REBASE_TYPE_MERGE) {
+	if (rebase->type == GIT_REBASE_MERGE) {
 		if (!checkout_opts->our_label)
 			checkout_opts->our_label = rebase->onto_name;
 
@@ -917,7 +917,7 @@ int git_rebase_next(
 
 	if (rebase->inmemory)
 		error = rebase_next_inmemory(out, rebase);
-	else if (rebase->type == GIT_REBASE_TYPE_MERGE)
+	else if (rebase->type == GIT_REBASE_MERGE)
 		error = rebase_next_merge(out, rebase);
 	else
 		abort();
@@ -1128,7 +1128,7 @@ int git_rebase_commit(
 	if (rebase->inmemory)
 		error = rebase_commit_inmemory(
 			id, rebase, author, committer, message_encoding, message);
-	else if (rebase->type == GIT_REBASE_TYPE_MERGE)
+	else if (rebase->type == GIT_REBASE_MERGE)
 		error = rebase_commit_merge(
 			id, rebase, author, committer, message_encoding, message);
 	else

--- a/src/status.c
+++ b/src/status.c
@@ -87,14 +87,14 @@ static unsigned int workdir_delta2status(
 			 * discern between RENAMED vs RENAMED+MODIFED
 			 */
 			if (git_oid_is_zero(&idx2wd->old_file.id) &&
-				diff->old_src == GIT_ITERATOR_TYPE_WORKDIR &&
+				diff->old_src == GIT_ITERATOR_WORKDIR &&
 				!git_diff__oid_for_file(
 					&idx2wd->old_file.id, diff, idx2wd->old_file.path,
 					idx2wd->old_file.mode, idx2wd->old_file.size))
 			idx2wd->old_file.flags |= GIT_DIFF_FLAG_VALID_ID;
 
 			if (git_oid_is_zero(&idx2wd->new_file.id) &&
-				diff->new_src == GIT_ITERATOR_TYPE_WORKDIR &&
+				diff->new_src == GIT_ITERATOR_WORKDIR &&
 				!git_diff__oid_for_file(
 					&idx2wd->new_file.id, diff, idx2wd->new_file.path,
 					idx2wd->new_file.mode, idx2wd->new_file.size))

--- a/src/transports/auth.c
+++ b/src/transports/auth.c
@@ -47,7 +47,7 @@ on_error:
 }
 
 static git_http_auth_context basic_context = {
-	GIT_AUTHTYPE_BASIC,
+	GIT_HTTP_AUTH_BASIC,
 	GIT_CREDTYPE_USERPASS_PLAINTEXT,
 	0,
 	NULL,

--- a/src/transports/auth.h
+++ b/src/transports/auth.h
@@ -14,16 +14,16 @@
 #include "netops.h"
 
 typedef enum {
-	GIT_AUTHTYPE_BASIC = 1,
-	GIT_AUTHTYPE_NEGOTIATE = 2,
-	GIT_AUTHTYPE_NTLM = 4,
-} git_http_authtype_t;
+	GIT_HTTP_AUTH_BASIC = 1,
+	GIT_HTTP_AUTH_NEGOTIATE = 2,
+	GIT_HTTP_AUTH_NTLM = 4,
+} git_http_auth_t;
 
 typedef struct git_http_auth_context git_http_auth_context;
 
 struct git_http_auth_context {
 	/** Type of scheme */
-	git_http_authtype_t type;
+	git_http_auth_t type;
 
 	/** Supported credentials */
 	git_credtype_t credtypes;
@@ -46,7 +46,7 @@ struct git_http_auth_context {
 
 typedef struct {
 	/** Type of scheme */
-	git_http_authtype_t type;
+	git_http_auth_t type;
 
 	/** Name of the scheme (as used in the Authorization header) */
 	const char *name;

--- a/src/transports/auth_negotiate.c
+++ b/src/transports/auth_negotiate.c
@@ -274,7 +274,7 @@ int git_http_auth_negotiate(
 		return -1;
 	}
 
-	ctx->parent.type = GIT_AUTHTYPE_NEGOTIATE;
+	ctx->parent.type = GIT_HTTP_AUTH_NEGOTIATE;
 	ctx->parent.credtypes = GIT_CREDTYPE_DEFAULT;
 	ctx->parent.connection_affinity = 1;
 	ctx->parent.set_challenge = negotiate_set_challenge;

--- a/src/transports/auth_ntlm.c
+++ b/src/transports/auth_ntlm.c
@@ -207,7 +207,7 @@ int git_http_auth_ntlm(
 		return -1;
 	}
 
-	ctx->parent.type = GIT_AUTHTYPE_NTLM;
+	ctx->parent.type = GIT_HTTP_AUTH_NTLM;
 	ctx->parent.credtypes = GIT_CREDTYPE_USERPASS_PLAINTEXT;
 	ctx->parent.connection_affinity = 1;
 	ctx->parent.set_challenge = ntlm_set_challenge;

--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -26,9 +26,9 @@
 #include "streams/socket.h"
 
 git_http_auth_scheme auth_schemes[] = {
-	{ GIT_AUTHTYPE_NEGOTIATE, "Negotiate", GIT_CREDTYPE_DEFAULT, git_http_auth_negotiate },
-	{ GIT_AUTHTYPE_NTLM, "NTLM", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_ntlm },
-	{ GIT_AUTHTYPE_BASIC, "Basic", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_basic },
+	{ GIT_HTTP_AUTH_NEGOTIATE, "Negotiate", GIT_CREDTYPE_DEFAULT, git_http_auth_negotiate },
+	{ GIT_HTTP_AUTH_NTLM, "NTLM", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_ntlm },
+	{ GIT_HTTP_AUTH_BASIC, "Basic", GIT_CREDTYPE_USERPASS_PLAINTEXT, git_http_auth_basic },
 };
 
 static const char *upload_pack_service = "upload-pack";
@@ -78,7 +78,7 @@ typedef struct {
 	git_net_url url;
 	git_stream *stream;
 
-	git_http_authtype_t authtypes;
+	git_http_auth_t authtypes;
 	git_credtype_t credtypes;
 
 	git_cred *cred;

--- a/tests/merge/merge_helpers.h
+++ b/tests/merge/merge_helpers.h
@@ -36,7 +36,7 @@ struct merge_index_conflict_data {
 	struct merge_index_with_status ancestor;
 	struct merge_index_with_status ours;
 	struct merge_index_with_status theirs;
-	git_merge_diff_type_t change_type;
+	git_merge_diff_t change_type;
 };
 
 int merge_trees_from_branches(


### PR DESCRIPTION
libgit2 does not use `type_t` suffixes as it's redundant; thus, rename some internal types to remove `type` from the name.

* `git_http_authtype_t` -> `git_http_auth_t`
* `git_iterator_type_t` -> `git_iterator_t`
* `git_rebase_type_t` -> `git_rebase_t`
* `git_merge_diff_type_t` -> `git_merge_diff_t`