### PR TITLE
Don't fail if a HTTP server announces he supports a protocol upgrade

### DIFF
--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1120,11 +1120,6 @@ GIT_INLINE(int) client_read_and_parse(git_http_client *client)
 		return -1;
 	}
 
-	if (parser->upgrade) {
-		git_error_set(GIT_ERROR_HTTP, "server requested upgrade");
-		return -1;
-	}
-
 	if (ctx->parse_status == PARSE_STATUS_ERROR) {
 		client->connected = 0;
 		return ctx->error ? ctx->error : -1;


### PR DESCRIPTION
cf. RFC7230 section 6.7, an Upgrade header in a normal response merely informs the client that the server supports upgrading to other protocols, and the client can ask for such an upgrade in a later request. The server requiring an upgrade is via the 426 Upgrade Required response code, not the mere presence of the Upgrade response header.

(closes issue #5573)

Signed-off-by: Sven Strickroth <email@cs-ware.de>