### PR TITLE
refs: Speed up packed lookups.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1963,3 +1963,8 @@ v0.22
   functions. This is not something which we can know to do. A
   last-resort convenience function is provided in sys/openssl.h,
   `git_openssl_set_locking()` which can be used to set the locking.
+
+* `git_reference_*()` functions use mmap() + binary search for packed
+  refs lookups when using the fs backend. Previously all entries were
+  read into a hashtable, which could be slow for repositories with a
+  large number of refs.

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -579,9 +579,8 @@ static const char *end_of_record(const char *p, const char *end)
 	while (1) {
 		size_t sz = end - p;
 		p = memchr(p, '\n', sz);
-		if (!p) {
+		if (!p)
 			return end;
-		}
 		++p;
 		if (p < end && p[0] == '^')
 			++p;

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -452,8 +452,8 @@ static int ref_error_notfound(const char *name)
 	return GIT_ENOTFOUND;
 }
 
-static const char *packed_set_peeling_mode(
-        const char *data,
+static char *packed_set_peeling_mode(
+        char *data,
         size_t data_sz,
         refdb_fs_backend *backend)
 {

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -141,7 +141,7 @@ static int packed_reload(refdb_fs_backend *backend)
 	scan = (char *)packedrefs.ptr;
 	eof  = scan + packedrefs.size;
 
-	scan = (char *)packed_set_peeling_mode(scan, packedrefs.size, backend);
+	scan = packed_set_peeling_mode(scan, packedrefs.size, backend);
 	if (!scan) {
 		goto parse_failed;
 	}

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -610,9 +610,8 @@ cmp_record_to_refname(const char *rec, size_t data_end, const char *ref_name)
 
 	cmp_val = memcmp(rec, ref_name, min(ref_len, data_end));
 
-	if (cmp_val == 0 && data_end != ref_len) {
+	if (cmp_val == 0 && data_end != ref_len)
 		return (data_end > ref_len) ? 1 : -1;
-	}
 	return cmp_val;
 }
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -479,7 +479,7 @@ static char *packed_set_peeling_mode(
 		else if (git__memmem(data, eol - data, peeled, strlen(peeled)))
 			backend->peeling_mode = PEELING_STANDARD;
 
-		backend->sorted = git__memmem(data, eol - data, sorted, strlen(sorted));
+		backend->sorted = NULL != git__memmem(data, eol - data, sorted, strlen(sorted));
 
 		return eol + 1;
 	}
@@ -683,7 +683,7 @@ static int packed_lookup(
 		return packed_unsorted_lookup(out, backend, ref_name);
 
 	left = backend->packed_refs_map.data;
-	right = data_end = backend->packed_refs_map.data +
+	right = data_end = (const char *) backend->packed_refs_map.data +
 	                   backend->packed_refs_map.len;
 
 	while (left < right && *left == '#') {

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -651,7 +651,7 @@ static int packed_lookup(
 		return packed_unsorted_lookup(out, backend, ref_name);
 
 	left = backend->packed_refs_map.data;
-	right = data_end = ((const char *)backend->packed_refs_map.data) +
+	right = data_end = backend->packed_refs_map.data +
 	                   backend->packed_refs_map.len;
 
 	while (left < right && *left == '#') {

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -556,7 +556,7 @@ static int packed_map_check(refdb_fs_backend *backend)
 static const char *start_of_record(const char *buf, const char *p)
 {
 	const char *nl = p;
-	while (1) {
+	while (true) {
 		nl = git__memrchr(buf, '\n', nl - buf);
 		if (!nl)
 			return buf;

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -500,9 +500,8 @@ static int packed_map_check(refdb_fs_backend *backend)
 	git_file fd = -1;
 	struct stat st;
 
-	if ((error = git_mutex_lock(&backend->prlock)) < 0) {
+	if ((error = git_mutex_lock(&backend->prlock)) < 0)
 		return error;
-	}
 
 	if (backend->packed_refs_map.data) {
 		git_mutex_unlock(&backend->prlock);

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -71,7 +71,7 @@ typedef struct refdb_fs_backend {
 } refdb_fs_backend;
 
 static int refdb_reflog_fs__delete(git_refdb_backend *_backend, const char *name);
-static const char * packed_set_peeling_mode(const char *data, size_t data_sz, refdb_fs_backend *backend);
+static char *packed_set_peeling_mode(char *data, size_t data_sz, refdb_fs_backend *backend);
 
 GIT_INLINE(int) loose_path(
 	git_str *out,

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -460,10 +460,6 @@ static char *packed_set_peeling_mode(
 	char *eol;
 	backend->peeling_mode = PEELING_NONE;
 
-	if (data_sz == 0 || *data != '#') {
-		return data;
-	}
-
 	if (git__prefixncmp(data, data_sz, traits_header) == 0) {
 		size_t hdr_sz = strlen(traits_header);
 		const char *sorted = " sorted ";

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -142,9 +142,8 @@ static int packed_reload(refdb_fs_backend *backend)
 	eof  = scan + packedrefs.size;
 
 	scan = packed_set_peeling_mode(scan, packedrefs.size, backend);
-	if (!scan) {
+	if (!scan)
 		goto parse_failed;
-	}
 
 	while (scan < eof && *scan == '#') {
 		if (!(eol = strchr(scan, '\n')))

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -654,9 +654,8 @@ static int packed_lookup(
 	if ((error = packed_map_check(backend)) < 0)
 		return error;
 
-	if (!backend->sorted) {
+	if (!backend->sorted)
 		return packed_unsorted_lookup(out, backend, ref_name);
-	}
 
 	left = backend->packed_refs_map.data;
 	right = data_end = ((const char *)backend->packed_refs_map.data) +

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -477,11 +477,10 @@ static char *packed_set_peeling_mode(
 		if (!eol)
 			return NULL;
 
-		if (git__memmem(data, eol - data, fully_peeled, strlen(fully_peeled))) {
+		if (git__memmem(data, eol - data, fully_peeled, strlen(fully_peeled)))
 			backend->peeling_mode = PEELING_FULL;
-		} else if (git__memmem(data, eol - data, peeled, strlen(peeled))) {
+		else if (git__memmem(data, eol - data, peeled, strlen(peeled)))
 			backend->peeling_mode = PEELING_STANDARD;
-		}
 
 		backend->sorted = git__memmem(data, eol - data, sorted, strlen(sorted));
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -605,9 +605,8 @@ cmp_record_to_refname(const char *rec, size_t data_end, const char *ref_name)
 	data_end -= GIT_OID_HEXSZ + 1;
 
 	end = memchr(rec, '\n', data_end);
-	if (end) {
+	if (end)
 		data_end = end - rec;
-	}
 
 	cmp_val = memcmp(rec, ref_name, min(ref_len, data_end));
 

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -138,7 +138,7 @@ static int packed_reload(refdb_fs_backend *backend)
 
 	GIT_UNUSED(git_sortedcache_clear(backend->refcache, false));
 
-	scan = (char *)packedrefs.ptr;
+	scan = packedrefs.ptr;
 	eof  = scan + packedrefs.size;
 
 	scan = packed_set_peeling_mode(scan, packedrefs.size, backend);

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -457,7 +457,7 @@ static char *packed_set_peeling_mode(
         refdb_fs_backend *backend)
 {
 	static const char *traits_header = "# pack-refs with:";
-	const char *eol;
+	char *eol;
 	backend->peeling_mode = PEELING_NONE;
 
 	if (data_sz == 0 || *data != '#') {

--- a/src/refdb_fs.c
+++ b/src/refdb_fs.c
@@ -483,11 +483,7 @@ static char *packed_set_peeling_mode(
 			backend->peeling_mode = PEELING_STANDARD;
 		}
 
-		if (git__memmem(data, eol - data, sorted, strlen(sorted))) {
-			backend->sorted = true;
-		} else {
-			backend->sorted = false;
-		}
+		backend->sorted = git__memmem(data, eol - data, sorted, strlen(sorted));
 
 		return eol + 1;
 	}

--- a/tests/refs/crashes.c
+++ b/tests/refs/crashes.c
@@ -1,4 +1,5 @@
 #include "clar_libgit2.h"
+#include "refs.h"
 
 void test_refs_crashes__double_free(void)
 {
@@ -17,4 +18,27 @@ void test_refs_crashes__double_free(void)
 	cl_git_fail(git_reference_lookup(&ref2, repo, REFNAME));
 
 	cl_git_sandbox_cleanup();
+}
+
+void test_refs_crashes__empty_packedrefs(void)
+{
+	git_repository *repo;
+	git_reference *ref;
+	const char *REFNAME = "refs/heads/xxx";
+	git_str temp_path = GIT_STR_INIT;
+	int fd = 0;
+
+	repo = cl_git_sandbox_init("empty_bare.git");
+
+	/* create zero-length packed-refs file */
+	cl_git_pass(git_str_joinpath(&temp_path, git_repository_path(repo), GIT_PACKEDREFS_FILE));
+	cl_git_pass(((fd = p_creat(temp_path.ptr, 0644)) < 0));
+	cl_git_pass(p_close(fd));
+
+	/* should fail gracefully */
+	cl_git_fail_with(
+	        GIT_ENOTFOUND, git_reference_lookup(&ref, repo, REFNAME));
+
+	cl_git_sandbox_cleanup();
+	git_str_dispose(&temp_path);
 }

--- a/tests/resources/peeled.git/packed-refs
+++ b/tests/resources/peeled.git/packed-refs
@@ -1,4 +1,4 @@
-# pack-refs with: peeled fully-peeled 
+# pack-refs with: peeled fully-peeled sorted 
 c2596aa0151888587ec5c0187f261e63412d9e11 refs/foo/tag-outside-tags
 ^0df1a5865c8abfc09f1f2182e6a31be550e99f07
 0df1a5865c8abfc09f1f2182e6a31be550e99f07 refs/heads/master

--- a/tests/resources/testrepo.git/packed-refs
+++ b/tests/resources/testrepo.git/packed-refs
@@ -1,3 +1,3 @@
-# pack-refs with: peeled 
+# pack-refs with: peeled sorted 
 41bc8c69075bbdb46c5c6f0566cc8cc5b46e8bd9 refs/heads/packed
 5b5b025afb0b4c913b4c338a42934a3863bf3644 refs/heads/packed-test

--- a/tests/resources/testrepo/.gitted/packed-refs
+++ b/tests/resources/testrepo/.gitted/packed-refs
@@ -1,4 +1,4 @@
-# pack-refs with: peeled 
+# pack-refs with: peeled sorted 
 41bc8c69075bbdb46c5c6f0566cc8cc5b46e8bd9 refs/heads/packed
 5b5b025afb0b4c913b4c338a42934a3863bf3644 refs/heads/packed-test
 b25fa35b38051e4ae45d4222e795f9df2e43f1d1 refs/tags/packed-tag

--- a/tests/resources/testrepo2/.gitted/packed-refs
+++ b/tests/resources/testrepo2/.gitted/packed-refs
@@ -1,4 +1,4 @@
-# pack-refs with: peeled fully-peeled 
+# pack-refs with: peeled fully-peeled sorted 
 36060c58702ed4c2a40832c51758d5344201d89a refs/remotes/origin/master
 41bc8c69075bbdb46c5c6f0566cc8cc5b46e8bd9 refs/remotes/origin/packed
 5b5b025afb0b4c913b4c338a42934a3863bf3644 refs/tags/v0.9


### PR DESCRIPTION
Currently ref lookups require loading the entire packed-refs file into
a hashmap in memory. For repos with large numbers of refs this can be
painfully slow.

This patch replaces the existing lookup code and instead mmap()'s the
packed-refs file and performs a binary search to locate the ref entry.
Git uses a similar approach.

The old hash table codepath is still used for unsorted packed-refs files.
A number of the test fixture repos were updated with the `sorted` trait so
that this new path is properly exercised.

This patch also fixes a minor bug where the "peeled" trait is never
parsed correctly.