### PR TITLE
Stabilize soname

### DIFF
--- a/include/git2/version.h
+++ b/include/git2/version.h
@@ -13,6 +13,6 @@
 #define LIBGIT2_VER_REVISION 0
 #define LIBGIT2_VER_PATCH 0
 
-#define LIBGIT2_SOVERSION "1.2"
+#define LIBGIT2_SOVERSION "1"
 
 #endif

--- a/script/release.py
+++ b/script/release.py
@@ -37,7 +37,7 @@ def verify_version(version):
         'VER_MINOR':    [ str(version.minor), None ],
         'VER_REVISION': [ str(version.revision), None ],
         'VER_PATCH':    [ '0', None ],
-        'SOVERSION':    [ '"{}.{}"'.format(version.major, version.minor), None ],
+        'SOVERSION':    [ '"{}"'.format(version.major), None ],
     }
 
     # Parse CMakeLists

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -393,7 +393,7 @@ IDE_SPLIT_SOURCES(git2)
 
 if(SONAME)
 	set_target_properties(git2 PROPERTIES VERSION ${libgit2_VERSION})
-	set_target_properties(git2 PROPERTIES SOVERSION "${libgit2_VERSION_MAJOR}.${libgit2_VERSION_MINOR}")
+	set_target_properties(git2 PROPERTIES SOVERSION "${libgit2_VERSION_MAJOR}")
 	if(LIBGIT2_FILENAME)
 		target_compile_definitions(git2 PRIVATE LIBGIT2_FILENAME=\"${LIBGIT2_FILENAME}\")
 		set_target_properties(git2 PROPERTIES OUTPUT_NAME ${LIBGIT2_FILENAME})


### PR DESCRIPTION
After the release 1.x has been released, we can perhaps expect an ABI
stabilization so that we don't need to recompile the libraries which
depends upon libgit2.

Running abidiff between 1.1.0 and 1.2.0 leads to no binary incompatible
changes.

This is already mentioned in #5670.