### PR TITLE
cmake: re-enable WinHTTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ include(DefaultCFlags)
 add_subdirectory(src)
 
 if(BUILD_TESTS)
+	enable_testing()
 	add_subdirectory(tests)
 endif()
 

--- a/cmake/SelectWinHTTP.cmake
+++ b/cmake/SelectWinHTTP.cmake
@@ -1,4 +1,4 @@
-if(WIN32 AND WINHTTP)
+if(WIN32 AND USE_WINHTTP)
 	set(GIT_WINHTTP 1)
 
 	# Since MinGW does not come with headers or an import library for winhttp,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,8 +68,6 @@ function(ADD_CLAR_TEST name)
 	endif()
 endfunction(ADD_CLAR_TEST)
 
-enable_testing()
-
 add_clar_test(offline             -v -xonline)
 add_clar_test(invasive            -v -score::ftruncate -sfilter::stream::bigfile -sodb::largefiles -siterator::workdir::filesystem_gunk -srepo::init -srepo::init::at_filesystem_root)
 add_clar_test(online              -v -sonline -xonline::customcert)


### PR DESCRIPTION
Re-enable WinHTTP support when `USE_WINHTTP` is specified.

Additionally, ensure that we `enable_testing()` at the top-level CMakeLists.txt or
else we'll need to navigate within the build directory to the correct
place in the hierarchy to run `ctest`.  Now we can `ctest` at the
top-level again.