### PR TITLE
Win32 findfile fixes: Add support for Git for Windows 2 and other git.exe installations

### DIFF
--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -93,7 +93,7 @@ static int win32_find_git_in_path(git_str *buf, const wchar_t *gitexe, const wch
 			continue;
 		wcscpy(&root.path[root.len], gitexe);
 
-		if (_waccess(root.path, F_OK) == 0 && root.len > 5) {
+		if (_waccess(root.path, F_OK) == 0 && root.len > 5 && (root.len - 4 + wcslen(subdir) < MAX_PATH)) {
 			/* replace "bin\\" or "cmd\\" with subdir */
 			wcscpy(&root.path[root.len - 4], subdir);
 

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -191,6 +191,12 @@ int git_win32__find_system_dirs(git_str *out, const wchar_t *subdir)
 			&buf, HKEY_CURRENT_USER, REG_MSYSGIT_INSTALL_LOCAL, subdir) && buf.size)
 		git_str_join(out, GIT_PATH_LIST_SEPARATOR, out->ptr, buf.ptr);
 
+#ifdef GIT_ARCH_64
+	if (!win32_find_git_in_registry(
+			&buf, HKEY_LOCAL_MACHINE, REG_MSYSGIT_INSTALL_LOCAL, subdir) && buf.size)
+		git_str_join(out, GIT_PATH_LIST_SEPARATOR, out->ptr, buf.ptr);
+#endif
+
 	if (!win32_find_git_in_registry(
 			&buf, HKEY_LOCAL_MACHINE, REG_MSYSGIT_INSTALL, subdir) && buf.size)
 		git_str_join(out, GIT_PATH_LIST_SEPARATOR, out->ptr, buf.ptr);

--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -93,9 +93,17 @@ static int win32_find_git_in_path(git_str *buf, const wchar_t *gitexe, const wch
 			continue;
 		wcscpy(&root.path[root.len], gitexe);
 
-		if (_waccess(root.path, F_OK) == 0 && root.len > 5 && (root.len - 4 + wcslen(subdir) < MAX_PATH)) {
-			/* replace "bin\\" or "cmd\\" with subdir */
-			wcscpy(&root.path[root.len - 4], subdir);
+		if (!_waccess(root.path, F_OK)) {
+			/* replace "bin\\" or "cmd\\" of a Git for Windows installation with subdir OR append path */
+			if ((root.len > 5 && wcscmp(root.path - 4, L"cmd\\")) || wcscmp(root.path - 4, L"bin\\")) {
+				if (root.len - 4 + wcslen(subdir) >= MAX_PATH)
+					continue;
+				wcscpy(&root.path[root.len - 4], subdir);
+			} else {
+				if (root.len + wcslen(subdir) >= MAX_PATH)
+					continue;
+				wcscat(root.path, subdir);
+			}
 
 			win32_path_to_8(buf, root.path);
 			return 0;


### PR DESCRIPTION
Resurrecting #5150
Updated #5773

In-between the initial PR and now there have been several changes to Git for Windows >= 2:
* up to 2.24 an architecture specific subfolder was necessary for the etc and usr folders
* starting from 2.24 the etc folder is located directly in the installation folder but the usr folder is still in an architecture specific subfolder