### PR TITLE
Access symrefs via refdb

### DIFF
--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -27,8 +27,12 @@
 #include <git2/sys/refs.h>
 #include <git2/sys/reflog.h>
 
+#define GIT_PACKEDREFS_FILE "packed-refs"
+#define GIT_PACKEDREFS_HEADER "# pack-refs with: peeled fully-peeled sorted "
+#define GIT_PACKEDREFS_FILE_MODE 0666
+
 #define DEFAULT_NESTING_LEVEL	5
-#define MAX_NESTING_LEVEL		10
+#define MAX_NESTING_LEVEL	10
 
 enum {
 	PACKREF_HAS_PEEL = 1,

--- a/src/refs.h
+++ b/src/refs.h
@@ -29,9 +29,6 @@ extern bool git_reference__enable_symbolic_ref_target_validation;
 #define GIT_RENAMED_REF_FILE GIT_REFS_DIR "RENAMED-REF"
 
 #define GIT_SYMREF "ref: "
-#define GIT_PACKEDREFS_FILE "packed-refs"
-#define GIT_PACKEDREFS_HEADER "# pack-refs with: peeled fully-peeled sorted "
-#define GIT_PACKEDREFS_FILE_MODE 0666
 
 #define GIT_HEAD_FILE "HEAD"
 #define GIT_ORIG_HEAD_FILE "ORIG_HEAD"

--- a/src/refs.h
+++ b/src/refs.h
@@ -26,8 +26,6 @@ extern bool git_reference__enable_symbolic_ref_target_validation;
 #define GIT_REFS_DIR_MODE 0777
 #define GIT_REFS_FILE_MODE 0666
 
-#define GIT_RENAMED_REF_FILE GIT_REFS_DIR "RENAMED-REF"
-
 #define GIT_SYMREF "ref: "
 
 #define GIT_HEAD_FILE "HEAD"

--- a/src/repository.h
+++ b/src/repository.h
@@ -233,7 +233,7 @@ GIT_INLINE(int) git_repository__ensure_not_bare(
 
 int git_repository__set_orig_head(git_repository *repo, const git_oid *orig_head);
 
-int git_repository__cleanup_files(git_repository *repo, const char *files[], size_t files_len);
+int git_repository_cleanup_files(git_repository *repo, const char *files[], size_t files_len);
 
 /* The default "reserved names" for a repository */
 extern git_buf git_repository__reserved_names_win32[];

--- a/tests/refs/pack.c
+++ b/tests/refs/pack.c
@@ -62,7 +62,7 @@ void test_refs_pack__loose(void)
 	packall();
 
 	/* Ensure the packed-refs file exists */
-	cl_git_pass(git_buf_joinpath(&temp_path, git_repository_path(g_repo), GIT_PACKEDREFS_FILE));
+	cl_git_pass(git_buf_joinpath(&temp_path, git_repository_path(g_repo), "packed-refs"));
 	cl_assert(git_path_exists(temp_path.ptr));
 
 	/* Ensure the known ref can still be looked up but is now packed */


### PR DESCRIPTION
This is another set of commits that fixes a subset of our codebase that's accessing symrefs directly via the filesystem, circumventing the refdb. This is a layering violation and also breaks our own abstractions, making reference backends essentially unfunctional in some situations.