### PR TITLE
config: fix included configs not refreshed more than once

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -164,22 +164,26 @@ out:
 	return error;
 }
 
+static void config_file_clear_includes(config_file_backend* cfg)
+{
+	config_file *include;
+	uint32_t i;
+
+	git_array_foreach(cfg->file.includes, i, include)
+		config_file_clear(include);
+	git_array_clear(cfg->file.includes);
+}
+
 static int config_file_set_entries(git_config_backend *cfg, git_config_entries *entries)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *old = NULL;
-	config_file *include;
 	int error;
-	uint32_t i;
 
 	if (b->parent.readonly) {
 		git_error_set(GIT_ERROR_CONFIG, "this backend is read-only");
 		return -1;
 	}
-
-	git_array_foreach(b->file.includes, i, include)
-		config_file_clear(include);
-	git_array_clear(b->file.includes);
 
 	if ((error = git_mutex_lock(&b->values_mutex)) < 0) {
 		git_error_set(GIT_ERROR_OS, "failed to lock config backend");
@@ -201,6 +205,8 @@ static int config_file_refresh_from_buffer(git_config_backend *cfg, const char *
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_entries *entries = NULL;
 	int error;
+
+	config_file_clear_includes(b);
 
 	if ((error = git_config_entries_new(&entries)) < 0 ||
 	    (error = config_file_read_buffer(entries, b->repo, &b->file,
@@ -228,6 +234,8 @@ static int config_file_refresh(git_config_backend *cfg)
 
 	if (!modified)
 		return 0;
+
+	config_file_clear_includes(b);
 
 	if ((error = git_config_entries_new(&entries)) < 0 ||
 	    (error = config_file_read(entries, b->repo, &b->file, b->level, 0)) < 0 ||


### PR DESCRIPTION
If an included config is refreshed twice, the second update is not taken
into account.

This is because the list of included files is cleared after re-reading
the new configuration, instead of being cleared before.

Fix it and add a test case to check for this bug.


This was probably introduced by commit a0dc3027f118119d3336db08251c646291f2c098