### PR TITLE
Fix worktree iteration when repository has no common directory

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -2339,6 +2339,12 @@ int git_repository_foreach_worktree(git_repository *repo,
 	int error;
 	size_t i;
 
+	/* apply operation to repository supplied when commondir is empty, implying there's
+	 * no linked worktrees to iterate, which can occur when using custom odb/refdb
+	 */
+	if (!repo->commondir)
+		return cb(repo, payload);
+
 	if ((error = git_repository_open(&worktree_repo, repo->commondir)) < 0 ||
 	    (error = cb(worktree_repo, payload) != 0))
 		goto out;


### PR DESCRIPTION
This is intended to fix #5851, which highlights an assertion within git_path_prettify that occurs during git_repository_foreach_worktree when it attempts to open the repository because repo->commondir is null.  This occurs in contexts where the repository has been created explicitly in conjunction with a custom odb/refdb backend.

git_repository_foreach_worktree has been changed to check when commondir is null, and in that case apply the callback operation to the repository supplied only, as it would appear there are no linked worktrees to iterate.