### PR TITLE
azure: docker: set up HOME variable to fix Coverity builds

### DIFF
--- a/azure-pipelines/docker/entrypoint.sh
+++ b/azure-pipelines/docker/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 useradd --shell /bin/bash libgit2
 chown --recursive libgit2:libgit2 /home/libgit2
-exec sudo --preserve-env --user=libgit2 "$@"
+exec sudo --preserve-env --set-home --user=libgit2 "$@"


### PR DESCRIPTION
In commit 01a834066 (azure: docker: fix ARM builds by replacing gosu(1),
2020-02-18), we've switched our entrypoint from gosu(1) to use sudo(1)
instead to fix our ARM builds. The switch introduced an incompatibility
that now causes our Coverity builds to fail, as the "--preserve-env"
switch will also keep HOME at its current value. As a result, Coverity
now tries to set up its configuration directory in root's home
directory, which it naturally can't write to.

Fix the issue by adding the "--set-home" flag to sudo(1).