### PR TITLE
deps: ntlmclient: fix htonll on big endian FreeBSD

### DIFF
--- a/deps/ntlmclient/compat.h
+++ b/deps/ntlmclient/compat.h
@@ -32,7 +32,7 @@
 #elif defined(__FreeBSD__)
 /* See man page bwaps64(9) */
 # include <sys/endian.h>
-# define htonll bswap64
+# define htonll htobe64
 #elif defined(sun) || defined(__sun)
 /* See man page byteorder(3SOCKET) */
 # include <sys/types.h>


### PR DESCRIPTION
In commit 3828ea67b (deps: ntlmclient: fix missing htonll symbols on
FreeBSD and SunOS, 2020-02-21), we've fixed compilation on BSDs due to
missing `htonll` wrappers. While we are now using `htobe64` for both
Linux and OpenBSD, we decided to use `bswap64` on FreeBSD. While correct
on little endian systems, where we will swap from little- to big-endian,
we will also do the swap on big endian systems. As a result, we do not
use network byte order on such systems.

Fix the issue by using htobe64, as well.

---

@mfechner: could you please confirm that this still works as expected?
@ethomson: this is the follow-up to #5417 