### PR TITLE
Thread-local storage: handle failure cases

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -225,7 +225,7 @@ GIT_EXTERN(int) git_oid_pathfmt(char *out, const git_oid *id);
  * concurrent calls of the function.
  *
  * @param oid The oid structure to format
- * @return the c-string
+ * @return the c-string or NULL on failure
  */
 GIT_EXTERN(char *) git_oid_tostr_s(const git_oid *oid);
 

--- a/src/libgit2/errors.c
+++ b/src/libgit2/errors.c
@@ -16,12 +16,12 @@
  * New error handling
  ********************************************/
 
-static git_error g_git_oom_error = {
+static git_error oom_error = {
 	"Out of memory",
 	GIT_ERROR_NOMEMORY
 };
 
-static git_error g_git_uninitialized_error = {
+static git_error uninitialized_error = {
 	"libgit2 has not been initialized; you must call git_libgit2_init",
 	GIT_ERROR_INVALID
 };
@@ -52,7 +52,7 @@ static void set_error(int error_class, char *string)
 
 void git_error_set_oom(void)
 {
-	GIT_THREADSTATE->last_error = &g_git_oom_error;
+	GIT_THREADSTATE->last_error = &oom_error;
 }
 
 void git_error_set(int error_class, const char *fmt, ...)
@@ -134,7 +134,7 @@ const git_error *git_error_last(void)
 {
 	/* If the library is not initialized, return a static error. */
 	if (!git_libgit2_init_count())
-		return &g_git_uninitialized_error;
+		return &uninitialized_error;
 
 	return GIT_THREADSTATE->last_error;
 }
@@ -150,13 +150,13 @@ int git_error_state_capture(git_error_state *state, int error_code)
 		return 0;
 
 	state->error_code = error_code;
-	state->oom = (error == &g_git_oom_error);
+	state->oom = (error == &oom_error);
 
 	if (error) {
 		state->error_msg.klass = error->klass;
 
 		if (state->oom)
-			state->error_msg.message = g_git_oom_error.message;
+			state->error_msg.message = oom_error.message;
 		else
 			state->error_msg.message = git_str_detach(error_buf);
 	}

--- a/src/libgit2/errors.c
+++ b/src/libgit2/errors.c
@@ -33,7 +33,7 @@ static git_error tlsdata_error = {
 
 static void set_error_from_buffer(int error_class)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 	git_error *error;
 	git_str *buf;
 
@@ -51,7 +51,7 @@ static void set_error_from_buffer(int error_class)
 
 static void set_error(int error_class, char *string)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 	git_str *buf;
 
 	if (!threadstate)
@@ -71,7 +71,7 @@ static void set_error(int error_class, char *string)
 
 void git_error_set_oom(void)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 
 	if (!threadstate)
 		return;
@@ -94,7 +94,7 @@ void git_error_vset(int error_class, const char *fmt, va_list ap)
 	DWORD win32_error_code = (error_class == GIT_ERROR_OS) ? GetLastError() : 0;
 #endif
 
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 	int error_code = (error_class == GIT_ERROR_OS) ? errno : 0;
 	git_str *buf;
 
@@ -135,7 +135,7 @@ void git_error_vset(int error_class, const char *fmt, va_list ap)
 
 int git_error_set_str(int error_class, const char *string)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 	git_str *buf;
 
 	GIT_ASSERT_ARG(string);
@@ -157,7 +157,7 @@ int git_error_set_str(int error_class, const char *string)
 
 void git_error_clear(void)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 
 	if (!threadstate)
 		return;
@@ -181,7 +181,7 @@ const git_error *git_error_last(void)
 	if (!git_libgit2_init_count())
 		return &uninitialized_error;
 
-	if ((threadstate = GIT_THREADSTATE) == NULL)
+	if ((threadstate = git_threadstate_get()) == NULL)
 		return &tlsdata_error;
 
 	return threadstate->last_error;
@@ -189,7 +189,7 @@ const git_error *git_error_last(void)
 
 int git_error_state_capture(git_error_state *state, int error_code)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 	git_error *error;
 	git_str *error_buf;
 

--- a/src/libgit2/indexer.c
+++ b/src/libgit2/indexer.c
@@ -519,7 +519,13 @@ static int store_object(git_indexer *idx)
 	pentry->offset = entry_start;
 
 	if (git_oidmap_exists(idx->pack->idx_cache, &pentry->id)) {
-		git_error_set(GIT_ERROR_INDEXER, "duplicate object %s found in pack", git_oid_tostr_s(&pentry->id));
+		const char *idstr = git_oid_tostr_s(&pentry->id);
+
+		if (!idstr)
+			git_error_set(GIT_ERROR_INDEXER, "failed to parse object id");
+		else
+			git_error_set(GIT_ERROR_INDEXER, "duplicate object %s found in pack", idstr);
+
 		git__free(pentry);
 		goto on_error;
 	}

--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -1494,11 +1494,16 @@ static int read_prefix_1(git_odb_object **out, git_odb *db,
 
 			if (found && git_oid__cmp(&full_oid, &found_full_oid)) {
 				git_str buf = GIT_STR_INIT;
+				const char *idstr;
 
-				git_str_printf(&buf, "multiple matches for prefix: %s",
-					git_oid_tostr_s(&full_oid));
-				git_str_printf(&buf, " %s",
-					git_oid_tostr_s(&found_full_oid));
+				if ((idstr = git_oid_tostr_s(&full_oid)) == NULL) {
+					git_str_puts(&buf, "failed to parse object id");
+				} else {
+					git_str_printf(&buf, "multiple matches for prefix: %s", idstr);
+
+					if ((idstr = git_oid_tostr_s(&found_full_oid)) != NULL)
+						git_str_printf(&buf, " %s", idstr);
+				}
 
 				error = git_odb__error_ambiguous(buf.ptr);
 				git_str_dispose(&buf);

--- a/src/libgit2/oid.c
+++ b/src/libgit2/oid.c
@@ -155,7 +155,13 @@ int git_oid_pathfmt(char *str, const git_oid *oid)
 
 char *git_oid_tostr_s(const git_oid *oid)
 {
-	char *str = GIT_THREADSTATE->oid_fmt;
+	git_threadstate *threadstate = GIT_THREADSTATE;
+	char *str;
+
+	if (!threadstate)
+		return NULL;
+
+	str = threadstate->oid_fmt;
 	git_oid_nfmt(str, git_oid_hexsize(git_oid_type(oid)) + 1, oid);
 	return str;
 }

--- a/src/libgit2/oid.c
+++ b/src/libgit2/oid.c
@@ -155,7 +155,7 @@ int git_oid_pathfmt(char *str, const git_oid *oid)
 
 char *git_oid_tostr_s(const git_oid *oid)
 {
-	git_threadstate *threadstate = GIT_THREADSTATE;
+	git_threadstate *threadstate = git_threadstate_get();
 	char *str;
 
 	if (!threadstate)

--- a/src/libgit2/threadstate.h
+++ b/src/libgit2/threadstate.h
@@ -19,6 +19,4 @@ typedef struct {
 extern int git_threadstate_global_init(void);
 extern git_threadstate *git_threadstate_get(void);
 
-#define GIT_THREADSTATE (git_threadstate_get())
-
 #endif


### PR DESCRIPTION
We never error-check our "threadstate" thread-local storage, where we keep a few reusable buffers and the thread's current error message.  Make sure that we have a threadstate data instance before reading to it or writing from it.

Depends on #5720 