### PR TITLE
httpclient: only free challenges for current_server type

### DIFF
--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1374,8 +1374,11 @@ int git_http_client_read_response(
 
 	git_http_response_dispose(response);
 
-	git_vector_free_deep(&client->server.auth_challenges);
-	git_vector_free_deep(&client->proxy.auth_challenges);
+	if (client->current_server == PROXY) {
+		git_vector_free_deep(&client->proxy.auth_challenges);
+	} else if(client->current_server == SERVER) {
+		git_vector_free_deep(&client->server.auth_challenges);
+	}
 
 	client->state = READING_RESPONSE;
 	client->keepalive = 0;


### PR DESCRIPTION
Prior to this commit we freed both the server and proxy auth challenges
in git_http_client_read_response. This works when the proxy needs auth
or when the server needs auth, but it does not work when both the proxy
and the server need auth as we erroneously remove the server auth
challenge before we have added them as server credentials. Instead only
remove the challenges for the current_server type.

Co-authored-by: Stephen Gelman <ssgelm@gmail.com>

We used `libgit2_clar -sonline::clone::proxy_credentials_in_url` to test:

Before the commit with debug output:

```
XXX NO REQ CREDS
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX NO AUTH CONTEXT
XXX CHALLENGES: 0
XXX RESP HEADER Proxy-Authenticate
XXX NO REQ CREDS
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX NO AUTH CONTEXT
XXX CHALLENGES: 1
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX CURRENT_SERVER SERVER
XXX APPLY_CREDS FOR github.example.com
XXX NO AUTH CONTEXT
XXX CHALLENGES: 0
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX RESP HEADER www-authenticate
XXX REQ CREDS x-access-token:secret
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX CURRENT_SERVER SERVER
XXX APPLY_CREDS FOR github.example.com
XXX NO AUTH CONTEXT
XXX CHALLENGES: 0
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX RESP HEADER www-authenticate
Loaded 386 suites:
Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
F

  1) Failure:
online::clone::proxy_credentials_in_url [/home/admin/src/libgit2/tests/online/clone.c:835]
  Function call failed: (git_clone(&g_repo, "https://x-access-token:secret@github.example.com/foo/bar", "./foo", &g_options))
  error -1 - remote authentication required but no callback set
```
After the commit with debug output:
```
XXX NO REQ CREDS
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX NO AUTH CONTEXT
XXX CHALLENGES: 0
XXX FREEING CHALLENGES IN PROXY
XXX RESP HEADER Proxy-Authenticate
XXX NO REQ CREDS
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX NO AUTH CONTEXT
XXX CHALLENGES: 1
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX FREEING CHALLENGES IN PROXY
XXX CURRENT_SERVER SERVER
XXX APPLY_CREDS FOR github.example.com
XXX NO AUTH CONTEXT
XXX CHALLENGES: 0
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX FREEING CHALLENGES IN SERVER
XXX RESP HEADER www-authenticate
XXX REQ CREDS x-access-token:secret
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX FREEING CHALLENGES IN PROXY
XXX CURRENT_SERVER SERVER
XXX APPLY_CREDS FOR github.example.com
XXX NO AUTH CONTEXT
XXX CHALLENGES: 1
XXX AUTH USER x-access-token
XXX AUTH PASS secret
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX FREEING CHALLENGES IN SERVER
XXX REQ CREDS x-access-token:secret
XXX CURRENT_SERVER PROXY
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX FREEING CHALLENGES IN PROXY
XXX CURRENT_SERVER SERVER
XXX APPLY_CREDS FOR github.example.com
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER x-access-token
XXX AUTH PASS secret
XXX APPLY_CREDS FOR localhost
XXX WITH AUTH CONTEXT
XXX CHALLENGES: 0
XXX AUTH USER butter
XXX AUTH PASS bubbles
XXX FREEING CHALLENGES IN SERVER
Loaded 386 suites:
Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
.
```