### PR TITLE
docker: remove the entrypoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   docker-registry: docker.pkg.github.com
-  docker-config-path: ci/docker
+  docker-config-path: source/ci/docker
 
 jobs:
   # Build the docker container images that we will use for our Linux
@@ -55,7 +55,7 @@ jobs:
       if: matrix.container.qemu == true
     - name: Download existing container
       run: |
-        "${{ github.workspace }}/ci/getcontainer.sh" "${{ matrix.container.name }}" "${{ matrix.container.dockerfile }}"
+        "${{ github.workspace }}/source/ci/getcontainer.sh" "${{ matrix.container.name }}" "${{ matrix.container.dockerfile }}"
       env:
         DOCKER_REGISTRY: ${{ env.docker-registry }}
         GITHUB_TOKEN: ${{ secrets.github_token }}
@@ -206,9 +206,10 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
       with:
+        path: source
         fetch-depth: 0
     - name: Set up build environment
-      run: ci/setup-${{ matrix.platform.setup-script }}.sh
+      run: source/ci/setup-${{ matrix.platform.setup-script }}.sh
       shell: bash
       if: matrix.platform.setup-script != ''
     - name: Setup QEMU
@@ -216,7 +217,7 @@ jobs:
       if: matrix.platform.container.qemu == true
     - name: Download container
       run: |
-        "${{ github.workspace }}/ci/getcontainer.sh" "${{ matrix.platform.container.name }}" "${{ matrix.platform.container.dockerfile }}"
+        "${{ github.workspace }}/source/ci/getcontainer.sh" "${{ matrix.platform.container.name }}" "${{ matrix.platform.container.dockerfile }}"
       env:
         DOCKER_REGISTRY: ${{ env.docker-registry }}
         GITHUB_TOKEN: ${{ secrets.github_token }}
@@ -233,8 +234,9 @@ jobs:
         if [ -n "${{ matrix.platform.container.name }}" ]; then
           docker run \
               --rm \
-              -v "$(pwd):/home/libgit2/source" \
-              -w /home/libgit2/source \
+              --user libgit2:libgit2 \
+              -v "$(pwd)/source:/home/libgit2/source" \
+              -w /home/libgit2 \
               -e ASAN_SYMBOLIZER_PATH \
               -e CC \
               -e CFLAGS \
@@ -247,11 +249,11 @@ jobs:
               -e TSAN_OPTIONS \
               -e UBSAN_OPTIONS \
               ${{ env.docker-registry-container-sha }} \
-              /bin/bash -c "mkdir build && cd build && ../ci/build.sh && ../ci/test.sh"
+              /bin/bash -c "mkdir build && cd build && ../source/ci/build.sh && ../source/ci/test.sh"
         else
           mkdir build && cd build
-          ../ci/build.sh
-          ../ci/test.sh
+          ../source/ci/build.sh
+          ../source/ci/test.sh
         fi
       shell: bash
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -215,6 +215,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
       with:
+        path: source
         fetch-depth: 0
     - name: Set up build environment
       run: ci/setup-${{ matrix.platform.setup-script }}.sh
@@ -242,8 +243,9 @@ jobs:
         if [ -n "${{ matrix.platform.container.name }}" ]; then
           docker run \
               --rm \
-              -v "$(pwd):/home/libgit2/source" \
-              -w /home/libgit2/source \
+              --user libgit2:libgit2 \
+              -v "$(pwd)/source:/home/libgit2/source" \
+              -w /home/libgit2 \
               -e ASAN_SYMBOLIZER_PATH \
               -e CC \
               -e CFLAGS \
@@ -255,11 +257,11 @@ jobs:
               -e SKIP_SSH_TESTS \
               -e TSAN_OPTIONS \
               ${{ env.docker-registry-container-sha }} \
-              /bin/bash -c "mkdir build && cd build && ../ci/build.sh && ../ci/test.sh"
+              /bin/bash -c "mkdir build && cd build && ../source/ci/build.sh && ../source/ci/test.sh"
         else
           mkdir build && cd build
-          ../ci/build.sh
-          ../ci/test.sh
+          ../source/ci/build.sh
+          ../source/ci/test.sh
         fi
       shell: bash
 

--- a/ci/docker/bionic
+++ b/ci/docker/bionic
@@ -36,9 +36,8 @@ RUN cd /tmp && \
     cd .. && \
     rm -rf mbedtls-2.16.2
 
-FROM mbedtls AS configure
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod a+x /usr/local/bin/entrypoint.sh
-RUN mkdir /var/run/sshd
+FROM mbedtls AS adduser
+RUN useradd --shell /bin/bash libgit2 --create-home
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+FROM adduser AS configure
+RUN mkdir /var/run/sshd

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-useradd --shell /bin/bash libgit2
-chown --recursive libgit2:libgit2 /home/libgit2
-exec sudo --preserve-env --set-home --user=libgit2 "$@"

--- a/ci/docker/focal
+++ b/ci/docker/focal
@@ -72,9 +72,8 @@ RUN cd /tmp && \
     cd .. && \
     rm -rf valgrind-3.15.0
 
-FROM valgrind AS configure
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod a+x /usr/local/bin/entrypoint.sh
-RUN mkdir /var/run/sshd
+FROM valgrind AS adduser
+RUN useradd --shell /bin/bash libgit2 --create-home
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+FROM adduser AS configure
+RUN mkdir /var/run/sshd

--- a/ci/docker/xenial
+++ b/ci/docker/xenial
@@ -59,9 +59,8 @@ RUN cd /tmp && \
     cd .. && \
     rm -rf valgrind-3.15.0
 
-FROM valgrind AS configure
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod a+x /usr/local/bin/entrypoint.sh
-RUN mkdir /var/run/sshd
+FROM valgrind AS adduser
+RUN useradd --shell /bin/bash libgit2 --create-home
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+FROM adduser AS configure
+RUN mkdir /var/run/sshd


### PR DESCRIPTION
Omitting an entrypoint.sh to configure the container and instead
depending on docker primitives allows us to be more portable.  (If a
distribution uses a different mechanism for adding users, we need not
have multiple entrypoint.sh files or invariants within it; instead we
can configure that in the dockerfile itself along with all the other
distribution specific components.)