### PR TITLE
Make git_index_write() generate valid v4 index

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -2744,7 +2744,7 @@ static int write_disk_entry(git_filebuf *file, git_index_entry *entry, const cha
 			++same_len;
 		}
 		path_len -= same_len;
-		varint_len = git_encode_varint(NULL, 0, same_len);
+		varint_len = git_encode_varint(NULL, 0, strlen(last) - same_len);
 	}
 
 	disk_size = index_entry_size(path_len, varint_len, entry->flags);
@@ -2795,7 +2795,7 @@ static int write_disk_entry(git_filebuf *file, git_index_entry *entry, const cha
 
 	if (last) {
 		varint_len = git_encode_varint((unsigned char *) path,
-					  disk_size, same_len);
+					  disk_size, strlen(last) - same_len);
 		assert(varint_len > 0);
 		path += varint_len;
 		disk_size -= varint_len;

--- a/tests/index/version.c
+++ b/tests/index/version.c
@@ -43,6 +43,7 @@ void test_index_version__can_write_v4(void)
 	    "xz",
 	    "xyzzyx"
 	};
+	git_repository *repo;
 	git_index_entry entry;
 	git_index *index;
 	size_t i;
@@ -63,7 +64,8 @@ void test_index_version__can_write_v4(void)
 	cl_git_pass(git_index_write(index));
 	git_index_free(index);
 
-	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_repository_open(&repo, git_repository_path(g_repo)));
+	cl_git_pass(git_repository_index(&index, repo));
 	cl_assert(git_index_version(index) == 4);
 
 	for (i = 0; i < ARRAY_SIZE(paths); i++) {
@@ -74,6 +76,7 @@ void test_index_version__can_write_v4(void)
 	}
 
 	git_index_free(index);
+	git_repository_free(repo);
 }
 
 void test_index_version__v4_uses_path_compression(void)


### PR DESCRIPTION
In v4 index, the path of an entry is prefix-compressed relative to the
path for the previous entry.

According to index-format.txt from git, the path of an entry is prefixed with N, where N indicates the length of bytes to be stripped from the previous path, not the length in common.

Given the `paths=[aaabbb,aaacc,aaaddd]`, correct index entries are `[(0)aaabbb,(3)cc,(2)ddd]`.
However, the index entries generated are `[(0)aaabbb,(3)cc,(3)ddd]`.

The following code snippet works now:

```c
git_repository *repo = NULL;
git_repository_open(&repo, ".");
git_repository_index(&index, repo));
git_index_write(index);              // wrote an invalid index
git_index_free(index);
git_repository_free(repo);
git_repository_open(&repo, ".");     // reopen repo
git_repository_index(&index, repo);  // failed
```