### PR TITLE
Honor GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH for all checkout types 

### DIFF
--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -89,6 +89,65 @@ void test_checkout_index__can_remove_untracked_files(void)
 	cl_assert_equal_i(false, git_path_isdir("./testrepo/dir"));
 }
 
+void test_checkout_index__can_disable_pathspec_match(void)
+{
+	static git_index *index;
+	git_oid commit_id;
+	git_checkout_options g_opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_object *g_object;
+
+	char *files_to_checkout[] = { "test11.txt", "test12.txt"};
+	size_t files_to_checkout_size = 2;
+
+	/* reset to beginning of history (i.e. just a README file) */
+	g_opts.checkout_strategy =
+		GIT_CHECKOUT_FORCE | GIT_CHECKOUT_REMOVE_UNTRACKED;
+
+	cl_git_pass(git_revparse_single(&g_object, g_repo, "8496071c1b46c854b31185ea97743be6a8774479"));
+	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
+	cl_git_pass(
+		git_repository_set_head_detached(g_repo, git_object_id(g_object)));
+	git_object_free(g_object);
+	g_object = NULL;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+
+	/* We create 4 files and commit them */
+	cl_git_mkfile("testrepo/test9.txt", "original\n");
+	cl_git_mkfile("testrepo/test10.txt", "original\n");
+	cl_git_mkfile("testrepo/test11.txt", "original\n");
+	cl_git_mkfile("testrepo/test12.txt", "original\n");
+
+	cl_git_pass(git_index_add_bypath(index, "test9.txt"));
+	cl_git_pass(git_index_add_bypath(index, "test10.txt"));
+	cl_git_pass(git_index_add_bypath(index, "test11.txt"));
+	cl_git_pass(git_index_add_bypath(index, "test12.txt"));
+	cl_git_pass(git_index_write(index));
+
+	cl_repo_commit_from_index(&commit_id, g_repo, NULL, 0, "commit our test files");
+
+	/* We modify the content of all 4 of our files */
+	cl_git_rewritefile("testrepo/test9.txt", "modified\n");
+	cl_git_rewritefile("testrepo/test10.txt", "modified\n");
+	cl_git_rewritefile("testrepo/test11.txt", "modified\n");
+	cl_git_rewritefile("testrepo/test12.txt", "modified\n");
+
+	/* We checkout only test10.txt and test11.txt */
+	g_opts.checkout_strategy =
+		GIT_CHECKOUT_FORCE | GIT_CHECKOUT_REMOVE_UNTRACKED |
+		GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
+	g_opts.paths.strings = files_to_checkout;
+	g_opts.paths.count = files_to_checkout_size;
+	cl_git_pass(git_checkout_index(g_repo, NULL, &g_opts));
+
+	/* The only files that have been reverted to their original content
+	   should be test10.txt and test11.txt */
+	check_file_contents("testrepo/test9.txt", "modified\n");
+	check_file_contents("testrepo/test10.txt", "original\n");
+	check_file_contents("testrepo/test11.txt", "original\n");
+	check_file_contents("testrepo/test12.txt", "modified\n");
+}
+
 void test_checkout_index__honor_the_specified_pathspecs(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -96,7 +96,7 @@ void test_checkout_index__can_disable_pathspec_match(void)
 	git_checkout_options g_opts = GIT_CHECKOUT_OPTIONS_INIT;
 	git_object *g_object;
 
-	char *files_to_checkout[] = { "test11.txt", "test12.txt"};
+	char *files_to_checkout[] = { "test10.txt", "test11.txt"};
 	size_t files_to_checkout_size = 2;
 
 	/* reset to beginning of history (i.e. just a README file) */
@@ -134,7 +134,7 @@ void test_checkout_index__can_disable_pathspec_match(void)
 
 	/* We checkout only test10.txt and test11.txt */
 	g_opts.checkout_strategy =
-		GIT_CHECKOUT_FORCE | GIT_CHECKOUT_REMOVE_UNTRACKED |
+		GIT_CHECKOUT_FORCE |
 		GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
 	g_opts.paths.strings = files_to_checkout;
 	g_opts.paths.count = files_to_checkout_size;


### PR DESCRIPTION
During checkout with GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH, we were previously applying the pathspec filter for the baseline iterator during checkout, as well as the target **tree**.  (We were not applying the pathspecs when the target was not a tree.)

This was an oversight; in fact, we should apply the pathspec filter to _all_ checkout targets, not just trees.

Add a helper function to set the iterator pathspecs from the given checkout pathspecs, and call it everywhere.

Includes the test provided by https://github.com/libgit2/libgit2/commit/f37c77b4186714b0a973cab1c0a9dcf8efd19fae with some minor modifications.