### PR TITLE
azure-pipelines: properly expand negotiate passwords

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
        CC=gcc
        CMAKE_GENERATOR=Ninja
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DVALGRIND=on -DUSE_GSSAPI=ON
-       GITTEST_NEGOTIATE_PASSWORD=$(GITTEST_NEGOTIATE_PASSWORD)
+       GITTEST_NEGOTIATE_PASSWORD=${{ variables.GITTEST_NEGOTIATE_PASSWORD }}
 
 - job: linux_amd64_xenial_gcc_mbedtls
   displayName: 'Linux (amd64; Xenial; GCC; mbedTLS)'
@@ -36,7 +36,7 @@ jobs:
        CC=gcc
        CMAKE_GENERATOR=Ninja
        CMAKE_OPTIONS=-DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DVALGRIND=on -DUSE_GSSAPI=ON
-       GITTEST_NEGOTIATE_PASSWORD=$(GITTEST_NEGOTIATE_PASSWORD)
+       GITTEST_NEGOTIATE_PASSWORD=${{ variables.GITTEST_NEGOTIATE_PASSWORD }}
 
 - job: linux_amd64_xenial_clang_openssl
   displayName: 'Linux (amd64; Xenial; Clang; OpenSSL)'
@@ -52,7 +52,7 @@ jobs:
        CC=clang
        CMAKE_GENERATOR=Ninja
        CMAKE_OPTIONS=-DUSE_HTTPS=OpenSSL -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DVALGRIND=on -DUSE_GSSAPI=ON
-       GITTEST_NEGOTIATE_PASSWORD=$(GITTEST_NEGOTIATE_PASSWORD)
+       GITTEST_NEGOTIATE_PASSWORD=${{ variables.GITTEST_NEGOTIATE_PASSWORD }}
 
 - job: linux_amd64_xenial_clang_mbedtls
   displayName: 'Linux (amd64; Xenial; Clang; mbedTLS)'
@@ -68,7 +68,7 @@ jobs:
        CC=clang
        CMAKE_GENERATOR=Ninja
        CMAKE_OPTIONS=-DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DVALGRIND=on -DUSE_GSSAPI=ON
-       GITTEST_NEGOTIATE_PASSWORD=$(GITTEST_NEGOTIATE_PASSWORD)
+       GITTEST_NEGOTIATE_PASSWORD=${{ variables.GITTEST_NEGOTIATE_PASSWORD }}
 
 - job: macos
   displayName: 'macOS'
@@ -85,7 +85,7 @@ jobs:
         CMAKE_GENERATOR: Ninja
         CMAKE_OPTIONS: -DREGEX_BACKEND=regcomp_l -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=leaks -DUSE_GSSAPI=ON
         SKIP_SSH_TESTS: true
-        GITTEST_NEGOTIATE_PASSWORD: $(GITTEST_NEGOTIATE_PASSWORD)
+        GITTEST_NEGOTIATE_PASSWORD: ${{ variables.GITTEST_NEGOTIATE_PASSWORD }}
 
 - job: windows_vs_amd64
   displayName: 'Windows (amd64; Visual Studio)'


### PR DESCRIPTION
To allow testing against a Kerberos instance, we have added variables
for the Kerberos password to allow authentication against LIBGIT2.ORG in
commit e5fb5fe5a (ci: perform SPNEGO tests, 2019-10-20). To set up the
password, we assign

    "GITTEST_NEGOTIATE_PASSWORD=$(GITTEST_NEGOTIATE_PASSWORD)"

in the environmentVariables section which is then passed through to a
template. As the template does build-time expansion of the environment
variables, it will expand the above line verbosely, and due to the
envVar section not doing any further expansion the password variable
will end up with the value "$(GITTEST_NEGOTIATE_PASSWORD)" in the
container's environment.

Fix this fixed by doing expansion of GITTEST_NEGOTIATE_PASSWORD at
build-time, as well.