### PR TITLE
Address inconsistent filenames from diff headers

### DIFF
--- a/tests/diff/parse.c
+++ b/tests/diff/parse.c
@@ -399,8 +399,8 @@ void test_diff_parse__new_file_with_space(void)
 	cl_git_pass(git_diff_from_buffer(&diff, content, strlen(content)));
 	cl_git_pass(git_patch_from_diff((git_patch **) &patch, diff, 0));
 
-	cl_assert_equal_p(patch->diff_opts.old_prefix, NULL);
-	cl_assert_equal_p(patch->delta->old_file.path, NULL);
+	cl_assert_equal_s(patch->diff_opts.old_prefix, "a/");
+	cl_assert_equal_s(patch->delta->old_file.path, "sp ace.txt");
 	cl_assert_equal_s(patch->diff_opts.new_prefix, "b/");
 	cl_assert_equal_s(patch->delta->new_file.path, "sp ace.txt");
 

--- a/tests/diff/stats.c
+++ b/tests/diff/stats.c
@@ -366,9 +366,9 @@ void test_diff_stats__new_file(void)
 	"2.21.0\n";
 
 	const char *stat =
-	" Gurjeet Singh | 1 +\n"
+	" Gurjeet Singh\t | 1 +\n"
 	" 1 file changed, 1 insertion(+)\n"
-	" create mode 100644 Gurjeet Singh\n";
+	" create mode 100644 Gurjeet Singh\t\n";
 
 	cl_git_pass(git_diff_from_buffer(&diff, input, strlen(input)));
 	cl_git_pass(git_diff_get_stats(&_stats, diff));

--- a/tests/patch/parse.c
+++ b/tests/patch/parse.c
@@ -176,7 +176,7 @@ void test_patch_parse__filenames_with_trailing_whitespace_are_valid(void)
 	const char *content = PATCH_NAME_WHITESPACE_TRAILING;
 
 	cl_git_pass(git_patch_from_buffer(&patch, content, strlen(content), NULL));
-	ensure_patch_validity_general(patch, "file with spaces.txt", "9432026", "83759c0");
+	ensure_patch_validity_general(patch, "file with spaces.txt ", "9432026", "83759c0");
 	git_patch_free(patch);
 }
 
@@ -186,7 +186,7 @@ void test_patch_parse__filenames_with_trailing_whitespace_and_crlf_endings_are_v
 	const char *content = PATCH_NAME_WHITESPACE_TRAILING_CRLF;
 
 	cl_git_pass(git_patch_from_buffer(&patch, content, strlen(content), NULL));
-	ensure_patch_validity_general(patch, "file with spaces.txt", "9432026", "83759c0");
+	ensure_patch_validity_general(patch, "file with spaces.txt ", "9432026", "83759c0");
 	git_patch_free(patch);
 }
 
@@ -203,30 +203,10 @@ void test_patch_parse__added_files_are_valid(void)
 void test_patch_parse__added_filenames_with_whitespace_are_valid(void)
 {
 	git_patch *patch;
-	const git_diff_delta *delta;
 	const char *content = PATCH_ORIGINAL_NEW_FILE_WITH_SPACE;
-	char idstr[GIT_OID_HEXSZ+1] = {0};
 
 	cl_git_pass(git_patch_from_buffer(&patch, content, strlen(content), NULL));
-	cl_assert((delta = git_patch_get_delta(patch)) != NULL);
-	cl_assert_equal_i(1, delta->nfiles);
-
-	cl_assert(delta->old_file.path == NULL);
-	cl_assert(delta->old_file.mode == GIT_FILEMODE_UNREADABLE);
-	cl_assert_equal_i(0, delta->old_file.id_abbrev);
-	git_oid_nfmt(idstr, delta->old_file.id_abbrev, &delta->old_file.id);
-	cl_assert_equal_s(idstr, "");
-	cl_assert_equal_i(0, delta->old_file.size);
-
-	idstr[0] = '\0';
-
-	cl_assert_equal_s(delta->new_file.path, "sp ace.txt");
-	cl_assert(delta->new_file.mode == GIT_FILEMODE_BLOB);
-	cl_assert_equal_i(9, delta->new_file.id_abbrev);
-	git_oid_nfmt(idstr, delta->new_file.id_abbrev, &delta->new_file.id);
-	cl_assert_equal_s(idstr, "789819226");
-	cl_assert_equal_i(0, delta->new_file.size);
-
+	ensure_patch_validity_general(patch, "sp ace.txt", "", "789819226");
 	git_patch_free(patch);
 }
 
@@ -243,30 +223,10 @@ void test_patch_parse__deleted_files_are_valid(void)
 void test_patch_parse__deleted_filenames_with_whitespace_are_valid(void)
 {
 	git_patch *patch;
-	const git_diff_delta *delta;
 	const char *content = PATCH_DELETE_ORIGINAL_SPACES;
-	char idstr[GIT_OID_HEXSZ+1] = {0};
 
 	cl_git_pass(git_patch_from_buffer(&patch, content, strlen(content), NULL));
-	cl_assert((delta = git_patch_get_delta(patch)) != NULL);
-	cl_assert_equal_i(1, delta->nfiles);
-
-	cl_assert_equal_s(delta->old_file.path, "file with spaces.txt");
-	cl_assert(delta->old_file.mode == GIT_FILEMODE_BLOB);
-	cl_assert_equal_i(7, delta->old_file.id_abbrev);
-	git_oid_nfmt(idstr, delta->old_file.id_abbrev, &delta->old_file.id);
-	cl_assert_equal_s(idstr, "9432026");
-	cl_assert_equal_i(0, delta->old_file.size);
-
-	idstr[0] = '\0';
-
-	cl_assert(delta->new_file.path == NULL);
-	cl_assert(delta->new_file.mode == GIT_FILEMODE_UNREADABLE);
-	cl_assert_equal_i(0, delta->new_file.id_abbrev);
-	git_oid_nfmt(idstr, delta->new_file.id_abbrev, &delta->new_file.id);
-	cl_assert_equal_s(idstr, "");
-	cl_assert_equal_i(0, delta->new_file.size);
-
+	ensure_patch_validity_general(patch, "file with spaces.txt", "9432026", "");
 	git_patch_free(patch);
 }
 

--- a/tests/patch/patch_common.h
+++ b/tests/patch/patch_common.h
@@ -573,6 +573,15 @@
 	"-is additional context\n" \
 	"-below it!\n"
 
+#define PATCH_DELETE_ORIGINAL_SPACES \
+	"diff --git a/file with spaces.txt b/file with spaces.txt\n" \
+	"deleted file mode 100644\n" \
+	"index 9432026..0000000\n" \
+	"--- a/file with spaces.txt\n" \
+	"+++ /dev/null\n" \
+	"@@ -1 +0,0 @@\n" \
+	"-a line\n"
+
 #define PATCH_RENAME_EXACT \
 	"diff --git a/file.txt b/newfile.txt\n" \
 	"similarity index 100%\n" \
@@ -766,6 +775,26 @@
 	" and this\n" \
 	"-is additional context\n" \
 	" below it!\n" \
+
+#define PATCH_NAME_WHITESPACE_TRAILING \
+	"diff --git a/file with spaces.txt  b/file with spaces.txt \n" \
+	"index 9432026..83759c0 100644\n" \
+	"--- a/file with spaces.txt \n" \
+	"+++ b/file with spaces.txt \n" \
+	"@@ -0,3 +0,2 @@\n" \
+	" and this\n" \
+	"-is additional context\n" \
+	" below it!\n" \
+
+#define PATCH_NAME_WHITESPACE_TRAILING_CRLF \
+	"diff --git a/file with spaces.txt  b/file with spaces.txt \r\n" \
+	"index 9432026..83759c0 100644\r\n" \
+	"--- a/file with spaces.txt \r\n" \
+	"+++ b/file with spaces.txt \r\n" \
+	"@@ -0,3 +0,2 @@\r\n" \
+	" and this\r\n" \
+	"-is additional context\r\n" \
+	" below it!\r\n" \
 
 #define PATCH_CORRUPT_GIT_HEADER \
 	"diff --git a/file.txt\n" \


### PR DESCRIPTION
Hi,

Apologies for the head fake but this PR is only for posterity.  It maybe could have been turned into something merge-worthy back when I wrote it and was using this awesome library every day (sorry, wasn't allowed on GitHub back then).

Anyway, I submitted this for the benefit of future people who might find themselves tackling the same issue because this solved it for me at the time.

I will close this in a couple days or so if no one else has by then.

Thanks so much to everyone involved in this amazing project!


Some nonsense from my notes back then:

> This patch aims to add more consistency to diff-header parsing with respect to file additions and deletions, specifically those involving unquoted filenames containing whitespace. It's somewhat related to: https://github.com/libgit2/libgit2/pull/5619 which became ec26b16d734a8a6b4838a1060af46e516c9c58e2
>
> If you recall, that patch was motivated by a bug originating from an emailed, QP-encoded diff. The diff described a new file addition with an unquoted, whitespaced filename. Either of these properties, without the other, would NOT have triggered the segfault (I can demo this). In the end, their combined presence demanded special attention because of quirks in parsing behavior addressed by this patch.
>
> For review purposes, these changes are presented as a sequence of three testable commits. The first adds some tests that fortify existing assertions about the flavor of diff in question. The second alters (fails) these tests to comport with the would-be "standardized" behavior introduced by the last commit.