### PR TITLE
azure: fix misleading messages printed to stderr being

### DIFF
--- a/azure-pipelines/docker/bionic
+++ b/azure-pipelines/docker/bionic
@@ -25,9 +25,8 @@ RUN apt-get update && \
 RUN mkdir /var/run/sshd
 
 RUN cd /tmp && \
-    curl -LO https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz && \
-    tar -xf mbedtls-2.16.2-apache.tgz && \
-    rm -f mbedtls-2.16.2-apache.tgz && \
+    curl --location --silent https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz | \
+    tar -xz && \
     cd mbedtls-2.16.2 && \
     scripts/config.pl set MBEDTLS_MD4_C 1 && \
     CFLAGS=-fPIC cmake -G Ninja -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=OFF -DUSE_STATIC_MBEDTLS_LIBRARY=ON . && \

--- a/azure-pipelines/docker/entrypoint.sh
+++ b/azure-pipelines/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
-useradd --shell /bin/bash --create-home libgit2
+#!/bin/bash -e
+useradd --shell /bin/bash libgit2
 chown -R $(id -u libgit2) /home/libgit2
 exec gosu libgit2 "$@"

--- a/azure-pipelines/docker/xenial
+++ b/azure-pipelines/docker/xenial
@@ -27,9 +27,8 @@ RUN apt-get update && \
 
 FROM apt AS mbedtls
 RUN cd /tmp && \
-    curl -LO https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz && \
-    tar -xf mbedtls-2.16.2-apache.tgz && \
-    rm -f mbedtls-2.16.2-apache.tgz && \
+    curl --location --silent https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz | \
+    tar -xz && \
     cd mbedtls-2.16.2 && \
     scripts/config.pl set MBEDTLS_MD4_C 1 && \
     CFLAGS=-fPIC cmake -G Ninja -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=OFF -DUSE_STATIC_MBEDTLS_LIBRARY=ON . && \
@@ -39,9 +38,8 @@ RUN cd /tmp && \
 
 FROM mbedtls AS libssh2
 RUN cd /tmp && \
-    curl -LO https://www.libssh2.org/download/libssh2-1.8.2.tar.gz && \
-    tar -xf libssh2-1.8.2.tar.gz && \
-    rm -f libssh2-1.8.2.tar.gz && \
+    curl --location --silent https://www.libssh2.org/download/libssh2-1.8.2.tar.gz | \
+    tar -xz && \
     cd libssh2-1.8.2 && \
     CFLAGS=-fPIC cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=Libgcrypt . && \
     ninja install && \
@@ -50,9 +48,8 @@ RUN cd /tmp && \
 
 FROM libssh2 AS valgrind
 RUN cd /tmp && \
-    curl -LO https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 && \
-    tar -xf valgrind-3.15.0.tar.bz2 && \
-    rm -f valgrind-3.15.0.tar.bz2 && \
+    curl --location --silent https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 | \
+    tar -xj && \
     cd valgrind-3.15.0 && \
     ./configure && \
     make && \

--- a/azure-pipelines/test.sh
+++ b/azure-pipelines/test.sh
@@ -84,7 +84,7 @@ if [ -z "$SKIP_GITDAEMON_TESTS" ]; then
 fi
 
 if [ -z "$SKIP_PROXY_TESTS" ]; then
-	curl -L https://github.com/ethomson/poxyproxy/releases/download/v0.7.0/poxyproxy-0.7.0.jar >poxyproxy.jar
+	curl --location --silent https://github.com/ethomson/poxyproxy/releases/download/v0.7.0/poxyproxy-0.7.0.jar >poxyproxy.jar
 
 	echo ""
 	echo "Starting HTTP proxy (Basic)..."
@@ -96,7 +96,7 @@ if [ -z "$SKIP_PROXY_TESTS" ]; then
 fi
 
 if [ -z "$SKIP_NTLM_TESTS" ]; then
-	curl -L https://github.com/ethomson/poxygit/releases/download/v0.4.0/poxygit-0.4.0.jar >poxygit.jar
+	curl --location --silent https://github.com/ethomson/poxygit/releases/download/v0.4.0/poxygit-0.4.0.jar >poxygit.jar
 
 	echo ""
 	echo "Starting HTTP server..."

--- a/azure-pipelines/test.sh
+++ b/azure-pipelines/test.sh
@@ -81,6 +81,7 @@ if [ -z "$SKIP_GITDAEMON_TESTS" ]; then
 	git init --bare "${GITDAEMON_DIR}/test.git"
 	git daemon --listen=localhost --export-all --enable=receive-pack --base-path="${GITDAEMON_DIR}" "${GITDAEMON_DIR}" 2>/dev/null &
 	GITDAEMON_PID=$!
+	disown $GITDAEMON_PID
 fi
 
 if [ -z "$SKIP_PROXY_TESTS" ]; then


### PR DESCRIPTION
Azure Pipelines will report all messages printed to stderr at the end of a pipeline step, leading to output like below. It's convoluted, hard to read and ultimately completely pointless clutter that points to nonexistent errors. So let's fix all instances that caused prints to stderr without any real (or at least with irrelevant) reason.

```
Total Test time (real) =   0.05 sec
Cleaning up...
Stopping git daemon...
Stopping SSH...
Done.
Some tests failed.
/home/libgit2/source/azure-pipelines/test.sh: line 317:    26 Terminated              git daemon --listen=localhost --export-all --enable=receive-pack --base-path="${GITDAEMON_DIR}" "${GITDAEMON_DIR}" 2> /dev/null
##[error]useradd: warning: the home directory already exists.
##[error]Not copying any file from skel directory into it.
##[error]  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
##[error]                                 Dload  Upload   Total   Spent    Left  Speed
##[error]
100   609    0   609    0     0   2381      0 --:--:-- --:--:-- --:--:--  2388
##[error]
100 73489  100 73489    0     0   125k      0 --:--:-- --:--:-- --:--:--  383k
##[error]ceived % Xferd  Average Speed   Time    Time     Time  Current
##[error]                                 Dload  Upload   Total   Spent    Left  Speed
##[error]
100   608    0   608    0     0   2491      0 --:--:-- --:--:-- --:--:--  2502
##[error]
100 71645  100 71645    0     0   184k      0 --:--:-- --:--:-- --:--:--  184k
##[error]Errors while running CTest
##[error]Errors while running CTest
##[error]Errors while running CTest
##[error]/home/libgit2/source/azure-pipelines/test.sh: line 317:    26 Terminated              git daemon --listen=localhost --export-all --enable=receive-pack --base-path="${GITDAEMON_DIR}" "${GITDAEMON_DIR}" 2> /dev/null
##[error]/usr/bin/docker failed with return code: 1
Finishing: Test
```