### PR TITLE
added flag to disable mmap

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -162,6 +162,9 @@ typedef enum {
 	 */
 	GIT_DIFF_SHOW_UNMODIFIED = (1u << 26),
 
+	/* Disable mmap in patches generated from this diff.*/
+	GIT_DIFF_DISABLE_MMAP = (1u << 27),
+
 	/** Use the "patience diff" algorithm */
 	GIT_DIFF_PATIENCE = (1u << 28),
 	/** Take extra time to find minimal diff */

--- a/src/diff_file.c
+++ b/src/diff_file.c
@@ -348,7 +348,7 @@ static int diff_file_content_load_workdir_file(
 		goto cleanup;
 
 	/* if there are no filters, try to mmap the file */
-	if (fl == NULL) {
+	if ((diff_opts->flags & GIT_DIFF_DISABLE_MMAP) == 0 && fl == NULL) {
 		if (!(error = git_futils_mmap_ro(
 				&fc->map, fd, 0, (size_t)fc->file->size))) {
 			fc->flags |= GIT_DIFF_FLAG__UNMAP_DATA;

--- a/src/diff_tform.c
+++ b/src/diff_tform.c
@@ -190,6 +190,9 @@ int git_diff__merge(
 			git_pool_strdup_safe(&onto->pool, onto->opts.new_prefix);
 	}
 
+	if ((from->opts.flags & GIT_DIFF_DISABLE_MMAP) != 0)
+		onto->opts.flags |= GIT_DIFF_DISABLE_MMAP;
+
 	git_vector_free_deep(&onto_new);
 	git_pool_clear(&onto_pool);
 


### PR DESCRIPTION
This was originally created for the GitAhead GUI. Maybe it is done for performance reasons.