### PR TITLE
revspec: rename git_revparse_mode_t to git_revspec_t

### DIFF
--- a/examples/blame.c
+++ b/examples/blame.c
@@ -54,7 +54,7 @@ int lg2_blame(git_repository *repo, int argc, char *argv[])
 	 */
 	if (o.commitspec) {
 		check_lg2(git_revparse(&revspec, repo, o.commitspec), "Couldn't parse commit spec", NULL);
-		if (revspec.flags & GIT_REVPARSE_SINGLE) {
+		if (revspec.flags & GIT_REVSPEC_SINGLE) {
 			git_oid_cpy(&blameopts.newest_commit, git_object_id(revspec.from));
 			git_object_free(revspec.from);
 		} else {

--- a/examples/log.c
+++ b/examples/log.c
@@ -245,7 +245,7 @@ static int add_revision(struct log_state *s, const char *revstr)
 	}
 
 	if (*revstr == '^') {
-		revs.flags = GIT_REVPARSE_SINGLE;
+		revs.flags = GIT_REVSPEC_SINGLE;
 		hide = !hide;
 
 		if (git_revparse_single(&revs.from, s->repo, revstr + 1) < 0)
@@ -253,12 +253,12 @@ static int add_revision(struct log_state *s, const char *revstr)
 	} else if (git_revparse(&revs, s->repo, revstr) < 0)
 		return -1;
 
-	if ((revs.flags & GIT_REVPARSE_SINGLE) != 0)
+	if ((revs.flags & GIT_REVSPEC_SINGLE) != 0)
 		push_rev(s, revs.from, hide);
 	else {
 		push_rev(s, revs.to, hide);
 
-		if ((revs.flags & GIT_REVPARSE_MERGE_BASE) != 0) {
+		if ((revs.flags & GIT_REVSPEC_MERGE_BASE) != 0) {
 			git_oid base;
 			check_lg2(git_merge_base(&base, s->repo,
 				git_object_id(revs.from), git_object_id(revs.to)),

--- a/examples/rev-list.c
+++ b/examples/rev-list.c
@@ -73,7 +73,7 @@ static int push_range(git_repository *repo, git_revwalk *walk, const char *range
 	if ((error = git_revparse(&revspec, repo, range)))
 		return error;
 
-	if (revspec.flags & GIT_REVPARSE_MERGE_BASE) {
+	if (revspec.flags & GIT_REVSPEC_MERGE_BASE) {
 		/* TODO: support "<commit>...<commit>" */
 		return GIT_EINVALIDSPEC;
 	}

--- a/examples/rev-parse.c
+++ b/examples/rev-parse.c
@@ -69,17 +69,17 @@ static int parse_revision(git_repository *repo, struct parse_state *ps)
 
 	check_lg2(git_revparse(&rs, repo, ps->spec), "Could not parse", ps->spec);
 
-	if ((rs.flags & GIT_REVPARSE_SINGLE) != 0) {
+	if ((rs.flags & GIT_REVSPEC_SINGLE) != 0) {
 		git_oid_tostr(str, sizeof(str), git_object_id(rs.from));
 		printf("%s\n", str);
 		git_object_free(rs.from);
 	}
-	else if ((rs.flags & GIT_REVPARSE_RANGE) != 0) {
+	else if ((rs.flags & GIT_REVSPEC_RANGE) != 0) {
 		git_oid_tostr(str, sizeof(str), git_object_id(rs.to));
 		printf("%s\n", str);
 		git_object_free(rs.to);
 
-		if ((rs.flags & GIT_REVPARSE_MERGE_BASE) != 0) {
+		if ((rs.flags & GIT_REVSPEC_MERGE_BASE) != 0) {
 			git_oid base;
 			check_lg2(git_merge_base(&base, repo,
 						git_object_id(rs.from), git_object_id(rs.to)),

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -29,6 +29,7 @@
 #include "trace.h"
 #include "repository.h"
 #include "revert.h"
+#include "revparse.h"
 #include "stash.h"
 #include "status.h"
 #include "submodule.h"
@@ -414,6 +415,25 @@ GIT_EXTERN(int) git_tag_create_frombuffer(
 
 /**@}*/
 
+/** @name Deprecated Revspec Constants
+ *
+ * These enumeration values are retained for backward compatibility.
+ * The newer versions of these values should be preferred in all new
+ * code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+typedef git_revspec_t git_revparse_mode_t;
+
+#define GIT_REVPARSE_SINGLE GIT_REVSPEC_SINGLE
+#define GIT_REVPARSE_RANGE GIT_REVSPEC_RANGE
+#define GIT_REVPARSE_MERGE_BASE GIT_REVSPEC_MERGE_BASE
+
+/**@}*/
+
 /** @name Deprecated Credential Types
  *
  * These types are retained for backward compatibility.  The newer
@@ -422,6 +442,7 @@ GIT_EXTERN(int) git_tag_create_frombuffer(
  * There is no plan to remove these backward compatibility values at
  * this time.
  */
+/**@{*/
 
 typedef git_credential git_cred;
 typedef git_credential_userpass_plaintext git_cred_userpass_plaintext;

--- a/include/git2/revparse.h
+++ b/include/git2/revparse.h
@@ -70,12 +70,12 @@ GIT_EXTERN(int) git_revparse_ext(
  */
 typedef enum {
 	/** The spec targeted a single object. */
-	GIT_REVPARSE_SINGLE         = 1 << 0,
+	GIT_REVSPEC_SINGLE         = 1 << 0,
 	/** The spec targeted a range of commits. */
-	GIT_REVPARSE_RANGE          = 1 << 1,
+	GIT_REVSPEC_RANGE          = 1 << 1,
 	/** The spec used the '...' operator, which invokes special semantics. */
-	GIT_REVPARSE_MERGE_BASE     = 1 << 2,
-} git_revparse_mode_t;
+	GIT_REVSPEC_MERGE_BASE     = 1 << 2,
+} git_revspec_t;
 
 /**
  * Git Revision Spec: output of a `git_revparse` operation
@@ -85,7 +85,7 @@ typedef struct {
 	git_object *from;
 	/** The right element of the revspec; must be freed by the user */
 	git_object *to;
-	/** The intent of the revspec (i.e. `git_revparse_mode_t` flags) */
+	/** The intent of the revspec (i.e. `git_revspec_mode_t` flags) */
 	unsigned int flags;
 } git_revspec;
 

--- a/src/revparse.c
+++ b/src/revparse.c
@@ -894,7 +894,7 @@ int git_revparse(
 	if ((dotdot = strstr(spec, "..")) != NULL) {
 		char *lstr;
 		const char *rstr;
-		revspec->flags = GIT_REVPARSE_RANGE;
+		revspec->flags = GIT_REVSPEC_RANGE;
 
 		/*
 		 * Following git.git, don't allow '..' because it makes command line
@@ -910,7 +910,7 @@ int git_revparse(
 		lstr = git__substrdup(spec, dotdot - spec);
 		rstr = dotdot + 2;
 		if (dotdot[2] == '.') {
-			revspec->flags |= GIT_REVPARSE_MERGE_BASE;
+			revspec->flags |= GIT_REVSPEC_MERGE_BASE;
 			rstr++;
 		}
 
@@ -928,7 +928,7 @@ int git_revparse(
 
 		git__free((void*)lstr);
 	} else {
-		revspec->flags = GIT_REVPARSE_SINGLE;
+		revspec->flags = GIT_REVSPEC_SINGLE;
 		error = git_revparse_single(&revspec->from, repo, spec);
 	}
 

--- a/src/revwalk.c
+++ b/src/revwalk.c
@@ -238,7 +238,7 @@ int git_revwalk_push_range(git_revwalk *walk, const char *range)
 		goto out;
 	}
 
-	if (revspec.flags & GIT_REVPARSE_MERGE_BASE) {
+	if (revspec.flags & GIT_REVSPEC_MERGE_BASE) {
 		/* TODO: support "<commit>...<commit>" */
 		git_error_set(GIT_ERROR_INVALID, "symmetric differences not implemented in revwalk");
 		error = GIT_EINVALIDSPEC;

--- a/tests/refs/revparse.c
+++ b/tests/refs/revparse.c
@@ -50,7 +50,7 @@ static void test_id_inrepo(
 	const char *spec,
 	const char *expected_left,
 	const char *expected_right,
-	git_revparse_mode_t expected_flags,
+	git_revspec_t expected_flags,
 	git_repository *repo)
 {
 	git_revspec revspec;
@@ -90,7 +90,7 @@ static void test_object_and_ref(const char *spec, const char *expected_oid, cons
 static void test_rangelike(const char *rangelike,
 						   const char *expected_left,
 						   const char *expected_right,
-						   git_revparse_mode_t expected_revparseflags)
+						   git_revspec_t expected_revparseflags)
 {
 	char objstr[64] = {0};
 	git_revspec revspec;
@@ -117,7 +117,7 @@ static void test_id(
 	const char *spec,
 	const char *expected_left,
 	const char *expected_right,
-	git_revparse_mode_t expected_flags)
+	git_revspec_t expected_flags)
 {
 	test_id_inrepo(spec, expected_left, expected_right, expected_flags, g_repo);
 }
@@ -735,53 +735,53 @@ void test_refs_revparse__range(void)
 	test_rangelike("be3563a^1..be3563a",
 	               "9fd738e8f7967c078dceed8190330fc8648ee56a",
 	               "be3563ae3f795b2b4353bcce3a527ad0a4f7f644",
-	               GIT_REVPARSE_RANGE);
+	               GIT_REVSPEC_RANGE);
 
 	test_rangelike("be3563a^1...be3563a",
 	               "9fd738e8f7967c078dceed8190330fc8648ee56a",
 	               "be3563ae3f795b2b4353bcce3a527ad0a4f7f644",
-	               GIT_REVPARSE_RANGE | GIT_REVPARSE_MERGE_BASE);
+	               GIT_REVSPEC_RANGE | GIT_REVSPEC_MERGE_BASE);
 
 	test_rangelike("be3563a^1.be3563a", NULL, NULL, 0);
 }
 
 void test_refs_revparse__parses_range_operator(void)
 {
-	test_id("HEAD", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVPARSE_SINGLE);
+	test_id("HEAD", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVSPEC_SINGLE);
 	test_id("HEAD~3..HEAD",
 		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
-		GIT_REVPARSE_RANGE);
+		GIT_REVSPEC_RANGE);
 
 	test_id("HEAD~3...HEAD",
 		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
-		GIT_REVPARSE_RANGE | GIT_REVPARSE_MERGE_BASE);
+		GIT_REVSPEC_RANGE | GIT_REVSPEC_MERGE_BASE);
 
 	test_id("HEAD~3..",
 		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
-		GIT_REVPARSE_RANGE);
+		GIT_REVSPEC_RANGE);
 
 	test_id("HEAD~3...",
 		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
-		GIT_REVPARSE_RANGE | GIT_REVPARSE_MERGE_BASE);
+		GIT_REVSPEC_RANGE | GIT_REVSPEC_MERGE_BASE);
 
 	test_id("..HEAD~3",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
-		GIT_REVPARSE_RANGE);
+		GIT_REVSPEC_RANGE);
 
 	test_id("...HEAD~3",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045",
-		GIT_REVPARSE_RANGE | GIT_REVPARSE_MERGE_BASE);
+		GIT_REVSPEC_RANGE | GIT_REVSPEC_MERGE_BASE);
 
 	test_id("...",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
 		"a65fedf39aefe402d3bb6e24df4d4f5fe4547750",
-		GIT_REVPARSE_RANGE | GIT_REVPARSE_MERGE_BASE);
+		GIT_REVSPEC_RANGE | GIT_REVSPEC_MERGE_BASE);
 
 	test_invalid_revspec("..");
 }


### PR DESCRIPTION
The information about the type of a revision spec is not information
about the parser.  Name it accordingly, so that `git_revparse_mode_t`
is now `git_revspec_t`.  Deprecate the old name.