### PR TITLE
filter: stop taking git_buf as user input

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -141,6 +141,16 @@ GIT_EXTERN(int) git_filter_list_stream_data(
 	git_buf *data,
 	git_writestream *target);
 
+/** Deprecated in favor of `git_filter_list_apply_to_buffer`.
+ *
+ * @deprecated Use git_filter_list_apply_to_buffer
+ * @see Use git_filter_list_apply_to_buffer
+ */
+GIT_EXTERN(int) git_filter_list_apply_to_data(
+	git_buf *out,
+	git_filter_list *filters,
+	git_buf *in);
+
 /**@}*/
 
 /** @name Deprecated Tree Functions

--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -18,6 +18,7 @@
 #include "describe.h"
 #include "diff.h"
 #include "errors.h"
+#include "filter.h"
 #include "index.h"
 #include "indexer.h"
 #include "merge.h"
@@ -116,6 +117,29 @@ GIT_EXTERN(int) git_blob_filtered_content(
 	git_blob *blob,
 	const char *as_path,
 	int check_for_binary_data);
+
+/**@}*/
+
+/** @name Deprecated Filter Functions
+ *
+ * These functions are retained for backward compatibility.  The
+ * newer versions of these functions should be preferred in all
+ * new code.
+ *
+ * There is no plan to remove these backward compatibility values at
+ * this time.
+ */
+/**@{*/
+
+/** Deprecated in favor of `git_filter_list_stream_buffer`.
+ *
+ * @deprecated Use git_filter_list_stream_buffer
+ * @see Use git_filter_list_stream_buffer
+ */
+GIT_EXTERN(int) git_filter_list_stream_data(
+	git_filter_list *filters,
+	git_buf *data,
+	git_writestream *target);
 
 /**@}*/
 

--- a/include/git2/filter.h
+++ b/include/git2/filter.h
@@ -135,19 +135,6 @@ GIT_EXTERN(int) git_filter_list_apply_to_buffer(
 	size_t in_len);
 
 /**
- * Apply filter list to a data buffer.
- *
- * @param out Buffer to store the result of the filtering
- * @param filters A loaded git_filter_list (or NULL)
- * @param in Buffer containing the data to filter
- * @return 0 on success, an error code otherwise
- */
-GIT_EXTERN(int) git_filter_list_apply_to_data(
-	git_buf *out,
-	git_filter_list *filters,
-	git_buf *in);
-
-/**
  * Apply a filter list to the contents of a file on disk
  *
  * @param out buffer into which to store the filtered file

--- a/include/git2/filter.h
+++ b/include/git2/filter.h
@@ -125,6 +125,21 @@ GIT_EXTERN(int) git_filter_list_contains(
  * @param out Buffer to store the result of the filtering
  * @param filters A loaded git_filter_list (or NULL)
  * @param in Buffer containing the data to filter
+ * @param in_len The length of the input buffer
+ * @return 0 on success, an error code otherwise
+ */
+GIT_EXTERN(int) git_filter_list_apply_to_buffer(
+	git_buf *out,
+	git_filter_list *filters,
+	const char *in,
+	size_t in_len);
+
+/**
+ * Apply filter list to a data buffer.
+ *
+ * @param out Buffer to store the result of the filtering
+ * @param filters A loaded git_filter_list (or NULL)
+ * @param in Buffer containing the data to filter
  * @return 0 on success, an error code otherwise
  */
 GIT_EXTERN(int) git_filter_list_apply_to_data(

--- a/include/git2/filter.h
+++ b/include/git2/filter.h
@@ -122,18 +122,6 @@ GIT_EXTERN(int) git_filter_list_contains(
 /**
  * Apply filter list to a data buffer.
  *
- * See `git2/buffer.h` for background on `git_buf` objects.
- *
- * If the `in` buffer holds data allocated by libgit2 (i.e. `in->asize` is
- * not zero), then it will be overwritten when applying the filters.  If
- * not, then it will be left untouched.
- *
- * If there are no filters to apply (or `filters` is NULL), then the `out`
- * buffer will reference the `in` buffer data (with `asize` set to zero)
- * instead of allocating data.  This keeps allocations to a minimum, but
- * it means you have to be careful about freeing the `in` data since `out`
- * may be pointing to it!
- *
  * @param out Buffer to store the result of the filtering
  * @param filters A loaded git_filter_list (or NULL)
  * @param in Buffer containing the data to filter

--- a/include/git2/filter.h
+++ b/include/git2/filter.h
@@ -175,12 +175,14 @@ GIT_EXTERN(int) git_filter_list_apply_to_blob(
  * Apply a filter list to an arbitrary buffer as a stream
  *
  * @param filters the list of filters to apply
- * @param data the buffer to filter
+ * @param buffer the buffer to filter
+ * @param len the size of the buffer
  * @param target the stream into which the data will be written
  */
-GIT_EXTERN(int) git_filter_list_stream_data(
+GIT_EXTERN(int) git_filter_list_stream_buffer(
 	git_filter_list *filters,
-	git_buf *data,
+	const char *buffer,
+	size_t len,
 	git_writestream *target);
 
 /**

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -2121,7 +2121,7 @@ static int checkout_write_merge(
 		if ((error = git_filter_list__load_ext(
 				&fl, data->repo, NULL, git_buf_cstr(&path_workdir),
 				GIT_FILTER_TO_WORKTREE, &filter_opts)) < 0 ||
-			(error = git_filter_list_apply_to_data(&out_data, fl, &in_data)) < 0)
+			(error = git_filter_list__convert_buf(&out_data, fl, &in_data)) < 0)
 			goto done;
 	} else {
 		out_data.ptr = (char *)result.ptr;

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -362,10 +362,7 @@ static int diff_file_content_load_workdir_file(
 	if (!(error = git_futils_readbuffer_fd(&raw, fd, (size_t)fc->file->size))) {
 		git_buf out = GIT_BUF_INIT;
 
-		error = git_filter_list_apply_to_data(&out, fl, &raw);
-
-		if (out.ptr != raw.ptr)
-			git_buf_dispose(&raw);
+		error = git_filter_list__convert_buf(&out, fl, &raw);
 
 		if (!error) {
 			fc->map.len  = out.size;

--- a/src/filter.c
+++ b/src/filter.c
@@ -742,17 +742,6 @@ int git_filter_list_apply_to_buffer(
 	return error;
 }
 
-int git_filter_list_apply_to_data(
-	git_buf *tgt, git_filter_list *filters, git_buf *src)
-{
-	int error;
-
-	if ((error = git_buf_sanitize(src)) < 0)
-	    return error;
-
-	return git_filter_list_apply_to_buffer(tgt, filters, src->ptr, src->size);
-}
-
 int git_filter_list_apply_to_file(
 	git_buf *out,
 	git_filter_list *filters,
@@ -1070,6 +1059,17 @@ int git_filter_list_stream_data(
 		return error;
 
 	return git_filter_list_stream_buffer(filters, data->ptr, data->size, target);
+}
+
+int git_filter_list_apply_to_data(
+	git_buf *tgt, git_filter_list *filters, git_buf *src)
+{
+	int error;
+
+	if ((error = git_buf_sanitize(src)) < 0)
+	    return error;
+
+	return git_filter_list_apply_to_buffer(tgt, filters, src->ptr, src->size);
 }
 
 #endif

--- a/src/filter.c
+++ b/src/filter.c
@@ -720,7 +720,7 @@ static void buf_stream_init(struct buf_stream *writer, git_buf *target)
 	git_buf_clear(target);
 }
 
-static int git_filter_list_apply_to_buffer(
+int git_filter_list_apply_to_buffer(
 	git_buf *out,
 	git_filter_list *filters,
 	const char *in,

--- a/src/filter.c
+++ b/src/filter.c
@@ -742,6 +742,28 @@ int git_filter_list_apply_to_buffer(
 	return error;
 }
 
+int git_filter_list__convert_buf(
+	git_buf *out,
+	git_filter_list *filters,
+	git_buf *in)
+{
+	int error;
+
+	if (!filters || git_filter_list_length(filters) == 0) {
+		git_buf_swap(out, in);
+		git_buf_dispose(in);
+		return 0;
+	}
+
+	error = git_filter_list_apply_to_buffer(out, filters,
+		in->ptr, in->size);
+
+	if (!error)
+		git_buf_dispose(in);
+
+	return error;
+}
+
 int git_filter_list_apply_to_file(
 	git_buf *out,
 	git_filter_list *filters,

--- a/src/filter.h
+++ b/src/filter.h
@@ -36,6 +36,15 @@ extern int git_filter_list__load_ext(
 	git_filter_options *filter_opts);
 
 /*
+ * The given input buffer will be converted to the given output buffer.
+ * The input buffer will be freed (_if_ it was allocated).
+ */
+extern int git_filter_list__convert_buf(
+	git_buf *out,
+	git_filter_list *filters,
+	git_buf *in);
+
+/*
  * Available filters
  */
 

--- a/src/odb.c
+++ b/src/odb.c
@@ -260,9 +260,7 @@ int git_odb__hashfd_filtered(
 	if (!(error = git_futils_readbuffer_fd(&raw, fd, size))) {
 		git_buf post = GIT_BUF_INIT;
 
-		error = git_filter_list_apply_to_data(&post, fl, &raw);
-
-		git_buf_dispose(&raw);
+		error = git_filter_list__convert_buf(&post, fl, &raw);
 
 		if (!error)
 			error = git_odb_hash(out, post.ptr, post.size, type);

--- a/tests/filter/custom.c
+++ b/tests/filter/custom.c
@@ -95,13 +95,17 @@ static void register_custom_filters(void)
 void test_filter_custom__to_odb(void)
 {
 	git_filter_list *fl;
-	git_buf out = { 0 };
-	git_buf in = GIT_BUF_INIT_CONST(workdir_data, strlen(workdir_data));
+	git_buf out = GIT_BUF_INIT;
+	const char *in;
+	size_t in_len;
 
 	cl_git_pass(git_filter_list_load(
 		&fl, g_repo, NULL, "herofile", GIT_FILTER_TO_ODB, 0));
 
-	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	in = workdir_data;
+	in_len = strlen(workdir_data);
+
+	cl_git_pass(git_filter_list_apply_to_buffer(&out, fl, in, in_len));
 
 	cl_assert_equal_i(BITFLIPPED_AND_REVERSED_DATA_LEN, out.size);
 
@@ -115,14 +119,17 @@ void test_filter_custom__to_odb(void)
 void test_filter_custom__to_workdir(void)
 {
 	git_filter_list *fl;
-	git_buf out = { 0 };
-	git_buf in = GIT_BUF_INIT_CONST(
-		bitflipped_and_reversed_data, BITFLIPPED_AND_REVERSED_DATA_LEN);
+	git_buf out = GIT_BUF_INIT;
+	const char *in;
+	size_t in_len;
 
 	cl_git_pass(git_filter_list_load(
 		&fl, g_repo, NULL, "herofile", GIT_FILTER_TO_WORKTREE, 0));
 
-	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	in = (char *)bitflipped_and_reversed_data;
+	in_len = BITFLIPPED_AND_REVERSED_DATA_LEN;
+
+	cl_git_pass(git_filter_list_apply_to_buffer(&out, fl, in, in_len));
 
 	cl_assert_equal_i(strlen(workdir_data), out.size);
 
@@ -246,12 +253,16 @@ void test_filter_custom__erroneous_filter_fails(void)
 {
 	git_filter_list *filters;
 	git_buf out = GIT_BUF_INIT;
-	git_buf in = GIT_BUF_INIT_CONST(workdir_data, strlen(workdir_data));
+	const char *in;
+	size_t in_len;
 
 	cl_git_pass(git_filter_list_load(
 		&filters, g_repo, NULL, "villain", GIT_FILTER_TO_WORKTREE, 0));
 
-	cl_git_fail(git_filter_list_apply_to_data(&out, filters, &in));
+	in = workdir_data;
+	in_len = strlen(workdir_data);
+
+	cl_git_fail(git_filter_list_apply_to_buffer(&out, filters, in, in_len));
 
 	git_filter_list_free(filters);
 	git_buf_dispose(&out);

--- a/tests/filter/wildcard.c
+++ b/tests/filter/wildcard.c
@@ -123,13 +123,12 @@ static git_filter *create_wildcard_filter(void)
 void test_filter_wildcard__reverse(void)
 {
 	git_filter_list *fl;
-	git_buf in = GIT_BUF_INIT, out = GIT_BUF_INIT;
+	git_buf out = GIT_BUF_INIT;
 
 	cl_git_pass(git_filter_list_load(
 		&fl, g_repo, NULL, "hero-reverse-foo", GIT_FILTER_TO_ODB, 0));
 
-	cl_git_pass(git_buf_put(&in, (char *)input, DATA_LEN));
-	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	cl_git_pass(git_filter_list_apply_to_buffer(&out, fl, (char *)input, DATA_LEN));
 
 	cl_assert_equal_i(DATA_LEN, out.size);
 
@@ -138,19 +137,17 @@ void test_filter_wildcard__reverse(void)
 
 	git_filter_list_free(fl);
 	git_buf_dispose(&out);
-	git_buf_dispose(&in);
 }
 
 void test_filter_wildcard__flip(void)
 {
 	git_filter_list *fl;
-	git_buf in = GIT_BUF_INIT, out = GIT_BUF_INIT;
+	git_buf out = GIT_BUF_INIT;
 
 	cl_git_pass(git_filter_list_load(
 		&fl, g_repo, NULL, "hero-flip-foo", GIT_FILTER_TO_ODB, 0));
 
-	cl_git_pass(git_buf_put(&in, (char *)input, DATA_LEN));
-	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	cl_git_pass(git_filter_list_apply_to_buffer(&out, fl, (char *)input, DATA_LEN));
 
 	cl_assert_equal_i(DATA_LEN, out.size);
 
@@ -159,19 +156,17 @@ void test_filter_wildcard__flip(void)
 
 	git_filter_list_free(fl);
 	git_buf_dispose(&out);
-	git_buf_dispose(&in);
 }
 
 void test_filter_wildcard__none(void)
 {
 	git_filter_list *fl;
-	git_buf in = GIT_BUF_INIT, out = GIT_BUF_INIT;
+	git_buf out = GIT_BUF_INIT;
 
 	cl_git_pass(git_filter_list_load(
 		&fl, g_repo, NULL, "none-foo", GIT_FILTER_TO_ODB, 0));
 
-	cl_git_pass(git_buf_put(&in, (char *)input, DATA_LEN));
-	cl_git_pass(git_filter_list_apply_to_data(&out, fl, &in));
+	cl_git_pass(git_filter_list_apply_to_buffer(&out, fl, (char *)input, DATA_LEN));
 
 	cl_assert_equal_i(DATA_LEN, out.size);
 
@@ -180,5 +175,4 @@ void test_filter_wildcard__none(void)
 
 	git_filter_list_free(fl);
 	git_buf_dispose(&out);
-	git_buf_dispose(&in);
 }


### PR DESCRIPTION
Our filter functionality takes `git_buf` as user input, which is awkward.  In particular, `git_filter_list_apply_to_data` might place the given input data into the output `git_buf`, and users are expected to understand what to do about that.  This is problematic, because even I'm not sure what to do about that, even after having read the function.

Simplify this mess, taking `const char *` / `size_t` pairings for buffers, and only using `git_buf` as a return type.  `git_filter_list_apply_to_data` now always writes into the given output buffer for predictability with API compatibility, at the expense of efficiency.  (Users should use - and should have been using - the streaming filters for the most efficient behavior anyway.)  `git_filter_list_apply_to_data` is deprecated for that reason.