### PR TITLE
Fix #5410: fix installing libgit2.pc in wrong location

### DIFF
--- a/cmake/Modules/PkgBuildConfig.cmake
+++ b/cmake/Modules/PkgBuildConfig.cmake
@@ -1,10 +1,5 @@
 # pkg-config file generation
 #
-# Uses the following globals:
-# - PKG_BUILD_PREFIX: the build location (aka prefix). Defaults to CMAKE_INSTALL_PREFIX
-# - PKG_BUILD_LIBDIR: the libdir location. Defaults to ${prefix}/lib.
-# - PKG_BUILD_INCLUDEDIR: the includedir location. Defaults to ${prefix}/include.
-#
 
 function(pkg_build_config)
     set(options)
@@ -29,37 +24,11 @@ function(pkg_build_config)
         message(FATAL_ERROR "Missing VERSION argument")
     endif()
 
-    if (DEFINED PKG_BUILD_PREFIX)
-        set(PKGCONFIG_PREFIX "${PKG_BUILD_PREFIX}")
-    else()
-        set(PKGCONFIG_PREFIX "${CMAKE_INSTALL_PREFIX}")
-    endif()
-
-    if(DEFINED PKG_BUILD_LIBDIR)
-        if (IS_ABSOLUTE ${PKG_BUILD_LIBDIR})
-            set(PKGCONFIG_LIBDIR ${PKG_BUILD_LIBDIR})
-        else()
-            set(PKGCONFIG_LIBDIR "\${prefix}/${PKG_BUILD_LIBDIR}")
-        endif()
-    else()
-        set(PKGCONFIG_LIBDIR "\${prefix}/lib")
-    endif()
-
-    if(DEFINED PKG_BUILD_INCLUDEDIR)
-        if (IS_ABSOLUTE ${PKG_BUILD_INCLUDEDIR})
-            set(PKGCONFIG_INCLUDEDIR ${PKG_BUILD_INCLUDEDIR})
-        else()
-            set(PKGCONFIG_INCLUDEDIR "\${prefix}/${PKG_BUILD_INCLUDEDIR}")
-        endif()
-    else()
-        set(PKGCONFIG_INCLUDEDIR "\${prefix}/include")
-    endif()
-
     # Write .pc "header"
     file(WRITE "${PKGCONFIG_FILE}"
-        "prefix=\"${PKGCONFIG_PREFIX}\"\n"
-        "libdir=\"${PKGCONFIG_LIBDIR}\"\n"
-        "includedir=\"${PKGCONFIG_INCLUDEDIR}\"\n"
+        "prefix=\"${CMAKE_INSTALL_PREFIX}\"\n"
+        "libdir=\"${LIB_INSTALL_DIR}\"\n"
+        "includedir=\"${INCLUDE_INSTALL_DIR}\"\n"
         "\n"
         "Name: ${PKGCONFIG_NAME}\n"
         "Description: ${PKGCONFIG_DESCRIPTION}\n"
@@ -105,6 +74,6 @@ function(pkg_build_config)
 
     # Install .pc file
     install(FILES "${PKGCONFIG_FILE}"
-        DESTINATION "${PKGCONFIG_PREFIX}/${PKGCONFIG_LIBDIR}/pkgconfig"
+        DESTINATION "${LIB_INSTALL_DIR}/pkgconfig"
     )
 endfunction()


### PR DESCRIPTION
Remove using custom PKG_BUILD_PREFIu, PKG_BUILD_LIBDIR and
PKG_BUILD_INCLUDEDIR variables.
Use cmake CMAKE_INSTALL_PREFIX, LIB_INSTALL_DIR, INCLUDE_INSTALL_DIR instead.
This patch fixes install libgit2.pc file in correct location and simpifies
cmake module.

When typical rpm package is build is passed typical set of cmakle switches. with base paths:
```
$ rpm -E %cmake | grep -- -D
        -DBUILD_SHARED_LIBS=ON \
        -DCMAKE_AR=${AR} \
        -DCMAKE_C_FLAGS_RELEASE="-DNDEBUG" \
        -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG" \
        -DCMAKE_Fortran_FLAGS_RELEASE="-DNDEBUG" \
        -DCMAKE_INSTALL_PREFIX=/usr \
        -DCMAKE_NM=${NM} \
        -DCMAKE_RANLIB=${RANLIB} \
        -DCMAKE_VERBOSE_MAKEFILE=ON \
        -DINCLUDE_INSTALL_DIR=/usr/include \
        -DLIB_INSTALL_DIR=/usr/lib64 \
        -DLIB_SUFFIX=64 \
        -DSHARE_INSTALL_PREFIX=/usr/share \
        -DSYSCONF_INSTALL_DIR=/etc
```
This patch switches to use those paths instead custom one.