### PR TITLE
winhttp: support optional client cert

### DIFF
--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -864,31 +864,28 @@ static int do_send_request(winhttp_stream *s, size_t len, bool chunked)
 
 static int send_request(winhttp_stream *s, size_t len, bool chunked)
 {
-	int request_failed = 1, cert_valid, client_cert_requested, error, attempts = 0;
+	int request_failed = 1, error, attempts = 0;
 	DWORD ignore_flags, send_request_error;
 
 	git_error_clear();
 
 	while (request_failed && attempts++ < 3) {
+		int cert_valid = 1;
+		int client_cert_requested = 0;
 		request_failed = 0;
-		cert_valid = 1;
-		client_cert_requested = 0;
 		if ((error = do_send_request(s, len, chunked)) < 0) {
 			send_request_error = GetLastError();
 			request_failed = 1;
 			switch (send_request_error) {
-				case ERROR_WINHTTP_SECURE_FAILURE: {
+				case ERROR_WINHTTP_SECURE_FAILURE:
 					cert_valid = 0;
 					break;
-				}
-				case ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED: {
+				case ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED:
 					client_cert_requested = 1;
 					break;
-				}
-				default: {
+				default:
 					git_error_set(GIT_ERROR_OS, "failed to send request");
 					return -1;
-				}
 			}
 		}
 

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -864,41 +864,67 @@ static int do_send_request(winhttp_stream *s, size_t len, bool chunked)
 
 static int send_request(winhttp_stream *s, size_t len, bool chunked)
 {
-	int request_failed = 0, cert_valid = 1, error = 0;
-	DWORD ignore_flags;
+	int request_failed = 1, cert_valid, client_cert_requested, error, attempts = 0;
+	DWORD ignore_flags, send_request_error;
 
 	git_error_clear();
-	if ((error = do_send_request(s, len, chunked)) < 0) {
-		if (GetLastError() != ERROR_WINHTTP_SECURE_FAILURE) {
-			git_error_set(GIT_ERROR_OS, "failed to send request");
-			return -1;
+
+	while (request_failed && attempts++ < 3) {
+		request_failed = 0;
+		cert_valid = 1;
+		client_cert_requested = 0;
+		if ((error = do_send_request(s, len, chunked)) < 0) {
+			send_request_error = GetLastError();
+			request_failed = 1;
+			switch (send_request_error) {
+				case ERROR_WINHTTP_SECURE_FAILURE: {
+					cert_valid = 0;
+					break;
+				}
+				case ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED: {
+					client_cert_requested = 1;
+					break;
+				}
+				default: {
+					git_error_set(GIT_ERROR_OS, "failed to send request");
+					return -1;
+				}
+			}
 		}
 
-		request_failed = 1;
-		cert_valid = 0;
+		if (!request_failed || send_request_error == ERROR_WINHTTP_SECURE_FAILURE) {
+			git_error_clear();
+			if ((error = certificate_check(s, cert_valid)) < 0) {
+				if (!git_error_last())
+					git_error_set(GIT_ERROR_OS, "user cancelled certificate check");
+
+				return error;
+			}
+		}
+
+		/* if neither the request nor the certificate check returned errors, we're done */
+		if (!request_failed)
+			return 0;
+
+		if (!cert_valid) {
+			ignore_flags = no_check_cert_flags;
+			if (!WinHttpSetOption(s->request, WINHTTP_OPTION_SECURITY_FLAGS, &ignore_flags, sizeof(ignore_flags))) {
+				git_error_set(GIT_ERROR_OS, "failed to set security options");
+				return -1;
+			}
+		}
+
+		if (client_cert_requested) {
+			/*
+			 * Client certificates are not supported, explicitly tell the server that
+			 * (it's possible a client certificate was requested but is not required)
+			 */
+			if (!WinHttpSetOption(s->request, WINHTTP_OPTION_CLIENT_CERT_CONTEXT, WINHTTP_NO_CLIENT_CERT_CONTEXT, 0)) {
+				git_error_set(GIT_ERROR_OS, "failed to set client cert context");
+				return -1;
+			}
+		}
 	}
-
-	git_error_clear();
-	if ((error = certificate_check(s, cert_valid)) < 0) {
-		if (!git_error_last())
-			git_error_set(GIT_ERROR_OS, "user cancelled certificate check");
-
-		return error;
-	}
-
-	/* if neither the request nor the certificate check returned errors, we're done */
-	if (!request_failed)
-		return 0;
-
-	ignore_flags = no_check_cert_flags;
-
-	if (!WinHttpSetOption(s->request, WINHTTP_OPTION_SECURITY_FLAGS, &ignore_flags, sizeof(ignore_flags))) {
-		git_error_set(GIT_ERROR_OS, "failed to set security options");
-		return -1;
-	}
-
-	if ((error = do_send_request(s, len, chunked)) < 0)
-		git_error_set(GIT_ERROR_OS, "failed to send request with unchecked certificate");
 
 	return error;
 }

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -889,7 +889,7 @@ static int send_request(winhttp_stream *s, size_t len, bool chunked)
 			}
 		}
 
-		if (!request_failed || send_request_error == ERROR_WINHTTP_SECURE_FAILURE) {
+		if (!request_failed || !cert_valid) {
 			git_error_clear();
 			if ((error = certificate_check(s, cert_valid)) < 0) {
 				if (!git_error_last())


### PR DESCRIPTION
Some reverse proxies/applications can be configured to require client certificates (mutual TLS authentication). It's also possible that the server requests a client certificate, but doesn't require it (allowing anonymous access). For example, an HAProxy frontend can be configured as so: `  bind *:8443 ssl crt /etc/ssl/certs/server.pem ca-file /etc/ssl/certs/ca.crt verify required`. `verify required` indicates that the server requires a valid client certificate to continue. Changing `verify required` to `verify optional` causes the server to request a client certificate, but allow anonymous access as well. In either case, `WinHttpSendRequest` will return `ERROR_WINHTTP_CLIENT_AUTH_CERT_NEEDED`. If this is returned, the request can be retried after setting the option `WINHTTP_OPTION_CLIENT_CERT_CONTEXT` to either `WINHTTP_NO_CLIENT_CERT_CONTEXT` (in which case we are requesting anonymous access) or by attaching a valid client certificate context.

Originally reported in: #4204
Related PR: #4787