### PR TITLE
git__timer: Limit ITimer usage to AmigaOS4

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -359,7 +359,7 @@ GIT_INLINE(double) git__timer(void)
    return (double)time * scaling_factor / 1.0E9;
 }
 
-#elif defined(AMIGA)
+#elif defined(__amigaos4__)
 
 #include <proto/timer.h>
 


### PR DESCRIPTION
The ITimer interface is specific to AmigaOS4 and doesn't exist on 3.x and lower.