### PR TITLE
Fix release build warnings

### DIFF
--- a/src/patch_parse.c
+++ b/src/patch_parse.c
@@ -198,7 +198,7 @@ static int parse_header_git_index(
 		return -1;
 
 	if (git_parse_peek(&c, &ctx->parse_ctx, 0) == 0 && c == ' ') {
-		uint16_t mode;
+		uint16_t mode = 0;
 
 		git_parse_advance_chars(&ctx->parse_ctx, 1);
 

--- a/src/refs.c
+++ b/src/refs.c
@@ -606,7 +606,7 @@ int git_reference_rename(
 	const char *log_message)
 {
 	refs_update_head_payload payload;
-	git_signature *signature;
+	git_signature *signature = NULL;
 	git_repository *repo;
 	int error;
 

--- a/src/sysdir.c
+++ b/src/sysdir.c
@@ -298,8 +298,11 @@ static int git_sysdir_find_in_dirlist(
 	}
 
 done:
+	if (name)
+		git_error_set(GIT_ERROR_OS, "the %s file '%s' doesn't exist", label, name);
+	else
+		git_error_set(GIT_ERROR_OS, "the %s directory doesn't exist", label);
 	git_buf_dispose(path);
-	git_error_set(GIT_ERROR_OS, "the %s file '%s' doesn't exist", label, name);
 	return GIT_ENOTFOUND;
 }
 


### PR DESCRIPTION
This fixes some warnings generated by GCC when building with `-DCMAKE_BUILD_TYPE=Release`.