### PR TITLE
tests: offer exact name matching with a `$` suffix

### DIFF
--- a/tests/clar.c
+++ b/tests/clar.c
@@ -293,6 +293,7 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 	const struct clar_func *test = suite->tests;
 	size_t i, matchlen;
 	struct clar_report *report;
+	int exact = 0;
 
 	if (!suite->enabled)
 		return;
@@ -317,11 +318,19 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 			while (*filter == ':')
 				++filter;
 			matchlen = strlen(filter);
+
+			if (matchlen && filter[matchlen - 1] == '$') {
+				exact = 1;
+				matchlen--;
+			}
 		}
 	}
 
 	for (i = 0; i < suite->test_count; ++i) {
 		if (filter && strncmp(test[i].name, filter, matchlen))
+			continue;
+
+		if (exact && strlen(test[i].name) != matchlen)
 			continue;
 
 		_clar.active_test = test[i].name;


### PR DESCRIPTION
When using `-s` to specify a particular test, it will do a prefix match.
Thus, `-sapply::both::rename_a_to_b_to_c` will match both a test named
`test_apply_both__rename_a_to_b_to_c` and a test that begins with that
name, like `test_apply_both__rename_a_to_b_to_c_exact`.

Permit a trailing `$` to `-s` syntax.  This allows a user to specify
`-sapply::both::rename_a_to_b_to_c$` to match _only_ the
`test_apply_both__rename_a_to_b_to_c` function.

We already filter to ensure that the given prefix matches the current
test name.  Also ensure that the length of the test name matches the
length of the filter, sans trailing `$`.

Fixes https://github.com/clar-test/clar/issues/83