### PR TITLE
pack: Improve error handling for get_delta_base()

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -265,10 +265,11 @@ static int advance_delta_offset(git_indexer *idx, git_object_t type)
 	if (type == GIT_OBJECT_REF_DELTA) {
 		idx->off += GIT_OID_RAWSZ;
 	} else {
-		off64_t base_off = get_delta_base(idx->pack, &w, &idx->off, type, idx->entry_start);
+		off64_t base_off;
+		int error = get_delta_base(&base_off, idx->pack, &w, &idx->off, type, idx->entry_start);
 		git_mwindow_close(&w);
-		if (base_off < 0)
-			return (int)base_off;
+		if (error < 0)
+			return error;
 	}
 
 	return 0;

--- a/src/pack.c
+++ b/src/pack.c
@@ -930,6 +930,9 @@ int get_delta_base(
 
 			git_oid_fromraw(&oid, base_info);
 			if ((entry = git_oidmap_get(p->idx_cache, &oid)) != NULL) {
+				if (entry->offset == 0)
+					return packfile_error("delta offset is zero");
+
 				*curpos += 20;
 				*delta_base_out = entry->offset;
 				return 0;
@@ -948,6 +951,9 @@ int get_delta_base(
 		*curpos += 20;
 	} else
 		return packfile_error("unknown object type");
+
+	if (base_offset == 0)
+		return packfile_error("delta offset is zero");
 
 	*delta_base_out = base_offset;
 	return 0;

--- a/src/pack.h
+++ b/src/pack.h
@@ -143,8 +143,12 @@ int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, 
 ssize_t git_packfile_stream_read(git_packfile_stream *obj, void *buffer, size_t len);
 void git_packfile_stream_dispose(git_packfile_stream *obj);
 
-off64_t get_delta_base(struct git_pack_file *p, git_mwindow **w_curs,
-		off64_t *curpos, git_object_t type,
+int get_delta_base(
+		off64_t *delta_base_out,
+		struct git_pack_file *p,
+		git_mwindow **w_curs,
+		off64_t *curpos,
+		git_object_t type,
 		off64_t delta_obj_offset);
 
 void git_packfile_close(struct git_pack_file *p, bool unlink_packfile);


### PR DESCRIPTION
This change moves the responsibility of setting the error upon failures
of get_delta_base() to get_delta_base() instead of its callers. That
way, the caller chan always check if the return value is negative and
mark the whole operation as an error instead of using garbage values,
which can lead to crashes if the `.pack` files are malformed.