### PR TITLE
Fix issues with Proxy Authentication after httpclient refactor

### DIFF
--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -1503,7 +1503,7 @@ int git_http_client_skip_body(git_http_client *client)
 			              "unexpected data handled in callback");
 			error = -1;
 		}
-	} while (!error);
+	} while (error >= 0 && client->state != DONE);
 
 	if (error < 0)
 		client->connected = 0;

--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -681,6 +681,11 @@ static int generate_connect_request(
 	return git_buf_oom(buf) ? -1 : 0;
 }
 
+static bool use_connect_proxy(git_http_client *client)
+{
+    return client->proxy.url.host && !strcmp(client->server.url.scheme, "https");
+}
+
 static int generate_request(
 	git_http_client *client,
 	git_http_request *request)
@@ -734,7 +739,8 @@ static int generate_request(
 		git_buf_printf(buf, "Expect: 100-continue\r\n");
 
 	if ((error = apply_server_credentials(buf, client, request)) < 0 ||
-	    (error = apply_proxy_credentials(buf, client, request)) < 0)
+	    (!use_connect_proxy(client) &&
+			(error = apply_proxy_credentials(buf, client, request)) < 0))
 		return error;
 
 	if (request->custom_headers) {
@@ -1027,8 +1033,7 @@ static int http_client_connect(
 	reset_parser(client);
 
 	/* Reconnect to the proxy if necessary. */
-	use_proxy = client->proxy.url.host &&
-	            !strcmp(client->server.url.scheme, "https");
+	use_proxy = use_connect_proxy(client);
 
 	if (use_proxy) {
 		if (!client->proxy_connected || !client->keepalive ||


### PR DESCRIPTION
**Issue 1**
When skipping the body, we used to wait for the `on_message_complete` callback to have been triggered, which set `parse_finished`. After the refactor with `httpclient`, we stopped relying on this value, and thus we no longer consume the entire body when skipping it in the client. Here's where we used to consume the body https://github.com/libgit2/libgit2/blob/bf55facf15e5b6897ff7305162a77d92089f6c82/src/transports/http.c#L956

This shows up as an issue primarily when working with the proxy connection workflow, where we need to discard the entire body (completely drain the socket of the response) before we start the retry with credentials.

**Issue 2**
We used to mutate `proxy_opts.type` to `GIT_PROXY_NONE` after successfully connecting the tunnel. After the httpclient refactor, we continue to apply proxy-authorization headers to all requests even after we've already built a tunnel. This is fixed by checking the status of the proxy tunnel before applying proxy credentials. I think this roughly translates to the same behavior as before.

This is where we used to mutate the `proxy_opts.type` before https://github.com/libgit2/libgit2/blob/bf55facf15e5b6897ff7305162a77d92089f6c82/src/transports/http.c#L1032 And this is where we used to rely on that mutation to stop attaching proxy credentials https://github.com/libgit2/libgit2/blob/bf55facf15e5b6897ff7305162a77d92089f6c82/src/transports/http.c#L233-L235