### PR TITLE
Don't send want-list more than once in a packfile negotiation

### DIFF
--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -389,9 +389,6 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 			git_pkt_ack *pkt;
 			unsigned int j;
 
-			if ((error = git_pkt_buffer_wants(wants, count, &t->caps, &data)) < 0)
-				goto on_error;
-
 			git_vector_foreach(&t->common, j, pkt) {
 				if ((error = git_pkt_buffer_have(&pkt->oid, &data)) < 0)
 					goto on_error;
@@ -408,9 +405,6 @@ int git_smart__negotiate_fetch(git_transport *transport, git_repository *repo, c
 	if (t->rpc && t->common.length > 0) {
 		git_pkt_ack *pkt;
 		unsigned int j;
-
-		if ((error = git_pkt_buffer_wants(wants, count, &t->caps, &data)) < 0)
-			goto on_error;
 
 		git_vector_foreach(&t->common, j, pkt) {
 			if ((error = git_pkt_buffer_have(&pkt->oid, &data)) < 0)


### PR DESCRIPTION
This change makes libgit2 be a bit more compliant with the packfile
negotiation spec[1] by avoiding sending the want-list more than once per
negotiation. This also is in line with how git's `find_common()`[2]
works, in which the
`want`s/`shallow`s/`deepen`s/`deepen-since`s/`deepen-not`s are sent once
before the second phase of the packfile negotiation starts, and that
phase only sends `have`s.

Fixes: #5799

1: https://git-scm.com/docs/pack-protocol#_packfile_negotiation
2: https://github.com/git/git/blob/2283e0e9af55689215afa39c03beb2315ce18e83/fetch-pack.c#L267