### PR TITLE
fetchhead: strip credentials from remote URL

### DIFF
--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -108,7 +108,7 @@ void test_fetchhead_nonetwork__write(void)
 typedef struct {
 	git_vector *fetchhead_vector;
 	size_t idx;
-} fetchhead_ref_cb_data; 
+} fetchhead_ref_cb_data;
 
 static int fetchhead_ref_cb(const char *name, const char *url,
 	const git_oid *oid, unsigned int is_merge, void *payload)
@@ -492,4 +492,22 @@ void test_fetchhead_nonetwork__create_with_multiple_refspecs(void)
 
 	git_remote_free(remote);
 	git_buf_dispose(&path);
+}
+
+void test_fetchhead_nonetwork__credentials_are_stripped(void)
+{
+	git_fetchhead_ref *ref;
+	git_oid oid;
+
+	cl_git_pass(git_oid_fromstr(&oid, "49322bb17d3acc9146f98c97d078513228bbf3c0"));
+	cl_git_pass(git_fetchhead_ref_create(&ref, &oid, 0,
+		"refs/tags/commit_tree", "http://foo:bar@github.com/libgit2/TestGitRepository"));
+	cl_assert_equal_s(ref->remote_url, "http://github.com/libgit2/TestGitRepository");
+	git_fetchhead_ref_free(ref);
+
+	cl_git_pass(git_oid_fromstr(&oid, "49322bb17d3acc9146f98c97d078513228bbf3c0"));
+	cl_git_pass(git_fetchhead_ref_create(&ref, &oid, 0,
+		"refs/tags/commit_tree", "https://foo:bar@github.com/libgit2/TestGitRepository"));
+	cl_assert_equal_s(ref->remote_url, "https://github.com/libgit2/TestGitRepository");
+	git_fetchhead_ref_free(ref);
 }

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -154,3 +154,20 @@ void test_online_fetchhead__colon_only_dst_refspec_creates_no_branch(void)
 
 	cl_assert_equal_i(refs, count_references());
 }
+
+void test_online_fetchhead__creds_get_stripped(void)
+{
+	git_buf buf = GIT_BUF_INIT;
+	git_remote *remote;
+
+	cl_git_pass(git_repository_init(&g_repo, "./foo", 0));
+	cl_git_pass(git_remote_create_anonymous(&remote, g_repo, "https://foo:bar@github.com/libgit2/TestGitRepository"));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+
+	cl_git_pass(git_futils_readbuffer(&buf, "./foo/.git/FETCH_HEAD"));
+	cl_assert_equal_s(buf.ptr,
+		"49322bb17d3acc9146f98c97d078513228bbf3c0\t\thttps://github.com/libgit2/TestGitRepository\n");
+
+	git_remote_free(remote);
+	git_buf_dispose(&buf);
+}


### PR DESCRIPTION
If fetching from an anonymous remote via its URL, then the URL gets
written into the FETCH_HEAD reference. This is mainly done to give
valuable context to some commands, like for example git-merge(1), which
will put the URL into the generated MERGE_MSG. As a result, what gets
written into FETCH_HEAD may become public in some cases. This is
especially important considering that URLs may contain credentials, e.g.
when cloning 'https://foo:bar@example.com/repo' we persist the complete
URL into FETCH_HEAD and put it without any kind of sanitization into the
MERGE_MSG. This is obviously bad, as your login data has now just leaked
as soon as you do git-push(1).

When writing the URL into FETCH_HEAD, upstream git does strip
credentials first. Let's do the same by trying to parse the remote URL
as a "real" URL, removing any credentials and then re-formatting the
URL. In case this fails, e.g. when it's a file path or not a valid URL,
we just fall back to using the URL as-is without any sanitization. Add
tests to verify our behaviour.

---

May fix #5370 