### PR TITLE
Fix typo causing removal of symbol 'git_worktree_prune_init_options'

### DIFF
--- a/src/worktree.c
+++ b/src/worktree.c
@@ -506,7 +506,7 @@ int git_worktree_prune_options_init(
 	return 0;
 }
 
-int git_worktree_pruneinit_options(git_worktree_prune_options *opts,
+int git_worktree_prune_init_options(git_worktree_prune_options *opts,
 	unsigned int version)
 {
 	return git_worktree_prune_options_init(opts, version);


### PR DESCRIPTION
Commit 0b5ba0d replaced this function with an "option_init"
equivallent, but misspelled the replacement function. As a result, this
symbol has been missing from libgit2.so ever since.