### PR TITLE
Document that `git_odb` is thread-safe

### DIFF
--- a/docs/threading.md
+++ b/docs/threading.md
@@ -21,6 +21,9 @@ There are some objects which are read-only/immutable and are thus safe
 to share across threads, such as references and configuration
 snapshots.
 
+The `git_odb` object uses locking internally, and is thread-safe to use from
+multiple threads simultaneously.
+
 Error messages
 --------------
 


### PR DESCRIPTION
Commit 4ae41f9c639d246d34dac89c3f1d9451c9cfa8d3 made `git_odb`
race-free, and added internal locking. Update `docs/threading.md`
accordingly, so that APIs built atop libgit2 (e.g. language bindings)
can count on this.

(This appears to be true as far as I can tell, at least.)