### PR TITLE
strarray refactoring

### DIFF
--- a/examples/checkout.c
+++ b/examples/checkout.c
@@ -239,7 +239,7 @@ next:
 
 out:
 	git_reference_free(remote_ref);
-	git_strarray_free(&remotes);
+	git_strarray_dispose(&remotes);
 	return error;
 }
 

--- a/examples/general.c
+++ b/examples/general.c
@@ -707,7 +707,7 @@ static void reference_listing(git_repository *repo)
 		git_reference_free(ref);
 	}
 
-	git_strarray_free(&ref_list);
+	git_strarray_dispose(&ref_list);
 }
 
 /**

--- a/examples/remote.c
+++ b/examples/remote.c
@@ -129,7 +129,7 @@ static int cmd_rename(git_repository *repo, struct remote_opts *o)
 		puts(problems.strings[0]);
 	}
 
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	return retval;
 }
@@ -207,7 +207,7 @@ static int cmd_show(git_repository *repo, struct remote_opts *o)
 		git_remote_free(remote);
 	}
 
-	git_strarray_free(&remotes);
+	git_strarray_dispose(&remotes);
 
 	return 0;
 }

--- a/examples/tag.c
+++ b/examples/tag.c
@@ -162,7 +162,7 @@ static void action_list_tags(tag_state *state)
 		each_tag(tag_names.strings[i], state);
 	}
 
-	git_strarray_free(&tag_names);
+	git_strarray_dispose(&tag_names);
 }
 
 static void action_delete_tag(tag_state *state)

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -524,6 +524,30 @@ typedef int GIT_CALLBACK(git_headlist_cb)(git_remote_head *rhead, void *payload)
 
 /**@}*/
 
+/** @name Deprecated String Array Functions
+ *
+ * These types are retained for backward compatibility.  The newer
+ * versions of these values should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+/**
+ * Free the memory referred to by the git_strarray.  This is an alias of
+ * `git_strarray_dispose` and is preserved for backward compatibility.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @deprecated Use git_strarray_dispose
+ * @see git_strarray_dispose
+ */
+GIT_EXTERN(void) git_strarray_free(git_strarray *array);
+
+/**@}*/
+
 /** @name Deprecated Options Initialization Functions
  *
  * These functions are retained for backward compatibility.  The newer

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -535,6 +535,18 @@ typedef int GIT_CALLBACK(git_headlist_cb)(git_remote_head *rhead, void *payload)
 /**@{*/
 
 /**
+ * Copy a string array object from source to target.
+ *
+ * This function is deprecated, but there is no plan to remove this
+ * function at this time.
+ *
+ * @param tgt target
+ * @param src source
+ * @return 0 on success, < 0 on allocation failure
+ */
+GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
+
+/**
  * Free the memory referred to by the git_strarray.  This is an alias of
  * `git_strarray_dispose` and is preserved for backward compatibility.
  *

--- a/include/git2/strarray.h
+++ b/include/git2/strarray.h
@@ -25,20 +25,16 @@ typedef struct git_strarray {
 } git_strarray;
 
 /**
- * Close a string array object
- *
- * This method should be called on `git_strarray` objects where the strings
- * array is allocated and contains allocated strings, such as what you
- * would get from `git_strarray_copy()`.  Not doing so, will result in a
- * memory leak.
+ * Free the strings contained in a string array.  This method should
+ * be called on `git_strarray` objects that were provided by the
+ * library.  Not doing so, will result in a memory leak.
  *
  * This does not free the `git_strarray` itself, since the library will
- * never allocate that object directly itself (it is more commonly embedded
- * inside another struct or created on the stack).
+ * never allocate that object directly itself.
  *
- * @param array git_strarray from which to free string data
+ * @param array The git_strarray that contains strings to free
  */
-GIT_EXTERN(void) git_strarray_free(git_strarray *array);
+GIT_EXTERN(void) git_strarray_dispose(git_strarray *array);
 
 /**
  * Copy a string array object from source to target.

--- a/src/branch.c
+++ b/src/branch.c
@@ -548,7 +548,7 @@ cleanup:
 	if (error < 0)
 		git_buf_dispose(buf);
 
-	git_strarray_free(&remote_list);
+	git_strarray_dispose(&remote_list);
 	return error;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -1237,7 +1237,7 @@ static int prune_candidates(git_vector *candidates, git_remote *remote)
 	}
 
 out:
-	git_strarray_free(&arr);
+	git_strarray_dispose(&arr);
 	return error;
 }
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -2289,7 +2289,7 @@ int git_repository_foreach_head(git_repository *repo,
 
 out:
 	git_buf_dispose(&path);
-	git_strarray_free(&worktrees);
+	git_strarray_dispose(&worktrees);
 	return error;
 }
 

--- a/src/strarray.c
+++ b/src/strarray.c
@@ -29,7 +29,7 @@ int git_strarray_copy(git_strarray *tgt, const git_strarray *src)
 
 		tgt->strings[tgt->count] = git__strdup(src->strings[i]);
 		if (!tgt->strings[tgt->count]) {
-			git_strarray_free(tgt);
+			git_strarray_dispose(tgt);
 			memset(tgt, 0, sizeof(*tgt));
 			return -1;
 		}
@@ -40,7 +40,7 @@ int git_strarray_copy(git_strarray *tgt, const git_strarray *src)
 	return 0;
 }
 
-void git_strarray_free(git_strarray *array)
+void git_strarray_dispose(git_strarray *array)
 {
 	size_t i;
 
@@ -53,4 +53,9 @@ void git_strarray_free(git_strarray *array)
 	git__free(array->strings);
 
 	memset(array, 0, sizeof(*array));
+}
+
+void git_strarray_free(git_strarray *array)
+{
+	git_strarray_dispose(array);
 }

--- a/src/strarray.c
+++ b/src/strarray.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "util.h"
+
+#include "common.h"
+
+int git_strarray_copy(git_strarray *tgt, const git_strarray *src)
+{
+	size_t i;
+
+	assert(tgt && src);
+
+	memset(tgt, 0, sizeof(*tgt));
+
+	if (!src->count)
+		return 0;
+
+	tgt->strings = git__calloc(src->count, sizeof(char *));
+	GIT_ERROR_CHECK_ALLOC(tgt->strings);
+
+	for (i = 0; i < src->count; ++i) {
+		if (!src->strings[i])
+			continue;
+
+		tgt->strings[tgt->count] = git__strdup(src->strings[i]);
+		if (!tgt->strings[tgt->count]) {
+			git_strarray_free(tgt);
+			memset(tgt, 0, sizeof(*tgt));
+			return -1;
+		}
+
+		tgt->count++;
+	}
+
+	return 0;
+}
+
+void git_strarray_free(git_strarray *array)
+{
+	size_t i;
+
+	if (array == NULL)
+		return;
+
+	for (i = 0; i < array->count; ++i)
+		git__free(array->strings[i]);
+
+	git__free(array->strings);
+
+	memset(array, 0, sizeof(*array));
+}

--- a/src/transports/local.c
+++ b/src/transports/local.c
@@ -185,12 +185,12 @@ static int store_refs(transport_local *t)
 	}
 
 	t->have_refs = 1;
-	git_strarray_free(&ref_names);
+	git_strarray_dispose(&ref_names);
 	return 0;
 
 on_error:
 	git_vector_free(&t->refs);
-	git_strarray_free(&ref_names);
+	git_strarray_dispose(&ref_names);
 	return -1;
 }
 

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -132,7 +132,7 @@ static int git_smart__set_custom_headers(
 	size_t i;
 
 	if (t->custom_headers.count)
-		git_strarray_free(&t->custom_headers);
+		git_strarray_dispose(&t->custom_headers);
 
 	if (!custom_headers)
 		return 0;
@@ -465,7 +465,7 @@ static void git_smart__free(git_transport *transport)
 	git_vector_free(refs);
 	git__free((char *)t->proxy.url);
 
-	git_strarray_free(&t->custom_headers);
+	git_strarray_dispose(&t->custom_headers);
 
 	git__free(t);
 }

--- a/src/util.c
+++ b/src/util.c
@@ -22,52 +22,6 @@
 # include <Shlwapi.h>
 #endif
 
-void git_strarray_free(git_strarray *array)
-{
-	size_t i;
-
-	if (array == NULL)
-		return;
-
-	for (i = 0; i < array->count; ++i)
-		git__free(array->strings[i]);
-
-	git__free(array->strings);
-
-	memset(array, 0, sizeof(*array));
-}
-
-int git_strarray_copy(git_strarray *tgt, const git_strarray *src)
-{
-	size_t i;
-
-	assert(tgt && src);
-
-	memset(tgt, 0, sizeof(*tgt));
-
-	if (!src->count)
-		return 0;
-
-	tgt->strings = git__calloc(src->count, sizeof(char *));
-	GIT_ERROR_CHECK_ALLOC(tgt->strings);
-
-	for (i = 0; i < src->count; ++i) {
-		if (!src->strings[i])
-			continue;
-
-		tgt->strings[tgt->count] = git__strdup(src->strings[i]);
-		if (!tgt->strings[tgt->count]) {
-			git_strarray_free(tgt);
-			memset(tgt, 0, sizeof(*tgt));
-			return -1;
-		}
-
-		tgt->count++;
-	}
-
-	return 0;
-}
-
 int git__strntol64(int64_t *result, const char *nptr, size_t nptr_len, const char **endptr, int base)
 {
 	const char *p;

--- a/tests/network/fetchlocal.c
+++ b/tests/network/fetchlocal.c
@@ -49,7 +49,7 @@ void test_network_fetchlocal__complete(void)
 	cl_assert_equal_i(19, (int)refnames.count);
 	cl_assert(callcount > 0);
 
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 	git_repository_free(repo);
 }
@@ -77,7 +77,7 @@ void test_network_fetchlocal__prune(void)
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(19, (int)refnames.count);
 	cl_assert(callcount > 0);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 
 	cl_git_pass(git_reference_lookup(&ref, remote_repo, "refs/heads/br2"));
@@ -90,7 +90,7 @@ void test_network_fetchlocal__prune(void)
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(18, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 
 	cl_git_pass(git_reference_lookup(&ref, remote_repo, "refs/heads/packed"));
@@ -103,7 +103,7 @@ void test_network_fetchlocal__prune(void)
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(17, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 
 	git_repository_free(repo);
@@ -168,7 +168,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	assert_ref_exists(repo, "refs/remotes/origin/pr/42");
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(20, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 
 	cl_git_pass(git_config_delete_multivar(config, "remote.origin.fetch", "refs"));
 	cl_git_pass(git_config_set_multivar(config, "remote.origin.fetch", "^$", "refs/pull/*/head:refs/remotes/origin/pr/*"));
@@ -183,7 +183,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	assert_ref_exists(repo, "refs/remotes/origin/pr/42");
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(20, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 
 	cl_git_pass(git_config_delete_multivar(config, "remote.origin.fetch", "refs"));
 	cl_git_pass(git_config_set_multivar(config, "remote.origin.fetch", "^$", "refs/heads/*:refs/remotes/origin/*"));
@@ -195,7 +195,7 @@ void test_network_fetchlocal__prune_overlapping(void)
 	cl_git_pass(git_remote_fetch(origin, NULL, &options, NULL));
 
 	git_config_free(config);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 	git_repository_free(repo);
 }
@@ -224,7 +224,7 @@ void test_network_fetchlocal__fetchprune(void)
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(19, (int)refnames.count);
 	cl_assert(callcount > 0);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 
 	cl_git_pass(git_reference_lookup(&ref, remote_repo, "refs/heads/br2"));
@@ -237,7 +237,7 @@ void test_network_fetchlocal__fetchprune(void)
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(18, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 
 	cl_git_pass(git_reference_lookup(&ref, remote_repo, "refs/heads/packed"));
@@ -253,7 +253,7 @@ void test_network_fetchlocal__fetchprune(void)
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(17, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 
 	git_repository_free(repo);
@@ -333,13 +333,13 @@ void test_network_fetchlocal__partial(void)
 	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
 	cl_git_pass(git_remote_fetch(origin, NULL, &options, NULL));
 
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(20, (int)refnames.count); /* 18 remote + 1 local */
 	cl_assert(callcount > 0);
 
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 }
 
@@ -420,7 +420,7 @@ void test_network_fetchlocal__multi_remotes(void)
 
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(33, (int)refnames.count);
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 
 	cl_git_pass(git_remote_set_url(repo, "test_with_pushurl", cl_git_fixture_url("testrepo.git")));
 	cl_git_pass(git_remote_lookup(&test2, repo, "test_with_pushurl"));
@@ -429,7 +429,7 @@ void test_network_fetchlocal__multi_remotes(void)
 	cl_git_pass(git_reference_list(&refnames, repo));
 	cl_assert_equal_i(45, (int)refnames.count);
 
-	git_strarray_free(&refnames);
+	git_strarray_dispose(&refnames);
 	git_remote_free(test);
 	git_remote_free(test2);
 }

--- a/tests/network/remote/remotes.c
+++ b/tests/network/remote/remotes.c
@@ -61,7 +61,7 @@ static int urlresolve_callback(git_buf *url_resolved, const char *url, int direc
 	cl_assert(strcmp(url, "git://github.com/libgit2/libgit2") == 0);
 	cl_assert(strcmp(payload, "payload") == 0);
 	cl_assert(url_resolved->size == 0);
-	
+
 	if (direction == GIT_DIRECTION_PUSH)
 		git_buf_sets(url_resolved, "pushresolve");
 	if (direction == GIT_DIRECTION_FETCH)
@@ -215,11 +215,11 @@ void test_network_remote_remotes__dup(void)
 	cl_git_pass(git_remote_get_fetch_refspecs(&array, _remote));
 	cl_assert_equal_i(1, (int)array.count);
 	cl_assert_equal_s("+refs/heads/*:refs/remotes/test/*", array.strings[0]);
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	cl_git_pass(git_remote_get_push_refspecs(&array, _remote));
 	cl_assert_equal_i(0, (int)array.count);
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	git_remote_free(dup);
 }
@@ -318,7 +318,7 @@ void test_network_remote_remotes__list(void)
 
 	cl_git_pass(git_remote_list(&list, _repo));
 	cl_assert(list.count == 5);
-	git_strarray_free(&list);
+	git_strarray_dispose(&list);
 
 	cl_git_pass(git_repository_config(&cfg, _repo));
 
@@ -330,7 +330,7 @@ void test_network_remote_remotes__list(void)
 
 	cl_git_pass(git_remote_list(&list, _repo));
 	cl_assert(list.count == 7);
-	git_strarray_free(&list);
+	git_strarray_dispose(&list);
 
 	git_config_free(cfg);
 }
@@ -466,13 +466,13 @@ void test_network_remote_remotes__query_refspecs(void)
 	for (i = 0; i < 3; i++) {
 		cl_assert_equal_s(fetch_refspecs[i], array.strings[i]);
 	}
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	cl_git_pass(git_remote_get_push_refspecs(&array, remote));
 	for (i = 0; i < 3; i++) {
 		cl_assert_equal_s(push_refspecs[i], array.strings[i]);
 	}
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	git_remote_free(remote);
 	git_remote_delete(_repo, "test");

--- a/tests/network/remote/rename.c
+++ b/tests/network/remote/rename.c
@@ -25,7 +25,7 @@ void test_network_remote_rename__renaming_a_remote_moves_related_configuration_s
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	assert_config_entry_existence(_repo, "remote.test.fetch", false);
 	assert_config_entry_existence(_repo, "remote.just/renamed.fetch", true);
@@ -39,7 +39,7 @@ void test_network_remote_rename__renaming_a_remote_updates_branch_related_config
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	assert_config_entry_value(_repo, "branch.master.remote", "just/renamed");
 }
@@ -50,7 +50,7 @@ void test_network_remote_rename__renaming_a_remote_updates_default_fetchrefspec(
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	assert_config_entry_value(_repo, "remote.just/renamed.fetch", "+refs/heads/*:refs/remotes/just/renamed/*");
 }
@@ -71,7 +71,7 @@ void test_network_remote_rename__renaming_a_remote_without_a_fetchrefspec_doesnt
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	assert_config_entry_existence(_repo, "remote.just/renamed.fetch", false);
 }
@@ -90,11 +90,11 @@ void test_network_remote_rename__renaming_a_remote_notifies_of_non_default_fetch
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(1, problems.count);
 	cl_assert_equal_s("+refs/*:refs/*", problems.strings[0]);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	assert_config_entry_value(_repo, "remote.just/renamed.fetch", "+refs/*:refs/*");
 
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 }
 
 void test_network_remote_rename__new_name_can_contain_dots(void)
@@ -103,7 +103,7 @@ void test_network_remote_rename__new_name_can_contain_dots(void)
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just.renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 	assert_config_entry_existence(_repo, "remote.just.renamed.fetch", true);
 }
 
@@ -126,7 +126,7 @@ void test_network_remote_rename__renamed_name_is_persisted(void)
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	cl_git_pass(git_repository_open(&another_repo, "testrepo.git"));
 	cl_git_pass(git_remote_lookup(&renamed, _repo, "just/renamed"));
@@ -154,7 +154,7 @@ void test_network_remote_rename__renaming_a_remote_moves_the_underlying_referenc
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "just/renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	cl_assert_equal_i(GIT_ENOTFOUND, git_reference_lookup(&underlying, _repo, "refs/remotes/test/master"));
 	cl_git_pass(git_reference_lookup(&underlying, _repo, "refs/remotes/just/renamed/master"));
@@ -176,7 +176,7 @@ void test_network_remote_rename__overwrite_ref_in_target(void)
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	/* make sure there's only one remote-tracking branch */
 	cl_git_pass(git_branch_iterator_new(&iter, _repo, GIT_BRANCH_REMOTE));
@@ -214,7 +214,7 @@ void test_network_remote_rename__symref_head(void)
 
 	cl_git_pass(git_remote_rename(&problems, _repo, _remote_name, "renamed"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 
 	cl_git_pass(git_vector_init(&refs, 2, (git_vector_cmp) git_reference_cmp));
 	cl_git_pass(git_branch_iterator_new(&iter, _repo, GIT_BRANCH_REMOTE));

--- a/tests/object/tag/list.c
+++ b/tests/object/tag/list.c
@@ -50,7 +50,7 @@ static void ensure_tag_pattern_match(git_repository *repo,
 	cl_assert_equal_i((int)sucessfully_found, (int)data->expected_matches);
 
 exit:
-	git_strarray_free(&tag_list);
+	git_strarray_dispose(&tag_list);
 	cl_git_pass(error);
 }
 
@@ -74,7 +74,7 @@ void test_object_tag_list__list_all(void)
 
 	cl_assert_equal_i((int)tag_list.count, 6);
 
-	git_strarray_free(&tag_list);
+	git_strarray_dispose(&tag_list);
 }
 
 static const struct pattern_match_t matches[] = {

--- a/tests/online/fetchhead.c
+++ b/tests/online/fetchhead.c
@@ -43,7 +43,7 @@ static size_t count_references(void)
 	cl_git_pass(git_reference_list(&array, g_repo));
 	refs = array.count;
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	return refs;
 }

--- a/tests/online/remotes.c
+++ b/tests/online/remotes.c
@@ -32,7 +32,7 @@ void test_online_remotes__single_branch(void)
 	}
 	cl_assert_equal_i(1, count);
 
-	git_strarray_free(&refs);
+	git_strarray_dispose(&refs);
 
 	cl_git_pass(git_remote_lookup(&remote, repo, "origin"));
 	cl_git_pass(git_remote_get_fetch_refspecs(&refs, remote));
@@ -40,7 +40,7 @@ void test_online_remotes__single_branch(void)
 	cl_assert_equal_i(1, refs.count);
 	cl_assert_equal_s(REFSPEC, refs.strings[0]);
 
-	git_strarray_free(&refs);
+	git_strarray_dispose(&refs);
 	git_remote_free(remote);
 	git_repository_free(repo);
 }

--- a/tests/refs/list.c
+++ b/tests/refs/list.c
@@ -38,7 +38,7 @@ void test_refs_list__all(void)
 	 * loose, but we only list it once */
 	cl_assert_equal_i((int)ref_list.count, 19);
 
-	git_strarray_free(&ref_list);
+	git_strarray_dispose(&ref_list);
 }
 
 void test_refs_list__do_not_retrieve_references_which_name_end_with_a_lock_extension(void)
@@ -53,5 +53,5 @@ void test_refs_list__do_not_retrieve_references_which_name_end_with_a_lock_exten
 	cl_git_pass(git_reference_list(&ref_list, g_repo));
 	cl_assert_equal_i((int)ref_list.count, 19);
 
-	git_strarray_free(&ref_list);
+	git_strarray_dispose(&ref_list);
 }

--- a/tests/refs/listall.c
+++ b/tests/refs/listall.c
@@ -16,7 +16,7 @@ static void ensure_no_refname_starts_with_a_forward_slash(const char *path)
 	for (i = 0; i < ref_list.count; i++)
 		cl_assert(git__prefixcmp(ref_list.strings[i], "/") != 0);
 
-	git_strarray_free(&ref_list);
+	git_strarray_dispose(&ref_list);
 	git_repository_free(repo);
 }
 
@@ -42,6 +42,6 @@ void test_refs_listall__from_repository_with_no_trailing_newline(void)
 
 	cl_assert(ref_list.count > 0);
 
-	git_strarray_free(&ref_list);
+	git_strarray_dispose(&ref_list);
 	git_repository_free(repo);
 }

--- a/tests/refs/namespaces.c
+++ b/tests/refs/namespaces.c
@@ -32,5 +32,5 @@ void test_refs_namespaces__namespace_doesnt_show_normal_refs(void)
 	cl_git_pass(git_repository_set_namespace(g_repo, "namespace"));
 	cl_git_pass(git_reference_list(&ref_list, g_repo));
 	cl_assert_equal_i(0, ref_list.count);
-	git_strarray_free(&ref_list);
+	git_strarray_dispose(&ref_list);
 }

--- a/tests/remote/create.c
+++ b/tests/remote/create.c
@@ -117,7 +117,7 @@ void test_remote_create__with_fetchspec(void)
 	cl_assert_equal_i(1, array.count);
 	cl_assert_equal_i(section_count + 2, count_config_entries_match(_repo, "remote\\."));
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -132,7 +132,7 @@ void test_remote_create__with_empty_fetchspec(void)
 	cl_assert_equal_i(0, array.count);
 	cl_assert_equal_i(section_count + 1, count_config_entries_match(_repo, "remote\\."));
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -167,7 +167,7 @@ void test_remote_create__anonymous(void)
 	cl_assert_equal_i(0, array.count);
 	cl_assert_equal_i(section_count, count_config_entries_match(_repo, "remote\\."));
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -195,7 +195,7 @@ void test_remote_create__detached(void)
 	cl_assert_equal_i(0, array.count);
 	cl_assert_equal_i(section_count, count_config_entries_match(_repo, "remote\\."));
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -225,7 +225,7 @@ void test_remote_create__with_opts_named(void)
 	cl_assert_equal_i(1, array.count);
 	cl_assert_equal_s("+refs/heads/*:refs/remotes/test-new/*", array.strings[0]);
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -248,7 +248,7 @@ void test_remote_create__with_opts_named_and_fetchspec(void)
 	cl_assert_equal_i(1, array.count);
 	cl_assert_equal_s("+refs/*:refs/*", array.strings[0]);
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -270,7 +270,7 @@ void test_remote_create__with_opts_named_no_fetchspec(void)
 	cl_git_pass(git_remote_get_fetch_refspecs(&array, remote));
 	cl_assert_equal_i(0, array.count);
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -290,7 +290,7 @@ void test_remote_create__with_opts_anonymous(void)
 	cl_git_pass(git_remote_get_fetch_refspecs(&array, remote));
 	cl_assert_equal_i(0, array.count);
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 	git_remote_free(remote);
 }
 
@@ -308,7 +308,7 @@ void test_remote_create__with_opts_detached(void)
 	cl_git_pass(git_remote_get_fetch_refspecs(&array, remote));
 	cl_assert_equal_i(0, array.count);
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	git_remote_free(remote);
 
@@ -320,7 +320,7 @@ void test_remote_create__with_opts_detached(void)
 	cl_git_pass(git_remote_get_fetch_refspecs(&array, remote));
 	cl_assert_equal_i(0, array.count);
 
-	git_strarray_free(&array);
+	git_strarray_dispose(&array);
 
 	git_remote_free(remote);
 }

--- a/tests/remote/list.c
+++ b/tests/remote/list.c
@@ -25,17 +25,17 @@ void test_remote_list__always_checks_disk_config(void)
 
 	cl_git_pass(git_remote_list(&remotes, _repo));
 	cl_assert_equal_sz(remotes.count, 1);
-	git_strarray_free(&remotes);
+	git_strarray_dispose(&remotes);
 
 	cl_git_pass(git_remote_create(&remote, _repo, "valid-name", TEST_URL));
 
 	cl_git_pass(git_remote_list(&remotes, _repo));
 	cl_assert_equal_sz(remotes.count, 2);
-	git_strarray_free(&remotes);
+	git_strarray_dispose(&remotes);
 
 	cl_git_pass(git_remote_list(&remotes, repo));
 	cl_assert_equal_sz(remotes.count, 2);
-	git_strarray_free(&remotes);
+	git_strarray_dispose(&remotes);
 
 	git_repository_free(repo);
 	git_remote_free(remote);

--- a/tests/submodule/add.c
+++ b/tests/submodule/add.c
@@ -90,7 +90,7 @@ void test_submodule_add__url_relative(void)
 	/* make sure we don't default to origin - rename origin -> test_remote */
 	cl_git_pass(git_remote_rename(&problems, g_repo, "origin", "test_remote"));
 	cl_assert_equal_i(0, problems.count);
-	git_strarray_free(&problems);
+	git_strarray_dispose(&problems);
 	cl_git_fail(git_remote_lookup(&remote, g_repo, "origin"));
 
 	cl_git_pass(

--- a/tests/worktree/bare.c
+++ b/tests/worktree/bare.c
@@ -28,7 +28,7 @@ void test_worktree_bare__list(void)
 	cl_git_pass(git_worktree_list(&wts, g_repo));
 	cl_assert_equal_i(wts.count, 0);
 
-	git_strarray_free(&wts);
+	git_strarray_dispose(&wts);
 }
 
 void test_worktree_bare__add(void)
@@ -48,7 +48,7 @@ void test_worktree_bare__add(void)
 	cl_assert_equal_i(0, git_repository_is_bare(wtrepo));
 	cl_assert_equal_i(1, git_repository_is_worktree(wtrepo));
 
-	git_strarray_free(&wts);
+	git_strarray_dispose(&wts);
 	git_worktree_free(wt);
 	git_repository_free(wtrepo);
 }

--- a/tests/worktree/refs.c
+++ b/tests/worktree/refs.c
@@ -56,8 +56,8 @@ void test_worktree_refs__list(void)
 	}
 
 exit:
-	git_strarray_free(&refs);
-	git_strarray_free(&wtrefs);
+	git_strarray_dispose(&refs);
+	git_strarray_dispose(&wtrefs);
 	cl_git_pass(error);
 }
 

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -30,7 +30,7 @@ void test_worktree_worktree__list(void)
 	cl_assert_equal_i(wts.count, 1);
 	cl_assert_equal_s(wts.strings[0], "testrepo-worktree");
 
-	git_strarray_free(&wts);
+	git_strarray_dispose(&wts);
 }
 
 void test_worktree_worktree__list_with_invalid_worktree_dirs(void)
@@ -61,7 +61,7 @@ void test_worktree_worktree__list_with_invalid_worktree_dirs(void)
 		cl_git_pass(git_worktree_list(&wts, fixture.worktree));
 		cl_assert_equal_i(wts.count, 1);
 		cl_assert_equal_s(wts.strings[0], "testrepo-worktree");
-		git_strarray_free(&wts);
+		git_strarray_dispose(&wts);
 
 		for (j = 0; j < ARRAY_SIZE(filesets[i]); j++) {
 			git_buf_truncate(&path, len);
@@ -81,7 +81,7 @@ void test_worktree_worktree__list_in_worktree_repo(void)
 	cl_assert_equal_i(wts.count, 1);
 	cl_assert_equal_s(wts.strings[0], "testrepo-worktree");
 
-	git_strarray_free(&wts);
+	git_strarray_dispose(&wts);
 }
 
 void test_worktree_worktree__list_without_worktrees(void)
@@ -380,7 +380,7 @@ void test_worktree_worktree__name(void)
 
 	cl_git_pass(git_worktree_lookup(&wt, fixture.repo, "testrepo-worktree"));
 	cl_assert_equal_s(git_worktree_name(wt), "testrepo-worktree");
-	
+
 	git_worktree_free(wt);
 }
 


### PR DESCRIPTION
We standardized on `dispose` as the verb for freeing the contents of a structure, but not the structure itself.  Thus, `git_strarray_free` should be `git_strarray_dispose`.  While we're here, we shouldn't offer the `git_strarray_copy` function publicly; there's no value in it for users.