### PR TITLE
Use `p_pwrite`/`p_pread` consistently throughout the codebase

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -656,7 +656,6 @@ static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 	size_t page_offset;
 	off64_t page_start;
 	off64_t current_size = idx->pack->mwf.size;
-	int fd = idx->pack->mwf.fd;
 	int error;
 
 	if (!size)
@@ -673,8 +672,7 @@ static int append_to_pack(git_indexer *idx, const void *data, size_t size)
 	page_offset = new_size % mmap_alignment;
 	page_start = new_size - page_offset;
 
-	if (p_lseek(fd, page_start + mmap_alignment - 1, SEEK_SET) < 0 ||
-	    p_write(idx->pack->mwf.fd, data, 1) < 0) {
+	if (p_pwrite(idx->pack->mwf.fd, data, 1, page_start + mmap_alignment - 1) < 0) {
 		git_error_set(GIT_ERROR_OS, "cannot extend packfile '%s'", idx->pack->pack_name);
 		return -1;
 	}

--- a/src/midx.c
+++ b/src/midx.c
@@ -353,12 +353,7 @@ bool git_midx_needs_refresh(
 		return true;
 	}
 
-	if (p_lseek(fd, -GIT_OID_RAWSZ, SEEK_END) < 0) {
-		p_close(fd);
-		return true;
-	}
-
-	bytes_read = p_read(fd, &idx_checksum, GIT_OID_RAWSZ);
+	bytes_read = p_pread(fd, &idx_checksum, GIT_OID_RAWSZ, st.st_size - GIT_OID_RAWSZ);
 	p_close(fd);
 
 	if (bytes_read != GIT_OID_RAWSZ)

--- a/src/pack.c
+++ b/src/pack.c
@@ -1130,8 +1130,7 @@ static int packfile_open_locked(struct git_pack_file *p)
 
 	/* Verify the pack matches its index. */
 	if (p->num_objects != ntohl(hdr.hdr_entries) ||
-		p_lseek(p->mwf.fd, p->mwf.size - GIT_OID_RAWSZ, SEEK_SET) == -1 ||
-		p_read(p->mwf.fd, sha1.id, GIT_OID_RAWSZ) < 0)
+		p_pread(p->mwf.fd, sha1.id, GIT_OID_RAWSZ, p->mwf.size - GIT_OID_RAWSZ) < 0)
 		goto cleanup;
 
 	idx_sha1 = ((unsigned char *)p->index_map.data) + p->index_map.len - 40;


### PR DESCRIPTION
This change stops using the seek+read/write combo to perform I/O with an
offset, since this is faster by one system call (and also more atomic
and therefore safer).