### PR TITLE
libgit2_clar is now libgit2_tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "(gdb) Launch",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/libgit2_clar",
+            "program": "${workspaceFolder}/build/libgit2_tests",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
       {
         "label": "Run Tests",
         "type": "shell",
-        "command": "build/libgit2_clar -v",
+        "command": "build/libgit2_tests -v",
         "group": "test",
         "presentation": {
           "reveal": "always",

--- a/README.md
+++ b/README.md
@@ -236,18 +236,18 @@ Once built, you can run the tests from the `build` directory with the command
 
 Alternatively you can run the test suite directly using,
 
-	$ ./libgit2_clar
+	$ ./libgit2_tests
 
 Invoking the test suite directly is useful because it allows you to execute
 individual tests, or groups of tests using the `-s` flag.  For example, to
 run the index tests:
 
-    $ ./libgit2_clar -sindex
+    $ ./libgit2_tests -sindex
 
 To run a single test named `index::racy::diff`, which corresponds to the test
 function [`test_index_racy__diff`](https://github.com/libgit2/libgit2/blob/main/tests/index/racy.c#L23):
 
-    $ ./libgit2_clar -sindex::racy::diff
+    $ ./libgit2_tests -sindex::racy::diff
 
 The test suite will print a `.` for every passing test, and an `F` for any
 failing test.  An `S` indicates that a test was skipped because it is not

--- a/cmake/IdeSplitSources.cmake
+++ b/cmake/IdeSplitSources.cmake
@@ -1,6 +1,6 @@
 # This function splits the sources files up into their appropriate
 # subdirectories.  This is especially useful for IDEs like Xcode and
-# Visual Studio, so that you can navigate into the libgit2_clar project,
+# Visual Studio, so that you can navigate into the libgit2_tests project,
 # and see the folders within the tests folder (instead of just seeing all
 # source and tests in a single folder.)
 FUNCTION(IDE_SPLIT_SOURCES target)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -120,15 +120,15 @@ In addition to new tests, please ensure that your changes do not cause
 any other test failures.  Running the entire test suite is helpful
 before you submit a pull request.  When you build libgit2, the test
 suite will also be built.  You can run most of the tests by simply running
-the resultant `libgit2_clar` binary.  If you want to run a specific
+the resultant `libgit2_tests` binary.  If you want to run a specific
 unit test, you can name it with the `-s` option.  For example:
 
-    libgit2_clar -sstatus::worktree::long_filenames
+    libgit2_tests -sstatus::worktree::long_filenames
 
 Or you can run an entire class of tests.  For example, to run all the
 worktree status tests:
 
-    libgit2_clar -sstatus::worktree
+    libgit2_tests -sstatus::worktree
 
 The default test run is fairly exhaustive, but it will exclude some
 unit tests by default: in particular, those that talk to network
@@ -136,7 +136,7 @@ servers and the tests that manipulate the filesystem in onerous
 ways (and may need to have special privileges to run).  To run the
 network tests:
 
-    libgit2_clar -ionline
+    libgit2_tests -ionline
 
 In addition, various tests may be enabled by environment variables,
 like the ones that write exceptionally large repositories or manipulate

--- a/fuzzers/corpora/objects/blob
+++ b/fuzzers/corpora/objects/blob
@@ -187,18 +187,18 @@ Once built, you can run the tests from the `build` directory with the command
 
 Alternatively you can run the test suite directly using,
 
-	$ ./libgit2_clar
+	$ ./libgit2_tests
 
 Invoking the test suite directly is useful because it allows you to execute
 individual tests, or groups of tests using the `-s` flag.  For example, to
 run the index tests:
 
-    $ ./libgit2_clar -sindex
+    $ ./libgit2_tests -sindex
 
 To run a single test named `index::racy::diff`, which corresponds to the test
 function (`test_index_racy__diff`)[https://github.com/libgit2/libgit2/blob/master/tests/index/racy.c#L23]:
 
-    $ ./libgit2_clar -sindex::racy::diff
+    $ ./libgit2_tests -sindex::racy::diff
 
 The test suite will print a `.` for every passing test, and an `F` for any
 failing test.  An `S` indicates that a test was skipped because it is not

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ https://github.com/vmg/clar
 
 * Test:
 
-        ./build/libgit2_clar
+        ./build/libgit2_tests
 
 * Make sure everything is fine.
 
@@ -34,8 +34,8 @@ Uses [`valgrind`](http://www.valgrind.org/):
 ```console
 $ cmake -DBUILD_TESTS=ON -DVALGRIND=ON ..
 $ cmake --build .
-$ valgrind --leak-check=full --show-reachable=yes --num-callers=50 --suppressions=../libgit2_clar.supp \
-  ./libgit2_clar
+$ valgrind --leak-check=full --show-reachable=yes --num-callers=50 --suppressions=../libgit2_tests.supp \
+  ./libgit2_tests
 ```
 
 #### macOS
@@ -44,5 +44,5 @@ Uses [`leaks`](https://developer.apple.com/library/archive/documentation/Perform
 
 ```console
 $ MallocStackLogging=1 MallocScribble=1 MallocLogFile=/dev/null CLAR_AT_EXIT="leaks -quiet \$PPID" \
-  ./libgit2_clar
+  ./libgit2_tests
 ```

--- a/tests/core/init.c
+++ b/tests/core/init.c
@@ -2,7 +2,7 @@
 
 void test_core_init__returns_count(void)
 {
-	/* libgit2_clar initializes us first, so we have an existing
+	/* libgit2_tests initializes us first, so we have an existing
 	 * initialization.
 	 */
 	cl_assert_equal_i(2, git_libgit2_init());


### PR DESCRIPTION
in #6083 the test runner was renamed to libgit2_tests,
but not all references to the old name were updated.
this change changes all of them to use the new name.
