### PR TITLE
Enable building git2.rc resource script with GCC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -278,10 +278,6 @@ list(SORT SRC_H)
 
 # On Windows use specific platform sources
 if(WIN32 AND NOT CYGWIN)
-	if(NOT MSVC)
-		ADD_DEFINITIONS(-DGCC_WINDRES)
-	endif()
-
 	SET(WIN_RC "win32/git2.rc")
 
 	file(GLOB SRC_OS win32/*.c win32/*.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -278,9 +278,11 @@ list(SORT SRC_H)
 
 # On Windows use specific platform sources
 if(WIN32 AND NOT CYGWIN)
-	if(MSVC)
-		SET(WIN_RC "win32/git2.rc")
+	if(NOT MSVC)
+		ADD_DEFINITIONS(-DGCC_WINDRES)
 	endif()
+
+	SET(WIN_RC "win32/git2.rc")
 
 	file(GLOB SRC_OS win32/*.c win32/*.h)
 	list(SORT SRC_OS)

--- a/src/win32/git2.rc
+++ b/src/win32/git2.rc
@@ -2,21 +2,25 @@
 #include "../../include/git2/version.h"
 
 #ifndef LIBGIT2_FILENAME
-# define LIBGIT2_FILENAME "git2"
+# ifdef __GNUC__
+#  define LIBGIT2_FILENAME git2
+# else
+#  define LIBGIT2_FILENAME "git2"
+# endif
 #endif
 
 #ifndef LIBGIT2_COMMENTS
 # define LIBGIT2_COMMENTS "For more information visit http://libgit2.github.com/"
 #endif
 
-#ifdef GCC_WINDRES
+#ifdef __GNUC__
 # define _STR(x) #x
 # define STR(x) _STR(x)
 #else
 # define STR(x) x
 #endif
 
-#ifdef GCC_WINDRES
+#ifdef __GNUC__
 VS_VERSION_INFO		VERSIONINFO
 #else
 VS_VERSION_INFO		VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE

--- a/src/win32/git2.rc
+++ b/src/win32/git2.rc
@@ -10,10 +10,10 @@
 #endif
 
 #ifdef GCC_WINDRES
-# define STRINGIZE(x) #x
-# define STRINGIZE_(x) STRINGIZE(x)
+# define _STR(x) #x
+# define STR(x) _STR(x)
 #else
-# define STRINGIZE_(x) x
+# define STR(x) x
 #endif
 
 #ifdef GCC_WINDRES
@@ -40,9 +40,9 @@ BEGIN
     BEGIN
       VALUE "FileDescription",	"libgit2 - the Git linkable library\0"
       VALUE "FileVersion",	LIBGIT2_VERSION "\0"
-      VALUE "InternalName",	STRINGIZE_(LIBGIT2_FILENAME) ".dll\0"
+      VALUE "InternalName",	STR(LIBGIT2_FILENAME) ".dll\0"
       VALUE "LegalCopyright",	"Copyright (C) the libgit2 contributors. All rights reserved.\0"
-      VALUE "OriginalFilename",	STRINGIZE_(LIBGIT2_FILENAME) ".dll\0"
+      VALUE "OriginalFilename",	STR(LIBGIT2_FILENAME) ".dll\0"
       VALUE "ProductName",	"libgit2\0"
       VALUE "ProductVersion",	LIBGIT2_VERSION "\0"
       VALUE "Comments",		LIBGIT2_COMMENTS "\0"

--- a/src/win32/git2.rc
+++ b/src/win32/git2.rc
@@ -9,7 +9,18 @@
 # define LIBGIT2_COMMENTS "For more information visit http://libgit2.github.com/"
 #endif
 
+#ifdef GCC_WINDRES
+# define STRINGIZE(x) #x
+# define STRINGIZE_(x) STRINGIZE(x)
+#else
+# define STRINGIZE_(x) x
+#endif
+
+#ifdef GCC_WINDRES
+VS_VERSION_INFO		VERSIONINFO
+#else
 VS_VERSION_INFO		VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE
+#endif
   FILEVERSION		LIBGIT2_VER_MAJOR,LIBGIT2_VER_MINOR,LIBGIT2_VER_REVISION,LIBGIT2_VER_PATCH
   PRODUCTVERSION	LIBGIT2_VER_MAJOR,LIBGIT2_VER_MINOR,LIBGIT2_VER_REVISION,LIBGIT2_VER_PATCH
   FILEFLAGSMASK		VS_FFI_FILEFLAGSMASK
@@ -29,9 +40,9 @@ BEGIN
     BEGIN
       VALUE "FileDescription",	"libgit2 - the Git linkable library\0"
       VALUE "FileVersion",	LIBGIT2_VERSION "\0"
-      VALUE "InternalName",	LIBGIT2_FILENAME ".dll\0"
+      VALUE "InternalName",	STRINGIZE_(LIBGIT2_FILENAME) ".dll\0"
       VALUE "LegalCopyright",	"Copyright (C) the libgit2 contributors. All rights reserved.\0"
-      VALUE "OriginalFilename",	LIBGIT2_FILENAME ".dll\0"
+      VALUE "OriginalFilename",	STRINGIZE_(LIBGIT2_FILENAME) ".dll\0"
       VALUE "ProductName",	"libgit2\0"
       VALUE "ProductVersion",	LIBGIT2_VERSION "\0"
       VALUE "Comments",		LIBGIT2_COMMENTS "\0"


### PR DESCRIPTION
The approach is similar to the one taken by zlib:
https://github.com/madler/zlib/blob/master/win32/zlib1.rc

Also, the LIBGIT2_FILENAME macro needs to be stringized for windres.exe to understand it.