### PR TITLE
Make the odb race-free

### DIFF
--- a/script/thread-sanitizer.supp
+++ b/script/thread-sanitizer.supp
@@ -8,11 +8,6 @@ deadlock:attr_cache_lock
 # data races.
 called_from_lib:libc.so.6
 
-# TODO(#5595): Remove these once the fixes land.
-race:src/odb.c
-race:git_repository_odb__weakptr
-race:cache_store
-
-# TODO(#5595): Investigate and fix this. It can be triggered by the `thread`
+# TODO(#5592): Investigate and fix this. It can be triggered by the `thread`
 # test suite.
 race:git_filter_list__load_ext

--- a/src/odb.h
+++ b/src/odb.h
@@ -40,6 +40,7 @@ struct git_odb_object {
 /* EXPORT */
 struct git_odb {
 	git_refcount rc;
+	git_mutex lock;  /* protects backends */
 	git_vector backends;
 	git_cache own_cache;
 	unsigned int do_fsync :1;

--- a/src/repository.c
+++ b/src/repository.c
@@ -1107,7 +1107,8 @@ int git_repository_odb__weakptr(git_odb **out, git_repository *repo)
 	GIT_ASSERT_ARG(repo);
 	GIT_ASSERT_ARG(out);
 
-	if (repo->_odb == NULL) {
+	*out = git__load(repo->_odb);
+	if (*out == NULL) {
 		git_buf odb_path = GIT_BUF_INIT;
 		git_odb *odb;
 
@@ -1131,9 +1132,9 @@ int git_repository_odb__weakptr(git_odb **out, git_repository *repo)
 		}
 
 		git_buf_dispose(&odb_path);
+		*out = git__load(repo->_odb);
 	}
 
-	*out = repo->_odb;
 	return error;
 }
 


### PR DESCRIPTION
This change adds all the necessary locking to the odb to avoid races in
the backends.
    
Part of: #5592