### PR TITLE
Default to GIT_BRANCH_DEFAULT if init.defaultBranch is empty string

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -2384,10 +2384,11 @@ int git_repository_initialbranch(git_buf *out, git_repository *repo)
 	if ((error = git_repository_config__weakptr(&config, repo)) < 0)
 		return error;
 
-	if ((error = git_config_get_entry(&entry, config, "init.defaultbranch")) == 0) {
+	if ((error = git_config_get_entry(&entry, config, "init.defaultbranch")) == 0 &&
+		*entry->value) {
 		branch = entry->value;
 	}
-	else if (error == GIT_ENOTFOUND) {
+	else if (!error || error == GIT_ENOTFOUND) {
 		branch = GIT_BRANCH_DEFAULT;
 	}
 	else {

--- a/tests/repo/getters.c
+++ b/tests/repo/getters.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "repo/repo_helpers.h"
 
 void test_repo_getters__is_empty_correctly_deals_with_pristine_looking_repos(void)
 {
@@ -18,6 +19,18 @@ void test_repo_getters__is_empty_can_detect_used_repositories(void)
 
 	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
 
+	cl_assert_equal_i(false, git_repository_is_empty(repo));
+
+	git_repository_free(repo);
+}
+
+void test_repo_getters__is_empty_can_detect_repositories_with_defaultbranch_config_empty(void)
+{
+	git_repository *repo;
+
+	create_tmp_global_config("tmp_global_path", "init.defaultBranch", "");
+
+	cl_git_pass(git_repository_open(&repo, cl_fixture("testrepo.git")));
 	cl_assert_equal_i(false, git_repository_is_empty(repo));
 
 	git_repository_free(repo);


### PR DESCRIPTION
`git_repository_is_empty` is returning `false` if `init.defaultBranch` is set to `""`. It probably shouldn't be an empty string, but work around this like in the referenced issue/PR.

See:
- https://github.com/libgit2/libgit2/issues/5761
- https://github.com/libgit2/libgit2/pull/5770