### PR TITLE
Fix `git_mwindow_scan_recently_used` spuriously returning true

### DIFF
--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -184,7 +184,8 @@ int git_mwindow_contains(git_mwindow *win, off64_t offset)
 /*
  * Find the least- or most-recently-used window in a file that is not currently
  * being used. The 'only_unused' flag controls whether the caller requires the
- * file to only have unused windows.
+ * file to only have unused windows. If '*out_window' is non-null, it is used as
+ * a starting point for the comparison.
  *
  * Returns whether such a window was found in the file.
  */
@@ -197,9 +198,14 @@ static bool git_mwindow_scan_recently_used(
 {
 	git_mwindow *w, *w_last;
 	git_mwindow *lru_window = NULL, *lru_last = NULL;
+	bool found = false;
 
 	assert(mwf);
 	assert(out_window);
+
+	lru_window = *out_window;
+	if (out_last)
+		lru_last = *out_last;
 
 	for (w_last = NULL, w = mwf->windows; w; w_last = w, w = w->next) {
 		if (w->inuse_cnt) {
@@ -219,10 +225,11 @@ static bool git_mwindow_scan_recently_used(
 				(comparison_sign == GIT_MWINDOW__MRU && lru_window->last_used < w->last_used)) {
 			lru_window = w;
 			lru_last = w_last;
+			found = true;
 		}
 	}
 
-	if (!lru_window)
+	if (!found)
 		return false;
 
 	*out_window = lru_window;

--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -201,10 +201,6 @@ static bool git_mwindow_scan_recently_used(
 	assert(mwf);
 	assert(out_window);
 
-	lru_window = *out_window;
-	if (out_last)
-		lru_last = *out_last;
-
 	for (w_last = NULL, w = mwf->windows; w; w_last = w, w = w->next) {
 		if (w->inuse_cnt) {
 			if (only_unused)
@@ -226,7 +222,7 @@ static bool git_mwindow_scan_recently_used(
 		}
 	}
 
-	if (!lru_window && !lru_last)
+	if (!lru_window)
 		return false;
 
 	*out_window = lru_window;


### PR DESCRIPTION
If `*out_window` was already non-null, then this function would always return true.

This was causing `git_mwindow_close_lru_window` to not remove the correct window from the list, leading to a double free.

Fixes #5591 