### PR TITLE
Draft: add blame progress callback

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ This is release v1.3.0, "Zugunruhe".  This release includes only minor new featu
 ## New Features
 * Support custom git extensions by @ethomson in https://github.com/libgit2/libgit2/pull/6031
 * Introduce `git_email_create`; deprecate `git_diff_format_email` by @ethomson in https://github.com/libgit2/libgit2/pull/6061
+* Add blame progress callback
 
 ## Deprecated APIs
 * `git_oidarray_free` is deprecated; callers should use `git_oidarray_dispose`

--- a/include/git2/blame.h
+++ b/include/git2/blame.h
@@ -77,6 +77,19 @@ typedef enum {
 } git_blame_flag_t;
 
 /**
+ * Blame progress callback.
+ *
+ * Called for each blame suspect.
+ *
+ * - 'suspect' is the id of the suspect commit.
+ *
+ * Returning a non-zero value will abort the blame.
+ */
+typedef int (*git_blame_progress_cb)(
+	const git_oid *suspect,
+	void *payload);
+
+/**
  * Blame options structure
  *
  * Initialize with `GIT_BLAME_OPTIONS_INIT`. Alternatively, you can
@@ -120,6 +133,9 @@ typedef struct git_blame_options {
 	 * The default is the last line of the file.
 	 */
 	size_t max_line;
+
+	git_blame_progress_cb progress_cb;
+	void                 *payload;
 } git_blame_options;
 
 #define GIT_BLAME_OPTIONS_VERSION 1

--- a/src/blame_git.c
+++ b/src/blame_git.c
@@ -653,6 +653,14 @@ int git_blame__like_git(git_blame *blame, uint32_t opt)
 		if (!suspect)
 			break;
 
+		/* Report progress. */
+		if (blame->options.progress_cb) {
+			int error;
+			const git_oid *id = git_commit_id(suspect->commit);
+			if ((error = blame->options.progress_cb(id, blame->options.payload)))
+				return error;
+		}
+
 		/* We'll use this suspect later in the loop, so hold on to it for now. */
 		origin_incref(suspect);
 


### PR DESCRIPTION
Add blame progress callback.


Originally created by the GitAhead creator. I would like to get it mainlined so upgrading to newer versions get easier