### PR TITLE
blob: fix name of `GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD`

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -113,7 +113,7 @@ typedef enum {
 	 * When set, filters will be loaded from a `.gitattributes` file
 	 * in the HEAD commit.
 	 */
-	GIT_BLOB_FILTER_ATTTRIBUTES_FROM_HEAD = (1 << 2),
+	GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD = (1 << 2),
 } git_blob_filter_flag_t;
 
 /**

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -80,15 +80,18 @@ typedef git_attr_value_t git_attr_t;
 
 /**@}*/
 
-/** @name Deprecated Blob Functions
+/** @name Deprecated Blob Functions and Constants
  *
- * These functions are retained for backward compatibility.  The newer
- * versions of these functions should be preferred in all new code.
+ * These functions and enumeration values are retained for backward
+ * compatibility.  The newer versions of these functions and values
+ * should be preferred in all new code.
  *
  * There is no plan to remove these backward compatibility values at
  * this time.
  */
 /**@{*/
+
+#define GIT_BLOB_FILTER_ATTTRIBUTES_FROM_HEAD GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD
 
 GIT_EXTERN(int) git_blob_create_fromworkdir(git_oid *id, git_repository *repo, const char *relative_path);
 GIT_EXTERN(int) git_blob_create_fromdisk(git_oid *id, git_repository *repo, const char *path);

--- a/src/blob.c
+++ b/src/blob.c
@@ -439,7 +439,7 @@ int git_blob_filter(
 	if ((opts.flags & GIT_BLOB_FILTER_NO_SYSTEM_ATTRIBUTES) != 0)
 		flags |= GIT_FILTER_NO_SYSTEM_ATTRIBUTES;
 
-	if ((opts.flags & GIT_BLOB_FILTER_ATTTRIBUTES_FROM_HEAD) != 0)
+	if ((opts.flags & GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD) != 0)
 		flags |= GIT_FILTER_ATTRIBUTES_FROM_HEAD;
 
 	if (!(error = git_filter_list_load(

--- a/tests/filter/bare.c
+++ b/tests/filter/bare.c
@@ -10,7 +10,7 @@ void test_filter_bare__initialize(void)
 	cl_git_pass(git_repository_open(&g_repo, "crlf.git"));
 
 	filter_opts.flags |= GIT_BLOB_FILTER_NO_SYSTEM_ATTRIBUTES;
-	filter_opts.flags |= GIT_BLOB_FILTER_ATTTRIBUTES_FROM_HEAD;
+	filter_opts.flags |= GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD;
 }
 
 void test_filter_bare__cleanup(void)


### PR DESCRIPTION
`GIT_BLOB_FILTER_ATTTRIBUTES_FROM_HEAD` is misspelled, it should be `GIT_BLOB_FILTER_ATTRIBUTES_FROM_HEAD`, and it would be if it were not for the MacBook Pro keyboard and my inattentiveness.

Fixes #5755 