### PR TITLE
clone: don't test remote url against filesystem

### DIFF
--- a/tests/online/clone.c
+++ b/tests/online/clone.c
@@ -7,6 +7,7 @@
 #include "refs.h"
 
 #define LIVE_REPO_URL "http://github.com/libgit2/TestGitRepository"
+#define LIVE_REPO_AS_DIR "http:/github.com/libgit2/TestGitRepository"
 #define LIVE_EMPTYREPO_URL "http://github.com/libgit2/TestEmptyRepository"
 #define BB_REPO_URL "https://libgit3@bitbucket.org/libgit2/testgitrepository.git"
 #define BB_REPO_URL_WITH_PASS "https://libgit3:libgit3@bitbucket.org/libgit2/testgitrepository.git"
@@ -86,6 +87,16 @@ void test_online_clone__initialize(void)
 	if (_remote_expectcontinue)
 		git_libgit2_opts(GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE, 1);
 
+#if !defined(GIT_WIN32)
+	/*
+	 * On system that allows ':' in filenames "http://path" can be misinterpreted
+	 * as the local path "http:/path".
+	 * Create a local path that looks like LIVE_REPO_URL to make sure we can
+	 * handle that case.
+	 */
+	git_futils_mkdir_r(LIVE_REPO_AS_DIR, 0777);
+#endif
+
 	_orig_proxies_need_reset = 0;
 }
 
@@ -98,6 +109,10 @@ void test_online_clone__cleanup(void)
 	cl_fixture_cleanup("./foo");
 	cl_fixture_cleanup("./initial");
 	cl_fixture_cleanup("./subsequent");
+
+#if !defined(GIT_WIN32)
+	cl_fixture_cleanup("http:");
+#endif
 
 	git__free(_remote_url);
 	git__free(_remote_user);


### PR DESCRIPTION
resolves #5982 

I removed the directory check in create_and_configure_origin
If the path given is to a bundle it will not be a directory but should probably have an absolute path anyway?

No test added, I'm not sure about the best approach to test this.
I suspect windows will act up on url's containing ':'