### PR TITLE
docs: fix some missing includes that cause Docurium to error out

### DIFF
--- a/include/git2/cert.h
+++ b/include/git2/cert.h
@@ -8,6 +8,7 @@
 #define INCLUDE_git_cert_h__
 
 #include "common.h"
+#include "types.h"
 
 /**
  * @file git2/cert.h

--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -9,6 +9,7 @@
 #define INCLUDE_sys_git_transport_h
 
 #include "git2/net.h"
+#include "git2/transport.h"
 #include "git2/types.h"
 #include "git2/strarray.h"
 #include "git2/proxy.h"


### PR DESCRIPTION
This adds a few missing includes so that Docurium doesn't skip some documentation when parsing.