### PR TITLE
Corrects git commit summary as described in #6065

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -563,6 +563,10 @@ const char *git_commit_summary(git_commit *commit)
 					space = msg;
 					space_contains_newline = false;
 				}
+
+                if(space_contains_newline && next_character == '\n')
+                    break;
+
 				space_contains_newline |= next_character == '\n';
 			}
 			/* the next character is non-space */

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -154,6 +154,7 @@ void test_commit_commit__summary(void)
 	assert_commit_summary(" Spaces around newlines are collapsed", "  \n  Spaces around newlines  \n  are  \n  collapsed  \n  ");
 	assert_commit_summary(" Trailing newlines are" , "  \n  Trailing newlines  \n  are  \n\n  collapsed  \n  ");
 	assert_commit_summary(" Trailing spaces are stripped", "  \n  Trailing spaces \n  are stripped \n\n  \n \t ");
+    assert_commit_summary("whitespaces between characters are ignored", "whitespaces between characters are ignored\n    \nsecond paragraph");
 	assert_commit_summary("", "");
 	assert_commit_summary("", " ");
 	assert_commit_summary("", "\n");


### PR DESCRIPTION
The issue #6065 describes a commit message by Linus that contains some white space characters between the two newlines.

This Pull Request adds a test case simulating the commit message by Linus and adds a fix to the git_commit_summary()
function.