### PR TITLE
index: Check git_vector_dup error in write_entries

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -2868,7 +2868,9 @@ static int write_entries(git_index *index, git_filebuf *file)
 	/* If index->entries is sorted case-insensitively, then we need
 	 * to re-sort it case-sensitively before writing */
 	if (index->ignore_case) {
-		git_vector_dup(&case_sorted, &index->entries, git_index_entry_cmp);
+		if ((error = git_vector_dup(&case_sorted, &index->entries, git_index_entry_cmp)) < 0)
+			return error;
+
 		git_vector_sort(&case_sorted);
 		entries = &case_sorted;
 	} else {

--- a/src/index.c
+++ b/src/index.c
@@ -2861,7 +2861,7 @@ static int write_entries(git_index *index, git_filebuf *file)
 {
 	int error = 0;
 	size_t i;
-	git_vector case_sorted, *entries;
+	git_vector case_sorted = GIT_VECTOR_INIT, *entries = NULL;
 	git_index_entry *entry;
 	const char *last = NULL;
 
@@ -2869,7 +2869,7 @@ static int write_entries(git_index *index, git_filebuf *file)
 	 * to re-sort it case-sensitively before writing */
 	if (index->ignore_case) {
 		if ((error = git_vector_dup(&case_sorted, &index->entries, git_index_entry_cmp)) < 0)
-			return error;
+			goto done;
 
 		git_vector_sort(&case_sorted);
 		entries = &case_sorted;
@@ -2887,9 +2887,8 @@ static int write_entries(git_index *index, git_filebuf *file)
 			last = entry->path;
 	}
 
-	if (index->ignore_case)
-		git_vector_free(&case_sorted);
-
+done:
+	git_vector_free(&case_sorted);
 	return error;
 }
 


### PR DESCRIPTION
If I'm understanding this right, `git_vector_sort` will segfault when allocating `case_sorted.contents` fails