### PR TITLE
Fix some typos

### DIFF
--- a/examples/checkout.c
+++ b/examples/checkout.c
@@ -14,7 +14,7 @@
 
 #include "common.h"
 
-/* Define the printf format specifer to use for size_t output */
+/* Define the printf format specifier to use for size_t output */
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #	define PRIuZ "Iu"
 #	define PRIxZ "Ix"

--- a/examples/common.h
+++ b/examples/common.h
@@ -36,7 +36,7 @@
 #endif
 
 #ifndef PRIuZ
-/* Define the printf format specifer to use for size_t output */
+/* Define the printf format specifier to use for size_t output */
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #	define PRIuZ "Iu"
 #else

--- a/examples/tag.c
+++ b/examples/tag.c
@@ -188,7 +188,7 @@ static void action_delete_tag(tag_state *state)
 	git_object_free(obj);
 }
 
-static void action_create_lighweight_tag(tag_state *state)
+static void action_create_lightweight_tag(tag_state *state)
 {
 	git_repository *repo = state->repo;
 	struct tag_options *opts = state->opts;
@@ -260,7 +260,7 @@ static void parse_options(tag_action *action, struct tag_options *opts, int argc
 				print_usage();
 
 			if (*action != &action_create_tag)
-				*action = &action_create_lighweight_tag;
+				*action = &action_create_lightweight_tag;
 		} else if (!strcmp(curr, "-n")) {
 			opts->num_lines = 1;
 			*action = &action_list_tags;

--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -45,7 +45,7 @@
 
 #define GIT_UNUSED(x) ((void)(x))
 
-/* Define the printf format specifer to use for size_t output */
+/* Define the printf format specifier to use for size_t output */
 #if defined(_MSC_VER) || defined(__MINGW32__)
 
 /* Visual Studio 2012 and prior lack PRId64 entirely */

--- a/src/refs.c
+++ b/src/refs.c
@@ -1343,7 +1343,7 @@ const char *git_reference__shorthand(const char *name)
 	else if (!git__prefixcmp(name, GIT_REFS_DIR))
 		return name + strlen(GIT_REFS_DIR);
 
-	/* No shorthands are avaiable, so just return the name */
+	/* No shorthands are available, so just return the name. */
 	return name;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -121,7 +121,7 @@ static int write_add_refspec(git_repository *repo, const char *name, const char 
 		return error;
 
 	/*
-	 * "$^" is a unmatcheable regexp: it will not match anything at all, so
+	 * "$^" is an unmatchable regexp: it will not match anything at all, so
 	 * all values will be considered new and we will not replace any
 	 * present value.
 	 */
@@ -1317,7 +1317,7 @@ int git_remote_prune(git_remote *remote, const git_remote_callbacks *callbacks)
 			if (error == GIT_ENOTFOUND)
 				continue;
 
-			/* if we did find a source, remove it from the candiates */
+			/* If we did find a source, remove it from the candidates. */
 			if ((error = git_vector_set((void **) &src_name, &candidates, i, NULL)) < 0)
 				goto cleanup;
 
@@ -1682,7 +1682,7 @@ int git_remote_update_tips(
 			goto out;
 	}
 
-	/* only try to do opportunisitic updates if the refpec lists differ */
+	/* Only try to do opportunistic updates if the refpec lists differ. */
 	if (remote->passed_refspecs)
 		error = opportunistic_updates(remote, callbacks, &refs, reflog_message);
 

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -268,7 +268,7 @@ static int acquire_fallback_cred(
 				pISM->lpVtbl->Release(pISM);
 			}
 
-			/* Only unitialize if the call to CoInitializeEx was successful. */
+			/* Only uninitialize if the call to CoInitializeEx was successful. */
 			if (SUCCEEDED(hCoInitResult))
 				CoUninitialize();
 		}

--- a/src/win32/w32_leakcheck.c
+++ b/src/win32/w32_leakcheck.c
@@ -513,7 +513,7 @@ int git_win32_leakcheck_stacktrace_dump(
  */
 void git_win32_leakcheck_stacktrace_cleanup(void)
 {
-	/* At shutdown/cleanup, dump cummulative leak info
+	/* At shutdown/cleanup, dump cumulative leak info
 	 * with everything since startup.  This might generate
 	 * extra noise if the caller has been doing checkpoint
 	 * dumps, but it might also eliminate some false


### PR DESCRIPTION
This PR fixes some typos in libgit2. Most of these are in comments. One of these typos is a method name, but it's in the example code, not the `src` folder, so it doesn't break compatibility or anything.