### PR TITLE
Respect `init.defaultBranch` setting

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -172,7 +172,7 @@ static int update_head_to_remote(
 	git_refspec *refspec;
 	const git_remote_head *remote_head, **refs;
 	const git_oid *remote_head_id;
-	git_buf remote_master_name = GIT_BUF_INIT;
+	git_buf remote_branch_name = GIT_BUF_INIT;
 	git_buf branch = GIT_BUF_INIT;
 
 	if ((error = git_remote_ls(&refs, &refs_len, remote)) < 0)
@@ -203,9 +203,9 @@ static int update_head_to_remote(
 		goto cleanup;
 	}
 
-	/* Determine the remote tracking reference name from the local master */
+	/* Determine the remote tracking ref name from the local branch */
 	if ((error = git_refspec_transform(
-		&remote_master_name,
+		&remote_branch_name,
 		refspec,
 		git_buf_cstr(&branch))) < 0)
 		goto cleanup;
@@ -217,7 +217,7 @@ static int update_head_to_remote(
 		reflog_message);
 
 cleanup:
-	git_buf_dispose(&remote_master_name);
+	git_buf_dispose(&remote_branch_name);
 	git_buf_dispose(&branch);
 
 	return error;

--- a/src/refs.h
+++ b/src/refs.h
@@ -45,7 +45,6 @@ extern bool git_reference__enable_symbolic_ref_target_validation;
 #define GIT_REBASE_APPLY_DIR "rebase-apply/"
 #define GIT_REBASE_APPLY_REBASING_FILE GIT_REBASE_APPLY_DIR "rebasing"
 #define GIT_REBASE_APPLY_APPLYING_FILE GIT_REBASE_APPLY_DIR "applying"
-#define GIT_REFS_HEADS_MASTER_FILE GIT_REFS_HEADS_DIR "master"
 
 #define GIT_SEQUENCER_DIR "sequencer/"
 #define GIT_SEQUENCER_HEAD_FILE GIT_SEQUENCER_DIR "head"

--- a/src/repository.h
+++ b/src/repository.h
@@ -232,4 +232,10 @@ extern size_t git_repository__reserved_names_posix_len;
 bool git_repository__reserved_names(
 	git_buf **out, size_t *outlen, git_repository *repo, bool include_ntfs);
 
+/*
+ * The default branch for the repository; the `init.defaultBranch`
+ * configuration option, if set, or `master` if it is not.
+ */
+int git_repository_initialbranch(git_buf *out, git_repository *repo);
+
 #endif

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -665,3 +665,19 @@ void test_repo_init__unwriteable_directory(void)
 	clar__skip();
 #endif
 }
+
+void test_repo_init__defaultbranch_config(void)
+{
+	git_reference *head;
+
+	cl_set_cleanup(&cleanup_repository, "repo");
+
+	create_tmp_global_config("tmp_global_path", "init.defaultbranch", "my_default_branch");
+
+	cl_git_pass(git_repository_init(&_repo, "repo", 0));
+	cl_git_pass(git_reference_lookup(&head, _repo, "HEAD"));
+
+	cl_assert_equal_s("refs/heads/my_default_branch", git_reference_symbolic_target(head));
+
+	git_reference_free(head);
+}


### PR DESCRIPTION
The git project is moving towards [more inclusive language](https://github.com/git/git/commit/11cbda2add5d3eb7c415f1f6dd8186181a7f9874).  In particular, they're making the name of the "default" branch (currently "master") configurable with the `init.defaultBranch` setting.

We should follow suit for compatibility.