### PR TITLE
Use __typeof__ GNUC keyword for ISO C compatibility

### DIFF
--- a/src/cc-compat.h
+++ b/src/cc-compat.h
@@ -29,12 +29,6 @@
 #	endif
 #endif
 
-#ifdef __GNUC__
-#	define GIT_TYPEOF(x) (__typeof__(x))
-#else
-#	define GIT_TYPEOF(x)
-#endif
-
 #if defined(__GNUC__)
 #	define GIT_ALIGN(x,size) x __attribute__ ((aligned(size)))
 #elif defined(_MSC_VER)
@@ -46,7 +40,7 @@
 #if defined(__GNUC__)
 # define GIT_UNUSED(x)                                                         \
 	do {                                                                   \
-		typeof(x) _unused __attribute__((unused));                     \
+		__typeof__(x) _unused __attribute__((unused));                 \
 		_unused = (x);                                                 \
 	} while (0)
 #else

--- a/src/util.h
+++ b/src/util.h
@@ -34,7 +34,7 @@
 # define GIT_CONTAINER_OF(ptr, type, member) \
 	__builtin_choose_expr( \
 	    __builtin_offsetof(type, member) == 0 && \
-	    __builtin_types_compatible_p(typeof(&((type *) 0)->member), typeof(ptr)), \
+	    __builtin_types_compatible_p(__typeof__(&((type *) 0)->member), __typeof__(ptr)), \
 		((type *) (ptr)), \
 		(void)0)
 #else


### PR DESCRIPTION
For issue: https://github.com/libgit2/libgit2/issues/6040

This PR converges on the use of `__typeof__` instead of `typeof` for ISO C compatibility with this GCC extension.

All uses of `typeof` or `__typeof__` are presently confined to `#if defined(__GNUC__) / #endif` blocks, which should limit the impact of this change.

Details:
- Remove the `GIT_TYPEOF` macro, since this is not used in the libgit2 project.
- Replace all occurrences of `typeof(x)` with `__typeof__(x)`.
