### PR TITLE
Missing declarations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,8 @@ SET(LIBGIT2_INCLUDES
 SET(LIBGIT2_SYSTEM_INCLUDES "")
 SET(LIBGIT2_LIBS "")
 
+enable_warnings(missing-declarations)
+
 # Enable tracing
 IF(ENABLE_TRACE)
 	SET(GIT_TRACE 1)

--- a/src/blame.c
+++ b/src/blame.c
@@ -538,7 +538,9 @@ int git_blame_options_init(git_blame_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_blame_init_options(git_blame_options *opts, unsigned int version)
 {
 	return git_blame_options_init(opts, version);
 }
+#endif

--- a/src/blob.c
+++ b/src/blob.c
@@ -445,6 +445,7 @@ int git_blob_filter(
 
 /* Deprecated functions */
 
+#ifndef GIT_DEPRECATE_HARD
 int git_blob_create_frombuffer(
 	git_oid *id, git_repository *repo, const void *buffer, size_t len)
 {
@@ -491,3 +492,4 @@ int git_blob_filtered_content(
 
 	return git_blob_filter(out, blob, path, &opts);
 }
+#endif

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -133,10 +133,12 @@ void git_buf_dispose(git_buf *buf)
 	git_buf_init(buf, 0);
 }
 
+#ifndef GIT_DEPRECATE_HARD
 void git_buf_free(git_buf *buf)
 {
 	git_buf_dispose(buf);
 }
+#endif
 
 void git_buf_sanitize(git_buf *buf)
 {

--- a/src/cache.c
+++ b/src/cache.c
@@ -41,27 +41,6 @@ int git_cache_set_max_object_size(git_object_t type, size_t size)
 	return 0;
 }
 
-void git_cache_dump_stats(git_cache *cache)
-{
-	git_cached_obj *object;
-
-	if (git_cache_size(cache) == 0)
-		return;
-
-	printf("Cache %p: %"PRIuZ" items cached, %"PRIdZ" bytes\n",
-		cache, git_cache_size(cache), cache->used_memory);
-
-	git_oidmap_foreach_value(cache->map, object, {
-		char oid_str[9];
-		printf(" %s%c %s (%"PRIuZ")\n",
-			git_object_type2string(object->type),
-			object->flags == GIT_CACHE_STORE_PARSED ? '*' : ' ',
-			git_oid_tostr(oid_str, sizeof(oid_str), &object->oid),
-			object->size
-		);
-	});
-}
-
 int git_cache_init(git_cache *cache)
 {
 	memset(cache, 0, sizeof(*cache));

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2820,7 +2820,9 @@ int git_checkout_options_init(git_checkout_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_checkout_init_options(git_checkout_options *opts, unsigned int version)
 {
 	return git_checkout_options_init(opts, version);
 }
+#endif

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -806,7 +806,7 @@ static int checkout_conflictdata_cmp(const void *a, const void *b)
 	return diff;
 }
 
-int checkout_conflictdata_empty(
+static int checkout_conflictdata_empty(
 	const git_vector *conflicts, size_t idx, void *payload)
 {
 	checkout_conflictdata *conflict;

--- a/src/cherrypick.c
+++ b/src/cherrypick.c
@@ -229,8 +229,10 @@ int git_cherrypick_options_init(
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_cherrypick_init_options(
 	git_cherrypick_options *opts, unsigned int version)
 {
 	return git_cherrypick_options_init(opts, version);
 }
+#endif

--- a/src/clone.c
+++ b/src/clone.c
@@ -479,10 +479,12 @@ int git_clone_options_init(git_clone_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_clone_init_options(git_clone_options *opts, unsigned int version)
 {
 	return git_clone_options_init(opts, version);
 }
+#endif
 
 static bool can_link(const char *src, const char *dst, int link)
 {

--- a/src/config.c
+++ b/src/config.c
@@ -1000,7 +1000,7 @@ static int multivar_iter_next(git_config_entry **entry, git_config_iterator *_it
 	return error;
 }
 
-void multivar_iter_free(git_config_iterator *_iter)
+static void multivar_iter_free(git_config_iterator *_iter)
 {
 	multivar_iter *iter = (multivar_iter *) _iter;
 

--- a/src/config_snapshot.c
+++ b/src/config_snapshot.c
@@ -5,8 +5,9 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "config.h"
+#include "config_backend.h"
 
+#include "config.h"
 #include "config_entries.h"
 
 typedef struct {

--- a/src/describe.c
+++ b/src/describe.c
@@ -876,10 +876,12 @@ int git_describe_options_init(git_describe_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_describe_init_options(git_describe_options *opts, unsigned int version)
 {
 	return git_describe_options_init(opts, version);
 }
+#endif
 
 int git_describe_format_options_init(git_describe_format_options *opts, unsigned int version)
 {
@@ -888,7 +890,9 @@ int git_describe_format_options_init(git_describe_format_options *opts, unsigned
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_describe_init_format_options(git_describe_format_options *opts, unsigned int version)
 {
 	return git_describe_format_options_init(opts, version);
 }
+#endif

--- a/src/diff.c
+++ b/src/diff.c
@@ -352,10 +352,12 @@ int git_diff_options_init(git_diff_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_diff_init_options(git_diff_options *opts, unsigned int version)
 {
 	return git_diff_options_init(opts, version);
 }
+#endif
 
 int git_diff_find_options_init(
 	git_diff_find_options *opts, unsigned int version)
@@ -365,11 +367,13 @@ int git_diff_find_options_init(
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_diff_find_init_options(
 	git_diff_find_options *opts, unsigned int version)
 {
 	return git_diff_find_options_init(opts, version);
 }
+#endif
 
 int git_diff_format_email_options_init(
 	git_diff_format_email_options *opts, unsigned int version)
@@ -380,11 +384,13 @@ int git_diff_format_email_options_init(
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_diff_format_email_init_options(
 	git_diff_format_email_options *opts, unsigned int version)
 {
 	return git_diff_format_email_options_init(opts, version);
 }
+#endif
 
 static int flush_hunk(git_oid *result, git_hash_ctx *ctx)
 {

--- a/src/diff.c
+++ b/src/diff.c
@@ -150,7 +150,7 @@ int git_diff_foreach(
 	return error;
 }
 
-int git_diff_format_email__append_header_tobuf(
+static int diff_format_email_append_header_tobuf(
 	git_buf *out,
 	const git_oid *id,
 	const git_signature *author,
@@ -207,7 +207,7 @@ int git_diff_format_email__append_header_tobuf(
 	return error;
 }
 
-int git_diff_format_email__append_patches_tobuf(
+static int diff_format_email_append_patches_tobuf(
 	git_buf *out,
 	git_diff *diff)
 {
@@ -287,7 +287,7 @@ int git_diff_format_email(
 		strncpy(summary, opts->summary, offset);
 	}
 
-	error = git_diff_format_email__append_header_tobuf(out,
+	error = diff_format_email_append_header_tobuf(out,
 		opts->id, opts->author, summary == NULL ? opts->summary : summary,
 		opts->body, opts->patch_no, opts->total_patches, ignore_marker);
 
@@ -300,7 +300,7 @@ int git_diff_format_email(
 		(error = git_diff_get_stats(&stats, diff)) < 0 ||
 		(error = git_diff_stats_to_buf(out, stats, format_flags, 0)) < 0 ||
 		(error = git_buf_putc(out, '\n')) < 0 ||
-		(error = git_diff_format_email__append_patches_tobuf(out, diff)) < 0)
+		(error = diff_format_email_append_patches_tobuf(out, diff)) < 0)
 			goto on_error;
 
 	error = git_buf_puts(out, "--\nlibgit2 " LIBGIT2_VERSION "\n\n");
@@ -421,7 +421,7 @@ static void strip_spaces(git_buf *buf)
 	git_buf_truncate(buf, len);
 }
 
-int git_diff_patchid_print_callback__to_buf(
+static int diff_patchid_print_callback_to_buf(
 	const git_diff_delta *delta,
 	const git_diff_hunk *hunk,
 	const git_diff_line *line,
@@ -480,7 +480,7 @@ int git_diff_patchid(git_oid *out, git_diff *diff, git_diff_patchid_options *opt
 
 	if ((error = git_diff_print(diff,
 				    GIT_DIFF_FORMAT_PATCH_ID,
-				    git_diff_patchid_print_callback__to_buf,
+				    diff_patchid_print_callback_to_buf,
 				    &args)) < 0)
 		goto out;
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -32,11 +32,6 @@ GIT_INLINE(const char *) diff_delta__path(const git_diff_delta *delta)
 	return str;
 }
 
-const char *git_diff_delta__path(const git_diff_delta *delta)
-{
-	return diff_delta__path(delta);
-}
-
 int git_diff_delta__cmp(const void *a, const void *b)
 {
 	const git_diff_delta *da = a, *db = b;

--- a/src/diff_generate.c
+++ b/src/diff_generate.c
@@ -301,14 +301,14 @@ GIT_INLINE(const char *) diff_delta__i2w_path(const git_diff_delta *delta)
 		delta->old_file.path : delta->new_file.path;
 }
 
-int git_diff_delta__i2w_cmp(const void *a, const void *b)
+static int diff_delta_i2w_cmp(const void *a, const void *b)
 {
 	const git_diff_delta *da = a, *db = b;
 	int val = strcmp(diff_delta__i2w_path(da), diff_delta__i2w_path(db));
 	return val ? val : ((int)da->status - (int)db->status);
 }
 
-int git_diff_delta__i2w_casecmp(const void *a, const void *b)
+static int diff_delta_i2w_casecmp(const void *a, const void *b)
 {
 	const git_diff_delta *da = a, *db = b;
 	int val = strcasecmp(diff_delta__i2w_path(da), diff_delta__i2w_path(db));
@@ -361,7 +361,7 @@ static const char *diff_mnemonic_prefix(
 	return pfx;
 }
 
-void git_diff__set_ignore_case(git_diff *diff, bool ignore_case)
+static void diff_set_ignore_case(git_diff *diff, bool ignore_case)
 {
 	if (!ignore_case) {
 		diff->opts.flags &= ~GIT_DIFF_IGNORE_CASE;
@@ -431,7 +431,7 @@ static git_diff_generated *diff_generated_alloc(
 
 	/* Use case-insensitive compare if either iterator has
 	 * the ignore_case bit set */
-	git_diff__set_ignore_case(
+	diff_set_ignore_case(
 		&diff->base,
 		git_iterator_ignore_case(old_iter) ||
 		git_iterator_ignore_case(new_iter));
@@ -1375,7 +1375,7 @@ int git_diff_tree_to_index(
 
 	/* if index is in case-insensitive order, re-sort deltas to match */
 	if (index_ignore_case)
-		git_diff__set_ignore_case(diff, true);
+		diff_set_ignore_case(diff, true);
 
 	*out = diff;
 	diff = NULL;
@@ -1526,7 +1526,7 @@ int git_diff_index_to_index(
 
 	/* if index is in case-insensitive order, re-sort deltas to match */
 	if (old_index->ignore_case || new_index->ignore_case)
-		git_diff__set_ignore_case(diff, true);
+		diff_set_ignore_case(diff, true);
 
 	*out = diff;
 	diff = NULL;
@@ -1583,10 +1583,10 @@ int git_diff__paired_foreach(
 	if (i2w_icase && !icase_mismatch) {
 		strcomp = git__strcasecmp;
 
-		git_vector_set_cmp(&idx2wd->deltas, git_diff_delta__i2w_casecmp);
+		git_vector_set_cmp(&idx2wd->deltas, diff_delta_i2w_casecmp);
 		git_vector_sort(&idx2wd->deltas);
 	} else if (idx2wd != NULL) {
-		git_vector_set_cmp(&idx2wd->deltas, git_diff_delta__i2w_cmp);
+		git_vector_set_cmp(&idx2wd->deltas, diff_delta_i2w_cmp);
 		git_vector_sort(&idx2wd->deltas);
 	}
 

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -337,7 +337,7 @@ static int diff_delta_format_with_paths(
 	return git_buf_printf(out, template, oldpath, newpath);
 }
 
-int diff_delta_format_similarity_header(
+static int diff_delta_format_similarity_header(
 	git_buf *out,
 	const git_diff_delta *delta)
 {

--- a/src/diff_stats.c
+++ b/src/diff_stats.c
@@ -46,7 +46,7 @@ static int digits_for_value(size_t val)
 	return count;
 }
 
-int git_diff_file_stats__full_to_buf(
+static int diff_file_stats_full_to_buf(
 	git_buf *out,
 	const git_diff_delta *delta,
 	const diff_file_stats *filestat,
@@ -134,7 +134,7 @@ on_error:
 	return (git_buf_oom(out) ? -1 : 0);
 }
 
-int git_diff_file_stats__number_to_buf(
+static int diff_file_stats_number_to_buf(
 	git_buf *out,
 	const git_diff_delta *delta,
 	const diff_file_stats *filestats)
@@ -151,7 +151,7 @@ int git_diff_file_stats__number_to_buf(
 	return error;
 }
 
-int git_diff_file_stats__summary_to_buf(
+static int diff_file_stats_summary_to_buf(
 	git_buf *out,
 	const git_diff_delta *delta)
 {
@@ -288,7 +288,7 @@ int git_diff_stats_to_buf(
 			if ((delta = git_diff_get_delta(stats->diff, i)) == NULL)
 				continue;
 
-			error = git_diff_file_stats__number_to_buf(
+			error = diff_file_stats_number_to_buf(
 				out, delta, &stats->filestats[i]);
 			if (error < 0)
 				return error;
@@ -309,7 +309,7 @@ int git_diff_stats_to_buf(
 			if ((delta = git_diff_get_delta(stats->diff, i)) == NULL)
 				continue;
 
-			error = git_diff_file_stats__full_to_buf(
+			error = diff_file_stats_full_to_buf(
 				out, delta, &stats->filestats[i], stats, width);
 			if (error < 0)
 				return error;
@@ -342,7 +342,7 @@ int git_diff_stats_to_buf(
 			if ((delta = git_diff_get_delta(stats->diff, i)) == NULL)
 				continue;
 
-			error = git_diff_file_stats__summary_to_buf(out, delta);
+			error = diff_file_stats_summary_to_buf(out, delta);
 			if (error < 0)
 				return error;
 		}

--- a/src/errors.c
+++ b/src/errors.c
@@ -210,6 +210,7 @@ void git_error_system_set(int code)
 
 /* Deprecated error values and functions */
 
+#ifndef GIT_DEPRECATE_HARD
 const git_error *giterr_last(void)
 {
 	return git_error_last();
@@ -229,3 +230,4 @@ void giterr_set_oom(void)
 {
 	git_error_set_oom();
 }
+#endif

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -155,7 +155,9 @@ int git_fetch_options_init(git_fetch_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_fetch_init_options(git_fetch_options *opts, unsigned int version)
 {
 	return git_fetch_options_init(opts, version);
 }
+#endif

--- a/src/filter.c
+++ b/src/filter.c
@@ -941,7 +941,7 @@ out:
 	return error;
 }
 
-void stream_list_free(git_vector *streams)
+static void filter_streams_free(git_vector *streams)
 {
 	git_writestream *stream;
 	size_t i;
@@ -990,7 +990,7 @@ done:
 
 	if (fd >= 0)
 		p_close(fd);
-	stream_list_free(&filter_streams);
+	filter_streams_free(&filter_streams);
 	git_buf_dispose(&abspath);
 	return error;
 }
@@ -1018,7 +1018,7 @@ out:
 	if (initialized)
 		error |= stream_start->close(stream_start);
 
-	stream_list_free(&filter_streams);
+	filter_streams_free(&filter_streams);
 	return error;
 }
 

--- a/src/idxmap.c
+++ b/src/idxmap.c
@@ -138,28 +138,6 @@ void *git_idxmap_icase_get(git_idxmap_icase *map, const git_index_entry *key)
 	return kh_val(map, idx);
 }
 
-void git_idxmap_insert(git_idxmap *map, const git_index_entry *key, void *value, int *rval)
-{
-	khiter_t idx = kh_put(idx, map, key, rval);
-
-	if ((*rval) >= 0) {
-		if ((*rval) == 0)
-			kh_key(map, idx) = key;
-		kh_val(map, idx) = value;
-	}
-}
-
-void git_idxmap_icase_insert(git_idxmap_icase *map, const git_index_entry *key, void *value, int *rval)
-{
-	khiter_t idx = kh_put(idxicase, map, key, rval);
-
-	if ((*rval) >= 0) {
-		if ((*rval) == 0)
-			kh_key(map, idx) = key;
-		kh_val(map, idx) = value;
-	}
-}
-
 int git_idxmap_delete(git_idxmap *map, const git_index_entry *key)
 {
 	khiter_t idx = kh_get(idx, map, key);

--- a/src/index.c
+++ b/src/index.c
@@ -3717,9 +3717,11 @@ void git_indexwriter_cleanup(git_indexwriter *writer)
 
 /* Deprecated functions */
 
+#ifndef GIT_DEPRECATE_HARD
 int git_index_add_frombuffer(
     git_index *index, const git_index_entry *source_entry,
     const void *buffer, size_t len)
 {
 	return git_index_add_from_buffer(index, source_entry, buffer, len);
 }
+#endif

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -123,10 +123,12 @@ int git_indexer_options_init(git_indexer_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_indexer_init_options(git_indexer_options *opts, unsigned int version)
 {
 	return git_indexer_options_init(opts, version);
 }
+#endif
 
 int git_indexer_new(
 		git_indexer **out,

--- a/src/merge.c
+++ b/src/merge.c
@@ -3351,10 +3351,12 @@ int git_merge_options_init(git_merge_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_merge_init_options(git_merge_options *opts, unsigned int version)
 {
 	return git_merge_options_init(opts, version);
 }
+#endif
 
 int git_merge_file_input_init(git_merge_file_input *input, unsigned int version)
 {
@@ -3363,10 +3365,12 @@ int git_merge_file_input_init(git_merge_file_input *input, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_merge_file_init_input(git_merge_file_input *input, unsigned int version)
 {
 	return git_merge_file_input_init(input, version);
 }
+#endif
 
 int git_merge_file_options_init(
 	git_merge_file_options *opts, unsigned int version)
@@ -3376,8 +3380,10 @@ int git_merge_file_options_init(
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_merge_file_init_options(
 	git_merge_file_options *opts, unsigned int version)
 {
 	return git_merge_file_options_init(opts, version);
 }
+#endif

--- a/src/merge.c
+++ b/src/merge.c
@@ -80,7 +80,7 @@ static int cache_invalid_marker;
 
 /* Merge base computation */
 
-int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_repository *repo, size_t length, const git_oid input_array[])
+static int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_repository *repo, size_t length, const git_oid input_array[])
 {
 	git_revwalk *walk = NULL;
 	git_vector list;
@@ -2845,7 +2845,7 @@ on_error:
 	return error;
 }
 
-const char *merge_their_label(const char *branchname)
+static const char *merge_their_label(const char *branchname)
 {
 	const char *slash;
 

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -28,7 +28,7 @@
 
 #define GIT_MERGE_FILE_SIDE_EXISTS(X)	((X)->mode != 0)
 
-int git_merge_file__input_from_index(
+static int merge_file_input_from_index(
 	git_merge_file_input *input_out,
 	git_odb_object **odb_object_out,
 	git_odb *odb,
@@ -276,17 +276,15 @@ int git_merge_file_from_index(
 		goto done;
 
 	if (ancestor) {
-		if ((error = git_merge_file__input_from_index(
+		if ((error = merge_file_input_from_index(
 			&ancestor_input, &odb_object[0], odb, ancestor)) < 0)
 			goto done;
 
 		ancestor_ptr = &ancestor_input;
 	}
 
-	if ((error = git_merge_file__input_from_index(
-			&our_input, &odb_object[1], odb, ours)) < 0 ||
-		(error = git_merge_file__input_from_index(
-			&their_input, &odb_object[2], odb, theirs)) < 0)
+	if ((error = merge_file_input_from_index(&our_input, &odb_object[1], odb, ours)) < 0 ||
+	    (error = merge_file_input_from_index(&their_input, &odb_object[2], odb, theirs)) < 0)
 		goto done;
 
 	error = merge_file__from_inputs(out,

--- a/src/odb.c
+++ b/src/odb.c
@@ -1510,10 +1510,12 @@ void *git_odb_backend_data_alloc(git_odb_backend *backend, size_t len)
 	return git__malloc(len);
 }
 
+#ifndef GIT_DEPRECATE_HARD
 void *git_odb_backend_malloc(git_odb_backend *backend, size_t len)
 {
 	return git_odb_backend_data_alloc(backend, len);
 }
+#endif
 
 void git_odb_backend_data_free(git_odb_backend *backend, void *data)
 {

--- a/src/oid.c
+++ b/src/oid.c
@@ -253,10 +253,12 @@ int git_oid_is_zero(const git_oid *oid_a)
 	return 1;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_oid_iszero(const git_oid *oid_a)
 {
 	return git_oid_is_zero(oid_a);
 }
+#endif
 
 typedef short node_index;
 

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1642,7 +1642,7 @@ static int mark_edges_uninteresting(git_packbuilder *pb, git_commit_list *commit
 	return 0;
 }
 
-int insert_tree(git_packbuilder *pb, git_tree *tree)
+static int pack_objects_insert_tree(git_packbuilder *pb, git_tree *tree)
 {
 	size_t i;
 	int error;
@@ -1669,7 +1669,7 @@ int insert_tree(git_packbuilder *pb, git_tree *tree)
 			if ((error = git_tree_lookup(&subtree, pb->repo, entry_id)) < 0)
 				return error;
 
-			error = insert_tree(pb, subtree);
+			error = pack_objects_insert_tree(pb, subtree);
 			git_tree_free(subtree);
 
 			if (error < 0)
@@ -1695,7 +1695,7 @@ int insert_tree(git_packbuilder *pb, git_tree *tree)
 	return error;
 }
 
-int insert_commit(git_packbuilder *pb, struct walk_object *obj)
+static int pack_objects_insert_commit(git_packbuilder *pb, struct walk_object *obj)
 {
 	int error;
 	git_commit *commit = NULL;
@@ -1712,7 +1712,7 @@ int insert_commit(git_packbuilder *pb, struct walk_object *obj)
 	if ((error = git_tree_lookup(&tree, pb->repo, git_commit_tree_id(commit))) < 0)
 		goto cleanup;
 
-	if ((error = insert_tree(pb, tree)) < 0)
+	if ((error = pack_objects_insert_tree(pb, tree)) < 0)
 		goto cleanup;
 
 cleanup:
@@ -1747,7 +1747,7 @@ int git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk)
 		if (obj->seen || obj->uninteresting)
 			continue;
 
-		if ((error = insert_commit(pb, obj)) < 0)
+		if ((error = pack_objects_insert_commit(pb, obj)) < 0)
 			return error;
 	}
 

--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -941,7 +941,7 @@ static int parse_patch_body(
 		return parse_patch_hunks(patch, ctx);
 }
 
-int check_header_names(
+static int check_header_names(
 	const char *one,
 	const char *two,
 	const char *old_or_new,

--- a/src/path.c
+++ b/src/path.c
@@ -322,7 +322,7 @@ int git_path_root(const char *path)
 	return -1;	/* Not a real error - signals that path is not rooted */
 }
 
-void git_path_trim_slashes(git_buf *path)
+static void path_trim_slashes(git_buf *path)
 {
 	int ceiling = git_path_root(path->ptr) + 1;
 	assert(ceiling >= 0);
@@ -1219,7 +1219,7 @@ int git_path_diriter_init(
 	if (git_buf_puts(&diriter->path_utf8, path) < 0)
 		return -1;
 
-	git_path_trim_slashes(&diriter->path_utf8);
+	path_trim_slashes(&diriter->path_utf8);
 
 	if (diriter->path_utf8.size == 0) {
 		git_error_set(GIT_ERROR_FILESYSTEM, "could not open directory '%s'", path);
@@ -1368,7 +1368,7 @@ int git_path_diriter_init(
 	if (git_buf_puts(&diriter->path, path) < 0)
 		return -1;
 
-	git_path_trim_slashes(&diriter->path);
+	path_trim_slashes(&diriter->path);
 
 	if (diriter->path.size == 0) {
 		git_error_set(GIT_ERROR_FILESYSTEM, "could not open directory '%s'", path);

--- a/src/pool.c
+++ b/src/pool.c
@@ -21,7 +21,7 @@ struct git_pool_page {
 
 static void *pool_alloc_page(git_pool *pool, size_t size);
 
-size_t git_pool__system_page_size(void)
+static size_t pool_system_page_size(void)
 {
 	static size_t size = 0;
 
@@ -44,7 +44,7 @@ int git_pool_init(git_pool *pool, size_t item_size)
 
 	memset(pool, 0, sizeof(git_pool));
 	pool->item_size = item_size;
-	pool->page_size = git_pool__system_page_size();
+	pool->page_size = pool_system_page_size();
 
 	return 0;
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -16,10 +16,12 @@ int git_proxy_options_init(git_proxy_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_proxy_init_options(git_proxy_options *opts, unsigned int version)
 {
 	return git_proxy_options_init(opts, version);
 }
+#endif
 
 int git_proxy_options_dup(git_proxy_options *tgt, const git_proxy_options *src)
 {

--- a/src/push.c
+++ b/src/push.c
@@ -555,7 +555,9 @@ int git_push_options_init(git_push_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_push_init_options(git_push_options *opts, unsigned int version)
 {
 	return git_push_options_init(opts, version);
 }
+#endif

--- a/src/rebase.c
+++ b/src/rebase.c
@@ -501,10 +501,12 @@ int git_rebase_options_init(git_rebase_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_rebase_init_options(git_rebase_options *opts, unsigned int version)
 {
 	return git_rebase_options_init(opts, version);
 }
+#endif
 
 static int rebase_ensure_not_in_progress(git_repository *repo)
 {

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -12,7 +12,8 @@
 #include "signature.h"
 #include "refdb.h"
 
-#include <git2/sys/refdb_backend.h>
+#include "git2/sys/refdb_backend.h"
+#include "git2/sys/reflog.h"
 
 void git_reflog_entry__free(git_reflog_entry *entry)
 {

--- a/src/reflog.c
+++ b/src/reflog.c
@@ -14,11 +14,6 @@
 
 #include <git2/sys/refdb_backend.h>
 
-git_reflog_entry *git_reflog_entry__alloc(void)
-{
-	return git__calloc(1, sizeof(git_reflog_entry));
-}
-
 void git_reflog_entry__free(git_reflog_entry *entry)
 {
 	git_signature_free(entry->committer);

--- a/src/refs.c
+++ b/src/refs.c
@@ -480,7 +480,7 @@ static int reference__create(
 	return 0;
 }
 
-int configured_ident(git_signature **out, const git_repository *repo)
+static int refs_configured_ident(git_signature **out, const git_repository *repo)
 {
 	if (repo->ident_name && repo->ident_email)
 		return git_signature_now(out, repo->ident_name, repo->ident_email);
@@ -494,7 +494,7 @@ int git_reference__log_signature(git_signature **out, git_repository *repo)
 	int error;
 	git_signature *who;
 
-	if(((error = configured_ident(&who, repo)) < 0) &&
+	if(((error = refs_configured_ident(&who, repo)) < 0) &&
 	   ((error = git_signature_default(&who, repo)) < 0) &&
 	   ((error = git_signature_now(&who, "unknown", "unknown")) < 0))
 		return error;

--- a/src/refs.h
+++ b/src/refs.h
@@ -90,6 +90,7 @@ int git_reference__is_valid_name(const char *refname, unsigned int flags);
 int git_reference__is_branch(const char *ref_name);
 int git_reference__is_remote(const char *ref_name);
 int git_reference__is_tag(const char *ref_name);
+int git_reference__is_note(const char *ref_name);
 const char *git_reference__shorthand(const char *name);
 
 /**

--- a/src/remote.c
+++ b/src/remote.c
@@ -195,10 +195,12 @@ int git_remote_create_options_init(git_remote_create_options *opts, unsigned int
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_remote_create_init_options(git_remote_create_options *opts, unsigned int version)
 {
 	return git_remote_create_options_init(opts, version);
 }
+#endif
 
 int git_remote_create_with_opts(git_remote **out, const char *url, const git_remote_create_options *opts)
 {

--- a/src/remote.c
+++ b/src/remote.c
@@ -686,7 +686,7 @@ int git_remote__urlfordirection(git_buf *url_out, struct git_remote *remote, int
 	return resolve_url(url_out, url, direction, callbacks);
 }
 
-int set_transport_callbacks(git_transport *t, const git_remote_callbacks *cbs)
+static int remote_transport_set_callbacks(git_transport *t, const git_remote_callbacks *cbs)
 {
 	if (!t->set_callbacks || !cbs)
 		return 0;
@@ -744,7 +744,7 @@ int git_remote__connect(git_remote *remote, git_direction direction, const git_r
 	if ((error = set_transport_custom_headers(t, conn->custom_headers)) != 0)
 		goto on_error;
 
-	if ((error = set_transport_callbacks(t, callbacks)) < 0 ||
+	if ((error = remote_transport_set_callbacks(t, callbacks)) < 0 ||
 	    (error = t->connect(t, url.ptr, credentials, payload, conn->proxy, direction, flags)) != 0)
 		goto on_error;
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -2928,11 +2928,13 @@ int git_repository_init_options_init(
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_repository_init_init_options(
 	git_repository_init_options *opts, unsigned int version)
 {
 	return git_repository_init_options_init(opts, version);
 }
+#endif
 
 int git_repository_ident(const char **name, const char **email, const git_repository *repo)
 {

--- a/src/revert.c
+++ b/src/revert.c
@@ -231,7 +231,9 @@ int git_revert_options_init(git_revert_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_revert_init_options(git_revert_options *opts, unsigned int version)
 {
 	return git_revert_options_init(opts, version);
 }
+#endif

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -659,7 +659,7 @@ static int ensure_left_hand_identifier_is_not_known_yet(git_object *object, git_
 	return GIT_EINVALIDSPEC;
 }
 
-int revparse__ext(
+static int revparse(
 	git_object **object_out,
 	git_reference **reference_out,
 	size_t *identifier_len_out,
@@ -835,7 +835,7 @@ int git_revparse_ext(
 	git_object *obj = NULL;
 	git_reference *ref = NULL;
 
-	if ((error = revparse__ext(&obj, &ref, &identifier_len, repo, spec)) < 0)
+	if ((error = revparse(&obj, &ref, &identifier_len, repo, spec)) < 0)
 		goto cleanup;
 
 	*object_out = obj;

--- a/src/stash.c
+++ b/src/stash.c
@@ -776,10 +776,12 @@ int git_stash_apply_options_init(git_stash_apply_options *opts, unsigned int ver
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_stash_apply_init_options(git_stash_apply_options *opts, unsigned int version)
 {
 	return git_stash_apply_options_init(opts, version);
 }
+#endif
 
 #define NOTIFY_PROGRESS(opts, progress_type)				\
 	do {								\

--- a/src/status.c
+++ b/src/status.c
@@ -548,10 +548,12 @@ int git_status_options_init(git_status_options *opts, unsigned int version)
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_status_init_options(git_status_options *opts, unsigned int version)
 {
 	return git_status_options_init(opts, version);
 }
+#endif
 
 int git_status_list_get_perfdata(
 	git_diff_perfdata *out, const git_status_list *status)

--- a/src/strarray.c
+++ b/src/strarray.c
@@ -55,7 +55,9 @@ void git_strarray_dispose(git_strarray *array)
 	memset(array, 0, sizeof(*array));
 }
 
+#ifndef GIT_DEPRECATE_HARD
 void git_strarray_free(git_strarray *array)
 {
 	git_strarray_dispose(array);
 }
+#endif

--- a/src/streams/registry.c
+++ b/src/streams/registry.c
@@ -5,9 +5,10 @@
  * a Linking Exception. For full terms see the included COPYING file.
  */
 
-#include "git2/errors.h"
-
 #include "common.h"
+
+#include "streams/registry.h"
+
 #include "global.h"
 #include "streams/tls.h"
 #include "streams/mbedtls.h"

--- a/src/streams/registry.c
+++ b/src/streams/registry.c
@@ -101,7 +101,7 @@ int git_stream_register(git_stream_t type, git_stream_registration *registration
 	return 0;
 }
 
-
+#ifndef GIT_DEPRECATE_HARD
 int git_stream_register_tls(
 	int GIT_CALLBACK(ctor)(git_stream **out, const char *host, const char *port))
 {
@@ -117,3 +117,4 @@ int git_stream_register_tls(
 		return git_stream_register(GIT_STREAM_TLS, NULL);
 	}
 }
+#endif

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -958,7 +958,7 @@ cleanup:
 	return error;
 }
 
-const char *git_submodule_update_to_str(git_submodule_update_t update)
+static const char *submodule_update_to_str(git_submodule_update_t update)
 {
 	int i;
 	for (i = 0; i < (int)ARRAY_SIZE(_sm_update_map); ++i)
@@ -1401,7 +1401,7 @@ int git_submodule_init(git_submodule *sm, int overwrite)
 	/* write "submodule.NAME.update" if not default */
 
 	val = (sm->update == GIT_SUBMODULE_UPDATE_CHECKOUT) ?
-		NULL : git_submodule_update_to_str(sm->update);
+		NULL : submodule_update_to_str(sm->update);
 
 	if ((error = git_buf_printf(&key, "submodule.%s.update", sm->name)) < 0 ||
 		(error = git_config__update_entry(
@@ -1838,7 +1838,7 @@ int git_submodule_parse_update(git_submodule_update_t *out, const char *value)
 	return 0;
 }
 
-int git_submodule_parse_recurse(git_submodule_recurse_t *out, const char *value)
+static int submodule_parse_recurse(git_submodule_recurse_t *out, const char *value)
 {
 	int val;
 
@@ -1934,7 +1934,7 @@ static int submodule_read_config(git_submodule *sm, git_config *cfg)
 
 	if ((error = get_value(&value, cfg, &key, sm->name, "fetchRecurseSubmodules")) == 0) {
 		in_config = 1;
-		if ((error = git_submodule_parse_recurse(&sm->fetch_recurse, value)) < 0)
+		if ((error = submodule_parse_recurse(&sm->fetch_recurse, value)) < 0)
 			goto cleanup;
 		sm->fetch_recurse_default = sm->fetch_recurse;
 	} else if (error != GIT_ENOTFOUND) {

--- a/src/submodule.c
+++ b/src/submodule.c
@@ -1240,10 +1240,12 @@ int git_submodule_update_options_init(git_submodule_update_options *opts, unsign
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version)
 {
 	return git_submodule_update_options_init(opts, version);
 }
+#endif
 
 int git_submodule_update(git_submodule *sm, int init, git_submodule_update_options *_update_options)
 {

--- a/src/tag.c
+++ b/src/tag.c
@@ -524,7 +524,9 @@ int git_tag_peel(git_object **tag_target, const git_tag *tag)
 
 /* Deprecated Functions */
 
+#ifndef GIT_DEPRECATE_HARD
 int git_tag_create_frombuffer(git_oid *oid, git_repository *repo, const char *buffer, int allow_ref_overwrite)
 {
 	return git_tag_create_from_buffer(oid, repo, buffer, allow_ref_overwrite);
 }
+#endif

--- a/src/transports/credential.c
+++ b/src/transports/credential.c
@@ -391,6 +391,7 @@ void git_credential_free(git_credential *cred)
 
 /* Deprecated credential functions */
 
+#ifndef GIT_DEPRECATE_HARD
 int git_cred_has_username(git_credential *cred)
 {
 	return git_credential_has_username(cred);
@@ -474,3 +475,4 @@ void git_cred_free(git_credential *cred)
 {
 	git_credential_free(cred);
 }
+#endif

--- a/src/transports/credential_helpers.c
+++ b/src/transports/credential_helpers.c
@@ -54,6 +54,7 @@ int git_credential_userpass(
 
 /* Deprecated credential functions */
 
+#ifndef GIT_DEPRECATE_HARD
 int git_cred_userpass(
 	git_credential **out,
 	const char *url,
@@ -64,3 +65,4 @@ int git_cred_userpass(
 	return git_credential_userpass(out, url, user_from_url,
 		allowed_types, payload);
 }
+#endif

--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -445,7 +445,7 @@ GIT_INLINE(int) client_write_request(git_http_client *client)
 				      0);
 }
 
-const char *name_for_method(git_http_method method)
+static const char *name_for_method(git_http_method method)
 {
 	switch (method) {
 	case GIT_HTTP_METHOD_GET:

--- a/src/util.c
+++ b/src/util.c
@@ -777,7 +777,7 @@ static const int8_t utf8proc_utf8class[256] = {
 	4, 4, 4, 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-int git__utf8_charlen(const uint8_t *str, size_t str_len)
+static int util_utf8_charlen(const uint8_t *str, size_t str_len)
 {
 	size_t length, i;
 
@@ -802,7 +802,7 @@ int git__utf8_iterate(const uint8_t *str, int str_len, int32_t *dst)
 	int32_t uc = -1;
 
 	*dst = -1;
-	length = git__utf8_charlen(str, str_len);
+	length = util_utf8_charlen(str, str_len);
 	if (length < 0)
 		return -1;
 
@@ -839,7 +839,7 @@ size_t git__utf8_valid_buf_length(const uint8_t *str, size_t str_len)
 	size_t offset = 0;
 
 	while (offset < str_len) {
-		int length = git__utf8_charlen(str + offset, str_len - offset);
+		int length = util_utf8_charlen(str + offset, str_len - offset);
 
 		if (length < 0)
 			break;

--- a/src/win32/path_w32.c
+++ b/src/win32/path_w32.c
@@ -151,7 +151,7 @@ int git_win32_path_canonicalize(git_win32_path path)
 	return (int)(to - path);
 }
 
-int git_win32_path__cwd(wchar_t *out, size_t len)
+static int win32_path_cwd(wchar_t *out, size_t len)
 {
 	int cwd_len;
 
@@ -241,7 +241,7 @@ int git_win32_path_from_utf8(git_win32_path out, const char *src)
 	else {
 		int cwd_len;
 
-		if ((cwd_len = git_win32_path__cwd(dest, MAX_PATH)) < 0)
+		if ((cwd_len = win32_path_cwd(dest, MAX_PATH)) < 0)
 			goto on_error;
 
 		dest[cwd_len++] = L'\\';

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -271,11 +271,13 @@ int git_worktree_add_options_init(git_worktree_add_options *opts,
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_worktree_add_init_options(git_worktree_add_options *opts,
 	unsigned int version)
 {
 	return git_worktree_add_options_init(opts, version);
 }
+#endif
 
 int git_worktree_add(git_worktree **out, git_repository *repo,
 	const char *name, const char *worktree,
@@ -506,11 +508,13 @@ int git_worktree_prune_options_init(
 	return 0;
 }
 
+#ifndef GIT_DEPRECATE_HARD
 int git_worktree_prune_init_options(git_worktree_prune_options *opts,
 	unsigned int version)
 {
 	return git_worktree_prune_options_init(opts, version);
 }
+#endif
 
 int git_worktree_is_prunable(git_worktree *wt,
 	git_worktree_prune_options *opts)

--- a/tests/stream/deprecated.c
+++ b/tests/stream/deprecated.c
@@ -1,18 +1,17 @@
-#undef GIT_DEPRECATE_HARD
-
 #include "clar_libgit2.h"
 #include "git2/sys/stream.h"
 #include "streams/tls.h"
 #include "streams/socket.h"
 #include "stream.h"
 
-static git_stream test_stream;
-static int ctor_called;
-
 void test_stream_deprecated__cleanup(void)
 {
 	cl_git_pass(git_stream_register(GIT_STREAM_TLS | GIT_STREAM_STANDARD, NULL));
 }
+
+#ifndef GIT_DEPRECATE_HARD
+static git_stream test_stream;
+static int ctor_called;
 
 static int test_stream_init(git_stream **out, const char *host, const char *port)
 {
@@ -24,9 +23,11 @@ static int test_stream_init(git_stream **out, const char *host, const char *port
 
 	return 0;
 }
+#endif
 
 void test_stream_deprecated__register_tls(void)
 {
+#ifndef GIT_DEPRECATE_HARD
 	git_stream *stream;
 	int error;
 
@@ -55,4 +56,5 @@ void test_stream_deprecated__register_tls(void)
 	cl_assert(&test_stream != stream);
 
 	git_stream_free(stream);
+#endif
 }


### PR DESCRIPTION
Over time, we have accumulated quite a lot of functions with missing
prototypes, missing `static` keywords or which were completely unused.
It's easy to miss these mistakes, but luckily GCC and Clang both have
the `-Wmissing-declarations` warning. Enabling this will cause them to
emit warnings for every not-static function that doesn't have a previous
declaration. This is a very sane thing to enable, and with the preceding
commits all these new warnings have been fixed.

So let's always enable this warning so we won't introduce new instances
of them.

---

Note that I've also renamed some now-static functions to match our coding style:

> All public functions must have a `git` prefix as well as a prefix indicating
their respective subsystem. E.g. a function that opens a repository should be
called `git_repository_open()`. Functions that are not public but declared in
an internal header file for use by other subsystems should follow the same
naming pattern. File-local static functions must not have a `git` prefix, but
should have a prefix indicating their respective subsystem.