### PR TITLE
Support custom git extensions

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -209,7 +209,9 @@ typedef enum {
 	GIT_OPT_GET_MWINDOW_FILE_LIMIT,
 	GIT_OPT_SET_MWINDOW_FILE_LIMIT,
 	GIT_OPT_SET_ODB_PACKED_PRIORITY,
-	GIT_OPT_SET_ODB_LOOSE_PRIORITY
+	GIT_OPT_SET_ODB_LOOSE_PRIORITY,
+	GIT_OPT_GET_EXTENSIONS,
+	GIT_OPT_SET_EXTENSIONS
 } git_libgit2_opt_t;
 
 /**
@@ -430,6 +432,22 @@ typedef enum {
  *   opts(GIT_OPT_SET_ODB_LOOSE_PRIORITY, int priority)
  *      > Override the default priority of the loose ODB backend which
  *      > is added when default backends are assigned to a repository
+ *
+ *   opts(GIT_OPT_GET_EXTENSIONS, git_strarray *out)
+ *      > Returns the list of git extensions that are supported.  This
+ *      > is the list of built-in extensions supported by libgit2 and
+ *      > custom extensions that have been added with
+ *      > `GIT_OPT_SET_EXTENSIONS`.  Extensions that have been negated
+ *      > will not be returned.  The returned list should be released
+ *      > with `git_strarray_dispose`.
+ *
+ *   opts(GIT_OPT_SET_EXTENSIONS, const char **extensions, size_t len)
+ *      > Set that the given git extensions are supported by the caller.
+ *      > Extensions supported by libgit2 may be negated by prefixing
+ *      > them with a `!`.  For example: setting extensions to
+ *      > { "!noop", "newext" } indicates that the caller does not want
+ *      > to support repositories with the `noop` extension but does want
+ *      > to support repositories with the `newext` extension.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/src/libgit2.c
+++ b/src/libgit2.c
@@ -52,6 +52,7 @@ static void libgit2_settings_global_shutdown(void)
 {
 	git__free(git__user_agent);
 	git__free(git__ssl_ciphers);
+	git_repository__free_extensions();
 }
 
 static int git_libgit2_settings_global_init(void)
@@ -365,6 +366,28 @@ int git_libgit2_opts(int key, ...)
 
 	case GIT_OPT_SET_ODB_LOOSE_PRIORITY:
 		git_odb__loose_priority = va_arg(ap, int);
+		break;
+
+	case GIT_OPT_SET_EXTENSIONS:
+		{
+			const char **extensions = va_arg(ap, const char **);
+			size_t len = va_arg(ap, size_t);
+			error = git_repository__set_extensions(extensions, len);
+		}
+		break;
+
+	case GIT_OPT_GET_EXTENSIONS:
+		{
+			git_strarray *out = va_arg(ap, git_strarray *);
+			char **extensions;
+			size_t len;
+
+			if ((error = git_repository__extensions(&extensions, &len)) < 0)
+				break;
+
+			out->strings = extensions;
+			out->count = len;
+		}
 		break;
 
 	default:

--- a/src/repository.h
+++ b/src/repository.h
@@ -249,4 +249,8 @@ int git_repository_initialbranch(git_buf *out, git_repository *repo);
  */
 int git_repository_workdir_path(git_buf *out, git_repository *repo, const char *path);
 
+int git_repository__extensions(char ***out, size_t *out_len);
+int git_repository__set_extensions(const char **extensions, size_t len);
+void git_repository__free_extensions(void);
+
 #endif

--- a/tests/core/opts.c
+++ b/tests/core/opts.c
@@ -1,6 +1,11 @@
 #include "clar_libgit2.h"
 #include "cache.h"
 
+void test_core_opts__cleanup(void)
+{
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, NULL, 0));
+}
+
 void test_core_opts__readwrite(void)
 {
 	size_t old_val = 0;
@@ -23,3 +28,44 @@ void test_core_opts__invalid_option(void)
 	cl_git_fail(git_libgit2_opts(-1, "foobar"));
 }
 
+void test_core_opts__extensions_query(void)
+{
+	git_strarray out = { 0 };
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
+
+	cl_assert_equal_sz(out.count, 1);
+	cl_assert_equal_s("noop", out.strings[0]);
+
+	git_strarray_dispose(&out);
+}
+
+void test_core_opts__extensions_add(void)
+{
+	const char *in[] = { "foo" };
+	git_strarray out = { 0 };
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
+
+	cl_assert_equal_sz(out.count, 2);
+	cl_assert_equal_s("noop", out.strings[0]);
+	cl_assert_equal_s("foo", out.strings[1]);
+
+	git_strarray_dispose(&out);
+}
+
+void test_core_opts__extensions_remove(void)
+{
+	const char *in[] = { "bar", "!negate", "!noop", "baz" };
+	git_strarray out = { 0 };
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
+
+	cl_assert_equal_sz(out.count, 2);
+	cl_assert_equal_s("bar", out.strings[0]);
+	cl_assert_equal_s("baz", out.strings[1]);
+
+	git_strarray_dispose(&out);
+}

--- a/tests/repo/extensions.c
+++ b/tests/repo/extensions.c
@@ -19,6 +19,7 @@ void test_repo_extensions__initialize(void)
 void test_repo_extensions__cleanup(void)
 {
 	cl_git_sandbox_cleanup();
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, NULL, 0));
 }
 
 void test_repo_extensions__builtin(void)
@@ -33,6 +34,19 @@ void test_repo_extensions__builtin(void)
 	git_repository_free(extended);
 }
 
+void test_repo_extensions__negate_builtin(void)
+{
+	const char *in[] = { "foo", "!noop", "baz" };
+	git_repository *extended;
+
+	cl_repo_set_string(repo, "extensions.noop", "foobar");
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
+
+	cl_git_fail(git_repository_open(&extended, "empty_bare.git"));
+	git_repository_free(extended);
+}
+
 void test_repo_extensions__unsupported(void)
 {
 	git_repository *extended = NULL;
@@ -40,5 +54,19 @@ void test_repo_extensions__unsupported(void)
 	cl_repo_set_string(repo, "extensions.unknown", "foobar");
 
 	cl_git_fail(git_repository_open(&extended, "empty_bare.git"));
+	git_repository_free(extended);
+}
+
+void test_repo_extensions__adds_extension(void)
+{
+	const char *in[] = { "foo", "!noop", "newextension", "baz" };
+	git_repository *extended;
+
+	cl_repo_set_string(repo, "extensions.newextension", "foobar");
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
+
+	cl_git_pass(git_repository_open(&extended, "empty_bare.git"));
+	cl_assert(git_repository_path(extended) != NULL);
+	cl_assert(git__suffixcmp(git_repository_path(extended), "/") == 0);
 	git_repository_free(extended);
 }

--- a/tests/repo/extensions.c
+++ b/tests/repo/extensions.c
@@ -1,0 +1,44 @@
+#include "clar_libgit2.h"
+#include "futils.h"
+#include "sysdir.h"
+#include <ctype.h>
+
+git_repository *repo;
+
+void test_repo_extensions__initialize(void)
+{
+	git_config *config;
+
+	repo = cl_git_sandbox_init("empty_bare.git");
+
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_int32(config, "core.repositoryformatversion", 1));
+	git_config_free(config);
+}
+
+void test_repo_extensions__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_repo_extensions__builtin(void)
+{
+	git_repository *extended;
+
+	cl_repo_set_string(repo, "extensions.noop", "foobar");
+
+	cl_git_pass(git_repository_open(&extended, "empty_bare.git"));
+	cl_assert(git_repository_path(extended) != NULL);
+	cl_assert(git__suffixcmp(git_repository_path(extended), "/") == 0);
+	git_repository_free(extended);
+}
+
+void test_repo_extensions__unsupported(void)
+{
+	git_repository *extended = NULL;
+
+	cl_repo_set_string(repo, "extensions.unknown", "foobar");
+
+	cl_git_fail(git_repository_open(&extended, "empty_bare.git"));
+	git_repository_free(extended);
+}

--- a/tests/repo/open.c
+++ b/tests/repo/open.c
@@ -42,48 +42,6 @@ void test_repo_open__format_version_1(void)
 	git_repository_free(repo);
 }
 
-void test_repo_open__format_version_1_with_valid_extension(void)
-{
-	git_repository *repo;
-	git_config *config;
-
-	repo = cl_git_sandbox_init("empty_bare.git");
-
-	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
-	cl_git_pass(git_repository_config(&config, repo));
-
-	cl_git_pass(git_config_set_int32(config, "core.repositoryformatversion", 1));
-	cl_git_pass(git_config_set_int32(config, "extensions.noop", 1));
-
-	git_config_free(config);
-	git_repository_free(repo);
-
-	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
-	cl_assert(git_repository_path(repo) != NULL);
-	cl_assert(git__suffixcmp(git_repository_path(repo), "/") == 0);
-	git_repository_free(repo);
-}
-
-void test_repo_open__format_version_1_with_invalid_extension(void)
-{
-	git_repository *repo;
-	git_config *config;
-
-	repo = cl_git_sandbox_init("empty_bare.git");
-
-	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
-	cl_git_pass(git_repository_config(&config, repo));
-
-	cl_git_pass(git_config_set_int32(config, "core.repositoryformatversion", 1));
-	cl_git_pass(git_config_set_int32(config, "extensions.invalid", 1));
-
-	git_config_free(config);
-	git_repository_free(repo);
-
-	cl_git_fail(git_repository_open(&repo, "empty_bare.git"));
-	git_repository_free(repo);
-}
-
 void test_repo_open__standard_empty_repo_through_gitdir(void)
 {
 	git_repository *repo;


### PR DESCRIPTION
Allow users to specify additional repository extensions that they want to support.  For example, callers can specify that they support `preciousObjects` and then may open repositories that support `extensions.preciousObjects`.

Similarly, callers may opt out of supporting extensions that the library itself supports.