### PR TITLE
Fix a gcc 11 warning in src/threadstate.c

### DIFF
--- a/src/threadstate.c
+++ b/src/threadstate.c
@@ -36,8 +36,8 @@ static void threadstate_dispose(git_threadstate *threadstate)
 	if (!threadstate)
 		return;
 
-    if (threadstate->error_t.message != git_str__initstr)
-        git__free(threadstate->error_t.message);
+	if (threadstate->error_t.message != git_str__initstr)
+		git__free(threadstate->error_t.message);
 	threadstate->error_t.message = NULL;
 }
 


### PR DESCRIPTION
When building under gcc 11, there is a warning about a misaligned guard clause
because there were mixed spaces and tabs:

```
[128/634] Building C object src/CMakeFiles/git2internal.dir/threadstate.c.o
../src/threadstate.c: In function ‘threadstate_dispose’:
../src/threadstate.c:39:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   39 |     if (threadstate->error_t.message != git_str__initstr)
      |     ^~
../src/threadstate.c:41:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
   41 |         threadstate->error_t.message = NULL;
      |         ^~~~~~~~~~~
../src/threadstate.c: At top level:
```

This change indents the code with tabs for consistency with the rest of the
code, which makes the warning go away.