### PR TITLE
Fix memory leak in git_smart__connect

### DIFF
--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -226,8 +226,7 @@ static int git_smart__connect(
 	t->url = git__strdup(url);
 	GIT_ERROR_CHECK_ALLOC(t->url);
 
-	if (t->proxy.url)
-		git_proxy_options_clear(&t->proxy);
+	git_proxy_options_clear(&t->proxy);
 
 	if (git_proxy_options_dup(&t->proxy, proxy) < 0)
 		return -1;

--- a/src/transports/smart.c
+++ b/src/transports/smart.c
@@ -226,6 +226,9 @@ static int git_smart__connect(
 	t->url = git__strdup(url);
 	GIT_ERROR_CHECK_ALLOC(t->url);
 
+	if (t->proxy.url)
+		git_proxy_options_clear(&t->proxy);
+
 	if (git_proxy_options_dup(&t->proxy, proxy) < 0)
 		return -1;
 


### PR DESCRIPTION
The call to git_proxy_options_dup will replace the url pointer of the
proxy.
But if the url pointer is already set, the old address will be lost
forever and will never be free.