### PR TITLE
tests: checkout: fix flaky test due to mtime race

### DIFF
--- a/src/checkout.c
+++ b/src/checkout.c
@@ -217,9 +217,10 @@ static bool checkout_is_workdir_modified(
 	ie = git_index_get_bypath(data->index, wditem->path, 0);
 
 	if (ie != NULL &&
-		git_index_time_eq(&wditem->mtime, &ie->mtime) &&
-		wditem->file_size == ie->file_size &&
-		!is_filemode_changed(wditem->mode, ie->mode, data->respect_filemode)) {
+	    !git_index_entry_newer_than_index(ie, data->index) &&
+	    git_index_time_eq(&wditem->mtime, &ie->mtime) &&
+	    wditem->file_size == ie->file_size &&
+	    !is_filemode_changed(wditem->mode, ie->mode, data->respect_filemode)) {
 
 		/* The workdir is modified iff the index entry is modified */
 		return !is_workdir_base_or_new(&ie->id, baseitem, newitem) ||

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -91,24 +91,18 @@ void test_checkout_index__can_remove_untracked_files(void)
 
 void test_checkout_index__can_disable_pathspec_match(void)
 {
-	static git_index *index;
-	git_oid commit_id;
-	git_checkout_options g_opts = GIT_CHECKOUT_OPTIONS_INIT;
-	git_object *g_object;
-
 	char *files_to_checkout[] = { "test10.txt", "test11.txt"};
-	size_t files_to_checkout_size = 2;
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_object *objects;
+	git_index *index;
 
 	/* reset to beginning of history (i.e. just a README file) */
-	g_opts.checkout_strategy =
-		GIT_CHECKOUT_FORCE | GIT_CHECKOUT_REMOVE_UNTRACKED;
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_REMOVE_UNTRACKED;
 
-	cl_git_pass(git_revparse_single(&g_object, g_repo, "8496071c1b46c854b31185ea97743be6a8774479"));
-	cl_git_pass(git_checkout_tree(g_repo, g_object, &g_opts));
-	cl_git_pass(
-		git_repository_set_head_detached(g_repo, git_object_id(g_object)));
-	git_object_free(g_object);
-	g_object = NULL;
+	cl_git_pass(git_revparse_single(&objects, g_repo, "8496071c1b46c854b31185ea97743be6a8774479"));
+	cl_git_pass(git_checkout_tree(g_repo, objects, &opts));
+	cl_git_pass(git_repository_set_head_detached(g_repo, git_object_id(objects)));
+	git_object_free(objects);
 
 	cl_git_pass(git_repository_index(&index, g_repo));
 
@@ -124,7 +118,7 @@ void test_checkout_index__can_disable_pathspec_match(void)
 	cl_git_pass(git_index_add_bypath(index, "test12.txt"));
 	cl_git_pass(git_index_write(index));
 
-	cl_repo_commit_from_index(&commit_id, g_repo, NULL, 0, "commit our test files");
+	cl_repo_commit_from_index(NULL, g_repo, NULL, 0, "commit our test files");
 
 	/* We modify the content of all 4 of our files */
 	cl_git_rewritefile("testrepo/test9.txt", "modified\n");
@@ -133,12 +127,12 @@ void test_checkout_index__can_disable_pathspec_match(void)
 	cl_git_rewritefile("testrepo/test12.txt", "modified\n");
 
 	/* We checkout only test10.txt and test11.txt */
-	g_opts.checkout_strategy =
+	opts.checkout_strategy =
 		GIT_CHECKOUT_FORCE |
 		GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
-	g_opts.paths.strings = files_to_checkout;
-	g_opts.paths.count = files_to_checkout_size;
-	cl_git_pass(git_checkout_index(g_repo, NULL, &g_opts));
+	opts.paths.strings = files_to_checkout;
+	opts.paths.count = ARRAY_SIZE(files_to_checkout);
+	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
 	/* The only files that have been reverted to their original content
 	   should be test10.txt and test11.txt */

--- a/tests/checkout/index.c
+++ b/tests/checkout/index.c
@@ -140,6 +140,8 @@ void test_checkout_index__can_disable_pathspec_match(void)
 	check_file_contents("testrepo/test10.txt", "original\n");
 	check_file_contents("testrepo/test11.txt", "original\n");
 	check_file_contents("testrepo/test12.txt", "modified\n");
+
+	git_index_free(index);
 }
 
 void test_checkout_index__honor_the_specified_pathspecs(void)


### PR DESCRIPTION
The test checkout::index::can_disable_pathspec_match creates a set of
files, rewrites them and then checks them out again with a pathspec with
the expectancy that a subset of files matching the pathspec is restored
to their original contents. One implementation detail of the test is
that both original content and modified content have the same number of
bytes. As a result, we'll only regard these files as changed in case
their mtime doesn't match what's in the index. And, if we do not think a
file was modified, we'll not restore its contents, resulting in a racy
test setup.

Fix the issue by using differently sized contents for original and
modified content. Like this, the stat cache will always be different and
not depend on the mtime anyomre, fixing the raciness.

Fixes #5514 