### PR TITLE
checkout: make safe checkout the default

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -31,17 +31,11 @@ GIT_BEGIN_DECL
  * check out, the "baseline" tree of what was checked out previously, the
  * working directory for actual files, and the index for staged changes.
  *
- * You give checkout one of three strategies for update:
+ * You give checkout one of two strategies for update:
  *
- * - `GIT_CHECKOUT_NONE` is a dry-run strategy that checks for conflicts,
- *   etc., but doesn't make any actual changes.
- *
- * - `GIT_CHECKOUT_FORCE` is at the opposite extreme, taking any action to
- *   make the working directory match the target (including potentially
- *   discarding modified files).
- *
- * - `GIT_CHECKOUT_SAFE` is between these two options, it will only make
- *   modifications that will not lose changes.
+ * - `GIT_CHECKOUT_SAFE` is the default, and similar to git's default,
+ *   which will make modifications that will not lose changes in the
+ *   working directory.
  *
  *                         |  target == baseline   |  target != baseline  |
  *    ---------------------|-----------------------|----------------------|
@@ -54,6 +48,10 @@ GIT_BEGIN_DECL
  *      workdir missing,   | notify dirty DELETED  |     create file      |
  *      baseline present   |                       |                      |
  *    ---------------------|-----------------------|----------------------|
+ *
+ * - `GIT_CHECKOUT_FORCE` will take any action to make the working
+ *   directory match the target (including potentially discarding
+ *   modified files).
  *
  * To emulate `git checkout`, use `GIT_CHECKOUT_SAFE` with a checkout
  * notification callback (see below) that displays information about dirty
@@ -68,6 +66,9 @@ GIT_BEGIN_DECL
  *
  *
  * There are some additional flags to modify the behavior of checkout:
+ *
+ * - `GIT_CHECKOUT_DRY_RUN` is a dry-run strategy that checks for conflicts,
+ *   etc., but doesn't make any actual changes.
  *
  * - GIT_CHECKOUT_ALLOW_CONFLICTS makes SAFE mode apply safe file updates
  *   even if there are conflicts (instead of cancelling the checkout).
@@ -104,26 +105,19 @@ GIT_BEGIN_DECL
  *   and write through existing symbolic links.
  */
 typedef enum {
-	GIT_CHECKOUT_NONE = 0, /**< default is a dry run, no actual updates */
-
 	/**
 	 * Allow safe updates that cannot overwrite uncommitted data.
-	 * If the uncommitted changes don't conflict with the checked out files,
-	 * the checkout will still proceed, leaving the changes intact.
-	 *
-	 * Mutually exclusive with GIT_CHECKOUT_FORCE.
-	 * GIT_CHECKOUT_FORCE takes precedence over GIT_CHECKOUT_SAFE.
+	 * If the uncommitted changes don't conflict with the checked
+	 * out files, the checkout will still proceed, leaving the
+	 * changes intact.
 	 */
-	GIT_CHECKOUT_SAFE = (1u << 0),
+	GIT_CHECKOUT_SAFE = 0,
 
 	/**
-	 * Allow all updates to force working directory to look like index.
-	 *
-	 * Mutually exclusive with GIT_CHECKOUT_SAFE.
-	 * GIT_CHECKOUT_FORCE takes precedence over GIT_CHECKOUT_SAFE.
+	 * Allow all updates to force working directory to look like
+	 * the index, potentially losing data in the process.
 	 */
 	GIT_CHECKOUT_FORCE = (1u << 1),
-
 
 	/** Allow checkout to recreate missing files */
 	GIT_CHECKOUT_RECREATE_MISSING = (1u << 2),
@@ -178,13 +172,22 @@ typedef enum {
 	GIT_CHECKOUT_DONT_WRITE_INDEX = (1u << 23),
 
 	/**
-	 * Show what would be done by a checkout.  Stop after sending
-	 * notifications; don't update the working directory or index.
+	 * Perform a "dry run", reporting what _would_ be done but
+	 * without actually making changes in the working directory
+	 * or the index.
 	 */
 	GIT_CHECKOUT_DRY_RUN = (1u << 24),
 
 	/** Include common ancestor data in zdiff3 format for conflicts */
 	GIT_CHECKOUT_CONFLICT_STYLE_ZDIFF3 = (1u << 25),
+
+	/**
+	 * Do not do a checkout and do not fire callbacks; this is primarily
+	 * useful only for internal functions that will perform the
+	 * checkout themselves but need to pass checkout options into
+	 * another function, for example, `git_clone`.
+	*/
+	GIT_CHECKOUT_NONE = (1u << 30),
 
 	/**
 	 * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
@@ -194,7 +197,6 @@ typedef enum {
 	GIT_CHECKOUT_UPDATE_SUBMODULES = (1u << 16),
 	/** Recursively checkout submodules if HEAD moved in super repo (NOT IMPLEMENTED) */
 	GIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED = (1u << 17)
-
 } git_checkout_strategy_t;
 
 /**
@@ -345,7 +347,7 @@ typedef struct git_checkout_options {
 } git_checkout_options;
 
 #define GIT_CHECKOUT_OPTIONS_VERSION 1
-#define GIT_CHECKOUT_OPTIONS_INIT {GIT_CHECKOUT_OPTIONS_VERSION, GIT_CHECKOUT_SAFE}
+#define GIT_CHECKOUT_OPTIONS_INIT {GIT_CHECKOUT_OPTIONS_VERSION}
 
 /**
  * Initialize git_checkout_options structure

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -189,7 +189,7 @@ typedef enum {
 	*/
 	GIT_CHECKOUT_NONE = (1u << 30),
 
-	/**
+	/*
 	 * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
 	 */
 

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -105,8 +105,8 @@ typedef struct git_clone_options {
 
 	/**
 	 * These options are passed to the checkout step. To disable
-	 * checkout, set the `checkout_strategy` to
-	 * `GIT_CHECKOUT_NONE`.
+	 * checkout, set the `checkout_strategy` to `GIT_CHECKOUT_NONE`
+	 * or `GIT_CHECKOUT_DRY_RUN`.
 	 */
 	git_checkout_options checkout_opts;
 
@@ -164,9 +164,10 @@ typedef struct git_clone_options {
 } git_clone_options;
 
 #define GIT_CLONE_OPTIONS_VERSION 1
-#define GIT_CLONE_OPTIONS_INIT { GIT_CLONE_OPTIONS_VERSION, \
-	{ GIT_CHECKOUT_OPTIONS_VERSION, GIT_CHECKOUT_SAFE }, \
-	GIT_FETCH_OPTIONS_INIT }
+#define GIT_CLONE_OPTIONS_INIT \
+	{ GIT_CLONE_OPTIONS_VERSION, \
+	  GIT_CHECKOUT_OPTIONS_INIT, \
+	  GIT_FETCH_OPTIONS_INIT }
 
 /**
  * Initialize git_clone_options structure

--- a/include/git2/rebase.h
+++ b/include/git2/rebase.h
@@ -67,10 +67,9 @@ typedef struct {
 
 	/**
 	 * Options to control how files are written during `git_rebase_init`,
-	 * `git_rebase_next` and `git_rebase_abort`.  Note that a minimum
-	 * strategy of `GIT_CHECKOUT_SAFE` is defaulted in `init` and `next`,
-	 * and a minimum strategy of `GIT_CHECKOUT_FORCE` is defaulted in
-	 * `abort` to match git semantics.
+	 * `git_rebase_next` and `git_rebase_abort`.  Note that during
+	 * `abort`, these options will add an implied `GIT_CHECKOUT_FORCE`
+	 * to match git semantics.
 	 */
 	git_checkout_options checkout_options;
 

--- a/include/git2/stash.h
+++ b/include/git2/stash.h
@@ -225,8 +225,6 @@ GIT_EXTERN(int) git_stash_apply_options_init(
  * GIT_EMERGECONFLICT and both the working directory and index will be left
  * unmodified.
  *
- * Note that a minimum checkout strategy of `GIT_CHECKOUT_SAFE` is implied.
- *
  * @param repo The owning repository.
  * @param index The position within the stash list. 0 points to the
  *              most recent stashed state.

--- a/include/git2/submodule.h
+++ b/include/git2/submodule.h
@@ -130,10 +130,8 @@ typedef struct git_submodule_update_options {
 
 	/**
 	 * These options are passed to the checkout step. To disable
-	 * checkout, set the `checkout_strategy` to
-	 * `GIT_CHECKOUT_NONE`. Generally you will want the use
-	 * GIT_CHECKOUT_SAFE to update files in the working
-	 * directory.
+	 * checkout, set the `checkout_strategy` to `GIT_CHECKOUT_NONE`
+	 * or `GIT_CHECKOUT_DRY_RUN`.
 	 */
 	git_checkout_options checkout_opts;
 
@@ -155,8 +153,9 @@ typedef struct git_submodule_update_options {
 #define GIT_SUBMODULE_UPDATE_OPTIONS_VERSION 1
 #define GIT_SUBMODULE_UPDATE_OPTIONS_INIT \
 	{ GIT_SUBMODULE_UPDATE_OPTIONS_VERSION, \
-		{ GIT_CHECKOUT_OPTIONS_VERSION, GIT_CHECKOUT_SAFE }, \
-	GIT_FETCH_OPTIONS_INIT, 1 }
+	  GIT_CHECKOUT_OPTIONS_INIT, \
+	  GIT_FETCH_OPTIONS_INIT, \
+	  1 }
 
 /**
  * Initialize git_submodule_update_options structure

--- a/src/libgit2/apply.c
+++ b/src/libgit2/apply.c
@@ -713,7 +713,6 @@ static int git_apply__to_workdir(
 			goto done;
 	}
 
-	checkout_opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
 	checkout_opts.checkout_strategy |= GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
 	checkout_opts.checkout_strategy |= GIT_CHECKOUT_DONT_WRITE_INDEX;
 

--- a/src/libgit2/checkout.c
+++ b/src/libgit2/checkout.c
@@ -294,6 +294,9 @@ static int checkout_action_no_wd(
 
 	*action = CHECKOUT_ACTION__NONE;
 
+	if ((data->strategy & GIT_CHECKOUT_NONE))
+		return 0;
+
 	switch (delta->status) {
 	case GIT_DELTA_UNMODIFIED: /* case 12 */
 		error = checkout_notify(data, GIT_CHECKOUT_NOTIFY_DIRTY, delta, NULL);
@@ -302,17 +305,17 @@ static int checkout_action_no_wd(
 		*action = CHECKOUT_ACTION_IF(RECREATE_MISSING, UPDATE_BLOB, NONE);
 		break;
 	case GIT_DELTA_ADDED:    /* case 2 or 28 (and 5 but not really) */
-		*action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+		*action = CHECKOUT_ACTION__UPDATE_BLOB;
 		break;
 	case GIT_DELTA_MODIFIED: /* case 13 (and 35 but not really) */
 		*action = CHECKOUT_ACTION_IF(RECREATE_MISSING, UPDATE_BLOB, CONFLICT);
 		break;
 	case GIT_DELTA_TYPECHANGE: /* case 21 (B->T) and 28 (T->B)*/
 		if (delta->new_file.mode == GIT_FILEMODE_TREE)
-			*action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+			*action = CHECKOUT_ACTION__UPDATE_BLOB;
 		break;
 	case GIT_DELTA_DELETED: /* case 8 or 25 */
-		*action = CHECKOUT_ACTION_IF(SAFE, REMOVE, NONE);
+		*action = CHECKOUT_ACTION__REMOVE;
 		break;
 	default: /* impossible */
 		break;
@@ -494,6 +497,9 @@ static int checkout_action_with_wd(
 {
 	*action = CHECKOUT_ACTION__NONE;
 
+	if ((data->strategy & GIT_CHECKOUT_NONE))
+		return 0;
+
 	switch (delta->status) {
 	case GIT_DELTA_UNMODIFIED: /* case 14/15 or 33 */
 		if (checkout_is_workdir_modified(data, &delta->old_file, &delta->new_file, wd)) {
@@ -512,14 +518,14 @@ static int checkout_action_with_wd(
 		if (checkout_is_workdir_modified(data, &delta->old_file, &delta->new_file, wd))
 			*action = CHECKOUT_ACTION_IF(FORCE, REMOVE, CONFLICT);
 		else
-			*action = CHECKOUT_ACTION_IF(SAFE, REMOVE, NONE);
+			*action = CHECKOUT_ACTION__REMOVE;
 		break;
 	case GIT_DELTA_MODIFIED: /* case 16, 17, 18 (or 36 but not really) */
 		if (wd->mode != GIT_FILEMODE_COMMIT &&
 			checkout_is_workdir_modified(data, &delta->old_file, &delta->new_file, wd))
 			*action = CHECKOUT_ACTION_IF(FORCE, UPDATE_BLOB, CONFLICT);
 		else
-			*action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+			*action = CHECKOUT_ACTION__UPDATE_BLOB;
 		break;
 	case GIT_DELTA_TYPECHANGE: /* case 22, 23, 29, 30 */
 		if (delta->old_file.mode == GIT_FILEMODE_TREE) {
@@ -527,13 +533,13 @@ static int checkout_action_with_wd(
 				/* either deleting items in old tree will delete the wd dir,
 				 * or we'll get a conflict when we attempt blob update...
 				 */
-				*action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+				*action = CHECKOUT_ACTION__UPDATE_BLOB;
 			else if (wd->mode == GIT_FILEMODE_COMMIT) {
 				/* workdir is possibly a "phantom" submodule - treat as a
 				 * tree if the only submodule info came from the config
 				 */
 				if (submodule_is_config_only(data, wd->path))
-					*action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+					*action = CHECKOUT_ACTION__UPDATE_BLOB;
 				else
 					*action = CHECKOUT_ACTION_IF(FORCE, REMOVE_AND_UPDATE, CONFLICT);
 			} else
@@ -542,7 +548,7 @@ static int checkout_action_with_wd(
 		else if (checkout_is_workdir_modified(data, &delta->old_file, &delta->new_file, wd))
 			*action = CHECKOUT_ACTION_IF(FORCE, REMOVE_AND_UPDATE, CONFLICT);
 		else
-			*action = CHECKOUT_ACTION_IF(SAFE, REMOVE_AND_UPDATE, NONE);
+			*action = CHECKOUT_ACTION__REMOVE_AND_UPDATE;
 
 		/* don't update if the typechange is to a tree */
 		if (delta->new_file.mode == GIT_FILEMODE_TREE)
@@ -562,6 +568,9 @@ static int checkout_action_with_wd_blocker(
 	const git_index_entry *wd)
 {
 	*action = CHECKOUT_ACTION__NONE;
+
+	if ((data->strategy & GIT_CHECKOUT_NONE))
+		return 0;
 
 	switch (delta->status) {
 	case GIT_DELTA_UNMODIFIED:
@@ -597,6 +606,9 @@ static int checkout_action_with_wd_dir(
 {
 	*action = CHECKOUT_ACTION__NONE;
 
+	if ((data->strategy & GIT_CHECKOUT_NONE))
+		return 0;
+
 	switch (delta->status) {
 	case GIT_DELTA_UNMODIFIED: /* case 19 or 24 (or 34 but not really) */
 		GIT_ERROR_CHECK_ERROR(
@@ -627,7 +639,7 @@ static int checkout_action_with_wd_dir(
 			 * directory if is it left empty, so we can defer removing the
 			 * dir and it will succeed if no children are left.
 			 */
-			*action = CHECKOUT_ACTION_IF(SAFE, UPDATE_BLOB, NONE);
+			*action = CHECKOUT_ACTION__UPDATE_BLOB;
 		}
 		else if (delta->new_file.mode != GIT_FILEMODE_TREE)
 			/* For typechange to dir, dir is already created so no action */
@@ -2433,14 +2445,12 @@ static int checkout_data_init(
 
 	/* if you are forcing, allow all safe updates, plus recreate missing */
 	if ((data->opts.checkout_strategy & GIT_CHECKOUT_FORCE) != 0)
-		data->opts.checkout_strategy |= GIT_CHECKOUT_SAFE |
-			GIT_CHECKOUT_RECREATE_MISSING;
+		data->opts.checkout_strategy |= GIT_CHECKOUT_RECREATE_MISSING;
 
 	/* if the repository does not actually have an index file, then this
 	 * is an initial checkout (perhaps from clone), so we allow safe updates
 	 */
-	if (!data->index->on_disk &&
-		(data->opts.checkout_strategy & GIT_CHECKOUT_SAFE) != 0)
+	if (!data->index->on_disk)
 		data->opts.checkout_strategy |= GIT_CHECKOUT_RECREATE_MISSING;
 
 	data->strategy = data->opts.checkout_strategy;

--- a/src/libgit2/checkout.h
+++ b/src/libgit2/checkout.h
@@ -12,8 +12,6 @@
 #include "git2/checkout.h"
 #include "iterator.h"
 
-#define GIT_CHECKOUT__NOTIFY_CONFLICT_TREE (1u << 12)
-
 /**
  * Update the working directory to match the target iterator.  The
  * expected baseline value can be passed in via the checkout options

--- a/src/libgit2/cherrypick.c
+++ b/src/libgit2/cherrypick.c
@@ -73,8 +73,7 @@ static int cherrypick_normalize_opts(
 	const char *their_label)
 {
 	int error = 0;
-	unsigned int default_checkout_strategy = GIT_CHECKOUT_SAFE |
-		GIT_CHECKOUT_ALLOW_CONFLICTS;
+	unsigned int default_checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
 
 	GIT_UNUSED(repo);
 

--- a/src/libgit2/clone.c
+++ b/src/libgit2/clone.c
@@ -25,8 +25,6 @@
 #include "odb.h"
 #include "net.h"
 
-static int clone_local_into(git_repository *repo, git_remote *remote, const git_fetch_options *fetch_opts, const git_checkout_options *co_opts, const char *branch, int link);
-
 static int create_branch(
 	git_reference **branch,
 	git_repository *repo,
@@ -367,12 +365,13 @@ static int should_checkout(
 	bool *out,
 	git_repository *repo,
 	bool is_bare,
-	const git_checkout_options *opts)
+	const git_clone_options *opts)
 {
 	int error;
 
-	if (!opts || is_bare || opts->checkout_strategy == GIT_CHECKOUT_NONE) {
-		*out = 0;
+	if (!opts || is_bare ||
+	    opts->checkout_opts.checkout_strategy == GIT_CHECKOUT_NONE) {
+		*out = false;
 		return 0;
 	}
 
@@ -383,13 +382,17 @@ static int should_checkout(
 	return 0;
 }
 
-static int checkout_branch(git_repository *repo, git_remote *remote, const git_checkout_options *co_opts, const char *branch, const char *reflog_message)
+static int checkout_branch(
+	git_repository *repo,
+	git_remote *remote,
+	const git_clone_options *opts,
+	const char *reflog_message)
 {
 	bool checkout;
 	int error;
 
-	if (branch)
-		error = update_head_to_branch(repo, remote, branch, reflog_message);
+	if (opts->checkout_branch)
+		error = update_head_to_branch(repo, remote, opts->checkout_branch, reflog_message);
 	/* Point HEAD to the same ref as the remote's head */
 	else
 		error = update_head_to_remote(repo, remote, reflog_message);
@@ -397,11 +400,11 @@ static int checkout_branch(git_repository *repo, git_remote *remote, const git_c
 	if (error < 0)
 		return error;
 
-	if ((error = should_checkout(&checkout, repo, git_repository_is_bare(repo), co_opts)) < 0)
+	if ((error = should_checkout(&checkout, repo, git_repository_is_bare(repo), opts)) < 0)
 		return error;
 
 	if (checkout)
-		error = git_checkout_head(repo, co_opts);
+		error = git_checkout_head(repo, &opts->checkout_opts);
 
 	return error;
 }
@@ -409,16 +412,13 @@ static int checkout_branch(git_repository *repo, git_remote *remote, const git_c
 static int clone_into(
 	git_repository *repo,
 	git_remote *_remote,
-	const git_fetch_options *opts,
-	const git_checkout_options *co_opts,
-	const char *branch)
+	const git_clone_options *opts)
 {
-	int error;
 	git_str reflog_message = GIT_STR_INIT;
 	git_remote_connect_options connect_opts = GIT_REMOTE_CONNECT_OPTIONS_INIT;
-	git_fetch_options fetch_opts;
 	git_remote *remote;
 	git_oid_t oid_type;
+	int error;
 
 	GIT_ASSERT_ARG(repo);
 	GIT_ASSERT_ARG(_remote);
@@ -431,13 +431,7 @@ static int clone_into(
 	if ((error = git_remote_dup(&remote, _remote)) < 0)
 		return error;
 
-	memcpy(&fetch_opts, opts, sizeof(git_fetch_options));
-	fetch_opts.update_fetchhead = 0;
-
-	if (!opts->depth)
-		fetch_opts.download_tags = GIT_REMOTE_DOWNLOAD_TAGS_ALL;
-
-	if ((error = git_remote_connect_options__from_fetch_opts(&connect_opts, remote, &fetch_opts)) < 0)
+	if ((error = git_remote_connect_options__from_fetch_opts(&connect_opts, remote, &opts->fetch_opts)) < 0)
 		goto cleanup;
 
 	git_str_printf(&reflog_message, "clone: from %s", git_remote_url(remote));
@@ -455,10 +449,10 @@ static int clone_into(
 	    (error = git_repository__set_objectformat(repo, oid_type)) < 0)
 		goto cleanup;
 
-	if ((error = git_remote_fetch(remote, NULL, &fetch_opts, git_str_cstr(&reflog_message))) != 0)
+	if ((error = git_remote_fetch(remote, NULL, &opts->fetch_opts, git_str_cstr(&reflog_message))) != 0)
 		goto cleanup;
 
-	error = checkout_branch(repo, remote, co_opts, branch, git_str_cstr(&reflog_message));
+	error = checkout_branch(repo, remote, opts, git_str_cstr(&reflog_message));
 
 cleanup:
 	git_remote_free(remote);
@@ -467,139 +461,6 @@ cleanup:
 
 	return error;
 }
-
-int git_clone__should_clone_local(const char *url_or_path, git_clone_local_t local)
-{
-	git_str fromurl = GIT_STR_INIT;
-	bool is_local;
-
-	if (local == GIT_CLONE_NO_LOCAL)
-		return 0;
-
-	if (git_net_str_is_url(url_or_path)) {
-		/* If GIT_CLONE_LOCAL_AUTO is specified, any url should be treated as remote */
-		if (local == GIT_CLONE_LOCAL_AUTO ||
-		    !git_fs_path_is_local_file_url(url_or_path))
-			return 0;
-
-		if (git_fs_path_fromurl(&fromurl, url_or_path) == 0)
-			is_local = git_fs_path_isdir(git_str_cstr(&fromurl));
-		else
-			is_local = -1;
-		git_str_dispose(&fromurl);
-	} else {
-		is_local = git_fs_path_isdir(url_or_path);
-	}
-	return is_local;
-}
-
-static int git__clone(
-	git_repository **out,
-	const char *url,
-	const char *local_path,
-	const git_clone_options *_options,
-	int use_existing)
-{
-	int error = 0;
-	git_repository *repo = NULL;
-	git_remote *origin;
-	git_clone_options options = GIT_CLONE_OPTIONS_INIT;
-	uint32_t rmdir_flags = GIT_RMDIR_REMOVE_FILES;
-	git_repository_create_cb repository_cb;
-
-	GIT_ASSERT_ARG(out);
-	GIT_ASSERT_ARG(url);
-	GIT_ASSERT_ARG(local_path);
-
-	if (_options)
-		memcpy(&options, _options, sizeof(git_clone_options));
-
-	GIT_ERROR_CHECK_VERSION(&options, GIT_CLONE_OPTIONS_VERSION, "git_clone_options");
-
-	/* Only clone to a new directory or an empty directory */
-	if (git_fs_path_exists(local_path) && !use_existing && !git_fs_path_is_empty_dir(local_path)) {
-		git_error_set(GIT_ERROR_INVALID,
-			"'%s' exists and is not an empty directory", local_path);
-		return GIT_EEXISTS;
-	}
-
-	/* Only remove the root directory on failure if we create it */
-	if (git_fs_path_exists(local_path))
-		rmdir_flags |= GIT_RMDIR_SKIP_ROOT;
-
-	if (options.repository_cb)
-		repository_cb = options.repository_cb;
-	else
-		repository_cb = default_repository_create;
-
-	if ((error = repository_cb(&repo, local_path, options.bare, options.repository_cb_payload)) < 0)
-		return error;
-
-	if (!(error = create_and_configure_origin(&origin, repo, url, &options))) {
-		int clone_local = git_clone__should_clone_local(url, options.local);
-		int link = options.local != GIT_CLONE_LOCAL_NO_LINKS;
-
-		if (clone_local == 1)
-			error = clone_local_into(
-				repo, origin, &options.fetch_opts, &options.checkout_opts,
-				options.checkout_branch, link);
-		else if (clone_local == 0)
-			error = clone_into(
-				repo, origin, &options.fetch_opts, &options.checkout_opts,
-				options.checkout_branch);
-		else
-			error = -1;
-
-		git_remote_free(origin);
-	}
-
-	if (error != 0) {
-		git_error *last_error;
-		git_error_save(&last_error);
-
-		git_repository_free(repo);
-		repo = NULL;
-
-		(void)git_futils_rmdir_r(local_path, NULL, rmdir_flags);
-
-		git_error_restore(last_error);
-	}
-
-	*out = repo;
-	return error;
-}
-
-int git_clone(
-	git_repository **out,
-	const char *url,
-	const char *local_path,
-	const git_clone_options *_options)
-{
-	return git__clone(out, url, local_path, _options, 0);
-}
-
-int git_clone__submodule(
-	git_repository **out,
-	const char *url,
-	const char *local_path,
-	const git_clone_options *_options)
-{
-	return git__clone(out, url, local_path, _options, 1);
-}
-
-int git_clone_options_init(git_clone_options *opts, unsigned int version)
-{
-	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
-		opts, version, git_clone_options, GIT_CLONE_OPTIONS_INIT);
-	return 0;
-}
-
-#ifndef GIT_DEPRECATE_HARD
-int git_clone_init_options(git_clone_options *opts, unsigned int version)
-{
-	return git_clone_options_init(opts, version);
-}
-#endif
 
 static bool can_link(const char *src, const char *dst, int link)
 {
@@ -625,12 +486,16 @@ static bool can_link(const char *src, const char *dst, int link)
 #endif
 }
 
-static int clone_local_into(git_repository *repo, git_remote *remote, const git_fetch_options *fetch_opts, const git_checkout_options *co_opts, const char *branch, int link)
+static int clone_local_into(
+	git_repository *repo,
+	git_remote *remote,
+	const git_clone_options *opts)
 {
 	int error, flags;
 	git_repository *src;
 	git_str src_odb = GIT_STR_INIT, dst_odb = GIT_STR_INIT, src_path = GIT_STR_INIT;
 	git_str reflog_message = GIT_STR_INIT;
+	bool link = (opts && opts->local != GIT_CLONE_LOCAL_NO_LINKS);
 
 	GIT_ASSERT_ARG(repo);
 	GIT_ASSERT_ARG(remote);
@@ -683,10 +548,10 @@ static int clone_local_into(git_repository *repo, git_remote *remote, const git_
 
 	git_str_printf(&reflog_message, "clone: from %s", git_remote_url(remote));
 
-	if ((error = git_remote_fetch(remote, NULL, fetch_opts, git_str_cstr(&reflog_message))) != 0)
+	if ((error = git_remote_fetch(remote, NULL, &opts->fetch_opts, git_str_cstr(&reflog_message))) != 0)
 		goto cleanup;
 
-	error = checkout_branch(repo, remote, co_opts, branch, git_str_cstr(&reflog_message));
+	error = checkout_branch(repo, remote, opts, git_str_cstr(&reflog_message));
 
 cleanup:
 	git_str_dispose(&reflog_message);
@@ -696,3 +561,146 @@ cleanup:
 	git_repository_free(src);
 	return error;
 }
+
+int git_clone__should_clone_local(
+	bool *out,
+	const char *url_or_path,
+	git_clone_local_t local)
+{
+	git_str fromurl = GIT_STR_INIT;
+
+	*out = false;
+
+	if (local == GIT_CLONE_NO_LOCAL)
+		return 0;
+
+	if (git_net_str_is_url(url_or_path)) {
+		/* If GIT_CLONE_LOCAL_AUTO is specified, any url should
+		 * be treated as remote */
+		if (local == GIT_CLONE_LOCAL_AUTO ||
+		    !git_fs_path_is_local_file_url(url_or_path))
+			return 0;
+
+		if (git_fs_path_fromurl(&fromurl, url_or_path) < 0)
+			return -1;
+
+		*out = git_fs_path_isdir(git_str_cstr(&fromurl));
+		git_str_dispose(&fromurl);
+	} else {
+		*out = git_fs_path_isdir(url_or_path);
+	}
+
+	return 0;
+}
+
+static int clone_repo(
+	git_repository **out,
+	const char *url,
+	const char *local_path,
+	const git_clone_options *given_opts,
+	int use_existing)
+{
+	int error = 0;
+	git_repository *repo = NULL;
+	git_remote *origin;
+	git_clone_options options = GIT_CLONE_OPTIONS_INIT;
+	uint32_t rmdir_flags = GIT_RMDIR_REMOVE_FILES;
+	git_repository_create_cb repository_cb;
+
+	GIT_ASSERT_ARG(out);
+	GIT_ASSERT_ARG(url);
+	GIT_ASSERT_ARG(local_path);
+
+	if (given_opts)
+		memcpy(&options, given_opts, sizeof(git_clone_options));
+
+	GIT_ERROR_CHECK_VERSION(&options, GIT_CLONE_OPTIONS_VERSION, "git_clone_options");
+
+	/* enforce some behavior on fetch */
+	options.fetch_opts.update_fetchhead = 0;
+
+	if (!options.fetch_opts.depth)
+		options.fetch_opts.download_tags = GIT_REMOTE_DOWNLOAD_TAGS_ALL;
+
+	/* Only clone to a new directory or an empty directory */
+	if (git_fs_path_exists(local_path) && !use_existing && !git_fs_path_is_empty_dir(local_path)) {
+		git_error_set(GIT_ERROR_INVALID,
+			"'%s' exists and is not an empty directory", local_path);
+		return GIT_EEXISTS;
+	}
+
+	/* Only remove the root directory on failure if we create it */
+	if (git_fs_path_exists(local_path))
+		rmdir_flags |= GIT_RMDIR_SKIP_ROOT;
+
+	if (options.repository_cb)
+		repository_cb = options.repository_cb;
+	else
+		repository_cb = default_repository_create;
+
+	if ((error = repository_cb(&repo, local_path, options.bare, options.repository_cb_payload)) < 0)
+		return error;
+
+	if (!(error = create_and_configure_origin(&origin, repo, url, &options))) {
+		bool clone_local;
+
+		if ((error = git_clone__should_clone_local(&clone_local, url, options.local)) < 0) {
+			git_remote_free(origin);
+			return error;
+		}
+
+		if (clone_local)
+			error = clone_local_into(repo, origin, &options);
+		else
+			error = clone_into(repo, origin, &options);
+
+		git_remote_free(origin);
+	}
+
+	if (error != 0) {
+		git_error *last_error;
+		git_error_save(&last_error);
+
+		git_repository_free(repo);
+		repo = NULL;
+
+		(void)git_futils_rmdir_r(local_path, NULL, rmdir_flags);
+
+		git_error_restore(last_error);
+	}
+
+	*out = repo;
+	return error;
+}
+
+int git_clone(
+	git_repository **out,
+	const char *url,
+	const char *local_path,
+	const git_clone_options *options)
+{
+	return clone_repo(out, url, local_path, options, 0);
+}
+
+int git_clone__submodule(
+	git_repository **out,
+	const char *url,
+	const char *local_path,
+	const git_clone_options *options)
+{
+	return clone_repo(out, url, local_path, options, 1);
+}
+
+int git_clone_options_init(git_clone_options *opts, unsigned int version)
+{
+	GIT_INIT_STRUCTURE_FROM_TEMPLATE(
+		opts, version, git_clone_options, GIT_CLONE_OPTIONS_INIT);
+	return 0;
+}
+
+#ifndef GIT_DEPRECATE_HARD
+int git_clone_init_options(git_clone_options *opts, unsigned int version)
+{
+	return git_clone_options_init(opts, version);
+}
+#endif

--- a/src/libgit2/clone.c
+++ b/src/libgit2/clone.c
@@ -16,6 +16,7 @@
 #include "git2/commit.h"
 #include "git2/tree.h"
 
+#include "checkout.h"
 #include "remote.h"
 #include "futils.h"
 #include "refs.h"

--- a/src/libgit2/clone.h
+++ b/src/libgit2/clone.h
@@ -15,6 +15,9 @@ extern int git_clone__submodule(git_repository **out,
 	const char *url, const char *local_path,
 	const git_clone_options *_options);
 
-extern int git_clone__should_clone_local(const char *url, git_clone_local_t local);
+extern int git_clone__should_clone_local(
+	bool *out,
+	const char *url,
+	git_clone_local_t local);
 
 #endif

--- a/src/libgit2/merge.c
+++ b/src/libgit2/merge.c
@@ -3352,8 +3352,7 @@ int git_merge(
 		goto done;
 
 	checkout_strategy = given_checkout_opts ?
-		given_checkout_opts->checkout_strategy :
-		GIT_CHECKOUT_SAFE;
+		given_checkout_opts->checkout_strategy : 0;
 
 	if ((error = git_indexwriter_init_for_operation(&indexwriter, repo,
 		&checkout_strategy)) < 0)

--- a/src/libgit2/revert.c
+++ b/src/libgit2/revert.c
@@ -74,8 +74,7 @@ static int revert_normalize_opts(
 	const char *their_label)
 {
 	int error = 0;
-	unsigned int default_checkout_strategy = GIT_CHECKOUT_SAFE |
-		GIT_CHECKOUT_ALLOW_CONFLICTS;
+	unsigned int default_checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
 
 	GIT_UNUSED(repo);
 

--- a/tests/libgit2/checkout/binaryunicode.c
+++ b/tests/libgit2/checkout/binaryunicode.c
@@ -28,8 +28,6 @@ static void execute_test(void)
 	cl_git_pass(git_commit_lookup(&commit, g_repo, &oid));
 	cl_git_pass(git_commit_tree(&tree, commit));
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
-
 	cl_git_pass(git_checkout_tree(g_repo, (git_object *)tree, &opts));
 
 	git_tree_free(tree);

--- a/tests/libgit2/checkout/conflict.c
+++ b/tests/libgit2/checkout/conflict.c
@@ -308,8 +308,6 @@ void test_checkout_conflict__directory_file(void)
 		{ 0100644, CONFLICTING_THEIRS_OID, 3, "df-4/file" },
 	};
 
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
-
 	create_index(checkout_index_entries, 12);
 	cl_git_pass(git_index_write(g_index));
 
@@ -347,7 +345,6 @@ void test_checkout_conflict__directory_file_with_custom_labels(void)
 		{ 0100644, CONFLICTING_THEIRS_OID, 3, "df-4/file" },
 	};
 
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
 	opts.our_label = "HEAD";
 	opts.their_label = "branch";
 
@@ -388,8 +385,6 @@ void test_checkout_conflict__link_file(void)
 		{ 0100644, CONFLICTING_THEIRS_OID, 3, "link-4" },
 	};
 
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
-
 	create_index(checkout_index_entries, 12);
 	cl_git_pass(git_index_write(g_index));
 
@@ -415,8 +410,6 @@ void test_checkout_conflict__links(void)
 		{ 0120000, LINK_THEIRS_OID, 3, "link-2" },
 	};
 
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
-
 	create_index(checkout_index_entries, 5);
 	cl_git_pass(git_index_write(g_index));
 
@@ -435,8 +428,6 @@ void test_checkout_conflict__add_add(void)
 		{ 0100644, CONFLICTING_OURS_OID, 2, "conflicting.txt" },
 		{ 0100644, CONFLICTING_THEIRS_OID, 3, "conflicting.txt" },
 	};
-
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
 
 	create_index(checkout_index_entries, 2);
 	cl_git_pass(git_index_write(g_index));
@@ -476,8 +467,6 @@ void test_checkout_conflict__mode_change(void)
 		{ 0100644, CONFLICTING_OURS_OID, 2, "executable-6" },
 		{ 0100755, CONFLICTING_THEIRS_OID, 3, "executable-6" },
 	};
-
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
 
 	create_index(checkout_index_entries, 18);
 	cl_git_pass(git_index_write(g_index));
@@ -607,8 +596,6 @@ void test_checkout_conflict__renames(void)
 			"7-both-renamed.txt"
 		}
 	};
-
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
 
 	create_index(checkout_index_entries, 41);
 	create_index_names(checkout_name_entries, 9);
@@ -793,7 +780,7 @@ void test_checkout_conflict__rename_keep_ours(void)
 		}
 	};
 
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE | GIT_CHECKOUT_USE_OURS;
+	opts.checkout_strategy |= GIT_CHECKOUT_USE_OURS;
 
 	create_index(checkout_index_entries, 41);
 	create_index_names(checkout_name_entries, 9);
@@ -925,8 +912,6 @@ void test_checkout_conflict__name_mangled_file_exists_in_workdir(void)
 			"test-three.txt"
 		}
 	};
-
-	opts.checkout_strategy |= GIT_CHECKOUT_SAFE;
 
 	create_index(checkout_index_entries, 24);
 	create_index_names(checkout_name_entries, 6);

--- a/tests/libgit2/checkout/head.c
+++ b/tests/libgit2/checkout/head.c
@@ -228,7 +228,6 @@ void test_checkout_head__workdir_filemode_is_simplified(void)
 	cl_git_pass(git_revparse_single(&branch, g_repo, "099fabac3a9ea935598528c27f866e34089c2eff"));
 
 	opts.checkout_strategy &= ~GIT_CHECKOUT_FORCE;
-	opts.checkout_strategy |=  GIT_CHECKOUT_SAFE;
 	cl_git_pass(git_checkout_tree(g_repo, branch, NULL));
 
 	git_object_free(branch);
@@ -256,7 +255,6 @@ void test_checkout_head__obeys_filemode_true(void)
 	cl_git_pass(git_revparse_single(&branch, g_repo, "099fabac3a9ea935598528c27f866e34089c2eff"));
 
 	opts.checkout_strategy &= ~GIT_CHECKOUT_FORCE;
-	opts.checkout_strategy |=  GIT_CHECKOUT_SAFE;
 	cl_git_fail_with(GIT_ECONFLICT, git_checkout_tree(g_repo, branch, NULL));
 
 	git_object_free(branch);
@@ -284,7 +282,6 @@ void test_checkout_head__obeys_filemode_false(void)
 	cl_git_pass(git_revparse_single(&branch, g_repo, "099fabac3a9ea935598528c27f866e34089c2eff"));
 
 	opts.checkout_strategy &= ~GIT_CHECKOUT_FORCE;
-	opts.checkout_strategy |=  GIT_CHECKOUT_SAFE;
 	cl_git_pass(git_checkout_tree(g_repo, branch, NULL));
 
 	git_object_free(branch);

--- a/tests/libgit2/checkout/icase.c
+++ b/tests/libgit2/checkout/icase.c
@@ -34,7 +34,6 @@ void test_checkout_icase__initialize(void)
 	cl_git_pass(git_object_lookup(&obj, repo, &id, GIT_OBJECT_ANY));
 
 	git_checkout_options_init(&checkout_opts, GIT_CHECKOUT_OPTIONS_VERSION);
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;
 }
 
 void test_checkout_icase__cleanup(void)
@@ -106,7 +105,7 @@ static int symlink_or_fake(git_repository *repo, const char *a, const char *b)
 
 void test_checkout_icase__refuses_to_overwrite_files_for_files(void)
 {
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE|GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_write2file("testrepo/BRANCH_FILE.txt", "neue file\n", 10, \
 		O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -128,7 +127,7 @@ void test_checkout_icase__overwrites_files_for_files_when_forced(void)
 
 void test_checkout_icase__refuses_to_overwrite_links_for_files(void)
 {
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE|GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_must_pass(symlink_or_fake(repo, "../tmp", "testrepo/BRANCH_FILE.txt"));
 
@@ -152,7 +151,7 @@ void test_checkout_icase__overwrites_links_for_files_when_forced(void)
 
 void test_checkout_icase__overwrites_empty_folders_for_files(void)
 {
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE|GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_must_pass(p_mkdir("testrepo/NEW.txt", 0777));
 
@@ -164,7 +163,7 @@ void test_checkout_icase__overwrites_empty_folders_for_files(void)
 
 void test_checkout_icase__refuses_to_overwrite_populated_folders_for_files(void)
 {
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE|GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_must_pass(p_mkdir("testrepo/BRANCH_FILE.txt", 0777));
 	cl_git_write2file("testrepo/BRANCH_FILE.txt/foobar", "neue file\n", 10, \
@@ -192,7 +191,7 @@ void test_checkout_icase__overwrites_folders_for_files_when_forced(void)
 
 void test_checkout_icase__refuses_to_overwrite_files_for_folders(void)
 {
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE|GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_write2file("testrepo/A", "neue file\n", 10, \
 		O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -216,7 +215,7 @@ void test_checkout_icase__overwrites_files_for_folders_when_forced(void)
 
 void test_checkout_icase__refuses_to_overwrite_links_for_folders(void)
 {
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE|GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_must_pass(symlink_or_fake(repo, "..", "testrepo/A"));
 
@@ -244,8 +243,6 @@ void test_checkout_icase__ignores_unstaged_casechange(void)
 	git_commit *orig, *br2;
 	git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
-
 	cl_git_pass(git_reference_lookup_resolved(&orig_ref, repo, "HEAD", 100));
 	cl_git_pass(git_commit_lookup(&orig, repo, git_reference_target(orig_ref)));
 	cl_git_pass(git_reset(repo, (git_object *)orig, GIT_RESET_HARD, NULL));
@@ -269,8 +266,6 @@ void test_checkout_icase__conflicts_with_casechanged_subtrees(void)
 	git_object *orig, *subtrees;
 	git_oid oid;
 	git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
-
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 
 	cl_git_pass(git_reference_lookup_resolved(&orig_ref, repo, "HEAD", 100));
 	cl_git_pass(git_object_lookup(&orig, repo, git_reference_target(orig_ref), GIT_OBJECT_COMMIT));

--- a/tests/libgit2/checkout/index.c
+++ b/tests/libgit2/checkout/index.c
@@ -61,7 +61,7 @@ void test_checkout_index__can_create_missing_files(void)
 	cl_assert_equal_i(false, git_fs_path_isfile("./testrepo/branch_file.txt"));
 	cl_assert_equal_i(false, git_fs_path_isfile("./testrepo/new.txt"));
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -81,7 +81,6 @@ void test_checkout_index__can_remove_untracked_files(void)
 	cl_assert_equal_i(true, git_fs_path_isdir("./testrepo/dir/subdir/subsubdir"));
 
 	opts.checkout_strategy =
-		GIT_CHECKOUT_SAFE |
 		GIT_CHECKOUT_RECREATE_MISSING |
 		GIT_CHECKOUT_REMOVE_UNTRACKED;
 
@@ -157,7 +156,7 @@ void test_checkout_index__honor_the_specified_pathspecs(void)
 	cl_assert_equal_i(false, git_fs_path_isfile("./testrepo/branch_file.txt"));
 	cl_assert_equal_i(false, git_fs_path_isfile("./testrepo/new.txt"));
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -176,7 +175,7 @@ void test_checkout_index__honor_the_gitattributes_directives(void)
 	cl_git_mkfile("./testrepo/.gitattributes", attributes);
 	cl_repo_set_bool(g_repo, "core.autocrlf", false);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -194,7 +193,7 @@ void test_checkout_index__honor_coreautocrlf_setting_set_to_true(void)
 	cl_git_pass(p_unlink("./testrepo/.gitattributes"));
 	cl_repo_set_bool(g_repo, "core.autocrlf", true);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -288,7 +287,7 @@ void test_checkout_index__coresymlinks_set_to_true_fails_when_unsupported(void)
 
 	cl_repo_set_bool(g_repo, "core.symlinks", true);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 	cl_git_fail(git_checkout_index(g_repo, NULL, &opts));
 }
 
@@ -304,7 +303,7 @@ void test_checkout_index__honor_coresymlinks_setting_set_to_true(void)
 
 	cl_repo_set_bool(g_repo, "core.symlinks", true);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -321,7 +320,7 @@ void test_checkout_index__honor_coresymlinks_setting_set_to_false(void)
 
 	cl_repo_set_bool(g_repo, "core.symlinks", false);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -337,7 +336,7 @@ void test_checkout_index__donot_overwrite_modified_file_by_default(void)
 	/* set this up to not return an error code on conflicts, but it
 	 * still will not have permission to overwrite anything...
 	 */
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS;
+	opts.checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
 
@@ -363,7 +362,7 @@ void test_checkout_index__options_disable_filters(void)
 
 	cl_git_mkfile("./testrepo/.gitattributes", "*.txt text eol=crlf\n");
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 	opts.disable_filters = false;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
@@ -394,7 +393,7 @@ void test_checkout_index__options_dir_modes(void)
 
 	reset_index_to_treeish((git_object *)commit);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 	opts.dir_mode = 0701;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
@@ -421,7 +420,7 @@ void test_checkout_index__options_override_file_modes(void)
 	if (!cl_is_chmod_supported())
 		return;
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 	opts.file_mode = 0700;
 
 	cl_git_pass(git_checkout_index(g_repo, NULL, &opts));
@@ -486,7 +485,7 @@ void test_checkout_index__can_notify_of_skipped_files(void)
 	data.file = "new.txt";
 	data.sha = "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd";
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE |
+	opts.checkout_strategy =
 		GIT_CHECKOUT_RECREATE_MISSING |
 		GIT_CHECKOUT_ALLOW_CONFLICTS;
 	opts.notify_flags = GIT_CHECKOUT_NOTIFY_CONFLICT;
@@ -526,7 +525,6 @@ void test_checkout_index__wont_notify_of_expected_line_ending_changes(void)
 	cl_git_mkfile("./testrepo/new.txt", "my new file\r\n");
 
 	opts.checkout_strategy =
-		GIT_CHECKOUT_SAFE |
 		GIT_CHECKOUT_RECREATE_MISSING |
 		GIT_CHECKOUT_ALLOW_CONFLICTS;
 	opts.notify_flags = GIT_CHECKOUT_NOTIFY_CONFLICT;
@@ -548,7 +546,7 @@ void test_checkout_index__calls_progress_callback(void)
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 	int calls = 0;
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 	opts.progress_cb = checkout_progress_counter;
 	opts.progress_payload = &calls;
 
@@ -583,7 +581,6 @@ void test_checkout_index__can_overcome_name_clashes(void)
 	cl_assert(git_fs_path_isfile("./testrepo/path0/file0"));
 
 	opts.checkout_strategy =
-		GIT_CHECKOUT_SAFE |
 		GIT_CHECKOUT_RECREATE_MISSING |
 		GIT_CHECKOUT_ALLOW_CONFLICTS;
 	cl_git_pass(git_checkout_index(g_repo, index, &opts));
@@ -635,7 +632,6 @@ void test_checkout_index__can_update_prefixed_files(void)
 	cl_git_pass(p_mkdir("./testrepo/branch_file.txt.after", 0777));
 
 	opts.checkout_strategy =
-		GIT_CHECKOUT_SAFE |
 		GIT_CHECKOUT_RECREATE_MISSING |
 		GIT_CHECKOUT_REMOVE_UNTRACKED;
 
@@ -686,7 +682,7 @@ void test_checkout_index__target_directory(void)
 	checkout_counts cts;
 	memset(&cts, 0, sizeof(cts));
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE |
+	opts.checkout_strategy =
 		GIT_CHECKOUT_RECREATE_MISSING;
 	opts.target_directory = "alternative";
 	cl_assert(!git_fs_path_isdir("alternative"));
@@ -731,7 +727,7 @@ void test_checkout_index__target_directory_from_bare(void)
 	cl_git_pass(git_index_write(index));
 	git_index_free(index);
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE |
+	opts.checkout_strategy =
 		GIT_CHECKOUT_RECREATE_MISSING;
 
 	opts.notify_flags = GIT_CHECKOUT_NOTIFY_ALL;
@@ -770,7 +766,7 @@ void test_checkout_index__can_get_repo_from_index(void)
 	cl_assert_equal_i(false, git_fs_path_isfile("./testrepo/branch_file.txt"));
 	cl_assert_equal_i(false, git_fs_path_isfile("./testrepo/new.txt"));
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	cl_git_pass(git_repository_index(&index, g_repo));
 

--- a/tests/libgit2/checkout/tree.c
+++ b/tests/libgit2/checkout/tree.c
@@ -186,8 +186,6 @@ void test_checkout_tree__can_switch_branches(void)
 	git_object_free(obj);
 
 	/* do second checkout safe because we should be clean after first */
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
-
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/subtrees"));
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJECT_ANY));
 
@@ -213,7 +211,7 @@ void test_checkout_tree__can_remove_untracked(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_REMOVE_UNTRACKED;
+	opts.checkout_strategy = GIT_CHECKOUT_REMOVE_UNTRACKED;
 
 	cl_git_mkfile("testrepo/untracked_file", "as you wish");
 	cl_assert(git_fs_path_isfile("testrepo/untracked_file"));
@@ -228,7 +226,7 @@ void test_checkout_tree__can_remove_ignored(void)
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 	int ignored = 0;
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_REMOVE_IGNORED;
+	opts.checkout_strategy = GIT_CHECKOUT_REMOVE_IGNORED;
 
 	cl_git_mkfile("testrepo/ignored_file", "as you wish");
 
@@ -313,7 +311,7 @@ void test_checkout_tree__conflict_on_ignored_when_not_overwriting(void)
 	int error;
 
 	cl_git_fail(error = checkout_tree_with_blob_ignored_in_workdir(
-		GIT_CHECKOUT_SAFE | GIT_CHECKOUT_DONT_OVERWRITE_IGNORED, false));
+		GIT_CHECKOUT_DONT_OVERWRITE_IGNORED, false));
 
 	cl_assert_equal_i(GIT_ECONFLICT, error);
 }
@@ -334,7 +332,7 @@ void test_checkout_tree__conflict_on_ignored_folder_when_not_overwriting(void)
 	int error;
 
 	cl_git_fail(error = checkout_tree_with_blob_ignored_in_workdir(
-		GIT_CHECKOUT_SAFE | GIT_CHECKOUT_DONT_OVERWRITE_IGNORED, true));
+		GIT_CHECKOUT_DONT_OVERWRITE_IGNORED, true));
 
 	cl_assert_equal_i(GIT_ECONFLICT, error);
 }
@@ -370,7 +368,7 @@ void test_checkout_tree__can_update_only(void)
 
 	/* now checkout branch but with update only */
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_UPDATE_ONLY;
+	opts.checkout_strategy = GIT_CHECKOUT_UPDATE_ONLY;
 
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "refs/heads/dir"));
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJECT_ANY));
@@ -417,7 +415,6 @@ void test_checkout_tree__can_checkout_with_pattern(void)
 
 	/* now to a narrow patterned checkout */
 
-	g_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	g_opts.paths.strings = entries;
 	g_opts.paths.count = 1;
 
@@ -489,7 +486,6 @@ void test_checkout_tree__can_disable_pattern_match(void)
 	/* now to a narrow patterned checkout, but disable pattern */
 
 	g_opts.checkout_strategy =
-		GIT_CHECKOUT_SAFE |
 		GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
 	g_opts.paths.strings = entries;
 	g_opts.paths.count = 1;
@@ -605,8 +601,6 @@ void test_checkout_tree__donot_update_deleted_file_by_default(void)
 	git_commit *old_commit = NULL, *new_commit = NULL;
 	git_index *index = NULL;
 	checkout_counts ct;
-
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 
 	memset(&ct, 0, sizeof(ct));
 	opts.notify_flags = GIT_CHECKOUT_NOTIFY_ALL;
@@ -883,8 +877,7 @@ void test_checkout_tree__target_directory_from_bare(void)
 	g_repo = cl_git_sandbox_init("testrepo.git");
 	cl_assert(git_repository_is_bare(g_repo));
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE |
-		GIT_CHECKOUT_RECREATE_MISSING;
+	opts.checkout_strategy = GIT_CHECKOUT_RECREATE_MISSING;
 
 	opts.notify_flags = GIT_CHECKOUT_NOTIFY_ALL;
 	opts.notify_cb = checkout_count_callback;
@@ -962,8 +955,6 @@ void test_checkout_tree__fails_when_conflicts_exist_in_index(void)
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 	git_oid oid;
 	git_object *obj = NULL;
-
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 
 	cl_git_pass(git_reference_name_to_id(&oid, g_repo, "HEAD"));
 	cl_git_pass(git_object_lookup(&obj, g_repo, &oid, GIT_OBJECT_ANY));
@@ -1622,8 +1613,6 @@ void test_checkout_tree__retains_external_index_changes(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE;
-
 	modify_index_and_checkout_tree(&opts);
 	assert_status_entrycount(g_repo, 1);
 }
@@ -1632,7 +1621,7 @@ void test_checkout_tree__no_index_refresh(void)
 {
 	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
 
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_NO_REFRESH;
+	opts.checkout_strategy = GIT_CHECKOUT_NO_REFRESH;
 
 	modify_index_and_checkout_tree(&opts);
 	assert_status_entrycount(g_repo, 0);
@@ -1659,7 +1648,7 @@ void test_checkout_tree__dry_run(void)
 	/* now checkout branch but with dry run enabled */
 
 	memset(&ct, 0, sizeof(ct));
-	opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_DRY_RUN;
+	opts.checkout_strategy = GIT_CHECKOUT_DRY_RUN;
 	opts.notify_flags = GIT_CHECKOUT_NOTIFY_ALL;
 	opts.notify_cb = checkout_count_callback;
 	opts.notify_payload = &ct;

--- a/tests/libgit2/cherrypick/workdir.c
+++ b/tests/libgit2/cherrypick/workdir.c
@@ -257,7 +257,7 @@ void test_cherrypick_workdir__conflict_use_ours(void)
 	};
 
 	/* leave the index in a conflicted state, but checkout "ours" to the workdir */
-	opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_USE_OURS;
+	opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_USE_OURS;
 
 	git_oid__fromstr(&head_oid, "bafbf6912c09505ac60575cd43d3f2aba3bd84d8", GIT_OID_SHA1);
 

--- a/tests/libgit2/clone/local.c
+++ b/tests/libgit2/clone/local.c
@@ -54,41 +54,87 @@ static int unc_path(git_str *buf, const char *host, const char *path)
 void test_clone_local__should_clone_local(void)
 {
 	git_str buf = GIT_STR_INIT;
+	bool local;
 
 	/* we use a fixture path because it needs to exist for us to want to clone */
 	const char *path = cl_fixture("testrepo.git");
 
+	/* empty string */
 	cl_git_pass(file_url(&buf, "", path));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_AUTO));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_NO_LOCAL));
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_AUTO));
+	cl_assert_equal_i(false, local);
 
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_AUTO));
+	cl_assert_equal_i(false, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_NO_LOCAL));
+	cl_assert_equal_i(false, local);
+
+	/* localhost is special */
 	cl_git_pass(file_url(&buf, "localhost", path));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_AUTO));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_NO_LOCAL));
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_AUTO));
+	cl_assert_equal_i(false, local);
 
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_NO_LOCAL));
+	cl_assert_equal_i(false, local);
+
+	/* a remote host */
 	cl_git_pass(file_url(&buf, "other-host.mycompany.com", path));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_AUTO));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_NO_LOCAL));
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_AUTO));
+	cl_assert_equal_i(false, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL));
+	cl_assert_equal_i(false, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
+	cl_assert_equal_i(false, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_NO_LOCAL));
+	cl_assert_equal_i(false, local);
 
 	/* Ensure that file:/// urls are percent decoded: .git == %2e%67%69%74 */
 	cl_git_pass(file_url(&buf, "", path));
 	git_str_shorten(&buf, 4);
 	cl_git_pass(git_str_puts(&buf, "%2e%67%69%74"));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_AUTO));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
-	cl_assert_equal_i(0, git_clone__should_clone_local(buf.ptr, GIT_CLONE_NO_LOCAL));
 
-	cl_assert_equal_i(1,  git_clone__should_clone_local(path, GIT_CLONE_LOCAL_AUTO));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(path, GIT_CLONE_LOCAL));
-	cl_assert_equal_i(1,  git_clone__should_clone_local(path, GIT_CLONE_LOCAL_NO_LINKS));
-	cl_assert_equal_i(0, git_clone__should_clone_local(path, GIT_CLONE_NO_LOCAL));
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_AUTO));
+	cl_assert_equal_i(false, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_LOCAL_NO_LINKS));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, buf.ptr, GIT_CLONE_NO_LOCAL));
+	cl_assert_equal_i(false, local);
+
+	/* a local path on disk */
+	cl_git_pass(git_clone__should_clone_local(&local, path, GIT_CLONE_LOCAL_AUTO));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, path, GIT_CLONE_LOCAL));
+
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, path, GIT_CLONE_LOCAL_NO_LINKS));
+	cl_assert_equal_i(true, local);
+
+	cl_git_pass(git_clone__should_clone_local(&local, path, GIT_CLONE_NO_LOCAL));
+	cl_assert_equal_i(false, local);
 
 	git_str_dispose(&buf);
 }

--- a/tests/libgit2/clone/nonetwork.c
+++ b/tests/libgit2/clone/nonetwork.c
@@ -24,7 +24,6 @@ void test_clone_nonetwork__initialize(void)
 	memset(&g_options, 0, sizeof(git_clone_options));
 	g_options.version = GIT_CLONE_OPTIONS_VERSION;
 	g_options.checkout_opts = dummy_opts;
-	g_options.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	g_options.fetch_opts = dummy_fetch;
 }
 

--- a/tests/libgit2/merge/workdir/dirty.c
+++ b/tests/libgit2/merge/workdir/dirty.c
@@ -97,7 +97,6 @@ static int merge_branch(void)
 	cl_git_pass(git_oid__fromstr(&their_oids[0], MERGE_BRANCH_OID, GIT_OID_SHA1));
 	cl_git_pass(git_annotated_commit_lookup(&their_head, repo, &their_oids[0]));
 
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	error = git_merge(repo, (const git_annotated_commit **)&their_head, 1, &merge_opts, &checkout_opts);
 
 	git_annotated_commit_free(their_head);

--- a/tests/libgit2/merge/workdir/renames.c
+++ b/tests/libgit2/merge/workdir/renames.c
@@ -100,7 +100,7 @@ void test_merge_workdir_renames__ours(void)
 
 	merge_opts.flags |= GIT_MERGE_FIND_RENAMES;
 	merge_opts.rename_threshold = 50;
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_USE_OURS;
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_USE_OURS;
 
 	cl_git_pass(merge_branches(repo, GIT_REFS_HEADS_DIR BRANCH_RENAME_OURS, GIT_REFS_HEADS_DIR BRANCH_RENAME_THEIRS, &merge_opts, &checkout_opts));
 	cl_git_pass(git_repository_index(&index, repo));

--- a/tests/libgit2/merge/workdir/simple.c
+++ b/tests/libgit2/merge/workdir/simple.c
@@ -103,7 +103,7 @@ static void merge_simple_branch(int merge_file_favor, int addl_checkout_strategy
 	cl_git_pass(git_annotated_commit_lookup(&their_heads[0], repo, &their_oids[0]));
 
 	merge_opts.file_favor = merge_file_favor;
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_ALLOW_CONFLICTS |
+	checkout_opts.checkout_strategy = GIT_CHECKOUT_ALLOW_CONFLICTS |
 		addl_checkout_strategy;
 
 	cl_git_pass(git_merge(repo, (const git_annotated_commit **)their_heads, 1, &merge_opts, &checkout_opts));
@@ -577,7 +577,7 @@ void test_merge_workdir_simple__checkout_ours(void)
 		REMOVED_IN_MASTER_REUC_ENTRY
 	};
 
-	merge_simple_branch(0, GIT_CHECKOUT_SAFE | GIT_CHECKOUT_USE_OURS);
+	merge_simple_branch(0, GIT_CHECKOUT_USE_OURS);
 
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 8));
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 3));

--- a/tests/libgit2/online/clone.c
+++ b/tests/libgit2/online/clone.c
@@ -73,7 +73,6 @@ void test_online_clone__initialize(void)
 	memset(&g_options, 0, sizeof(git_clone_options));
 	g_options.version = GIT_CLONE_OPTIONS_VERSION;
 	g_options.checkout_opts = dummy_opts;
-	g_options.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	g_options.fetch_opts = dummy_fetch;
 	g_options.fetch_opts.callbacks.certificate_check = ssl_cert;
 
@@ -249,7 +248,6 @@ void test_online_clone__can_checkout_a_cloned_repo(void)
 	bool checkout_progress_cb_was_called = false,
 		  fetch_progress_cb_was_called = false;
 
-	g_options.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	g_options.checkout_opts.progress_cb = &checkout_progress;
 	g_options.checkout_opts.progress_payload = &checkout_progress_cb_was_called;
 	g_options.fetch_opts.callbacks.transfer_progress = &fetch_progress;

--- a/tests/libgit2/online/fetchhead.c
+++ b/tests/libgit2/online/fetchhead.c
@@ -12,12 +12,9 @@ static git_clone_options g_options;
 
 void test_online_fetchhead__initialize(void)
 {
-	git_fetch_options dummy_fetch = GIT_FETCH_OPTIONS_INIT;
 	g_repo = NULL;
 
-	memset(&g_options, 0, sizeof(git_clone_options));
-	g_options.version = GIT_CLONE_OPTIONS_VERSION;
-	g_options.fetch_opts = dummy_fetch;
+	git_clone_options_init(&g_options, GIT_CLONE_OPTIONS_VERSION);
 }
 
 void test_online_fetchhead__cleanup(void)

--- a/tests/libgit2/perf/helper__perf__do_merge.c
+++ b/tests/libgit2/perf/helper__perf__do_merge.c
@@ -26,13 +26,12 @@ void perf__do_merge(const char *fixture,
 
 	perf__timer__start(&t_total);
 
-	checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE;
 	clone_opts.checkout_opts = checkout_opts;
 
 	perf__timer__start(&t_clone);
 	cl_git_pass(git_clone(&g_repo, fixture, test_name, &clone_opts));
 	perf__timer__stop(&t_clone);
-	
+
 	git_oid__fromstr(&oid_a, id_a, GIT_OID_SHA1);
 	cl_git_pass(git_commit_lookup(&commit_a, g_repo, &oid_a));
 	cl_git_pass(git_branch_create(&ref_branch_a, g_repo,

--- a/tests/libgit2/revert/workdir.c
+++ b/tests/libgit2/revert/workdir.c
@@ -374,7 +374,7 @@ void test_revert_workdir__conflict_use_ours(void)
 		{ 0100644, "0f5bfcf58c558d865da6be0281d7795993646cee", 0, "file6.txt" },
 	};
 
-	opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_USE_OURS;
+	opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_USE_OURS;
 
 	git_oid__fromstr(&head_oid, "72333f47d4e83616630ff3b0ffe4c0faebcc3c45", GIT_OID_SHA1);
 	cl_git_pass(git_commit_lookup(&head, repo, &head_oid));


### PR DESCRIPTION
Make `GIT_CHECKOUT_SAFE` the default.  `NONE` is never what the user wants _by default_; people expect checkout to, well, check things out. Instead, it should be an opt-in "dry run" mode.

But, in fact, it should be a dry run and fire notifications.  So we keep `DRY_RUN` and remove the `NONE` mode entirely.

This removes some odd code in internal callers of `checkout` that takes a `git_checkout_options` and updates the mode to `SAFE`.  This is now unnecessary since everything has better defaults.