### PR TITLE
submodule: Read superproject configs for `ignore'

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,7 +75,7 @@ with v0.28.0.
 
 * Several function signatures have been changed to return an `int` to
   indicate error conditions.  We encourage you to check them for errors
-  in the standard way. 
+  in the standard way.
 
   * `git_attr_cache_flush`
   * `git_error_set_str`
@@ -194,7 +194,7 @@ with v0.28.0.
 
 * Several attribute macros have been renamed: `GIT_ATTR_TRUE` is now
   `GIT_ATTR_IS_TRUE`, `GIT_ATTR_FALSE` is now `GIT_ATTR_IS_FALSE`,
-  `GIT_ATTR_UNSPECIFIED` is now `GIT_ATTR_IS_UNSPECIFIED`.  The 
+  `GIT_ATTR_UNSPECIFIED` is now `GIT_ATTR_IS_UNSPECIFIED`.  The
   attribute enum `git_attr_t` is now `git_attr_value_t` and its
   values have been renamed: `GIT_ATTR_UNSPECIFIED_T` is now
   `GIT_ATTR_VALUE_UNSPECIFIED`, `GIT_ATTR_TRUE_T` is now


### PR DESCRIPTION
Introduces an additional step to check configuration values for `ignore` from the parent repository values when reading configuration for a submodule in `submodule_read_config`.

According to gitmodules(5):
> If this option is also present in the submodules entry in .git/config of the superproject, the setting there  will override the one found in .gitmodules.

Ref: https://kernel.org/pub/software/scm/git/docs/gitmodules.html.

Fixes: #5304.