### PR TITLE
clar: use internal functions instead of /bin/cp and /bin/rm

### DIFF
--- a/tests/clar/fs.h
+++ b/tests/clar/fs.h
@@ -277,32 +277,6 @@ cl_fs_cleanup(void)
 # include <copyfile.h>
 #endif
 
-static int
-shell_out(char * const argv[])
-{
-	int status, piderr;
-	pid_t pid;
-
-	pid = fork();
-
-	if (pid < 0) {
-		fprintf(stderr,
-			"System error: `fork()` call failed (%d) - %s\n",
-			errno, strerror(errno));
-		exit(-1);
-	}
-
-	if (pid == 0) {
-		execv(argv[0], argv);
-	}
-
-	do {
-		piderr = waitpid(pid, &status, WUNTRACED);
-	} while (piderr < 0 && (errno == EAGAIN || errno == EINTR));
-
-	return WEXITSTATUS(status);
-}
-
 static void basename_r(const char **out, int *out_len, const char *in)
 {
 	size_t in_len = strlen(in), start_pos;


### PR DESCRIPTION
clar has historically shelled out to `/bin/cp` to copy test fixtures into a sandbox and `/bin/rm` to clean them up.  This has two deficiencies:

1. `/bin/cp` is slower than simply opening the source and destination and copying them in a read/write loop.  On my Mac, the `/bin/cp` based approach takes ~2:40 for a full test pass.  Using a read/write loop to copy the files ourselves takes ~1:50.  Similarly, `/bin/rm` is slower than doing this internally.  Moving to an internal traversal shaves another 20 seconds off.

   These numbers are less impressive on Linux, but using `sendfile` there makes a notable improvement.

2. It's noisy.  Since the leak detector follows fork/exec, we'll end up running the leak detector on `/bin/cp` and `/bin/rm`.  This would be fine, except that the leak detector spams the console on startup and shutdown, so it adds a _lot_ of additional information to the test runs that is useless.  By not forking and using this internal system, we see much less output.

Since this repo actually has tests and fixtures, I'm opening this PR here and will port it to https://github.com/clar-test/clar once approved.