### PR TITLE
[CMake] Check futimens function via symbol.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,10 +33,13 @@ IF(ENABLE_TRACE)
 ENDIF()
 ADD_FEATURE_INFO(tracing GIT_TRACE "tracing support")
 
-CHECK_FUNCTION_EXISTS(futimens HAVE_FUTIMENS)
+enable_warnings(error)
+CHECK_SYMBOL_EXISTS(futimens sys/stat.h HAVE_FUTIMENS)
+# CHECK_FUNCTION_EXISTS(futimens HAVE_FUTIMENS)
 IF (HAVE_FUTIMENS)
 	SET(GIT_USE_FUTIMENS 1)
 ENDIF ()
+DISABLE_WARNINGS(error)
 
 CHECK_PROTOTYPE_DEFINITION(qsort_r
 	"void qsort_r(void *base, size_t nmemb, size_t size, void *thunk, int (*compar)(void *, const void *, const void *))"


### PR DESCRIPTION
Addressed issue

- [x] #5856 

It seems that `check_function_exists` doesn't respect `MACOSX_DEPLOYMENT_TARGET`.
Example file with `futimens` test also doesn't contain any header and compiles with or without `futimens` function at `sys/stat.h`.


Script
```sh
export MACOSX_DEPLOYMENT_TARGET=10.10

rm -rf "xcode"
mkdir "xcode"
cd "xcode"
cmake --debug-trycompile -G "Xcode" .. 
```

( and add `message(FATAL_ERROR)` right after check function `futimens`. )