### PR TITLE
ci: don't use ninja on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,6 @@ jobs:
           env:
             CC: clang
             CMAKE_OPTIONS: -DREGEX_BACKEND=regcomp_l -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=leaks -DUSE_GSSAPI=ON
-            CMAKE_GENERATOR: Ninja
             PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
             SKIP_SSH_TESTS: true
             SKIP_NEGOTIATE_TESTS: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,7 +112,6 @@ jobs:
           env:
             CC: clang
             CMAKE_OPTIONS: -DREGEX_BACKEND=regcomp_l -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=leaks -DUSE_GSSAPI=ON
-            CMAKE_GENERATOR: Ninja
             PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
             SKIP_SSH_TESTS: true
             SKIP_NEGOTIATE_TESTS: true


### PR DESCRIPTION
Ninja is not installed by default on the macOS machines; stop trying to
use it.  Instead just use `make -j` when we're doing a `Unix Makefiles` build