### PR TITLE
Fix binary diff showing /dev/null

### DIFF
--- a/src/patch_generate.c
+++ b/src/patch_generate.c
@@ -209,9 +209,7 @@ static int patch_generated_load(git_patch_generated *patch, git_patch_generated_
 
 	if ((error = git_diff_file_content__load(
 			&patch->ofile, &patch->base.diff_opts)) < 0 ||
-		should_skip_binary(patch, patch->ofile.file))
-		goto cleanup;
-	if ((error = git_diff_file_content__load(
+	    (error = git_diff_file_content__load(
 			&patch->nfile, &patch->base.diff_opts)) < 0 ||
 		should_skip_binary(patch, patch->nfile.file))
 		goto cleanup;

--- a/tests/diff/format_email.c
+++ b/tests/diff/format_email.c
@@ -487,7 +487,7 @@ void test_diff_format_email__binary(void)
 	"Subject: [PATCH] Modified binary file\n" \
 	"\n" \
 	"---\n" \
-	" binary.bin | Bin 3 -> 0 bytes\n" \
+	" binary.bin | Bin 3 -> 5 bytes\n" \
 	" 1 file changed, 0 insertions(+), 0 deletions(-)\n" \
 	"\n" \
 	"diff --git a/binary.bin b/binary.bin\n" \
@@ -496,7 +496,6 @@ void test_diff_format_email__binary(void)
 	"--\n" \
 	"libgit2 " LIBGIT2_VERSION "\n" \
 	"\n";
-	/* TODO: Actually 0 bytes here should be 5!. Seems like we don't load the new content for binary files? */
 
 	opts.summary = "Modified binary file";
 

--- a/tests/diff/stats.c
+++ b/tests/diff/stats.c
@@ -298,9 +298,8 @@ void test_diff_stats__binary(void)
 {
 	git_buf buf = GIT_BUF_INIT;
 	const char *stat =
-	" binary.bin | Bin 3 -> 0 bytes\n"
+	" binary.bin | Bin 3 -> 5 bytes\n"
 	" 1 file changed, 0 insertions(+), 0 deletions(-)\n";
-	/* TODO: Actually 0 bytes here should be 5!. Seems like we don't load the new content for binary files? */
 
 	diff_stats_from_commit_oid(
 		&_stats, "8d7523f6fcb2404257889abe0d96f093d9f524f9", false);


### PR DESCRIPTION
Fixes #5493 where a changed binary file's content in the working tree isn't displayed correctly, instead showing an OID of zero, and with its path being reported incorrectly as "/dev/null".

Initial focus was on the `maybe_modified` function in `diff_generate.c`: the binary file is stat'd, but because `modified_uncertain` is set to 0, `maybe_modified` does not (further down) calculate the relevant OID. Setting `modified_uncertain` to 1 rectifies the issue, but the test suite suggests an increased load on OID calculations which I suspect is best avoided where possible.

Instead, `patch_generate.c` can be adjusted to fix the problem by ensuring that for binary files both old **and** new files are loaded. This PR supplies that fix.

Note: with this fix in place, two tests then failed. On examination, both tests were seen to be deliberately broken *because* of this outstanding issue, so this PR also supplies the relevant corrections to the broken tests.