### PR TITLE
Define `git___load` when building with `-DTHREADSAFE=OFF`

### DIFF
--- a/src/thread-utils.h
+++ b/src/thread-utils.h
@@ -311,6 +311,11 @@ GIT_INLINE(volatile void *) git___swap(
 	return old;
 }
 
+GIT_INLINE(volatile void *) git___load(void * volatile *ptr)
+{
+	return *ptr;
+}
+
 #ifdef GIT_ARCH_64
 
 GIT_INLINE(int64_t) git_atomic64_add(git_atomic64 *a, int64_t addend)


### PR DESCRIPTION
This should allow folks that build in non-thread-safe environments to
still be able to build the library.

Fixes: #5663