### PR TITLE
mwindow: Fix a bug in the LRU window finding code

### DIFF
--- a/src/mwindow.c
+++ b/src/mwindow.c
@@ -312,8 +312,10 @@ static int git_mwindow_find_lru_file_locked(git_mwindow_file **out)
 				current_file, &mru_window, NULL, true, GIT_MWINDOW__MRU)) {
 			continue;
 		}
-		if (!lru_window || lru_window->last_used > mru_window->last_used)
+		if (!lru_window || lru_window->last_used > mru_window->last_used) {
+			lru_window = mru_window;
 			lru_file = current_file;
+		}
 	}
 
 	if (!lru_file) {


### PR DESCRIPTION
This change now updates the `lru_window` variable to match the current
file's MRU window. This makes it such that it doesn't always choose the
file that happened to come last in the list of window files, and instead
should now correctly choose the file with the least-recently-used one.