### PR TITLE
win32: don't canonicalize relative paths

### DIFF
--- a/src/win32/path_w32.h
+++ b/src/win32/path_w32.h
@@ -11,13 +11,25 @@
 #include "vector.h"
 
 /**
- * Create a Win32 path (in UCS-2 format) from a UTF-8 string.
+ * Create a Win32 path (in UCS-2 format) from a UTF-8 string.  If the given
+ * path is relative, then it will be turned into an absolute path by having
+ * the current working directory prepended.
  *
  * @param dest The buffer to receive the wide string.
  * @param src The UTF-8 string to convert.
  * @return The length of the wide string, in characters (not counting the NULL terminator), or < 0 for failure
  */
 extern int git_win32_path_from_utf8(git_win32_path dest, const char *src);
+
+/**
+ * Create a Win32 path (in UCS-2 format) from a UTF-8 string.  If the given
+ * path is relative, then it will not be turned into an absolute path.
+ *
+ * @param dest The buffer to receive the wide string.
+ * @param src The UTF-8 string to convert.
+ * @return The length of the wide string, in characters (not counting the NULL terminator), or < 0 for failure
+ */
+extern int git_win32_path_relative_from_utf8(git_win32_path dest, const char *src);
 
 /**
  * Canonicalize a Win32 UCS-2 path so that it is suitable for delivery to the

--- a/src/win32/path_w32.h
+++ b/src/win32/path_w32.h
@@ -26,6 +26,9 @@ extern int git_win32_path_from_utf8(git_win32_path dest, const char *src);
  * canonical (always backslashes, never forward slashes) and process any
  * directory entries of '.' or '..'.
  *
+ * Note that this is intended to be used on absolute Windows paths, those
+ * that start with `C:\`, `\\server\share`, `\\?\`, etc.
+ *
  * This processes the buffer in place.
  *
  * @param path The buffer to process

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -447,8 +447,7 @@ int p_symlink(const char *target, const char *path)
 	 * relative symlinks, this is not someting we want.
 	 */
 	if (git_win32_path_from_utf8(path_w, path) < 0 ||
-	    git__utf8_to_16(target_w, MAX_PATH, target) < 0 ||
-	    git_win32_path_canonicalize(target_w) < 0)
+	    git_win32_path_relative_from_utf8(target_w, target) < 0)
 		return -1;
 
 	dwFlags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;

--- a/tests/core/posix.c
+++ b/tests/core/posix.c
@@ -190,6 +190,26 @@ void test_core_posix__symlink_resolves_to_correct_type(void)
 	git_buf_dispose(&contents);
 }
 
+void test_core_posix__relative_symlink(void)
+{
+	git_buf contents = GIT_BUF_INIT;
+
+	if (!git_path_supports_symlinks(clar_sandbox_path()))
+		clar__skip();
+
+	cl_must_pass(git_futils_mkdir("dir", 0777, 0));
+	cl_git_mkfile("file", "contents");
+	cl_git_pass(p_symlink("../file", "dir/link"));
+	cl_git_pass(git_futils_readbuffer(&contents, "dir/link"));
+	cl_assert_equal_s(contents.ptr, "contents");
+
+	cl_must_pass(p_unlink("file"));
+	cl_must_pass(p_unlink("dir/link"));
+	cl_must_pass(p_rmdir("dir"));
+
+	git_buf_dispose(&contents);
+}
+
 void test_core_posix__symlink_to_file_across_dirs(void)
 {
 	git_buf contents = GIT_BUF_INIT;

--- a/tests/path/win32.c
+++ b/tests/path/win32.c
@@ -21,6 +21,21 @@ void test_utf8_to_utf16(const char *utf8_in, const wchar_t *utf16_expected)
 #endif
 }
 
+void test_utf8_to_utf16_relative(const char* utf8_in, const wchar_t* utf16_expected)
+{
+#ifdef GIT_WIN32
+	git_win32_path path_utf16;
+	int path_utf16len;
+
+	cl_assert((path_utf16len = git_win32_path_relative_from_utf8(path_utf16, utf8_in)) >= 0);
+	cl_assert_equal_wcs(utf16_expected, path_utf16);
+	cl_assert_equal_i(wcslen(utf16_expected), path_utf16len);
+#else
+	GIT_UNUSED(utf8_in);
+	GIT_UNUSED(utf16_expected);
+#endif
+}
+
 void test_path_win32__utf8_to_utf16(void)
 {
 #ifdef GIT_WIN32
@@ -126,6 +141,31 @@ void test_path_win32__absolute_from_relative(void)
 	test_utf8_to_utf16("", L"\\\\?\\C:\\Windows");
 
 	cl_must_pass(p_chdir(cwd_backup));
+#endif
+}
+
+void test_path_win32__keeps_relative(void)
+{
+#ifdef GIT_WIN32
+	/* Relative paths stay relative */
+	test_utf8_to_utf16_relative("Foo", L"Foo");
+	test_utf8_to_utf16_relative("..\\..\\Foo", L"..\\..\\Foo");
+	test_utf8_to_utf16_relative("Foo\\..", L"Foo\\..");
+	test_utf8_to_utf16_relative("Foo\\..\\..", L"Foo\\..\\..");
+	test_utf8_to_utf16_relative("Foo\\Bar", L"Foo\\Bar");
+	test_utf8_to_utf16_relative("Foo\\..\\Bar", L"Foo\\..\\Bar");
+	test_utf8_to_utf16_relative("../../Foo", L"..\\..\\Foo");
+	test_utf8_to_utf16_relative("Foo/..", L"Foo\\..");
+	test_utf8_to_utf16_relative("Foo/../..", L"Foo\\..\\..");
+	test_utf8_to_utf16_relative("Foo/Bar", L"Foo\\Bar");
+	test_utf8_to_utf16_relative("Foo/../Bar", L"Foo\\..\\Bar");
+	test_utf8_to_utf16_relative("Foo/../Bar/", L"Foo\\..\\Bar\\");
+	test_utf8_to_utf16_relative("", L"");
+
+	/* Absolute paths are canonicalized */
+	test_utf8_to_utf16_relative("\\Foo", L"\\\\?\\C:\\Foo");
+	test_utf8_to_utf16_relative("/Foo/Bar/", L"\\\\?\\C:\\Foo\\Bar");
+	test_utf8_to_utf16_relative("\\\\server\\c$\\unc\\path", L"\\\\?\\UNC\\server\\c$\\unc\\path");
 #endif
 }
 

--- a/tests/path/win32.c
+++ b/tests/path/win32.c
@@ -203,16 +203,6 @@ void test_path_win32__canonicalize(void)
 	test_canonicalize(L"C:/Foo/Bar", L"C:\\Foo\\Bar");
 	test_canonicalize(L"C:/", L"C:\\");
 
-	test_canonicalize(L"Foo\\\\Bar\\\\Asdf\\\\", L"Foo\\Bar\\Asdf");
-	test_canonicalize(L"Foo\\\\Bar\\\\..\\\\Asdf\\", L"Foo\\Asdf");
-	test_canonicalize(L"Foo\\\\Bar\\\\.\\\\Asdf\\", L"Foo\\Bar\\Asdf");
-	test_canonicalize(L"Foo\\\\..\\Bar\\\\.\\\\Asdf\\", L"Bar\\Asdf");
-	test_canonicalize(L"\\", L"");
-	test_canonicalize(L"", L"");
-	test_canonicalize(L"Foo\\..\\..\\..\\..", L"");
-	test_canonicalize(L"..\\..\\..\\..", L"");
-	test_canonicalize(L"\\..\\..\\..\\..", L"");
-
 	test_canonicalize(L"\\\\?\\C:\\Foo\\Bar", L"\\\\?\\C:\\Foo\\Bar");
 	test_canonicalize(L"\\\\?\\C:\\Foo\\Bar\\", L"\\\\?\\C:\\Foo\\Bar");
 	test_canonicalize(L"\\\\?\\C:\\\\Foo\\.\\Bar\\\\..\\", L"\\\\?\\C:\\Foo");


### PR DESCRIPTION
Our path canonicalization (beginning in  cceae9a) was meant to deal with absolute paths, converting things like `C:\Foo\Bar` into `\\?\C:\Foo\Bar` so that we could avoid some of the dangers of NTFS (like eliding trailing dots in filenames).  But by using those paths, we need to do canonicalization ourselves, as giving `\\?\C:\Foo\..\Bar` to the filesystem APIs will return an error instead of resolving the path.

These canonicalization function were not meant to deal with relative paths.  In particular, this means that leading ".." segments at the beginning of paths were removed, to translate `C:\..\..\..\` into the correct `\\?\C:\`.  (This is despite having some tests around relative path components, they were not well thought out since they were not intended to be used.)

Update the documentation on the function to point out that it's not to be used for relative paths, and remove the tests that suggest that it should be used that way.

Add a new function that will keep relative paths relative, while converting them to UTF-16 and translating `/` to `\\`.

Use this new relative path handling function when creating Windows symlinks.