### PR TITLE
diff:add option to ignore blank line changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tags
 CMakeSettings.json
 .vs
+.idea

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -168,6 +168,10 @@ typedef enum {
 	 *  can apply given diff information to binary files.
 	 */
 	GIT_DIFF_SHOW_BINARY = (1u << 30),
+
+	/** Ignore blank lines */
+	GIT_DIFF_IGNORE_BLANK_LINES = (1u << 31),
+
 } git_diff_option_t;
 
 /**

--- a/src/diff_xdiff.c
+++ b/src/diff_xdiff.c
@@ -259,5 +259,8 @@ void git_xdiff_init(git_xdiff_output *xo, const git_diff_options *opts)
 	if (flags & GIT_DIFF_MINIMAL)
 		xo->params.flags |= XDF_NEED_MINIMAL;
 
+	if (flags & GIT_DIFF_IGNORE_BLANK_LINES)
+		xo->params.flags |= XDF_IGNORE_BLANK_LINES;
+
 	xo->callback.outf = git_xdiff_cb;
 }


### PR DESCRIPTION

I found out that we have defined the parameter  (`XDF_IGNORE_BLANK_LINES`) is in `src/xdiff/xdiff.h`.

I added support for this parameter(`GIT_DIFF_IGNORE_BLANK_LINES`) in `include/git2/diff.h` and `src/diff_xdiff.c`
This is my first PR, if there is anything wrong, please point it out and I will be happy to improve it.😊