### PR TITLE
Return false instead of segfaulting when checking for default port

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -336,7 +336,12 @@ bool git_net_url_valid(git_net_url *url)
 
 int git_net_url_is_default_port(git_net_url *url)
 {
-	return (strcmp(url->port, default_port_for_scheme(url->scheme)) == 0);
+	const char *default_port;
+
+	if ((default_port = default_port_for_scheme(url->scheme)) != NULL)
+		return (strcmp(url->port, default_port) == 0);
+	else
+		return false;
 }
 
 void git_net_url_swap(git_net_url *a, git_net_url *b)


### PR DESCRIPTION
`default_port_for_scheme` returns NULL if the scheme is not one of the
builtin ones. This may cause a segmentation fault if a custom transport
URL happens to contain a port number, and this code path is triggered
(e.g. by setting git_fetch_options->update_fetchhead to 1).