### PR TITLE
Fix misleading doc for `git_index_find`

### DIFF
--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -702,7 +702,7 @@ GIT_EXTERN(int) git_index_update_all(
  * @param at_pos the address to which the position of the index entry is written (optional)
  * @param index an existing index object
  * @param path path to search
- * @return 0 with valid value in at_pos; an error code otherwise
+ * @return 0 or an error code
  */
 GIT_EXTERN(int) git_index_find(size_t *at_pos, git_index *index, const char *path);
 
@@ -713,7 +713,7 @@ GIT_EXTERN(int) git_index_find(size_t *at_pos, git_index *index, const char *pat
  * @param at_pos the address to which the position of the index entry is written (optional)
  * @param index an existing index object
  * @param prefix the prefix to search for
- * @return 0 with valid value in at_pos; an error code otherwise
+ * @return 0 or an error code
  */
 GIT_EXTERN(int) git_index_find_prefix(size_t *at_pos, git_index *index, const char *prefix);
 

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -702,7 +702,7 @@ GIT_EXTERN(int) git_index_update_all(
  * @param at_pos the address to which the position of the index entry is written (optional)
  * @param index an existing index object
  * @param path path to search
- * @return a zero-based position in the index if found; GIT_ENOTFOUND otherwise
+ * @return 0 with valid value in at_pos; an error code otherwise
  */
 GIT_EXTERN(int) git_index_find(size_t *at_pos, git_index *index, const char *path);
 


### PR DESCRIPTION
In https://github.com/libgit2/libgit2/pull/5723/files/fc46dc06f52f854f74371682f911f13856c68edb#r540092847, I was confused by the semantics of `git_index_find`. The documentation says both that it returns the output value in `at_pos` and that it returns it directly as an `int`. This is incorrect; the return value is only returned via `at_pos`.