### PR TITLE
deps: ntlmclient: fix missing htonll symbols on FreeBSD and SunOS

### DIFF
--- a/deps/ntlmclient/compat.h
+++ b/deps/ntlmclient/compat.h
@@ -22,8 +22,30 @@
 #endif
 
 #ifdef __linux__
+/* See man page endian(3) */
 # include <endian.h>
 # define htonll htobe64
+#elif defined(__OpenBSD__)
+/* See man page htobe64(3) */
+# include <endian.h>
+# define htonll htobe64
+#elif defined(__FreeBSD__)
+/* See man page bwaps64(9) */
+# include <sys/endian.h>
+# define htonll bswap64
+#elif defined(sun) || defined(__sun)
+/* See man page byteorder(3SOCKET) */
+# include <sys/types.h>
+# include <netinet/in.h>
+# include <inttypes.h>
+
+# if !defined(htonll)
+#  if defined(_BIG_ENDIAN)
+#   define htonll(x) (x)
+#  else
+#   define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl((uint64_t)(x) >> 32))
+#  endif
+# endif
 #endif
 
 #ifndef MIN

--- a/src/transports/auth_ntlm.c
+++ b/src/transports/auth_ntlm.c
@@ -50,10 +50,10 @@ static int ntlm_set_credentials(http_auth_ntlm_context *ctx, git_credential *_cr
 	cred = (git_credential_userpass_plaintext *)_cred;
 
 	if ((sep = strchr(cred->username, '\\')) != NULL) {
-		domain = strndup(cred->username, (sep - cred->username));
+		domain = git__strndup(cred->username, (sep - cred->username));
 		GIT_ERROR_CHECK_ALLOC(domain);
 
-		domainuser = strdup(sep + 1);
+		domainuser = git__strdup(sep + 1);
 		GIT_ERROR_CHECK_ALLOC(domainuser);
 
 		username = domainuser;


### PR DESCRIPTION
The ntlmclient dependency defines htonll on Linux-based systems, only.
As a result, non-Linux systems will run into compiler and/or linker
errors due to undefined symbols.

Fix this issue for FreeBSD, OpenBSD and SunOS/OpenSolaris by including
the proper headers and defining the symbol accordingly.

---

We should probably merge this upstream first, but given that upstream means @ethomson I've decided to create the PR here first to let people in #5414 verify the fix more easily.

Fixes #5414