### PR TITLE
httpclient: support googlesource

### DIFF
--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1195,7 +1195,7 @@ static void complete_response_body(git_http_client *client)
 	/* If we're not keeping alive, don't bother. */
 	if (!client->keepalive) {
 		client->connected = 0;
-		return;
+		goto done;
 	}
 
 	parser_context.client = client;
@@ -1209,6 +1209,9 @@ static void complete_response_body(git_http_client *client)
 		git_error_clear();
 		client->connected = 0;
 	}
+
+done:
+	git_buf_clear(&client->read_buf);
 }
 
 int git_http_client_send_request(

--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1038,6 +1038,7 @@ on_error:
 
 GIT_INLINE(int) client_read(git_http_client *client)
 {
+	http_parser_context *parser_context = client->parser.data;
 	git_stream *stream;
 	char *buf = client->read_buf.ptr + client->read_buf.size;
 	size_t max_len;
@@ -1053,6 +1054,9 @@ GIT_INLINE(int) client_read(git_http_client *client)
 	 */
 	max_len = client->read_buf.asize - client->read_buf.size;
 	max_len = min(max_len, INT_MAX);
+
+	if (parser_context->output_size)
+		max_len = min(max_len, parser_context->output_size);
 
 	if (max_len == 0) {
 		git_error_set(GIT_ERROR_HTTP, "no room in output buffer");

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -11,6 +11,7 @@
 #define BB_REPO_URL "https://libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_PASS "https://libgit3:libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_WRONG_PASS "https://libgit3:wrong@bitbucket.org/libgit2/testgitrepository.git"
+#define GOOGLESOURCE_REPO_URL "https://chromium.googlesource.com/external/github.com/sergi/go-diff"
 
 #define SSH_REPO_URL "ssh://github.com/libgit2/TestGitRepository"
 
@@ -459,6 +460,13 @@ void test_online_clone__bitbucket_falls_back_to_specified_creds(void)
 	 * the `git_credential_userpass_payload` should be used as a fallback.
 	 */
 	cl_git_pass(git_clone(&g_repo, BB_REPO_URL_WITH_WRONG_PASS, "./foo", &g_options));
+	git_repository_free(g_repo); g_repo = NULL;
+	cl_fixture_cleanup("./foo");
+}
+
+void test_online_clone__googlesource(void)
+{
+	cl_git_pass(git_clone(&g_repo, GOOGLESOURCE_REPO_URL, "./foo", &g_options));
 	git_repository_free(g_repo); g_repo = NULL;
 	cl_fixture_cleanup("./foo");
 }


### PR DESCRIPTION
After the [great smart http refactoring of 2020](https://github.com/libgit2/libgit2/pull/5286), we [no longer support googlesource](https://github.com/libgit2/libgit2/issues/5525).  It turns out that google code - by default - sends very large data packets (65520) which is very neat to the upper limit of a packet size for a git data packet over the smart protocols.  This illustrates some problems in our handling of very large data packets.

In particular, we read a block of data from the client and try to put it in the output buffer.  When the output buffer (for data packets, this is a buffer of 65536) is nearly full, we do not take that into account and do a read of a block, despite the fact that we cannot fit it into the caller's output buffer.  We then discard what cannot be sent back.

While debugging this, I found two other problems as well.  This PR fixes the root cause and these other two issues.

* First, this adds an integration test that clones (a small repository) from googlesource that illustrates our deficiencies.
* Next, we ensure that `git_http_client_read_body` will always return `0` at the end of an http response.  If a buffer size that is being read into is very near the number of bytes sent by the remote server, then we may be in a position where we have read all the content in the http response, and the only bytes remaining are part of the http metadata, like the zero-length chunk signifier of the end of the stream. In that case, we do not actually return _content bytes_, but should signify that we have finished reading the stream.  Identify this by the `on_message_complete` callback and return `0` to the caller.
* Next, we only read _at most_ what the client has requested.  `git_http_client_read_body` takes a buffer size that should be respected when reading from the stream.  Without this, we would read data from the server, but not return it to the client, which would mean that it was lost.
* Finally, we should clear the interim read buffer when starting a new request.  The read buffer is used when we read data from the remote server that contains both headers _and_ body content.  The header data will be returned to the caller (in `read_response`) but the body data should be saved for a subsequent call to `read_body`.  If such call never comes, we should clear the saved data, it should not be returned to callers for future requests.

Fixes #5525 