### PR TITLE
mbedTLS: Fix setting certificate directory

### DIFF
--- a/src/libgit2.c
+++ b/src/libgit2.c
@@ -261,10 +261,7 @@ int git_libgit2_opts(int key, ...)
 		{
 			const char *file = va_arg(ap, const char *);
 			const char *path = va_arg(ap, const char *);
-			if (file)
-				error = git_mbedtls__set_cert_location(file, 0);
-			if (error && path)
-				error = git_mbedtls__set_cert_location(path, 1);
+			error = git_mbedtls__set_cert_location(file, path);
 		}
 #else
 		git_error_set(GIT_ERROR_SSL, "TLS backend doesn't support certificate locations");

--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -442,6 +442,8 @@ int git_mbedtls__set_cert_location(const char *file, const char *path)
 	char errbuf[512];
 	mbedtls_x509_crt *cacert;
 
+	GIT_ASSERT_ARG(file || path);
+
 	cacert = git__malloc(sizeof(mbedtls_x509_crt));
 	GIT_ERROR_CHECK_ALLOC(cacert);
 

--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -68,8 +68,6 @@ static void shutdown_ssl(void)
 	}
 }
 
-int git_mbedtls__set_cert_location(const char *path, int is_dir);
-
 int git_mbedtls_stream_global_init(void)
 {
 	int loaded = 0;
@@ -148,9 +146,9 @@ int git_mbedtls_stream_global_init(void)
 
 	/* load default certificates */
 	if (crtpath != NULL && stat(crtpath, &statbuf) == 0 && S_ISREG(statbuf.st_mode))
-		loaded = (git_mbedtls__set_cert_location(crtpath, 0) == 0);
+		loaded = (git_mbedtls__set_cert_location(crtpath, NULL) == 0);
 	if (!loaded && crtpath != NULL && stat(crtpath, &statbuf) == 0 && S_ISDIR(statbuf.st_mode))
-		loaded = (git_mbedtls__set_cert_location(crtpath, 1) == 0);
+		loaded = (git_mbedtls__set_cert_location(NULL, crtpath) == 0);
 
 	return git_runtime_shutdown_register(shutdown_ssl);
 
@@ -438,7 +436,7 @@ int git_mbedtls_stream_new(
 	return error;
 }
 
-int git_mbedtls__set_cert_location(const char *path, int is_dir)
+int git_mbedtls__set_cert_location(const char *file, const char *path)
 {
 	int ret = 0;
 	char errbuf[512];
@@ -450,11 +448,10 @@ int git_mbedtls__set_cert_location(const char *path, int is_dir)
 	GIT_ERROR_CHECK_ALLOC(cacert);
 
 	mbedtls_x509_crt_init(cacert);
-	if (is_dir) {
+	if (file)
+		ret = mbedtls_x509_crt_parse_file(cacert, file);
+	if (ret >= 0 && path)
 		ret = mbedtls_x509_crt_parse_path(cacert, path);
-	} else {
-		ret = mbedtls_x509_crt_parse_file(cacert, path);
-	}
 	/* mbedtls_x509_crt_parse_path returns the number of invalid certs on success */
 	if (ret < 0) {
 		mbedtls_x509_crt_free(cacert);

--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -442,8 +442,6 @@ int git_mbedtls__set_cert_location(const char *file, const char *path)
 	char errbuf[512];
 	mbedtls_x509_crt *cacert;
 
-	GIT_ASSERT_ARG(path);
-
 	cacert = git__malloc(sizeof(mbedtls_x509_crt));
 	GIT_ERROR_CHECK_ALLOC(cacert);
 

--- a/src/streams/mbedtls.h
+++ b/src/streams/mbedtls.h
@@ -14,7 +14,7 @@
 extern int git_mbedtls_stream_global_init(void);
 
 #ifdef GIT_MBEDTLS
-extern int git_mbedtls__set_cert_location(const char *path, int is_dir);
+extern int git_mbedtls__set_cert_location(const char *file, const char *path);
 
 extern int git_mbedtls_stream_new(git_stream **out, const char *host, const char *port);
 extern int git_mbedtls_stream_wrap(git_stream **out, git_stream *in, const char *host);


### PR DESCRIPTION
fixes #6003

This attempts to make the mbedtls call more consistent with the openssl behavior. (UNTESTED)

Thank you!