### PR TITLE
repo: remove an inappropriate use of PASSTHROUGH

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -2354,21 +2354,19 @@ int git_repository_head_unborn(git_repository *repo)
 	return 0;
 }
 
-static int at_least_one_cb(const char *refname, void *payload)
-{
-	GIT_UNUSED(refname);
-	GIT_UNUSED(payload);
-	return GIT_PASSTHROUGH;
-}
-
 static int repo_contains_no_reference(git_repository *repo)
 {
-	int error = git_reference_foreach_name(repo, &at_least_one_cb, NULL);
+	git_reference_iterator *iter;
+	const char *refname;
+	int error;
 
-	if (error == GIT_PASSTHROUGH)
-		return 0;
+	if ((error = git_reference_iterator_new(&iter, repo)) < 0)
+		return error;
 
-	if (!error)
+	error = git_reference_next_name(&refname, iter);
+	git_reference_iterator_free(iter);
+
+	if (error == GIT_ITEROVER)
 		return 1;
 
 	return error;


### PR DESCRIPTION
This error code is for callbacks where we should act as though the callback was
not set. This is not something that makes sense for a `_foreach` and checking
for that error message to bubble up mostly is happenstance precisely because
this is not an error code we expect in the callback.

As part of removing this, let's also remove a use of foreach as we can open-code
this check.

I just found this while double-checking this empty heuristic and was confused by the pass-through here. It looks like it was changed from this `EUSER`