### PR TITLE
clone: set refs/remotes/origin/HEAD to default branch when branch is specified, attempt 2

### DIFF
--- a/src/clone.c
+++ b/src/clone.c
@@ -162,37 +162,6 @@ done:
 	return error;
 }
 
-static int update_remote_head_byname(
-	git_repository *repo,
-	const char *remote_name,
-	const char *tracking_branch_name,
-	const char *reflog_message)
-{
-	git_buf tracking_head_name = GIT_BUF_INIT;
-	git_reference *remote_head = NULL;
-	int error;
-
-	if ((error = git_buf_printf(&tracking_head_name,
-		"%s%s/%s",
-		GIT_REFS_REMOTES_DIR,
-		remote_name,
-		GIT_HEAD_FILE)) < 0)
-		goto cleanup;
-
-	error = git_reference_symbolic_create(
-		&remote_head,
-		repo,
-		git_buf_cstr(&tracking_head_name),
-		tracking_branch_name,
-		true,
-		reflog_message);
-
-cleanup:
-	git_reference_free(remote_head);
-	git_buf_dispose(&tracking_head_name);
-	return error;
-}
-
 static int update_remote_head(
 	git_repository *repo,
 	git_remote *remote,
@@ -200,7 +169,9 @@ static int update_remote_head(
 	const char *reflog_message)
 {
 	git_refspec *refspec;
-	git_buf tracking_branch_name = GIT_BUF_INIT;
+	git_reference *remote_head = NULL;
+	git_buf remote_head_name = GIT_BUF_INIT;
+	git_buf remote_branch_name = GIT_BUF_INIT;
 	int error;
 
 	/* Determine the remote tracking ref name from the local branch */
@@ -213,19 +184,30 @@ static int update_remote_head(
 	}
 
 	if ((error = git_refspec_transform(
-		&tracking_branch_name,
+		&remote_branch_name,
 		refspec,
 		git_buf_cstr(target))) < 0)
 		goto cleanup;
 
-	error = update_remote_head_byname(
-		repo,
+	if ((error = git_buf_printf(&remote_head_name,
+		"%s%s/%s",
+		GIT_REFS_REMOTES_DIR,
 		git_remote_name(remote),
-		git_buf_cstr(&tracking_branch_name),
+		GIT_HEAD_FILE)) < 0)
+		goto cleanup;
+
+	error = git_reference_symbolic_create(
+		&remote_head,
+		repo,
+		git_buf_cstr(&remote_head_name),
+		git_buf_cstr(&remote_branch_name),
+		true,
 		reflog_message);
 
 cleanup:
-	git_buf_dispose(&tracking_branch_name);
+	git_reference_free(remote_head);
+	git_buf_dispose(&remote_branch_name);
+	git_buf_dispose(&remote_head_name);
 	return error;
 }
 
@@ -295,11 +277,8 @@ static int update_head_to_branch(
 	if ((retcode = git_reference_lookup(&remote_ref, repo, git_buf_cstr(&remote_branch_name))) < 0)
 		goto cleanup;
 
-	if ((retcode = update_head_to_new_branch(repo, git_reference_target(remote_ref), branch,
-			reflog_message)) < 0)
-		goto cleanup;
-
-	retcode = update_remote_head_byname(repo, remote_name, remote_branch_name.ptr, reflog_message);
+	retcode = update_head_to_new_branch(repo, git_reference_target(remote_ref), branch,
+			reflog_message);
 
 cleanup:
 	git_reference_free(remote_ref);

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -158,6 +158,8 @@ void test_clone_nonetwork__can_prevent_the_checkout_of_a_standard_repo(void)
 
 void test_clone_nonetwork__can_checkout_given_branch(void)
 {
+	git_reference *remote_head;
+
 	g_options.checkout_branch = "test";
 	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 
@@ -167,6 +169,12 @@ void test_clone_nonetwork__can_checkout_given_branch(void)
 	cl_assert_equal_s(git_reference_name(g_ref), "refs/heads/test");
 
 	cl_assert(git_path_exists("foo/readme.txt"));
+
+	cl_git_pass(git_reference_lookup(&remote_head, g_repo, "refs/remotes/origin/HEAD"));
+	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(remote_head));
+	cl_assert_equal_s("refs/remotes/origin/master", git_reference_symbolic_target(remote_head));
+
+	git_reference_free(remote_head);
 }
 
 static int clone_cancel_fetch_transfer_progress_cb(

--- a/tests/clone/nonetwork.c
+++ b/tests/clone/nonetwork.c
@@ -158,8 +158,6 @@ void test_clone_nonetwork__can_prevent_the_checkout_of_a_standard_repo(void)
 
 void test_clone_nonetwork__can_checkout_given_branch(void)
 {
-	git_reference *remote_head;
-
 	g_options.checkout_branch = "test";
 	cl_git_pass(git_clone(&g_repo, cl_git_fixture_url("testrepo.git"), "./foo", &g_options));
 
@@ -169,12 +167,6 @@ void test_clone_nonetwork__can_checkout_given_branch(void)
 	cl_assert_equal_s(git_reference_name(g_ref), "refs/heads/test");
 
 	cl_assert(git_path_exists("foo/readme.txt"));
-
-	cl_git_pass(git_reference_lookup(&remote_head, g_repo, "refs/remotes/origin/HEAD"));
-	cl_assert_equal_i(GIT_REFERENCE_SYMBOLIC, git_reference_type(remote_head));
-	cl_assert_equal_s("refs/remotes/origin/test", git_reference_symbolic_target(remote_head));
-
-	git_reference_free(remote_head);
 }
 
 static int clone_cancel_fetch_transfer_progress_cb(


### PR DESCRIPTION
Another attempt to fix #5751 :)

I have first reverted the previous attempt and re-introduced changes that seem to work correctly. Please let me know if you don't want the revert though.