### PR TITLE
Fix diff_entrycount -> diff_num_deltas doc typo

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -998,7 +998,7 @@ GIT_EXTERN(size_t) git_diff_num_deltas(const git_diff *diff);
 /**
  * Query how many diff deltas are there in a diff filtered by type.
  *
- * This works just like `git_diff_entrycount()` with an extra parameter
+ * This works just like `git_diff_num_deltas()` with an extra parameter
  * that is a `git_delta_t` and returns just the count of how many deltas
  * match that particular type.
  *


### PR DESCRIPTION
This just fixes a typo in the documentation, actual rename change was
done in 5f69a31f