### PR TITLE
repo: specify init.defaultbranch is meant to be a branch name

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -2401,7 +2401,7 @@ int git_repository_initialbranch(git_buf *out, git_repository *repo)
 	    goto done;
 
 	if (!valid) {
-		git_error_set(GIT_ERROR_INVALID, "the value of init.defaultBranch is not a valid reference name");
+		git_error_set(GIT_ERROR_INVALID, "the value of init.defaultBranch is not a valid branch name");
 		error = -1;
 	}
 


### PR DESCRIPTION
We don't want the default branch's refname here but its name as branch.
Returning an error saying it's not a valid reference here suggests we want the
value of `init.defaultbranch` to be something like `refs/heads/default` which is
not the case.