### PR TITLE
mwindow: set limit on number of open files

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -205,7 +205,9 @@ typedef enum {
 	GIT_OPT_GET_PACK_MAX_OBJECTS,
 	GIT_OPT_SET_PACK_MAX_OBJECTS,
 	GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS,
-	GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE
+	GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE,
+	GIT_OPT_GET_MWINDOW_OPEN_LIMIT,
+	GIT_OPT_SET_MWINDOW_OPEN_LIMIT
 } git_libgit2_opt_t;
 
 /**
@@ -227,7 +229,7 @@ typedef enum {
  *
  *	* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):
  *
- *		>Set the maximum amount of memory that can be mapped at any time
+ *		> Set the maximum amount of memory that can be mapped at any time
  *		by the library
  *
  *	* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)
@@ -403,6 +405,16 @@ typedef enum {
  *		> When connecting to a server using NTLM or Negotiate
  *		> authentication, use expect/continue when POSTing data.
  *		> This option is not available on Windows.
+ *
+ *	* opts(GIT_OPT_GET_MWINDOW_OPEN_LIMIT, unsigned int *):
+ *
+ *		> Get the maximum number of files that will be mapped at any time by the library
+ *
+ *	* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, unsigned int):
+ *
+ *		> Set the maximum number of files that can be mapped at any time
+ *		by the library
+ *
  *
  * @param option Option key
  * @param ... value to set the option

--- a/src/settings.c
+++ b/src/settings.c
@@ -59,6 +59,7 @@ int git_libgit2_features(void)
 /* Declarations for tuneable settings */
 extern size_t git_mwindow__window_size;
 extern size_t git_mwindow__mapped_limit;
+extern size_t git_mwindow__open_limit;
 extern size_t git_indexer__max_objects;
 extern bool git_disable_pack_keep_file_checks;
 
@@ -122,6 +123,14 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_GET_MWINDOW_MAPPED_LIMIT:
 		*(va_arg(ap, size_t *)) = git_mwindow__mapped_limit;
+		break;
+
+	case GIT_OPT_SET_MWINDOW_OPEN_LIMIT:
+		git_mwindow__open_limit = va_arg(ap, unsigned int);
+		break;
+
+	case GIT_OPT_GET_MWINDOW_OPEN_LIMIT:
+		*(va_arg(ap, unsigned int *)) = git_mwindow__open_limit;
 		break;
 
 	case GIT_OPT_GET_SEARCH_PATH:


### PR DESCRIPTION
Doing many network operations can lead to lots of small packfiles.
The existing mwindow limit was only the total size of mmap'd files,
not on their number, so having lots of small packfiles could exhaust
the allowed number of open files, particularly on macOS, where
the default ulimit is very low.

Add a limit to the number of files as well as their total size,
and set the default limit low enough that even macOS users should not
hit it during normal use.

Fixes #2758
