### PR TITLE
Introduce GIT_WARN_UNUSED_RESULT

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -71,7 +71,18 @@ typedef size_t size_t;
 # define GIT_FORMAT_PRINTF(a,b) /* empty */
 #endif
 
-/** Declare that a function's return value must be used. */
+/**
+ * Declare that a function's return value must be used.
+ *
+ * Used mostly to guard against potential silent bugs at runtime. This is
+ * recommended to be added to functions that:
+ *
+ * - Allocate / reallocate memory. This prevents memory leaks or errors where
+ *   buffers are expected to have grown to a certain size, but could not be
+ *   resized.
+ * - Acquire locks. When a lock cannot be acquired, that will almost certainly
+ *   cause a data race / undefined behavior.
+ */
 #if defined(__GNUC__)
 # define GIT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #else

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -71,24 +71,6 @@ typedef size_t size_t;
 # define GIT_FORMAT_PRINTF(a,b) /* empty */
 #endif
 
-/**
- * Declare that a function's return value must be used.
- *
- * Used mostly to guard against potential silent bugs at runtime. This is
- * recommended to be added to functions that:
- *
- * - Allocate / reallocate memory. This prevents memory leaks or errors where
- *   buffers are expected to have grown to a certain size, but could not be
- *   resized.
- * - Acquire locks. When a lock cannot be acquired, that will almost certainly
- *   cause a data race / undefined behavior.
- */
-#if defined(__GNUC__)
-# define GIT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#else
-# define GIT_WARN_UNUSED_RESULT
-#endif
-
 #if (defined(_WIN32)) && !defined(__CYGWIN__)
 #define GIT_WIN32 1
 #endif

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -71,6 +71,13 @@ typedef size_t size_t;
 # define GIT_FORMAT_PRINTF(a,b) /* empty */
 #endif
 
+/** Declare that a function's return value must be used. */
+#if defined(__GNUC__)
+# define GIT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+# define GIT_WARN_UNUSED_RESULT
+#endif
+
 #if (defined(_WIN32)) && !defined(__CYGWIN__)
 #define GIT_WIN32 1
 #endif

--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -43,7 +43,15 @@
 #	define GIT_ALIGN(x,size) x
 #endif
 
-#define GIT_UNUSED(x) ((void)(x))
+#if defined(__GNUC__)
+# define GIT_UNUSED(x)                                                                              \
+	do {                                                                                       \
+		typeof(x) _unused __attribute__((unused));                                         \
+		_unused = (x);                                                                     \
+	} while (0)
+#else
+# define GIT_UNUSED(x) ((void)(x))
+#endif
 
 /* Define the printf format specifier to use for size_t output */
 #if defined(_MSC_VER) || defined(__MINGW32__)

--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -44,10 +44,10 @@
 #endif
 
 #if defined(__GNUC__)
-# define GIT_UNUSED(x)                                                                              \
-	do {                                                                                       \
-		typeof(x) _unused __attribute__((unused));                                         \
-		_unused = (x);                                                                     \
+# define GIT_UNUSED(x)                                                         \
+	do {                                                                   \
+		typeof(x) _unused __attribute__((unused));                     \
+		_unused = (x);                                                 \
 	} while (0)
 #else
 # define GIT_UNUSED(x) ((void)(x))

--- a/src/common.h
+++ b/src/common.h
@@ -30,6 +30,24 @@
 # define __has_builtin(x) 0
 #endif
 
+/**
+ * Declare that a function's return value must be used.
+ *
+ * Used mostly to guard against potential silent bugs at runtime. This is
+ * recommended to be added to functions that:
+ *
+ * - Allocate / reallocate memory. This prevents memory leaks or errors where
+ *   buffers are expected to have grown to a certain size, but could not be
+ *   resized.
+ * - Acquire locks. When a lock cannot be acquired, that will almost certainly
+ *   cause a data race / undefined behavior.
+ */
+#if defined(__GNUC__)
+# define GIT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+# define GIT_WARN_UNUSED_RESULT
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>
@@ -134,24 +152,6 @@ GIT_INLINE(int) git_error__check_version(const void *structure, unsigned int exp
 	return -1;
 }
 #define GIT_ERROR_CHECK_VERSION(S,V,N) if (git_error__check_version(S,V,N) < 0) return -1
-
-/**
- * Declare that a function's return value must be used.
- *
- * Used mostly to guard against potential silent bugs at runtime. This is
- * recommended to be added to functions that:
- *
- * - Allocate / reallocate memory. This prevents memory leaks or errors where
- *   buffers are expected to have grown to a certain size, but could not be
- *   resized.
- * - Acquire locks. When a lock cannot be acquired, that will almost certainly
- *   cause a data race / undefined behavior.
- */
-#if defined(__GNUC__)
-# define GIT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#else
-# define GIT_WARN_UNUSED_RESULT
-#endif
 
 /**
  * Initialize a structure with a version.

--- a/src/common.h
+++ b/src/common.h
@@ -136,6 +136,24 @@ GIT_INLINE(int) git_error__check_version(const void *structure, unsigned int exp
 #define GIT_ERROR_CHECK_VERSION(S,V,N) if (git_error__check_version(S,V,N) < 0) return -1
 
 /**
+ * Declare that a function's return value must be used.
+ *
+ * Used mostly to guard against potential silent bugs at runtime. This is
+ * recommended to be added to functions that:
+ *
+ * - Allocate / reallocate memory. This prevents memory leaks or errors where
+ *   buffers are expected to have grown to a certain size, but could not be
+ *   resized.
+ * - Acquire locks. When a lock cannot be acquired, that will almost certainly
+ *   cause a data race / undefined behavior.
+ */
+#if defined(__GNUC__)
+# define GIT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+# define GIT_WARN_UNUSED_RESULT
+#endif
+
+/**
  * Initialize a structure with a version.
  */
 GIT_INLINE(void) git__init_structure(void *structure, size_t len, unsigned int version)

--- a/src/odb.c
+++ b/src/odb.c
@@ -573,7 +573,7 @@ int git_odb__add_default_backends(
 	git_odb *db, const char *objects_dir,
 	bool as_alternates, int alternate_depth)
 {
-	size_t i;
+	size_t i = 0;
 	struct stat st;
 	ino_t inode;
 	git_odb_backend *loose, *packed;
@@ -582,7 +582,7 @@ int git_odb__add_default_backends(
 	 * a cross-platform workaround for this */
 #ifdef GIT_WIN32
 	GIT_UNUSED(i);
-	GIT_UNUSED(st);
+	GIT_UNUSED(&st);
 
 	inode = 0;
 #else

--- a/src/path.c
+++ b/src/path.c
@@ -1915,7 +1915,13 @@ GIT_INLINE(bool) should_validate_longpaths(git_repository *repo)
 }
 
 #else
-# define should_validate_longpaths(repo) (GIT_UNUSED(repo), false)
+
+GIT_INLINE(bool) should_validate_longpaths(git_repository *repo)
+{
+	GIT_UNUSED(repo);
+
+	return false;
+}
 #endif
 
 int git_path_validate_workdir(git_repository *repo, const char *path)

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -122,7 +122,7 @@ static int packed_reload(refdb_fs_backend *backend)
 	 */
 	if (error <= 0) {
 		if (error == GIT_ENOTFOUND) {
-			git_sortedcache_clear(backend->refcache, true);
+			GIT_UNUSED(git_sortedcache_clear(backend->refcache, true));
 			git_error_clear();
 			error = 0;
 		}
@@ -131,7 +131,7 @@ static int packed_reload(refdb_fs_backend *backend)
 
 	/* At this point, refresh the packed refs from the loaded buffer. */
 
-	git_sortedcache_clear(backend->refcache, false);
+	GIT_UNUSED(git_sortedcache_clear(backend->refcache, false));
 
 	scan = (char *)packedrefs.ptr;
 	eof  = scan + packedrefs.size;
@@ -219,7 +219,7 @@ static int packed_reload(refdb_fs_backend *backend)
 parse_failed:
 	git_error_set(GIT_ERROR_REFERENCE, "corrupted packed references file");
 
-	git_sortedcache_clear(backend->refcache, false);
+	GIT_UNUSED(git_sortedcache_clear(backend->refcache, false));
 	git_sortedcache_wunlock(backend->refcache);
 	git_buf_dispose(&packedrefs);
 

--- a/src/sortedcache.h
+++ b/src/sortedcache.h
@@ -58,7 +58,7 @@ typedef struct {
  *        may be NULL.  The cache makes it easy to load this and check
  *        if it has been modified since the last load and/or write.
  */
-int git_sortedcache_new(
+GIT_WARN_UNUSED_RESULT int git_sortedcache_new(
 	git_sortedcache **out,
 	size_t item_path_offset, /* use offsetof(struct, path-field) macro */
 	git_sortedcache_free_item_fn free_item,
@@ -71,7 +71,7 @@ int git_sortedcache_new(
  * - `copy_item` can be NULL to just use memcpy
  * - if `lock`, grabs read lock on `src` during copy and releases after
  */
-int git_sortedcache_copy(
+GIT_WARN_UNUSED_RESULT int git_sortedcache_copy(
 	git_sortedcache **out,
 	git_sortedcache *src,
 	bool lock,
@@ -88,7 +88,7 @@ void git_sortedcache_free(git_sortedcache *sc);
 void git_sortedcache_incref(git_sortedcache *sc);
 
 /* Get the pathname associated with this cache at creation time */
-const char *git_sortedcache_path(git_sortedcache *sc);
+GIT_WARN_UNUSED_RESULT const char *git_sortedcache_path(git_sortedcache *sc);
 
 /*
  * CACHE WRITE FUNCTIONS
@@ -100,7 +100,7 @@ const char *git_sortedcache_path(git_sortedcache *sc);
  */
 
 /* Lock sortedcache for write */
-int git_sortedcache_wlock(git_sortedcache *sc);
+GIT_WARN_UNUSED_RESULT int git_sortedcache_wlock(git_sortedcache *sc);
 
 /* Unlock sorted cache when done with write */
 void git_sortedcache_wunlock(git_sortedcache *sc);
@@ -120,7 +120,8 @@ void git_sortedcache_wunlock(git_sortedcache *sc);
  *
  * @return 0 if up-to-date, 1 if out-of-date, <0 on error
  */
-int git_sortedcache_lockandload(git_sortedcache *sc, git_buf *buf);
+GIT_WARN_UNUSED_RESULT int git_sortedcache_lockandload(
+	git_sortedcache *sc, git_buf *buf);
 
 /* Refresh file timestamp after write completes
  * You should already be holding the write lock when you call this.
@@ -137,13 +138,13 @@ int git_sortedcache_clear(git_sortedcache *sc, bool wlock);
 /* Find and/or insert item, returning pointer to item data.
  * You should already be holding the write lock when you call this.
  */
-int git_sortedcache_upsert(
+GIT_WARN_UNUSED_RESULT int git_sortedcache_upsert(
 	void **out, git_sortedcache *sc, const char *key);
 
 /* Removes entry at pos from cache
  * You should already be holding the write lock when you call this.
  */
-int git_sortedcache_remove(git_sortedcache *sc, size_t pos);
+GIT_WARN_UNUSED_RESULT int git_sortedcache_remove(git_sortedcache *sc, size_t pos);
 
 /*
  * CACHE READ FUNCTIONS
@@ -155,26 +156,29 @@ int git_sortedcache_remove(git_sortedcache *sc, size_t pos);
  */
 
 /* Lock sortedcache for read */
-int git_sortedcache_rlock(git_sortedcache *sc);
+GIT_WARN_UNUSED_RESULT int git_sortedcache_rlock(git_sortedcache *sc);
 
 /* Unlock sorted cache when done with read */
 void git_sortedcache_runlock(git_sortedcache *sc);
 
 /* Lookup item by key - returns NULL if not found */
-void *git_sortedcache_lookup(const git_sortedcache *sc, const char *key);
+GIT_WARN_UNUSED_RESULT void *git_sortedcache_lookup(
+	const git_sortedcache *sc, const char *key);
 
 /* Get how many items are in the cache
  *
  * You can call this function without holding a lock, but be aware
  * that it may change before you use it.
  */
-size_t git_sortedcache_entrycount(const git_sortedcache *sc);
+GIT_WARN_UNUSED_RESULT size_t git_sortedcache_entrycount(
+	const git_sortedcache *sc);
 
 /* Lookup item by index - returns NULL if out of range */
-void *git_sortedcache_entry(git_sortedcache *sc, size_t pos);
+GIT_WARN_UNUSED_RESULT void *git_sortedcache_entry(
+	git_sortedcache *sc, size_t pos);
 
 /* Lookup index of item by key - returns GIT_ENOTFOUND if not found */
-int git_sortedcache_lookup_index(
+GIT_WARN_UNUSED_RESULT int git_sortedcache_lookup_index(
 	size_t *out, git_sortedcache *sc, const char *key);
 
 #endif

--- a/src/sortedcache.h
+++ b/src/sortedcache.h
@@ -133,7 +133,8 @@ void git_sortedcache_updated(git_sortedcache *sc);
  * If `wlock` is true, grabs write lock and releases when done, otherwise
  * you should already be holding a write lock when you call this.
  */
-int git_sortedcache_clear(git_sortedcache *sc, bool wlock);
+GIT_WARN_UNUSED_RESULT int git_sortedcache_clear(
+	git_sortedcache *sc, bool wlock);
 
 /* Find and/or insert item, returning pointer to item data.
  * You should already be holding the write lock when you call this.

--- a/src/sortedcache.h
+++ b/src/sortedcache.h
@@ -88,7 +88,7 @@ void git_sortedcache_free(git_sortedcache *sc);
 void git_sortedcache_incref(git_sortedcache *sc);
 
 /* Get the pathname associated with this cache at creation time */
-GIT_WARN_UNUSED_RESULT const char *git_sortedcache_path(git_sortedcache *sc);
+const char *git_sortedcache_path(git_sortedcache *sc);
 
 /*
  * CACHE WRITE FUNCTIONS
@@ -145,7 +145,7 @@ GIT_WARN_UNUSED_RESULT int git_sortedcache_upsert(
 /* Removes entry at pos from cache
  * You should already be holding the write lock when you call this.
  */
-GIT_WARN_UNUSED_RESULT int git_sortedcache_remove(git_sortedcache *sc, size_t pos);
+int git_sortedcache_remove(git_sortedcache *sc, size_t pos);
 
 /*
  * CACHE READ FUNCTIONS
@@ -163,23 +163,20 @@ GIT_WARN_UNUSED_RESULT int git_sortedcache_rlock(git_sortedcache *sc);
 void git_sortedcache_runlock(git_sortedcache *sc);
 
 /* Lookup item by key - returns NULL if not found */
-GIT_WARN_UNUSED_RESULT void *git_sortedcache_lookup(
-	const git_sortedcache *sc, const char *key);
+void *git_sortedcache_lookup(const git_sortedcache *sc, const char *key);
 
 /* Get how many items are in the cache
  *
  * You can call this function without holding a lock, but be aware
  * that it may change before you use it.
  */
-GIT_WARN_UNUSED_RESULT size_t git_sortedcache_entrycount(
-	const git_sortedcache *sc);
+size_t git_sortedcache_entrycount(const git_sortedcache *sc);
 
 /* Lookup item by index - returns NULL if out of range */
-GIT_WARN_UNUSED_RESULT void *git_sortedcache_entry(
-	git_sortedcache *sc, size_t pos);
+void *git_sortedcache_entry(git_sortedcache *sc, size_t pos);
 
 /* Lookup index of item by key - returns GIT_ENOTFOUND if not found */
-GIT_WARN_UNUSED_RESULT int git_sortedcache_lookup_index(
+int git_sortedcache_lookup_index(
 	size_t *out, git_sortedcache *sc, const char *key);
 
 #endif

--- a/src/vector.h
+++ b/src/vector.h
@@ -26,11 +26,13 @@ typedef struct git_vector {
 
 #define GIT_VECTOR_INIT {0}
 
-int git_vector_init(git_vector *v, size_t initial_size, git_vector_cmp cmp);
+GIT_WARN_UNUSED_RESULT int git_vector_init(
+	git_vector *v, size_t initial_size, git_vector_cmp cmp);
 void git_vector_free(git_vector *v);
 void git_vector_free_deep(git_vector *v); /* free each entry and self */
 void git_vector_clear(git_vector *v);
-int git_vector_dup(git_vector *v, const git_vector *src, git_vector_cmp cmp);
+GIT_WARN_UNUSED_RESULT int git_vector_dup(
+	git_vector *v, const git_vector *src, git_vector_cmp cmp);
 void git_vector_swap(git_vector *a, git_vector *b);
 int git_vector_size_hint(git_vector *v, size_t size_hint);
 

--- a/src/win32/path_w32.h
+++ b/src/win32/path_w32.h
@@ -8,7 +8,6 @@
 #define INCLUDE_win32_path_w32_h__
 
 #include "common.h"
-#include "vector.h"
 
 /**
  * Create a Win32 path (in UCS-2 format) from a UTF-8 string.  If the given

--- a/tests/core/sha1.c
+++ b/tests/core/sha1.c
@@ -52,7 +52,7 @@ void test_core_sha1__detect_collision_attack(void)
 	git_oid oid, expected;
 
 #ifdef GIT_SHA1_COLLISIONDETECT
-	GIT_UNUSED(expected);
+	GIT_UNUSED(&expected);
 	cl_git_fail(sha1_file(&oid, FIXTURE_DIR "/shattered-1.pdf"));
 	cl_assert_equal_s("SHA1 collision attack detected", git_error_last()->message);
 #else

--- a/tests/core/sortedcache.c
+++ b/tests/core/sortedcache.c
@@ -54,7 +54,7 @@ void test_core_sortedcache__name_only(void)
 	cl_assert_equal_i(
 		GIT_ENOTFOUND, git_sortedcache_lookup_index(&pos, sc, "abc"));
 
-	git_sortedcache_clear(sc, true);
+	cl_git_pass(git_sortedcache_clear(sc, true));
 
 	cl_assert_equal_sz(0, git_sortedcache_entrycount(sc));
 	cl_assert(git_sortedcache_entry(sc, 0) == NULL);
@@ -154,7 +154,7 @@ void test_core_sortedcache__in_memory(void)
 
 	cl_assert_equal_i(0, free_count);
 
-	git_sortedcache_clear(sc, true);
+	cl_git_pass(git_sortedcache_clear(sc, true));
 
 	cl_assert_equal_i(5, free_count);
 
@@ -247,7 +247,7 @@ static void sortedcache_test_reload(git_sortedcache *sc)
 
 	cl_assert(git_sortedcache_lockandload(sc, &buf) > 0);
 
-	git_sortedcache_clear(sc, false); /* clear once we already have lock */
+	cl_git_pass(git_sortedcache_clear(sc, false)); /* clear once we already have lock */
 
 	for (scan = buf.ptr; *scan; scan = after + 1) {
 		int val = strtol(scan, &after, 0);

--- a/tests/core/vector.c
+++ b/tests/core/vector.c
@@ -8,7 +8,7 @@ void test_core_vector__0(void)
 {
 	git_vector x;
 	int i;
-	git_vector_init(&x, 1, NULL);
+	cl_git_pass(git_vector_init(&x, 1, NULL));
 	for (i = 0; i < 10; ++i) {
 		git_vector_insert(&x, (void*) 0xabc);
 	}
@@ -21,7 +21,7 @@ void test_core_vector__1(void)
 {
 	git_vector x;
 	/* make initial capacity exact for our insertions. */
-	git_vector_init(&x, 3, NULL);
+	cl_git_pass(git_vector_init(&x, 3, NULL));
 	git_vector_insert(&x, (void*) 0xabc);
 	git_vector_insert(&x, (void*) 0xdef);
 	git_vector_insert(&x, (void*) 0x123);
@@ -76,7 +76,7 @@ void test_core_vector__3(void)
 {
 	git_vector x;
 	intptr_t i;
-	git_vector_init(&x, 1, &compare_them);
+	cl_git_pass(git_vector_init(&x, 1, &compare_them));
 
 	for (i = 0; i < 10; i += 2) {
 		git_vector_insert_sorted(&x, (void*)(i + 1), NULL);
@@ -99,7 +99,7 @@ void test_core_vector__4(void)
 {
 	git_vector x;
 	intptr_t i;
-	git_vector_init(&x, 1, &compare_them);
+	cl_git_pass(git_vector_init(&x, 1, &compare_them));
 
 	for (i = 0; i < 10; i += 2) {
 		git_vector_insert_sorted(&x, (void*)(i + 1), NULL);
@@ -163,7 +163,7 @@ void test_core_vector__5(void)
 	git_vector x;
 	int i;
 
-	git_vector_init(&x, 1, &compare_structs);
+	cl_git_pass(git_vector_init(&x, 1, &compare_structs));
 
 	for (i = 0; i < 10; i += 2)
 		git_vector_insert_sorted(&x, alloc_struct(i), &merge_structs);
@@ -205,7 +205,7 @@ void test_core_vector__remove_matching(void)
 	size_t i;
 	void *compare;
 
-	git_vector_init(&x, 1, NULL);
+	cl_git_pass(git_vector_init(&x, 1, NULL));
 	git_vector_insert(&x, (void*) 0x001);
 
 	cl_assert(x.length == 1);

--- a/tests/fetchhead/nonetwork.c
+++ b/tests/fetchhead/nonetwork.c
@@ -82,7 +82,7 @@ void test_fetchhead_nonetwork__write(void)
 	int equals = 0;
 	size_t i;
 
-	git_vector_init(&fetchhead_vector, 6, NULL);
+	cl_git_pass(git_vector_init(&fetchhead_vector, 6, NULL));
 
 	cl_set_cleanup(&cleanup_repository, "./test1");
 	cl_git_pass(git_repository_init(&g_repo, "./test1", 0));

--- a/tests/index/addall.c
+++ b/tests/index/addall.c
@@ -318,11 +318,9 @@ void test_index_addall__files_in_folders(void)
 
 void test_index_addall__hidden_files(void)
 {
+#ifdef GIT_WIN32
 	git_index *index;
 
-	GIT_UNUSED(index);
-
-#ifdef GIT_WIN32
 	addall_create_test_repo(true);
 
 	cl_git_pass(git_repository_index(&index, g_repo));

--- a/tests/index/bypath.c
+++ b/tests/index/bypath.c
@@ -49,13 +49,10 @@ void test_index_bypath__add_submodule_unregistered(void)
 
 void test_index_bypath__add_hidden(void)
 {
+#ifdef GIT_WIN32
 	const git_index_entry *entry;
 	bool hidden;
 
-	GIT_UNUSED(entry);
-	GIT_UNUSED(hidden);
-
-#ifdef GIT_WIN32
 	cl_git_mkfile("submod2/hidden_file", "you can't see me");
 
 	cl_git_pass(git_win32__hidden(&hidden, "submod2/hidden_file"));


### PR DESCRIPTION
This change adds the GIT_WARN_UNUSED_RESULT annotation, which makes the
compiler warn when a return result is not used. This avoids bugs.