### PR TITLE
sha1dc: remove conditional for <sys/types.h>

### DIFF
--- a/src/hash/sha1/sha1dc/sha1.c
+++ b/src/hash/sha1/sha1dc/sha1.c
@@ -10,9 +10,7 @@
 #include <memory.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef __unix__
 #include <sys/types.h> /* make sure macros like _BIG_ENDIAN visible */
-#endif
 #endif
 
 #ifdef SHA1DC_CUSTOM_INCLUDE_SHA1_C


### PR DESCRIPTION
src/hash/sha1/sha1dc/sha1.c is testing if \_\_unix\_\_ is defined before including <sys/types.h>
Since it is included unconditionally elsewhere it isn't necessary to include it conditionally and it prevents systems that doesn't define \_\_unix\_\_ from specifying endianess in the include files.
