### PR TITLE
http: don't require a password

### DIFF
--- a/src/transports/http.c
+++ b/src/transports/http.c
@@ -104,6 +104,11 @@ static int apply_url_credentials(
 	const char *username,
 	const char *password)
 {
+	GIT_ASSERT_ARG(username);
+
+	if (!password)
+		password = "";
+
 	if (allowed_types & GIT_CREDENTIAL_USERPASS_PLAINTEXT)
 		return git_credential_userpass_plaintext_new(cred, username, password);
 
@@ -138,8 +143,7 @@ static int handle_auth(
 	/* Start with URL-specified credentials, if there were any. */
 	if ((allowed_credtypes & GIT_CREDENTIAL_USERPASS_PLAINTEXT) &&
 	    !server->url_cred_presented &&
-	    server->url.username &&
-	    server->url.password) {
+	    server->url.username) {
 		error = apply_url_credentials(&server->cred, allowed_credtypes, server->url.username, server->url.password);
 		server->url_cred_presented = 1;
 


### PR DESCRIPTION
Attempt authentication when a username is presented but a password is
not; this can happen in particular when users are doing token
authentication and specifying the token in the URL itself.  For example,
`https://token@host/` is a valid URI and should be treated as a username
of `token` with an empty password.

Fixes #5967 