### PR TITLE
Return int from non-free functions

### DIFF
--- a/include/git2/attr.h
+++ b/include/git2/attr.h
@@ -238,8 +238,11 @@ GIT_EXTERN(int) git_attr_foreach(
  * disk no longer match the cached contents of memory.  This will cause
  * the attributes files to be reloaded the next time that an attribute
  * access function is called.
+ *
+ * @param repo The repository containing the gitattributes cache
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_attr_cache_flush(
+GIT_EXTERN(int) git_attr_cache_flush(
 	git_repository *repo);
 
 /**

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -117,8 +117,9 @@ GIT_BEGIN_DECL
  * @param major Store the major version number
  * @param minor Store the minor version number
  * @param rev Store the revision (patch) number
+ * @return 0 on success or an error code on failure
  */
-GIT_EXTERN(void) git_libgit2_version(int *major, int *minor, int *rev);
+GIT_EXTERN(int) git_libgit2_version(int *major, int *minor, int *rev);
 
 /**
  * Combinations of these values describe the features with which libgit2

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -143,8 +143,9 @@ GIT_EXTERN(void) git_error_clear(void);
  * @param error_class One of the `git_error_t` enum above describing the
  *                    general subsystem that is responsible for the error.
  * @param string The formatted error message to keep
+ * @return 0 on success or -1 on failure
  */
-GIT_EXTERN(void) git_error_set_str(int error_class, const char *string);
+GIT_EXTERN(int) git_error_set_str(int error_class, const char *string);
 
 /**
  * Set the error message to a special value for memory allocation failure.

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -73,8 +73,9 @@ GIT_EXTERN(int) git_oid_fromstrn(git_oid *out, const char *str, size_t length);
  *
  * @param out oid structure the result is written into.
  * @param raw the raw input bytes to be copied.
+ * @return 0 on success or error code
  */
-GIT_EXTERN(void) git_oid_fromraw(git_oid *out, const unsigned char *raw);
+GIT_EXTERN(int) git_oid_fromraw(git_oid *out, const unsigned char *raw);
 
 /**
  * Format a git_oid into a hex string.
@@ -85,8 +86,9 @@ GIT_EXTERN(void) git_oid_fromraw(git_oid *out, const unsigned char *raw);
  *		oid digits are written; a '\\0' terminator must be added
  *		by the caller if it is required.
  * @param id oid structure to format.
+ * @return 0 on success or error code
  */
-GIT_EXTERN(void) git_oid_fmt(char *out, const git_oid *id);
+GIT_EXTERN(int) git_oid_fmt(char *out, const git_oid *id);
 
 /**
  * Format a git_oid into a partial hex string.
@@ -96,8 +98,9 @@ GIT_EXTERN(void) git_oid_fmt(char *out, const git_oid *id);
  *		will be zeroed; if not, a '\0' terminator is NOT added.
  * @param n number of characters to write into out string
  * @param id oid structure to format.
+ * @return 0 on success or error code
  */
-GIT_EXTERN(void) git_oid_nfmt(char *out, size_t n, const git_oid *id);
+GIT_EXTERN(int) git_oid_nfmt(char *out, size_t n, const git_oid *id);
 
 /**
  * Format a git_oid into a loose-object path string.
@@ -111,8 +114,9 @@ GIT_EXTERN(void) git_oid_nfmt(char *out, size_t n, const git_oid *id);
  *		oid digits are written; a '\\0' terminator must be added
  *		by the caller if it is required.
  * @param id oid structure to format.
+ * @return 0 on success, non-zero callback return value, or error code
  */
-GIT_EXTERN(void) git_oid_pathfmt(char *out, const git_oid *id);
+GIT_EXTERN(int) git_oid_pathfmt(char *out, const git_oid *id);
 
 /**
  * Format a git_oid into a statically allocated c-string.
@@ -151,8 +155,9 @@ GIT_EXTERN(char *) git_oid_tostr(char *out, size_t n, const git_oid *id);
  *
  * @param out oid structure the result is written into.
  * @param src oid structure to copy from.
+ * @return 0 on success or error code
  */
-GIT_EXTERN(void) git_oid_cpy(git_oid *out, const git_oid *src);
+GIT_EXTERN(int) git_oid_cpy(git_oid *out, const git_oid *src);
 
 /**
  * Compare two oid structures.

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -378,8 +378,9 @@ GIT_EXTERN(int) git_remote_connected(const git_remote *remote);
  * the operation has been cancelled and if so stops the operation.
  *
  * @param remote the remote
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_remote_stop(git_remote *remote);
+GIT_EXTERN(int) git_remote_stop(git_remote *remote);
 
 /**
  * Disconnect from the remote
@@ -387,8 +388,9 @@ GIT_EXTERN(void) git_remote_stop(git_remote *remote);
  * Close the connection to the remote.
  *
  * @param remote the remote to disconnect from
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_remote_disconnect(git_remote *remote);
+GIT_EXTERN(int) git_remote_disconnect(git_remote *remote);
 
 /**
  * Free the memory associated with a remote

--- a/include/git2/revwalk.h
+++ b/include/git2/revwalk.h
@@ -84,8 +84,9 @@ GIT_EXTERN(int) git_revwalk_new(git_revwalk **out, git_repository *repo);
  * is over.
  *
  * @param walker handle to reset.
+ * @return 0 or an error code
  */
-GIT_EXTERN(void) git_revwalk_reset(git_revwalk *walker);
+GIT_EXTERN(int) git_revwalk_reset(git_revwalk *walker);
 
 /**
  * Add a new root for the traversal
@@ -224,8 +225,9 @@ GIT_EXTERN(int) git_revwalk_next(git_oid *out, git_revwalk *walk);
  *
  * @param walk the walker being used for the traversal.
  * @param sort_mode combination of GIT_SORT_XXX flags
+ * @return 0 or an error code
  */
-GIT_EXTERN(void) git_revwalk_sorting(git_revwalk *walk, unsigned int sort_mode);
+GIT_EXTERN(int) git_revwalk_sorting(git_revwalk *walk, unsigned int sort_mode);
 
 /**
  * Push and hide the respective endpoints of the given range.
@@ -246,8 +248,10 @@ GIT_EXTERN(int) git_revwalk_push_range(git_revwalk *walk, const char *range);
  * Simplify the history by first-parent
  *
  * No parents other than the first for each commit will be enqueued.
+ *
+ * @return 0 or an error code
  */
-GIT_EXTERN(void) git_revwalk_simplify_first_parent(git_revwalk *walk);
+GIT_EXTERN(int) git_revwalk_simplify_first_parent(git_revwalk *walk);
 
 
 /**

--- a/include/git2/sys/index.h
+++ b/include/git2/sys/index.h
@@ -75,8 +75,9 @@ GIT_EXTERN(int) git_index_name_add(git_index *index,
  * Remove all filename conflict entries.
  *
  * @param index an existing index object
+ * @return 0 or an error code
  */
-GIT_EXTERN(void) git_index_name_clear(git_index *index);
+GIT_EXTERN(int) git_index_name_clear(git_index *index);
 
 /**@}*/
 
@@ -170,8 +171,9 @@ GIT_EXTERN(int) git_index_reuc_remove(git_index *index, size_t n);
  * Remove all resolve undo entries from the index
  *
  * @param index an existing index object
+ * @return 0 or an error code
  */
-GIT_EXTERN(void) git_index_reuc_clear(git_index *index);
+GIT_EXTERN(int) git_index_reuc_clear(git_index *index);
 
 /**@}*/
 

--- a/include/git2/sys/mempack.h
+++ b/include/git2/sys/mempack.h
@@ -78,8 +78,9 @@ GIT_EXTERN(int) git_mempack_dump(git_buf *pack, git_repository *repo, git_odb_ba
  * semantics to the Git repository.
  *
  * @param backend The mempack backend
+ * @return 0 on success; error code otherwise
  */
-GIT_EXTERN(void) git_mempack_reset(git_odb_backend *backend);
+GIT_EXTERN(int) git_mempack_reset(git_odb_backend *backend);
 
 GIT_END_DECL
 

--- a/include/git2/sys/repository.h
+++ b/include/git2/sys/repository.h
@@ -44,8 +44,11 @@ GIT_EXTERN(int) git_repository_new(git_repository **out);
  * trying to aggressively cleanup the repo before its
  * deallocation. `git_repository_free` already performs this operation
  * before deallocating the repo.
+ *
+ * @param repo The repository to clean up
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_repository__cleanup(git_repository *repo);
+GIT_EXTERN(int) git_repository__cleanup(git_repository *repo);
 
 /**
  * Update the filesystem config settings for an open repository
@@ -78,8 +81,9 @@ GIT_EXTERN(int) git_repository_reinit_filesystem(
  *
  * @param repo A repository object
  * @param config A Config object
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_repository_set_config(git_repository *repo, git_config *config);
+GIT_EXTERN(int) git_repository_set_config(git_repository *repo, git_config *config);
 
 /**
  * Set the Object Database for this repository
@@ -93,8 +97,9 @@ GIT_EXTERN(void) git_repository_set_config(git_repository *repo, git_config *con
  *
  * @param repo A repository object
  * @param odb An ODB object
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_repository_set_odb(git_repository *repo, git_odb *odb);
+GIT_EXTERN(int) git_repository_set_odb(git_repository *repo, git_odb *odb);
 
 /**
  * Set the Reference Database Backend for this repository
@@ -108,8 +113,9 @@ GIT_EXTERN(void) git_repository_set_odb(git_repository *repo, git_odb *odb);
  *
  * @param repo A repository object
  * @param refdb An refdb object
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_repository_set_refdb(git_repository *repo, git_refdb *refdb);
+GIT_EXTERN(int) git_repository_set_refdb(git_repository *repo, git_refdb *refdb);
 
 /**
  * Set the index file for this repository
@@ -123,8 +129,9 @@ GIT_EXTERN(void) git_repository_set_refdb(git_repository *repo, git_refdb *refdb
  *
  * @param repo A repository object
  * @param index An index object
+ * @return 0 on success, or an error code
  */
-GIT_EXTERN(void) git_repository_set_index(git_repository *repo, git_index *index);
+GIT_EXTERN(int) git_repository_set_index(git_repository *repo, git_index *index);
 
 /**
  * Set a repository to be bare.

--- a/include/git2/tree.h
+++ b/include/git2/tree.h
@@ -258,8 +258,9 @@ GIT_EXTERN(int) git_treebuilder_new(
  * Clear all the entires in the builder
  *
  * @param bld Builder to clear
+ * @return 0 on success; error code otherwise
  */
-GIT_EXTERN(void) git_treebuilder_clear(git_treebuilder *bld);
+GIT_EXTERN(int) git_treebuilder_clear(git_treebuilder *bld);
 
 /**
  * Get the number of entries listed in a treebuilder
@@ -357,8 +358,9 @@ typedef int GIT_CALLBACK(git_treebuilder_filter_cb)(
  * @param bld Tree builder
  * @param filter Callback to filter entries
  * @param payload Extra data to pass to filter callback
+ * @return 0 on success, non-zero callback return value, or error code
  */
-GIT_EXTERN(void) git_treebuilder_filter(
+GIT_EXTERN(int) git_treebuilder_filter(
 	git_treebuilder *bld,
 	git_treebuilder_filter_cb filter,
 	void *payload);

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -411,7 +411,7 @@ cancel:
 	return ret;
 }
 
-void git_attr_cache_flush(git_repository *repo)
+int git_attr_cache_flush(git_repository *repo)
 {
 	git_attr_cache *cache;
 
@@ -420,6 +420,8 @@ void git_attr_cache_flush(git_repository *repo)
 	 */
 	if (repo && (cache = git__swap(repo->attrcache, NULL)) != NULL)
 		attr_cache__free(cache);
+
+	return 0;
 }
 
 int git_attr_cache__insert_macro(git_repository *repo, git_attr_rule *macro)

--- a/src/errors.c
+++ b/src/errors.c
@@ -95,19 +95,25 @@ void git_error_vset(int error_class, const char *fmt, va_list ap)
 		set_error_from_buffer(error_class);
 }
 
-void git_error_set_str(int error_class, const char *string)
+int git_error_set_str(int error_class, const char *string)
 {
 	git_buf *buf = &GIT_GLOBAL->error_buf;
 
 	assert(string);
 
-	if (!string)
-		return;
+	if (!string) {
+		git_error_set(GIT_ERROR_INVALID, "unspecified caller error");
+		return -1;
+	}
 
 	git_buf_clear(buf);
 	git_buf_puts(buf, string);
-	if (!git_buf_oom(buf))
-		set_error_from_buffer(error_class);
+
+	if (git_buf_oom(buf))
+		return -1;
+
+	set_error_from_buffer(error_class);
+	return 0;
 }
 
 void git_error_clear(void)

--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -125,7 +125,7 @@ cleanup:
 	return err;
 }
 
-void git_mempack_reset(git_odb_backend *_backend)
+int git_mempack_reset(git_odb_backend *_backend)
 {
 	struct memory_packer_db *db = (struct memory_packer_db *)_backend;
 	struct memobject *object = NULL;
@@ -137,6 +137,8 @@ void git_mempack_reset(git_odb_backend *_backend)
 	git_array_clear(db->commits);
 
 	git_oidmap_clear(db->objects);
+
+	return 0;
 }
 
 static void impl__free(git_odb_backend *_backend)

--- a/src/oid.c
+++ b/src/oid.c
@@ -64,13 +64,13 @@ GIT_INLINE(char) *fmt_one(char *str, unsigned int val)
 	return str;
 }
 
-void git_oid_nfmt(char *str, size_t n, const git_oid *oid)
+int git_oid_nfmt(char *str, size_t n, const git_oid *oid)
 {
 	size_t i, max_i;
 
 	if (!oid) {
 		memset(str, 0, n);
-		return;
+		return 0;
 	}
 	if (n > GIT_OID_HEXSZ) {
 		memset(&str[GIT_OID_HEXSZ], 0, n - GIT_OID_HEXSZ);
@@ -84,14 +84,16 @@ void git_oid_nfmt(char *str, size_t n, const git_oid *oid)
 
 	if (n & 1)
 		*str++ = to_hex[oid->id[i] >> 4];
+
+	return 0;
 }
 
-void git_oid_fmt(char *str, const git_oid *oid)
+int git_oid_fmt(char *str, const git_oid *oid)
 {
-	git_oid_nfmt(str, GIT_OID_HEXSZ, oid);
+	return git_oid_nfmt(str, GIT_OID_HEXSZ, oid);
 }
 
-void git_oid_pathfmt(char *str, const git_oid *oid)
+int git_oid_pathfmt(char *str, const git_oid *oid)
 {
 	size_t i;
 
@@ -99,6 +101,8 @@ void git_oid_pathfmt(char *str, const git_oid *oid)
 	*str++ = '/';
 	for (i = 1; i < sizeof(oid->id); i++)
 		str = fmt_one(str, oid->id[i]);
+
+	return 0;
 }
 
 char *git_oid_tostr_s(const git_oid *oid)
@@ -167,14 +171,16 @@ void git_oid__writebuf(git_buf *buf, const char *header, const git_oid *oid)
 	git_buf_putc(buf, '\n');
 }
 
-void git_oid_fromraw(git_oid *out, const unsigned char *raw)
+int git_oid_fromraw(git_oid *out, const unsigned char *raw)
 {
 	memcpy(out->id, raw, sizeof(out->id));
+	return 0;
 }
 
-void git_oid_cpy(git_oid *out, const git_oid *src)
+int git_oid_cpy(git_oid *out, const git_oid *src)
 {
 	memcpy(out->id, src->id, sizeof(out->id));
+	return 0;
 }
 
 int git_oid_cmp(const git_oid *a, const git_oid *b)

--- a/src/remote.c
+++ b/src/remote.c
@@ -1676,20 +1676,24 @@ int git_remote_connected(const git_remote *remote)
 	return remote->transport->is_connected(remote->transport);
 }
 
-void git_remote_stop(git_remote *remote)
+int git_remote_stop(git_remote *remote)
 {
 	assert(remote);
 
 	if (remote->transport && remote->transport->cancel)
 		remote->transport->cancel(remote->transport);
+
+	return 0;
 }
 
-void git_remote_disconnect(git_remote *remote)
+int git_remote_disconnect(git_remote *remote)
 {
 	assert(remote);
 
 	if (git_remote_connected(remote))
 		remote->transport->close(remote->transport);
+
+	return 0;
 }
 
 void git_remote_free(git_remote *remote)

--- a/src/repository.c
+++ b/src/repository.c
@@ -138,7 +138,7 @@ static void set_index(git_repository *repo, git_index *index)
 	}
 }
 
-void git_repository__cleanup(git_repository *repo)
+int git_repository__cleanup(git_repository *repo)
 {
 	assert(repo);
 
@@ -150,6 +150,8 @@ void git_repository__cleanup(git_repository *repo)
 	set_index(repo, NULL);
 	set_odb(repo, NULL);
 	set_refdb(repo, NULL);
+
+	return 0;
 }
 
 void git_repository_free(git_repository *repo)
@@ -1070,10 +1072,11 @@ int git_repository_config_snapshot(git_config **out, git_repository *repo)
 	return git_config_snapshot(out, weak);
 }
 
-void git_repository_set_config(git_repository *repo, git_config *config)
+int git_repository_set_config(git_repository *repo, git_config *config)
 {
 	assert(repo && config);
 	set_config(repo, config);
+	return 0;
 }
 
 int git_repository_odb__weakptr(git_odb **out, git_repository *repo)
@@ -1121,10 +1124,11 @@ int git_repository_odb(git_odb **out, git_repository *repo)
 	return 0;
 }
 
-void git_repository_set_odb(git_repository *repo, git_odb *odb)
+int git_repository_set_odb(git_repository *repo, git_odb *odb)
 {
 	assert(repo && odb);
 	set_odb(repo, odb);
+	return 0;
 }
 
 int git_repository_refdb__weakptr(git_refdb **out, git_repository *repo)
@@ -1161,10 +1165,11 @@ int git_repository_refdb(git_refdb **out, git_repository *repo)
 	return 0;
 }
 
-void git_repository_set_refdb(git_repository *repo, git_refdb *refdb)
+int git_repository_set_refdb(git_repository *repo, git_refdb *refdb)
 {
 	assert(repo && refdb);
 	set_refdb(repo, refdb);
+	return 0;
 }
 
 int git_repository_index__weakptr(git_index **out, git_repository *repo)
@@ -1210,10 +1215,11 @@ int git_repository_index(git_index **out, git_repository *repo)
 	return 0;
 }
 
-void git_repository_set_index(git_repository *repo, git_index *index)
+int git_repository_set_index(git_repository *repo, git_index *index)
 {
 	assert(repo);
 	set_index(repo, index);
+	return 0;
 }
 
 int git_repository_set_namespace(git_repository *repo, const char *namespace)

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -700,7 +700,7 @@ git_repository *git_revwalk_repository(git_revwalk *walk)
 	return walk->repo;
 }
 
-void git_revwalk_sorting(git_revwalk *walk, unsigned int sort_mode)
+int git_revwalk_sorting(git_revwalk *walk, unsigned int sort_mode)
 {
 	assert(walk);
 
@@ -719,11 +719,14 @@ void git_revwalk_sorting(git_revwalk *walk, unsigned int sort_mode)
 
 	if (walk->sorting != GIT_SORT_NONE)
 		walk->limited = 1;
+
+	return 0;
 }
 
-void git_revwalk_simplify_first_parent(git_revwalk *walk)
+int git_revwalk_simplify_first_parent(git_revwalk *walk)
 {
 	walk->first_parent = 1;
+	return 0;
 }
 
 int git_revwalk_next(git_oid *oid, git_revwalk *walk)
@@ -752,7 +755,7 @@ int git_revwalk_next(git_oid *oid, git_revwalk *walk)
 	return error;
 }
 
-void git_revwalk_reset(git_revwalk *walk)
+int git_revwalk_reset(git_revwalk *walk)
 {
 	git_commit_list_node *commit;
 
@@ -777,6 +780,8 @@ void git_revwalk_reset(git_revwalk *walk)
 	walk->limited = 0;
 	walk->did_push = walk->did_hide = 0;
 	walk->sorting = GIT_SORT_NONE;
+
+	return 0;
 }
 
 int git_revwalk_add_hide_cb(

--- a/src/settings.c
+++ b/src/settings.c
@@ -29,11 +29,13 @@
 #include "streams/openssl.h"
 #include "streams/mbedtls.h"
 
-void git_libgit2_version(int *major, int *minor, int *rev)
+int git_libgit2_version(int *major, int *minor, int *rev)
 {
 	*major = LIBGIT2_VER_MAJOR;
 	*minor = LIBGIT2_VER_MINOR;
 	*rev = LIBGIT2_VER_REVISION;
+
+	return 0;
 }
 
 int git_libgit2_features(void)

--- a/src/tree.c
+++ b/src/tree.c
@@ -834,7 +834,7 @@ out:
 	return error;
 }
 
-void git_treebuilder_filter(
+int git_treebuilder_filter(
 	git_treebuilder *bld,
 	git_treebuilder_filter_cb filter,
 	void *payload)
@@ -850,9 +850,11 @@ void git_treebuilder_filter(
 				git_tree_entry_free(entry);
 			}
 	});
+
+	return 0;
 }
 
-void git_treebuilder_clear(git_treebuilder *bld)
+int git_treebuilder_clear(git_treebuilder *bld)
 {
 	git_tree_entry *e;
 
@@ -860,6 +862,8 @@ void git_treebuilder_clear(git_treebuilder *bld)
 
 	git_strmap_foreach_value(bld->map, e, git_tree_entry_free(e));
 	git_strmap_clear(bld->map);
+
+	return 0;
 }
 
 void git_treebuilder_free(git_treebuilder *bld)


### PR DESCRIPTION
Return `int` from all the functions that aren't `dispose` or `free` functions.  This allows us to gracefully fail on bad inputs (instead of an `assert` or crashing with a segmentation fault).

Only functions that cannot fail will remain void.  This includes:

* `*_dispose` and `*_free`: which should gracefully take `NULL` pointers, ignore them, and continue.
* `giterr_clear`: which cannot fail (since it just updates pointers in global state)
* `giterr_set_oom`: which cannot fail (since it just updates pointers in global state)
