### PR TITLE
indexer: Avoid one `mmap(2)`/`munmap(2)` pair per `git_indexer_append` call

### DIFF
--- a/src/indexer.c
+++ b/src/indexer.c
@@ -1307,8 +1307,11 @@ int git_indexer_commit(git_indexer *idx, git_indexer_progress *stats)
 
 #if !defined(NO_MMAP) && defined(GIT_WIN32)
 	/*
-	 * Truncate file to undo rounding up to next page_size in append_to_pack only
-	 * when mmap was used, to prevent failures in non-Windows remote filesystems.
+	 * Some non-Windows remote filesystems fail when truncating files if the
+	 * file permissions change after opening the file (done by p_mkstemp).
+	 *
+	 * Truncation is only needed when mmap is used to undo rounding up to next
+	 * page_size in append_to_pack.
 	 */
 	if (p_ftruncate(idx->pack->mwf.fd, idx->pack->mwf.size) < 0) {
 		git_error_set(GIT_ERROR_OS, "failed to truncate pack file '%s'", idx->pack->pack_name);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -1234,12 +1234,6 @@ int git_indexer_commit(git_indexer *idx, git_indexer_progress *stats)
 	if (git_mwindow_free_all(&idx->pack->mwf) < 0)
 		goto on_error;
 
-	/* Truncate file to undo rounding up to next page_size in append_to_pack */
-	if (p_ftruncate(idx->pack->mwf.fd, idx->pack->mwf.size) < 0) {
-		git_error_set(GIT_ERROR_OS, "failed to truncate pack file '%s'", idx->pack->pack_name);
-		return -1;
-	}
-
 	if (idx->do_fsync && p_fsync(idx->pack->mwf.fd) < 0) {
 		git_error_set(GIT_ERROR_OS, "failed to fsync packfile");
 		goto on_error;


### PR DESCRIPTION
This change makes `append_to_pack` completely rely on `p_pwrite` to do
all its I/O instead of splitting it between `p_pwrite` and a
`mmap(2)`/`munmap(2)`+`memcpy(3)`. This saves a good chunk of user CPU
time and avoids making two syscalls per round, but doesn't really cut
down a lot of wall time (~1% on cloning the
[git](https://github.com/git/git.git) repository).

Part of: #6038
Fixes: #5556