### PR TITLE
Release v1.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,54 @@
+v1.0
+----
+
+This is release v1.0 "Luftschloss", which is the first stabe release of
+libgit2. The API will stay compatible across all releases of the same major
+version. This release includes bugfixes only and supersedes v0.99, which will
+stop being maintained. Both v0.27 and v0.28 stay supported in accordance with
+our release policy.
+
+### Changes or improvements
+
+- CMake was converted to make use of the GNUInstallDirs module for both our
+  pkgconfig and install targets in favor of our custom build options
+  `BIN_INSTALL_DIR`, `LIB_INSTALL_DIR` and `INCLUDE_INSTALL_DIR`. Instead, you
+  can now use CMakes standard variables `CMAKE_INSTALL_BINDIR`,
+  `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR`.
+
+- Some CMake build options accepted either a specific value or a boolean value
+  to disable the option altogether or use automatic detection. We only accepted
+  "ON" or "OFF", but none of the other values CMake recognizes as boolean. This
+  was aligned with CMake's understanding of booleans.
+
+- The installed pkgconfig file contained incorrect values for both `libdir` and
+  `includedir` variables.
+
+- If using pcre2 for regular expressions, then we incorrectly added "pcre2"
+  instead of "pcre2-8" to our pkgconfig dependencies, which was corrected.
+
+- Fixed building the bundled ntlmclient dependency on FreeBSD, OpenBSD and
+  SunOS.
+
+- When writing symlinks on Windows, we incorrectly handled relative symlink
+  targets, which was corrected.
+
+- When using the HTTP protocol via macOS' SecureTransport implementation, reads
+  could stall at the end of the session and only continue after a timeout of 60
+  seconds was reached.
+
+- The filesystem-based reference callback didn't corectly initialize the backend
+  version.
+
+- A segmentation fault was fixed when calling `git_blame_buffer()` for files
+  that were modified and added to the index.
+
+- A backwards-incompatible change was introduced when we moved some structures
+  from "git2/credentials.h" into "git2/sys/credentials.h". This was fixed in the
+  case where you do not use hard deprecation.
+
+- Improved error handling in various places.
+
+
 v0.99
 -----
 

--- a/include/git2/version.h
+++ b/include/git2/version.h
@@ -7,12 +7,12 @@
 #ifndef INCLUDE_git_version_h__
 #define INCLUDE_git_version_h__
 
-#define LIBGIT2_VERSION "0.99.0"
-#define LIBGIT2_VER_MAJOR 0
-#define LIBGIT2_VER_MINOR 99
+#define LIBGIT2_VERSION "1.0.0"
+#define LIBGIT2_VER_MAJOR 1
+#define LIBGIT2_VER_MINOR 0
 #define LIBGIT2_VER_REVISION 0
 #define LIBGIT2_VER_PATCH 0
 
-#define LIBGIT2_SOVERSION "0.99"
+#define LIBGIT2_SOVERSION "1.0"
 
 #endif


### PR DESCRIPTION
This is in preparation for v1.0, including the update to our changelog and the version bump. I don't think we settled for any name yet, so I just chose a temporary one ("Aprilscherz" -> April Fools' joke). @carlosmn, you always manage to come up with weird German words, so if you want to give this a go I'd be happy to change it ;)

Right now, it looks like we should be able to release both v1.0 and v0.28.5 right on schedule on April 1st. 