### PR TITLE
commit-graph: Use the commit-graph in revwalks

### DIFF
--- a/fuzzers/commit_graph_fuzzer.c
+++ b/fuzzers/commit_graph_fuzzer.c
@@ -31,7 +31,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv)
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-	git_commit_graph_file cgraph = {{0}};
+	git_commit_graph_file file = {{0}};
 	git_commit_graph_entry e;
 	git_buf commit_graph_buf = GIT_BUF_INIT;
 	git_oid oid = {{0}};
@@ -62,19 +62,19 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		git_buf_attach_notowned(&commit_graph_buf, (char *)data, size);
 	}
 
-	if (git_commit_graph_parse(
-			    &cgraph,
+	if (git_commit_graph_file_parse(
+			    &file,
 			    (const unsigned char *)git_buf_cstr(&commit_graph_buf),
 			    git_buf_len(&commit_graph_buf))
 	    < 0)
 		goto cleanup;
 
 	/* Search for any oid, just to exercise that codepath. */
-	if (git_commit_graph_entry_find(&e, &cgraph, &oid, GIT_OID_HEXSZ) < 0)
+	if (git_commit_graph_entry_find(&e, &file, &oid, GIT_OID_HEXSZ) < 0)
 		goto cleanup;
 
 cleanup:
-	git_commit_graph_close(&cgraph);
+	git_commit_graph_file_close(&file);
 	git_buf_dispose(&commit_graph_buf);
 	return 0;
 }

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -544,6 +544,21 @@ GIT_EXTERN(size_t) git_odb_num_backends(git_odb *odb);
  */
 GIT_EXTERN(int) git_odb_get_backend(git_odb_backend **out, git_odb *odb, size_t pos);
 
+/**
+ * Set the git commit-graph for the ODB.
+ *
+ * After a successfull call, the ownership of the cgraph parameter will be
+ * transferred to libgit2, and the caller should not free it.
+ *
+ * The commit-graph can also be unset by explicitly passing NULL as the cgraph
+ * parameter.
+ *
+ * @param odb object database
+ * @param cgraph the git commit-graph
+ * @return 0 on success; error code otherwise
+ */
+GIT_EXTERN(int) git_odb_set_commit_graph(git_odb *odb, git_commit_graph *cgraph);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/sys/commit_graph.h
+++ b/include/git2/sys/commit_graph.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_sys_git_commit_graph_h__
+#define INCLUDE_sys_git_commit_graph_h__
+
+#include "git2/common.h"
+#include "git2/types.h"
+
+/**
+ * @file git2/sys/commit_graph.h
+ * @brief Git commit-graph
+ * @defgroup git_commit_graph Git commit-graph APIs
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Opens a `git_commit_graph` from a path to an objects directory.
+ *
+ * This finds, opens, and validates the `commit-graph` file.
+ *
+ * @param cgraph_out the `git_commit_graph` struct to initialize.
+ * @param objects_dir the path to a git objects directory.
+ * @return Zero on success; -1 on failure.
+ */
+GIT_EXTERN(int) git_commit_graph_open(git_commit_graph **cgraph_out, const char *objects_dir);
+
+/**
+ * Frees commit-graph data. This should only be called when memory allocated
+ * using `git_commit_graph_open` is not returned to libgit2 because it was not
+ * associated with the ODB through a successful call to
+ * `git_odb_set_commit_graph`.
+ *
+ * @param cgraph the commit-graph object to free. If NULL, no action is taken.
+ */
+GIT_EXTERN(void) git_commit_graph_free(git_commit_graph *cgraph);
+
+GIT_END_DECL
+
+#endif

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -102,6 +102,9 @@ typedef struct git_refdb git_refdb;
 /** A custom backend for refs */
 typedef struct git_refdb_backend git_refdb_backend;
 
+/** A git commit-graph */
+typedef struct git_commit_graph git_commit_graph;
+
 /**
  * Representation of an existing git repository,
  * including all its object contents

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -144,18 +144,18 @@ static int commit_quick_parse(
 int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit)
 {
 	git_odb_object *obj;
-	git_commit_graph_file *cgraph = NULL;
+	git_commit_graph_file *cgraph_file = NULL;
 	int error;
 
 	if (commit->parsed)
 		return 0;
 
 	/* Let's try to use the commit graph first. */
-	git_odb__get_commit_graph(&cgraph, walk->odb);
-	if (cgraph) {
+	git_odb__get_commit_graph_file(&cgraph_file, walk->odb);
+	if (cgraph_file) {
 		git_commit_graph_entry e;
 
-		error = git_commit_graph_entry_find(&e, cgraph, &commit->oid, GIT_OID_RAWSZ);
+		error = git_commit_graph_entry_find(&e, cgraph_file, &commit->oid, GIT_OID_RAWSZ);
 		if (error == 0 && git__is_uint16(e.parent_count)) {
 			size_t i;
 			commit->generation = (uint32_t)e.generation;
@@ -166,7 +166,7 @@ int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit)
 
 			for (i = 0; i < commit->out_degree; ++i) {
 				git_commit_graph_entry parent;
-				error = git_commit_graph_entry_parent(&parent, cgraph, &e, i);
+				error = git_commit_graph_entry_parent(&parent, cgraph_file, &e, i);
 				if (error < 0)
 					return error;
 				commit->parents[i] = git_revwalk__commit_lookup(walk, &parent.sha1);

--- a/src/commit_list.c
+++ b/src/commit_list.c
@@ -124,6 +124,7 @@ static int commit_quick_parse(
 		return -1;
 	}
 
+	node->generation = 0;
 	node->time = commit->committer->when.time;
 	node->out_degree = (uint16_t) git_array_size(commit->parent_ids);
 	node->parents = alloc_parents(walk, node, node->out_degree);
@@ -143,10 +144,37 @@ static int commit_quick_parse(
 int git_commit_list_parse(git_revwalk *walk, git_commit_list_node *commit)
 {
 	git_odb_object *obj;
+	git_commit_graph_file *cgraph = NULL;
 	int error;
 
 	if (commit->parsed)
 		return 0;
+
+	/* Let's try to use the commit graph first. */
+	git_odb__get_commit_graph(&cgraph, walk->odb);
+	if (cgraph) {
+		git_commit_graph_entry e;
+
+		error = git_commit_graph_entry_find(&e, cgraph, &commit->oid, GIT_OID_RAWSZ);
+		if (error == 0 && git__is_uint16(e.parent_count)) {
+			size_t i;
+			commit->generation = (uint32_t)e.generation;
+			commit->time = e.commit_time;
+			commit->out_degree = (uint16_t)e.parent_count;
+			commit->parents = alloc_parents(walk, commit, commit->out_degree);
+			GIT_ERROR_CHECK_ALLOC(commit->parents);
+
+			for (i = 0; i < commit->out_degree; ++i) {
+				git_commit_graph_entry parent;
+				error = git_commit_graph_entry_parent(&parent, cgraph, &e, i);
+				if (error < 0)
+					return error;
+				commit->parents[i] = git_revwalk__commit_lookup(walk, &parent.sha1);
+			}
+			commit->parsed = 1;
+			return 0;
+		}
+	}
 
 	if ((error = git_odb_read(&obj, walk->odb, &commit->oid)) < 0)
 		return error;

--- a/src/commit_list.h
+++ b/src/commit_list.h
@@ -26,6 +26,7 @@
 typedef struct git_commit_list_node {
 	git_oid oid;
 	int64_t time;
+	uint32_t generation;
 	unsigned int seen:1,
 			 uninteresting:1,
 			 topo_delay:1,

--- a/src/odb.c
+++ b/src/odb.c
@@ -465,6 +465,13 @@ int git_odb_new(git_odb **out)
 		git__free(db);
 		return -1;
 	}
+	if (git_buf_init(&db->objects_dir, 0) < 0) {
+		git_vector_free(&db->backends);
+		git_cache_dispose(&db->own_cache);
+		git_mutex_free(&db->lock);
+		git__free(db);
+		return -1;
+	}
 
 	*out = db;
 	GIT_REFCOUNT_INC(db);
@@ -612,6 +619,17 @@ int git_odb__add_default_backends(
 	git_mutex_unlock(&db->lock);
 #endif
 
+	if (git_mutex_lock(&db->lock) < 0) {
+		git_error_set(GIT_ERROR_ODB, "failed to acquire the odb lock");
+		return -1;
+	}
+	if (git_buf_len(&db->objects_dir) == 0 && git_buf_sets(&db->objects_dir, objects_dir) < 0) {
+		git_mutex_unlock(&db->lock);
+		git_odb_free(db);
+		return -1;
+	}
+	git_mutex_unlock(&db->lock);
+
 	/* add the loose object backend */
 	if (git_odb_backend_loose(&loose, objects_dir, -1, db->do_fsync, 0, 0) < 0 ||
 		add_backend_internal(db, loose, GIT_LOOSE_PRIORITY, as_alternates, inode) < 0)
@@ -742,6 +760,8 @@ static void odb_free(git_odb *db)
 	if (locked)
 		git_mutex_unlock(&db->lock);
 
+	git_buf_dispose(&db->objects_dir);
+	git_commit_graph_free(db->cgraph);
 	git_vector_free(&db->backends);
 	git_cache_dispose(&db->own_cache);
 	git_mutex_free(&db->lock);
@@ -784,6 +804,53 @@ static int odb_exists_1(
 	git_mutex_unlock(&db->lock);
 
 	return (int)found;
+}
+
+int git_odb__get_commit_graph(git_commit_graph_file **out, git_odb *db)
+{
+	int error = 0;
+
+	if ((error = git_mutex_lock(&db->lock)) < 0) {
+		git_error_set(GIT_ERROR_ODB, "failed to acquire the db lock");
+		return error;
+	}
+	if (!db->cgraph_checked) {
+		git_buf commit_graph_path = GIT_BUF_INIT;
+		git_commit_graph_file *cgraph = NULL;
+
+		/* We only check once, no matter the result. */
+		db->cgraph_checked = 1;
+
+		if (git_buf_len(&db->objects_dir) == 0) {
+			/*
+			 * This odb was not opened with an objects directory
+			 * associated. Skip opening the commit graph.
+			 */
+			goto done;
+		}
+
+		if ((error = git_buf_joinpath(
+				     &commit_graph_path,
+				     git_buf_cstr(&db->objects_dir),
+				     "info/commit-graph"))
+		    < 0) {
+			git_buf_dispose(&commit_graph_path);
+			goto done;
+		}
+		/* Best effort */
+		error = git_commit_graph_open(&cgraph, git_buf_cstr(&commit_graph_path));
+		git_buf_dispose(&commit_graph_path);
+
+		if (error < 0)
+			goto done;
+
+		db->cgraph = cgraph;
+	}
+
+done:
+	*out = db->cgraph;
+	git_mutex_unlock(&db->lock);
+	return 0;
 }
 
 static int odb_freshen_1(
@@ -1695,6 +1762,13 @@ int git_odb_refresh(struct git_odb *db)
 			}
 		}
 	}
+	if (db->cgraph && git_commit_graph_needs_refresh(db->cgraph, NULL)) {
+		/* We just free the commit graph. The next time it is requested, it will be re-loaded. */
+		git_commit_graph_free(db->cgraph);
+		db->cgraph = NULL;
+	}
+	/* Force a lazy re-check next time it is needed. */
+	db->cgraph_checked = 0;
 	git_mutex_unlock(&db->lock);
 
 	return 0;

--- a/src/odb.h
+++ b/src/odb.h
@@ -12,6 +12,7 @@
 #include "git2/odb.h"
 #include "git2/oid.h"
 #include "git2/types.h"
+#include "git2/sys/commit_graph.h"
 
 #include "cache.h"
 #include "commit_graph.h"
@@ -44,10 +45,8 @@ struct git_odb {
 	git_mutex lock;  /* protects backends */
 	git_vector backends;
 	git_cache own_cache;
-	git_buf objects_dir;
-	git_commit_graph_file *cgraph;
+	git_commit_graph *cgraph;
 	unsigned int do_fsync :1;
-	unsigned int cgraph_checked :1;
 };
 
 typedef enum {
@@ -132,11 +131,11 @@ int git_odb__read_header_or_object(
 	git_odb *db, const git_oid *id);
 
 /*
- * Attempt to get the ODB's commit graph. This object is still owned by the
- * ODB. If the repository does not contain a commit graph, it will return zero
- * and `*out` will be set to NULL.
+ * Attempt to get the ODB's commit-graph file. This object is still owned by
+ * the ODB. If the repository does not contain a commit-graph, it will return
+ * GIT_ENOTFOUND.
  */
-int git_odb__get_commit_graph(git_commit_graph_file **out, git_odb *odb);
+int git_odb__get_commit_graph_file(git_commit_graph_file **out, git_odb *odb);
 
 /* freshen an entry in the object database */
 int git_odb__freshen(git_odb *db, const git_oid *id);

--- a/tests/graph/commit_graph.c
+++ b/tests/graph/commit_graph.c
@@ -7,18 +7,18 @@
 void test_graph_commit_graph__parse(void)
 {
 	git_repository *repo;
-	struct git_commit_graph_file *cgraph;
+	struct git_commit_graph_file *file;
 	struct git_commit_graph_entry e, parent;
 	git_oid id;
 	git_buf commit_graph_path = GIT_BUF_INIT;
 
 	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
 	cl_git_pass(git_buf_joinpath(&commit_graph_path, git_repository_path(repo), "objects/info/commit-graph"));
-	cl_git_pass(git_commit_graph_open(&cgraph, git_buf_cstr(&commit_graph_path)));
-	cl_assert_equal_i(git_commit_graph_needs_refresh(cgraph, git_buf_cstr(&commit_graph_path)), 0);
+	cl_git_pass(git_commit_graph_file_open(&file, git_buf_cstr(&commit_graph_path)));
+	cl_assert_equal_i(git_commit_graph_file_needs_refresh(file, git_buf_cstr(&commit_graph_path)), 0);
 
 	cl_git_pass(git_oid_fromstr(&id, "5001298e0c09ad9c34e4249bc5801c75e9754fa5"));
-	cl_git_pass(git_commit_graph_entry_find(&e, cgraph, &id, GIT_OID_HEXSZ));
+	cl_git_pass(git_commit_graph_entry_find(&e, file, &id, GIT_OID_HEXSZ));
 	cl_assert_equal_oid(&e.sha1, &id);
 	cl_git_pass(git_oid_fromstr(&id, "418382dff1ffb8bdfba833f4d8bbcde58b1e7f47"));
 	cl_assert_equal_oid(&e.tree_oid, &id);
@@ -27,23 +27,23 @@ void test_graph_commit_graph__parse(void)
 	cl_assert_equal_i(e.parent_count, 0);
 
 	cl_git_pass(git_oid_fromstr(&id, "be3563ae3f795b2b4353bcce3a527ad0a4f7f644"));
-	cl_git_pass(git_commit_graph_entry_find(&e, cgraph, &id, GIT_OID_HEXSZ));
+	cl_git_pass(git_commit_graph_entry_find(&e, file, &id, GIT_OID_HEXSZ));
 	cl_assert_equal_oid(&e.sha1, &id);
 	cl_assert_equal_i(e.generation, 5);
 	cl_assert_equal_i(e.commit_time, 1274813907ull);
 	cl_assert_equal_i(e.parent_count, 2);
 
 	cl_git_pass(git_oid_fromstr(&id, "9fd738e8f7967c078dceed8190330fc8648ee56a"));
-	cl_git_pass(git_commit_graph_entry_parent(&parent, cgraph, &e, 0));
+	cl_git_pass(git_commit_graph_entry_parent(&parent, file, &e, 0));
 	cl_assert_equal_oid(&parent.sha1, &id);
 	cl_assert_equal_i(parent.generation, 4);
 
 	cl_git_pass(git_oid_fromstr(&id, "c47800c7266a2be04c571c04d5a6614691ea99bd"));
-	cl_git_pass(git_commit_graph_entry_parent(&parent, cgraph, &e, 1));
+	cl_git_pass(git_commit_graph_entry_parent(&parent, file, &e, 1));
 	cl_assert_equal_oid(&parent.sha1, &id);
 	cl_assert_equal_i(parent.generation, 3);
 
-	git_commit_graph_free(cgraph);
+	git_commit_graph_file_free(file);
 	git_repository_free(repo);
 	git_buf_dispose(&commit_graph_path);
 }
@@ -51,17 +51,17 @@ void test_graph_commit_graph__parse(void)
 void test_graph_commit_graph__parse_octopus_merge(void)
 {
 	git_repository *repo;
-	struct git_commit_graph_file *cgraph;
+	struct git_commit_graph_file *file;
 	struct git_commit_graph_entry e, parent;
 	git_oid id;
 	git_buf commit_graph_path = GIT_BUF_INIT;
 
 	cl_git_pass(git_repository_open(&repo, cl_fixture("merge-recursive/.gitted")));
 	cl_git_pass(git_buf_joinpath(&commit_graph_path, git_repository_path(repo), "objects/info/commit-graph"));
-	cl_git_pass(git_commit_graph_open(&cgraph, git_buf_cstr(&commit_graph_path)));
+	cl_git_pass(git_commit_graph_file_open(&file, git_buf_cstr(&commit_graph_path)));
 
 	cl_git_pass(git_oid_fromstr(&id, "d71c24b3b113fd1d1909998c5bfe33b86a65ee03"));
-	cl_git_pass(git_commit_graph_entry_find(&e, cgraph, &id, GIT_OID_HEXSZ));
+	cl_git_pass(git_commit_graph_entry_find(&e, file, &id, GIT_OID_HEXSZ));
 	cl_assert_equal_oid(&e.sha1, &id);
 	cl_git_pass(git_oid_fromstr(&id, "348f16ffaeb73f319a75cec5b16a0a47d2d5e27c"));
 	cl_assert_equal_oid(&e.tree_oid, &id);
@@ -70,21 +70,21 @@ void test_graph_commit_graph__parse_octopus_merge(void)
 	cl_assert_equal_i(e.parent_count, 3);
 
 	cl_git_pass(git_oid_fromstr(&id, "ad2ace9e15f66b3d1138922e6ffdc3ea3f967fa6"));
-	cl_git_pass(git_commit_graph_entry_parent(&parent, cgraph, &e, 0));
+	cl_git_pass(git_commit_graph_entry_parent(&parent, file, &e, 0));
 	cl_assert_equal_oid(&parent.sha1, &id);
 	cl_assert_equal_i(parent.generation, 6);
 
 	cl_git_pass(git_oid_fromstr(&id, "483065df53c0f4a02cdc6b2910b05d388fc17ffb"));
-	cl_git_pass(git_commit_graph_entry_parent(&parent, cgraph, &e, 1));
+	cl_git_pass(git_commit_graph_entry_parent(&parent, file, &e, 1));
 	cl_assert_equal_oid(&parent.sha1, &id);
 	cl_assert_equal_i(parent.generation, 2);
 
 	cl_git_pass(git_oid_fromstr(&id, "815b5a1c80ca749d705c7aa0cb294a00cbedd340"));
-	cl_git_pass(git_commit_graph_entry_parent(&parent, cgraph, &e, 2));
+	cl_git_pass(git_commit_graph_entry_parent(&parent, file, &e, 2));
 	cl_assert_equal_oid(&parent.sha1, &id);
 	cl_assert_equal_i(parent.generation, 6);
 
-	git_commit_graph_free(cgraph);
+	git_commit_graph_file_free(file);
 	git_repository_free(repo);
 	git_buf_dispose(&commit_graph_path);
 }


### PR DESCRIPTION
This change makes revwalks a bit faster by using the `commit-graph` file
(if present). This is thanks to the `commit-graph` allow much faster
parsing of the commit information by requiring near-zero I/O (aside from
reading a few dozen bytes off of a `mmap(2)`-ed file) for each commit,
instead of having to read the ODB, inflate the commit, and parse it.

Part of: #5757