### PR TITLE
deps: ntlmclient: use htobe64 on NetBSD too

### DIFF
--- a/deps/ntlmclient/compat.h
+++ b/deps/ntlmclient/compat.h
@@ -25,7 +25,7 @@
 /* See man page endian(3) */
 # include <endian.h>
 # define htonll htobe64
-#elif defined(__OpenBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
 /* See man page htobe64(3) */
 # include <endian.h>
 # define htonll htobe64


### PR DESCRIPTION
unbreaks the build. should probably use this by default with the operating systems that don't have it being the exception.