### PR TITLE
Stdint header condition has been reverted.

### DIFF
--- a/include/git2/stdint.h
+++ b/include/git2/stdint.h
@@ -29,9 +29,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef _MSC_VER // [
-#error "Use this header only with Microsoft Visual C++ compilers!"
-#endif // _MSC_VER ]
+#ifdef _MSC_VER // [
 
 #ifndef _MSC_STDINT_H_ // [
 #define _MSC_STDINT_H_
@@ -245,3 +243,5 @@ typedef uint64_t  uintmax_t;
 
 
 #endif // _MSC_STDINT_H_ ]
+
+#endif // _MSC_VER ]


### PR DESCRIPTION
This PR hides header content from non-Windows builds.
( Well, it is better to include this header via "relative" search path ).