### PR TITLE
remote: Mark `git_remote_name_is_valid` as `GIT_EXTERN`

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -971,7 +971,7 @@ GIT_EXTERN(int) git_remote_rename(
  * @param remote_name name to be checked.
  * @return 0 on success or an error code
  */
-int git_remote_name_is_valid(int *valid, const char *remote_name);
+GIT_EXTERN(int) git_remote_name_is_valid(int *valid, const char *remote_name);
 
 /**
 * Delete an existing persisted remote.


### PR DESCRIPTION
This change makes `git_remote_name_is_valid` be part of the public
interface of the library. This is needed for other language bindings to
be able to find this symbol (like in git2go, when linking against
libgit2 dynamically).