### PR TITLE
Attribute lookups are always on relative paths

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -762,13 +762,15 @@ GIT_EXTERN(int) git_repository_mergehead_foreach(
  *
  * @param out Output value of calculated SHA
  * @param repo Repository pointer
- * @param path Path to file on disk whose contents should be hashed. If the
- *             repository is not NULL, this can be a relative path.
+ * @param path Path to file on disk whose contents should be hashed.  This
+ *             may be an absolute path or a relative path, in which case it
+ *             will be treated as a path within the working directory.
  * @param type The object type to hash as (e.g. GIT_OBJECT_BLOB)
  * @param as_path The path to use to look up filtering rules. If this is
- *             NULL, then the `path` parameter will be used instead. If
- *             this is passed as the empty string, then no filters will be
- *             applied when calculating the hash.
+ *             an empty string then no filters will be applied when
+ *             calculating the hash. If this is `NULL` and the `path`
+ *             parameter is a file within the repository's working
+ *             directory, then the `path` will be used.
  * @return 0 on success, or an error code
  */
 GIT_EXTERN(int) git_repository_hashfile(

--- a/src/attr.c
+++ b/src/attr.c
@@ -629,6 +629,8 @@ static int collect_attr_files(
 	const char *workdir = git_repository_workdir(repo);
 	attr_walk_up_info info = { NULL };
 
+	GIT_ASSERT(!git_path_is_absolute(path));
+
 	if ((error = attr_setup(repo, attr_session, opts)) < 0)
 		return error;
 

--- a/src/blob.c
+++ b/src/blob.c
@@ -277,21 +277,20 @@ int git_blob_create_from_disk(
 {
 	int error;
 	git_buf full_path = GIT_BUF_INIT;
-	const char *workdir, *hintpath;
+	const char *workdir, *hintpath = NULL;
 
 	if ((error = git_path_prettify(&full_path, path, NULL)) < 0) {
 		git_buf_dispose(&full_path);
 		return error;
 	}
 
-	hintpath = git_buf_cstr(&full_path);
 	workdir  = git_repository_workdir(repo);
 
-	if (workdir && !git__prefixcmp(hintpath, workdir))
-		hintpath += strlen(workdir);
+	if (workdir && !git__prefixcmp(full_path.ptr, workdir))
+		hintpath = full_path.ptr + strlen(workdir);
 
 	error = git_blob__create_from_paths(
-		id, NULL, repo, git_buf_cstr(&full_path), hintpath, 0, true);
+		id, NULL, repo, git_buf_cstr(&full_path), hintpath, 0, !!hintpath);
 
 	git_buf_dispose(&full_path);
 	return error;

--- a/src/checkout.c
+++ b/src/checkout.c
@@ -1520,8 +1520,7 @@ static int blob_content_to_file(
 	int fd;
 	int error = 0;
 
-	if (hint_path == NULL)
-		hint_path = path;
+	GIT_ASSERT(hint_path != NULL);
 
 	if ((error = mkpath2file(data, path, data->opts.dir_mode)) < 0)
 		return error;
@@ -1789,7 +1788,7 @@ static int checkout_blob(
 	}
 
 	error = checkout_write_content(
-		data, &file->id, fullpath->ptr, NULL, file->mode, &st);
+		data, &file->id, fullpath->ptr, file->path, file->mode, &st);
 
 	/* update the index unless prevented */
 	if (!error && (data->strategy & GIT_CHECKOUT_DONT_UPDATE_INDEX) == 0)
@@ -1975,7 +1974,7 @@ static int checkout_write_entry(
 	checkout_conflictdata *conflict,
 	const git_index_entry *side)
 {
-	const char *hint_path = NULL, *suffix;
+	const char *hint_path, *suffix;
 	git_buf *fullpath;
 	struct stat st;
 	int error;
@@ -1998,9 +1997,9 @@ static int checkout_write_entry(
 
 		if (checkout_path_suffixed(fullpath, suffix) < 0)
 			return -1;
-
-		hint_path = side->path;
 	}
+
+	hint_path = side->path;
 
 	if ((data->strategy & GIT_CHECKOUT_UPDATE_ONLY) != 0 &&
 		(error = checkout_safe_for_update_only(data, fullpath->ptr, side->mode)) <= 0)
@@ -2118,7 +2117,7 @@ static int checkout_write_merge(
 		filter_session.temp_buf = &data->tmp;
 
 		if ((error = git_filter_list__load(
-				&fl, data->repo, NULL, git_buf_cstr(&path_workdir),
+				&fl, data->repo, NULL, result.path,
 				GIT_FILTER_TO_WORKTREE, &filter_session)) < 0 ||
 			(error = git_filter_list__convert_buf(&out_data, fl, &in_data)) < 0)
 			goto done;

--- a/src/win32/posix_w32.c
+++ b/src/win32/posix_w32.c
@@ -648,6 +648,8 @@ int p_getcwd(char *buffer_out, size_t size)
 	if (!cwd)
 		return -1;
 
+	git_win32_path_remove_namespace(cwd, wcslen(cwd));
+
 	/* Convert the working directory back to UTF-8 */
 	if (git__utf16_to_8(buffer_out, size, cwd) < 0) {
 		DWORD code = GetLastError();
@@ -660,6 +662,7 @@ int p_getcwd(char *buffer_out, size_t size)
 		return -1;
 	}
 
+	git_path_mkposix(buffer_out);
 	return 0;
 }
 


### PR DESCRIPTION
We previously (erroneously) passed absolute paths to attribute lookup functions.  This sometimes led to ridiculous paths being constructed, like taking an absolute path within a workdir and prefixing the workdir to it.  Always provide attribute lookups with a relative path, and enforce in the attribute lookup code that we have done so.