### PR TITLE
Fix allowed creation of file that already exists by `git_apply_to_tree`

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -562,7 +562,6 @@ static int apply_one(
 		post_entry.path = filename;
 		post_entry.mode = mode;
 		git_oid_cpy(&post_entry.id, &post_id);
-
 		if ((error = git_index_add(postimage, &post_entry)) < 0)
 			goto done;
 	}
@@ -650,7 +649,12 @@ int git_apply_to_tree(
 	 */
 	for (i = 0; i < git_diff_num_deltas(diff); i++) {
 		delta = git_diff_get_delta(diff, i);
-
+		if (delta->status == GIT_DELTA_ADDED &&
+			git_index_find(NULL, postimage, delta->new_file.path) != GIT_ENOTFOUND) {
+				git_error_clear();
+				error = GIT_EEXISTS;
+				goto done;
+		}
 		if (delta->status == GIT_DELTA_DELETED ||
 			delta->status == GIT_DELTA_RENAMED) {
 			if ((error = git_index_remove(postimage,

--- a/tests/apply/apply_helpers.h
+++ b/tests/apply/apply_helpers.h
@@ -68,6 +68,16 @@
 	"+This is a new file!\n" \
 	"+Added by a patch.\n"
 
+#define DIFF_DUPLICATE_FILE \
+	"diff --git a/veal.txt b/veal.txt\n" \
+	"new file mode 100644\n" \
+	"index 0000000..6370543\n" \
+	"--- /dev/null\n" \
+	"+++ b/veal.txt\n" \
+	"@@ -0,0 +1,2 @@\n" \
+	"+This is a duplicate file!\n" \
+	"+It should not be added.\n"
+
 #define DIFF_EXECUTABLE_FILE \
 	"diff --git a/beef.txt b/beef.txt\n" \
 	"old mode 100644\n" \

--- a/tests/apply/tree.c
+++ b/tests/apply/tree.c
@@ -87,6 +87,10 @@ void test_apply_tree__adds_file(void)
 	cl_git_pass(git_apply_to_tree(&index, repo, a_tree, diff, NULL));
 	merge_test_index(index, expected, 7);
 
+	cl_git_pass(git_diff_from_buffer(&diff,
+		DIFF_DUPLICATE_FILE, strlen(DIFF_DUPLICATE_FILE)));
+	cl_git_fail(git_apply_to_tree(&index, repo, a_tree, diff, NULL));
+
 	git_index_free(index);
 	git_diff_free(diff);
 	git_tree_free(a_tree);


### PR DESCRIPTION
Fixes #5717 