### PR TITLE
Make `git_index` hold `conflicts`/`git_merge_file_result`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ build/
 tags
 CMakeSettings.json
 .vs
+
+.idea/
+.vscode/
+.history/
+Testing/
+cmake-build-debug/

--- a/examples/merge.c
+++ b/examples/merge.c
@@ -182,15 +182,17 @@ static void output_conflicts(git_index *index)
 	const git_index_entry *ancestor;
 	const git_index_entry *our;
 	const git_index_entry *their;
+	const git_merge_file_result *merge_result;
 	int err = 0;
 
 	check_lg2(git_index_conflict_iterator_new(&conflicts, index), "failed to create conflict iterator", NULL);
 
-	while ((err = git_index_conflict_next(&ancestor, &our, &their, conflicts)) == 0) {
-		fprintf(stderr, "conflict: a:%s o:%s t:%s\n",
+	while ((err = git_index_conflict_next(&ancestor, &our, &their, &merge_result, conflicts)) == 0) {
+		fprintf(stderr, "conflict: a:%s o:%s t:%s result:%s\n",
 		        ancestor ? ancestor->path : "NULL",
 		        our->path ? our->path : "NULL",
-		        their->path ? their->path : "NULL");
+		        their->path ? their->path : "NULL",
+                merge_result ? merge_result->path : "NULL");
 	}
 
 	if (err != GIT_ITEROVER) {

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -425,4 +425,30 @@ GIT_EXTERN(int) git_libgit2_opts(int option, ...);
 /** @} */
 GIT_END_DECL
 
+/**
+ * Information about file-level merging
+ */
+typedef struct {
+    /**
+     * True if the output was automerged, false if the output contains
+     * conflict markers.
+     */
+    unsigned int automergeable;
+
+    /**
+     * The path that the resultant merge file should use, or NULL if a
+     * filename conflict would occur.
+     */
+    const char *path;
+
+    /** The mode that the resultant merge file should use.  */
+    unsigned int mode;
+
+    /** The contents of the merge. */
+    const char *ptr;
+
+    /** The length of the merge contents. */
+    size_t len;
+} git_merge_file_result;
+
 #endif

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -818,6 +818,7 @@ GIT_EXTERN(int) git_index_conflict_next(
 	const git_index_entry **ancestor_out,
 	const git_index_entry **our_out,
 	const git_index_entry **their_out,
+	const git_merge_file_result **merge_file_result_out,
 	git_index_conflict_iterator *iterator);
 
 /**

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -215,32 +215,6 @@ typedef struct {
 GIT_EXTERN(int) git_merge_file_options_init(git_merge_file_options *opts, unsigned int version);
 
 /**
- * Information about file-level merging
- */
-typedef struct {
-	/**
-	 * True if the output was automerged, false if the output contains
-	 * conflict markers.
-	 */
-	unsigned int automergeable;
-
-	/**
-	 * The path that the resultant merge file should use, or NULL if a
-	 * filename conflict would occur.
-	 */
-	const char *path;
-
-	/** The mode that the resultant merge file should use.  */
-	unsigned int mode;
-
-	/** The contents of the merge. */
-	const char *ptr;
-
-	/** The length of the merge contents. */
-	size_t len;
-} git_merge_file_result;
-
-/**
  * Merging options
  */
 typedef struct {

--- a/include/git2/sys/merge.h
+++ b/include/git2/sys/merge.h
@@ -110,6 +110,7 @@ typedef int GIT_CALLBACK(git_merge_driver_apply_fn)(
 	const char **path_out,
 	uint32_t *mode_out,
 	git_buf *merged_out,
+	git_merge_file_result *merge_result_out,
 	const char *filter_name,
 	const git_merge_driver_source *src);
 

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -939,7 +939,7 @@ static int checkout_conflicts_foreach(
 		goto done;
 
 	/* Collect the conflicts */
-	while ((error = git_index_conflict_next(&ancestor, &ours, &theirs, iterator)) == 0) {
+	while ((error = git_index_conflict_next(&ancestor, &ours, &theirs, NULL, iterator)) == 0) {
 		if (!conflict_pathspec_match(data, workdir, pathspec, ancestor, ours, theirs))
 			continue;
 

--- a/src/index.h
+++ b/src/index.h
@@ -35,6 +35,12 @@ struct git_index {
 	git_vector deleted; /* deleted entries if readers > 0 */
 	git_atomic readers; /* number of active iterators */
 
+	/* Vector of git_merge_diff entries that represent the conflicts that
+	* have not been automerged.  These items will be written to high-stage
+	* entries in the main index.
+	*/
+	git_vector conflicts;
+
 	unsigned int on_disk:1;
 	unsigned int ignore_case:1;
 	unsigned int distrust_filemode:1;

--- a/src/merge.h
+++ b/src/merge.h
@@ -123,6 +123,7 @@ typedef struct {
 	git_index_entry their_entry;
 	git_delta_t their_status;
 
+	git_merge_file_result merge_result;
 } git_merge_diff;
 
 int git_merge__bases_many(
@@ -212,5 +213,7 @@ GIT_INLINE(uint32_t) git_merge_file__best_mode(
 
 	return 0;
 }
+
+void print_merge_file_result(const git_merge_file_result *input);
 
 #endif

--- a/src/merge_driver.h
+++ b/src/merge_driver.h
@@ -47,6 +47,7 @@ extern int git_merge_driver__builtin_apply(
 	const char **path_out,
 	uint32_t *mode_out,
 	git_buf *merged_out,
+	git_merge_file_result *merge_result_out,
 	const char *filter_name,
 	const git_merge_driver_source *src);
 

--- a/src/merge_file.c
+++ b/src/merge_file.c
@@ -154,8 +154,9 @@ static int merge_file__xdiff(
 		theirs->mode);
 
 done:
-	if (error < 0)
-		git_merge_file_result_free(out);
+	// We should not free git_merge_file_result here, or use (error != GIT_EMERGECONFLICT) to estimate it,
+	// cause the GIT_EMERGECONFLICT situation has not been clear here.
+	// git_merge_file_result_free(out);
 
 	return error;
 }

--- a/tests/index/conflicts.c
+++ b/tests/index/conflicts.c
@@ -221,7 +221,7 @@ void test_index_conflicts__iterate(void)
 
 	cl_git_pass(git_index_conflict_iterator_new(&iterator, repo_index));
 
-	cl_git_pass(git_index_conflict_next(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], iterator));
+	cl_git_pass(git_index_conflict_next(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], NULL, iterator));
 
 	git_oid_fromstr(&oid, CONFLICTS_ONE_ANCESTOR_OID);
 	cl_assert_equal_oid(&oid, &conflict_entry[0]->id);
@@ -235,7 +235,7 @@ void test_index_conflicts__iterate(void)
 	cl_assert_equal_oid(&oid, &conflict_entry[2]->id);
 	cl_assert(git__strcmp(conflict_entry[0]->path, "conflicts-one.txt") == 0);
 
-	cl_git_pass(git_index_conflict_next(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], iterator));
+	cl_git_pass(git_index_conflict_next(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], NULL, iterator));
 
 	git_oid_fromstr(&oid, CONFLICTS_TWO_ANCESTOR_OID);
 	cl_assert_equal_oid(&oid, &conflict_entry[0]->id);
@@ -249,7 +249,7 @@ void test_index_conflicts__iterate(void)
 	cl_assert_equal_oid(&oid, &conflict_entry[2]->id);
 	cl_assert(git__strcmp(conflict_entry[0]->path, "conflicts-two.txt") == 0);
 
-	cl_assert(git_index_conflict_next(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], iterator) == GIT_ITEROVER);
+	cl_assert(git_index_conflict_next(&conflict_entry[0], &conflict_entry[1], &conflict_entry[2], NULL, iterator) == GIT_ITEROVER);
 
 	cl_assert(conflict_entry[0] == NULL);
 	cl_assert(conflict_entry[2] == NULL);

--- a/tests/index/read_index.c
+++ b/tests/index/read_index.c
@@ -197,32 +197,32 @@ void test_index_read_index__handles_conflicts(void)
 	cl_git_pass(git_index_conflict_iterator_new(&conflict_iterator, index));
 
 	cl_git_pass(git_index_conflict_next(
-		&ancestor, &ours, &theirs, conflict_iterator));
+		&ancestor, &ours, &theirs, NULL, conflict_iterator));
 	cl_assert_equal_s("both_sides-1.txt", ancestor->path);
 	cl_assert_equal_s("both_sides-1.txt", ours->path);
 	cl_assert_equal_s("both_sides-1.txt", theirs->path);
 
 	cl_git_pass(git_index_conflict_next(
-		&ancestor, &ours, &theirs, conflict_iterator));
+		&ancestor, &ours, &theirs, NULL, conflict_iterator));
 	cl_assert_equal_s("both_sides-2.txt", ancestor->path);
 	cl_assert_equal_s("both_sides-2.txt", ours->path);
 	cl_assert_equal_s("both_sides-2.txt", theirs->path);
 
 	cl_git_pass(git_index_conflict_next(
-		&ancestor, &ours, &theirs, conflict_iterator));
+		&ancestor, &ours, &theirs, NULL, conflict_iterator));
 	cl_assert_equal_s("new_side-1.txt", ancestor->path);
 	cl_assert_equal_s("new_side-1.txt", ours->path);
 	cl_assert_equal_s("new_side-1.txt", theirs->path);
 
 	cl_git_pass(git_index_conflict_next(
-		&ancestor, &ours, &theirs, conflict_iterator));
+		&ancestor, &ours, &theirs, NULL, conflict_iterator));
 	cl_assert_equal_s("new_side-2.txt", ancestor->path);
 	cl_assert_equal_s("new_side-2.txt", ours->path);
 	cl_assert_equal_s("new_side-2.txt", theirs->path);
 
 
 	cl_git_fail_with(GIT_ITEROVER, git_index_conflict_next(
-		&ancestor, &ours, &theirs, conflict_iterator));
+		&ancestor, &ours, &theirs, NULL, conflict_iterator));
 
 	git_index_conflict_iterator_free(conflict_iterator);
 

--- a/tests/merge/driver.c
+++ b/tests/merge/driver.c
@@ -68,11 +68,13 @@ static int test_driver_apply(
 	const char **path_out,
 	uint32_t *mode_out,
 	git_buf *merged_out,
+    git_merge_file_result *merge_result_out,
 	const char *filter_name,
 	const git_merge_driver_source *src)
 {
 	GIT_UNUSED(s);
 	GIT_UNUSED(src);
+    GIT_UNUSED(merge_result_out);
 
 	*path_out = "applied.txt";
 	*mode_out = GIT_FILEMODE_BLOB;
@@ -197,6 +199,7 @@ static int defer_driver_apply(
 	const char **path_out,
 	uint32_t *mode_out,
 	git_buf *merged_out,
+    git_merge_file_result *merge_result_out,
 	const char *filter_name,
 	const git_merge_driver_source *src)
 {
@@ -204,6 +207,7 @@ static int defer_driver_apply(
 	GIT_UNUSED(path_out);
 	GIT_UNUSED(mode_out);
 	GIT_UNUSED(merged_out);
+	GIT_UNUSED(merge_result_out);
 	GIT_UNUSED(filter_name);
 	GIT_UNUSED(src);
 
@@ -242,6 +246,7 @@ static int conflict_driver_apply(
 	const char **path_out,
 	uint32_t *mode_out,
 	git_buf *merged_out,
+    git_merge_file_result *merge_result_out,
 	const char *filter_name,
 	const git_merge_driver_source *src)
 {
@@ -249,6 +254,7 @@ static int conflict_driver_apply(
 	GIT_UNUSED(path_out);
 	GIT_UNUSED(mode_out);
 	GIT_UNUSED(merged_out);
+	GIT_UNUSED(merge_result_out);
 	GIT_UNUSED(filter_name);
 	GIT_UNUSED(src);
 


### PR DESCRIPTION
Make `git_index` hold `conflicts`/`git_merge_file_result`, so we can get `conflicts` directly from `git_index` to preview them.