### PR TITLE
src: fix typos in header files

### DIFF
--- a/src/runtime.h
+++ b/src/runtime.h
@@ -42,7 +42,7 @@ int git_runtime_init_count(void);
  * such that there are no remaining `init` calls, then any
  * shutdown hooks that have been registered will be invoked.
  *
- * The number of oustanding initializations will be returned.
+ * The number of outstanding initializations will be returned.
  * If this number is 0, then the runtime is shutdown.
  *
  * @return The number of outstanding initializations (after this one) or an error

--- a/src/transports/httpclient.h
+++ b/src/transports/httpclient.h
@@ -90,7 +90,7 @@ extern int git_http_client_new(
 
 /*
  * Sends a request to the host specified by the request URL.  If the
- * method is POST, either the the content_length or the chunked flag must
+ * method is POST, either the content_length or the chunked flag must
  * be specified.  The body should be provided in subsequent calls to
  * git_http_client_send_body.
  *


### PR DESCRIPTION
Just two small typos in the header files :)