### PR TITLE
work around failure to fetch annotated tags added to existing commits

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -29,7 +29,7 @@ static int maybe_want(git_remote *remote, git_remote_head *head, git_odb *odb, g
 	if (!valid)
 		return 0;
 
-	if (tagopt == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {
+	if (tagopt != GIT_REMOTE_DOWNLOAD_TAGS_NONE) {
 		/*
 		 * If tagopt is --tags, always request tags
 		 * in addition to the remote's refspecs


### PR DESCRIPTION
I'm not sure what the reason for is. Maybe the scenario is:
1) tag added to commit
2) tag added to other commit on upstream
3) fetch

It comes originally from GitAhead but I would like to get it mainlined.