### PR TITLE
win32: fix path canonicalization for paths starting with "../"

### DIFF
--- a/src/win32/path_w32.c
+++ b/src/win32/path_w32.c
@@ -110,11 +110,10 @@ int git_win32_path_canonicalize(git_win32_path path)
 
 		else if (len == 2 && from[0] == L'.' && from[1] == L'.') {
 			if (to == base) {
-				/* no more path segments to strip, eat the "../" */
+				/* Skip over leading "../" */
 				if (*next == L'\\')
 					len++;
-
-				base = to;
+				to += len;
 			} else {
 				/* back up a path segment */
 				while (to > base && to[-1] == L'\\') to--;

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -190,6 +190,26 @@ void test_core_posix__symlink_resolves_to_correct_type(void)
 	git_buf_dispose(&contents);
 }
 
+void test_core_posix__relative_symlink(void)
+{
+       git_buf contents = GIT_BUF_INIT;
+
+       if (!git_path_supports_symlinks(clar_sandbox_path()))
+               clar__skip();
+
+       cl_must_pass(git_futils_mkdir("dir", 0777, 0));
+       cl_git_mkfile("file", "contents");
+       cl_git_pass(p_symlink("../file", "dir/link"));
+       cl_git_pass(git_futils_readbuffer(&contents, "dir/link"));
+       cl_assert_equal_s(contents.ptr, "contents");
+
+       cl_must_pass(p_unlink("file"));
+       cl_must_pass(p_unlink("dir/link"));
+       cl_must_pass(p_rmdir("dir"));
+
+       git_buf_dispose(&contents);
+}
+
 void test_core_posix__symlink_to_file_across_dirs(void)
 {
 	git_buf contents = GIT_BUF_INIT;


### PR DESCRIPTION
The path canonicalization function for Windows strips leading "../".
This behaviour has been introduced with commit cceae9a25 (win32: use
NT-prefixed "\\?\" paths, 2014-12-01), saying that

> we must not rely on the system to translate "." and ".." in paths

The reasoning is that we mostly try to use NT-prefixed "\\?\" paths,
which does turn off path canonicalization. What's weird though is that
if we simply strip leading "..", then there is no way that we can end up
with the correct path, as we do not adjust any of the following path
components accordingly.

One place where this bites us is with the path canonicalization
for symlink targets introduced with commit 7d55bee6d (win32: fix
relative symlinks pointing into dirs, 2020-01-10). If creating a symlink
with target "../target", then the canonicalization function will strip
the leading "../" and create a symlink with target "target".

Given that stripping this prefix cannot be correct in general, let's
remove the stripping code and instead leave such prefixes intact. If
understanding the code correctly, then the change _should_ fix cases as
with the symlink while not breaking anything else.

---

@ethomson: this is a regression in v0.99, so we should fix it for v1.0. I'm reeeeeeally unsure about the fix, though, so please review it with extra scrutiny. You might also know more about the original code as you're the author ;)

Fixes #5424 