### PR TITLE
include: fix typos in comments

### DIFF
--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -263,7 +263,7 @@ GIT_EXTERN(int) git_config_open_level(
  *
  * Git allows you to store your global configuration at
  * `$HOME/.gitconfig` or `$XDG_CONFIG_HOME/git/config`. For backwards
- * compatability, the XDG file shouldn't be used unless the use has
+ * compatibility, the XDG file shouldn't be used unless the use has
  * created it explicitly. With this function you'll open the correct
  * one to write to.
  *

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -349,7 +349,7 @@ GIT_EXTERN(int) git_index_write_tree(git_oid *out, git_index *index);
  *
  * The index must not contain any file in conflict.
  *
- * @param out Pointer where to store OID of the the written tree
+ * @param out Pointer where to store OID of the written tree
  * @param index Index to write
  * @param repo Repository where to write the tree
  * @return 0 on success, GIT_EUNMERGED when the index is not clean

--- a/include/git2/refs.h
+++ b/include/git2/refs.h
@@ -169,7 +169,7 @@ GIT_EXTERN(int) git_reference_symbolic_create(git_reference **out, git_repositor
  *
  * The message for the reflog will be ignored if the reference does
  * not belong in the standard set (HEAD, branches and remote-tracking
- * branches) and and it does not have a reflog.
+ * branches) and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param repo Repository where that reference will live
@@ -206,7 +206,7 @@ GIT_EXTERN(int) git_reference_create(git_reference **out, git_repository *repo, 
  *
  * The message for the reflog will be ignored if the reference does
  * not belong in the standard set (HEAD, branches and remote-tracking
- * branches) and and it does not have a reflog.
+ * branches) and it does not have a reflog.
  *
  * It will return GIT_EMODIFIED if the reference's value at the time
  * of updating does not match the one passed through `current_id`
@@ -318,7 +318,7 @@ GIT_EXTERN(git_repository *) git_reference_owner(const git_reference *ref);
  *
  * The message for the reflog will be ignored if the reference does
  * not belong in the standard set (HEAD, branches and remote-tracking
- * branches) and and it does not have a reflog.
+ * branches) and it does not have a reflog.
  *
  * @param out Pointer to the newly created reference
  * @param ref The reference

--- a/include/git2/transport.h
+++ b/include/git2/transport.h
@@ -23,7 +23,7 @@
 GIT_BEGIN_DECL
 
 /**
- * Callback for messages recieved by the transport.
+ * Callback for messages received by the transport.
  *
  * Return a negative value to cancel the network operation.
  *


### PR DESCRIPTION
Just a few typo fixes within the `include` directory :)