### PR TITLE
Release v1.0.1

### DIFF
--- a/deps/ntlmclient/compat.h
+++ b/deps/ntlmclient/compat.h
@@ -25,7 +25,7 @@
 /* See man page endian(3) */
 # include <endian.h>
 # define htonll htobe64
-#elif defined(__OpenBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
 /* See man page htobe64(3) */
 # include <endian.h>
 # define htonll htobe64

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,33 @@
+v1.0.1
+------
+
+This is a bugfix release with the following changes:
+
+- Calculating information about renamed files during merges is more
+  efficient because dissimilarity about files is now being cached and
+  no longer needs to be recomputed.
+  
+- The `git_worktree_prune_init_options` has been correctly restored for
+  backward compatibility.  In v1.0 it was incorrectly deprecated with a
+  typo.
+
+- The optional ntlmclient dependency now supports NetBSD.
+
+- A bug where attempting to stash on a bare repository may have failed
+  has been fixed.
+
+- Configuration files that are unreadable due to permissions are now
+  silently ignored, and treated as if they do not exist.  This matches
+  git's behavior; previously this case would have been an error.
+
+- v4 index files are now correctly written; previously we would read
+  them correctly but would not write the prefix-compression accurately,
+  causing corruption.
+
+- A bug where the smart HTTP transport could not read large data packets
+  has been fixed.  Previously, fetching from servers like Gerrit, that
+  sent large data packets, would error.
+
 v1.0
 ----
 

--- a/script/release.py
+++ b/script/release.py
@@ -56,6 +56,17 @@ def verify_version(version):
         if v[0] != v[1]:
             raise Error("version.h: define '{}' does not match (got '{}', expected '{}')".format(k, v[0], v[1]))
 
+    with open('package.json') as f:
+        pkg = json.load(f)
+
+    try:
+        pkg_version = Version(pkg["version"])
+    except KeyError as err:
+        raise Error("package.json: missing the field {}".format(err))
+
+    if pkg_version != version:
+        raise Error("package.json: version does not match (got '{}', expected '{}')".format(pkg_version, version))
+
 def generate_relnotes(tree, version):
     with open('docs/changelog.md') as f:
         lines = f.readlines()

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -111,6 +111,15 @@ static int config_file_open(git_config_backend *cfg, git_config_level_t level, c
 	if (!git_path_exists(b->file.path))
 		return 0;
 
+	/*
+	 * git silently ignores configuration files that are not
+	 * readable.  We emulate that behavior.  This is particularly
+	 * important for sandboxed applications on macOS where the
+	 * git configuration files may not be readable.
+	 */
+	if (p_access(b->file.path, R_OK) < 0)
+		return GIT_ENOTFOUND;
+
 	if (res < 0 || (res = config_file_read(b->entries, repo, &b->file, level, 0)) < 0) {
 		git_config_entries_free(b->entries);
 		b->entries = NULL;

--- a/src/index.c
+++ b/src/index.c
@@ -2744,7 +2744,7 @@ static int write_disk_entry(git_filebuf *file, git_index_entry *entry, const cha
 			++same_len;
 		}
 		path_len -= same_len;
-		varint_len = git_encode_varint(NULL, 0, same_len);
+		varint_len = git_encode_varint(NULL, 0, strlen(last) - same_len);
 	}
 
 	disk_size = index_entry_size(path_len, varint_len, entry->flags);
@@ -2795,7 +2795,7 @@ static int write_disk_entry(git_filebuf *file, git_index_entry *entry, const cha
 
 	if (last) {
 		varint_len = git_encode_varint((unsigned char *) path,
-					  disk_size, same_len);
+					  disk_size, strlen(last) - same_len);
 		assert(varint_len > 0);
 		path += varint_len;
 		disk_size -= varint_len;

--- a/src/stash.c
+++ b/src/stash.c
@@ -173,7 +173,7 @@ static int stash_to_index(
 	git_index *index,
 	const char *path)
 {
-	git_index *repo_index;
+	git_index *repo_index = NULL;
 	git_index_entry entry = {{0}};
 	struct stat st;
 	int error;
@@ -187,7 +187,7 @@ static int stash_to_index(
 		return error;
 
 	git_index_entry__init_from_stat(&entry, &st,
-		(repo_index != NULL || !repo_index->distrust_filemode));
+		(repo_index == NULL || !repo_index->distrust_filemode));
 
 	entry.path = path;
 

--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1195,7 +1195,7 @@ static void complete_response_body(git_http_client *client)
 	/* If we're not keeping alive, don't bother. */
 	if (!client->keepalive) {
 		client->connected = 0;
-		return;
+		goto done;
 	}
 
 	parser_context.client = client;
@@ -1209,6 +1209,9 @@ static void complete_response_body(git_http_client *client)
 		git_error_clear();
 		client->connected = 0;
 	}
+
+done:
+	git_buf_clear(&client->read_buf);
 }
 
 int git_http_client_send_request(

--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1038,6 +1038,7 @@ on_error:
 
 GIT_INLINE(int) client_read(git_http_client *client)
 {
+	http_parser_context *parser_context = client->parser.data;
 	git_stream *stream;
 	char *buf = client->read_buf.ptr + client->read_buf.size;
 	size_t max_len;
@@ -1053,6 +1054,9 @@ GIT_INLINE(int) client_read(git_http_client *client)
 	 */
 	max_len = client->read_buf.asize - client->read_buf.size;
 	max_len = min(max_len, INT_MAX);
+
+	if (parser_context->output_size)
+		max_len = min(max_len, parser_context->output_size);
 
 	if (max_len == 0) {
 		git_error_set(GIT_ERROR_HTTP, "no room in output buffer");

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -506,7 +506,7 @@ int git_worktree_prune_options_init(
 	return 0;
 }
 
-int git_worktree_pruneinit_options(git_worktree_prune_options *opts,
+int git_worktree_prune_init_options(git_worktree_prune_options *opts,
 	unsigned int version)
 {
 	return git_worktree_prune_options_init(opts, version);

--- a/tests/config/read.c
+++ b/tests/config/read.c
@@ -849,6 +849,23 @@ void test_config_read__invalid_quoted_third_section(void)
 	git_config_free(cfg);
 }
 
+void test_config_read__unreadable_file_ignored(void)
+{
+	git_buf buf = GIT_BUF_INIT;
+	git_config *cfg;
+	int ret;
+
+	cl_set_cleanup(&clean_test_config, NULL);
+	cl_git_mkfile("./testconfig", "[some] var = value\n[some \"OtheR\"] var = value");
+	cl_git_pass(p_chmod("./testconfig", 0));
+
+	ret = git_config_open_ondisk(&cfg, "./test/config");
+	cl_assert(ret == 0 || ret == GIT_ENOTFOUND);
+
+	git_config_free(cfg);
+	git_buf_dispose(&buf);
+}
+
 void test_config_read__single_line(void)
 {
 	git_buf buf = GIT_BUF_INIT;

--- a/tests/index/version.c
+++ b/tests/index/version.c
@@ -43,6 +43,7 @@ void test_index_version__can_write_v4(void)
 	    "xz",
 	    "xyzzyx"
 	};
+	git_repository *repo;
 	git_index_entry entry;
 	git_index *index;
 	size_t i;
@@ -63,7 +64,8 @@ void test_index_version__can_write_v4(void)
 	cl_git_pass(git_index_write(index));
 	git_index_free(index);
 
-	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_repository_open(&repo, git_repository_path(g_repo)));
+	cl_git_pass(git_repository_index(&index, repo));
 	cl_assert(git_index_version(index) == 4);
 
 	for (i = 0; i < ARRAY_SIZE(paths); i++) {
@@ -74,6 +76,7 @@ void test_index_version__can_write_v4(void)
 	}
 
 	git_index_free(index);
+	git_repository_free(repo);
 }
 
 void test_index_version__v4_uses_path_compression(void)

--- a/tests/merge/trees/renames.c
+++ b/tests/merge/trees/renames.c
@@ -274,3 +274,80 @@ void test_merge_trees_renames__submodules(void)
 	cl_assert(merge_test_index(index, merge_index_entries, 7));
 	git_index_free(index);
 }
+
+void test_merge_trees_renames__cache_recomputation(void)
+{
+	git_oid blob, binary, ancestor_oid, theirs_oid, ours_oid;
+	git_merge_options opts = GIT_MERGE_OPTIONS_INIT;
+	git_buf path = GIT_BUF_INIT;
+	git_treebuilder *builder;
+	git_tree *ancestor_tree, *their_tree, *our_tree;
+	git_index *index;
+	size_t blob_size;
+	void *data;
+	size_t i;
+
+	cl_git_pass(git_oid_fromstr(&blob, "a2d8d1824c68541cca94ffb90f79291eba495921"));
+
+	/*
+	 * Create a 50MB blob that consists of NUL bytes only. It is important
+	 * that this blob is of a special format, most importantly it cannot
+	 * contain more than four non-consecutive newlines or NUL bytes. This
+	 * is because of git_hashsig's inner workings where all files with less
+	 * than four "lines" are deemed to small.
+	 */
+	blob_size = 50 * 1024 * 1024;
+	cl_assert(data = git__calloc(blob_size, 1));
+	cl_git_pass(git_blob_create_from_buffer(&binary, repo, data, blob_size));
+
+	/*
+	 * Create the common ancestor, which has 1000 dummy blobs and the binary
+	 * blob. The dummy blobs serve as potential rename targets for the
+	 * dummy blob.
+	 */
+	cl_git_pass(git_treebuilder_new(&builder, repo, NULL));
+	for (i = 0; i < 1000; i++) {
+		cl_git_pass(git_buf_printf(&path, "%"PRIuMAX".txt", i));
+		cl_git_pass(git_treebuilder_insert(NULL, builder, path.ptr, &blob, GIT_FILEMODE_BLOB));
+		git_buf_clear(&path);
+	}
+	cl_git_pass(git_treebuilder_insert(NULL, builder, "original.bin", &binary, GIT_FILEMODE_BLOB));
+	cl_git_pass(git_treebuilder_write(&ancestor_oid, builder));
+
+	/* We now the binary blob in our tree. */
+	cl_git_pass(git_treebuilder_remove(builder, "original.bin"));
+	cl_git_pass(git_treebuilder_insert(NULL, builder, "renamed.bin", &binary, GIT_FILEMODE_BLOB));
+	cl_git_pass(git_treebuilder_write(&ours_oid, builder));
+
+	git_treebuilder_free(builder);
+
+	/* And move everything into a subdirectory in their tree. */
+	cl_git_pass(git_treebuilder_new(&builder, repo, NULL));
+	cl_git_pass(git_treebuilder_insert(NULL, builder, "subdir", &ancestor_oid, GIT_FILEMODE_TREE));
+	cl_git_pass(git_treebuilder_write(&theirs_oid, builder));
+
+	/*
+	 * Now merge ancestor, ours and theirs. As `git_hashsig` refuses to
+	 * create a hash signature for the 50MB binary file, we historically
+	 * didn't cache the hashsig computation for it. As a result, we now
+	 * started looking up the 50MB blob and scanning it at least 1000
+	 * times, which takes a long time.
+	 *
+	 * The number of 1000 blobs is chosen in such a way that it's
+	 * noticeable when the bug creeps in again, as it takes around 12
+	 * minutes on my machine to compute the following merge.
+	 */
+	opts.target_limit = 5000;
+	cl_git_pass(git_tree_lookup(&ancestor_tree, repo, &ancestor_oid));
+	cl_git_pass(git_tree_lookup(&their_tree, repo, &theirs_oid));
+	cl_git_pass(git_tree_lookup(&our_tree, repo, &ours_oid));
+	cl_git_pass(git_merge_trees(&index, repo, ancestor_tree, our_tree, their_tree, &opts));
+
+	git_treebuilder_free(builder);
+	git_buf_dispose(&path);
+	git_index_free(index);
+	git_tree_free(ancestor_tree);
+	git_tree_free(their_tree);
+	git_tree_free(our_tree);
+	git__free(data);
+}

--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -11,6 +11,7 @@
 #define BB_REPO_URL "https://libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_PASS "https://libgit3:libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_WRONG_PASS "https://libgit3:wrong@bitbucket.org/libgit2/testgitrepository.git"
+#define GOOGLESOURCE_REPO_URL "https://chromium.googlesource.com/external/github.com/sergi/go-diff"
 
 #define SSH_REPO_URL "ssh://github.com/libgit2/TestGitRepository"
 
@@ -459,6 +460,13 @@ void test_online_clone__bitbucket_falls_back_to_specified_creds(void)
 	 * the `git_credential_userpass_payload` should be used as a fallback.
 	 */
 	cl_git_pass(git_clone(&g_repo, BB_REPO_URL_WITH_WRONG_PASS, "./foo", &g_options));
+	git_repository_free(g_repo); g_repo = NULL;
+	cl_fixture_cleanup("./foo");
+}
+
+void test_online_clone__googlesource(void)
+{
+	cl_git_pass(git_clone(&g_repo, GOOGLESOURCE_REPO_URL, "./foo", &g_options));
 	git_repository_free(g_repo); g_repo = NULL;
 	cl_fixture_cleanup("./foo");
 }


### PR DESCRIPTION
This includes the following changes, cherry-picked from the PRs that have been labeled `release-1.0.1`, and includes a changelog.

11dca3ca20af4bfa74d926db5693ed2314ecceb2 v1.0.1: prepare the changelog
79507cd8b2fb89555fa1a900d84f24e629fdf902 httpclient: clear the read_buf on new requests
bc61161b9879e03842a8df6764d40a49497e765e httpclient: don't read more than the client wants
ed045f0912ad6cbc512a98ebfbdd6ea08682f4ad httpclient: read_body should return 0 at EOF
7a6566e391f50845ea81e3dc18d0da69790c31ee online::clone: test a googlesource URL
3939e810493b4dde595f9b523e24ad1b684ba9bb tests: index::version: write v4 index: re-open repo to read written v4 index
e2294859bdd1a9f65d04e1b132c2a0466b0c2bd1 index: write v4: bugfix: prefix path with strip_len, not same_len
8edc39df3b9268960775be840e15e4e5ad8dfd25 config: test that unreadable files are treated as notfound
c0bf387ffc6914bbba3a77fac2d50f61bf7769d6 config: ignore unreadable configuration files
c229591e3285e57e74c24f9d939ffcabd0a5694f feat: Check the version in package.json
234a2e6e622415af84dd402df1c24e278dfcdea2 Fix uninitialized stack memory and NULL ptr dereference in stash_to_index
88ced11585ebaf7e9f43ab0a0a72459306707890 deps: ntlmclient: use htobe64 on NetBSD too
aee48d27add60ea7677d7133b3b28e6ce8181db6 Fix typo causing removal of symbol 'git_worktree_prune_init_options'
1740bbb38d1bae48ad91aca021117735c4c4988a merge: cache negative cache results for similarity metrics