### PR TITLE
Friendlier getting started in the lack of git_libgit2_init

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -8,10 +8,22 @@
 #include "alloc.h"
 #include "runtime.h"
 
+#include "allocators/failalloc.h"
 #include "allocators/stdalloc.h"
 #include "allocators/win32_leakcheck.h"
 
-git_allocator git__allocator;
+/* Fail any allocation until git_libgit2_init is called. */
+git_allocator git__allocator = {
+	git_failalloc_malloc,
+	git_failalloc_calloc,
+	git_failalloc_strdup,
+	git_failalloc_strndup,
+	git_failalloc_substrdup,
+	git_failalloc_realloc,
+	git_failalloc_reallocarray,
+	git_failalloc_mallocarray,
+	git_failalloc_free
+};
 
 static int setup_default_allocator(void)
 {
@@ -25,10 +37,10 @@ static int setup_default_allocator(void)
 int git_allocator_global_init(void)
 {
 	/*
-	 * We don't want to overwrite any allocator which has been set before
-	 * the init function is called.
+	 * We don't want to overwrite any allocator which has been set
+	 * before the init function is called.
 	 */
-	if (git__allocator.gmalloc != NULL)
+	if (git__allocator.gmalloc != git_failalloc_malloc)
 		return 0;
 
 	return setup_default_allocator();

--- a/src/allocators/failalloc.c
+++ b/src/allocators/failalloc.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "failalloc.h"
+
+void *git_failalloc_malloc(size_t len, const char *file, int line)
+{
+	GIT_UNUSED(len);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+void *git_failalloc_calloc(size_t nelem, size_t elsize, const char *file, int line)
+{
+	GIT_UNUSED(nelem);
+	GIT_UNUSED(elsize);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+char *git_failalloc_strdup(const char *str, const char *file, int line)
+{
+	GIT_UNUSED(str);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+char *git_failalloc_strndup(const char *str, size_t n, const char *file, int line)
+{
+	GIT_UNUSED(str);
+	GIT_UNUSED(n);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+char *git_failalloc_substrdup(const char *start, size_t n, const char *file, int line)
+{
+	GIT_UNUSED(start);
+	GIT_UNUSED(n);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+void *git_failalloc_realloc(void *ptr, size_t size, const char *file, int line)
+{
+	GIT_UNUSED(ptr);
+	GIT_UNUSED(size);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+void *git_failalloc_reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line)
+{
+	GIT_UNUSED(ptr);
+	GIT_UNUSED(nelem);
+	GIT_UNUSED(elsize);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+void *git_failalloc_mallocarray(size_t nelem, size_t elsize, const char *file, int line)
+{
+	GIT_UNUSED(nelem);
+	GIT_UNUSED(elsize);
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	return NULL;
+}
+
+void git_failalloc_free(void *ptr)
+{
+	GIT_UNUSED(ptr);
+}

--- a/src/allocators/failalloc.h
+++ b/src/allocators/failalloc.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_allocators_failalloc_h__
+#define INCLUDE_allocators_failalloc_h__
+
+#include "common.h"
+
+extern void *git_failalloc_malloc(size_t len, const char *file, int line);
+extern void *git_failalloc_calloc(size_t nelem, size_t elsize, const char *file, int line);
+extern char *git_failalloc_strdup(const char *str, const char *file, int line);
+extern char *git_failalloc_strndup(const char *str, size_t n, const char *file, int line);
+extern char *git_failalloc_substrdup(const char *start, size_t n, const char *file, int line);
+extern void *git_failalloc_realloc(void *ptr, size_t size, const char *file, int line);
+extern void *git_failalloc_reallocarray(void *ptr, size_t nelem, size_t elsize, const char *file, int line);
+extern void *git_failalloc_mallocarray(size_t nelem, size_t elsize, const char *file, int line);
+extern void git_failalloc_free(void *ptr);
+
+#endif

--- a/src/errors.c
+++ b/src/errors.c
@@ -10,6 +10,7 @@
 #include "threadstate.h"
 #include "posix.h"
 #include "buffer.h"
+#include "libgit2.h"
 
 /********************************************
  * New error handling
@@ -18,6 +19,11 @@
 static git_error g_git_oom_error = {
 	"Out of memory",
 	GIT_ERROR_NOMEMORY
+};
+
+static git_error g_git_uninitialized_error = {
+	"libgit2 has not been initialized; you must call git_libgit2_init",
+	GIT_ERROR_INVALID
 };
 
 static void set_error_from_buffer(int error_class)
@@ -131,6 +137,10 @@ void git_error_clear(void)
 
 const git_error *git_error_last(void)
 {
+	/* If the library is not initialized, return a static error. */
+	if (!git_libgit2_init_count())
+		return &g_git_uninitialized_error;
+
 	return GIT_THREADSTATE->last_error;
 }
 

--- a/src/libgit2.c
+++ b/src/libgit2.c
@@ -90,6 +90,11 @@ int git_libgit2_init(void)
 	return git_runtime_init(init_fns, ARRAY_SIZE(init_fns));
 }
 
+int git_libgit2_init_count(void)
+{
+	return git_runtime_init_count();
+}
+
 int git_libgit2_shutdown(void)
 {
 	return git_runtime_shutdown();

--- a/src/libgit2.h
+++ b/src/libgit2.h
@@ -7,6 +7,8 @@
 #ifndef INCLUDE_libgit2_h__
 #define INCLUDE_libgit2_h__
 
+extern int git_libgit2_init_count(void);
+
 extern const char *git_libgit2__user_agent(void);
 extern const char *git_libgit2__ssl_ciphers(void);
 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -127,6 +127,21 @@ int git_runtime_init(git_runtime_init_fn init_fns[], size_t cnt)
 	return ret;
 }
 
+int git_runtime_init_count(void)
+{
+	int ret;
+
+	if (init_lock() < 0)
+		return -1;
+
+	ret = git_atomic32_get(&init_count);
+
+	if (init_unlock() < 0)
+		return -1;
+
+	return ret;
+}
+
 int git_runtime_shutdown(void)
 {
 	int ret;

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -28,6 +28,15 @@ typedef void (*git_runtime_shutdown_fn)(void);
  */
 int git_runtime_init(git_runtime_init_fn init_fns[], size_t cnt);
 
+/*
+ * Returns the number of initializations active (the number of calls to
+ * `git_runtime_init` minus the number of calls sto `git_runtime_shutdown`).
+ * If 0, the runtime is not currently initialized.
+ *
+ * @return The number of initializations performed or an error
+ */
+int git_runtime_init_count(void);
+
 /**
  * Shut down the runtime.  If this is the last shutdown call,
  * such that there are no remaining `init` calls, then any


### PR DESCRIPTION
We require the library to be initialized with git_libgit2_init before it is functional.  However, if a user tries to uses the library without doing so - as they might when getting started with the library for the first time - we will likely crash.

This PR attempts to set up some guard rails to help a user out in this case.

Now, instead of having _no_ allocator by default, we'll have an allocator that always fails, and never tries to set an error message (since the thread-local state is set up by git_libgit2_init).  We've modified the error retrieval function to (try to) ensure that the library has been initialized before getting the thread-local error message.

(Unfortunately, we cannot determine if the thread local storage has actually been configured, this does require initialization by git_libgit2_init.  But a naive attempt should be good enough for most cases.)

Of course, this pre-supposes that the first program a user builds will actually check the error message.  I'm not certain that this is generally true.  I actually often write a quick little program and forget to call git_libgit2_init (but do error checking).  But I don't think that I'm a very typical user of the library.

It might be valuable to `fprintf(stderr, "hey! call git_libgit2_init!\n")`...?  But I thought that I'd start with this PR here and iterate.

Depends on #5546 