### PR TITLE
Cope with empty default branch

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -1141,6 +1141,16 @@ static int remote_head_for_ref(git_remote_head **out, git_remote *remote, git_re
 		ref_name = git_reference_name(resolved_ref);
 	}
 
+	/*
+	 * The ref name may be unresolvable - perhaps it's pointing to
+	 * something invalid.  In this case, there is no remote head for
+	 * this ref.
+	 */
+	if (!ref_name) {
+		error = 0;
+		goto cleanup;
+	}
+
 	if ((error = ref_to_update(&update, &remote_name, remote, spec, ref_name)) < 0)
 		goto cleanup;
 

--- a/src/repository.c
+++ b/src/repository.c
@@ -2092,7 +2092,8 @@ static int repo_init_head(const char *repo_dir, const char *given)
 	if (given) {
 		initial_head = given;
 	} else if ((error = git_config_open_default(&cfg)) >= 0 &&
-	           (error = git_config_get_string_buf(&cfg_branch, cfg, "init.defaultbranch")) >= 0) {
+	           (error = git_config_get_string_buf(&cfg_branch, cfg, "init.defaultbranch")) >= 0 &&
+	           *cfg_branch.ptr) {
 		initial_head = cfg_branch.ptr;
 	}
 

--- a/tests/repo/init.c
+++ b/tests/repo/init.c
@@ -688,3 +688,19 @@ void test_repo_init__defaultbranch_config(void)
 
 	git_reference_free(head);
 }
+
+void test_repo_init__defaultbranch_config_empty(void)
+{
+	git_reference *head;
+
+	cl_set_cleanup(&cleanup_repository, "repo");
+
+	create_tmp_global_config("tmp_global_path", "init.defaultbranch", "");
+
+	cl_git_pass(git_repository_init(&g_repo, "repo", 0));
+	cl_git_pass(git_reference_lookup(&head, g_repo, "HEAD"));
+
+	cl_assert_equal_s("refs/heads/master", git_reference_symbolic_target(head));
+
+	git_reference_free(head);
+}


### PR DESCRIPTION
Previously, when `init.defaultbranch` was present in the config but set to an empty string, we treated it as if the empty string was the default branch.  This meant we set `HEAD` to `refs/heads/`.  Instead, when `init.defaultbranch` is empty, we should ignore it.

Also, fetch should not try to create `FETCH_HEAD` entries that include an invalid branch.

Fixes #5761 