### PR TITLE
ci: only update docs on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,4 +300,4 @@ jobs:
     - name: Push documentation branch
       working-directory: source
       run: git push origin gh-pages
-      if: github.event_name != 'pull_request' && github.repository == 'libgit2/libgit2'
+      if: github.event_name == 'push' && github.repository == 'libgit2/libgit2'


### PR DESCRIPTION
Only update the documentation on a `push`.  We were previously updating the documentation only when not in a `pull_request`, which meant that we would push documentation updates in manual build triggers.