### PR TITLE
Add support for additional SSH hostkey types.

### DIFF
--- a/ci/docker/focal
+++ b/ci/docker/focal
@@ -48,9 +48,9 @@ RUN cd /tmp && \
 
 FROM mbedtls AS libssh2
 RUN cd /tmp && \
-    curl --insecure --location --silent --show-error https://www.libssh2.org/download/libssh2-1.8.2.tar.gz | \
+    curl --insecure --location --silent --show-error https://www.libssh2.org/download/libssh2-1.9.0.tar.gz | \
         tar -xz && \
-    cd libssh2-1.8.2 && \
+    cd libssh2-1.9.0 && \
     mkdir build build-msan && \
     cd build && \
     CC=clang-10 CFLAGS="-fPIC" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=Libgcrypt -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
@@ -59,7 +59,7 @@ RUN cd /tmp && \
     CC=clang-10 CFLAGS="-fPIC -fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer" LDFLAGS="-fsanitize=memory" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=mbedTLS -DCMAKE_PREFIX_PATH=/usr/local/msan -DCMAKE_INSTALL_PREFIX=/usr/local/msan .. && \
     ninja install && \
     cd .. && \
-    rm -rf libssh2-1.8.2
+    rm -rf libssh2-1.9.0
 
 FROM libssh2 AS valgrind
 RUN cd /tmp && \

--- a/include/git2/cert.h
+++ b/include/git2/cert.h
@@ -91,6 +91,14 @@ typedef enum {
 	GIT_CERT_SSH_RAW_TYPE_RSA = 1,
 	/** The raw key is a DSS key. */
 	GIT_CERT_SSH_RAW_TYPE_DSS = 2,
+	/** The raw key is a ECDSA 256 key. */
+	GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_256 = 3,
+	/** The raw key is a ECDSA 384 key. */
+	GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_384 = 4,
+	/** The raw key is a ECDSA 521 key. */
+	GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_521 = 5,
+	/** The raw key is a ED25519 key. */
+	GIT_CERT_SSH_RAW_TYPE_KEY_ED25519 = 6
 } git_cert_ssh_raw_type_t;
 
 /**

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -580,6 +580,8 @@ post_extract:
 				case LIBSSH2_HOSTKEY_TYPE_DSS:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_DSS;
 					break;
+					
+#ifdef LIBSSH2_HOSTKEY_TYPE_ECDSA_256
 				case LIBSSH2_HOSTKEY_TYPE_ECDSA_256:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_256;
 					break;
@@ -589,9 +591,13 @@ post_extract:
 				case LIBSSH2_KNOWNHOST_KEY_ECDSA_521:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_521;
 					break;
+#endif
+					
+#ifdef LIBSSH2_HOSTKEY_TYPE_ED25519
 				case LIBSSH2_HOSTKEY_TYPE_ED25519:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ED25519;
 					break;
+#endif
 				default:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_UNKNOWN;
 			}

--- a/src/transports/ssh.c
+++ b/src/transports/ssh.c
@@ -580,6 +580,18 @@ post_extract:
 				case LIBSSH2_HOSTKEY_TYPE_DSS:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_DSS;
 					break;
+				case LIBSSH2_HOSTKEY_TYPE_ECDSA_256:
+					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_256;
+					break;
+				case LIBSSH2_HOSTKEY_TYPE_ECDSA_384:
+					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_384;
+					break;
+				case LIBSSH2_KNOWNHOST_KEY_ECDSA_521:
+					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ECDSA_521;
+					break;
+				case LIBSSH2_HOSTKEY_TYPE_ED25519:
+					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_KEY_ED25519;
+					break;
 				default:
 					cert.raw_type = GIT_CERT_SSH_RAW_TYPE_UNKNOWN;
 			}


### PR DESCRIPTION
The raw hostkey in the certificate is incredibly useful to subsequently compare and add it to a known_hosts file. However, the current code only support RSA and DSS typed keys. LibSSH2 supports a few more, including ED25519 which is the default hostkey type for many systems (macOS, for example, and I believe Raspbian as well).

This patch adds support for ECDSA_256, ECDSA_384, ECDSA_521 and ED25519 hostkey types on top of the already existing ones.