### PR TITLE
clone: set refs/remotes/origin/HEAD when branch is specified

### DIFF
--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -158,6 +158,8 @@ void test_clone_nonetwork__can_prevent_the_checkout_of_a_standard_repo(void)
 
 void test_clone_nonetwork__can_checkout_given_branch(void)
 {
+	git_reference *remote_head;
+
 	g_options.checkout_branch = "test";
 	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 
@@ -167,6 +169,12 @@ void test_clone_nonetwork__can_checkout_given_branch(void)
 	cl_assert_equal_s(git_reference_name(g_ref), "refs/heads/test");
 
 	cl_assert(git_path_exists("foo/readme.txt"));
+
+	cl_git_pass(git_reference_lookup(&remote_head, g_repo, "refs/remotes/origin/HEAD"));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(remote_head));
+	cl_assert_equal_s("refs/remotes/origin/test", git_reference_symbolic_target(remote_head));
+
+	git_reference_free(remote_head);
 }
 
 static int clone_cancel_fetch_transfer_progress_cb(


### PR DESCRIPTION
When a branch is specified to check out in clone, update the remote tracking `HEAD` to point to it.  This mimics git's behavior, when `git clone -b <name>` is used.

Fixes #5751 