### PR TITLE
Build with NO_MMAP

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,6 +96,17 @@ jobs:
             ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-10
             TSAN_OPTIONS: suppressions=/home/libgit2/source/script/thread-sanitizer.supp second_deadlock_stack=1
           os: ubuntu-latest
+        - # Focal, Clang 10, mmap emulation (NO_MMAP)
+          container:
+            name: focal
+          env:
+            CC: clang-10
+            CFLAGS: -DNO_MMAP
+            CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local
+            CMAKE_GENERATOR: Ninja
+            SKIP_SSH_TESTS: true
+            SKIP_NEGOTIATE_TESTS: true
+          os: ubuntu-latest
         - # macOS
           os: macos-10.15
           env:
@@ -112,6 +123,15 @@ jobs:
             ARCH: amd64
             CMAKE_GENERATOR: Visual Studio 16 2019
             CMAKE_OPTIONS: -A x64 -DWIN32_LEAKCHECK=ON -DDEPRECATE_HARD=ON
+            SKIP_SSH_TESTS: true
+            SKIP_NEGOTIATE_TESTS: true
+        - # Windows amd64 Visual Studio (NO_MMAP)
+          os: windows-2019
+          env:
+            ARCH: amd64
+            CMAKE_GENERATOR: Visual Studio 16 2019
+            CFLAGS: -DNO_MMAP
+            CMAKE_OPTIONS: -A x64 -DDEPRECATE_HARD=ON
             SKIP_SSH_TESTS: true
             SKIP_NEGOTIATE_TESTS: true
         - # Windows x86 Visual Studio

--- a/src/posix.h
+++ b/src/posix.h
@@ -89,6 +89,12 @@
 #define EAFNOSUPPORT (INT_MAX-1)
 #endif
 
+/* Compiler independent macro to handle signal interrpted system calls */
+#define HANDLE_EINTR(result, x) do {					\
+		result = (x);						\
+	} while (result == -1 && errno == EINTR);
+
+
 /* Provide a 64-bit size for offsets. */
 
 #if defined(_MSC_VER)
@@ -118,6 +124,9 @@ typedef int git_file;
 
 extern ssize_t p_read(git_file fd, void *buf, size_t cnt);
 extern int p_write(git_file fd, const void *buf, size_t cnt);
+
+extern ssize_t p_pread(int fd, void *data, size_t size, off64_t offset);
+extern ssize_t p_pwrite(int fd, const void *data, size_t size, off64_t offset);
 
 #define p_close(fd) close(fd)
 #define p_umask(m) umask(m)

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -101,4 +101,7 @@ GIT_INLINE(int) p_futimes(int f, const struct p_timeval t[2])
 # define p_futimes futimes
 #endif
 
+#define p_pread(f, d, s, o) pread(f, d, s, o)
+#define p_pwrite(f, d, s, o) pwrite(f, d, s, o)
+
 #endif


### PR DESCRIPTION
This patch fixes building libgit2 without mmap (NO_MMAP)

Since 'mmap' does not update the position in file descriptor. Hence, we have to capture and restore the position of file descriptor in 'mmap' emulation.