### PR TITLE
patch_parse: handle absence of "index" header for new/deleted cases

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -407,6 +407,7 @@ static const parse_header_transition transitions[] = {
 
 	{ "--- "                , STATE_DIFF,       STATE_PATH,       parse_header_git_oldpath },
 	{ "--- "                , STATE_INDEX,      STATE_PATH,       parse_header_git_oldpath },
+	{ "--- "                , STATE_FILEMODE,   STATE_PATH,       parse_header_git_oldpath },
 	{ "+++ "                , STATE_PATH,       STATE_END,        parse_header_git_newpath },
 	{ "GIT binary patch"    , STATE_INDEX,      STATE_END,        NULL },
 	{ "Binary files "       , STATE_INDEX,      STATE_END,        NULL },

--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -107,6 +107,29 @@ void test_diff_parse__no_extended_headers(void)
 	git_diff_free(diff);
 }
 
+void test_diff_parse__add_delete_no_index(void)
+{
+	const char *content =
+	    "diff --git a/file.txt b/file.txt\n"
+	    "new file mode 100644\n"
+	    "--- /dev/null\n"
+	    "+++ b/file.txt\n"
+	    "@@ -0,0 +1,2 @@\n"
+	    "+one\n"
+	    "+two\n"
+	    "diff --git a/otherfile.txt b/otherfile.txt\n"
+	    "deleted file mode 100644\n"
+	    "--- a/otherfile.txt\n"
+	    "+++ /dev/null\n"
+	    "@@ -1,1 +0,0 @@\n"
+	    "-three\n";
+	git_diff *diff;
+
+	cl_git_pass(git_diff_from_buffer(
+		&diff, content, strlen(content)));
+	git_diff_free(diff);
+}
+
 void test_diff_parse__invalid_patches_fails(void)
 {
 	test_parse_invalid_diff(PATCH_CORRUPT_MISSING_NEW_FILE);


### PR DESCRIPTION
This follows up on 11de594f85479e4804b07dc4f7b33cfe9212bea0 which added support for parsing patches without extended headers (the "index <hash>..<hash> <mode>" line); issue #5267.

We now allow transition from "file mode" state to "path" state directly if there is no "index", which will happen for patches adding or deleting files as demonstrated in added test case.