### PR TITLE
Fix repo init when template dir is non-existent

### DIFF
--- a/src/repository.c
+++ b/src/repository.c
@@ -2038,9 +2038,8 @@ static int repo_init_structure(
 		 * `git` prints to stderr: 'warning: templates not found in /path/to/tdir'
 		 */
 		if (error < 0) {
-			if (!default_template && error != GIT_ENOTFOUND) {
+			if (!default_template && error != GIT_ENOTFOUND)
 				return error;
-			}
 
 			/* if template was default, ignore error and use internal */
 			git_error_clear();

--- a/src/repository.c
+++ b/src/repository.c
@@ -2032,9 +2032,15 @@ static int repo_init_structure(
 		git_str_dispose(&template_buf);
 		git_config_free(cfg);
 
+		/* If tdir does not exist, then do not error out. This matches the
+		 * behaviour of git(1), which just prints a warning and continues.
+		 * TODO: issue warning when warning API is available.
+		 * `git` prints to stderr: 'warning: templates not found in /path/to/tdir'
+		 */
 		if (error < 0) {
-			if (!default_template)
+			if (!default_template && error != GIT_ENOTFOUND) {
 				return error;
+			}
 
 			/* if template was default, ignore error and use internal */
 			git_error_clear();

--- a/tests/repo/template.c
+++ b/tests/repo/template.c
@@ -293,3 +293,13 @@ void test_repo_template__empty_template_path(void)
 
 	setup_repo("foo", &opts);
 }
+
+void test_repo_template__nonexistent_template_path(void)
+{
+	git_repository_init_options opts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
+
+	opts.flags = GIT_REPOSITORY_INIT_MKPATH | GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE;
+	opts.template_path = "/tmp/path/that/does/not/exist/for/libgit2/test";
+
+	setup_repo("bar", &opts);
+}


### PR DESCRIPTION
This PR changes the behaviour of libgit2 to match that of `git`. See below for details.

With a git config containing:
```ini
[init]
  templatedir = "/tmp/DoesNotExist"
```

`git init` prints a warning but still successfully initalises the git directory:
```sh
> git init -q foo
warning: templates not found in /tmp/DoesNotExist
> find foo
foo
foo/.git
foo/.git/objects
foo/.git/objects/info
foo/.git/objects/pack
foo/.git/config
foo/.git/HEAD
foo/.git/refs
foo/.git/refs/tags
foo/.git/refs/heads
```
git source for reference: https://github.com/git/git/blob/5d5b1473453400224ebb126bf3947e0a3276bdf5/builtin/init-db.c#L121-L125

However with `libgit2` this throws an error and the directory is not initialised as expected:
```c
// source code for reproducer
#include <assert.h>
#include <git2.h>
#include <stdio.h>

int main(void) {
    git_libgit2_init();
    git_repository_init_options opts;
    assert(git_repository_init_init_options(&opts, GIT_REPOSITORY_INIT_OPTIONS_VERSION) == 0);
    opts.flags = GIT_REPOSITORY_INIT_MKDIR | GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE;
    git_repository *repo;
    if (git_repository_init_ext(&repo, "foo", &opts) != 0) {
    	const git_error *err = giterr_last();
        printf("%d - %s\n", err->klass, err->message);
    }
    git_libgit2_shutdown();
    return 0;
}
```

```sh
> ./reproducer
2 - could not find '/tmp/DoesNotExist/' to stat: No such file or directory
> find foo
foo
foo/.git
```