### PR TITLE
CIFuzz dog food

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
       uses: actions/upload-artifact@v1
       if: failure()
       with:
-        name: bug_report
-        path: ./out/bug_report
+        name: artifacts
+        path: ./out/artifacts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,13 @@ jobs:
     - name: Build Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
-        project-name: 'libgit2'
+        oss-fuzz-project-name: 'libgit2'
         dry-run: true
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
-        fuzz-time: 600
+        oss-fuzz-project-name: 'libgit2'
+        fuzz-seconds: 600
         dry-run: true
     - name: Upload Crash
       uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on: [push]
+on: [pull_request]
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [push]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        project-name: 'libgit2'
+        dry-run: true
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        fuzz-time: 600
+        dry-run: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: bug_report
+        path: ./out/bug_report
+


### PR DESCRIPTION
OSS-Fuzz was wondering if libgit2 would dogfood CIFuzz,
a new feature being rolled out in OSS-Fuzz. It allows for pull
requests to be fuzzed in CI using fuzz targets enabled in OSS-Fuzz.
It will be active in dry-run mode meaning that it will never fail.