### PR TITLE
Add documentation for git_blob_filter_options.version

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -120,6 +120,7 @@ typedef enum {
  * The options used when applying filter options to a file.
  */
 typedef struct {
+	/** The struct version; set to `GIT_BLOB_FILTER_OPTIONS_VERSION`. */
 	int version;
 
 	/** Flags to control the filtering process, see `git_blob_filter_flag_t` above */

--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -118,9 +118,11 @@ typedef enum {
 
 /**
  * The options used when applying filter options to a file.
+ *
+ * Initialize with `GIT_BLOB_FILTER_OPTIONS_VERSION`.
+ *
  */
 typedef struct {
-	/** The struct version; set to `GIT_BLOB_FILTER_OPTIONS_VERSION`. */
 	int version;
 
 	/** Flags to control the filtering process, see `git_blob_filter_flag_t` above */

--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -119,7 +119,8 @@ typedef enum {
 /**
  * The options used when applying filter options to a file.
  *
- * Initialize with `GIT_BLOB_FILTER_OPTIONS_INIT`.
+ * Initialize with `GIT_BLOB_FILTER_OPTIONS_INIT`. Alternatively, you can
+ * use `git_blob_filter_options_init`.
  *
  */
 typedef struct {

--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -119,7 +119,7 @@ typedef enum {
 /**
  * The options used when applying filter options to a file.
  *
- * Initialize with `GIT_BLOB_FILTER_OPTIONS_VERSION`.
+ * Initialize with `GIT_BLOB_FILTER_OPTIONS_INIT`.
  *
  */
 typedef struct {

--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -133,6 +133,18 @@ typedef struct {
 #define GIT_BLOB_FILTER_OPTIONS_INIT {GIT_BLOB_FILTER_OPTIONS_VERSION, GIT_BLOB_FILTER_CHECK_FOR_BINARY}
 
 /**
+ * Initialize git_blob_filter_options structure
+ *
+ * Initializes a `git_blob_filter_options` with default values. Equivalent
+ * to creating an instance with `GIT_BLOB_FILTER_OPTIONS_INIT`.
+ *
+ * @param opts The `git_blob_filter_options` struct to initialize.
+ * @param version The struct version; pass `GIT_BLOB_FILTER_OPTIONS_VERSION`.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_blob_filter_options_init(git_blob_filter_options *opts, unsigned int version);
+
+/**
  * Get a buffer with the filtered content of a blob.
  *
  * This applies filters as if the blob was being checked out to the

--- a/src/blob.c
+++ b/src/blob.c
@@ -408,6 +408,15 @@ int git_blob_is_binary(const git_blob *blob)
 	return git_buf_text_is_binary(&content);
 }
 
+int git_blob_filter_options_init(
+	git_blob_filter_options *opts,
+	unsigned int version)
+{
+	GIT_INIT_STRUCTURE_FROM_TEMPLATE(opts, version,
+		git_blob_filter_options, GIT_BLOB_FILTER_OPTIONS_INIT);
+	return 0;
+}
+
 int git_blob_filter(
 	git_buf *out,
 	git_blob *blob,

--- a/tests/core/structinit.c
+++ b/tests/core/structinit.c
@@ -82,6 +82,11 @@ void test_core_structinit__compare(void)
 		git_blame_options, GIT_BLAME_OPTIONS_VERSION, \
 		GIT_BLAME_OPTIONS_INIT, git_blame_options_init);
 
+	/* blob_filter_options */
+	CHECK_MACRO_FUNC_INIT_EQUAL( \
+		git_blob_filter_options, GIT_BLOB_FILTER_OPTIONS_VERSION, \
+		GIT_BLOB_FILTER_OPTIONS_INIT, git_blob_filter_options_init);
+
 	/* checkout */
 	CHECK_MACRO_FUNC_INIT_EQUAL( \
 		git_checkout_options, GIT_CHECKOUT_OPTIONS_VERSION, \


### PR DESCRIPTION
"The struct version; set to `GIT_BLOB_FILTER_OPTIONS_VERSION`."

Resolves #5756.