### PR TITLE
midx: Fix a bug in `git_midx_needs_refresh()`

### DIFF
--- a/src/midx.c
+++ b/src/midx.c
@@ -364,7 +364,7 @@ bool git_midx_needs_refresh(
 	if (bytes_read != GIT_OID_RAWSZ)
 		return true;
 
-	return git_oid_cmp(&idx_checksum, &idx->checksum) == 0;
+	return !git_oid_equal(&idx_checksum, &idx->checksum);
 }
 
 int git_midx_entry_find(

--- a/tests/pack/midx.c
+++ b/tests/pack/midx.c
@@ -15,6 +15,7 @@ void test_pack_midx__parse(void)
 	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
 	cl_git_pass(git_buf_joinpath(&midx_path, git_repository_path(repo), "objects/pack/multi-pack-index"));
 	cl_git_pass(git_midx_open(&idx, git_buf_cstr(&midx_path)));
+	cl_assert_equal_i(git_midx_needs_refresh(idx, git_buf_cstr(&midx_path)), 0);
 
 	cl_git_pass(git_oid_fromstr(&id, "5001298e0c09ad9c34e4249bc5801c75e9754fa5"));
 	cl_git_pass(git_midx_entry_find(&e, idx, &id, GIT_OID_HEXSZ));


### PR DESCRIPTION
The very last check in the freshness check for the midx was wrong ><
This was also because this function was not tested.