### PR TITLE
[WIP] Use vectored file IO for mmap emulation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,17 @@ jobs:
             ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-10
             TSAN_OPTIONS: suppressions=/home/libgit2/source/script/thread-sanitizer.supp second_deadlock_stack=1
           os: ubuntu-latest
+        - # Focal, Clang 10, mmap emulation (NO_MMAP)
+          container:
+            name: focal
+          env:
+            CC: clang-10
+            CFLAGS: -DNO_MMAP
+            CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local
+            CMAKE_GENERATOR: Ninja
+            SKIP_SSH_TESTS: true
+            SKIP_NEGOTIATE_TESTS: true
+          os: ubuntu-latest
         - # macOS
           os: macos-10.15
           env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
             name: focal
           env:
             CC: clang-10
-            CFLAGS: -DNO_MMAP
+            CFLAGS: -DNO_MMAP -DUSE_VECTORED_IO
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local
             CMAKE_GENERATOR: Ninja
             SKIP_SSH_TESTS: true

--- a/src/posix.c
+++ b/src/posix.c
@@ -239,14 +239,15 @@ int p_mmap(git_map *out, size_t len, int prot, int flags, int fd, off64_t offset
 {
 	GIT_MMAP_VALIDATE(out, len, prot, flags);
 
-	out->data = NULL;
-	out->len = 0;
-
-	if ((prot & GIT_PROT_WRITE) && ((flags & GIT_MAP_TYPE) == GIT_MAP_SHARED)) {
-		git_error_set(GIT_ERROR_OS, "trying to map shared-writeable");
+	/* writes cannot be emulated without handling pagefaults since write happens by
+	 * writing to mapped memory */
+	if (prot & GIT_PROT_WRITE) {
+		git_error_set(GIT_ERROR_OS, "trying to map %s-writeable",
+				((flags & GIT_MAP_TYPE) == GIT_MAP_SHARED) ? "shared": "private");
 		return -1;
 	}
 
+	out->len = 0;
 	out->data = git__malloc(len);
 	GIT_ERROR_CHECK_ALLOC(out->data);
 

--- a/src/posix.h
+++ b/src/posix.h
@@ -119,6 +119,9 @@ typedef int git_file;
 extern ssize_t p_read(git_file fd, void *buf, size_t cnt);
 extern int p_write(git_file fd, const void *buf, size_t cnt);
 
+extern ssize_t p_pread(git_file fd, void *data, size_t size, git_off_t offset);
+extern ssize_t p_pwrite(git_file fd, const void *data, size_t size, git_off_t offset);
+
 #define p_close(fd) close(fd)
 #define p_umask(m) umask(m)
 

--- a/src/unix/posix_unix.c
+++ b/src/unix/posix_unix.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "../posix.h"
+
+#ifndef GIT_WIN32
+ssize_t p_pread(git_file fd, void *data, size_t size, git_off_t offset)
+{
+	char *b = (char *)data;
+	if (!git__is_ssizet(size)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	while (size > 0) {
+		ssize_t r = pread(fd, b, size, offset);
+		if (r < 0) {
+			if (errno == EINTR || GIT_ISBLOCKED(errno))
+				continue;
+			return -1;
+		}
+		if (!r)
+			break;
+
+		size -= r;
+		offset += r;
+		b += r;
+	}
+
+	return (b - (char *)data);
+}
+
+ssize_t p_pwrite(git_file fd, const void *data, size_t size, git_off_t offset)
+{
+	char *b = (char *)data;
+	if (!git__is_ssizet(size)) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	while (size > 0) {
+		ssize_t r = pwrite(fd, b, size, offset);
+		if (r < 0) {
+			if (errno == EINTR || GIT_ISBLOCKED(errno))
+				continue;
+			return -1;
+		}
+		if (!r)
+			break;
+
+		size -= r;
+		offset += r;
+		b += r;
+	}
+
+	return (b - (char *)data);
+}
+#endif

--- a/src/unix/posix_unix.c
+++ b/src/unix/posix_unix.c
@@ -9,16 +9,55 @@
 #include "../posix.h"
 
 #ifndef GIT_WIN32
+
+#ifdef USE_VECTORED_IO
+#include <sys/uio.h>
+
+static int prepare_iovec(uint8_t *data, size_t size, struct iovec *iov,
+		int count) {
+	int cc;
+	size_t chunk;
+	size_t page_size;
+
+	git__page_size(&page_size);
+	count = min((size > page_size) ? (int)(size/page_size) : 1, count);
+	chunk = size / count;
+
+	for (cc = 0; cc < count; ++cc) {
+		iov[cc].iov_base = &data[chunk * cc];
+		iov[cc].iov_len = chunk;
+	}
+
+	/* Last chunk reads the extra bytes beyond a chunk */
+	if (count > 1) {
+		iov[count - 1].iov_len = chunk + (size % chunk);
+	}
+
+	return count;
+}
+#endif
+
 ssize_t p_pread(git_file fd, void *data, size_t size, git_off_t offset)
 {
 	char *b = (char *)data;
+
+#ifdef USE_VECTORED_IO
+	struct iovec iov[8];
+	int iov_count = prepare_iovec((uint8_t *)data, size, iov,
+			sizeof(iov)/sizeof(iov[0]));
+#endif
+
 	if (!git__is_ssizet(size)) {
 		errno = EINVAL;
 		return -1;
 	}
 
 	while (size > 0) {
+#ifdef USE_VECTORED_IO
+		ssize_t r = preadv(fd, iov, iov_count, offset);
+#else
 		ssize_t r = pread(fd, b, size, offset);
+#endif
 		if (r < 0) {
 			if (errno == EINTR || GIT_ISBLOCKED(errno))
 				continue;
@@ -38,13 +77,24 @@ ssize_t p_pread(git_file fd, void *data, size_t size, git_off_t offset)
 ssize_t p_pwrite(git_file fd, const void *data, size_t size, git_off_t offset)
 {
 	char *b = (char *)data;
+
+#ifdef USE_VECTORED_IO
+	struct iovec iov[8];
+	int iov_count = prepare_iovec((uint8_t *)data, size, iov,
+			sizeof(iov)/sizeof(iov[0]));
+#endif
+
 	if (!git__is_ssizet(size)) {
 		errno = EINVAL;
 		return -1;
 	}
 
 	while (size > 0) {
+#ifdef USE_VECTORED_IO
+		ssize_t r = pwritev(fd, iov, iov_count, offset);
+#else
 		ssize_t r = pwrite(fd, b, size, offset);
+#endif
 		if (r < 0) {
 			if (errno == EINTR || GIT_ISBLOCKED(errno))
 				continue;

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -981,3 +981,73 @@ int p_inet_pton(int af, const char *src, void *dst)
 	errno = EINVAL;
 	return -1;
 }
+
+ssize_t p_pread(git_file fd, void *data, size_t size, git_off_t offset)
+{
+	size_t mmap_alignment;
+	size_t page_offset;
+	git_off_t page_start;
+	unsigned char *map_data;
+	git_map map;
+	int error;
+
+	assert(data && size);
+
+	if (!git__is_ssizet(size)) {
+		errno = EINVAL;
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return -1;
+	}
+
+	if ((error = git__mmap_alignment(&mmap_alignment)) < 0)
+		return error;
+
+	/* the offset needs to be at the mmap boundary for the platform */
+	page_offset = offset % mmap_alignment;
+	page_start = offset - page_offset;
+
+	if ((error = p_mmap(&map, page_offset + size, GIT_PROT_READ,
+					GIT_MAP_SHARED, fd, page_start)) < 0)
+		return error;
+
+	map_data = (unsigned char *)map.data;
+	memcpy(data, map_data + page_offset, size);
+	p_munmap(&map);
+
+	return size;
+}
+
+ssize_t p_pwrite(git_file fd, const void *data, size_t size, git_off_t offset)
+{
+	size_t mmap_alignment;
+	size_t page_offset;
+	git_off_t page_start;
+	unsigned char *map_data;
+	git_map map;
+	int error;
+
+	assert(data && size);
+
+	if (!git__is_ssizet(size)) {
+		errno = EINVAL;
+		SetLastError(ERROR_INVALID_PARAMETER);
+		return -1;
+	}
+
+	if ((error = git__mmap_alignment(&mmap_alignment)) < 0)
+		return error;
+
+	/* the offset needs to be at the mmap boundary for the platform */
+	page_offset = offset % mmap_alignment;
+	page_start = offset - page_offset;
+
+	if ((error = p_mmap(&map, page_offset + size, GIT_PROT_WRITE,
+					GIT_MAP_SHARED, fd, page_start)) < 0)
+		return error;
+
+	map_data = (unsigned char *)map.data;
+	memcpy(map_data + page_offset, data, size);
+	p_munmap(&map);
+
+	return size;
+}


### PR DESCRIPTION
`p_pread` and `p_pwrite` can optionally use vectored IO by using underlying `preadv` and `pwritev`.
`mmap` emulation uses `p_pread` and writing pack files use `p_pwrite` (from `write_at`).

Reading objects and writing pack files will not benefit from vectored IO with `mmap` emulation and should help with reduced latency when IO bandwidth is available.