### PR TITLE
stash: add git stash create and git stash store.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,8 @@ vNext
   replaces `git_reference_is_valid_name`.  Tthe former functions are
   deprecated.
 
+* Support has been added for `git_stash_create` and `git_stash_store`.
+
 ### Breaking CMake configuration changes
 
 The `MVSC_CRTDBG` configuration option is now `WIN32_LEAKCHECK`.

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -48,6 +48,49 @@ typedef enum {
 } git_stash_flags;
 
 /**
+ * Create a new stash containing local modifications without storing it anywhere
+ * in the ref namespace.
+ *
+ * @param out Object id of the commit containing the stashed state.
+ *
+ * @param repo The owning repository.
+ *
+ * @param stasher The identity of the person performing the stashing.
+ *
+ * @param message Optional description along with the stashed state.
+ *
+ * @param flags Flags to control the stashing process. (see GIT_STASH_* above)
+ *
+ * @return 0 on success, GIT_ENOTFOUND where there's nothing to stash,
+ * or error code.
+ */
+GIT_EXTERN(int) git_stash_create(
+	git_oid *out,
+	git_repository *repo,
+	const git_signature *stasher,
+	const char *message,
+	uint32_t flags);
+
+/**
+ * Store a stash created via git_stash_create in the stash ref, updating the
+ * stash reflog.
+ *
+ * @param stash_id Object id of the commit containing the stashed state.
+ * This commit becomes the target of the direct reference refs/stash.
+ *
+ * @param repo The owning repository.
+ *
+ * @param message Optional description along with the stashed state.
+ *
+ * @return 0 on success, GIT_ENOTFOUND where there's nothing to stash,
+ * or error code.
+ */
+GIT_EXTERN(int) git_stash_store(
+	const git_oid *stash_id,
+	git_repository *repo,
+	const char *message);
+
+/**
  * Save the local modifications to a new stash.
  *
  * @param out Object id of the commit containing the stashed state.

--- a/tests/stash/create.c
+++ b/tests/stash/create.c
@@ -1,0 +1,94 @@
+#include "clar_libgit2.h"
+#include "futils.h"
+#include "stash_helpers.h"
+
+static git_repository *repo;
+static git_signature *signature;
+static git_oid stash_tip_oid;
+
+/*
+ * Friendly reminder, in order to ease the reading of the following tests:
+ *
+ * "stash"		points to the worktree commit
+ * "stash^1"	points to the base commit (HEAD when the stash was created)
+ * "stash^2"	points to the index commit
+ * "stash^3"	points to the untracked commit
+ */
+
+void test_stash_create__initialize(void)
+{
+	cl_git_pass(git_repository_init(&repo, "stash", 0));
+	cl_git_pass(git_signature_new(&signature, "nulltoken", "emeric.fermas@gmail.com", 1323847743, 60)); /* Wed Dec 14 08:29:03 2011 +0100 */
+
+	setup_stash(repo, signature);
+}
+
+void test_stash_create__cleanup(void)
+{
+	git_signature_free(signature);
+	signature = NULL;
+
+	git_repository_free(repo);
+	repo = NULL;
+
+	cl_git_pass(git_futils_rmdir_r("stash", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_fixture_cleanup("sorry-it-is-a-non-bare-only-party");
+}
+
+static void assert_blob_oid(const char* revision, const char* expected_oid)
+{
+	assert_object_oid(repo, revision, expected_oid, GIT_OBJECT_BLOB);
+}
+
+void test_stash_create__creates_stash_without_storing_it(void)
+{
+	/* Asserts expected initial status. */
+
+	assert_status(repo, "what", GIT_STATUS_INDEX_MODIFIED | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "who", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "why", GIT_STATUS_INDEX_NEW);
+	assert_status(repo, "where", GIT_STATUS_INDEX_NEW | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+
+	/* Runs `git stash create`. */
+
+	cl_git_pass(git_stash_create(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
+
+	/* Tests that the stash commit is created successfully. */
+
+	cl_assert_equal_s("493568b7a2681187aaac8a58d3f1eab1527cba84", git_oid_tostr_s(&stash_tip_oid));
+
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:what", "bc99dc98b3eba0e9157e94769cd4d49cb49de449");	/* see you later */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:how", "e6d64adb2c7f3eb8feb493b556cc8070dca379a3");	/* not so small and */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:who", "a0400d4954659306a976567af43125a0b1aa8595");	/* funky world */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:when", NULL);
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:why", "88c2533e21f098b89c91a431d8075cbdbe422a51"); /* would anybody use stash? */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:where", "e3d6434ec12eb76af8dfa843a64ba6ab91014a0b"); /* .... */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:.gitignore", "ac4d88de61733173d9959e4b77c69b9f17a00980");
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84:just.ignore", NULL);
+
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:what", "dd7e1c6f0fefe118f0b63d9f10908c460aa317a6");	/* goodbye */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:how", "e6d64adb2c7f3eb8feb493b556cc8070dca379a3");	/* not so small and */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:who", "cc628ccd10742baea8241c5924df992b5c019f71");	/* world */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:when", NULL);
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:why", "88c2533e21f098b89c91a431d8075cbdbe422a51"); /* would anybody use stash? */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:where", "e08f7fbb9a42a0c5367cf8b349f1f08c3d56bd72"); /* ???? */
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:.gitignore", "ac4d88de61733173d9959e4b77c69b9f17a00980");
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^2:just.ignore", NULL);
+
+	assert_blob_oid("493568b7a2681187aaac8a58d3f1eab1527cba84^3", NULL);
+
+	/* Tests that the created stash is not in the reflog. */
+
+	assert_blob_oid("refs/stash", NULL);
+
+	/* Tests that the working directory and index have not changed. */
+
+	assert_status(repo, "what", GIT_STATUS_INDEX_MODIFIED | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "who", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "why", GIT_STATUS_INDEX_NEW);
+	assert_status(repo, "where", GIT_STATUS_INDEX_NEW | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}

--- a/tests/stash/save.c
+++ b/tests/stash/save.c
@@ -35,27 +35,9 @@ void test_stash_save__cleanup(void)
 	cl_fixture_cleanup("sorry-it-is-a-non-bare-only-party");
 }
 
-static void assert_object_oid(const char* revision, const char* expected_oid, git_object_t type)
-{
-	int result;
-	git_object *obj;
-
-	result = git_revparse_single(&obj, repo, revision);
-
-	if (!expected_oid) {
-		cl_assert_equal_i(GIT_ENOTFOUND, result);
-		return;
-	} else
-		cl_assert_equal_i(0, result);
-
-	cl_git_pass(git_oid_streq(git_object_id(obj), expected_oid));
-	cl_assert_equal_i(type, git_object_type(obj));
-	git_object_free(obj);
-}
-
 static void assert_blob_oid(const char* revision, const char* expected_oid)
 {
-	assert_object_oid(revision, expected_oid, GIT_OBJECT_BLOB);
+	assert_object_oid(repo, revision, expected_oid, GIT_OBJECT_BLOB);
 }
 
 void test_stash_save__does_not_keep_index_by_default(void)
@@ -275,12 +257,12 @@ void test_stash_save__can_stash_against_a_detached_head(void)
 
 void test_stash_save__stashing_updates_the_reflog(void)
 {
-	assert_object_oid("refs/stash@{0}", NULL, GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "refs/stash@{0}", NULL, GIT_OBJECT_COMMIT);
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
 
-	assert_object_oid("refs/stash@{0}", git_oid_tostr_s(&stash_tip_oid), GIT_OBJECT_COMMIT);
-	assert_object_oid("refs/stash@{1}", NULL, GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "refs/stash@{0}", git_oid_tostr_s(&stash_tip_oid), GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "refs/stash@{1}", NULL, GIT_OBJECT_COMMIT);
 }
 
 void test_stash_save__multiline_message(void)
@@ -289,7 +271,7 @@ void test_stash_save__multiline_message(void)
 	const git_reflog_entry *entry;
 	git_reflog *reflog;
 
-	assert_object_oid("refs/stash@{0}", NULL, GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "refs/stash@{0}", NULL, GIT_OBJECT_COMMIT);
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, msg, GIT_STASH_DEFAULT));
 
@@ -297,7 +279,7 @@ void test_stash_save__multiline_message(void)
 	cl_assert(entry = git_reflog_entry_byindex(reflog, 0));
 	cl_assert_equal_s(git_reflog_entry_message(entry), "On master: This  is a multiline message");
 
-	assert_object_oid("refs/stash@{0}", git_oid_tostr_s(&stash_tip_oid), GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "refs/stash@{0}", git_oid_tostr_s(&stash_tip_oid), GIT_OBJECT_COMMIT);
 	assert_commit_message_contains("refs/stash@{0}", msg);
 
 	git_reflog_free(reflog);
@@ -406,7 +388,7 @@ void test_stash_save__can_stage_normal_then_stage_untracked(void)
 	assert_blob_oid("stash@{1}^2:who", "cc628ccd10742baea8241c5924df992b5c019f71");		/* world */
 	assert_blob_oid("stash@{1}^2:when", NULL);
 
-	assert_object_oid("stash@{1}^3", NULL, GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "stash@{1}^3", NULL, GIT_OBJECT_COMMIT);
 
 	assert_blob_oid("stash@{0}^0:what", "ce013625030ba8dba906f756967f9e9ca394464a");	/* hello */
 	assert_blob_oid("stash@{0}^0:how", "ac790413e2d7a26c3767e78c57bb28716686eebc");		/* small */
@@ -435,7 +417,7 @@ void test_stash_save__including_untracked_without_any_untracked_file_creates_an_
 
 	cl_git_pass(git_stash_save(&stash_tip_oid, repo, signature, NULL, GIT_STASH_INCLUDE_UNTRACKED));
 
-	assert_object_oid("stash^3^{tree}", EMPTY_TREE, GIT_OBJECT_TREE);
+	assert_object_oid(repo, "stash^3^{tree}", EMPTY_TREE, GIT_OBJECT_TREE);
 }
 
 void test_stash_save__ignored_directory(void)

--- a/tests/stash/stash_helpers.c
+++ b/tests/stash/stash_helpers.c
@@ -55,3 +55,25 @@ void assert_status(
 		cl_assert_equal_i((unsigned int)status_flags, status);
 	}
 }
+
+void assert_object_oid(
+	git_repository *repo,
+	const char* revision,
+	const char* expected_oid,
+	git_object_t type)
+{
+	int result;
+	git_object *obj;
+
+	result = git_revparse_single(&obj, repo, revision);
+
+	if (!expected_oid) {
+		cl_assert_equal_i(GIT_ENOTFOUND, result);
+		return;
+	} else
+		cl_assert_equal_i(0, result);
+
+	cl_git_pass(git_oid_streq(git_object_id(obj), expected_oid));
+	cl_assert_equal_i(type, git_object_type(obj));
+	git_object_free(obj);
+}

--- a/tests/stash/stash_helpers.h
+++ b/tests/stash/stash_helpers.h
@@ -6,3 +6,9 @@ void assert_status(
 	git_repository *repo,
 	const char *path,
 	int status_flags);
+
+void assert_object_oid(
+	git_repository *repo,
+	const char* revision,
+	const char* expected_oid,
+	git_object_t type);

--- a/tests/stash/store.c
+++ b/tests/stash/store.c
@@ -1,0 +1,131 @@
+#include "clar_libgit2.h"
+#include "futils.h"
+#include "stash_helpers.h"
+
+static git_repository *repo;
+static git_signature *signature;
+static git_oid stash_tip_oid;
+
+/*
+ * Friendly reminder, in order to ease the reading of the following tests:
+ *
+ * "stash"		points to the worktree commit
+ * "stash^1"	points to the base commit (HEAD when the stash was created)
+ * "stash^2"	points to the index commit
+ * "stash^3"	points to the untracked commit
+ */
+
+void test_stash_store__initialize(void)
+{
+	cl_git_pass(git_repository_init(&repo, "stash", 0));
+	cl_git_pass(git_signature_new(&signature, "nulltoken", "emeric.fermas@gmail.com", 1323847743, 60)); /* Wed Dec 14 08:29:03 2011 +0100 */
+
+	setup_stash(repo, signature);
+}
+
+void test_stash_store__cleanup(void)
+{
+	git_signature_free(signature);
+	signature = NULL;
+
+	git_repository_free(repo);
+	repo = NULL;
+
+	cl_git_pass(git_futils_rmdir_r("stash", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_fixture_cleanup("sorry-it-is-a-non-bare-only-party");
+}
+
+static void assert_blob_oid(const char* revision, const char* expected_oid)
+{
+	assert_object_oid(repo, revision, expected_oid, GIT_OBJECT_BLOB);
+}
+
+void test_stash_store__saves_stash_without_updating_workdir(void)
+{
+	/* Asserts expected initial status. */
+
+	assert_status(repo, "what", GIT_STATUS_INDEX_MODIFIED | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "who", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "why", GIT_STATUS_INDEX_NEW);
+	assert_status(repo, "where", GIT_STATUS_INDEX_NEW | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+
+	cl_git_pass(git_stash_create(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
+	cl_git_pass(git_stash_store(&stash_tip_oid, repo, NULL));
+
+	/* Tests that the stash commit is created successfully. */
+
+	assert_object_oid(repo, "refs/stash", git_oid_tostr_s(&stash_tip_oid), GIT_OBJECT_COMMIT);
+
+	assert_blob_oid("refs/stash:what", "bc99dc98b3eba0e9157e94769cd4d49cb49de449");	/* see you later */
+	assert_blob_oid("refs/stash:how", "e6d64adb2c7f3eb8feb493b556cc8070dca379a3");	/* not so small and */
+	assert_blob_oid("refs/stash:who", "a0400d4954659306a976567af43125a0b1aa8595");	/* funky world */
+	assert_blob_oid("refs/stash:when", NULL);
+	assert_blob_oid("refs/stash:why", "88c2533e21f098b89c91a431d8075cbdbe422a51"); /* would anybody use stash? */
+	assert_blob_oid("refs/stash:where", "e3d6434ec12eb76af8dfa843a64ba6ab91014a0b"); /* .... */
+	assert_blob_oid("refs/stash:.gitignore", "ac4d88de61733173d9959e4b77c69b9f17a00980");
+	assert_blob_oid("refs/stash:just.ignore", NULL);
+
+	assert_blob_oid("refs/stash^2:what", "dd7e1c6f0fefe118f0b63d9f10908c460aa317a6");	/* goodbye */
+	assert_blob_oid("refs/stash^2:how", "e6d64adb2c7f3eb8feb493b556cc8070dca379a3");	/* not so small and */
+	assert_blob_oid("refs/stash^2:who", "cc628ccd10742baea8241c5924df992b5c019f71");	/* world */
+	assert_blob_oid("refs/stash^2:when", NULL);
+	assert_blob_oid("refs/stash^2:why", "88c2533e21f098b89c91a431d8075cbdbe422a51"); /* would anybody use stash? */
+	assert_blob_oid("refs/stash^2:where", "e08f7fbb9a42a0c5367cf8b349f1f08c3d56bd72"); /* ???? */
+	assert_blob_oid("refs/stash^2:.gitignore", "ac4d88de61733173d9959e4b77c69b9f17a00980");
+	assert_blob_oid("refs/stash^2:just.ignore", NULL);
+
+	assert_blob_oid("refs/stash^3", NULL);
+
+	/* Tests that the working directory and index have not changed. */
+
+	assert_status(repo, "what", GIT_STATUS_INDEX_MODIFIED | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "how", GIT_STATUS_INDEX_MODIFIED);
+	assert_status(repo, "who", GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "why", GIT_STATUS_INDEX_NEW);
+	assert_status(repo, "where", GIT_STATUS_INDEX_NEW | GIT_STATUS_WT_MODIFIED);
+	assert_status(repo, "when", GIT_STATUS_WT_NEW);
+}
+
+void test_stash_store__updates_the_reflog(void)
+{
+	assert_object_oid(repo, "refs/stash@{0}", NULL, GIT_OBJECT_COMMIT);
+
+	cl_git_pass(git_stash_create(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
+	cl_git_pass(git_stash_store(&stash_tip_oid, repo, NULL));
+
+	assert_object_oid(repo, "refs/stash@{0}", git_oid_tostr_s(&stash_tip_oid), GIT_OBJECT_COMMIT);
+	assert_object_oid(repo, "refs/stash@{1}", NULL, GIT_OBJECT_COMMIT);
+}
+
+void test_stash_store__saves_a_default_stash_message(void)
+{
+	const git_reflog_entry *entry;
+	git_reflog *reflog;
+
+	cl_git_pass(git_stash_create(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
+	cl_git_pass(git_stash_store(&stash_tip_oid, repo, NULL));
+
+	cl_git_pass(git_reflog_read(&reflog, repo, "refs/stash"));
+	cl_assert(entry = git_reflog_entry_byindex(reflog, 0));
+	cl_assert_equal_s(git_reflog_entry_message(entry), "Created via \"git stash store\".");
+
+	git_reflog_free(reflog);
+}
+
+#define CUSTOM_STORE_MESSAGE "Look Ma! I'm on TV!"
+void test_stash_store__can_save_a_custom_stash_message(void)
+{
+	const git_reflog_entry *entry;
+	git_reflog *reflog;
+
+	cl_git_pass(git_stash_create(&stash_tip_oid, repo, signature, NULL, GIT_STASH_DEFAULT));
+	cl_git_pass(git_stash_store(&stash_tip_oid, repo, CUSTOM_STORE_MESSAGE));
+
+	cl_git_pass(git_reflog_read(&reflog, repo, "refs/stash"));
+	cl_assert(entry = git_reflog_entry_byindex(reflog, 0));
+	cl_assert_equal_s(git_reflog_entry_message(entry), CUSTOM_STORE_MESSAGE);
+
+	git_reflog_free(reflog);
+}


### PR DESCRIPTION
I have a need for `git stash create` and `git stash store` for a program I'm writing that needs to back up the state of the repository without updating the file system and notifying file watchers. This is an attempt to add this functionality and close #4354.

I am not a C or C++ programmer by trade, so please pardon any obvious mistakes. In addition to feedback related to functionality, I'd also welcome feedback on code style.

I added a couple of basic unit tests, but I think there is an opportunity to share tests between stash save and stash create. But I don't know how to do it in an elegant way, so I thought I'd put this up for review as-is and incorporate any ideas folks have.