### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-build/
+/build/
 .DS_Store
 *~
 .*.swp
-tags
+/tags
 CMakeSettings.json
 .vs


### PR DESCRIPTION
Resolves #5779: Only exclude tags files/folders and build folders at the repository root.