### PR TITLE
Fix a gcc 11 warning in src/thread.h

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -180,7 +180,7 @@ GIT_INLINE(volatile void *) git_atomic__swap(
 #if defined(GIT_WIN32)
 	return InterlockedExchangePointer(ptr, newval);
 #elif defined(GIT_BUILTIN_ATOMIC)
-	void * volatile foundval = NULL;
+	void * foundval = NULL;
 	__atomic_exchange(ptr, &newval, &foundval, __ATOMIC_SEQ_CST);
 	return foundval;
 #elif defined(GIT_BUILTIN_SYNC)


### PR DESCRIPTION
When building under gcc 11, there is a warning about an incompatible pointer
type, since
[`__atomic_exchange`](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)
does not take `volatile` pointers:

```
In file included from ../src/common.h:81,
                 from ../src/transports/winhttp.c:8:
../src/thread-utils.h: In function ‘git___swap’:
../src/thread-utils.h:168:9: warning: argument 3 of ‘__atomic_exchange’ discards ‘volatile’ qualifier [-Wincompatible-pointer-types]
  168 |         __atomic_exchange(ptr, &newval, &foundval, __ATOMIC_SEQ_CST);
      |         ^~~~~~~~~~~~~~~~~
```

This change drops the `volatile` qualifier so that the pointer type matches
what `__atomic_exchange` expects.