### PR TITLE
Update describe.c

### DIFF
--- a/src/describe.c
+++ b/src/describe.c
@@ -414,9 +414,9 @@ static int show_suffix(
 
 static int describe_not_found(const git_oid *oid, const char *message_format) {
 	char oid_str[GIT_OID_HEXSZ + 1];
-	git_oid_tostr(oid_str, sizeof(oid_str), oid);
 
-	git_error_set(GIT_ERROR_DESCRIBE, message_format, oid_str);
+	git_error_set(GIT_ERROR_DESCRIBE, message_format, 
+		      git_oid_tostr(oid_str, sizeof(oid_str), oid));
 	return GIT_ENOTFOUND;
 }
 


### PR DESCRIPTION
Fixes issue #5672 

Uses the return value of the `git_oid_tostr()` to set error in `git_error_set()` which was previously not done.