### PR TITLE
transports: http: fix custom headers not being applied

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -346,6 +346,7 @@ static int generate_request(
 	request->credentials = transport->server.cred;
 	request->proxy = use_proxy ? &transport->proxy.url : NULL;
 	request->proxy_credentials = transport->proxy.cred;
+	request->custom_headers = &transport->owner->custom_headers;
 
 	if (stream->service->method == GIT_HTTP_METHOD_POST) {
 		request->chunked = stream->service->chunked;

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -392,6 +392,21 @@ void test_online_clone__credentials(void)
 	cl_fixture_cleanup("./foo");
 }
 
+void test_online_clone__credentials_via_custom_headers(void)
+{
+	const char *creds = "libgit3:libgit3";
+	git_buf auth = GIT_BUF_INIT;
+
+	cl_git_pass(git_buf_puts(&auth, "Authorization: Basic "));
+	cl_git_pass(git_buf_encode_base64(&auth, creds, strlen(creds)));
+	g_options.fetch_opts.custom_headers.count = 1;
+	g_options.fetch_opts.custom_headers.strings = &auth.ptr;
+
+	cl_git_pass(git_clone(&g_repo, "https://bitbucket.org/libgit2/testgitrepository.git", "./foo", &g_options));
+
+	git_buf_dispose(&auth);
+}
+
 void test_online_clone__bitbucket_style(void)
 {
 	git_credential_userpass_payload user_pass = {


### PR DESCRIPTION
In commit b9c5b15a7 (http: use the new httpclient, 2019-12-22), the HTTP
code got refactored to extract a generic HTTP client that operates
independently of the Git protocol. Part of refactoring was the creation
of a new `git_http_request` struct that encapsulates the generation of
requests. Our Git-specific HTTP transport was converted to use that in
`generate_request`, but during the process we forgot to set up custom
headers for the `git_http_request` and as a result we do not send out
these headers anymore.

Fix the issue by correctly setting up the request's custom headers.

---

Fixes #5385.