### PR TITLE
Longpath filter bug

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -138,12 +138,13 @@ static int write_file_filtered(
 	git_object_size_t *size,
 	git_odb *odb,
 	const char *full_path,
-	git_filter_list *fl)
+	git_filter_list *fl,
+	git_repository* repo)
 {
 	int error;
 	git_buf tgt = GIT_BUF_INIT;
 
-	error = git_filter_list_apply_to_file(&tgt, fl, NULL, full_path);
+	error = git_filter_list_apply_to_file(&tgt, fl, repo, full_path);
 
 	/* Write the file to disk if it was properly filtered */
 	if (!error) {
@@ -238,7 +239,7 @@ int git_blob__create_from_paths(
 			error = write_file_stream(id, odb, content_path, size);
 		else {
 			/* We need to apply one or more filters */
-			error = write_file_filtered(id, &size, odb, content_path, fl);
+			error = write_file_filtered(id, &size, odb, content_path, fl, repo);
 
 			git_filter_list_free(fl);
 		}

--- a/tests/win32/longpath.c
+++ b/tests/win32/longpath.c
@@ -64,15 +64,11 @@ void test_win32_longpath__workdir_path_validated(void)
 #endif
 }
 
-void test_win32_longpath__status_and_add(void)
-{
-#ifdef GIT_WIN32
-	git_repository *repo = cl_git_sandbox_init("testrepo");
+static void assert_longpath_status_and_add(git_repository* repo) {
 	git_index *index;
 	git_buf out = GIT_BUF_INIT;
 	unsigned int status_flags;
 
-	cl_repo_set_bool(repo, "core.longpaths", true);
 	cl_git_pass(git_repository_workdir_path(&out, repo, LONG_FILENAME));
 
 	cl_git_rewritefile(out.ptr, "This is a long path.\r\n");
@@ -88,6 +84,16 @@ void test_win32_longpath__status_and_add(void)
 
 	git_index_free(index);
 	git_buf_dispose(&out);
+}
+
+void test_win32_longpath__status_and_add(void)
+{
+#ifdef GIT_WIN32
+	git_repository *repo = cl_git_sandbox_init("testrepo");
+
+	cl_repo_set_bool(repo, "core.longpaths", true);
+
+	assert_longpath_status_and_add(repo);
 #endif
 }
 
@@ -95,26 +101,10 @@ void test_win32_longpath__status_and_add_with_filter(void)
 {
 #ifdef GIT_WIN32
 	git_repository *repo = cl_git_sandbox_init("testrepo");
-	git_index *index;
-	git_buf out = GIT_BUF_INIT;
-	unsigned int status_flags;
 
 	cl_repo_set_bool(repo, "core.longpaths", true);
-        cl_repo_set_bool(repo, "core.autocrlf", true);
-	cl_git_pass(git_repository_workdir_path(&out, repo, LONG_FILENAME));
+	cl_repo_set_bool(repo, "core.autocrlf", true);
 
-	cl_git_rewritefile(out.ptr, "This is a long path.\r\n");
-
-	cl_git_pass(git_status_file(&status_flags, repo, LONG_FILENAME));
-	cl_assert_equal_i(GIT_STATUS_WT_NEW, status_flags);
-
-	cl_git_pass(git_repository_index(&index, repo));
-	cl_git_pass(git_index_add_bypath(index, LONG_FILENAME));
-
-	cl_git_pass(git_status_file(&status_flags, repo, LONG_FILENAME));
-	cl_assert_equal_i(GIT_STATUS_INDEX_NEW, status_flags);
-
-	git_index_free(index);
-	git_buf_dispose(&out);
+	assert_longpath_status_and_add(repo);
 #endif
 }

--- a/tests/win32/longpath.c
+++ b/tests/win32/longpath.c
@@ -90,3 +90,31 @@ void test_win32_longpath__status_and_add(void)
 	git_buf_dispose(&out);
 #endif
 }
+
+void test_win32_longpath__status_and_add_with_filter(void)
+{
+#ifdef GIT_WIN32
+	git_repository *repo = cl_git_sandbox_init("testrepo");
+	git_index *index;
+	git_buf out = GIT_BUF_INIT;
+	unsigned int status_flags;
+
+	cl_repo_set_bool(repo, "core.longpaths", true);
+        cl_repo_set_bool(repo, "core.autocrlf", true);
+	cl_git_pass(git_repository_workdir_path(&out, repo, LONG_FILENAME));
+
+	cl_git_rewritefile(out.ptr, "This is a long path.\r\n");
+
+	cl_git_pass(git_status_file(&status_flags, repo, LONG_FILENAME));
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, status_flags);
+
+	cl_git_pass(git_repository_index(&index, repo));
+	cl_git_pass(git_index_add_bypath(index, LONG_FILENAME));
+
+	cl_git_pass(git_status_file(&status_flags, repo, LONG_FILENAME));
+	cl_assert_equal_i(GIT_STATUS_INDEX_NEW, status_flags);
+
+	git_index_free(index);
+	git_buf_dispose(&out);
+#endif
+}

--- a/tests/win32/longpath.c
+++ b/tests/win32/longpath.c
@@ -64,6 +64,7 @@ void test_win32_longpath__workdir_path_validated(void)
 #endif
 }
 
+#ifdef GIT_WIN32
 static void assert_longpath_status_and_add(git_repository* repo) {
 	git_index *index;
 	git_buf out = GIT_BUF_INIT;
@@ -85,6 +86,7 @@ static void assert_longpath_status_and_add(git_repository* repo) {
 	git_index_free(index);
 	git_buf_dispose(&out);
 }
+#endif
 
 void test_win32_longpath__status_and_add(void)
 {


### PR DESCRIPTION
Fixes #6054.

An alternative might be to handle the null git_repository case in the longpath check ((bool) should_validate_longpaths(git_repository *repo)). Could also put an assert on "repo" argument in should_validate_longpaths.