### PR TITLE
Fix the `-DENABLE_WERROR=ON` build for gcc 10.2

### DIFF
--- a/tests/clar/fs.h
+++ b/tests/clar/fs.h
@@ -396,7 +396,7 @@ static void
 fs_copy(const char *source, const char *_dest)
 {
 	char *dbuf = NULL;
-	const char *dest;
+	const char *dest = NULL;
 	struct stat source_st, dest_st;
 
 	cl_must_pass_(lstat(source, &source_st), "Failed to stat copy source");

--- a/tests/clar/sandbox.h
+++ b/tests/clar/sandbox.h
@@ -2,7 +2,7 @@
 #include <sys/syslimits.h>
 #endif
 
-static char _clar_path[4096];
+static char _clar_path[4096 + 1];
 
 static int
 is_valid_tmp_path(const char *path)
@@ -39,7 +39,8 @@ find_tmp_path(char *buffer, size_t length)
 			if (length >= PATH_MAX && realpath(env, buffer) != NULL)
 				return 0;
 #endif
-			strncpy(buffer, env, length);
+			strncpy(buffer, env, length - 1);
+			buffer[length - 1] = '\0';
 			return 0;
 		}
 	}
@@ -50,7 +51,8 @@ find_tmp_path(char *buffer, size_t length)
 		if (length >= PATH_MAX && realpath("/tmp", buffer) != NULL)
 			return 0;
 #endif
-		strncpy(buffer, "/tmp", length);
+		strncpy(buffer, "/tmp", length - 1);
+		buffer[length - 1] = '\0';
 		return 0;
 	}
 
@@ -65,7 +67,8 @@ find_tmp_path(char *buffer, size_t length)
 
 	/* This system doesn't like us, try to use the current directory */
 	if (is_valid_tmp_path(".")) {
-		strncpy(buffer, ".", length);
+		strncpy(buffer, ".", length - 1);
+		buffer[length - 1] = '\0';
 		return 0;
 	}
 

--- a/tests/clar_libgit2.c
+++ b/tests/clar_libgit2.c
@@ -275,7 +275,7 @@ const char* cl_git_fixture_url(const char *fixturename)
 
 const char* cl_git_path_url(const char *path)
 {
-	static char url[4096];
+	static char url[4096 + 1];
 
 	const char *in_buf;
 	git_buf path_buf = GIT_BUF_INIT;
@@ -311,9 +311,10 @@ const char* cl_git_path_url(const char *path)
 		in_buf++;
 	}
 
-	cl_assert(url_buf.size < 4096);
+	cl_assert(url_buf.size < sizeof(url) - 1);
 
-	strncpy(url, git_buf_cstr(&url_buf), 4096);
+	strncpy(url, git_buf_cstr(&url_buf), sizeof(url) - 1);
+	url[sizeof(url) - 1] = '\0';
 	git_buf_dispose(&url_buf);
 	git_buf_dispose(&path_buf);
 	return url;


### PR DESCRIPTION
This change makes it possible to build with newer versions of gcc
without warnings. There were two warnings issued:

* gcc 8 added
  [`-Wstringop-truncation`](https://developers.redhat.com/blog/2018/05/24/detecting-string-truncation-with-gcc-8/),
  which warns if a call to `strncpy(3)` is prone to accidentally
  truncating the destination string, since `strncpy(3)` does NOT add a
  terminating `NULL` if the destination buffer is not large enough to
  hold the input.

  This change uses the pattern suggested in
  https://us-cert.cisa.gov/bsi/articles/knowledge/coding-practices/strncpy-and-strncat
  to fix the locations flagged by gcc.
* There was a potentially uninitialized access of `dest` in `fs_copy`.