### PR TITLE
Support authentication in push example

### DIFF
--- a/examples/push.c
+++ b/examples/push.c
@@ -32,6 +32,7 @@
 /** Entry point for this command */
 int lg2_push(git_repository *repo, int argc, char **argv) {
 	git_push_options options;
+	git_remote_callbacks callbacks;
 	git_remote* remote = NULL;
 	char *refspec = "refs/heads/master";
 	const git_strarray refspecs = {
@@ -47,7 +48,11 @@ int lg2_push(git_repository *repo, int argc, char **argv) {
 
 	check_lg2(git_remote_lookup(&remote, repo, "origin" ), "Unable to lookup remote", NULL);
 	
+	check_lg2(git_remote_init_callbacks(&callbacks, GIT_REMOTE_CALLBACKS_VERSION), "Error initializing remote callbacks", NULL);
+	callbacks.credentials = cred_acquire_cb;
+
 	check_lg2(git_push_options_init(&options, GIT_PUSH_OPTIONS_VERSION ), "Error initializing push", NULL);
+	options.callbacks = callbacks;
 
 	check_lg2(git_remote_push(remote, &refspecs, &options), "Error pushing", NULL);
 


### PR DESCRIPTION
This adds basic support for user/password and SSH authentication to the push example. Authentication is implemented by using the [`cred_acquire_cb` credential callback defined in `examples/common.c`](https://github.com/libgit2/libgit2/blob/868f4bcb4d3290f4b5320f030fccdf1e7fc8ac8a/examples/common.c#L179-L226).

We think that supporting authentication is valuable because pushing to a target repository requires authentication in most practical applications (especially for testing). Also, we would like to use this extended version of the push example in a reproduction step of an issue we are going to submit (this makes reproducing the issue easier than having to build and debug a separate code example).