### PR TITLE
sysdir: remove unused git_sysdir_get_str

### DIFF
--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -216,25 +216,6 @@ int git_sysdir_get(const git_buf **out, git_sysdir_t which)
 	return 0;
 }
 
-int git_sysdir_get_str(
-	char *out,
-	size_t outlen,
-	git_sysdir_t which)
-{
-	const git_buf *path = NULL;
-
-	GIT_ERROR_CHECK_ERROR(git_sysdir_check_selector(which));
-	GIT_ERROR_CHECK_ERROR(git_sysdir_get(&path, which));
-
-	if (!out || path->size >= outlen) {
-		git_error_set(GIT_ERROR_NOMEMORY, "buffer is too short for the path");
-		return GIT_EBUFS;
-	}
-
-	git_buf_copy_cstr(out, outlen, path);
-	return 0;
-}
-
 #define PATH_MAGIC "$PATH"
 
 int git_sysdir_set(git_sysdir_t which, const char *search_path)

--- a/src/sysdir.h
+++ b/src/sysdir.h
@@ -94,17 +94,6 @@ extern int git_sysdir_global_init(void);
 extern int git_sysdir_get(const git_buf **out, git_sysdir_t which);
 
 /**
- * Get search path into a preallocated buffer
- *
- * @param out String buffer to write into
- * @param outlen Size of string buffer
- * @param which Which search path to return
- * @return 0 on success, GIT_EBUFS if out is too small, <0 on other failure
- */
-
-extern int git_sysdir_get_str(char *out, size_t outlen, git_sysdir_t which);
-
-/**
  * Set search paths for global/system/xdg files
  *
  * The first occurrence of the magic string "$PATH" in the new value will


### PR DESCRIPTION
This appears to be leftover from when we exposed this to the user.  We've moved to `git_buf`.