### PR TITLE
git_pool_init: allow the function to fail

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -63,7 +63,8 @@ static int patch_image_init_fromstr(
 
 	memset(out, 0x0, sizeof(patch_image));
 
-	git_pool_init(&out->pool, sizeof(git_diff_line));
+	if (git_pool_init(&out->pool, sizeof(git_diff_line)) < 0)
+		return -1;
 
 	for (start = in; start < in + in_len; start = end) {
 		end = memchr(start, '\n', in_len - (start - in));

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -41,16 +41,21 @@ int git_attr_file__new(
 
 	if (git_mutex_init(&attrs->lock) < 0) {
 		git_error_set(GIT_ERROR_OS, "failed to initialize lock");
-		git__free(attrs);
-		return -1;
+		goto on_error;
 	}
 
-	git_pool_init(&attrs->pool, 1);
+	if (git_pool_init(&attrs->pool, 1) < 0)
+		goto on_error;
+
 	GIT_REFCOUNT_INC(attrs);
 	attrs->entry  = entry;
 	attrs->source = source;
 	*out = attrs;
 	return 0;
+
+on_error:
+	git__free(attrs);
+	return -1;
 }
 
 int git_attr_file__clear_rules(git_attr_file *file, bool need_lock)

--- a/src/attrcache.c
+++ b/src/attrcache.c
@@ -391,10 +391,9 @@ int git_attr_cache__init(git_repository *repo)
 	 * hashtable for attribute macros, and string pool
 	 */
 	if ((ret = git_strmap_new(&cache->files)) < 0 ||
-	    (ret = git_strmap_new(&cache->macros)) < 0)
+	    (ret = git_strmap_new(&cache->macros)) < 0 ||
+	    (ret = git_pool_init(&cache->pool, 1)) < 0)
 		goto cancel;
-
-	git_pool_init(&cache->pool, 1);
 
 	cache = git__compare_and_swap(&repo->attrcache, NULL, cache);
 	if (cache)

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1310,7 +1310,8 @@ static int checkout_get_actions(
 	size_t i, *counts = NULL;
 	uint32_t *actions = NULL;
 
-	git_pool_init(&pathpool, 1);
+	if (git_pool_init(&pathpool, 1) < 0)
+		return -1;
 
 	if (data->opts.paths.count > 0 &&
 		git_pathspec__vinit(&pathspec, &data->opts.paths, &pathpool) < 0)
@@ -2526,9 +2527,8 @@ static int checkout_data_init(
 		git_config_entry_free(conflict_style);
 	}
 
-	git_pool_init(&data->pool, 1);
-
-	if ((error = git_vector_init(&data->removes, 0, git__strcmp_cb)) < 0 ||
+	if ((error = git_pool_init(&data->pool, 1)) < 0 ||
+	    (error = git_vector_init(&data->removes, 0, git__strcmp_cb)) < 0 ||
 	    (error = git_vector_init(&data->remove_conflicts, 0, NULL)) < 0 ||
 	    (error = git_vector_init(&data->update_conflicts, 0, NULL)) < 0 ||
 	    (error = git_buf_puts(&data->target_path, data->opts.target_directory)) < 0 ||

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -423,9 +423,8 @@ static git_diff_generated *diff_generated_alloc(
 	git_attr_session__init(&diff->base.attrsession, repo);
 	memcpy(&diff->base.opts, &dflt, sizeof(git_diff_options));
 
-	git_pool_init(&diff->base.pool, 1);
-
-	if (git_vector_init(&diff->base.deltas, 0, git_diff_delta__cmp) < 0) {
+	if (git_pool_init(&diff->base.pool, 1) < 0 ||
+	    git_vector_init(&diff->base.deltas, 0, git_diff_delta__cmp) < 0) {
 		git_diff_free(&diff->base);
 		return NULL;
 	}

--- a/src/diff_parse.c
+++ b/src/diff_parse.c
@@ -52,9 +52,8 @@ static git_diff_parsed *diff_parsed_alloc(void)
 
 	diff->base.opts.flags &= ~GIT_DIFF_IGNORE_CASE;
 
-	git_pool_init(&diff->base.pool, 1);
-
-	if (git_vector_init(&diff->patches, 0, NULL) < 0 ||
+	if (git_pool_init(&diff->base.pool, 1) < 0 ||
+	    git_vector_init(&diff->patches, 0, NULL) < 0 ||
 		git_vector_init(&diff->base.deltas, 0, git_diff_delta__cmp) < 0) {
 		git_diff_free(&diff->base);
 		return NULL;

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -136,10 +136,9 @@ int git_diff__merge(
 		return -1;
 	}
 
-	if (git_vector_init(&onto_new, onto->deltas.length, git_diff_delta__cmp) < 0)
+	if (git_vector_init(&onto_new, onto->deltas.length, git_diff_delta__cmp) < 0 ||
+	    git_pool_init(&onto_pool, 1) < 0)
 		return -1;
-
-	git_pool_init(&onto_pool, 1);
 
 	for (i = 0, j = 0; i < onto->deltas.length || j < from->deltas.length; ) {
 		git_diff_delta *o = GIT_VECTOR_GET(&onto->deltas, i);

--- a/src/index.c
+++ b/src/index.c
@@ -411,7 +411,8 @@ int git_index_open(git_index **index_out, const char *index_path)
 	index = git__calloc(1, sizeof(git_index));
 	GIT_ERROR_CHECK_ALLOC(index);
 
-	git_pool_init(&index->tree_pool, 1);
+	if (git_pool_init(&index->tree_pool, 1) < 0)
+		goto fail;
 
 	if (index_path != NULL) {
 		index->index_file_path = git__strdup(index_path);

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -897,9 +897,8 @@ static int tree_iterator_init(tree_iterator *iter)
 {
 	int error;
 
-	git_pool_init(&iter->entry_pool, sizeof(tree_iterator_entry));
-
-	if ((error = tree_iterator_frame_init(iter, iter->root, NULL)) < 0)
+	if ((error = git_pool_init(&iter->entry_pool, sizeof(tree_iterator_entry))) < 0 ||
+	    (error = tree_iterator_frame_init(iter, iter->root, NULL)) < 0)
 		return error;
 
 	iter->base.flags &= ~GIT_ITERATOR_FIRST_ACCESS;
@@ -1376,7 +1375,8 @@ static int filesystem_iterator_frame_push(
 			filesystem_iterator_entry_cmp)) < 0)
 		goto done;
 
-	git_pool_init(&new_frame->entry_pool, 1);
+	if ((error = git_pool_init(&new_frame->entry_pool, 1)) < 0)
+		goto done;
 
 	/* check if this directory is ignored */
 	filesystem_iterator_frame_push_ignores(iter, frame_entry, new_frame);

--- a/src/merge.c
+++ b/src/merge.c
@@ -1810,12 +1810,12 @@ git_merge_diff_list *git_merge_diff_list__alloc(git_repository *repo)
 
 	diff_list->repo = repo;
 
-	git_pool_init(&diff_list->pool, 1);
 
-	if (git_vector_init(&diff_list->staged, 0, NULL) < 0 ||
-		git_vector_init(&diff_list->conflicts, 0, NULL) < 0 ||
-		git_vector_init(&diff_list->resolved, 0, NULL) < 0) {
-		git_merge_diff_list__free(diff_list);
+	if (git_pool_init(&diff_list->pool, 1) < 0 ||
+	    git_vector_init(&diff_list->staged, 0, NULL) < 0 ||
+	    git_vector_init(&diff_list->conflicts, 0, NULL) < 0 ||
+	    git_vector_init(&diff_list->resolved, 0, NULL) < 0) {
+	    git_merge_diff_list__free(diff_list);
 		return NULL;
 	}
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -141,13 +141,10 @@ int git_packbuilder_new(git_packbuilder **out, git_repository *repo)
 	pb = git__calloc(1, sizeof(*pb));
 	GIT_ERROR_CHECK_ALLOC(pb);
 
-	if (git_oidmap_new(&pb->object_ix) < 0)
+	if (git_oidmap_new(&pb->object_ix) < 0 ||
+	    git_oidmap_new(&pb->walk_objects) < 0 ||
+	    git_pool_init(&pb->object_pool, sizeof(struct walk_object)) < 0)
 		goto on_error;
-
-	if (git_oidmap_new(&pb->walk_objects) < 0)
-		goto on_error;
-
-	git_pool_init(&pb->object_pool, sizeof(struct walk_object));
 
 	pb->repo = repo;
 	pb->nr_threads = 1; /* do not spawn any thread by default */

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -238,9 +238,9 @@ int git_pathspec__init(git_pathspec *ps, const git_strarray *paths)
 	memset(ps, 0, sizeof(*ps));
 
 	ps->prefix = git_pathspec_prefix(paths);
-	git_pool_init(&ps->pool, 1);
 
-	if ((error = git_pathspec__vinit(&ps->pathspec, paths, &ps->pool)) < 0)
+	if ((error = git_pool_init(&ps->pool, 1)) < 0 ||
+	    (error = git_pathspec__vinit(&ps->pathspec, paths, &ps->pool)) < 0)
 		git_pathspec__clear(ps);
 
 	return error;
@@ -316,7 +316,8 @@ static git_pathspec_match_list *pathspec_match_alloc(
 	if (!m)
 		return NULL;
 
-	git_pool_init(&m->pool, 1);
+	if (git_pool_init(&m->pool, 1) < 0)
+		return NULL;
 
 	/* need to keep reference to pathspec and increment refcount because
 	 * failures array stores pointers to the pattern strings of the

--- a/src/pool.c
+++ b/src/pool.c
@@ -37,7 +37,7 @@ size_t git_pool__system_page_size(void)
 }
 
 #ifndef GIT_DEBUG_POOL
-void git_pool_init(git_pool *pool, size_t item_size)
+int git_pool_init(git_pool *pool, size_t item_size)
 {
 	assert(pool);
 	assert(item_size >= 1);
@@ -45,6 +45,8 @@ void git_pool_init(git_pool *pool, size_t item_size)
 	memset(pool, 0, sizeof(git_pool));
 	pool->item_size = item_size;
 	pool->page_size = git_pool__system_page_size();
+
+	return 0;
 }
 
 void git_pool_clear(git_pool *pool)
@@ -125,7 +127,7 @@ static int git_pool__ptr_cmp(const void * a, const void * b)
 	}
 }
 
-void git_pool_init(git_pool *pool, size_t item_size)
+int git_pool_init(git_pool *pool, size_t item_size)
 {
 	assert(pool);
 	assert(item_size >= 1);
@@ -134,6 +136,8 @@ void git_pool_init(git_pool *pool, size_t item_size)
 	pool->item_size = item_size;
 	pool->page_size = git_pool__system_page_size();
 	git_vector_init(&pool->allocations, 100, git_pool__ptr_cmp);
+
+	return 0;
 }
 
 void git_pool_clear(git_pool *pool)

--- a/src/pool.h
+++ b/src/pool.h
@@ -81,7 +81,7 @@ typedef struct {
  * Of course, you can use this in other ways, but those are the
  * two most common patterns.
  */
-extern void git_pool_init(git_pool *pool, size_t item_size);
+extern int git_pool_init(git_pool *pool, size_t item_size);
 
 /**
  * Free all items in pool

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -683,7 +683,8 @@ static int refdb_fs_backend__iterator(
 	iter = git__calloc(1, sizeof(refdb_fs_iter));
 	GIT_ERROR_CHECK_ALLOC(iter);
 
-	git_pool_init(&iter->pool, 1);
+	if ((error = git_pool_init(&iter->pool, 1)) < 0)
+		goto out;
 
 	if ((error = git_vector_init(&iter->loose, 8, NULL)) < 0)
 		goto out;

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -659,13 +659,11 @@ int git_revwalk_new(git_revwalk **revwalk_out, git_repository *repo)
 	git_revwalk *walk = git__calloc(1, sizeof(git_revwalk));
 	GIT_ERROR_CHECK_ALLOC(walk);
 
-	if (git_oidmap_new(&walk->commits) < 0)
+	if (git_oidmap_new(&walk->commits) < 0 ||
+	    git_pqueue_init(&walk->iterator_time, 0, 8, git_commit_list_time_cmp) < 0 ||
+	    git_pool_init(&walk->commit_pool, COMMIT_ALLOC) < 0)
 		return -1;
 
-	if (git_pqueue_init(&walk->iterator_time, 0, 8, git_commit_list_time_cmp) < 0)
-		return -1;
-
-	git_pool_init(&walk->commit_pool, COMMIT_ALLOC);
 	walk->get_next = &revwalk_next_unsorted;
 	walk->enqueue = &revwalk_enqueue_unsorted;
 

--- a/src/sortedcache.c
+++ b/src/sortedcache.c
@@ -25,9 +25,8 @@ int git_sortedcache_new(
 	sc = git__calloc(1, alloclen);
 	GIT_ERROR_CHECK_ALLOC(sc);
 
-	git_pool_init(&sc->pool, 1);
-
-	if (git_vector_init(&sc->items, 4, item_cmp) < 0 ||
+	if (git_pool_init(&sc->pool, 1) < 0 ||
+	    git_vector_init(&sc->items, 4, item_cmp) < 0 ||
 	    git_strmap_new(&sc->map) < 0)
 		goto fail;
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -76,7 +76,8 @@ int git_transaction_new(git_transaction **out, git_repository *repo)
 
 	assert(out && repo);
 
-	git_pool_init(&pool, 1);
+	if ((error = git_pool_init(&pool, 1)) < 0)
+		goto on_error;
 
 	tx = git_pool_mallocz(&pool, sizeof(git_transaction));
 	if (!tx) {


### PR DESCRIPTION
`git_pool_init` should be allowed to fail.  At the moment, `git_pool_init` will `assert` that the given arguments are correct.  We would like to use `GIT_ASSERT` instead.

This change is in preparation for removing uses of `assert` and replacing them with our `GIT_ASSERT`, however that requires a function that returns a value.