### PR TITLE
index: Update the documentation for git_index_add_from_buffer()

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -555,8 +555,7 @@ GIT_EXTERN(int) git_index_add_bypath(git_index *index, const char *path);
  *
  * If a previous index entry exists that has the same path as the
  * given 'entry', it will be replaced.  Otherwise, the 'entry' will be
- * added. The `id` and the `file_size` of the 'entry' are updated with the
- * real value of the blob.
+ * added.
  *
  * This forces the file to be added to the index, not looking
  * at gitignore rules.  Those rules can be evaluated through


### PR DESCRIPTION
This change makes the docs reflect reality. The id and size were never
updated in the entry!