### PR TITLE
ntlm: update ntlm dependency for htonll

### DIFF
--- a/deps/ntlmclient/compat.h
+++ b/deps/ntlmclient/compat.h
@@ -21,40 +21,6 @@
 # include <stdbool.h>
 #endif
 
-#if defined(_WIN32) || defined(__APPLE__)
-/* winsock and macOS > 10.9 have htonll already */
-#elif defined(__linux__)
-/* See man page endian(3) */
-# include <endian.h>
-# define htonll htobe64
-#elif defined(__NetBSD__) || defined(__OpenBSD__)
-/* See man page htobe64(3) */
-# include <endian.h>
-# define htonll htobe64
-#elif defined(__FreeBSD__)
-/* See man page bwaps64(9) */
-# include <sys/endian.h>
-# define htonll htobe64
-#elif defined(sun) || defined(__sun)
-/* See man page byteorder(3SOCKET) */
-# include <sys/types.h>
-# include <netinet/in.h>
-# include <inttypes.h>
-
-# if !defined(htonll)
-#  if defined(_BIG_ENDIAN)
-#   define htonll(x) (x)
-#  else
-#   define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl((uint64_t)(x) >> 32))
-#  endif
-# endif
-#elif defined(__HAIKU__)
-# include <ByteOrder.h>
-# define htonll B_HOST_TO_BENDIAN_INT64
-#else
-# error "Please implement htonll for your platform"
-#endif
-
 #ifndef MIN
 # define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif

--- a/deps/ntlmclient/crypt_openssl.c
+++ b/deps/ntlmclient/crypt_openssl.c
@@ -71,7 +71,7 @@ static inline void HMAC_CTX_free(HMAC_CTX *ctx)
 static inline int HMAC_CTX_reset(HMAC_CTX *ctx)
 {
 	HMAC_CTX_cleanup(ctx);
-	memzero(ctx, sizeof(HMAC_CTX));
+	ntlm_memzero(ctx, sizeof(HMAC_CTX));
 	return 1;
 }
 

--- a/deps/ntlmclient/ntlm.c
+++ b/deps/ntlmclient/ntlm.c
@@ -132,10 +132,10 @@ int ntlm_client_set_hostname(
 static void free_credentials(ntlm_client *ntlm)
 {
 	if (ntlm->password)
-		memzero(ntlm->password, strlen(ntlm->password));
+		ntlm_memzero(ntlm->password, strlen(ntlm->password));
 
 	if (ntlm->password_utf16)
-		memzero(ntlm->password_utf16, ntlm->password_utf16_len);
+		ntlm_memzero(ntlm->password_utf16, ntlm->password_utf16_len);
 
 	free(ntlm->username);
 	free(ntlm->username_upper);
@@ -1125,7 +1125,7 @@ static bool generate_lm2_response(ntlm_client *ntlm,
 	size_t lm2_len = 16;
 	uint64_t local_nonce;
 
-	local_nonce = htonll(ntlm->nonce);
+	local_nonce = ntlm_htonll(ntlm->nonce);
 
 	if (!ntlm_hmac_ctx_reset(ntlm->hmac_ctx) ||
 		!ntlm_hmac_md5_init(ntlm->hmac_ctx,
@@ -1197,8 +1197,8 @@ static bool generate_ntlm2_response(ntlm_client *ntlm)
 
 	/* the blob's integer values are in network byte order */
 	signature = htonl(0x01010000);
-	timestamp = htonll(ntlm->timestamp);
-	nonce = htonll(ntlm->nonce);
+	timestamp = ntlm_htonll(ntlm->timestamp);
+	nonce = ntlm_htonll(ntlm->nonce);
 
 	/* construct the blob */
 	memcpy(&blob[0], &signature, 4);

--- a/deps/ntlmclient/util.c
+++ b/deps/ntlmclient/util.c
@@ -8,14 +8,28 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <arpa/inet.h>
 
 #include "compat.h"
 #include "util.h"
 
-void memzero(void *data, size_t size)
+void ntlm_memzero(void *data, size_t size)
 {
 	volatile uint8_t *scan = (volatile uint8_t *)data;
 
 	while (size--)
 		*scan++ = 0x0;
+}
+
+uint64_t ntlm_htonll(uint64_t value)
+{
+	static union {
+		uint32_t i;
+		char c[8];
+	} test = { 0x01020304 };
+
+	if (test.c[0] == 0x01)
+		return value;
+	else
+		return ((uint64_t)htonl(value) << 32) | htonl((uint64_t)value >> 32);
 }

--- a/deps/ntlmclient/util.h
+++ b/deps/ntlmclient/util.h
@@ -9,6 +9,7 @@
 #ifndef PRIVATE_UTIL_H__
 #define PRIVATE_UTIL_H__
 
-extern void memzero(void *data, size_t size);
+extern void ntlm_memzero(void *data, size_t size);
+extern uint64_t ntlm_htonll(uint64_t value);
 
 #endif /* PRIVATE_UTIL_H__ */


### PR DESCRIPTION
Update ntlm to include an htonll that is not dependent on system
libraries.