### PR TITLE
Fix crash in git_describe_commit when opts are NULL.

### DIFF
--- a/src/describe.c
+++ b/src/describe.c
@@ -685,7 +685,7 @@ int git_describe_commit(
 			get_name, &data)) < 0)
 				goto cleanup;
 
-	if (git_oidmap_size(data.names) == 0 && !opts->show_commit_oid_as_fallback) {
+	if (git_oidmap_size(data.names) == 0 && !normalized.show_commit_oid_as_fallback) {
 		git_error_set(GIT_ERROR_DESCRIBE, "cannot describe - "
 			"no reference found, cannot describe anything.");
 		error = -1;


### PR DESCRIPTION
The argument "opts" can be NULL, which selects default options. Do not access
"opts" directly but only the normalized copy.