### PR TITLE
Random fixes for diff-printing

### DIFF
--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -491,6 +491,9 @@ static int format_binary(
 	}
 	git_buf_putc(pi->buf, '\n');
 
+	if (git_buf_oom(pi->buf))
+		return -1;
+
 	return 0;
 }
 

--- a/src/diff_print.c
+++ b/src/diff_print.c
@@ -351,12 +351,11 @@ static int diff_delta_format_similarity_header(
 		goto done;
 	}
 
+	GIT_ASSERT(delta->status == GIT_DELTA_RENAMED || delta->status == GIT_DELTA_COPIED);
 	if (delta->status == GIT_DELTA_RENAMED)
 		type = "rename";
-	else if (delta->status == GIT_DELTA_COPIED)
-		type = "copy";
 	else
-		abort();
+		type = "copy";
 
 	if ((error = git_buf_puts(&old_path, delta->old_file.path)) < 0 ||
 	    (error = git_buf_puts(&new_path, delta->new_file.path)) < 0 ||


### PR DESCRIPTION
This is some random fixes for the diff-printing code:

- removed a call to abort and replace it with `GIT_ASSERT`
- fix silent success when printing to a file fails
- detection of an out-of-memory situation when printing binaries
- some fixes to our code style