### PR TITLE
win32: allow empty environment variables

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -755,7 +755,7 @@ int git__getenv(git_buf *out, const char *name)
 
 	if (value_len)
 		error = git_buf_put_w(out, wide_value, value_len);
-	else if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
+	else if (GetLastError() == ERROR_SUCCESS || GetLastError() == ERROR_ENVVAR_NOT_FOUND)
 		error = GIT_ENOTFOUND;
 	else
 		git_error_set(GIT_ERROR_OS, "could not read environment variable '%s'", name);


### PR DESCRIPTION
A length of 0 indicates an error and GetLastError() will be set.  If
GetLastError() is unset then the environment variable has a length of 0.