### PR TITLE
Update link to libgit2 Julia language binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Here are the bindings to libgit2 that are currently available:
 * Java
     * Jagged <https://github.com/ethomson/jagged>
 * Julia
-    * LibGit2.jl <https://github.com/jakebolewski/LibGit2.jl>
+    * LibGit2.jl <https://github.com/JuliaLang/julia/tree/master/stdlib/LibGit2>
 * Lua
     * luagit2 <https://github.com/libgit2/luagit2>
 * .NET


### PR DESCRIPTION
https://github.com/libgit2/libgit2#language-bindings mentions the Julia binding to be at https://github.com/jakebolewski/LibGit2.jl , which doesn't exist anymore. LibGit2.jl has been merged into the Julia standard library (inside the main Julia language repo). Updated the link to the new location in this PR.