### PR TITLE
docs: fix incorrect comment marker

### DIFF
--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -172,7 +172,7 @@ tags:
  *
  * @param s String to froznicate
  * @return A newly allocated string or `NULL` in case an error occurred.
- * /
+ */
 char *froznicate(const char *s);
 ```
 


### PR DESCRIPTION
The broken ending marker would cause the rest of the file to be parsed as part of the comment.