### PR TITLE
blob: identify binary content

### DIFF
--- a/include/git2/blob.h
+++ b/include/git2/blob.h
@@ -285,6 +285,18 @@ GIT_EXTERN(int) git_blob_create_from_buffer(
 GIT_EXTERN(int) git_blob_is_binary(const git_blob *blob);
 
 /**
+ * Determine if the given content is most certainly binary or not;
+ * this is the same mechanism used by `git_blob_is_binary` but only
+ * looking at raw data.
+ *
+ * @param data The blob data which content should be analyzed
+ * @param len The length of the data
+ * @return 1 if the content of the blob is detected
+ * as binary; 0 otherwise.
+ */
+GIT_EXTERN(int) git_blob_data_is_binary(const char *data, size_t len);
+
+/**
  * Create an in-memory copy of a blob. The copy must be explicitly
  * free'd or it will leak.
  *

--- a/src/blob.c
+++ b/src/blob.c
@@ -404,6 +404,15 @@ int git_blob_is_binary(const git_blob *blob)
 	return git_str_is_binary(&content);
 }
 
+int git_blob_data_is_binary(const char *str, size_t len)
+{
+	git_str content = GIT_STR_INIT;
+
+	git_str_attach_notowned(&content, str, len);
+
+	return git_str_is_binary(&content);
+}
+
 int git_blob_filter_options_init(
 	git_blob_filter_options *opts,
 	unsigned int version)

--- a/tests/diff/blob.c
+++ b/tests/diff/blob.c
@@ -604,10 +604,26 @@ void test_diff_blob__can_correctly_detect_a_binary_blob_as_binary(void)
 	cl_assert_equal_i(true, git_blob_is_binary(alien));
 }
 
+void test_diff_blob__can_correctly_detect_binary_blob_data_as_binary(void)
+{
+	/* alien.png */
+	const char *content = git_blob_rawcontent(alien);
+	size_t len = (size_t)git_blob_rawsize(alien);
+	cl_assert_equal_i(true, git_blob_data_is_binary(content, len));
+}
+
 void test_diff_blob__can_correctly_detect_a_textual_blob_as_non_binary(void)
 {
 	/* tests/resources/attr/root_test4.txt */
 	cl_assert_equal_i(false, git_blob_is_binary(d));
+}
+
+void test_diff_blob__can_correctly_detect_textual_blob_data_as_non_binary(void)
+{
+	/* tests/resources/attr/root_test4.txt */
+	const char *content = git_blob_rawcontent(d);
+	size_t len = (size_t)git_blob_rawsize(d);
+	cl_assert_equal_i(false, git_blob_data_is_binary(content, len));
 }
 
 /*


### PR DESCRIPTION
Introduce `git_blob_data_is_binary` to examine a blob's data, instead of the blob itself.  A replacement for `git_buf_is_binary`.