### PR TITLE
mempack: Use threads when building the pack

### DIFF
--- a/src/odb_mempack.c
+++ b/src/odb_mempack.c
@@ -110,6 +110,8 @@ int git_mempack_dump(git_buf *pack, git_repository *repo, git_odb_backend *_back
 	if (git_packbuilder_new(&packbuilder, repo) < 0)
 		return -1;
 
+	git_packbuilder_set_threads(packbuilder, 0);
+
 	for (i = 0; i < db->commits.size; ++i) {
 		struct memobject *commit = db->commits.ptr[i];
 


### PR DESCRIPTION
The mempack ODB backend creates a packbuilder internally to write out a
pack; call git_packbuilder_set_threads on that packbuilder, to use
threads for packing if available.