### PR TITLE
Fix wrong time_t used in function

### DIFF
--- a/src/date.c
+++ b/src/date.c
@@ -204,7 +204,7 @@ static int is_date(int year, int month, int day, struct tm *now_tm, time_t now, 
 	if (month > 0 && month < 13 && day > 0 && day < 32) {
 		struct tm check = *tm;
 		struct tm *r = (now_tm ? &check : tm);
-		time_t specified;
+		git_time_t specified;
 
 		r->tm_mon = month - 1;
 		r->tm_mday = day;


### PR DESCRIPTION
This function doesn't interoperate with any system functions that use the system `time_t`, but rather only works with the `git_time_t` type in libgit2, which could be a different width than the system one. Fixes a compile warning.