### PR TITLE
git__hexdump: better mimic `hexdump -C`

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -424,35 +424,48 @@ void git__hexdump(const char *buffer, size_t len)
 	last_line = (len % LINE_WIDTH);
 
 	for (i = 0; i < line_count; ++i) {
-		line = buffer + (i * LINE_WIDTH);
-		for (j = 0; j < LINE_WIDTH; ++j, ++line)
-			printf("%02X ", (unsigned char)*line & 0xFF);
+		printf("%08" PRIxZ "  ", (i * LINE_WIDTH));
 
-		printf("| ");
+		line = buffer + (i * LINE_WIDTH);
+		for (j = 0; j < LINE_WIDTH; ++j, ++line) {
+			printf("%02x ", (unsigned char)*line & 0xFF);
+
+			if (j == (LINE_WIDTH / 2))
+				printf(" ");
+		}
+
+		printf(" |");
 
 		line = buffer + (i * LINE_WIDTH);
 		for (j = 0; j < LINE_WIDTH; ++j, ++line)
 			printf("%c", (*line >= 32 && *line <= 126) ? *line : '.');
 
-		printf("\n");
+		printf("|\n");
 	}
 
 	if (last_line > 0) {
+		printf("%08" PRIxZ "  ", (line_count * LINE_WIDTH));
 
 		line = buffer + (line_count * LINE_WIDTH);
-		for (j = 0; j < last_line; ++j, ++line)
-			printf("%02X ", (unsigned char)*line & 0xFF);
+		for (j = 0; j < last_line; ++j, ++line) {
+			printf("%02x ", (unsigned char)*line & 0xFF);
 
+			if (j == (LINE_WIDTH / 2))
+				printf(" ");
+		}
+
+		if (j < (LINE_WIDTH / 2))
+			printf(" ");
 		for (j = 0; j < (LINE_WIDTH - last_line); ++j)
-			printf("	");
+			printf("   ");
 
-		printf("| ");
+		printf(" |");
 
 		line = buffer + (line_count * LINE_WIDTH);
 		for (j = 0; j < last_line; ++j, ++line)
 			printf("%c", (*line >= 32 && *line <= 126) ? *line : '.');
 
-		printf("\n");
+		printf("|\n");
 	}
 
 	printf("\n");


### PR DESCRIPTION
When debugging issues, `git__hexdump` can be useful, but its format is unlike the familiar `hexdump` command-line tool.  If you wanted to parse this output, it would be more helpful if it matched.

Update it to match `hexdump -C`.