### PR TITLE
odb_backend: Implement support for the  manual reordering of odb backends

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -205,7 +205,9 @@ typedef enum {
 	GIT_OPT_GET_PACK_MAX_OBJECTS,
 	GIT_OPT_SET_PACK_MAX_OBJECTS,
 	GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS,
-	GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE
+	GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE,
+	GIT_OPT_SET_ODB_PACKED_PRIORITY,
+	GIT_OPT_SET_ODB_LOOSE_PRIORITY
 } git_libgit2_opt_t;
 
 /**
@@ -403,6 +405,14 @@ typedef enum {
  *		> When connecting to a server using NTLM or Negotiate
  *		> authentication, use expect/continue when POSTing data.
  *		> This option is not available on Windows.
+ *
+ *   opts(GIT_OPT_SET_ODB_PACKED_PRIORITY, int priority)
+ *      > Override the default priority of the packed ODB backend which
+ *      > is added when default backends are assigned to a repository
+ *
+ *   opts(GIT_OPT_SET_ODB_LOOSE_PRIORITY, int priority)
+ *      > Override the default priority of the loose ODB backend which
+ *      > is added when default backends are assigned to a repository
  *
  * @param option Option key
  * @param ... value to set the option

--- a/src/odb.c
+++ b/src/odb.c
@@ -23,14 +23,14 @@
 
 #define GIT_ALTERNATES_FILE "info/alternates"
 
+#define GIT_ALTERNATES_MAX_DEPTH 5
+
 /*
  * We work under the assumption that most objects for long-running
  * operations will be packed
  */
-#define GIT_LOOSE_PRIORITY 1
-#define GIT_PACKED_PRIORITY 2
-
-#define GIT_ALTERNATES_MAX_DEPTH 5
+int git_odb_loose_priority = 1;
+int git_odb_packed_priority = 2;
 
 bool git_odb__strict_hash_verification = true;
 
@@ -572,12 +572,12 @@ int git_odb__add_default_backends(
 
 	/* add the loose object backend */
 	if (git_odb_backend_loose(&loose, objects_dir, -1, db->do_fsync, 0, 0) < 0 ||
-		add_backend_internal(db, loose, GIT_LOOSE_PRIORITY, as_alternates, inode) < 0)
+		add_backend_internal(db, loose, git_odb_loose_priority, as_alternates, inode) < 0)
 		return -1;
 
 	/* add the packed file backend */
 	if (git_odb_backend_pack(&packed, objects_dir) < 0 ||
-		add_backend_internal(db, packed, GIT_PACKED_PRIORITY, as_alternates, inode) < 0)
+		add_backend_internal(db, packed, git_odb_packed_priority, as_alternates, inode) < 0)
 		return -1;
 
 	return load_alternates(db, objects_dir, alternate_depth);

--- a/src/settings.c
+++ b/src/settings.c
@@ -61,6 +61,8 @@ extern size_t git_mwindow__window_size;
 extern size_t git_mwindow__mapped_limit;
 extern size_t git_indexer__max_objects;
 extern bool git_disable_pack_keep_file_checks;
+extern int git_odb_packed_priority;
+extern int git_odb_loose_priority;
 
 static int config_level_to_sysdir(int config_level)
 {
@@ -289,6 +291,14 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE:
 		git_http__expect_continue = (va_arg(ap, int) != 0);
+		break;
+
+	case GIT_OPT_SET_ODB_PACKED_PRIORITY:
+		git_odb_packed_priority = va_arg(ap, int);
+		break;
+
+	case GIT_OPT_SET_ODB_LOOSE_PRIORITY:
+		git_odb_loose_priority = va_arg(ap, int);
 		break;
 
 	default:

--- a/tests/odb/sorting.c
+++ b/tests/odb/sorting.c
@@ -68,3 +68,26 @@ void test_odb_sorting__alternate_backends_sorting(void)
 
 	check_backend_sorting(_odb);
 }
+
+void test_odb_sorting__override_default_backend_priority(void)
+{
+	git_odb *new_odb;
+	git_odb_backend *loose, *packed, *backend;
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_ODB_LOOSE_PRIORITY, 5));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_ODB_PACKED_PRIORITY, 3));
+	git_odb_backend_pack(&packed, "./testrepo.git/objects");
+	git_odb_backend_loose(&loose, "./testrepo.git/objects", -1, 0, 0, 0);
+
+	cl_git_pass(git_odb_open(&new_odb, cl_fixture("testrepo.git/objects")));
+	cl_assert_equal_sz(2, git_odb_num_backends(new_odb));
+
+	cl_git_pass(git_odb_get_backend(&backend, new_odb, 0));
+	cl_assert_equal_p(loose->read, backend->read);
+
+	cl_git_pass(git_odb_get_backend(&backend, new_odb, 1));
+	cl_assert_equal_p(packed->read, backend->read);
+
+	git_odb_free(new_odb);
+	loose->free(loose);
+	packed->free(packed);
+}


### PR DESCRIPTION
libgit2 has historically assumed that most objects for long-running
operations will be packed, therefore GIT_LOOSE_PRIORITY is set to
1 by default, and GIT_PACKED_PRIORITY is set at 2. 

When a client allows libgit2 to set the default backends, it would be helpful to
be able to rearrange the default backends without having to completely
set up a new odb from scratch. This commit adds a method to set
the priority for a backend in an odb and relies on the sorting in
git_odb_add_backend to rearrange the backends.

A use case for this would be to: create a new odb for a repository, let libgit2 set the default backends, then manually set the packed_backend priority to 1, loose_backend to 2, and add a custom backend with priority 3 to trigger the sort and have the custom backend be the first backend accessed. 