### PR TITLE
refdb_fs: initialize backend version

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -2129,6 +2129,9 @@ int git_refdb_backend_fs(
 	backend = git__calloc(1, sizeof(refdb_fs_backend));
 	GIT_ERROR_CHECK_ALLOC(backend);
 
+	if (git_refdb_init_backend(&backend->parent, GIT_REFDB_BACKEND_VERSION) < 0)
+		goto fail;
+
 	backend->repo = repository;
 
 	if (repository->gitdir) {


### PR DESCRIPTION
While the `git_refdb_backend()` struct has a version, we do not
initialize it correctly when calling `git_refdb_backend_fs()`. Fix this
by adding the call to `git_refdb_init_backend()`.