### PR TITLE
refdb: a set of preliminary refactorings for the reftable backend

### DIFF
--- a/src/refdb.c
+++ b/src/refdb.c
@@ -326,7 +326,7 @@ int git_refdb_should_write_reflog(int *out, git_refdb *db, const git_reference *
 
 int git_refdb_should_write_head_reflog(int *out, git_refdb *db, const git_reference *ref)
 {
-	git_reference *head = NULL, *peeled = NULL;
+	git_reference *head = NULL, *resolved = NULL;
 	const char *name;
 	int error;
 
@@ -344,22 +344,15 @@ int git_refdb_should_write_head_reflog(int *out, git_refdb *db, const git_refere
 		goto out;
 
 	/* Go down the symref chain until we find the branch */
-	while (git_reference_type(head) == GIT_REFERENCE_SYMBOLIC) {
-		if ((error = git_refdb_lookup(&peeled, db, git_reference_symbolic_target(head))) < 0)
-			break;
-
-		git_reference_free(head);
-		head = peeled;
-		peeled = NULL;
-	}
-
-	if (error < 0) {
+	if ((error = git_refdb_resolve(&resolved, db, git_reference_symbolic_target(head), -1)) < 0) {
 		if (error != GIT_ENOTFOUND)
 			goto out;
 		error = 0;
 		name = git_reference_symbolic_target(head);
+	} else if (git_reference_type(resolved) == GIT_REFERENCE_SYMBOLIC) {
+		name = git_reference_symbolic_target(resolved);
 	} else {
-		name = git_reference_name(head);
+		name = git_reference_name(resolved);
 	}
 
 	if (strcmp(name, ref->name))
@@ -368,7 +361,7 @@ int git_refdb_should_write_head_reflog(int *out, git_refdb *db, const git_refere
 	*out = 1;
 
 out:
-	git_reference_free(peeled);
+	git_reference_free(resolved);
 	git_reference_free(head);
 	return error;
 }

--- a/src/refdb.c
+++ b/src/refdb.c
@@ -161,8 +161,16 @@ int git_refdb_resolve(
 
 		if (ref->type == GIT_REFERENCE_DIRECT)
 			break;
-		if ((error = git_refdb_lookup(&resolved, db, git_reference_symbolic_target(ref))) < 0)
+
+		if ((error = git_refdb_lookup(&resolved, db, git_reference_symbolic_target(ref))) < 0) {
+			/* If we found a symbolic reference with a nonexistent target, return it. */
+			if (error == GIT_ENOTFOUND) {
+				error = 0;
+				*out = ref;
+				ref = NULL;
+			}
 			goto out;
+		}
 
 		git_reference_free(ref);
 		ref = resolved;

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -30,6 +30,12 @@ int git_refdb_lookup(
 	git_refdb *refdb,
 	const char *ref_name);
 
+int git_refdb_resolve(
+	git_reference **out,
+	git_refdb *db,
+	const char *ref_name,
+	int max_nesting);
+
 int git_refdb_rename(
 	git_reference **out,
 	git_refdb *db,

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -50,6 +50,34 @@ int git_refdb_delete(git_refdb *refdb, const char *ref_name, const git_oid *old_
 int git_refdb_reflog_read(git_reflog **out, git_refdb *db,  const char *name);
 int git_refdb_reflog_write(git_reflog *reflog);
 
+/**
+ * Determine whether a reflog entry should be created for the given reference.
+ *
+ * Whether or not writing to a reference should create a reflog entry is
+ * dependent on a number of things. Most importantly, there's the
+ * "core.logAllRefUpdates" setting that controls in which situations a
+ * reference should get a corresponding reflog entry. The following values for
+ * it are understood:
+ *
+ *     - "false": Do not log reference updates.
+ *
+ *     - "true": Log normal reference updates. This will write entries for
+ *               references in "refs/heads", "refs/remotes", "refs/notes" and
+ *               "HEAD" or if the reference already has a log entry.
+ *
+ *     - "always": Always create a reflog entry.
+ *
+ * If unset, the value will default to "true" for non-bare repositories and
+ * "false" for bare ones.
+ *
+ * @param out pointer to which the result will be written, `1` means a reflog
+ *            entry should be written, `0` means none should be written.
+ * @param db The refdb to decide this for.
+ * @param ref The reference one wants to check.
+ * @return `0` on success, a negative error code otherwise.
+ */
+int git_refdb_should_write_reflog(int *out, git_refdb *db, const git_reference *ref);
+
 int git_refdb_has_log(git_refdb *db, const char *refname);
 int git_refdb_ensure_log(git_refdb *refdb, const char *refname);
 

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -30,6 +30,25 @@ int git_refdb_lookup(
 	git_refdb *refdb,
 	const char *ref_name);
 
+/**
+ * Resolve the reference by following symbolic references.
+ *
+ * Given a reference name, this function will follow any symbolic references up
+ * to `max_nesting` deep and return the resolved direct reference. If any of
+ * the intermediate symbolic references points to a non-existing reference,
+ * then that symbolic reference is returned instead with an error code of `0`.
+ * If the given reference is a direct reference already, it is returned
+ * directly.
+ *
+ * If `max_nesting` is `0`, the reference will not be resolved. If it's
+ * negative, it will be set to the default resolve depth which is `5`.
+ *
+ * @param out Pointer to store the result in.
+ * @param db The refdb to use for resolving the reference.
+ * @param ref_name The reference name to lookup and resolve.
+ * @param max_nesting The maximum nesting depth.
+ * @return `0` on success, a negative error code otherwise.
+ */
 int git_refdb_resolve(
 	git_reference **out,
 	git_refdb *db,

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -78,6 +78,22 @@ int git_refdb_reflog_write(git_reflog *reflog);
  */
 int git_refdb_should_write_reflog(int *out, git_refdb *db, const git_reference *ref);
 
+/**
+ * Determine whether a reflog entry should be created for HEAD if creating one
+ * for the given reference
+ *
+ * In case the given reference is being pointed to by HEAD, then creating a
+ * reflog entry for this reference also requires us to create a corresponding
+ * reflog entry for HEAD. This function can be used to determine that scenario.
+ *
+ * @param out pointer to which the result will be written, `1` means a reflog
+ *            entry should be written, `0` means none should be written.
+ * @param db The refdb to decide this for.
+ * @param ref The reference one wants to check.
+ * @return `0` on success, a negative error code otherwise.
+ */
+int git_refdb_should_write_head_reflog(int *out, git_refdb *db, const git_reference *ref);
+
 int git_refdb_has_log(git_refdb *db, const char *refname);
 int git_refdb_ensure_log(git_refdb *refdb, const char *refname);
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -27,9 +27,6 @@
 
 bool git_reference__enable_symbolic_ref_target_validation = true;
 
-#define DEFAULT_NESTING_LEVEL	5
-#define MAX_NESTING_LEVEL		10
-
 enum {
 	GIT_PACKREF_HAS_PEEL = 1,
 	GIT_PACKREF_WAS_LOOSE = 2
@@ -1131,40 +1128,6 @@ int git_reference_cmp(
 	return git_oid__cmp(&ref1->target.oid, &ref2->target.oid);
 }
 
-/**
- * Get the end of a chain of references. If the final one is not
- * found, we return the reference just before that.
- */
-static int get_terminal(git_reference **out, git_repository *repo, const char *ref_name, int nesting)
-{
-	git_reference *ref;
-	int error = 0;
-
-	if (nesting > MAX_NESTING_LEVEL) {
-		git_error_set(GIT_ERROR_REFERENCE, "reference chain too deep (%d)", nesting);
-		return GIT_ENOTFOUND;
-	}
-
-	/* set to NULL to let the caller know that they're at the end of the chain */
-	if ((error = git_reference_lookup(&ref, repo, ref_name)) < 0) {
-		*out = NULL;
-		return error;
-	}
-
-	if (git_reference_type(ref) == GIT_REFERENCE_DIRECT) {
-		*out = ref;
-		error = 0;
-	} else {
-		error = get_terminal(out, repo, git_reference_symbolic_target(ref), nesting + 1);
-		if (error == GIT_ENOTFOUND && !*out)
-			*out = ref;
-		else
-			git_reference_free(ref);
-	}
-
-	return error;
-}
-
 /*
  * Starting with the reference given by `ref_name`, follows symbolic
  * references until a direct reference is found and updated the OID
@@ -1179,31 +1142,37 @@ int git_reference__update_terminal(
 {
 	git_reference *ref = NULL, *ref2 = NULL;
 	git_signature *who = NULL;
+	git_refdb *refdb = NULL;
 	const git_signature *to_use;
 	int error = 0;
 
 	if (!sig && (error = git_reference__log_signature(&who, repo)) < 0)
-		return error;
+		goto out;
 
 	to_use = sig ? sig : who;
-	error = get_terminal(&ref, repo, ref_name, 0);
 
-	/* found a dangling symref */
-	if (error == GIT_ENOTFOUND && ref) {
-		assert(git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC);
-		git_error_clear();
+	if ((error = git_repository_refdb__weakptr(&refdb, repo)) < 0)
+		goto out;
+
+	if ((error = git_refdb_resolve(&ref, refdb, ref_name, -1)) < 0) {
+		if (error == GIT_ENOTFOUND) {
+			git_error_clear();
+			error = reference__create(&ref2, repo, ref_name, oid, NULL, 0, to_use,
+						  log_message, NULL, NULL);
+		}
+		goto out;
+	}
+
+	/* In case the resolved reference is symbolic, then it's a dangling symref. */
+	if (git_reference_type(ref) == GIT_REFERENCE_SYMBOLIC) {
 		error = reference__create(&ref2, repo, ref->target.symbolic, oid, NULL, 0, to_use,
 					  log_message, NULL, NULL);
-	} else if (error == GIT_ENOTFOUND) {
-		git_error_clear();
-		error = reference__create(&ref2, repo, ref_name, oid, NULL, 0, to_use,
-					  log_message, NULL, NULL);
-	}  else if (error == 0) {
-		assert(git_reference_type(ref) == GIT_REFERENCE_DIRECT);
+	} else {
 		error = reference__create(&ref2, repo, ref->name, oid, NULL, 1, to_use,
 					  log_message, &ref->target.oid, NULL);
 	}
 
+out:
 	git_reference_free(ref2);
 	git_reference_free(ref);
 	git_signature_free(who);

--- a/src/refs.c
+++ b/src/refs.c
@@ -225,6 +225,18 @@ int git_reference_lookup_resolved(
 	    (error = git_refdb_resolve(ref_out, refdb, normalized, max_nesting)) < 0)
 		return error;
 
+	/*
+	 * The resolved reference may be a symbolic reference in case its
+	 * target doesn't exist. If the user asked us to resolve (e.g.
+	 * `max_nesting != 0`), then we need to return an error in case we got
+	 * a symbolic reference back.
+	 */
+	if (max_nesting && git_reference_type(*ref_out) == GIT_REFERENCE_SYMBOLIC) {
+		git_reference_free(*ref_out);
+		*ref_out = NULL;
+		return GIT_ENOTFOUND;
+	}
+
 	return 0;
 }
 

--- a/tests/refs/reflog/messages.c
+++ b/tests/refs/reflog/messages.c
@@ -24,10 +24,7 @@ void test_refs_reflog_messages__cleanup(void)
 void test_refs_reflog_messages__setting_head_updates_reflog(void)
 {
 	git_object *tag;
-	git_signature *sig;
 	git_annotated_commit *annotated;
-
-	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
 	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/haacked")); /* 4 */
 	cl_git_pass(git_repository_set_head(g_repo, "refs/heads/unborn"));
@@ -68,7 +65,6 @@ void test_refs_reflog_messages__setting_head_updates_reflog(void)
 
 	git_annotated_commit_free(annotated);
 	git_object_free(tag);
-	git_signature_free(sig);
 }
 
 void test_refs_reflog_messages__setting_head_to_same_target_ignores_reflog(void)
@@ -87,11 +83,8 @@ void test_refs_reflog_messages__setting_head_to_same_target_ignores_reflog(void)
 
 void test_refs_reflog_messages__detaching_writes_reflog(void)
 {
-	git_signature *sig;
 	git_oid id;
 	const char *msg;
-
-	cl_git_pass(git_signature_now(&sig, "me", "foo@example.com"));
 
 	msg = "checkout: moving from master to e90810b8df3e80c413d903f631643c716887138d";
 	git_oid_fromstr(&id, "e90810b8df3e80c413d903f631643c716887138d");
@@ -107,8 +100,6 @@ void test_refs_reflog_messages__detaching_writes_reflog(void)
 		"e90810b8df3e80c413d903f631643c716887138d",
 		"258f0e2a959a364e40ed6603d5d44fbb24765b10",
 		NULL, msg);
-
-	git_signature_free(sig);
 }
 
 void test_refs_reflog_messages__orphan_branch_does_not_count(void)


### PR DESCRIPTION
I've decided to pull out some of the preliminary work for the reftable backend in order to keep #5462 focussed on the already-intense refdb logic. This PR is what I ended up with. I did several refactorings to pull out functions that are commonly needed for refdb backend implementations and moved the resolving logic from the refs code into the refdb code, mostly in order to deduplicate the three different symref resolvers we had. This also fixes a bug where we could spin indefinitely resolving symrefs in case there's a symref loop in our repo.