### PR TITLE
repository: use intptr_t's in the config map cache

### DIFF
--- a/src/repository.h
+++ b/src/repository.h
@@ -154,7 +154,7 @@ struct git_repository {
 
 	git_atomic32 attr_session_key;
 
-	git_configmap_value configmap_cache[GIT_CONFIGMAP_CACHE_MAX];
+	intptr_t configmap_cache[GIT_CONFIGMAP_CACHE_MAX];
 	git_strmap *submodule_cache;
 };
 


### PR DESCRIPTION
Since we're using atomic primitives to read and write into the config map cache, we need to read/write something pointer-sized.  Use an `intptr_t` for the config map cache.

Fixes #5745 