### PR TITLE
diff::parse: don't include `diff.h`

### DIFF
--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -2,7 +2,6 @@
 #include "patch.h"
 #include "patch_parse.h"
 #include "diff_helpers.h"
-#include "../src/diff.h"
 
 #include "../patch/patch_common.h"
 


### PR DESCRIPTION
We don't call any internal functions in the test; we don't need to
include `../src/diff.h`.