### PR TITLE
tests: merge: fix printf formatter on 32 bit arches

### DIFF
--- a/tests/merge/trees/renames.c
+++ b/tests/merge/trees/renames.c
@@ -307,7 +307,7 @@ void test_merge_trees_renames__cache_recomputation(void)
 	 */
 	cl_git_pass(git_treebuilder_new(&builder, repo, NULL));
 	for (i = 0; i < 1000; i++) {
-		cl_git_pass(git_buf_printf(&path, "%"PRIuMAX".txt", i));
+		cl_git_pass(git_buf_printf(&path, "%"PRIuZ".txt", i));
 		cl_git_pass(git_treebuilder_insert(NULL, builder, path.ptr, &blob, GIT_FILEMODE_BLOB));
 		git_buf_clear(&path);
 	}


### PR DESCRIPTION
We currently use `PRIuMAX` to print an integer of type `size_t` in
merge::trees::rename::cache_recomputation. While this works just fine on
64 bit arches, it doesn't on 32 bit ones. As a result, our nightly
builds on x86 and arm32 fail.

Fix the issue by using `PRIuZ` instead.