### PR TITLE
Handle long paths when querying attributes

### DIFF
--- a/src/attr.c
+++ b/src/attr.c
@@ -68,7 +68,7 @@ int git_attr_get_ext(
 	if (git_repository_is_bare(repo))
 		dir_flag = GIT_DIR_FLAG_FALSE;
 
-	if (git_attr_path__init(&path, repo, pathname, git_repository_workdir(repo), dir_flag) < 0)
+	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo), dir_flag) < 0)
 		return -1;
 
 	if ((error = collect_attr_files(repo, NULL, opts, pathname, &files)) < 0)
@@ -149,7 +149,7 @@ int git_attr_get_many_with_session(
 	if (git_repository_is_bare(repo))
 		dir_flag = GIT_DIR_FLAG_FALSE;
 
-	if (git_attr_path__init(&path, repo, pathname, git_repository_workdir(repo), dir_flag) < 0)
+	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo), dir_flag) < 0)
 		return -1;
 
 	if ((error = collect_attr_files(repo, attr_session, opts, pathname, &files)) < 0)
@@ -264,7 +264,7 @@ int git_attr_foreach_ext(
 	if (git_repository_is_bare(repo))
 		dir_flag = GIT_DIR_FLAG_FALSE;
 
-	if (git_attr_path__init(&path, repo, pathname, git_repository_workdir(repo), dir_flag) < 0)
+	if (git_attr_path__init(&path, pathname, git_repository_workdir(repo), dir_flag) < 0)
 		return -1;
 
 	if ((error = collect_attr_files(repo, NULL, opts, pathname, &files)) < 0 ||

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -561,8 +561,7 @@ int git_attr_path__init(
 	/* build full path as best we can */
 	git_buf_init(&info->full, 0);
 
-	if (git_path_join_unrooted(&info->full, path, base, &root) < 0 ||
-	    git_path_validate_workdir_buf(repo, &info->full) < 0)
+	if (git_path_join_unrooted(&info->full, path, base, &root) < 0)
 		return -1;
 
 	info->path = info->full.ptr + root;

--- a/src/attr_file.c
+++ b/src/attr_file.c
@@ -551,7 +551,6 @@ git_attr_assignment *git_attr_rule__lookup_assignment(
 
 int git_attr_path__init(
 	git_attr_path *info,
-	git_repository *repo,
 	const char *path,
 	const char *base,
 	git_dir_flag dir_flag)

--- a/src/attr_file.h
+++ b/src/attr_file.h
@@ -227,7 +227,6 @@ typedef enum { GIT_DIR_FLAG_TRUE = 1, GIT_DIR_FLAG_FALSE = 0, GIT_DIR_FLAG_UNKNO
 
 extern int git_attr_path__init(
 	git_attr_path *out,
-	git_repository *repo,
 	const char *path,
 	const char *base,
 	git_dir_flag is_dir);

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -468,7 +468,7 @@ int git_ignore__lookup(
 	*out = GIT_IGNORE_NOTFOUND;
 
 	if (git_attr_path__init(
-		&path, ignores->repo, pathname, git_repository_workdir(ignores->repo), dir_flag) < 0)
+		&path, pathname, git_repository_workdir(ignores->repo), dir_flag) < 0)
 		return -1;
 
 	/* first process builtins - success means path was found */
@@ -552,7 +552,7 @@ int git_ignore_path_is_ignored(
 	else if (git_repository_is_bare(repo))
 		dir_flag = GIT_DIR_FLAG_FALSE;
 
-	if ((error = git_attr_path__init(&path, repo, pathname, workdir, dir_flag)) < 0 ||
+	if ((error = git_attr_path__init(&path, pathname, workdir, dir_flag)) < 0 ||
 		(error = git_ignore__for_path(repo, path.path, &ignores)) < 0)
 		goto cleanup;
 

--- a/tests/attr/lookup.c
+++ b/tests/attr/lookup.c
@@ -13,7 +13,7 @@ void test_attr_lookup__simple(void)
 	cl_assert_equal_s(cl_fixture("attr/attr0"), file->entry->path);
 	cl_assert(file->rules.length == 1);
 
-	cl_git_pass(git_attr_path__init(&path, NULL, "test", NULL, GIT_DIR_FLAG_UNKNOWN));
+	cl_git_pass(git_attr_path__init(&path, "test", NULL, GIT_DIR_FLAG_UNKNOWN));
 	cl_assert_equal_s("test", path.path);
 	cl_assert_equal_s("test", path.basename);
 	cl_assert(!path.is_dir);
@@ -36,7 +36,7 @@ static void run_test_cases(git_attr_file *file, struct attr_expected *cases, int
 	int error;
 
 	for (c = cases; c->path != NULL; c++) {
-		cl_git_pass(git_attr_path__init(&path, NULL, c->path, NULL, GIT_DIR_FLAG_UNKNOWN));
+		cl_git_pass(git_attr_path__init(&path, c->path, NULL, GIT_DIR_FLAG_UNKNOWN));
 
 		if (force_dir)
 			path.is_dir = 1;
@@ -133,7 +133,7 @@ void test_attr_lookup__match_variants(void)
 	cl_assert_equal_s(cl_fixture("attr/attr1"), file->entry->path);
 	cl_assert(file->rules.length == 10);
 
-	cl_git_pass(git_attr_path__init(&path, NULL, "/testing/for/pat0", NULL, GIT_DIR_FLAG_UNKNOWN));
+	cl_git_pass(git_attr_path__init(&path, "/testing/for/pat0", NULL, GIT_DIR_FLAG_UNKNOWN));
 	cl_assert_equal_s("pat0", path.basename);
 
 	run_test_cases(file, cases, 0);


### PR DESCRIPTION
When looking up attributes for a file, we construct an absolute path
to the queried file within the working directory so that we can accept
both absolute paths and working directory relative paths.  We then trim
the leading working directory path to give us an in-repo path.

Since we only want the in-repo path to look up attributes - and not to
read it from disk - we don't need to validate its length.