### PR TITLE
futils: fix order of declared parameters for `git_futils_fake_symlink`

### DIFF
--- a/src/futils.c
+++ b/src/futils.c
@@ -834,12 +834,12 @@ int git_futils_rmdir_r(
 	return error;
 }
 
-int git_futils_fake_symlink(const char *old, const char *new)
+int git_futils_fake_symlink(const char *target, const char *path)
 {
 	int retcode = GIT_ERROR;
-	int fd = git_futils_creat_withpath(new, 0755, 0644);
+	int fd = git_futils_creat_withpath(path, 0755, 0644);
 	if (fd >= 0) {
-		retcode = p_write(fd, old, strlen(old));
+		retcode = p_write(fd, target, strlen(target));
 		p_close(fd);
 	}
 	return retcode;

--- a/src/futils.h
+++ b/src/futils.h
@@ -316,11 +316,11 @@ extern void git_futils_mmap_free(git_map *map);
 /**
  * Create a "fake" symlink (text file containing the target path).
  *
- * @param new symlink file to be created
- * @param old original symlink target
+ * @param target original symlink target
+ * @param path symlink file to be created
  * @return 0 on success, -1 on error
  */
-extern int git_futils_fake_symlink(const char *new, const char *old);
+extern int git_futils_fake_symlink(const char *target, const char *path);
 
 /**
  * A file stamp represents a snapshot of information about a file that can


### PR DESCRIPTION
While the function `git_futils_fake_symlink` is declared with arguments
`new, old`, the implementation uses the reverse order `old, new`. Let's
fix the ordering issues to be `new, old` for both, which matches what
symlink(3P) has. While at it, we also rename these parameters: `old` and
`new` doesn't really make a lot of sense in the context of symlinks,
which is why this commit renames them to be called `target` and `path`.

Fixes #5489