### PR TITLE
azure-pipelines: download GlobalSign's certificate manually

### DIFF
--- a/azure-pipelines/docker/xenial
+++ b/azure-pipelines/docker/xenial
@@ -29,7 +29,9 @@ RUN apt-get update && \
 
 FROM apt AS mbedtls
 RUN cd /tmp && \
-    curl --location --silent https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz | \
+    curl --location http://secure.globalsign.com/cacert/gsrsaovsslca2018.crt | openssl x509 -inform der -out /tmp/cacert.pem && \
+    curl --location https://curl.haxx.se/ca/cacert.pem >> /tmp/cacert.pem && \
+    curl --location --silent https://tls.mbed.org/download/mbedtls-2.16.2-apache.tgz --cacert /tmp/cacert.pem | \
     tar -xz && \
     cd mbedtls-2.16.2 && \
     scripts/config.pl set MBEDTLS_MD4_C 1 && \


### PR DESCRIPTION
[tls.mbed.org](tls.mbed.org) is not providing their [full certificate chain](https://www.ssllabs.com/ssltest/analyze.html?d=tls.mbed.org).  Download their intermediate cert and use it (and the normal cacert list) during the mbedTLS download.