### PR TITLE
#6028: Check if `threadstate->error_t.message` is not `git_buf__initbuf` before freeing.

### DIFF
--- a/src/threadstate.c
+++ b/src/threadstate.c
@@ -36,7 +36,8 @@ static void threadstate_dispose(git_threadstate *threadstate)
 	if (!threadstate)
 		return;
 
-	git__free(threadstate->error_t.message);
+    if (threadstate->error_t.message != git_buf__initbuf)
+        git__free(threadstate->error_t.message);
 	threadstate->error_t.message = NULL;
 }
 


### PR DESCRIPTION
This follows the same principle as `buffer.c` where the same check is done before freeing the buffer. It fixes the crash described in #6028.