### PR TITLE
Deprecate `is_valid_name` functions; replace with `name_is_valid` functions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,18 @@
+vNext
+-----
+
+### Changes or improvements
+
+* Branch and tag name validation functions have been introduced:
+  `git_branch_name_is_valid` will check if a branch name is valid,
+  and `git_tag_name_is_valid` will check if a tag name is valid.
+
+* Some remote and reference validity checking functions have been
+  introduced with error reporting semantics.  `git_remote_name_is_valid`
+  replaces `git_remote_is_valid_name`.  `git_reference_name_is_valid`
+  replaces `git_reference_is_valid_name`.  Tthe former functions are
+  deprecated.
+
 v1.1
 ----
 

--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -304,6 +304,18 @@ GIT_EXTERN(int) git_branch_remote_name(
  */
  GIT_EXTERN(int) git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname);
 
+/**
+ * Determine whether a branch name is valid, meaning that (when prefixed
+ * with `refs/heads/`) that it is a valid reference name, and that any
+ * additional branch name restrictions are imposed (eg, it cannot start
+ * with a `-`).
+ *
+ * @param valid output pointer to set with validity of given branch name
+ * @param name a branch name to test
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) git_branch_name_is_valid(int *valid, const char *name);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -340,6 +340,27 @@ GIT_EXTERN(size_t) git_object__size(git_object_t type);
 
 /**@}*/
 
+/** @name Deprecated Remote Functions
+ *
+ * These functions are retained for backward compatibility.  The newer
+ * versions of these functions should be preferred in all new code.
+ *
+ * There is no plan to remove these backward compatibility functions at
+ * this time.
+ */
+/**@{*/
+
+/**
+ * Ensure the remote name is well-formed.
+ *
+ * @deprecated Use git_remote_name_is_valid
+ * @param remote_name name to be checked.
+ * @return 1 if the reference name is acceptable; 0 if it isn't
+ */
+GIT_EXTERN(int) git_remote_is_valid_name(const char *remote_name);
+
+/**@}*/
+
 /** @name Deprecated Reference Functions and Constants
  *
  * These functions and enumeration values are retained for backward

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -340,10 +340,11 @@ GIT_EXTERN(size_t) git_object__size(git_object_t type);
 
 /**@}*/
 
-/** @name Deprecated Reference Constants
+/** @name Deprecated Reference Functions and Constants
  *
- * These enumeration values are retained for backward compatibility.  The
- * newer versions of these values should be preferred in all new code.
+ * These functions and enumeration values are retained for backward
+ * compatibility.  The newer versions of these values should be
+ * preferred in all new code.
  *
  * There is no plan to remove these backward compatibility values at
  * this time.
@@ -363,6 +364,23 @@ GIT_EXTERN(size_t) git_object__size(git_object_t type);
 #define GIT_REF_FORMAT_ALLOW_ONELEVEL GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL
 #define GIT_REF_FORMAT_REFSPEC_PATTERN GIT_REFERENCE_FORMAT_REFSPEC_PATTERN
 #define GIT_REF_FORMAT_REFSPEC_SHORTHAND GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND
+
+/**
+ * Ensure the reference name is well-formed.
+ *
+ * Valid reference names must follow one of two patterns:
+ *
+ * 1. Top-level names must contain only capital letters and underscores,
+ *    and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
+ * 2. Names prefixed with "refs/" can be almost anything.  You must avoid
+ *    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
+ *    sequences ".." and "@{" which have special meaning to revparse.
+ *
+ * @deprecated Use git_reference_name_is_valid
+ * @param refname name to be checked.
+ * @return 1 if the reference name is acceptable; 0 if it isn't
+ */
+GIT_EXTERN(int) git_reference_is_valid_name(const char *refname);
 
 GIT_EXTERN(int) git_tag_create_frombuffer(
 	git_oid *oid,

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -743,6 +743,23 @@ GIT_EXTERN(int) git_reference_peel(
  *    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
  *    sequences ".." and "@{" which have special meaning to revparse.
  *
+ * @param valid output pointer to set with validity of given reference name
+ * @param refname name to be checked.
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) git_reference_name_is_valid(int *valid, const char *refname);
+
+/**
+ * Ensure the reference name is well-formed.
+ *
+ * Valid reference names must follow one of two patterns:
+ *
+ * 1. Top-level names must contain only capital letters and underscores,
+ *    and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
+ * 2. Names prefixed with "refs/" can be almost anything.  You must avoid
+ *    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
+ *    sequences ".." and "@{" which have special meaning to revparse.
+ *
  * @param refname name to be checked.
  * @return 1 if the reference name is acceptable; 0 if it isn't
  */

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -750,22 +750,6 @@ GIT_EXTERN(int) git_reference_peel(
 GIT_EXTERN(int) git_reference_name_is_valid(int *valid, const char *refname);
 
 /**
- * Ensure the reference name is well-formed.
- *
- * Valid reference names must follow one of two patterns:
- *
- * 1. Top-level names must contain only capital letters and underscores,
- *    and must begin and end with a letter. (e.g. "HEAD", "ORIG_HEAD").
- * 2. Names prefixed with "refs/" can be almost anything.  You must avoid
- *    the characters '~', '^', ':', '\\', '?', '[', and '*', and the
- *    sequences ".." and "@{" which have special meaning to revparse.
- *
- * @param refname name to be checked.
- * @return 1 if the reference name is acceptable; 0 if it isn't
- */
-GIT_EXTERN(int) git_reference_is_valid_name(const char *refname);
-
-/**
  * Get the reference's short name
  *
  * This will transform the reference name into a name "human-readable"

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -922,14 +922,6 @@ GIT_EXTERN(int) git_remote_rename(
 int git_remote_name_is_valid(int *valid, const char *remote_name);
 
 /**
- * Ensure the remote name is well-formed.
- *
- * @param remote_name name to be checked.
- * @return 1 if the reference name is acceptable; 0 if it isn't
- */
-GIT_EXTERN(int) git_remote_is_valid_name(const char *remote_name);
-
-/**
 * Delete an existing persisted remote.
 *
 * All remote-tracking branches and configuration settings

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -915,6 +915,15 @@ GIT_EXTERN(int) git_remote_rename(
 /**
  * Ensure the remote name is well-formed.
  *
+ * @param valid output pointer to set with validity of given remote name
+ * @param remote_name name to be checked.
+ * @return 0 on success or an error code
+ */
+int git_remote_name_is_valid(int *valid, const char *remote_name);
+
+/**
+ * Ensure the remote name is well-formed.
+ *
  * @param remote_name name to be checked.
  * @return 1 if the reference name is acceptable; 0 if it isn't
  */

--- a/include/git2/tag.h
+++ b/include/git2/tag.h
@@ -365,6 +365,18 @@ GIT_EXTERN(int) git_tag_peel(
  */
 GIT_EXTERN(int) git_tag_dup(git_tag **out, git_tag *source);
 
+/**
+ * Determine whether a tag name is valid, meaning that (when prefixed
+ * with `refs/tags/`) that it is a valid reference name, and that any
+ * additional tag name restrictions are imposed (eg, it cannot start
+ * with a `-`).
+ *
+ * @param valid output pointer to set with validity of given tag name
+ * @param name a tag name to test
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) git_tag_name_is_valid(int *valid, const char *name);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/src/branch.c
+++ b/src/branch.c
@@ -723,3 +723,32 @@ int git_branch_is_head(
 
 	return is_same;
 }
+
+int git_branch_name_is_valid(int *valid, const char *name)
+{
+	git_buf ref_name = GIT_BUF_INIT;
+	int error = 0;
+
+	GIT_ASSERT(valid);
+
+	*valid = 0;
+
+	/*
+	 * Discourage branch name starting with dash,
+	 * https://github.com/git/git/commit/6348624010888b
+	 * and discourage HEAD as branch name,
+	 * https://github.com/git/git/commit/a625b092cc5994
+	 */
+	if (!name || name[0] == '-' || !git__strcmp(name, "HEAD"))
+		goto done;
+
+	if ((error = git_buf_puts(&ref_name, GIT_REFS_HEADS_DIR)) < 0 ||
+	    (error = git_buf_puts(&ref_name, name)) < 0)
+		goto done;
+
+	error = git_reference_name_is_valid(valid, ref_name.ptr);
+
+done:
+	git_buf_dispose(&ref_name);
+	return error;
+}

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -21,9 +21,12 @@
 
 static int maybe_want(git_remote *remote, git_remote_head *head, git_odb *odb, git_refspec *tagspec, git_remote_autotag_option_t tagopt)
 {
-	int match = 0;
+	int match = 0, valid;
 
-	if (!git_reference_is_valid_name(head->name))
+	if (git_reference_name_is_valid(&valid, head->name) < 0)
+		return -1;
+
+	if (!valid)
 		return 0;
 
 	if (tagopt == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {

--- a/src/refs.c
+++ b/src/refs.c
@@ -1287,19 +1287,32 @@ cleanup:
 	return error;
 }
 
-int git_reference__is_valid_name(const char *refname, unsigned int flags)
+int git_reference__name_is_valid(
+	int *valid,
+	const char *refname,
+	unsigned int flags)
 {
-	if (git_reference__normalize_name(NULL, refname, flags) < 0) {
-		git_error_clear();
-		return false;
-	}
+	int error;
 
-	return true;
+	*valid = 0;
+
+	error = git_reference__normalize_name(NULL, refname, flags);
+
+	if (!error)
+		*valid = 1;
+	else if (error == GIT_EINVALIDSPEC)
+		error = 0;
+
+	return error;
 }
 
 int git_reference_is_valid_name(const char *refname)
 {
-	return git_reference__is_valid_name(refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
+	int valid = 0;
+
+	git_reference__name_is_valid(&valid, refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
+
+	return valid;
 }
 
 const char *git_reference__shorthand(const char *name)

--- a/src/refs.c
+++ b/src/refs.c
@@ -239,7 +239,7 @@ int git_reference_lookup_resolved(
 
 int git_reference_dwim(git_reference **out, git_repository *repo, const char *refname)
 {
-	int error = 0, i;
+	int error = 0, i, valid;
 	bool fallbackmode = true, foundvalid = false;
 	git_reference *ref;
 	git_buf refnamebuf = GIT_BUF_INIT, name = GIT_BUF_INIT;
@@ -265,10 +265,11 @@ int git_reference_dwim(git_reference **out, git_repository *repo, const char *re
 
 		git_buf_clear(&refnamebuf);
 
-		if ((error = git_buf_printf(&refnamebuf, formatters[i], git_buf_cstr(&name))) < 0)
+		if ((error = git_buf_printf(&refnamebuf, formatters[i], git_buf_cstr(&name))) < 0 ||
+		    (error = git_reference_name_is_valid(&valid, git_buf_cstr(&refnamebuf))) < 0)
 			goto cleanup;
 
-		if (!git_reference_is_valid_name(git_buf_cstr(&refnamebuf))) {
+		if (!valid) {
 			error = GIT_EINVALIDSPEC;
 			continue;
 		}

--- a/src/refs.c
+++ b/src/refs.c
@@ -1314,15 +1314,6 @@ int git_reference_name_is_valid(int *valid, const char *refname)
 	return git_reference__name_is_valid(valid, refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
 }
 
-int git_reference_is_valid_name(const char *refname)
-{
-	int valid = 0;
-
-	git_reference__name_is_valid(&valid, refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
-
-	return valid;
-}
-
 const char *git_reference__shorthand(const char *name)
 {
 	if (!git__prefixcmp(name, GIT_REFS_HEADS_DIR))
@@ -1366,3 +1357,18 @@ int git_reference__is_unborn_head(bool *unborn, const git_reference *ref, git_re
 
 	return 0;
 }
+
+/* Deprecated functions */
+
+#ifndef GIT_DEPRECATE_HARD
+
+int git_reference_is_valid_name(const char *refname)
+{
+	int valid = 0;
+
+	git_reference__name_is_valid(&valid, refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
+
+	return valid;
+}
+
+#endif

--- a/src/refs.c
+++ b/src/refs.c
@@ -1294,6 +1294,8 @@ int git_reference__name_is_valid(
 {
 	int error;
 
+	GIT_ASSERT(valid && refname);
+
 	*valid = 0;
 
 	error = git_reference__normalize_name(NULL, refname, flags);
@@ -1304,6 +1306,11 @@ int git_reference__name_is_valid(
 		error = 0;
 
 	return error;
+}
+
+int git_reference_name_is_valid(int *valid, const char *refname)
+{
+	return git_reference__name_is_valid(valid, refname, GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL);
 }
 
 int git_reference_is_valid_name(const char *refname)

--- a/src/refs.h
+++ b/src/refs.h
@@ -85,7 +85,7 @@ git_reference *git_reference__realloc(git_reference **ptr_to_ref, const char *na
 
 int git_reference__normalize_name(git_buf *buf, const char *name, unsigned int flags);
 int git_reference__update_terminal(git_repository *repo, const char *ref_name, const git_oid *oid, const git_signature *sig, const char *log_message);
-int git_reference__is_valid_name(const char *refname, unsigned int flags);
+int git_reference__name_is_valid(int *valid, const char *name, unsigned int flags);
 int git_reference__is_branch(const char *ref_name);
 int git_reference__is_remote(const char *ref_name);
 int git_reference__is_tag(const char *ref_name);

--- a/src/refspec.c
+++ b/src/refspec.c
@@ -155,12 +155,13 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 	return 0;
 
 invalid:
-        git_error_set(
-                GIT_ERROR_INVALID,
-                "'%s' is not a valid refspec.", input);
+	git_error_set(GIT_ERROR_INVALID,
+	              "'%s' is not a valid refspec.", input);
+	git_refspec__dispose(refspec);
+	return GIT_EINVALIDSPEC;
 
 on_error:
-        git_refspec__dispose(refspec);
+	git_refspec__dispose(refspec);
 	return -1;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -110,12 +110,8 @@ static int write_add_refspec(git_repository *repo, const char *name, const char 
 	if ((error = ensure_remote_name_is_valid(name)) < 0)
 		return error;
 
-	if ((error = git_refspec__parse(&spec, refspec, fetch)) < 0) {
-		if (git_error_last()->klass != GIT_ERROR_NOMEMORY)
-			error = GIT_EINVALIDSPEC;
-
+	if ((error = git_refspec__parse(&spec, refspec, fetch)) < 0)
 		return error;
-	}
 
 	git_refspec__dispose(&spec);
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -82,9 +82,11 @@ static int download_tags_value(git_remote *remote, git_config *cfg)
 
 static int ensure_remote_name_is_valid(const char *name)
 {
-	int error = 0;
+	int valid, error;
 
-	if (!git_remote_is_valid_name(name)) {
+	error = git_remote_name_is_valid(&valid, name);
+
+	if (!error && !valid) {
 		git_error_set(
 			GIT_ERROR_CONFIG,
 			"'%s' is not a valid remote name.", name ? name : "(null)");

--- a/src/remote.c
+++ b/src/remote.c
@@ -2124,14 +2124,6 @@ done:
 	return error;
 }
 
-int git_remote_is_valid_name(const char *remote_name)
-{
-	int valid = 0;
-
-	git_remote_name_is_valid(&valid, remote_name);
-	return valid;
-}
-
 git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refname)
 {
 	git_refspec *spec;
@@ -2628,3 +2620,17 @@ char *apply_insteadof(git_config *config, const char *url, int direction)
 
 	return result.ptr;
 }
+
+/* Deprecated functions */
+
+#ifndef GIT_DEPRECATE_HARD
+
+int git_remote_is_valid_name(const char *remote_name)
+{
+	int valid = 0;
+
+	git_remote_name_is_valid(&valid, remote_name);
+	return valid;
+}
+
+#endif

--- a/src/repository.c
+++ b/src/repository.c
@@ -2359,7 +2359,7 @@ int git_repository_initialbranch(git_buf *out, git_repository *repo)
 	git_config *config;
 	git_config_entry *entry = NULL;
 	const char *branch;
-	int error;
+	int valid, error;
 
 	if ((error = git_repository_config__weakptr(&config, repo)) < 0)
 		return error;
@@ -2375,10 +2375,11 @@ int git_repository_initialbranch(git_buf *out, git_repository *repo)
 	}
 
 	if ((error = git_buf_puts(out, GIT_REFS_HEADS_DIR)) < 0 ||
-	    (error = git_buf_puts(out, branch)) < 0)
+	    (error = git_buf_puts(out, branch)) < 0 ||
+	    (error = git_reference_name_is_valid(&valid, out->ptr)) < 0)
 	    goto done;
 
-	if (!git_reference_is_valid_name(out->ptr)) {
+	if (!valid) {
 		git_error_set(GIT_ERROR_INVALID, "the value of init.defaultBranch is not a valid reference name");
 		error = -1;
 	}

--- a/src/tag.c
+++ b/src/tag.c
@@ -522,6 +522,31 @@ int git_tag_peel(git_object **tag_target, const git_tag *tag)
 	return git_object_peel(tag_target, (const git_object *)tag, GIT_OBJECT_ANY);
 }
 
+int git_tag_name_is_valid(int *valid, const char *name)
+{
+	git_buf ref_name = GIT_BUF_INIT;
+	int error = 0;
+
+	GIT_ASSERT(valid);
+
+	/*
+	 * Discourage tag name starting with dash,
+	 * https://github.com/git/git/commit/4f0accd638b8d2
+	 */
+	if (!name || name[0] == '-')
+		goto done;
+
+	if ((error = git_buf_puts(&ref_name, GIT_REFS_TAGS_DIR)) < 0 ||
+	    (error = git_buf_puts(&ref_name, name)) < 0)
+		goto done;
+
+	error = git_reference_name_is_valid(valid, ref_name.ptr);
+
+done:
+	git_buf_dispose(&ref_name);
+	return error;
+}
+
 /* Deprecated Functions */
 
 #ifndef GIT_DEPRECATE_HARD

--- a/tests/network/refspecs.c
+++ b/tests/network/refspecs.c
@@ -13,7 +13,7 @@ static void assert_refspec(unsigned int direction, const char *input, bool is_ex
 	if (is_expected_to_be_valid)
 		cl_assert_equal_i(0, error);
 	else
-		cl_assert_equal_i(GIT_ERROR, error);
+		cl_assert_equal_i(GIT_EINVALIDSPEC, error);
 }
 
 void test_network_refspecs__parsing(void)

--- a/tests/network/remote/isvalidname.c
+++ b/tests/network/remote/isvalidname.c
@@ -1,17 +1,24 @@
 #include "clar_libgit2.h"
 
+static int is_valid_name(const char *name)
+{
+	int valid = 0;
+	cl_git_pass(git_remote_name_is_valid(&valid, name));
+	return valid;
+}
+
 void test_network_remote_isvalidname__can_detect_invalid_formats(void)
 {
-	cl_assert_equal_i(false, git_remote_is_valid_name("/"));
-	cl_assert_equal_i(false, git_remote_is_valid_name("//"));
-	cl_assert_equal_i(false, git_remote_is_valid_name(".lock"));
-	cl_assert_equal_i(false, git_remote_is_valid_name("a.lock"));
-	cl_assert_equal_i(false, git_remote_is_valid_name("/no/leading/slash"));
-	cl_assert_equal_i(false, git_remote_is_valid_name("no/trailing/slash/"));
+	cl_assert_equal_i(false, is_valid_name("/"));
+	cl_assert_equal_i(false, is_valid_name("//"));
+	cl_assert_equal_i(false, is_valid_name(".lock"));
+	cl_assert_equal_i(false, is_valid_name("a.lock"));
+	cl_assert_equal_i(false, is_valid_name("/no/leading/slash"));
+	cl_assert_equal_i(false, is_valid_name("no/trailing/slash/"));
 }
 
 void test_network_remote_isvalidname__wont_hopefully_choke_on_valid_formats(void)
 {
-	cl_assert_equal_i(true, git_remote_is_valid_name("webmatrix"));
-	cl_assert_equal_i(true, git_remote_is_valid_name("yishaigalatzer/rules"));
+	cl_assert_equal_i(true, is_valid_name("webmatrix"));
+	cl_assert_equal_i(true, is_valid_name("yishaigalatzer/rules"));
 }

--- a/tests/online/push_util.c
+++ b/tests/online/push_util.c
@@ -58,12 +58,14 @@ int record_update_tips_cb(const char *refname, const git_oid *a, const git_oid *
 int create_deletion_refspecs(git_vector *out, const git_remote_head **heads, size_t heads_len)
 {
 	git_buf del_spec = GIT_BUF_INIT;
+	int valid;
 	size_t i;
 
 	for (i = 0; i < heads_len; i++) {
 		const git_remote_head *head = heads[i];
 		/* Ignore malformed ref names (which also saves us from tag^{} */
-		if (!git_reference_is_valid_name(head->name))
+		cl_git_pass(git_reference_name_is_valid(&valid, head->name));
+		if (!valid)
 			return 0;
 
 		/* Create a refspec that deletes a branch in the remote */

--- a/tests/refs/branches/name.c
+++ b/tests/refs/branches/name.c
@@ -43,3 +43,20 @@ void test_refs_branches_name__error_when_ref_is_no_branch(void)
 	cl_git_pass(git_reference_lookup(&ref,repo,"refs/notes/fanout"));
 	cl_git_fail(git_branch_name(&name,ref));
 }
+
+static int name_is_valid(const char *name)
+{
+	int valid;
+	cl_git_pass(git_branch_name_is_valid(&valid, name));
+	return valid;
+}
+
+void test_refs_branches_is_name_valid(void)
+{
+	cl_assert_equal_i(true, name_is_valid("master"));
+	cl_assert_equal_i(true, name_is_valid("test/master"));
+
+	cl_assert_equal_i(false, name_is_valid(""));
+	cl_assert_equal_i(false, name_is_valid("HEAD"));
+	cl_assert_equal_i(false, name_is_valid("-dash"));
+}

--- a/tests/refs/isvalidname.c
+++ b/tests/refs/isvalidname.c
@@ -1,31 +1,38 @@
 #include "clar_libgit2.h"
 
+static bool is_valid_name(const char *name)
+{
+	int valid;
+	cl_git_pass(git_reference_name_is_valid(&valid, name));
+	return valid;
+}
+
 void test_refs_isvalidname__can_detect_invalid_formats(void)
 {
-	cl_assert_equal_i(false, git_reference_is_valid_name("refs/tags/0.17.0^{}"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("TWO/LEVELS"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("ONE.LEVEL"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("HEAD/"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("NO_TRAILING_UNDERSCORE_"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("_NO_LEADING_UNDERSCORE"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("HEAD/aa"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("lower_case"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("/stupid/name/master"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("/"));
-	cl_assert_equal_i(false, git_reference_is_valid_name("//"));
-	cl_assert_equal_i(false, git_reference_is_valid_name(""));
-	cl_assert_equal_i(false, git_reference_is_valid_name("refs/heads/sub.lock/webmatrix"));
+	cl_assert_equal_i(false, is_valid_name("refs/tags/0.17.0^{}"));
+	cl_assert_equal_i(false, is_valid_name("TWO/LEVELS"));
+	cl_assert_equal_i(false, is_valid_name("ONE.LEVEL"));
+	cl_assert_equal_i(false, is_valid_name("HEAD/"));
+	cl_assert_equal_i(false, is_valid_name("NO_TRAILING_UNDERSCORE_"));
+	cl_assert_equal_i(false, is_valid_name("_NO_LEADING_UNDERSCORE"));
+	cl_assert_equal_i(false, is_valid_name("HEAD/aa"));
+	cl_assert_equal_i(false, is_valid_name("lower_case"));
+	cl_assert_equal_i(false, is_valid_name("/stupid/name/master"));
+	cl_assert_equal_i(false, is_valid_name("/"));
+	cl_assert_equal_i(false, is_valid_name("//"));
+	cl_assert_equal_i(false, is_valid_name(""));
+	cl_assert_equal_i(false, is_valid_name("refs/heads/sub.lock/webmatrix"));
 }
 
 void test_refs_isvalidname__wont_hopefully_choke_on_valid_formats(void)
 {
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/tags/0.17.0"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/LEVELS"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("HEAD"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("ONE_LEVEL"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/stash"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/remotes/origin/bim_with_3d@11296"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/master{yesterday"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/master}yesterday"));
-	cl_assert_equal_i(true, git_reference_is_valid_name("refs/master{yesterday}"));
+	cl_assert_equal_i(true, is_valid_name("refs/tags/0.17.0"));
+	cl_assert_equal_i(true, is_valid_name("refs/LEVELS"));
+	cl_assert_equal_i(true, is_valid_name("HEAD"));
+	cl_assert_equal_i(true, is_valid_name("ONE_LEVEL"));
+	cl_assert_equal_i(true, is_valid_name("refs/stash"));
+	cl_assert_equal_i(true, is_valid_name("refs/remotes/origin/bim_with_3d@11296"));
+	cl_assert_equal_i(true, is_valid_name("refs/master{yesterday"));
+	cl_assert_equal_i(true, is_valid_name("refs/master}yesterday"));
+	cl_assert_equal_i(true, is_valid_name("refs/master{yesterday}"));
 }

--- a/tests/refs/tags/name.c
+++ b/tests/refs/tags/name.c
@@ -1,0 +1,17 @@
+#include "clar_libgit2.h"
+
+static int name_is_valid(const char *name)
+{
+	int valid;
+	cl_git_pass(git_tag_name_is_valid(&valid, name));
+	return valid;
+}
+
+void test_refs_tags_is_name_valid(void)
+{
+	cl_assert_equal_i(true, name_is_valid("sometag"));
+	cl_assert_equal_i(true, name_is_valid("test/sometag"));
+
+	cl_assert_equal_i(false, name_is_valid(""));
+	cl_assert_equal_i(false, name_is_valid("-dash"));
+}


### PR DESCRIPTION
`git_reference_is_name_valid` and `git_remote_is_name_valid` can fail due to issues like out-of-memory, but cannot communicate this failure to the user.  Replace them with functions that can communicate failure as usual (with an integer return value) and communicate validity with an out param.

The new functions are `name_is_valid`, which better communicates that you're checking the validity of a given name, not checking the name's validity of a given reference/remote.

Include #5625, but with the new format.