### PR TITLE
Syntax fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
           env:
             CC: gcc
             CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DDEBUG_STRICT_ALLOC=ON
+            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DDEBUG_STRICT_ALLOC=ON -DDEBUG_ARRAY_CASTING=ON
           os: ubuntu-latest
         - # Xenial, GCC, mbedTLS
           container:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ OPTION(USE_STANDALONE_FUZZERS		"Enable standalone fuzzers (compatible with gcc)"
 OPTION(USE_LEAK_CHECKER			"Run tests with leak checker"				OFF)
 OPTION(DEBUG_POOL			"Enable debug pool allocator"				OFF)
 OPTION(DEBUG_STRICT_ALLOC		"Enable strict allocator behavior"			OFF)
+OPTION(DEBUG_ARRAY_CASTING		"Enable void casting of arrays"			OFF)
 OPTION(ENABLE_WERROR			"Enable compilation with -Werror"			OFF)
 OPTION(USE_BUNDLED_ZLIB    		"Use the bundled version of zlib. Can be set to one of Bundled(ON)/Chromium. The Chromium option requires a x86_64 processor with SSE4.2 and CLMUL"			OFF)
    SET(USE_HTTP_PARSER			"" CACHE STRING "Specifies the HTTP Parser implementation; either system or builtin.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ ELSE ()
 	enable_warnings(unused-const-variable)
 	enable_warnings(unused-function)
 	enable_warnings(int-conversion)
+	enable_warnings(c11-extensions)
 
 	# MinGW uses gcc, which expects POSIX formatting for printf, but
 	# uses the Windows C library, which uses its own format specifiers.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,11 @@ IF(DEBUG_STRICT_ALLOC)
 ENDIF()
 ADD_FEATURE_INFO(debugalloc GIT_DEBUG_STRICT_ALLOC "debug strict allocators")
 
+IF(DEBUG_ARRAY_CASTING)
+	SET(GIT_DEBUG_ARRAY_CASTING 1)
+ENDIF()
+ADD_FEATURE_INFO(debugarray GIT_DEBUG_ARRAY_CASTING "test array type usage")
+
 INCLUDE(PkgBuildConfig)
 INCLUDE(SanitizeBool)
 

--- a/src/array.h
+++ b/src/array.h
@@ -41,8 +41,8 @@
 
 typedef git_array_t(char) git_array_generic_t;
 
-/* use a generic array for growth so this can return the new item */
-GIT_INLINE(void *) git_array_grow(void *_a, size_t item_size)
+/* use a generic array for growth, return 0 on success */
+GIT_INLINE(int) git_array_grow(void *_a, size_t item_size)
 {
 	volatile git_array_generic_t *a = _a;
 	size_t new_size;
@@ -59,24 +59,35 @@ GIT_INLINE(void *) git_array_grow(void *_a, size_t item_size)
 	if ((new_array = git__reallocarray(a->ptr, new_size, item_size)) == NULL)
 		goto on_oom;
 
-	a->ptr = new_array; a->asize = new_size; a->size++;
-	return a->ptr + (a->size - 1) * item_size;
+	a->ptr = new_array;
+	a->asize = new_size;
+	return 0;
 
 on_oom:
 	git_array_clear(*a);
-	return NULL;
+	return -1;
 }
 
-#define git_array_alloc(a) \
-	(((a).size >= (a).asize) ? \
-	git_array_grow(&(a), sizeof(*(a).ptr)) : \
-	((a).ptr ? &(a).ptr[(a).size++] : NULL))
+/*
+ * Type macro for array access.
+ * Cast to same type as NULL to catch code that relies on dead code elimination.
+ * This is needed becasue gcc and clang removes code before syntax validation.
+ */
+#ifdef GIT_DEBUG_ARRAY_CASTING
+#define GIT_ARRAY_CAST(x)	((void *)(x))
+#else
+#define GIT_ARRAY_CAST(x)	(x)
+#endif
 
-#define git_array_last(a) ((a).size ? &(a).ptr[(a).size - 1] : NULL)
+#define git_array_alloc(a) ( \
+	(a).size < (a).asize || git_array_grow(&(a), sizeof(*(a).ptr)) == 0 ? \
+	GIT_ARRAY_CAST(&(a).ptr[(a).size++]) : NULL)
 
-#define git_array_pop(a) ((a).size ? &(a).ptr[--(a).size] : NULL)
+#define git_array_last(a) ((a).size ? GIT_ARRAY_CAST(&(a).ptr[(a).size - 1]) : NULL)
 
-#define git_array_get(a, i) (((i) < (a).size) ? &(a).ptr[(i)] : NULL)
+#define git_array_pop(a) ((a).size ? GIT_ARRAY_CAST(&(a).ptr[--(a).size]) : NULL)
+
+#define git_array_get(a, i) (((i) < (a).size) ? GIT_ARRAY_CAST(&(a).ptr[(i)]) : NULL)
 
 #define git_array_size(a) (a).size
 

--- a/src/diff_driver.c
+++ b/src/diff_driver.c
@@ -389,13 +389,13 @@ int git_diff_driver_lookup(
 
 void git_diff_driver_free(git_diff_driver *driver)
 {
-	size_t i;
+	git_diff_driver_pattern *pat;
 
 	if (!driver)
 		return;
 
-	for (i = 0; i < git_array_size(driver->fn_patterns); ++i)
-		git_regexp_dispose(& git_array_get(driver->fn_patterns, i)->re);
+	while ((pat = git_array_pop(driver->fn_patterns)) != NULL)
+		git_regexp_dispose(&pat->re);
 	git_array_clear(driver->fn_patterns);
 
 	git_regexp_dispose(&driver->word_pattern);

--- a/src/features.h.in
+++ b/src/features.h.in
@@ -3,6 +3,7 @@
 
 #cmakedefine GIT_DEBUG_POOL 1
 #cmakedefine GIT_DEBUG_STRICT_ALLOC 1
+#cmakedefine GIT_DEBUG_ARRAY_CASTING 1
 
 #cmakedefine GIT_TRACE 1
 #cmakedefine GIT_THREADS 1

--- a/src/hash.c
+++ b/src/hash.c
@@ -16,7 +16,7 @@ int git_hash_ctx_init(git_hash_ctx *ctx)
 {
 	int error;
 
-	if ((error = git_hash_sha1_ctx_init(&ctx->sha1)) < 0)
+	if ((error = git_hash_sha1_ctx_init(&ctx->ctx.sha1)) < 0)
 		return error;
 
 	ctx->algo = GIT_HASH_ALGO_SHA1;
@@ -28,7 +28,7 @@ void git_hash_ctx_cleanup(git_hash_ctx *ctx)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			git_hash_sha1_ctx_cleanup(&ctx->sha1);
+			git_hash_sha1_ctx_cleanup(&ctx->ctx.sha1);
 			return;
 		default:
 			/* unreachable */ ;
@@ -39,7 +39,7 @@ int git_hash_init(git_hash_ctx *ctx)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			return git_hash_sha1_init(&ctx->sha1);
+			return git_hash_sha1_init(&ctx->ctx.sha1);
 		default:
 			/* unreachable */ ;
 	}
@@ -51,7 +51,7 @@ int git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			return git_hash_sha1_update(&ctx->sha1, data, len);
+			return git_hash_sha1_update(&ctx->ctx.sha1, data, len);
 		default:
 			/* unreachable */ ;
 	}
@@ -63,7 +63,7 @@ int git_hash_final(git_oid *out, git_hash_ctx *ctx)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			return git_hash_sha1_final(out, &ctx->sha1);
+			return git_hash_sha1_final(out, &ctx->ctx.sha1);
 		default:
 			/* unreachable */ ;
 	}

--- a/src/hash.h
+++ b/src/hash.h
@@ -27,7 +27,7 @@ typedef enum {
 typedef struct git_hash_ctx {
 	union {
 		git_hash_sha1_ctx sha1;
-	};
+	} ctx;
 	git_hash_algo_t algo;
 } git_hash_ctx;
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -1251,8 +1251,9 @@ int git_tree_create_updated(git_oid *out, git_repository *repo, git_tree *baseli
 			}
 			case GIT_TREE_UPDATE_REMOVE:
 			{
+				tree_stack_entry *last = git_array_last(stack);
 				char *basename = git_path_basename(update->path);
-				error = git_treebuilder_remove(git_array_last(stack)->bld, basename);
+				error = git_treebuilder_remove(last->bld, basename);
 				git__free(basename);
 				break;
 			}


### PR DESCRIPTION
Fix two syntactical issues
1) Unnamed structs/unions aren't allowed
2) git_array_x(y)->z macro expanded to (NULL)->z on non-optimizing compilers
