### PR TITLE
git_packbuilder_write: Allow setting path to NULL to use the default path

### DIFF
--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -155,7 +155,7 @@ GIT_EXTERN(int) git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb);
  * Write the new pack and corresponding index file to path.
  *
  * @param pb The packbuilder
- * @param path to the directory where the packfile and index should be stored
+ * @param path Path to the directory where the packfile and index should be stored, or NULL for default location
  * @param mode permissions to use creating a packfile or 0 for defaults
  * @param progress_cb function to call with progress information from the indexer (optional)
  * @param progress_cb_payload payload for the progress callback (optional)

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1385,6 +1385,7 @@ int git_packbuilder_write(
 	void *progress_cb_payload)
 {
 	int error = -1;
+	git_buf object_path = GIT_BUF_INIT;
 	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
 	git_indexer *indexer = NULL;
 	git_indexer_progress stats;
@@ -1392,6 +1393,14 @@ int git_packbuilder_write(
 	int t;
 
 	PREPARE_PACK;
+
+	if (path == NULL) {
+		if ((error = git_repository_item_path(&object_path, pb->repo, GIT_REPOSITORY_ITEM_OBJECTS)) < 0)
+			goto cleanup;
+		if ((error = git_buf_joinpath(&object_path, git_buf_cstr(&object_path), "pack")) < 0)
+			goto cleanup;
+		path = git_buf_cstr(&object_path);
+	}
 
 	opts.progress_cb = progress_cb;
 	opts.progress_cb_payload = progress_cb_payload;
@@ -1415,6 +1424,7 @@ int git_packbuilder_write(
 
 cleanup:
 	git_indexer_free(indexer);
+	git_buf_dispose(&object_path);
 	return error;
 }
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1384,8 +1384,9 @@ int git_packbuilder_write(
 	git_indexer_progress_cb progress_cb,
 	void *progress_cb_payload)
 {
+	int error = -1;
 	git_indexer_options opts = GIT_INDEXER_OPTIONS_INIT;
-	git_indexer *indexer;
+	git_indexer *indexer = NULL;
 	git_indexer_progress stats;
 	struct pack_write_context ctx;
 	int t;
@@ -1395,9 +1396,8 @@ int git_packbuilder_write(
 	opts.progress_cb = progress_cb;
 	opts.progress_cb_payload = progress_cb_payload;
 
-	if (git_indexer_new(
-		&indexer, path, mode, pb->odb, &opts) < 0)
-		return -1;
+	if ((error = git_indexer_new(&indexer, path, mode, pb->odb, &opts)) < 0)
+		goto cleanup;
 
 	if (!git_repository__configmap_lookup(&t, pb->repo, GIT_CONFIGMAP_FSYNCOBJECTFILES) && t)
 		git_indexer__set_fsync(indexer, 1);
@@ -1405,16 +1405,17 @@ int git_packbuilder_write(
 	ctx.indexer = indexer;
 	ctx.stats = &stats;
 
-	if (git_packbuilder_foreach(pb, write_cb, &ctx) < 0 ||
-		git_indexer_commit(indexer, &stats) < 0) {
-		git_indexer_free(indexer);
-		return -1;
-	}
+	if ((error = git_packbuilder_foreach(pb, write_cb, &ctx)) < 0)
+		goto cleanup;
+
+	if ((error = git_indexer_commit(indexer, &stats)) < 0)
+		goto cleanup;
 
 	git_oid_cpy(&pb->pack_oid, git_indexer_hash(indexer));
 
+cleanup:
 	git_indexer_free(indexer);
-	return 0;
+	return error;
 }
 
 #undef PREPARE_PACK

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -151,6 +151,15 @@ void test_pack_packbuilder__get_hash(void)
 	cl_assert_equal_s(hex, "7f5fa362c664d68ba7221259be1cbd187434b2f0");
 }
 
+void test_pack_packbuilder__write_default_path(void)
+{
+	seed_packbuilder();
+
+	cl_git_pass(git_packbuilder_write(_packbuilder, NULL, 0, NULL, NULL));
+	cl_assert(git_path_exists("objects/pack/pack-7f5fa362c664d68ba7221259be1cbd187434b2f0.idx"));
+	cl_assert(git_path_exists("objects/pack/pack-7f5fa362c664d68ba7221259be1cbd187434b2f0.pack"));
+}
+
 static void test_write_pack_permission(mode_t given, mode_t expected)
 {
 	struct stat statbuf;


### PR DESCRIPTION
If given a NULL path, write to the object path of the repository.

Includes tests.