### PR TITLE
Add create-signature-from-env functions, per #3751

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,13 @@
+v1.?
+----
+
+### Changes or improvements
+
+- Add two new functions, `git_signature_committer_env()` and
+  `git_signature_author_env()`, which create action signatures based on the
+  same environment variables used by the git command line tools, falling
+  back to the default (config) user if need be.
+
 v1.2
 -----
 
@@ -238,7 +248,7 @@ This is a bugfix release with the following changes:
 - Calculating information about renamed files during merges is more
   efficient because dissimilarity about files is now being cached and
   no longer needs to be recomputed.
-  
+
 - The `git_worktree_prune_init_options` has been correctly restored for
   backward compatibility.  In v1.0 it was incorrectly deprecated with a
   typo.
@@ -337,7 +347,7 @@ with v0.28.0.
 
 * Several function signatures have been changed to return an `int` to
   indicate error conditions.  We encourage you to check them for errors
-  in the standard way. 
+  in the standard way.
 
   * `git_attr_cache_flush`
   * `git_error_set_str`
@@ -456,7 +466,7 @@ with v0.28.0.
 
 * Several attribute macros have been renamed: `GIT_ATTR_TRUE` is now
   `GIT_ATTR_IS_TRUE`, `GIT_ATTR_FALSE` is now `GIT_ATTR_IS_FALSE`,
-  `GIT_ATTR_UNSPECIFIED` is now `GIT_ATTR_IS_UNSPECIFIED`.  The 
+  `GIT_ATTR_UNSPECIFIED` is now `GIT_ATTR_IS_UNSPECIFIED`.  The
   attribute enum `git_attr_t` is now `git_attr_value_t` and its
   values have been renamed: `GIT_ATTR_UNSPECIFIED_T` is now
   `GIT_ATTR_VALUE_UNSPECIFIED`, `GIT_ATTR_TRUE_T` is now

--- a/include/git2/signature.h
+++ b/include/git2/signature.h
@@ -63,6 +63,50 @@ GIT_EXTERN(int) git_signature_now(git_signature **out, const char *name, const c
 GIT_EXTERN(int) git_signature_default(git_signature **out, git_repository *repo);
 
 /**
+ * Create a new action signature based on AUTHOR environment variables,
+ * falling back to the default user, with a now timestamp.
+ *
+ * This uses the GIT_AUTHOR_NAME environment variable for the name,
+ * and GIT_AUTHOR_EMAIL for the email. If GIT_AUTHOR_EMAIL is not found,
+ * it falls back to the EMAIL environment variable.
+ *
+ * If either name or email aren't found in the environment, it uses
+ * the appropriate value from the default user.
+ *
+ * It takes the name and email found above, uses the current time as the
+ * timestamp, and creates a new signature based on that information.
+ * It will return GIT_ENOTFOUND if either the name or email could
+ * not be determined.
+ *
+ * @param out new signature
+ * @param repo repository pointer
+ * @return 0 on success, GIT_ENOTFOUND if config is missing, or error code
+ */
+GIT_EXTERN(int) git_signature_author_env(git_signature **out, git_repository *repo);
+
+/**
+ * Create a new action signature based on COMMITTER environment variables,
+ * falling back to the default user, with a now timestamp.
+ *
+ * This uses the GIT_COMMITTER_NAME environment variable for the name,
+ * and GIT_COMMITTER_EMAIL for the email. If GIT_COMMITTER_EMAIL is not found,
+ * it falls back to the EMAIL environment variable.
+ *
+ * If either name or email aren't found in the environment, it uses
+ * the appropriate value from the default user.
+ *
+ * It takes the name and email found above, uses the current time as the
+ * timestamp, and creates a new signature based on that information.
+ * It will return GIT_ENOTFOUND if either the name or email could
+ * not be determined.
+ *
+ * @param out new signature
+ * @param repo repository pointer
+ * @return 0 on success, GIT_ENOTFOUND if config is missing, or error code
+ */
+GIT_EXTERN(int) git_signature_committer_env(git_signature **out, git_repository *repo);
+
+/**
  * Create a new signature by parsing the given buffer, which is
  * expected to be in the format "Real Name <email> timestamp tzoffset",
  * where `timestamp` is the number of seconds since the Unix epoch and

--- a/tests/resources/testrepo.git/config
+++ b/tests/resources/testrepo.git/config
@@ -9,7 +9,7 @@
 [remote "joshaber"]
 	url = git://github.com/libgit2/libgit2
 [remote "empty-remote-url"]
-	url = 
+	url =
 	pushurl =
 [remote "empty-remote-pushurl"]
 	pushurl =
@@ -34,7 +34,10 @@
    merge = refs/heads/master
 [branch "mergeless"]
    remote = test
-   merge = 
+   merge =
 [branch "mergeandremoteless"]
-   remote = 
-   merge = 
+   remote =
+   merge =
+[user]
+   name = name from config
+   email = emailfromconfig@example.com


### PR DESCRIPTION
Use GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL if available (or
GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL)

Fall back to EMAIL if GIT_AUTHOR_EMAIL/GIT_COMMITTER_EMAIL is not available

Use the default user info (user.name, user.email) as last resorts.

Return GIT_ENOTFOUND if we don't have enough info for a signature