### PR TITLE
Tolerate readlink size less than st_size

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -297,14 +297,15 @@ int git_odb__hashlink(git_oid *out, const char *path)
 		GIT_ERROR_CHECK_ALLOC(link_data);
 
 		read_len = p_readlink(path, link_data, size);
-		link_data[size] = '\0';
-		if (read_len != size) {
+		if (read_len == -1) {
 			git_error_set(GIT_ERROR_OS, "failed to read symlink data for '%s'", path);
 			git__free(link_data);
 			return -1;
 		}
+		GIT_ASSERT(read_len <= size);
+		link_data[read_len] = '\0';
 
-		result = git_odb_hash(out, link_data, size, GIT_OBJECT_BLOB);
+		result = git_odb_hash(out, link_data, read_len, GIT_OBJECT_BLOB);
 		git__free(link_data);
 	} else {
 		int fd = git_futils_open_ro(path);


### PR DESCRIPTION
This creates compatibility with systems that overestimate the symlink path's size, such as Android (https://issuetracker.google.com/189629152).

The GNU coreutils `stat` tool is similarly tolerant of `readlink` returning a path that is smaller than reported by `st_size`:

- https://github.com/coreutils/coreutils/blob/370c294018316f005bb259f51024497333d24ee0/src/stat.c#L1482
- https://github.com/coreutils/gnulib/blob/c45faf7f48bcbe57df3bbf8df81a016c5f15df55/lib/areadlink-with-size.c#L97-L99

Without this change, I observed that [Cargo](https://github.com/rust-lang/cargo) (which is built on libgit2) would tend to fail many commands with "failed to read symlink data for '...'" on Android in repositories containing symlinks.