### PR TITLE
openssl: don't fail when we can't customize allocators

### DIFF
--- a/src/streams/openssl.c
+++ b/src/streams/openssl.c
@@ -251,13 +251,18 @@ int git_openssl_stream_global_init(void)
 #endif
 
 #ifdef VALGRIND
-	/* Swap in our own allocator functions that initialize allocated memory */
-	if (!allocators_initialized &&
+	/*
+	 * Swap in our own allocator functions that initialize
+	 * allocated memory to avoid spurious valgrind warnings.
+	 * Don't error on failure; many builds of OpenSSL do not
+	 * allow you to set these functions.
+	 */
+	if (!allocators_initialized) {
 	    CRYPTO_set_mem_functions(git_openssl_malloc,
 				     git_openssl_realloc,
-				     git_openssl_free) != 1)
-		goto error;
-	allocators_initialized = true;
+				     git_openssl_free);
+		allocators_initialized = true;
+	}
 #endif
 
 	OPENSSL_init_ssl(0, NULL);


### PR DESCRIPTION
During valgrind runs, we try to swap out the OpenSSL allocators for our
own.  This allows us to avoid some unnecessary warnings about usage.
Unfortunately, many builds of OpenSSL do not allow you to swap
allocators; for example FIPS builds and the builds running in CentOS.

Try to swap the allocators, but do not fail when they cannot be
customized.