### PR TITLE
Set Host Header to match CONNECT authority target

### DIFF
--- a/src/transports/httpclient.c
+++ b/src/transports/httpclient.c
@@ -670,7 +670,7 @@ static int generate_connect_request(
 	git_buf_puts(buf, "\r\n");
 
 	git_buf_puts(buf, "Host: ");
-	puts_host_and_port(buf, &client->proxy.url, false);
+	puts_host_and_port(buf, &client->server.url, true);
 	git_buf_puts(buf, "\r\n");
 
 	if ((error = apply_proxy_credentials(buf, client, request) < 0))


### PR DESCRIPTION
Prior to this change, for CONNECT requests, the Host header was set to
the host and port of the target http proxy. However, per the rfc7230 for
HTTP/1.1 this is incorrect as the Host header should match the target of
the CONNECT request, as detailed in section 5.3.3 & 5.4.

  5.3.3.  authority-form

   The authority-form of request-target is only used for CONNECT
   requests (Section 4.3.6 of [RFC7231]).

     authority-form = authority

   When making a CONNECT request to establish a tunnel through one or
   more proxies, a client MUST send only the target URI's authority
   component (excluding any userinfo and its "@" delimiter) as the
   request-target.  For example,

     CONNECT www.example.com:80 HTTP/1.1

  5.4.  Host

   <snip>

   A client MUST send a Host header field in all HTTP/1.1 request
   messages.  If the target URI includes an authority component, then a
   client MUST send a field-value for Host that is identical to that
   authority component, excluding any userinfo subcomponent and its "@"
   delimiter (Section 2.7.1).  If the authority component is missing or
   undefined for the target URI, then a client MUST send a Host header
   field with an empty field-value.

This issue was noticed when proxying requests through HAProxy 2.2 which
rejects these invalid http requests.