### PR TITLE
Fix a possible null pointer dereference

### DIFF
--- a/src/commit_graph.c
+++ b/src/commit_graph.c
@@ -716,7 +716,8 @@ int git_commit_graph_writer_add_index_file(
 		goto cleanup;
 
 cleanup:
-	git_mwindow_put_pack(p);
+	if (p)
+		git_mwindow_put_pack(p);
 	git_odb_free(state.db);
 	return error;
 }


### PR DESCRIPTION
This change fixes a possible null pointer dereference if anything inside
`git_commit_graph_writer_add_index_file` fails before the packfile being
valid.

https://scan6.coverity.com/reports.htm#v52218/p10377/fileInstanceId=122935896&defectInstanceId=32525576&mergedDefectId=1461634