### PR TITLE
git__timer: Allow compilation on systems without CLOCK_MONOTONIC

### DIFF
--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -251,7 +251,7 @@ int git_packbuilder_insert(git_packbuilder *pb, const git_oid *oid,
 		double current_time = git__timer();
 		double elapsed = current_time - pb->last_progress_report_time;
 
-		if (elapsed >= MIN_PROGRESS_UPDATE_INTERVAL) {
+		if (elapsed < 0 || elapsed >= MIN_PROGRESS_UPDATE_INTERVAL) {
 			pb->last_progress_report_time = current_time;
 
 			ret = pb->progress_cb(
@@ -922,7 +922,7 @@ static int report_delta_progress(
 		double current_time = git__timer();
 		double elapsed = current_time - pb->last_progress_report_time;
 
-		if (force || elapsed >= MIN_PROGRESS_UPDATE_INTERVAL) {
+		if (force || elapsed < 0 || elapsed >= MIN_PROGRESS_UPDATE_INTERVAL) {
 			pb->last_progress_report_time = current_time;
 
 			ret = pb->progress_cb(

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -975,9 +975,10 @@ static int stream_thunk(void *buf, size_t size, void *data)
 
 	if (payload->cb) {
 		double current_time = git__timer();
+		double elapsed = current_time - payload->last_progress_report_time;
 		payload->last_bytes += size;
 
-		if ((current_time - payload->last_progress_report_time) >= MIN_PROGRESS_UPDATE_INTERVAL) {
+		if (elapsed < 0 || elapsed >= MIN_PROGRESS_UPDATE_INTERVAL) {
 			payload->last_progress_report_time = current_time;
 			error = payload->cb(payload->pb->nr_written, payload->pb->nr_objects, payload->last_bytes, payload->cb_payload);
 		}

--- a/src/util.h
+++ b/src/util.h
@@ -376,17 +376,17 @@ GIT_INLINE(double) git__timer(void)
 
 GIT_INLINE(double) git__timer(void)
 {
-	struct timespec tp;
+	struct timeval tv;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &tp) == 0) {
+#ifdef CLOCK_MONOTONIC
+	struct timespec tp;
+	if (clock_gettime(CLOCK_MONOTONIC, &tp) == 0)
 		return (double) tp.tv_sec + (double) tp.tv_nsec / 1.0E9;
-	} else {
-		/* Fall back to using gettimeofday */
-		struct timeval tv;
-		struct timezone tz;
-		gettimeofday(&tv, &tz);
-		return (double)tv.tv_sec + (double)tv.tv_usec / 1.0E6;
-	}
+#endif
+
+	/* Fall back to using gettimeofday */
+	gettimeofday(&tv, NULL);
+	return (double)tv.tv_sec + (double)tv.tv_usec / 1.0E6;
 }
 
 #endif


### PR DESCRIPTION
Makes usage of CLOCK_MONOTONIC conditional.

Functions that uses git__timer checks for negative time difference to handle clock synchronization when a non-monotonic timer is used.

According to [opengroup.org](https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html) gettimeofday() have unspecified behaviour if tzp is set to anything but NULL.