### PR TITLE
git_commit_summary: ignore lines with spaces

### DIFF
--- a/src/commit.c
+++ b/src/commit.c
@@ -546,7 +546,7 @@ const char *git_commit_message(const git_commit *commit)
 const char *git_commit_summary(git_commit *commit)
 {
 	git_str summary = GIT_STR_INIT;
-	const char *msg, *space;
+	const char *msg, *space, *next;
 	bool space_contains_newline = false;
 
 	GIT_ASSERT_ARG_WITH_RETVAL(commit, NULL);
@@ -555,10 +555,21 @@ const char *git_commit_summary(git_commit *commit)
 		for (msg = git_commit_message(commit), space = NULL; *msg; ++msg) {
 			char next_character = msg[0];
 			/* stop processing at the end of the first paragraph */
-			if (next_character == '\n' && (!msg[1] || msg[1] == '\n'))
-				break;
+			if (next_character == '\n') {
+				if (!msg[1])
+					break;
+				if (msg[1] == '\n')
+					break;
+				/* stop processing if next line contains only whitespace */
+				next = msg + 1;
+				while (*next && git__isspace_nonlf(*next)) {
+					++next;
+				}
+				if (!*next || *next == '\n') 
+					break;
+			}
 			/* record the beginning of contiguous whitespace runs */
-			else if (git__isspace(next_character)) {
+			if (git__isspace(next_character)) {
 				if(space == NULL) {
 					space = msg;
 					space_contains_newline = false;

--- a/tests/commit/commit.c
+++ b/tests/commit/commit.c
@@ -139,8 +139,11 @@ void test_commit_commit__summary(void)
 {
 	assert_commit_summary("One-liner with no trailing newline", "One-liner with no trailing newline");
 	assert_commit_summary("One-liner with trailing newline", "One-liner with trailing newline\n");
+	assert_commit_summary("One-liner with trailing newline and space", "One-liner with trailing newline and space\n ");
 	assert_commit_summary("Trimmed leading&trailing newlines", "\n\nTrimmed leading&trailing newlines\n\n");
 	assert_commit_summary("First paragraph only", "\nFirst paragraph only\n\n(There are more!)");
+	assert_commit_summary("First paragraph only with space in the next line", "\nFirst paragraph only with space in the next line\n \n(There are more!)");
+	assert_commit_summary("First paragraph only with spaces in the next line", "\nFirst paragraph only with spaces in the next line\n    \n(There are more!)");
 	assert_commit_summary("First paragraph with  unwrapped trailing\tlines", "\nFirst paragraph\nwith  unwrapped\ntrailing\tlines\n\n(Yes, unwrapped!)");
 	assert_commit_summary("\tLeading tabs", "\tLeading\n\ttabs\n\nare preserved"); /* tabs around newlines are collapsed down to a single space */
 	assert_commit_summary(" Leading Spaces", " Leading\n Spaces\n\nare preserved"); /* spaces around newlines are collapsed down to a single space */


### PR DESCRIPTION
Fixes libgit2/libgit2#6065