### PR TITLE
Fix the `ENABLE_WERROR=ON` build in Groovy Gorilla (gcc 10.2)

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -41,8 +41,10 @@ int git_hash_init(git_hash_ctx *ctx)
 		case GIT_HASH_ALGO_SHA1:
 			return git_hash_sha1_init(&ctx->sha1);
 		default:
-			GIT_ASSERT(0);
+			/* unreachable */ ;
 	}
+	GIT_ASSERT(0);
+	return -1;
 }
 
 int git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)
@@ -51,8 +53,10 @@ int git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)
 		case GIT_HASH_ALGO_SHA1:
 			return git_hash_sha1_update(&ctx->sha1, data, len);
 		default:
-			GIT_ASSERT(0);
+			/* unreachable */ ;
 	}
+	GIT_ASSERT(0);
+	return -1;
 }
 
 int git_hash_final(git_oid *out, git_hash_ctx *ctx)
@@ -61,8 +65,10 @@ int git_hash_final(git_oid *out, git_hash_ctx *ctx)
 		case GIT_HASH_ALGO_SHA1:
 			return git_hash_sha1_final(out, &ctx->sha1);
 		default:
-			GIT_ASSERT(0);
+			/* unreachable */ ;
 	}
+	GIT_ASSERT(0);
+	return -1;
 }
 
 int git_hash_buf(git_oid *out, const void *data, size_t len)


### PR DESCRIPTION
The `ENABLE_WERROR=ON` build has been failing with the following error:

```shell
FAILED: src/CMakeFiles/git2internal.dir/hash.c.o
/usr/bin/cc -DHAVE_QSORT_R_GNU -DSHA1DC_CUSTOM_INCLUDE_SHA1_C=\"common.h\" -DSHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C=\"common.h\" -DSHA1DC_NO_STANDARD_INCLUDES=1 -D_FILE_OFFSET_BITS=64 -Isrc -I../src -I../include -I../deps/pcre -I../deps/http-parser -D_GNU_SOURCE -fsanitize=thread -fno-optimize-sibling-calls -fno-omit-frame-pointer -Werror -Wall -Wextra -fvisibility=
hidden -fPIC -Wno-documentation-deprecated-sync -Wno-missing-field-initializers -Wstrict-aliasing -Wstrict-prototypes -Wdeclaration-after-statement -Wshift-count-overflow -Wunused-const-variable -Wunused-function -Wint-conversion -Wformat -Wformat-security -Wmissing-declarations -g -D_DEBUG -O0   -std=gnu90 -MD -MT src/CMakeFiles/git2internal.dir/hash.c.o -MF s
rc/CMakeFiles/git2internal.dir/hash.c.o.d -o src/CMakeFiles/git2internal.dir/hash.c.o   -c ../src/hash.c
../src/hash.c: In function ‘git_hash_init’:
../src/hash.c:47:1: error: control reaches end of non-void function [-Werror=return-type]
   47 | }
      | ^
../src/hash.c: In function ‘git_hash_update’:
../src/hash.c:58:1: error: control reaches end of non-void function [-Werror=return-type]
   58 | }
      | ^
../src/hash.c: In function ‘git_hash_final’:
../src/hash.c:68:1: error: control reaches end of non-void function [-Werror=return-type]
   68 | }
      | ^
../src/hash.c: At top level:
cc1: note: unrecognized command-line option ‘-Wno-documentation-deprecated-sync’ may have been intended to silence earlier diagnostics
cc1: all warnings being treated as errors
[11/533] Building C object src/CMakeFiles/git2internal.dir/odb_pack.c.o
ninja: build stopped: subcommand failed.
```

The compiler _should_ be able to figure out that there is no way to reach the
end of the non-void function since `GIT_ASSERT(0)` expands to either `assert()`
or an unconditional `return -1;` (after doing constant folding and stuff,
depending on the debug level). But it's not doing so at the moment, so let's
help it.