### PR TITLE
RFC: separate object lookup error for promisor packs

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -58,6 +58,7 @@ typedef enum {
 	GIT_EMISMATCH       = -33,	/**< Hashsum mismatch in object */
 	GIT_EINDEXDIRTY     = -34,	/**< Unsaved changes in the index would be overwritten */
 	GIT_EAPPLYFAIL      = -35,	/**< Patch application failed */
+	GIT_EMISSING        = -36,	/**< Requested object is missing but promised */
 } git_error_code;
 
 /**

--- a/src/odb.c
+++ b/src/odb.c
@@ -1727,6 +1727,17 @@ int git_odb__error_notfound(
 	return GIT_ENOTFOUND;
 }
 
+int git_odb__error_missing(
+	const char *message, const git_oid *oid, size_t oid_len)
+{
+	char oid_str[GIT_OID_HEXSZ + 1];
+	git_oid_tostr(oid_str, oid_len+1, oid);
+	git_error_set(GIT_ERROR_ODB, "object missing/promised - %s (%.*s)",
+		message, (int) oid_len, oid_str);
+
+	return GIT_EMISSING;
+}
+
 static int error_null_oid(int error, const char *message)
 {
 	git_error_set(GIT_ERROR_ODB, "odb: %s: null OID cannot exist", message);

--- a/src/odb.h
+++ b/src/odb.h
@@ -115,6 +115,12 @@ int git_odb__error_notfound(
 	const char *message, const git_oid *oid, size_t oid_len);
 
 /*
+ * Generate a GIT_EMISSING error for the ODB.
+ */
+int git_odb__error_missing(
+	const char *message, const git_oid *oid, size_t oid_len);
+
+/*
  * Generate a GIT_EAMBIGUOUS error for the ODB.
  */
 int git_odb__error_ambiguous(const char *message);

--- a/src/pack.h
+++ b/src/pack.h
@@ -94,7 +94,7 @@ struct git_pack_file {
 
 	int index_version;
 	git_time_t mtime;
-	unsigned pack_local:1, pack_keep:1, has_cache:1;
+	unsigned pack_local:1, pack_keep:1, has_cache:1, pack_promisor:1;
 	git_oidmap *idx_cache;
 	git_oid **oids;
 


### PR DESCRIPTION
There's currently no support in libgit2 for partial clones (#5564). This attempts to start support them by distinguishing object-lookup faults between `ENOTFOUND` (the requested oid is bad or the repo is corrupt) from a new `EMISSING` error (indicating the oid is referenced from a promisor pack, and therefore _should_ be available remotely).

1. Detect a promisor packfile by looking for a `.packfile` sidecar and track it in an attribute of `git_pack_file`
2. When an object is referenced from a promisor packfile (eg. tree_entry → blob), raise EMISSING instead of ENOTFOUND if the object isn't present anywhere in the ODB.

To be clear, there's no support for _fetching_ missing objects from a promisor remote.

The code doesn't actually do (2) properly when there are multiple ODB backends in place, but hopefully it conveys the basic idea.

Conceptually, EMISSING could also be used for things like shallow clones where parent commits aren't available locally, etc.