### PR TITLE
fix check for ignoring of negate rules

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -141,14 +141,14 @@ static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match
 		if (git_buf_oom(&buf))
 			goto out;
 
-		/* if rule isn't for full path we match without PATHNAME flag
+		/*
+		 * if rule isn't for full path we match without PATHNAME flag
 		 * as lines like *.txt should match something like dir/test.txt
 		 * requiring * to also match /
-		*/
+		 */
 		effective_flags = wildmatch_flags;
-		if (!(rule->flags & GIT_ATTR_FNMATCH_FULLPATH)) {
+		if (!(rule->flags & GIT_ATTR_FNMATCH_FULLPATH))
 			effective_flags &= ~WM_PATHNAME;
-		}
 
 		/* if we found a match, we want to keep this rule */
 		if ((wildmatch(git_buf_cstr(&buf), path, effective_flags)) == WM_MATCH) {

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -142,8 +142,8 @@ static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match
 			goto out;
 
 		/* if rule isn't for full path we match without PATHNAME flag
-			 as lines like *.txt should match something like dir/test.txt
-			 requiring * to also match /
+		 * as lines like *.txt should match something like dir/test.txt
+		 * requiring * to also match /
 		*/
 		effective_flags = wildmatch_flags;
 		if (!(rule->flags & GIT_ATTR_FNMATCH_FULLPATH)) {

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -146,7 +146,7 @@ static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match
 			 requiring * to also match /
 		*/
 		effective_flags = wildmatch_flags;
-		if ((rule->flags & GIT_ATTR_FNMATCH_FULLPATH) == 0) {
+		if (!(rule->flags & GIT_ATTR_FNMATCH_FULLPATH)) {
 			effective_flags &= ~WM_PATHNAME;
 		}
 
@@ -645,4 +645,3 @@ int git_ignore__check_pathspec_for_exact_ignores(
 
 	return error;
 }
-

--- a/tests/ignore/path.c
+++ b/tests/ignore/path.c
@@ -575,3 +575,11 @@ void test_ignore_path__negative_prefix_rule(void)
 	assert_is_ignored(true, "ff");
 	assert_is_ignored(false, "f");
 }
+
+void test_ignore_path__negative_more_specific(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "*.txt\n!/dir/test.txt\n");
+	assert_is_ignored(true, "test.txt");
+	assert_is_ignored(false, "dir/test.txt");
+	assert_is_ignored(true, "outer/dir/test.txt");
+}


### PR DESCRIPTION
A gitignore rule like "*.txt" should be negated by "!dir/test.txt" even though one is inside a directory since *.txt isn't restricted to any directory.

This is fixed by making wildcard match treat * like ** by excluding the WM_PATHNAME flag when the rule isn't for a full path.

This problem can be replicated with a repository with the following .gitignore file:

     *.txt
     !/dir/test.txt

by creating a `dir/test.txt` file.

Commandline Git shows `dir/test.txt` as untracked while libgit2 without this PR shows it as ignored.