### PR TITLE
Solve compilation warning reported by MSVC related to possible loss of data

### DIFF
--- a/src/xdiff/xdiffi.c
+++ b/src/xdiff/xdiffi.c
@@ -364,7 +364,7 @@ int xdl_do_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	kvdf += xe->xdf2.nreff + 1;
 	kvdb += xe->xdf2.nreff + 1;
 
-	xenv.mxcost = xdl_bogosqrt(ndiags);
+	xenv.mxcost = xdl_bogosqrt((long)ndiags);
 	if (xenv.mxcost < XDL_MAX_COST_MIN)
 		xenv.mxcost = XDL_MAX_COST_MIN;
 	xenv.snake_cnt = XDL_SNAKE_CNT;

--- a/src/xdiff/xutils.c
+++ b/src/xdiff/xutils.c
@@ -62,14 +62,14 @@ int xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
 
 void *xdl_mmfile_first(mmfile_t *mmf, long *size)
 {
-	*size = mmf->size;
+	*size = (long)mmf->size;
 	return mmf->ptr;
 }
 
 
 long xdl_mmfile_size(mmfile_t *mmf)
 {
-	return mmf->size;
+	return (long)mmf->size;
 }
 
 
@@ -339,7 +339,7 @@ int xdl_num_out(char *out, long val) {
 		*str++ = '0';
 	*str = '\0';
 
-	return str - out;
+	return (int)(str - out);
 }
 
 int xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
@@ -377,7 +377,7 @@ int xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
 	if (func && funclen) {
 		buf[nb++] = ' ';
 		if (funclen > (long)(sizeof(buf) - nb - 1))
-			funclen = sizeof(buf) - nb - 1;
+			funclen = (long)sizeof(buf) - nb - 1;
 		memcpy(buf + nb, func, funclen);
 		nb += funclen;
 	}


### PR DESCRIPTION
Hi!

I was trying to build the library on ``MSVC`` (2019) and it was claiming about possible loss of data. This commit just adds the necessary casting to silent off this kind of annoying warning.

I chose the casting because I suppose that the use of ``int`` or ``long`` in replacement of ``size_t`` seems to be a project decision, so I kept it up.

I felt tempted to change ``int xdl_num_out()`` to ``size_t xdl_num_out()`` (since it returns the buffer size taking its delta from current position to its head), again, due to the massive use of ``long`` instead of ``size_t``, it seems to be a choice  so I just made the things clearer for the compiler not complain about.
