### PR TITLE
Support for legacy Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ IF(WIN32)
 	# By default, libgit2 is built with WinHTTP.  To use the built-in
 	# HTTP transport, invoke CMake with the "-DWINHTTP=OFF" argument.
 	OPTION(WINHTTP			"Use Win32 WinHTTP routines"				 ON)
+	SET(WIN32_TARGET_VERSION	"0x0600" CACHE STRING "The version of Win32 to target. Vista (0x0600) is default, older versions can be set with compromises in functionality.")
 ENDIF()
 
 IF(MSVC)
@@ -246,7 +247,7 @@ ENDIF()
 
 # Ensure that MinGW provides the correct header files.
 IF (WIN32 AND NOT CYGWIN)
-	ADD_DEFINITIONS(-DWIN32 -D_WIN32_WINNT=0x0600)
+	ADD_DEFINITIONS(-DWIN32 "-D_WIN32_WINNT=${WIN32_TARGET_VERSION}")
 ENDIF()
 
 IF( NOT CMAKE_CONFIGURATION_TYPES )

--- a/deps/http-parser/http_parser.c
+++ b/deps/http-parser/http_parser.c
@@ -33,6 +33,10 @@
 # define ULLONG_MAX ((uint64_t) -1) /* 2^64-1 */
 #endif
 
+#ifndef UINT16_MAX
+# define UINT16_MAX 0xFFFF
+#endif
+
 #ifndef MIN
 # define MIN(a,b) ((a) < (b) ? (a) : (b))
 #endif

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -21,7 +21,7 @@
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
-# include <stdint.h>
+# include "stdint.h"
 #elif !defined(__CLANG_INTTYPES_H)
 # include <inttypes.h>
 #endif

--- a/include/git2/types.h
+++ b/include/git2/types.h
@@ -39,7 +39,12 @@ GIT_BEGIN_DECL
 #if defined(_MSC_VER)
 
 typedef __int64 git_off_t;
+#if _MSC_VER >= 1400
 typedef __time64_t git_time_t;
+#else
+/* Not a time type, but keeps it 64-bit on legacy MSVC */
+typedef __int64 git_time_t;
+#endif
 
 #elif defined(__MINGW32__)
 

--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -59,6 +59,15 @@
 #		define PRIxZ "I64x"
 #		define PRIXZ "I64X"
 #		define PRIdZ "I64d"
+#	elif defined(_MSC_VER) && _MSC_VER < 1300
+/* Old MSVC doesn't support these identifiers. (Assumes LP32, but I believe
+ * the unreleased AXP64 target is the only LP64 target that doesn't support
+ * the I length.)
+ */
+#		define PRIuZ "u"
+#		define PRIxZ "x"
+#		define PRIXZ "X"
+#		define PRIdZ "d"
 #	else
 #		define PRIuZ "Iu"
 #		define PRIxZ "Ix"

--- a/src/errors.h
+++ b/src/errors.h
@@ -37,8 +37,18 @@ GIT_INLINE(int) git_error_set_after_callback_function(
 }
 
 #ifdef GIT_WIN32
+#if defined(_MSC_VER) && _MSC_VER >= 1300
 #define git_error_set_after_callback(code) \
 	git_error_set_after_callback_function((code), __FUNCTION__)
+#else
+/* VC++6 doesn't support __FUNCTION__, fallback to __FILE__:__LINE__, with
+ * macro to handle the fact _LINE__ isn't a string
+ */
+#define __AS_STRING__(x) #x
+#define __LINESTRING__ __AS_STRING__(__LINE__)
+#define git_error_set_after_callback(code) \
+	git_error_set_after_callback_function((code), __FILE__ ":" __LINESTRING__)
+#endif
 #else
 #define git_error_set_after_callback(code) \
 	git_error_set_after_callback_function((code), __func__)

--- a/src/integer.h
+++ b/src/integer.h
@@ -86,8 +86,10 @@ GIT_INLINE(int) git__is_int(int64_t p)
      __builtin_mul_overflow(one, two, out)
 # endif
 
-/* Use Microsoft's safe integer handling functions where available */
-#elif defined(_MSC_VER)
+/* Use Microsoft's safe integer handling functions where available.
+ * Seems intsafe.h is available with the Vista PSDK or VS 2010, maybe earlier
+ */
+#elif defined(_MSC_VER) && (_MSC_VER >= 1600 || (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600))
 
 # define ENABLE_INTSAFE_SIGNED_FUNCTIONS
 # include <intsafe.h>

--- a/src/path.c
+++ b/src/path.c
@@ -1223,7 +1223,11 @@ int git_path_diriter_init(
 
 	diriter->handle = FindFirstFileExW(
 		path_filter,
+#if _WIN32_WINNT >= 0x0600
 		is_win7_or_later ? FindExInfoBasic : FindExInfoStandard,
+#else
+		FindExInfoStandard,
+#endif
 		&diriter->current,
 		FindExSearchNameMatch,
 		NULL,

--- a/src/transports/winhttp.c
+++ b/src/transports/winhttp.c
@@ -1347,7 +1347,7 @@ static int put_uuid_string(LPWSTR buffer, size_t buffer_len_cch)
 		return -1;
 	}
 
-#if !defined(__MINGW32__) || defined(MINGW_HAS_SECURE_API)
+#if ((defined(_MSC_VER) && _MSC_VER >= 1400) && !defined(__MINGW32__)) || defined(MINGW_HAS_SECURE_API)
 	result = swprintf_s(buffer, buffer_len_cch,
 #else
 	result = wsprintfW(buffer,

--- a/src/util.h
+++ b/src/util.h
@@ -322,7 +322,7 @@ extern size_t git__unescape(char *str);
  */
 GIT_INLINE(void) git__memzero(void *data, size_t size)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0501)
 	SecureZeroMemory((PVOID)data, size);
 #else
 	volatile uint8_t *scan = (volatile uint8_t *)data;

--- a/src/varint.h
+++ b/src/varint.h
@@ -9,8 +9,6 @@
 
 #include "common.h"
 
-#include <stdint.h>
-
 extern int git_encode_varint(unsigned char *, size_t, uintmax_t);
 extern uintmax_t git_decode_varint(const unsigned char *, size_t *);
 

--- a/src/win32/path_w32.c
+++ b/src/win32/path_w32.c
@@ -13,6 +13,10 @@
 #include "reparse.h"
 #include "dir.h"
 
+#ifndef IO_REPARSE_TAG_SYMLINK
+#define IO_REPARSE_TAG_SYMLINK (0xA000000CL)
+#endif
+
 #define PATH__NT_NAMESPACE     L"\\\\?\\"
 #define PATH__NT_NAMESPACE_LEN 4
 

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -666,6 +666,7 @@ static int getfinalpath_w(
 	git_win32_path dest,
 	const wchar_t *path)
 {
+#if _WIN32_WINNT >= 0x0600
 	HANDLE hFile;
 	DWORD dwChars;
 
@@ -687,6 +688,14 @@ static int getfinalpath_w(
 
 	/* The path may be delivered to us with a namespace prefix; remove */
 	return (int)git_win32_path_remove_namespace(dest, dwChars);
+#else
+	/* GetFinalPathNameByHandle is Vista only, though I think a reimpl is
+	 * possible. We could revert 307712613b77e8290a2c5d08ef3ae81c1e3139f3
+	 * which made it dynamically loaded, but it doesn't change the
+	 * semantics anyways; it'd just return -1. So let's do that for now.
+	 */
+	return -1;
+#endif
 }
 
 static int follow_and_lstat_link(git_win32_path path, struct stat* buf)

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -436,6 +436,7 @@ out:
 
 int p_symlink(const char *target, const char *path)
 {
+#ifdef _WIN32_WINNT >= 0x0600
 	git_win32_path target_w, path_w;
 	DWORD dwFlags;
 
@@ -458,6 +459,10 @@ int p_symlink(const char *target, const char *path)
 		return -1;
 
 	return 0;
+#else
+	/* Symlinks are unavailable before Vista. */
+	return git_futils_fake_symlink(target, path);
+#endif
 }
 
 struct open_opts {

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -823,6 +823,24 @@ char *p_realpath(const char *orig_path, char *buffer)
 	return buffer;
 }
 
+#if defined(_MSC_VER) && _MSC_VER < 1300
+/* _vscprintf seems to be a 2002/2003 addition to MSVC. The next easiest way
+ * to get the length of a formatted string? Why, just measure the result of
+ * fprintf writing to /dev/null! (This would be easier if _vsnprintf had the
+ * same semantics as vsnprintf...) Unsure how slow this can be, but it works.
+ */
+static int _vscprintf(const char *format, va_list argptr)
+{
+	int chars;
+	FILE *nulf = fopen("NUL", "wb");
+	if (nulf == NULL)
+		return -1;
+	chars = vfprintf(nulf, format, argptr);
+	fclose(nulf);
+	return chars;
+}
+#endif
+
 int p_vsnprintf(char *buffer, size_t count, const char *format, va_list argptr)
 {
 #if defined(_MSC_VER)

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -436,7 +436,7 @@ out:
 
 int p_symlink(const char *target, const char *path)
 {
-#ifdef _WIN32_WINNT >= 0x0600
+#if _WIN32_WINNT >= 0x0600
 	git_win32_path target_w, path_w;
 	DWORD dwFlags;
 

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -216,7 +216,8 @@ int p_ftruncate(int fd, off64_t size)
 		return -1;
 	}
 
-#if !defined(__MINGW32__) || defined(MINGW_HAS_SECURE_API)
+	/* Requires MSVC 2005 */
+#if ((defined(_MSC_VER) && _MSC_VER >= 1400) && !defined(__MINGW32__)) || defined(MINGW_HAS_SECURE_API)
 	return ((_chsize_s(fd, size) == 0) ? 0 : -1);
 #else
 	/* TODO MINGW32 Find a replacement for _chsize() that handles big files. */

--- a/src/win32/utf-conv.h
+++ b/src/win32/utf-conv.h
@@ -12,7 +12,12 @@
 #include <wchar.h>
 
 #ifndef WC_ERR_INVALID_CHARS
-# define WC_ERR_INVALID_CHARS	0x80
+# if _WIN32_WINNT >= 0x0600
+#  define WC_ERR_INVALID_CHARS	0x80
+# else
+/* Windows before Vista will reject this flag */
+#  define WC_ERR_INVALID_CHARS	0x0
+# endif
 #endif
 
 /**

--- a/src/win32/w32_util.h
+++ b/src/win32/w32_util.h
@@ -78,7 +78,7 @@ GIT_INLINE(void) git_win32__filetime_to_timespec(
 	winTime -= INT64_C(116444736000000000); /* Windows to Unix Epoch conversion */
 	ts->tv_sec = (time_t)(winTime / 10000000);
 #ifdef GIT_USE_NSEC
-	ts->tv_nsec = (winTime % 10000000) * 100;
+	ts->tv_nsec = (long)(winTime % 10000000) * 100;
 #else
 	ts->tv_nsec = 0;
 #endif
@@ -90,8 +90,8 @@ GIT_INLINE(void) git_win32__timeval_to_filetime(
 	int64_t ticks = (tv.tv_sec * INT64_C(10000000)) +
 		(tv.tv_usec * INT64_C(10)) + INT64_C(116444736000000000);
 
-	ft->dwHighDateTime = ((ticks >> 32) & INT64_C(0xffffffff));
-	ft->dwLowDateTime = (ticks & INT64_C(0xffffffff));
+	ft->dwHighDateTime = (DWORD)((ticks >> 32) & INT64_C(0xffffffff));
+	ft->dwLowDateTime = (DWORD)(ticks & INT64_C(0xffffffff));
 }
 
 GIT_INLINE(void) git_win32__stat_init(

--- a/src/win32/win32-compat.h
+++ b/src/win32/win32-compat.h
@@ -7,7 +7,7 @@
 #ifndef INCLUDE_win32_win32_compat_h__
 #define INCLUDE_win32_win32_compat_h__
 
-#include <stdint.h>
+#include <git2/stdint.h>
 #include <time.h>
 #include <wchar.h>
 #include <sys/stat.h>


### PR DESCRIPTION
(Upstreaming a branch I've had kicking for a month or two. I have not rebased yet; caveat emptor)

I've been [making a source control provider](https://visualgit.io/) compatible with [the APIs Microsoft has for it.](https://docs.microsoft.com/en-us/visualstudio/extensibility/source-control-plug-ins?view=vs-2019)

I've built up a patchset and this is a cleaned up version that should cleanly support the changes when possible. I can verify the gcc/amd64 Linux build isn't regressed by this. The changes to Vista+ should also be minimal, because everything is tidy ifdefs. (You should be able to test most of this by setting _WIN32_WINNT, which this PR makes changeable at the CMake level. Such a method could also be used to raise Windows versions supported if needed.) Many of the ifdefs handle the older SDK versions as well.

This should support Windows 2000 (primarily tested on XP) and Visual C++ 6 (with processor pack for align and 2003/02 Platform SDK); NT 4 should be trivial to support with 1. changing the version API checks 2. removing all flags for UTF-8 conversions [since those were added in 2000 SP4/XP](https://sporks.space/2021/08/27/utf-8-conversion-issues-on-legacy-windows/), but I have not added these just yet. Technically 9x is supportable, but it'd require Unicows to wrap wide APIs and I don't know if it supports \\?\.

Related, old VC++ does make for a good DeathStation 9000 in terms of no C89 or GNU extensions. I wonder if it might be possible to hack up CI with it considering some versions of it were freely available :thinking: 