### PR TITLE
Build generic internal library interface for thread local storage

### DIFF
--- a/src/thread-utils.c
+++ b/src/thread-utils.c
@@ -56,3 +56,208 @@ int git_online_cpus(void)
 
 	return 1;
 }
+
+#ifndef GIT_THREADS
+
+struct git_tls_data {
+	void GIT_CALLBACK(free_fn)(void *payload);
+	void *storage;
+};
+
+int git_tls_data__init(git_tls_data **out,
+	void GIT_CALLBACK(free_fn)(void *storage))
+{
+	struct git_tls_data *tls = git__malloc(sizeof(struct git_tls_data));
+	GIT_ERROR_CHECK_ALLOC(tls);
+
+	tls->storage = NULL;
+	tls->free_fn = free_fn;
+	*out = tls;
+
+	return 0;
+}
+
+int git_tls_data__set(git_tls_data *tls, void *payload)
+{
+	tls->storage = payload;
+	return 0;
+}
+
+void *git_tls_data__get(git_tls_data *tls)
+{
+	return tls->storage;
+}
+
+void git_tls_data__free(git_tls_data *tls)
+{
+	tls->free_fn(tls->storage);
+	git__free(tls);
+}
+
+#elif defined(GIT_WIN32)
+
+struct git_tls_data {
+	void GIT_CALLBACK(free_fn)(void *payload);
+	DWORD fls_index;
+};
+
+struct git_tls_cell {
+	void GIT_CALLBACK(free_fn)(void *storage);
+	void *storage;
+};
+
+static void WINAPI git_tls_cell__free(void *sc)
+{
+  struct git_tls_cell *storage_cell = sc;
+	if (storage_cell == NULL) {
+		return;
+	}
+
+	storage_cell->free_fn(storage_cell->storage);
+	git__free(storage_cell);
+}
+
+int git_tls_data__init(git_tls_data **out,
+	void GIT_CALLBACK(free_fn)(void *payload))
+{
+	struct git_tls_data *tls = git__malloc(sizeof(struct git_tls_data));
+	GIT_ERROR_CHECK_ALLOC(tls);
+
+	if ((tls->fls_index = FlsAlloc(git_tls_cell__free)) == FLS_OUT_OF_INDEXES) {
+		git__free(tls);
+		return -1;
+	}
+
+	tls->free_fn = free_fn;
+	*out = tls;
+
+	return 0;
+}
+
+int git_tls_data__set(git_tls_data *tls, void *payload)
+{
+	struct git_tls_cell *storage_cell;
+
+	if (payload == NULL) {
+		if ((storage_cell = FlsGetValue(tls->fls_index)) != NULL)
+			git_tls_cell__free(storage_cell);
+
+		if (FlsSetValue(tls->fls_index, NULL) == 0)
+			return -1;
+
+		return 0;
+	}
+
+	storage_cell = git__malloc(sizeof(struct git_tls_cell));
+	GIT_ERROR_CHECK_ALLOC(storage_cell);
+
+	storage_cell->free_fn = tls->free_fn;
+	storage_cell->storage = payload;
+
+	if (FlsSetValue(tls->fls_index, storage_cell) == 0) {
+		git__free(storage_cell);
+		return -1;
+	}
+
+	return 0;
+}
+
+void *git_tls_data__get(git_tls_data *tls)
+{
+	struct git_tls_cell *storage_cell = FlsGetValue(tls->fls_index);
+	if (storage_cell == NULL)
+		return NULL;
+
+	return storage_cell->storage;
+}
+
+void git_tls_data__free(git_tls_data *tls)
+{
+	FlsFree(tls->fls_index);
+	tls->free_fn = NULL;
+	git__free(tls);
+}
+
+#elif defined(_POSIX_THREADS)
+
+struct git_tls_data {
+	void GIT_CALLBACK(free_fn)(void *payload);
+	pthread_key_t tls_key;
+};
+
+struct git_tls_cell {
+	void GIT_CALLBACK(free_fn)(void *storage);
+	void *storage;
+};
+
+static void git_tls_cell__free(void *sc)
+{
+  struct git_tls_cell *storage_cell = sc;
+	storage_cell->free_fn(storage_cell->storage);
+	git__free(storage_cell);
+}
+
+int git_tls_data__init(git_tls_data **out,
+	void GIT_CALLBACK(free_fn)(void *payload))
+{
+	struct git_tls_data *tls = git__malloc(sizeof(struct git_tls_data));
+	GIT_ERROR_CHECK_ALLOC(tls);
+
+	if (pthread_key_create(&tls->tls_key, git_tls_cell__free) != 0) {
+		git__free(tls);
+		return -1;
+	}
+
+	tls->free_fn = free_fn;
+	*out = tls;
+
+	return 0;
+}
+
+int git_tls_data__set(git_tls_data *tls, void *payload)
+{
+	struct git_tls_cell *storage_cell;
+
+	if (payload == NULL) {
+		if ((storage_cell = pthread_getspecific(tls->tls_key)) != NULL)
+			git_tls_cell__free(storage_cell);
+
+		if (pthread_setspecific(tls->tls_key, NULL) != 0)
+			return -1;
+
+		return 0;
+	}
+
+	storage_cell = git__malloc(sizeof(struct git_tls_cell));
+	GIT_ERROR_CHECK_ALLOC(storage_cell);
+
+	storage_cell->free_fn = tls->free_fn;
+	storage_cell->storage = payload;
+
+	if (pthread_setspecific(tls->tls_key, storage_cell) != 0) {
+		git__free(storage_cell);
+		return -1;
+	}
+
+	return 0;
+}
+
+void *git_tls_data__get(git_tls_data *tls)
+{
+	struct git_tls_cell *storage_cell = pthread_getspecific(tls->tls_key);
+	if (storage_cell == NULL)
+		return NULL;
+
+	return storage_cell->storage;
+}
+
+void git_tls_data__free(git_tls_data *tls)
+{
+	git_tls_data__set(tls, NULL);
+	pthread_key_delete(tls->tls_key);
+	git__free(tls);
+}
+
+#else
+#  error unknown threading model
+#endif

--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -243,4 +243,52 @@ extern int git_online_cpus(void);
 # define GIT_MEMORY_BARRIER /* noop */
 #endif
 
+/**
+ * An opaque structure for managing TLS in the library
+ */
+typedef struct git_tls_data git_tls_data;
+
+/**
+ * Initializes a thread local storage container.
+ * This has an implementation even without GIT_THREADS
+ * which just serves to encourage use of this where TLS
+ * is necessary.
+ *
+ * Do not call this before the allocator has been initialized.
+ *
+ * @param  out a pointer to store the TLS container in
+ * @param  free_fn the method that should be called when
+ *                 deleting something in the TLS. Will be
+ *                 registered as the clean up callback for
+ *                 the OS specific TLS construct.
+ * @return 0 on success, non-zero on failure
+ */
+int git_tls_data__init(git_tls_data **out,
+	void GIT_CALLBACK(free_fn)(void *payload));
+
+/**
+ * Will set a thread specific value on the TLS. Passing NULL will free the
+ * currently held thread specific value.
+ *
+ * @param  tls the TLS instance to store data on
+ * @param  payload the pointer to store
+ * @return 0 on success, non-zero on failure
+ */
+int git_tls_data__set(git_tls_data *tls, void *payload);
+
+/**
+ * Will get the thread specific value stored in TLS.
+ *
+ * @param  tls the TLS instance to retrieve data from
+ */
+void *git_tls_data__get(git_tls_data *tls);
+
+/**
+ * Must call this to clean up the TLS when no longer in use.
+ * The TLS pointer is unusable after a call to this.
+ * 
+ * @param tls the TLS to free
+ */
+void git_tls_data__free(git_tls_data *tls);
+
 #endif


### PR DESCRIPTION
As the library starts using more threads internally to accelerate certain operations, it becomes more necessary to easily usable TLS handles. My threaded checkout PR I opened awhile ago would be able to address the abundance of allocations I introduced around the `target_path` and `tmp` buffers in `checkout_data` by converting those parts of the `checkout_data` structure to TLS. That way, the performance benefits of not over allocating in single threaded checkout does not suffer at all.

This PR replaces the way we setup the global state on TLS. I was hoping that it might be fairly simple to bring in this change set with #5546 instead of using the proposed tlsdata from that PR.

Thoughts? @ethomson @pks-t