### PR TITLE
Handle unreadable configuration files

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -111,6 +111,15 @@ static int config_file_open(git_config_backend *cfg, git_config_level_t level, c
 	if (!git_path_exists(b->file.path))
 		return 0;
 
+	/*
+	 * git silently ignores configuration files that are not
+	 * readable.  We emulate that behavior.  This is particularly
+	 * important for sandboxed applications on macOS where the
+	 * git configuration files may not be readable.
+	 */
+	if (p_access(b->file.path, R_OK) < 0)
+		return GIT_ENOTFOUND;
+
 	if (res < 0 || (res = config_file_read(b->entries, repo, &b->file, level, 0)) < 0) {
 		git_config_entries_free(b->entries);
 		b->entries = NULL;

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -849,6 +849,23 @@ void test_config_read__invalid_quoted_third_section(void)
 	git_config_free(cfg);
 }
 
+void test_config_read__unreadable_file_ignored(void)
+{
+	git_buf buf = GIT_BUF_INIT;
+	git_config *cfg;
+	int ret;
+
+	cl_set_cleanup(&clean_test_config, NULL);
+	cl_git_mkfile("./testconfig", "[some] var = value\n[some \"OtheR\"] var = value");
+	cl_git_pass(p_chmod("./testconfig", 0));
+
+	ret = git_config_open_ondisk(&cfg, "./test/config");
+	cl_assert(ret == 0 || ret == GIT_ENOTFOUND);
+
+	git_config_free(cfg);
+	git_buf_dispose(&buf);
+}
+
 void test_config_read__single_line(void)
 {
 	git_buf buf = GIT_BUF_INIT;


### PR DESCRIPTION
A quick cleanup of #5503, with an added test case.