### PR TITLE
buf: common_prefix takes a string array

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1201,25 +1201,26 @@ int git_buf_lf_to_crlf(git_buf *tgt, const git_buf *src)
 	return git_buf_put(tgt, scan, end - scan);
 }
 
-int git_buf_common_prefix(git_buf *buf, const git_strarray *strings)
+int git_buf_common_prefix(git_buf *buf, char *const *const strings, size_t count)
 {
 	size_t i;
 	const char *str, *pfx;
 
 	git_buf_clear(buf);
 
-	if (!strings || !strings->count)
+	if (!strings || !count)
 		return 0;
 
 	/* initialize common prefix to first string */
-	if (git_buf_sets(buf, strings->strings[0]) < 0)
+	if (git_buf_sets(buf, strings[0]) < 0)
 		return -1;
 
 	/* go through the rest of the strings, truncating to shared prefix */
-	for (i = 1; i < strings->count; ++i) {
+	for (i = 1; i < count; ++i) {
 
-		for (str = strings->strings[i], pfx = buf->ptr;
-			 *str && *str == *pfx; str++, pfx++)
+		for (str = strings[i], pfx = buf->ptr;
+		     *str && *str == *pfx;
+		     str++, pfx++)
 			/* scanning */;
 
 		git_buf_truncate(buf, pfx - buf->ptr);

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -324,7 +324,7 @@ extern int git_buf_lf_to_crlf(git_buf *tgt, const git_buf *src);
  *
  * Buffer will be set to empty if there is no common prefix
  */
-extern int git_buf_common_prefix(git_buf *buf, const git_strarray *strs);
+extern int git_buf_common_prefix(git_buf *buf, char *const *const strings, size_t count);
 
 /**
  * Check if a buffer begins with a UTF BOM

--- a/src/pathspec.c
+++ b/src/pathspec.c
@@ -24,7 +24,7 @@ char *git_pathspec_prefix(const git_strarray *pathspec)
 	const char *scan;
 
 	if (!pathspec || !pathspec->count ||
-		git_buf_common_prefix(&prefix, pathspec) < 0)
+		git_buf_common_prefix(&prefix, pathspec->strings, pathspec->count) < 0)
 		return NULL;
 
 	/* diff prefix will only be leading non-wildcards */

--- a/tests/core/buffer.c
+++ b/tests/core/buffer.c
@@ -632,7 +632,6 @@ void test_core_buffer__join3(void)
 void test_core_buffer__11(void)
 {
 	git_buf a = GIT_BUF_INIT;
-	git_strarray t;
 	char *t1[] = { "nothing", "in", "common" };
 	char *t2[] = { "something", "something else", "some other" };
 	char *t3[] = { "something", "some fun", "no fun" };
@@ -641,39 +640,25 @@ void test_core_buffer__11(void)
 	char *t6[] = { "no", "nope", "" };
 	char *t7[] = { "", "doesn't matter" };
 
-	t.strings = t1;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t1, 3));
 	cl_assert_equal_s(a.ptr, "");
 
-	t.strings = t2;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t2, 3));
 	cl_assert_equal_s(a.ptr, "some");
 
-	t.strings = t3;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t3, 3));
 	cl_assert_equal_s(a.ptr, "");
 
-	t.strings = t4;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t4, 3));
 	cl_assert_equal_s(a.ptr, "happ");
 
-	t.strings = t5;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t5, 3));
 	cl_assert_equal_s(a.ptr, "happ");
 
-	t.strings = t6;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t6, 3));
 	cl_assert_equal_s(a.ptr, "");
 
-	t.strings = t7;
-	t.count = 3;
-	cl_git_pass(git_buf_common_prefix(&a, &t));
+	cl_git_pass(git_buf_common_prefix(&a, t7, 3));
 	cl_assert_equal_s(a.ptr, "");
 
 	git_buf_dispose(&a);


### PR DESCRIPTION
`git_strarray` is a public-facing type.  Change
`git_buf_text_common_prefix` to not use it, and just take an array of
strings instead.