### PR TITLE
Allow user checkout options on git_worktree_add

### DIFF
--- a/include/git2/worktree.h
+++ b/include/git2/worktree.h
@@ -86,10 +86,15 @@ typedef struct git_worktree_add_options {
 
 	int lock; /**< lock newly created worktree */
 	git_reference *ref; /**< reference to use for the new worktree HEAD */
+
+	/**
+	 * Options for the checkout.
+	 */
+	git_checkout_options checkout_opts;
 } git_worktree_add_options;
 
 #define GIT_WORKTREE_ADD_OPTIONS_VERSION 1
-#define GIT_WORKTREE_ADD_OPTIONS_INIT {GIT_WORKTREE_ADD_OPTIONS_VERSION,0,NULL}
+#define GIT_WORKTREE_ADD_OPTIONS_INIT {GIT_WORKTREE_ADD_OPTIONS_VERSION,0,NULL,GIT_CHECKOUT_OPTIONS_INIT}
 
 /**
  * Initialize git_worktree_add_options structure

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -407,8 +407,6 @@ int git_worktree_add(git_worktree **out, git_repository *repo,
 	/* Checkout worktree's HEAD */
 	if (opts != NULL)
 		memcpy(&coopts, &wtopts.checkout_opts, sizeof(coopts));
-	else
-		coopts.checkout_strategy = GIT_CHECKOUT_FORCE;
 	if ((err = git_checkout_head(wt, &coopts)) < 0)
 		goto out;
 

--- a/src/worktree.c
+++ b/src/worktree.c
@@ -405,7 +405,10 @@ int git_worktree_add(git_worktree **out, git_repository *repo,
 		goto out;
 
 	/* Checkout worktree's HEAD */
-	coopts.checkout_strategy = GIT_CHECKOUT_FORCE;
+	if (opts != NULL)
+		memcpy(&coopts, &wtopts.checkout_opts, sizeof(coopts));
+	else
+		coopts.checkout_strategy = GIT_CHECKOUT_FORCE;
 	if ((err = git_checkout_head(wt, &coopts)) < 0)
 		goto out;
 

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -292,6 +292,27 @@ void test_worktree_worktree__add_with_explicit_branch(void)
 	git_worktree_free(wt);
 }
 
+void test_worktree_worktree__add_no_checkout(void)
+{
+	git_worktree *wt;
+	git_repository *wtrepo;
+	git_index *index;
+	git_buf path = GIT_BUF_INIT;
+	git_worktree_add_options opts = GIT_WORKTREE_ADD_OPTIONS_INIT;
+
+	opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;
+
+	cl_git_pass(git_buf_joinpath(&path, fixture.repo->workdir, "../worktree-no-checkout"));
+	cl_git_pass(git_worktree_add(&wt, fixture.repo, "worktree-no-checkout", path.ptr, &opts));
+
+	cl_git_pass(git_repository_open(&wtrepo, path.ptr));
+	cl_git_pass(git_repository_index(&index, wtrepo));
+	cl_assert_equal_i(git_index_entrycount(index), 0);
+
+	git_buf_dispose(&path);
+	git_worktree_free(wt);
+	git_repository_free(wtrepo);
+}
 
 void test_worktree_worktree__init_existing_worktree(void)
 {

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -311,6 +311,7 @@ void test_worktree_worktree__add_no_checkout(void)
 
 	git_str_dispose(&path);
 	git_worktree_free(wt);
+	git_index_free(index);
 	git_repository_free(wtrepo);
 }
 

--- a/tests/worktree/worktree.c
+++ b/tests/worktree/worktree.c
@@ -297,19 +297,19 @@ void test_worktree_worktree__add_no_checkout(void)
 	git_worktree *wt;
 	git_repository *wtrepo;
 	git_index *index;
-	git_buf path = GIT_BUF_INIT;
+	git_str path = GIT_STR_INIT;
 	git_worktree_add_options opts = GIT_WORKTREE_ADD_OPTIONS_INIT;
 
 	opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;
 
-	cl_git_pass(git_buf_joinpath(&path, fixture.repo->workdir, "../worktree-no-checkout"));
+	cl_git_pass(git_str_joinpath(&path, fixture.repo->workdir, "../worktree-no-checkout"));
 	cl_git_pass(git_worktree_add(&wt, fixture.repo, "worktree-no-checkout", path.ptr, &opts));
 
 	cl_git_pass(git_repository_open(&wtrepo, path.ptr));
 	cl_git_pass(git_repository_index(&index, wtrepo));
 	cl_assert_equal_i(git_index_entrycount(index), 0);
 
-	git_buf_dispose(&path);
+	git_str_dispose(&path);
 	git_worktree_free(wt);
 	git_repository_free(wtrepo);
 }


### PR DESCRIPTION
Extend the `git_worktree_add_options` to include `git_checkout_options`.

github issue #5949