### PR TITLE
Modified `config_file_open()` to work in macOS sandboxing.

### DIFF
--- a/include/git2/sys/features.h
+++ b/include/git2/sys/features.h
@@ -1,0 +1,44 @@
+#ifndef INCLUDE_features_h__
+#define INCLUDE_features_h__
+
+//#define GIT_DEBUG_POOL 1
+//#define GIT_TRACE 1
+#define GIT_THREADS 1
+//#define GIT_MSVC_CRTDBG 1
+
+#define GIT_ARCH_64 1
+//#define GIT_ARCH_32 1
+
+#define GIT_USE_ICONV 1
+//#define GIT_USE_NSEC 1
+//#define GIT_USE_STAT_MTIM 1
+//#define GIT_USE_STAT_MTIMESPEC 1
+#define GIT_USE_STAT_MTIME_NSEC 1
+//#define GIT_USE_FUTIMENS 1
+
+#define GIT_REGEX_REGCOMP_L
+//#define GIT_REGEX_REGCOMP
+//#define GIT_REGEX_PCRE
+//#define GIT_REGEX_PCRE2
+//#define GIT_REGEX_BUILTIN 1
+
+//#define GIT_SSH 1
+//#define GIT_SSH_MEMORY_CREDENTIALS 1
+
+//#define GIT_NTLM 1
+//#define GIT_GSSAPI 1
+//#define GIT_GSSFRAMEWORK 1
+
+//#define GIT_WINHTTP 1
+#define GIT_HTTPS 1
+//#define GIT_OPENSSL 1
+#define GIT_SECURE_TRANSPORT 1
+//#define GIT_MBEDTLS 1
+
+//#define GIT_SHA1_COLLISIONDETECT 1
+//#define GIT_SHA1_WIN32 1
+#define GIT_SHA1_COMMON_CRYPTO 1
+//#define GIT_SHA1_OPENSSL 1
+//#define GIT_SHA1_MBEDTLS 1
+
+#endif

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -108,10 +108,12 @@ static int config_file_open(git_config_backend *cfg, git_config_level_t level, c
 	if ((res = git_config_entries_new(&b->entries)) < 0)
 		return res;
 
-	if (!git_path_exists(b->file.path))
+	if (!git_path_exists(b->file.path)) {
 		return 0;
-    if (p_access(b->file.path, R_OK) < 0)
+    }
+    if (p_access(b->file.path, R_OK) < 0) {
         res = GIT_ENOTFOUND; // without this read check sandboxed applications on macOS can't open any repository, because `config_file_read()` below will return GIT_ERROR when it can't read the global /Users/username/.gitconfig file, and the upper layers will just completely abort on GIT_ERROR when loading a config file (which seems a bit extreme).
+    }
 
 	if (res < 0 || (res = config_file_read(b->entries, repo, &b->file, level, 0)) < 0) {
 		git_config_entries_free(b->entries);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -110,6 +110,8 @@ static int config_file_open(git_config_backend *cfg, git_config_level_t level, c
 
 	if (!git_path_exists(b->file.path))
 		return 0;
+    if (p_access(b->file.path, R_OK) < 0)
+        res = GIT_ENOTFOUND; // without this read check sandboxed applications on macOS can't open any repository, because `config_file_read()` below will return GIT_ERROR when it can't read the global /Users/username/.gitconfig file, and the upper layers will just completely abort on GIT_ERROR when loading a config file (which seems a bit extreme).
 
 	if (res < 0 || (res = config_file_read(b->entries, repo, &b->file, level, 0)) < 0) {
 		git_config_entries_free(b->entries);


### PR DESCRIPTION
- Modified `config_file_open()` so it returns GIT_ENOTFOUND if the config file is not *readable*, which happens on global config files under macOS sandboxing (note that for some reason `access(..., F_OK)` DOES work with sandboxing, but it is lying). Without this read check sandboxed applications on macOS can not open any repository, because `config_file_read()` will return GIT_ERROR when it cannot read the global /Users/username/.gitconfig file, and the upper layers will just completely abort on GIT_ERROR when attempting to load the global config file, so no repositories can be opened.