### PR TITLE
Fix uninitialized stack memory and NULL ptr dereference in stash_to_index

### DIFF
--- a/src/stash.c
+++ b/src/stash.c
@@ -173,7 +173,7 @@ static int stash_to_index(
 	git_index *index,
 	const char *path)
 {
-	git_index *repo_index;
+	git_index *repo_index = NULL;
 	git_index_entry entry = {{0}};
 	struct stat st;
 	int error;
@@ -187,7 +187,7 @@ static int stash_to_index(
 		return error;
 
 	git_index_entry__init_from_stat(&entry, &st,
-		(repo_index != NULL || !repo_index->distrust_filemode));
+		(repo_index == NULL || !repo_index->distrust_filemode));
 
 	entry.path = path;
 


### PR DESCRIPTION
I was playing around with some new static analyzer features in Visual C++ and used libgit2 as a guinea pig. The only really interesting thing flagged was the function `stash_to_index` in [stash.c](https://github.com/libgit2/libgit2/blob/284816093ee733490d2129031cb2634b0ac61f6d/src/stash.c#L171).

At the start of the function we say: if the repo is *not* bare, then get a pointer to the index and put it in `repo_index`. If that fails, return the error. OK, but if the repo *is* bare, `repo_index` remains uninitialized stack memory.

Later we must pass the boolean `trust_mode` parameter to `git_index_entry__init_from_stat`. The expression used is `(repo_index != NULL || !repo_index->distrust_filemode)`. This seems like it must be wrong. It says: if `repo_index` is not `NULL`, pass `true`. If `repo_index` is `NULL`, then dereference `NULL` plus offset `distrust_filemode`, take an access violation, and crash.

OK, so we need to initialize `repo_index` to `NULL`. And we need to fix the `trust_mode` expression. This means we must decide the value of `trust_mode` when the repository is bare. I don't know the original intention here, so I drafted this PR with it being `true`. If it should be inverted let me know and I will flip it.

I am not an expert, but this doesn't seem like a security bug. Even if an attacker controls the uninitialized stack memory for `repo_index`, we never dereference it unless it's equal to `NULL`. And that's not really useful; we just crash.