### PR TITLE
MSVC: Enable Control Flow Guard (CFG)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,11 @@ IF (MSVC)
 	# /Gd - explicitly set cdecl calling convention
 	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gd")
 
+	IF (NOT (MSVC_VERSION LESS 1900))
+		# /guard:cf - Enable Control Flow Guard
+		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /guard:cf")
+	ENDIF()
+
 	IF (STATIC_CRT)
 		SET(CRT_FLAG_DEBUG "/MTd")
 		SET(CRT_FLAG_RELEASE "/MT")
@@ -182,6 +187,11 @@ IF (MSVC)
 	# /LARGEADDRESSAWARE - >2GB user address space on x86
 	# /VERSION - Embed version information in PE header
 	SET(CMAKE_EXE_LINKER_FLAGS "/DYNAMICBASE /NXCOMPAT /LARGEADDRESSAWARE /VERSION:${LIBGIT2_VERSION_MAJOR}.${LIBGIT2_VERSION_MINOR}")
+
+	IF (NOT (MSVC_VERSION LESS 1900))
+		# /GUARD:CF - Enable Control Flow Guard
+		SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /GUARD:CF")
+	ENDIF()
 
 	# /DEBUG - Create a PDB
 	# /LTCG - Link time code generation (whole program optimization)


### PR DESCRIPTION
This feature requires Visual Studio 2015 (`MSVC_VERSION` = 1900) or later. As the minimum required CMake version is currently less than 3.7, `GREATER_EQUAL` is not available to us and we must invert the result of the `LESS` operator.