### PR TITLE
[Branch] Branch upstream with format

### DIFF
--- a/include/git2/branch.h
+++ b/include/git2/branch.h
@@ -305,6 +305,19 @@ GIT_EXTERN(int) git_branch_remote_name(
  GIT_EXTERN(int) git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname);
 
 /**
+ * Retrieve the upstream merge of a local branch
+ *
+ * This will return the currently configured "branch.*.merge" for a given
+ * branch. This branch must be local.
+ *
+ * @param buf the buffer into which to write the name
+ * @param repo the repository in which to look
+ * @param refname the full name of the branch
+ * @return 0 or an error code
+ */
+ GIT_EXTERN(int) git_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname);
+
+/**
  * Determine whether a branch name is valid, meaning that (when prefixed
  * with `refs/heads/`) that it is a valid reference name, and that any
  * additional branch name restrictions are imposed (eg, it cannot start

--- a/src/branch.c
+++ b/src/branch.c
@@ -492,11 +492,13 @@ static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, c
 	return error;
 }
 
-int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname) {
+int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname)
+{
 	git_branch_upstream_with_format(buf, repo, refname, "branch.%s.remote");
 }
 
-int git_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname) {
+int git_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname)
+{
 	git_branch_upstream_with_format(buf, repo, refname, "branch.%s.merge");
 }
 

--- a/src/branch.c
+++ b/src/branch.c
@@ -492,6 +492,14 @@ static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, c
 	return error;
 }
 
+int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname) {
+	git_branch_upstream_with_format(buf, repo, refname, "branch.%s.remote");
+}
+
+int git_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname) {
+	git_branch_upstream_with_format(buf, repo, refname, "branch.%s.merge");
+}
+
 int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refname)
 {
 	git_strarray remote_list = {0};

--- a/src/branch.c
+++ b/src/branch.c
@@ -468,35 +468,10 @@ cleanup:
 	return error;
 }
 
-typedef enum {
-  GIT_BRANCH_UPSTREAM_FORMAT_REMOTE = 1,
-  GIT_BRANCH_UPSTREAM_FORMAT_MERGE = 2
-} git_branch_upstream_format_type_t;
-
-static const char* git_branch_upstream_format_string_for_id(git_branch_upstream_format_type_t id)
-{
-  switch (id) {
-  case GIT_BRANCH_UPSTREAM_FORMAT_REMOTE: return "branch.%s.remote";
-  case GIT_BRANCH_UPSTREAM_FORMAT_MERGE: return "branch.%s.merge";
-  default: return ""; // OK?
-  };
-}
-
-static const char* git_branch_upstream_format_name_for_id(git_branch_upstream_format_type_t id)
-{
-  switch (id) {
-  case GIT_BRANCH_UPSTREAM_FORMAT_REMOTE: return "remote";
-  case GIT_BRANCH_UPSTREAM_FORMAT_MERGE: return "merge";
-  default: return "UNDEFINED"; // OK?
-  };
-}
-
-static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, const char *refname, git_branch_upstream_format_type_t id)
+static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, const char *refname, const char *format, const char *format_name)
 {
 	int error;
 	git_config *cfg;
-	const char *format = git_branch_upstream_format_string_for_id(id);
-	const char *format_name = git_branch_upstream_format_name_for_id(id);
 
 	if (!git_reference__is_branch(refname))
 		return not_a_local_branch(refname);
@@ -519,12 +494,12 @@ static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, c
 
 int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname)
 {
-	return git_branch_upstream_with_format(buf, repo, refname, GIT_BRANCH_UPSTREAM_FORMAT_REMOTE);
+	return git_branch_upstream_with_format(buf, repo, refname, "branch.%s.remote", "remote");
 }
 
 int git_branch_upstream_merge(git_buf *buf, git_repository *repo, const char *refname)
 {
-	return git_branch_upstream_with_format(buf, repo, refname, GIT_BRANCH_UPSTREAM_FORMAT_MERGE);
+	return git_branch_upstream_with_format(buf, repo, refname, "branch.%s.merge", "merge");
 }
 
 int git_branch_remote_name(git_buf *buf, git_repository *repo, const char *refname)

--- a/src/branch.c
+++ b/src/branch.c
@@ -468,7 +468,7 @@ cleanup:
 	return error;
 }
 
-int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname)
+static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, const char *refname, const char *format)
 {
 	int error;
 	git_config *cfg;
@@ -480,7 +480,7 @@ int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *r
 		return error;
 
 	if ((error = git_buf_sanitize(buf)) < 0 ||
-	    (error = retrieve_upstream_configuration(buf, cfg, refname, "branch.%s.remote")) < 0)
+	    (error = retrieve_upstream_configuration(buf, cfg, refname, format)) < 0)
 		return error;
 
 	if (git_buf_len(buf) == 0) {

--- a/src/branch.c
+++ b/src/branch.c
@@ -471,9 +471,10 @@ cleanup:
 typedef enum {
   GIT_BRANCH_UPSTREAM_FORMAT_REMOTE = 1,
   GIT_BRANCH_UPSTREAM_FORMAT_MERGE = 2
-} git_branch_upstream_format;
+} git_branch_upstream_format_type_t;
 
-static const char* git_branch_upstream_format_string_for_id(git_branch_upstream_format id) {
+static const char* git_branch_upstream_format_string_for_id(git_branch_upstream_format_type_t id)
+{
   switch (id) {
   case GIT_BRANCH_UPSTREAM_FORMAT_REMOTE: return "branch.%s.remote";
   case GIT_BRANCH_UPSTREAM_FORMAT_MERGE: return "branch.%s.merge";
@@ -481,7 +482,8 @@ static const char* git_branch_upstream_format_string_for_id(git_branch_upstream_
   };
 }
 
-static const char* git_branch_upstream_format_name_for_id(git_branch_upstream_format id) {
+static const char* git_branch_upstream_format_name_for_id(git_branch_upstream_format_type_t id)
+{
   switch (id) {
   case GIT_BRANCH_UPSTREAM_FORMAT_REMOTE: return "remote";
   case GIT_BRANCH_UPSTREAM_FORMAT_MERGE: return "merge";
@@ -489,7 +491,7 @@ static const char* git_branch_upstream_format_name_for_id(git_branch_upstream_fo
   };
 }
 
-static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, const char *refname, git_branch_upstream_format id)
+static int git_branch_upstream_with_format(git_buf *buf, git_repository *repo, const char *refname, git_branch_upstream_format_type_t id)
 {
 	int error;
 	git_config *cfg;

--- a/tests/refs/branches/upstream.c
+++ b/tests/refs/branches/upstream.c
@@ -71,6 +71,29 @@ void test_refs_branches_upstream__upstream_remote(void)
 	git_buf_dispose(&buf);
 }
 
+void test_refs_branches_upstream__upstream_merge(void)
+{
+	git_reference *branch;
+	git_repository *repository;
+    git_buf buf = GIT_BUF_INIT;
+    
+	repository = cl_git_sandbox_init("testrepo.git");
+
+	/* check repository */
+	cl_git_pass(git_reference_lookup(&branch, repository, "refs/heads/test"));
+	cl_git_pass(git_branch_set_upstream(branch, "test/master"));
+
+	assert_config_entry_value(repository, "branch.test.remote", "test");
+	assert_config_entry_value(repository, "branch.test.merge", "refs/heads/master");
+
+	git_reference_free(branch);
+
+	/* check merge branch */
+    cl_git_pass(git_branch_upstream_merge(&buf, repository, "refs/heads/test"));
+    cl_assert_equal_s("refs/heads/master", buf.ptr);
+    git_buf_dispose(&buf);
+}
+
 void test_refs_branches_upstream__upstream_remote_empty_value(void)
 {
 	git_repository *repository;


### PR DESCRIPTION
It is a convenient accessor for merge branch name.

- [x] static `git_branch_upstream_with_format` has been added.
- [x] public `git_branch_upstream_merge` has been added.