### PR TITLE
hash: changed git_repository_hashfile to hash symlinks the same as when they are added to the index

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -2675,6 +2675,7 @@ int git_repository_hashfile(
 	git_file fd = -1;
 	uint64_t len;
 	git_buf full_path = GIT_BUF_INIT;
+	struct stat st;
 
 	 /* as_path can be NULL */
 	GIT_ASSERT_ARG(out);
@@ -2691,6 +2692,11 @@ int git_repository_hashfile(
 	if (error < 0)
 		return error;
 
+	if (!p_lstat(full_path.ptr, &st) && S_ISLNK(st.st_mode)) {
+		error = git_odb__hashlink(out, full_path.ptr);
+		goto cleanup;
+	}
+
 	if (!as_path)
 		as_path = path;
 
@@ -2700,7 +2706,7 @@ int git_repository_hashfile(
 			&fl, repo, NULL, as_path,
 			GIT_FILTER_TO_ODB, GIT_FILTER_DEFAULT);
 		if (error < 0)
-			return error;
+			goto cleanup;
 	} else {
 		error = 0;
 	}


### PR DESCRIPTION
hash: changed git_repository_hashfile to hash symlinks the same as when they are added to the index