### PR TITLE
credentials: provide backcompat for opaque structs

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -41,6 +41,13 @@
  */
 #ifndef GIT_DEPRECATE_HARD
 
+/*
+ * The credential structures are now opaque by default, and their
+ * definition has moved into the `sys/credential.h` header; include
+ * them here for backward compatibility.
+ */
+#include "sys/credential.h"
+
 /**
  * @file git2/deprecated.h
  * @brief libgit2 deprecated functions and values


### PR DESCRIPTION
The credential structures are now opaque and defined in `sys/credential.h`.  However, we should continue to provide them for backward compatibility, unless `GIT_DEPRECATED_HARD` is set.

Fixes #5415