### PR TITLE
merge: Check insert_head_ids error in create_virtual_base

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -2277,8 +2277,11 @@ static int create_virtual_base(
 	result->type = GIT_ANNOTATED_COMMIT_VIRTUAL;
 	result->index = index;
 
-	insert_head_ids(&result->parents, one);
-	insert_head_ids(&result->parents, two);
+	if (insert_head_ids(&result->parents, one) < 0 ||
+		insert_head_ids(&result->parents, two) < 0) {
+		git_annotated_commit_free(result);
+		return -1;
+	}
 
 	*out = result;
 	return 0;


### PR DESCRIPTION
`insert_head_ids` can fail due to allocation error