### PR TITLE
C11 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ ELSE ()
 	enable_warnings(unused-const-variable)
 	enable_warnings(unused-function)
 	enable_warnings(int-conversion)
+	enable_warnings(c11-extensions)
 
 	# MinGW uses gcc, which expects POSIX formatting for printf, but
 	# uses the Windows C library, which uses its own format specifiers.

--- a/src/hash.c
+++ b/src/hash.c
@@ -16,7 +16,7 @@ int git_hash_ctx_init(git_hash_ctx *ctx)
 {
 	int error;
 
-	if ((error = git_hash_sha1_ctx_init(&ctx->sha1)) < 0)
+	if ((error = git_hash_sha1_ctx_init(&ctx->ctx.sha1)) < 0)
 		return error;
 
 	ctx->algo = GIT_HASH_ALGO_SHA1;
@@ -28,7 +28,7 @@ void git_hash_ctx_cleanup(git_hash_ctx *ctx)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			git_hash_sha1_ctx_cleanup(&ctx->sha1);
+			git_hash_sha1_ctx_cleanup(&ctx->ctx.sha1);
 			return;
 		default:
 			/* unreachable */ ;
@@ -39,7 +39,7 @@ int git_hash_init(git_hash_ctx *ctx)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			return git_hash_sha1_init(&ctx->sha1);
+			return git_hash_sha1_init(&ctx->ctx.sha1);
 		default:
 			/* unreachable */ ;
 	}
@@ -51,7 +51,7 @@ int git_hash_update(git_hash_ctx *ctx, const void *data, size_t len)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			return git_hash_sha1_update(&ctx->sha1, data, len);
+			return git_hash_sha1_update(&ctx->ctx.sha1, data, len);
 		default:
 			/* unreachable */ ;
 	}
@@ -63,7 +63,7 @@ int git_hash_final(git_oid *out, git_hash_ctx *ctx)
 {
 	switch (ctx->algo) {
 		case GIT_HASH_ALGO_SHA1:
-			return git_hash_sha1_final(out, &ctx->sha1);
+			return git_hash_sha1_final(out, &ctx->ctx.sha1);
 		default:
 			/* unreachable */ ;
 	}

--- a/src/hash.h
+++ b/src/hash.h
@@ -27,7 +27,7 @@ typedef enum {
 typedef struct git_hash_ctx {
 	union {
 		git_hash_sha1_ctx sha1;
-	};
+	} ctx;
 	git_hash_algo_t algo;
 } git_hash_ctx;
 


### PR DESCRIPTION
GCC and Clang defaults to allowing some C11 specific extensions even if C99 is specified
This PR enables warnings when compiling with Clang.

To enable warnings for GCC -Wc99-c11-compat has to be added, but this reveals a similar issue in win32/reparse.h. That code seems to be pulled in from the Windows 2000 SDK. Is it safe to fix this?

This is the same code as in #5912, but since it was 3 different issues baked into one and the array related test needed some more thought I decided to split it up in separate PR.