### PR TITLE
clar: add tap output option

### DIFF
--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -108,7 +108,7 @@ done:
 		git_buf details = GIT_BUF_INIT;
 		git_buf_printf(&details, "filename=%s, system=%s, autocrlf=%s, attrs={%s}",
 			git_path_basename(actual_path->ptr), systype, cd->autocrlf, cd->attrs);
-		clar__fail(__FILE__, __LINE__,
+		clar__fail(__FILE__, __func__, __LINE__,
 			"checked out contents did not match expected", details.ptr, 0);
 		git_buf_dispose(&details);
 	}

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -96,6 +96,7 @@ fixture_path(const char *base, const char *fixture_name);
 
 struct clar_error {
 	const char *file;
+	const char *function;
 	size_t line_number;
 	const char *error_msg;
 	char *description;
@@ -603,6 +604,7 @@ void clar__skip(void)
 
 void clar__fail(
 	const char *file,
+	const char *function,
 	size_t line,
 	const char *error_msg,
 	const char *description,
@@ -619,6 +621,7 @@ void clar__fail(
 	_clar.last_report->last_error = error;
 
 	error->file = file;
+	error->function = function;
 	error->line_number = line;
 	error->error_msg = error_msg;
 
@@ -635,6 +638,7 @@ void clar__fail(
 void clar__assert(
 	int condition,
 	const char *file,
+	const char *function,
 	size_t line,
 	const char *error_msg,
 	const char *description,
@@ -643,11 +647,12 @@ void clar__assert(
 	if (condition)
 		return;
 
-	clar__fail(file, line, error_msg, description, should_abort);
+	clar__fail(file, function, line, error_msg, description, should_abort);
 }
 
 void clar__assert_equal(
 	const char *file,
+	const char *function,
 	size_t line,
 	const char *err,
 	int should_abort,
@@ -758,7 +763,7 @@ void clar__assert_equal(
 	va_end(args);
 
 	if (!is_equal)
-		clar__fail(file, line, err, buf, should_abort);
+		clar__fail(file, function, line, err, buf, should_abort);
 }
 
 void cl_set_cleanup(void (*cleanup)(void *), void *opaque)

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -363,6 +363,7 @@ clar_usage(const char *arg)
 	printf("  -v            Increase verbosity (show suite names)\n");
 	printf("  -q            Only report tests that had an error\n");
 	printf("  -Q            Quit as soon as a test fails\n");
+	printf("  -t            Display results in tap format\n");
 	printf("  -l            Print suite names\n");
 	printf("  -r[filename]  Write summary file (to the optional filename)\n");
 	exit(-1);
@@ -378,7 +379,7 @@ clar_parse_args(int argc, char **argv)
 		char *argument = argv[i];
 
 		if (argument[0] != '-' || argument[1] == '\0'
-		    || strchr("sixvqQlr", argument[1]) == NULL) {
+		    || strchr("sixvqQtlr", argument[1]) == NULL) {
 			clar_usage(argv[0]);
 		}
 	}
@@ -459,6 +460,10 @@ clar_parse_args(int argc, char **argv)
 
 		case 'Q':
 			_clar.exit_on_error = 1;
+			break;
+
+		case 't':
+			_clar.output_format = CL_OUTPUT_TAP;
 			break;
 
 		case 'l': {

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -487,6 +487,9 @@ clar_parse_args(int argc, char **argv)
 void
 clar_test_init(int argc, char **argv)
 {
+	if (argc > 1)
+		clar_parse_args(argc, argv);
+
 	clar_print_init(
 		(int)_clar_callback_count,
 		(int)_clar_suite_count,
@@ -497,9 +500,6 @@ clar_test_init(int argc, char **argv)
 		_clar.write_summary = 1;
 		_clar.summary_filename = strdup(_clar.summary_filename);
 	}
-
-	if (argc > 1)
-		clar_parse_args(argc, argv);
 
 	if (_clar.write_summary &&
 	    !(_clar.summary = clar_summary_init(_clar.summary_filename))) {

--- a/tests/clar.c
+++ b/tests/clar.c
@@ -140,6 +140,8 @@ static struct {
 	int tests_ran;
 	int suites_ran;
 
+	enum cl_output_format output_format;
+
 	int report_errors_only;
 	int exit_on_error;
 	int report_suite_names;

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -16,6 +16,10 @@ enum cl_test_status {
 	CL_TEST_NOTRUN,
 };
 
+enum cl_output_format {
+	CL_OUTPUT_CLAP,
+};
+
 /** Setup clar environment */
 void clar_test_init(int argc, char *argv[]);
 int clar_test_run(void);

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -86,16 +86,16 @@ const char *cl_fixture_basename(const char *fixture_name);
 /**
  * Assertion macros with explicit error message
  */
-#define cl_must_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __LINE__, "Function call failed: " #expr, desc, 1)
-#define cl_must_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __LINE__, "Expected function call to fail: " #expr, desc, 1)
-#define cl_assert_(expr, desc) clar__assert((expr) != 0, __FILE__, __LINE__, "Expression is not true: " #expr, desc, 1)
+#define cl_must_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __func__, __LINE__, "Function call failed: " #expr, desc, 1)
+#define cl_must_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __func__, __LINE__, "Expected function call to fail: " #expr, desc, 1)
+#define cl_assert_(expr, desc) clar__assert((expr) != 0, __FILE__, __func__, __LINE__, "Expression is not true: " #expr, desc, 1)
 
 /**
  * Check macros with explicit error message
  */
-#define cl_check_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __LINE__, "Function call failed: " #expr, desc, 0)
-#define cl_check_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __LINE__, "Expected function call to fail: " #expr, desc, 0)
-#define cl_check_(expr, desc) clar__assert((expr) != 0, __FILE__, __LINE__, "Expression is not true: " #expr, desc, 0)
+#define cl_check_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __func__, __LINE__, "Function call failed: " #expr, desc, 0)
+#define cl_check_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __func__, __LINE__, "Expected function call to fail: " #expr, desc, 0)
+#define cl_check_(expr, desc) clar__assert((expr) != 0, __FILE__, __func__, __LINE__, "Expression is not true: " #expr, desc, 0)
 
 /**
  * Assertion macros with no error message
@@ -114,38 +114,39 @@ const char *cl_fixture_basename(const char *fixture_name);
 /**
  * Forced failure/warning
  */
-#define cl_fail(desc) clar__fail(__FILE__, __LINE__, "Test failed.", desc, 1)
-#define cl_warning(desc) clar__fail(__FILE__, __LINE__, "Warning during test execution:", desc, 0)
+#define cl_fail(desc) clar__fail(__FILE__, __func__, __LINE__, "Test failed.", desc, 1)
+#define cl_warning(desc) clar__fail(__FILE__, __func__, __LINE__, "Warning during test execution:", desc, 0)
 
 #define cl_skip() clar__skip()
 
 /**
  * Typed assertion macros
  */
-#define cl_assert_equal_s(s1,s2) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%s", (s1), (s2))
-#define cl_assert_equal_s_(s1,s2,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%s", (s1), (s2))
+#define cl_assert_equal_s(s1,s2) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%s", (s1), (s2))
+#define cl_assert_equal_s_(s1,s2,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%s", (s1), (s2))
 
-#define cl_assert_equal_wcs(wcs1,wcs2) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%ls", (wcs1), (wcs2))
-#define cl_assert_equal_wcs_(wcs1,wcs2,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%ls", (wcs1), (wcs2))
+#define cl_assert_equal_wcs(wcs1,wcs2) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%ls", (wcs1), (wcs2))
+#define cl_assert_equal_wcs_(wcs1,wcs2,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%ls", (wcs1), (wcs2))
 
-#define cl_assert_equal_strn(s1,s2,len) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%.*s", (s1), (s2), (int)(len))
-#define cl_assert_equal_strn_(s1,s2,len,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%.*s", (s1), (s2), (int)(len))
+#define cl_assert_equal_strn(s1,s2,len) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%.*s", (s1), (s2), (int)(len))
+#define cl_assert_equal_strn_(s1,s2,len,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%.*s", (s1), (s2), (int)(len))
 
-#define cl_assert_equal_wcsn(wcs1,wcs2,len) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%.*ls", (wcs1), (wcs2), (int)(len))
-#define cl_assert_equal_wcsn_(wcs1,wcs2,len,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%.*ls", (wcs1), (wcs2), (int)(len))
+#define cl_assert_equal_wcsn(wcs1,wcs2,len) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%.*ls", (wcs1), (wcs2), (int)(len))
+#define cl_assert_equal_wcsn_(wcs1,wcs2,len,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%.*ls", (wcs1), (wcs2), (int)(len))
 
-#define cl_assert_equal_i(i1,i2) clar__assert_equal(__FILE__,__LINE__,#i1 " != " #i2, 1, "%d", (int)(i1), (int)(i2))
-#define cl_assert_equal_i_(i1,i2,note) clar__assert_equal(__FILE__,__LINE__,#i1 " != " #i2 " (" #note ")", 1, "%d", (i1), (i2))
-#define cl_assert_equal_i_fmt(i1,i2,fmt) clar__assert_equal(__FILE__,__LINE__,#i1 " != " #i2, 1, (fmt), (int)(i1), (int)(i2))
+#define cl_assert_equal_i(i1,i2) clar__assert_equal(__FILE__,__func__,__LINE__,#i1 " != " #i2, 1, "%d", (int)(i1), (int)(i2))
+#define cl_assert_equal_i_(i1,i2,note) clar__assert_equal(__FILE__,__func__,__LINE__,#i1 " != " #i2 " (" #note ")", 1, "%d", (i1), (i2))
+#define cl_assert_equal_i_fmt(i1,i2,fmt) clar__assert_equal(__FILE__,__func__,__LINE__,#i1 " != " #i2, 1, (fmt), (int)(i1), (int)(i2))
 
-#define cl_assert_equal_b(b1,b2) clar__assert_equal(__FILE__,__LINE__,#b1 " != " #b2, 1, "%d", (int)((b1) != 0),(int)((b2) != 0))
+#define cl_assert_equal_b(b1,b2) clar__assert_equal(__FILE__,__func__,__LINE__,#b1 " != " #b2, 1, "%d", (int)((b1) != 0),(int)((b2) != 0))
 
-#define cl_assert_equal_p(p1,p2) clar__assert_equal(__FILE__,__LINE__,"Pointer mismatch: " #p1 " != " #p2, 1, "%p", (p1), (p2))
+#define cl_assert_equal_p(p1,p2) clar__assert_equal(__FILE__,__func__,__LINE__,"Pointer mismatch: " #p1 " != " #p2, 1, "%p", (p1), (p2))
 
 void clar__skip(void);
 
 void clar__fail(
 	const char *file,
+	const char *func,
 	size_t line,
 	const char *error,
 	const char *description,
@@ -154,6 +155,7 @@ void clar__fail(
 void clar__assert(
 	int condition,
 	const char *file,
+	const char *func,
 	size_t line,
 	const char *error,
 	const char *description,
@@ -161,6 +163,7 @@ void clar__assert(
 
 void clar__assert_equal(
 	const char *file,
+	const char *func,
 	size_t line,
 	const char *err,
 	int should_abort,

--- a/tests/clar.h
+++ b/tests/clar.h
@@ -18,6 +18,7 @@ enum cl_test_status {
 
 enum cl_output_format {
 	CL_OUTPUT_CLAP,
+	CL_OUTPUT_TAP,
 };
 
 /** Setup clar environment */

--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -1,12 +1,12 @@
 
-static void clar_print_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_cl_init(int test_count, int suite_count, const char *suite_names)
 {
 	(void)test_count;
 	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
 	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
 
-static void clar_print_shutdown(int test_count, int suite_count, int error_count)
+static void clar_print_cl_shutdown(int test_count, int suite_count, int error_count)
 {
 	(void)test_count;
 	(void)suite_count;
@@ -16,7 +16,7 @@ static void clar_print_shutdown(int test_count, int suite_count, int error_count
 	clar_report_all();
 }
 
-static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
+static void clar_print_cl_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
 
@@ -35,7 +35,7 @@ static void clar_print_error(int num, const struct clar_report *report, const st
 	fflush(stdout);
 }
 
-static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
+static void clar_print_cl_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
 	(void)test_name;
 	(void)test_number;
@@ -50,7 +50,7 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	fflush(stdout);
 }
 
-static void clar_print_onsuite(const char *suite_name, int suite_index)
+static void clar_print_cl_onsuite(const char *suite_name, int suite_index)
 {
 	if (_clar.report_suite_names)
 		printf("\n%s", suite_name);
@@ -58,10 +58,40 @@ static void clar_print_onsuite(const char *suite_name, int suite_index)
 	(void)suite_index;
 }
 
+static void clar_print_cl_onabort(const char *fmt, va_list arg)
+{
+	vfprintf(stderr, fmt, arg);
+}
+
+static void clar_print_init(int test_count, int suite_count, const char *suite_names)
+{
+	clar_print_cl_init(test_count, suite_count, suite_names);
+}
+
+static void clar_print_shutdown(int test_count, int suite_count, int error_count)
+{
+	clar_print_cl_shutdown(test_count, suite_count, error_count);
+}
+
+static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
+{
+	clar_print_cl_error(num, report, error);
+}
+
+static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
+{
+	clar_print_cl_ontest(test_name, test_number, status);
+}
+
+static void clar_print_onsuite(const char *suite_name, int suite_index)
+{
+	clar_print_cl_onsuite(suite_name, suite_index);
+}
+
 static void clar_print_onabort(const char *msg, ...)
 {
 	va_list argp;
 	va_start(argp, msg);
-	vfprintf(stderr, msg, argp);
+	clar_print_cl_onabort(msg, argp);
 	va_end(argp);
 }

--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -126,7 +126,7 @@ static void clar_print_tap_ontest(const char *test_name, int test_number, enum c
 		printf("    at:\n");
 		printf("      file: '"); print_escaped(error->file); printf("'\n");
 		printf("      line: %" PRIuZ "\n", error->line_number);
-		printf("      function: '%s::%s'\n", _clar.active_suite, test_name);
+		printf("      function: '%s'\n", error->function);
 		printf("    ---\n");
 
 		break;

--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -1,12 +1,13 @@
+/* clap: clar protocol, the traditional clar output format */
 
-static void clar_print_cl_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_clap_init(int test_count, int suite_count, const char *suite_names)
 {
 	(void)test_count;
 	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
 	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
 
-static void clar_print_cl_shutdown(int test_count, int suite_count, int error_count)
+static void clar_print_clap_shutdown(int test_count, int suite_count, int error_count)
 {
 	(void)test_count;
 	(void)suite_count;
@@ -16,7 +17,7 @@ static void clar_print_cl_shutdown(int test_count, int suite_count, int error_co
 	clar_report_all();
 }
 
-static void clar_print_cl_error(int num, const struct clar_report *report, const struct clar_error *error)
+static void clar_print_clap_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
 
@@ -35,7 +36,7 @@ static void clar_print_cl_error(int num, const struct clar_report *report, const
 	fflush(stdout);
 }
 
-static void clar_print_cl_ontest(const char *test_name, int test_number, enum cl_test_status status)
+static void clar_print_clap_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
 	(void)test_name;
 	(void)test_number;
@@ -50,7 +51,7 @@ static void clar_print_cl_ontest(const char *test_name, int test_number, enum cl
 	fflush(stdout);
 }
 
-static void clar_print_cl_onsuite(const char *suite_name, int suite_index)
+static void clar_print_clap_onsuite(const char *suite_name, int suite_index)
 {
 	if (_clar.report_suite_names)
 		printf("\n%s", suite_name);
@@ -58,40 +59,52 @@ static void clar_print_cl_onsuite(const char *suite_name, int suite_index)
 	(void)suite_index;
 }
 
-static void clar_print_cl_onabort(const char *fmt, va_list arg)
+static void clar_print_clap_onabort(const char *fmt, va_list arg)
 {
 	vfprintf(stderr, fmt, arg);
 }
 
+/* indirection between protocol output selection */
+
+#define PRINT(FN, args...) do { \
+		switch (_clar.output_format) { \
+			case CL_OUTPUT_CLAP: \
+				clar_print_clap_##FN (args); \
+				break; \
+			default: \
+				abort(); \
+		} \
+	} while (0)
+
 static void clar_print_init(int test_count, int suite_count, const char *suite_names)
 {
-	clar_print_cl_init(test_count, suite_count, suite_names);
+	PRINT(init, test_count, suite_count, suite_names);
 }
 
 static void clar_print_shutdown(int test_count, int suite_count, int error_count)
 {
-	clar_print_cl_shutdown(test_count, suite_count, error_count);
+	PRINT(shutdown, test_count, suite_count, error_count);
 }
 
 static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
-	clar_print_cl_error(num, report, error);
+	PRINT(error, num, report, error);
 }
 
 static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
-	clar_print_cl_ontest(test_name, test_number, status);
+	PRINT(ontest, test_name, test_number, status);
 }
 
 static void clar_print_onsuite(const char *suite_name, int suite_index)
 {
-	clar_print_cl_onsuite(suite_name, suite_index);
+	PRINT(onsuite, suite_name, suite_index);
 }
 
 static void clar_print_onabort(const char *msg, ...)
 {
 	va_list argp;
 	va_start(argp, msg);
-	clar_print_cl_onabort(msg, argp);
+	PRINT(onabort, msg, argp);
 	va_end(argp);
 }

--- a/tests/clar/print.h
+++ b/tests/clar/print.h
@@ -64,12 +64,102 @@ static void clar_print_clap_onabort(const char *fmt, va_list arg)
 	vfprintf(stderr, fmt, arg);
 }
 
+/* tap: test anywhere protocol format */
+
+static void clar_print_tap_init(int test_count, int suite_count, const char *suite_names)
+{
+	(void)test_count;
+	(void)suite_count;
+	(void)suite_names;
+	printf("TAP version 13\n");
+}
+
+static void clar_print_tap_shutdown(int test_count, int suite_count, int error_count)
+{
+	(void)suite_count;
+	(void)error_count;
+
+	printf("1..%d\n", test_count);
+}
+
+static void clar_print_tap_error(int num, const struct clar_report *report, const struct clar_error *error)
+{
+	(void)num;
+	(void)report;
+	(void)error;
+}
+
+static void print_escaped(const char *str)
+{
+	char *c;
+
+	while ((c = strchr(str, '\'')) != NULL) {
+		printf("%.*s", (int)(c - str), str);
+		printf("''");
+		str = c + 1;
+	}
+
+	printf("%s", str);
+}
+
+static void clar_print_tap_ontest(const char *test_name, int test_number, enum cl_test_status status)
+{
+	const struct clar_error *error = _clar.last_report->errors;
+
+	(void)test_name;
+	(void)test_number;
+
+	switch(status) {
+	case CL_TEST_OK:
+		printf("ok %d - %s::%s\n", test_number, _clar.active_suite, test_name);
+		break;
+	case CL_TEST_FAILURE:
+		printf("not ok %d - %s::%s\n", test_number, _clar.active_suite, test_name);
+
+		printf("    ---\n");
+		printf("    reason: |\n");
+		printf("      %s\n", error->error_msg);
+
+		if (error->description)
+			printf("      %s\n", error->description);
+
+		printf("    at:\n");
+		printf("      file: '"); print_escaped(error->file); printf("'\n");
+		printf("      line: %" PRIuZ "\n", error->line_number);
+		printf("      function: '%s::%s'\n", _clar.active_suite, test_name);
+		printf("    ---\n");
+
+		break;
+	case CL_TEST_SKIP:
+	case CL_TEST_NOTRUN:
+		printf("ok %d - # SKIP %s::%s\n", test_number, _clar.active_suite, test_name);
+		break;
+	}
+
+	fflush(stdout);
+}
+
+static void clar_print_tap_onsuite(const char *suite_name, int suite_index)
+{
+	printf("# start of suite %d: %s\n", suite_index, suite_name);
+}
+
+static void clar_print_tap_onabort(const char *fmt, va_list arg)
+{
+	printf("Bail out! ");
+	vprintf(fmt, arg);
+	fflush(stdout);
+}
+
 /* indirection between protocol output selection */
 
-#define PRINT(FN, args...) do { \
+#define PRINT(FN, ...) do { \
 		switch (_clar.output_format) { \
 			case CL_OUTPUT_CLAP: \
-				clar_print_clap_##FN (args); \
+				clar_print_clap_##FN (__VA_ARGS__); \
+				break; \
+			case CL_OUTPUT_TAP: \
+				clar_print_tap_##FN (__VA_ARGS__); \
 				break; \
 			default: \
 				abort(); \

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -4,7 +4,7 @@
 #include "git2/sys/repository.h"
 
 void cl_git_report_failure(
-	int error, int expected, const char *file, int line, const char *fncall)
+	int error, int expected, const char *file, const char *func, int line, const char *fncall)
 {
 	char msg[4096];
 	const git_error *last = git_error_last();
@@ -18,7 +18,7 @@ void cl_git_report_failure(
 	else
 		p_snprintf(msg, 4096, "no error, expected non-zero return");
 
-	clar__assert(0, file, line, fncall, msg, 1);
+	clar__assert(0, file, func, line, fncall, msg, 1);
 }
 
 void cl_git_mkfile(const char *filename, const char *content)
@@ -507,6 +507,7 @@ void clar__assert_equal_file(
 	int ignore_cr,
 	const char *path,
 	const char *file,
+	const char *func,
 	int line)
 {
 	char buf[4000];
@@ -519,7 +520,7 @@ void clar__assert_equal_file(
 
 	while ((bytes = p_read(fd, buf, sizeof(buf))) != 0) {
 		clar__assert(
-			bytes > 0, file, line, "error reading from file", path, 1);
+			bytes > 0, file, func, line, "error reading from file", path, 1);
 
 		if (ignore_cr)
 			bytes = strip_cr_from_buf(buf, bytes);
@@ -532,7 +533,7 @@ void clar__assert_equal_file(
 				buf, sizeof(buf), "file content mismatch at byte %"PRIdZ,
 				(ssize_t)(total_bytes + pos));
 			p_close(fd);
-			clar__fail(file, line, path, buf, 1);
+			clar__fail(file, func, line, path, buf, 1);
 		}
 
 		expected_data += bytes;
@@ -541,8 +542,8 @@ void clar__assert_equal_file(
 
 	p_close(fd);
 
-	clar__assert(!bytes, file, line, "error reading from file", path, 1);
-	clar__assert_equal(file, line, "mismatched file length", 1, "%"PRIuZ,
+	clar__assert(!bytes, file, func, line, "error reading from file", path, 1);
+	clar__assert_equal(file, func, line, "mismatched file length", 1, "%"PRIuZ,
 		(size_t)expected_bytes, (size_t)total_bytes);
 }
 

--- a/tests/core/mkdir.c
+++ b/tests/core/mkdir.c
@@ -150,10 +150,11 @@ static void cleanup_chmod_root(void *ref)
 	git_futils_rmdir_r("r", NULL, GIT_RMDIR_EMPTY_HIERARCHY);
 }
 
-#define check_mode(X,A) check_mode_at_line((X), (A), __FILE__, __LINE__)
+#define check_mode(X,A) check_mode_at_line((X), (A), __FILE__, __func__, __LINE__)
 
 static void check_mode_at_line(
-	mode_t expected, mode_t actual, const char *file, int line)
+	mode_t expected, mode_t actual,
+	const char *file, const char *func, int line)
 {
 	/* FAT filesystems don't support exec bit, nor group/world bits */
 	if (!cl_is_chmod_supported()) {
@@ -162,7 +163,7 @@ static void check_mode_at_line(
 	}
 
 	clar__assert_equal(
-		file, line, "expected_mode != actual_mode", 1,
+		file, func, line, "expected_mode != actual_mode", 1,
 		"%07o", (int)expected, (int)(actual & 0777));
 }
 

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -48,7 +48,7 @@ static void options_cmp(void *one, void *two, size_t size, const char *name)
 
 			p_snprintf(desc, 1024, "Difference in %s at byte %" PRIuZ ": macro=%u / func=%u",
 				name, i, ((char *)one)[i], ((char *)two)[i]);
-			clar__fail(__FILE__, __LINE__,
+			clar__fail(__FILE__, __func__, __LINE__,
 				"Difference between macro and function options initializer",
 				desc, 0);
 			return;

--- a/tests/core/wildmatch.c
+++ b/tests/core/wildmatch.c
@@ -3,21 +3,21 @@
 #include "wildmatch.h"
 
 #define assert_matches(string, pattern, wildmatch, iwildmatch, pathmatch, ipathmatch) \
-	assert_matches_(string, pattern, wildmatch, iwildmatch, pathmatch, ipathmatch, __FILE__, __LINE__)
+	assert_matches_(string, pattern, wildmatch, iwildmatch, pathmatch, ipathmatch, __FILE__, __func__, __LINE__)
 
 static void assert_matches_(const char *string, const char *pattern,
 		char expected_wildmatch, char expected_iwildmatch,
 		char expected_pathmatch, char expected_ipathmatch,
-		const char *file, size_t line)
+		const char *file, const char *func, size_t line)
 {
 	if (wildmatch(pattern, string, WM_PATHNAME) == expected_wildmatch)
-		clar__fail(file, line, "Test failed (wildmatch).", string, 1);
+		clar__fail(file, func, line, "Test failed (wildmatch).", string, 1);
 	if (wildmatch(pattern, string, WM_PATHNAME|WM_CASEFOLD) == expected_iwildmatch)
-		clar__fail(file, line, "Test failed (iwildmatch).", string, 1);
+		clar__fail(file, func, line, "Test failed (iwildmatch).", string, 1);
 	if (wildmatch(pattern, string, 0) == expected_pathmatch)
-		clar__fail(file, line, "Test failed (pathmatch).", string, 1);
+		clar__fail(file, func, line, "Test failed (pathmatch).", string, 1);
 	if (wildmatch(pattern, string, WM_CASEFOLD) == expected_ipathmatch)
-		clar__fail(file, line, "Test failed (ipathmatch).", string, 1);
+		clar__fail(file, func, line, "Test failed (ipathmatch).", string, 1);
 }
 
 /*

--- a/tests/core/zstream.c
+++ b/tests/core/zstream.c
@@ -9,7 +9,7 @@ static const char *data = "This is a test test test of This is a test";
 static void assert_zlib_equal_(
 	const void *expected, size_t e_len,
 	const void *compressed, size_t c_len,
-	const char *msg, const char *file, int line)
+	const char *msg, const char *file, const char *func, int line)
 {
 	z_stream stream;
 	char *expanded = git__calloc(1, e_len + INFLATE_EXTRA);
@@ -26,21 +26,21 @@ static void assert_zlib_equal_(
 	inflateEnd(&stream);
 
 	clar__assert_equal(
-		file, line, msg, 1,
+		file, func, line, msg, 1,
 		"%d", (int)stream.total_out, (int)e_len);
 	clar__assert_equal(
-		file, line, "Buffer len was not exact match", 1,
+		file, func, line, "Buffer len was not exact match", 1,
 		"%d", (int)stream.avail_out, (int)INFLATE_EXTRA);
 
 	clar__assert(
 		memcmp(expanded, expected, e_len) == 0,
-		file, line, "uncompressed data did not match", NULL, 1);
+		file, func, line, "uncompressed data did not match", NULL, 1);
 
 	git__free(expanded);
 }
 
 #define assert_zlib_equal(E,EL,C,CL) \
-	assert_zlib_equal_(E, EL, C, CL, #EL " != " #CL, __FILE__, (int)__LINE__)
+	assert_zlib_equal_(E, EL, C, CL, #EL " != " #CL, __FILE__, __func__, (int)__LINE__)
 
 void test_core_zstream__basic(void)
 {

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -319,20 +319,20 @@ void test_diff_parse__patch_roundtrip_succeeds(void)
 	git_buf_dispose(&diffbuf);
 }
 
-#define cl_assert_equal_i_src(i1,i2,file,line) clar__assert_equal(file,line,#i1 " != " #i2, 1, "%d", (int)(i1), (int)(i2))
+#define cl_assert_equal_i_src(i1,i2,file,func,line) clar__assert_equal(file,func,line,#i1 " != " #i2, 1, "%d", (int)(i1), (int)(i2))
 
-static void cl_git_assert_lineinfo_(int old_lineno, int new_lineno, int num_lines, git_patch *patch, size_t hunk_idx, size_t line_idx, const char *file, int lineno)
+static void cl_git_assert_lineinfo_(int old_lineno, int new_lineno, int num_lines, git_patch *patch, size_t hunk_idx, size_t line_idx, const char *file, const char *func, int lineno)
 {
 	const git_diff_line *line;
 
-	cl_git_expect(git_patch_get_line_in_hunk(&line, patch, hunk_idx, line_idx), 0, file, lineno);
-	cl_assert_equal_i_src(old_lineno, line->old_lineno, file, lineno);
-	cl_assert_equal_i_src(new_lineno, line->new_lineno, file, lineno);
-	cl_assert_equal_i_src(num_lines, line->num_lines, file, lineno);
+	cl_git_expect(git_patch_get_line_in_hunk(&line, patch, hunk_idx, line_idx), 0, file, func, lineno);
+	cl_assert_equal_i_src(old_lineno, line->old_lineno, file, func, lineno);
+	cl_assert_equal_i_src(new_lineno, line->new_lineno, file, func, lineno);
+	cl_assert_equal_i_src(num_lines, line->num_lines, file, func, lineno);
 }
 
 #define cl_git_assert_lineinfo(old, new, num, p, h, l) \
-	cl_git_assert_lineinfo_(old,new,num,p,h,l,__FILE__,__LINE__)
+	cl_git_assert_lineinfo_(old,new,num,p,h,l,__FILE__,__func__,__LINE__)
 
 
 void test_diff_parse__issue4672(void)

--- a/tests/diff/submodules.c
+++ b/tests/diff/submodules.c
@@ -18,7 +18,8 @@ void test_diff_submodules__cleanup(void)
 #define get_buf_ptr(buf) ((buf)->asize ? (buf)->ptr : NULL)
 
 static void check_diff_patches_at_line(
-	git_diff *diff, const char **expected, const char *file, int line)
+	git_diff *diff, const char **expected,
+	const char *file, const char *func, int line)
 {
 	const git_diff_delta *delta;
 	git_patch *patch = NULL;
@@ -30,34 +31,34 @@ static void check_diff_patches_at_line(
 		cl_assert((delta = git_patch_get_delta(patch)) != NULL);
 
 		if (delta->status == GIT_DELTA_UNMODIFIED) {
-			cl_assert_at_line(expected[d] == NULL, file, line);
+			cl_assert_at_line(expected[d] == NULL, file, func, line);
 			continue;
 		}
 
 		if (expected[d] && !strcmp(expected[d], "<SKIP>"))
 			continue;
 		if (expected[d] && !strcmp(expected[d], "<UNTRACKED>")) {
-			cl_assert_at_line(delta->status == GIT_DELTA_UNTRACKED, file, line);
+			cl_assert_at_line(delta->status == GIT_DELTA_UNTRACKED, file, func, line);
 			continue;
 		}
 		if (expected[d] && !strcmp(expected[d], "<END>")) {
 			cl_git_pass(git_patch_to_buf(&buf, patch));
-			cl_assert_at_line(!strcmp(expected[d], "<END>"), file, line);
+			cl_assert_at_line(!strcmp(expected[d], "<END>"), file, func, line);
 		}
 
 		cl_git_pass(git_patch_to_buf(&buf, patch));
 
 		clar__assert_equal(
-			file, line, "expected diff did not match actual diff", 1,
+			file, func, line, "expected diff did not match actual diff", 1,
 			"%s", expected[d], get_buf_ptr(&buf));
 		git_buf_dispose(&buf);
 	}
 
-	cl_assert_at_line(expected[d] && !strcmp(expected[d], "<END>"), file, line);
+	cl_assert_at_line(expected[d] && !strcmp(expected[d], "<END>"), file, func, line);
 }
 
 #define check_diff_patches(diff, exp) \
-	check_diff_patches_at_line(diff, exp, __FILE__, __LINE__)
+	check_diff_patches_at_line(diff, exp, __FILE__, __func__, __LINE__)
 
 void test_diff_submodules__unmodified_submodule(void)
 {

--- a/tests/ignore/path.c
+++ b/tests/ignore/path.c
@@ -17,19 +17,20 @@ void test_ignore_path__cleanup(void)
 }
 
 static void assert_is_ignored_(
-	bool expected, const char *filepath, const char *file, int line)
+	bool expected, const char *filepath,
+	const char *file, const char *func, int line)
 {
 	int is_ignored = 0;
 
 	cl_git_expect(
-		git_ignore_path_is_ignored(&is_ignored, g_repo, filepath), 0, file, line);
+		git_ignore_path_is_ignored(&is_ignored, g_repo, filepath), 0, file, func, line);
 
 	clar__assert_equal(
-		file, line, "expected != is_ignored", 1, "%d",
+		file, func, line, "expected != is_ignored", 1, "%d",
 		(int)(expected != 0), (int)(is_ignored != 0));
 }
 #define assert_is_ignored(expected, filepath) \
-	assert_is_ignored_(expected, filepath, __FILE__, __LINE__)
+	assert_is_ignored_(expected, filepath, __FILE__, __func__, __LINE__)
 
 void test_ignore_path__honor_temporary_rules(void)
 {

--- a/tests/ignore/status.c
+++ b/tests/ignore/status.c
@@ -17,21 +17,22 @@ void test_ignore_status__cleanup(void)
 }
 
 static void assert_ignored_(
-	bool expected, const char *filepath, const char *file, int line)
+	bool expected, const char *filepath,
+	const char *file, const char *func, int line)
 {
 	int is_ignored = 0;
 	cl_git_expect(
-		git_status_should_ignore(&is_ignored, g_repo, filepath), 0, file, line);
+		git_status_should_ignore(&is_ignored, g_repo, filepath), 0, file, func, line);
 	clar__assert(
 		(expected != 0) == (is_ignored != 0),
-		file, line, "expected != is_ignored", filepath, 1);
+		file, func, line, "expected != is_ignored", filepath, 1);
 }
 #define assert_ignored(expected, filepath) \
-	assert_ignored_(expected, filepath, __FILE__, __LINE__)
+	assert_ignored_(expected, filepath, __FILE__, __func__, __LINE__)
 #define assert_is_ignored(filepath) \
-	assert_ignored_(true, filepath, __FILE__, __LINE__)
+	assert_ignored_(true, filepath, __FILE__, __func__, __LINE__)
 #define refute_is_ignored(filepath) \
-	assert_ignored_(false, filepath, __FILE__, __LINE__)
+	assert_ignored_(false, filepath, __FILE__, __func__, __LINE__)
 
 void test_ignore_status__0(void)
 {

--- a/tests/index/addall.c
+++ b/tests/index/addall.c
@@ -75,7 +75,7 @@ static void check_status_at_line(
 	git_repository *repo,
 	size_t index_adds, size_t index_dels, size_t index_mods,
 	size_t wt_adds, size_t wt_dels, size_t wt_mods, size_t ignores,
-	size_t conflicts, const char *file, int line)
+	size_t conflicts, const char *file, const char *func, int line)
 {
 	index_status_counts vals;
 
@@ -84,25 +84,25 @@ static void check_status_at_line(
 	cl_git_pass(git_status_foreach(repo, index_status_cb, &vals));
 
 	clar__assert_equal(
-		file,line,"wrong index adds", 1, "%"PRIuZ, index_adds, vals.index_adds);
+		file,func,line,"wrong index adds", 1, "%"PRIuZ, index_adds, vals.index_adds);
 	clar__assert_equal(
-		file,line,"wrong index dels", 1, "%"PRIuZ, index_dels, vals.index_dels);
+		file,func,line,"wrong index dels", 1, "%"PRIuZ, index_dels, vals.index_dels);
 	clar__assert_equal(
-		file,line,"wrong index mods", 1, "%"PRIuZ, index_mods, vals.index_mods);
+		file,func,line,"wrong index mods", 1, "%"PRIuZ, index_mods, vals.index_mods);
 	clar__assert_equal(
-		file,line,"wrong workdir adds", 1, "%"PRIuZ, wt_adds, vals.wt_adds);
+		file,func,line,"wrong workdir adds", 1, "%"PRIuZ, wt_adds, vals.wt_adds);
 	clar__assert_equal(
-		file,line,"wrong workdir dels", 1, "%"PRIuZ, wt_dels, vals.wt_dels);
+		file,func,line,"wrong workdir dels", 1, "%"PRIuZ, wt_dels, vals.wt_dels);
 	clar__assert_equal(
-		file,line,"wrong workdir mods", 1, "%"PRIuZ, wt_mods, vals.wt_mods);
+		file,func,line,"wrong workdir mods", 1, "%"PRIuZ, wt_mods, vals.wt_mods);
 	clar__assert_equal(
-		file,line,"wrong ignores", 1, "%"PRIuZ, ignores, vals.ignores);
+		file,func,line,"wrong ignores", 1, "%"PRIuZ, ignores, vals.ignores);
 	clar__assert_equal(
-		file,line,"wrong conflicts", 1, "%"PRIuZ, conflicts, vals.conflicts);
+		file,func,line,"wrong conflicts", 1, "%"PRIuZ, conflicts, vals.conflicts);
 }
 
 #define check_status(R,IA,ID,IM,WA,WD,WM,IG,C) \
-	check_status_at_line(R,IA,ID,IM,WA,WD,WM,IG,C,__FILE__,__LINE__)
+	check_status_at_line(R,IA,ID,IM,WA,WD,WM,IG,C,__FILE__,__func__,__LINE__)
 
 static void check_stat_data(git_index *index, const char *path, bool match)
 {

--- a/tests/index/crlf.c
+++ b/tests/index/crlf.c
@@ -96,7 +96,7 @@ done:
 		git_buf details = GIT_BUF_INIT;
 		git_buf_printf(&details, "filename=%s, system=%s, autocrlf=%s, safecrlf=%s, attrs={%s}",
 			basename, cd->systype, cd->autocrlf, cd->safecrlf, cd->attrs);
-		clar__fail(__FILE__, __LINE__,
+		clar__fail(__FILE__, __func__, __LINE__,
 			"index contents did not match expected", details.ptr, 0);
 		git_buf_dispose(&details);
 	}

--- a/tests/index/filemodes.c
+++ b/tests/index/filemodes.c
@@ -51,11 +51,11 @@ static void replace_file_with_mode(
 	git_buf_dispose(&content);
 }
 
-#define add_and_check_mode(I,F,X) add_and_check_mode_(I,F,X,__FILE__,__LINE__)
+#define add_and_check_mode(I,F,X) add_and_check_mode_(I,F,X,__FILE__,__func__,__LINE__)
 
 static void add_and_check_mode_(
 	git_index *index, const char *filename, unsigned int expect_mode,
-	const char *file, int line)
+	const char *file, const char *func, int line)
 {
 	size_t pos;
 	const git_index_entry *entry;
@@ -63,11 +63,11 @@ static void add_and_check_mode_(
 	cl_git_pass(git_index_add_bypath(index, filename));
 
 	clar__assert(!git_index_find(&pos, index, filename),
-		file, line, "Cannot find index entry", NULL, 1);
+		file, func, line, "Cannot find index entry", NULL, 1);
 
 	entry = git_index_get_byindex(index, pos);
 
-	clar__assert_equal(file, line, "Expected mode does not match index",
+	clar__assert_equal(file, func, line, "Expected mode does not match index",
 		1, "%07o", (unsigned int)entry->mode, (unsigned int)expect_mode);
 }
 
@@ -153,11 +153,11 @@ void test_index_filemodes__trusted(void)
 	git_index_free(index);
 }
 
-#define add_entry_and_check_mode(I,FF,X) add_entry_and_check_mode_(I,FF,X,__FILE__,__LINE__)
+#define add_entry_and_check_mode(I,FF,X) add_entry_and_check_mode_(I,FF,X,__FILE__,__func__,__LINE__)
 
 static void add_entry_and_check_mode_(
 	git_index *index, bool from_file, git_filemode_t mode,
-	const char *file, int line)
+	const char *file, const char *func, int line)
 {
 	size_t pos;
 	const git_index_entry* entry;
@@ -169,7 +169,7 @@ static void add_entry_and_check_mode_(
 	if (from_file)
 	{
 		clar__assert(!git_index_find(&pos, index, "exec_off"),
-			file, line, "Cannot find original index entry", NULL, 1);
+			file, func, line, "Cannot find original index entry", NULL, 1);
 
 		entry = git_index_get_byindex(index, pos);
 
@@ -184,21 +184,21 @@ static void add_entry_and_check_mode_(
 	if (from_file)
 	{
 		clar__assert(!git_index_add(index, &new_entry),
-			file, line, "Cannot add index entry", NULL, 1);
+			file, func, line, "Cannot add index entry", NULL, 1);
 	}
 	else
 	{
 		const char *content = "hey there\n";
 		clar__assert(!git_index_add_from_buffer(index, &new_entry, content, strlen(content)),
-			file, line, "Cannot add index entry from buffer", NULL, 1);
+			file, func, line, "Cannot add index entry from buffer", NULL, 1);
 	}
 
 	clar__assert(!git_index_find(&pos, index, "filemodes/explicit_test"),
-		file, line, "Cannot find new index entry", NULL, 1);
+		file, func, line, "Cannot find new index entry", NULL, 1);
 
 	entry = git_index_get_byindex(index, pos);
 
-	clar__assert_equal(file, line, "Expected mode does not match index",
+	clar__assert_equal(file, func, line, "Expected mode does not match index",
 		1, "%07o", (unsigned int)entry->mode, (unsigned int)mode);
 }
 

--- a/tests/object/commit/commitstagedfile.c
+++ b/tests/object/commit/commitstagedfile.c
@@ -49,9 +49,9 @@ void test_object_commit_commitstagedfile__generate_predictable_object_ids(void)
 	 * tree 2b297e643c551e76cfa1f93810c50811382f9117
 	 * author nulltoken <emeric.fermas@gmail.com> 1323847743 +0100
 	 * committer nulltoken <emeric.fermas@gmail.com> 1323847743 +0100
-	 * 
+	 *
 	 *     Initial commit
-	 * 
+	 *
 	 * diff --git a/test.txt b/test.txt
 	 * new file mode 100644
 	 * index 0000000..9daeafb
@@ -141,14 +141,14 @@ static void assert_commit_tree_has_n_entries(git_commit *c, int count)
 	git_tree_free(tree);
 }
 
-static void assert_commit_is_head_(git_commit *c, const char *file, int line)
+static void assert_commit_is_head_(git_commit *c, const char *file, const char *func, int line)
 {
 	git_commit *head;
 	cl_git_pass(git_revparse_single((git_object **)&head, repo, "HEAD"));
-	clar__assert(git_oid_equal(git_commit_id(c), git_commit_id(head)), file, line, "Commit is not the HEAD", NULL, 1);
+	clar__assert(git_oid_equal(git_commit_id(c), git_commit_id(head)), file, func, line, "Commit is not the HEAD", NULL, 1);
 	git_commit_free(head);
 }
-#define assert_commit_is_head(C) assert_commit_is_head_((C),__FILE__,__LINE__)
+#define assert_commit_is_head(C) assert_commit_is_head_((C),__FILE__,__func__,__LINE__)
 
 void test_object_commit_commitstagedfile__amend_commit(void)
 {

--- a/tests/object/tree/write.c
+++ b/tests/object/tree/write.c
@@ -453,7 +453,8 @@ static void test_invalid_objects(bool should_allow_invalid)
 	git_oid valid_blob_id, invalid_blob_id, valid_tree_id, invalid_tree_id;
 
 #define assert_allowed(expr) \
-	clar__assert(!(expr) == should_allow_invalid, __FILE__, __LINE__, \
+	clar__assert(!(expr) == should_allow_invalid, \
+		__FILE__, __func__, __LINE__, \
 		(should_allow_invalid ? \
 		 "Expected function call to succeed: " #expr : \
 		 "Expected function call to fail: " #expr), \

--- a/tests/refs/reflog/reflog_helpers.c
+++ b/tests/refs/reflog/reflog_helpers.c
@@ -29,7 +29,8 @@ size_t reflog_entrycount(git_repository *repo, const char *name)
 
 void cl_reflog_check_entry_(git_repository *repo, const char *reflog, size_t idx,
 	const char *old_spec, const char *new_spec,
-	const char *email, const char *message, const char *file, int line)
+	const char *email, const char *message,
+	const char *file, const char *func, int line)
 {
 	git_reflog *log;
 	const git_reflog_entry *entry;
@@ -38,7 +39,7 @@ void cl_reflog_check_entry_(git_repository *repo, const char *reflog, size_t idx
 	cl_git_pass(git_reflog_read(&log, repo, reflog));
 	entry = git_reflog_entry_byindex(log, idx);
 	if (entry == NULL)
-		clar__fail(file, line, "Reflog has no such entry", NULL, 1);
+		clar__fail(file, func, line, "Reflog has no such entry", NULL, 1);
 
 	if (old_spec) {
 		git_object *obj = NULL;
@@ -92,7 +93,7 @@ void cl_reflog_check_entry_(git_repository *repo, const char *reflog, size_t idx
 			git_buf_printf(&result, "\tMessage: \"%s\" != \"%s\"\n", message, entry_msg);
 	}
 	if (git_buf_len(&result) != 0)
-		clar__fail(file, line, "Reflog entry mismatch", git_buf_cstr(&result), 1);
+		clar__fail(file, func, line, "Reflog entry mismatch", git_buf_cstr(&result), 1);
 
 	git_buf_dispose(&result);
 	git_reflog_free(log);

--- a/tests/repo/env.c
+++ b/tests/repo/env.c
@@ -53,44 +53,44 @@ static int GIT_FORMAT_PRINTF(2, 3) cl_setenv_printf(const char *name, const char
  * from the caller rather than those of the helper. The expression strings
  * distinguish between the possible failures within the helper. */
 
-static void env_pass_(const char *path, const char *file, int line)
+static void env_pass_(const char *path, const char *file, const char *func, int line)
 {
 	git_repository *repo;
-	cl_git_expect(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
-	cl_git_expect(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
-	cl_assert_at_line(git__suffixcmp(git_repository_path(repo), "attr/.git/") == 0, file, line);
-	cl_assert_at_line(git__suffixcmp(git_repository_workdir(repo), "attr/") == 0, file, line);
-	cl_assert_at_line(!git_repository_is_bare(repo), file, line);
+	cl_git_expect(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, func, line);
+	cl_git_expect(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, func, line);
+	cl_assert_at_line(git__suffixcmp(git_repository_path(repo), "attr/.git/") == 0, file, func, line);
+	cl_assert_at_line(git__suffixcmp(git_repository_workdir(repo), "attr/") == 0, file, func, line);
+	cl_assert_at_line(!git_repository_is_bare(repo), file, func, line);
 	git_repository_free(repo);
 }
-#define env_pass(path) env_pass_((path), __FILE__, __LINE__)
+#define env_pass(path) env_pass_((path), __FILE__, __func__, __LINE__)
 
-#define cl_git_fail_at_line(expr, file, line) clar__assert((expr) < 0, file, line, "Expected function call to fail: " #expr, NULL, 1)
+#define cl_git_fail_at_line(expr, file, func, line) clar__assert((expr) < 0, file, func, line, "Expected function call to fail: " #expr, NULL, 1)
 
-static void env_fail_(const char *path, const char *file, int line)
+static void env_fail_(const char *path, const char *file, const char *func, int line)
 {
 	git_repository *repo;
-	cl_git_fail_at_line(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, line);
-	cl_git_fail_at_line(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, line);
+	cl_git_fail_at_line(git_repository_open_ext(NULL, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, func, line);
+	cl_git_fail_at_line(git_repository_open_ext(&repo, path, GIT_REPOSITORY_OPEN_FROM_ENV, NULL), file, func, line);
 }
-#define env_fail(path) env_fail_((path), __FILE__, __LINE__)
+#define env_fail(path) env_fail_((path), __FILE__, __func__, __LINE__)
 
 static void env_cd_(
 	const char *path,
-	void (*passfail_)(const char *, const char *, int),
-	const char *file, int line)
+	void (*passfail_)(const char *, const char *, const char *, int),
+	const char *file, const char *func, int line)
 {
 	git_buf cwd_buf = GIT_BUF_INIT;
 	cl_git_pass(git_path_prettify_dir(&cwd_buf, ".", NULL));
 	cl_must_pass(p_chdir(path));
-	passfail_(NULL, file, line);
+	passfail_(NULL, file, func, line);
 	cl_must_pass(p_chdir(git_buf_cstr(&cwd_buf)));
 	git_buf_dispose(&cwd_buf);
 }
-#define env_cd_pass(path) env_cd_((path), env_pass_, __FILE__, __LINE__)
-#define env_cd_fail(path) env_cd_((path), env_fail_, __FILE__, __LINE__)
+#define env_cd_pass(path) env_cd_((path), env_pass_, __FILE__, __func__, __LINE__)
+#define env_cd_fail(path) env_cd_((path), env_fail_, __FILE__, __func__, __LINE__)
 
-static void env_check_objects_(bool a, bool t, bool p, const char *file, int line)
+static void env_check_objects_(bool a, bool t, bool p, const char *file, const char *func, int line)
 {
 	git_repository *repo;
 	git_oid oid_a, oid_t, oid_p;
@@ -98,32 +98,32 @@ static void env_check_objects_(bool a, bool t, bool p, const char *file, int lin
 	cl_git_pass(git_oid_fromstr(&oid_a, "45141a79a77842c59a63229403220a4e4be74e3d"));
 	cl_git_pass(git_oid_fromstr(&oid_t, "1385f264afb75a56a5bec74243be9b367ba4ca08"));
 	cl_git_pass(git_oid_fromstr(&oid_p, "0df1a5865c8abfc09f1f2182e6a31be550e99f07"));
-	cl_git_expect(git_repository_open_ext(&repo, "attr", GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, line);
+	cl_git_expect(git_repository_open_ext(&repo, "attr", GIT_REPOSITORY_OPEN_FROM_ENV, NULL), 0, file, func, line);
 
 	if (a) {
-		cl_git_expect(git_object_lookup(&object, repo, &oid_a, GIT_OBJECT_BLOB), 0, file, line);
+		cl_git_expect(git_object_lookup(&object, repo, &oid_a, GIT_OBJECT_BLOB), 0, file, func, line);
 		git_object_free(object);
 	} else {
-		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_a, GIT_OBJECT_BLOB), file, line);
+		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_a, GIT_OBJECT_BLOB), file, func, line);
 	}
 
 	if (t) {
-		cl_git_expect(git_object_lookup(&object, repo, &oid_t, GIT_OBJECT_BLOB), 0, file, line);
+		cl_git_expect(git_object_lookup(&object, repo, &oid_t, GIT_OBJECT_BLOB), 0, file, func, line);
 		git_object_free(object);
 	} else {
-		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_t, GIT_OBJECT_BLOB), file, line);
+		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_t, GIT_OBJECT_BLOB), file, func, line);
 	}
 
 	if (p) {
-		cl_git_expect(git_object_lookup(&object, repo, &oid_p, GIT_OBJECT_COMMIT), 0, file, line);
+		cl_git_expect(git_object_lookup(&object, repo, &oid_p, GIT_OBJECT_COMMIT), 0, file, func, line);
 		git_object_free(object);
 	} else {
-		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_p, GIT_OBJECT_COMMIT), file, line);
+		cl_git_fail_at_line(git_object_lookup(&object, repo, &oid_p, GIT_OBJECT_COMMIT), file, func, line);
 	}
 
 	git_repository_free(repo);
 }
-#define env_check_objects(a, t, t2) env_check_objects_((a), (t), (t2), __FILE__, __LINE__)
+#define env_check_objects(a, t, t2) env_check_objects_((a), (t), (t2), __FILE__, __func__, __LINE__)
 
 void test_repo_env__open(void)
 {

--- a/tests/status/status_helpers.h
+++ b/tests/status/status_helpers.h
@@ -9,6 +9,7 @@ typedef struct {
 	const char** expected_paths;
 	int expected_entry_count;
 	const char *file;
+	const char *func;
 	int line;
 	bool debug;
 } status_entry_counts;
@@ -18,6 +19,7 @@ typedef struct {
 	(counts).expected_statuses = (statuses); \
 	(counts).expected_paths = (paths); \
 	(counts).file = __FILE__; \
+	(counts).func = __func__; \
 	(counts).line = __LINE__; \
 	} while (0)
 

--- a/tests/status/submodules.c
+++ b/tests/status/submodules.c
@@ -71,12 +71,12 @@ static int cb_status__match(const char *p, unsigned int s, void *payload)
 	int idx = counts->entry_count++;
 
 	clar__assert_equal(
-		counts->file, counts->line,
+		counts->file, counts->func, counts->line,
 		"Status path mismatch", 1,
 		"%s", counts->expected_paths[idx], p);
 
 	clar__assert_equal(
-		counts->file, counts->line,
+		counts->file, counts->func, counts->line,
 		"Status code mismatch", 1,
 		"%o", counts->expected_statuses[idx], s);
 

--- a/tests/submodule/submodule_helpers.c
+++ b/tests/submodule/submodule_helpers.c
@@ -199,22 +199,22 @@ git_repository *setup_fixture_submodule_with_path(void)
 
 void assert__submodule_exists(
 	git_repository *repo, const char *name,
-	const char *msg, const char *file, int line)
+	const char *msg, const char *file, const char *func, int line)
 {
 	git_submodule *sm;
 	int error = git_submodule_lookup(&sm, repo, name);
 	if (error)
-		cl_git_report_failure(error, 0, file, line, msg);
-	cl_assert_at_line(sm != NULL, file, line);
+		cl_git_report_failure(error, 0, file, func, line, msg);
+	cl_assert_at_line(sm != NULL, file, func, line);
 	git_submodule_free(sm);
 }
 
 void refute__submodule_exists(
 	git_repository *repo, const char *name, int expected_error,
-	const char *msg, const char *file, int line)
+	const char *msg, const char *file, const char *func, int line)
 {
 	clar__assert_equal(
-		file, line, msg, 1, "%i",
+		file, func, line, msg, 1, "%i",
 		expected_error, (int)(git_submodule_lookup(NULL, repo, name)));
 }
 

--- a/tests/submodule/submodule_helpers.h
+++ b/tests/submodule/submodule_helpers.h
@@ -10,16 +10,16 @@ extern git_repository *setup_fixture_submodule_with_path(void);
 
 extern unsigned int get_submodule_status(git_repository *, const char *);
 
-extern void assert__submodule_exists(
-	git_repository *, const char *, const char *, const char *, int);
+extern void assert__submodule_exists(git_repository *, const char *,
+	const char *, const char *, const char *, int);
 
 #define assert_submodule_exists(repo,name)								\
-	assert__submodule_exists(repo, name, "git_submodule_lookup(" #name ") failed", __FILE__, __LINE__)
+	assert__submodule_exists(repo, name, "git_submodule_lookup(" #name ") failed", __FILE__, __func__, __LINE__)
 
-extern void refute__submodule_exists(
-	git_repository *, const char *, int err, const char *, const char *, int);
+extern void refute__submodule_exists(git_repository *, const char *,
+	int err, const char *, const char *, const char *, int);
 
 #define refute_submodule_exists(repo,name,code) \
-	refute__submodule_exists(repo, name, code, "expected git_submodule_lookup(" #name ") to fail with error " #code, __FILE__, __LINE__)
+	refute__submodule_exists(repo, name, code, "expected git_submodule_lookup(" #name ") to fail with error " #code, __FILE__, __func__, __LINE__)
 
 extern void dump_submodules(git_repository *repo);


### PR DESCRIPTION
This adds a new command-line option to clar, `-t`, which will produce output in the popular TAP format, which can be used by multiple different frontends to display test output.

This retroactively names the existing clar output format as "clap" (the "clar protocol"), and adds support for tap (the [test anywhere protocol](https://testanything.org/)).

This adds support for [TAP version 13](https://testanything.org/tap-version-13-specification.html).

It includes the optional YAML block to provide more information about test failures.  Since this is not yet standardized, we have copied the output format of the popular [node tap](https://node-tap.org/tap-protocol).