### PR TITLE
Change bare free to allocator free (fixes #5653)

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -2045,7 +2045,7 @@ int git_path_validate_system_file_ownership(const char *path)
 		git_error_set(GIT_ERROR_INVALID, "programdata configuration file owner is not valid");
 		ret = GIT_ERROR;
 	}
-	free(info);
+	git__free(info);
 
 cleanup:
 	if (descriptor)


### PR DESCRIPTION
The info pointer was allocated with git__malloc, so needs to be free'd with git__free.
This bug can lurk pretty easily since if there's no custom allocator this is fine.