### PR TITLE
mktmp: use fchmod for changing mode

### DIFF
--- a/src/futils.c
+++ b/src/futils.c
@@ -26,7 +26,7 @@ int git_futils_mkpath2file(const char *file_path, const mode_t mode)
 
 int git_futils_mktmp(git_str *path_out, const char *filename, mode_t mode)
 {
-	int fd;
+	int fd, r;
 	mode_t mask;
 
 	p_umask(mask = p_umask(0));
@@ -43,7 +43,12 @@ int git_futils_mktmp(git_str *path_out, const char *filename, mode_t mode)
 		return -1;
 	}
 
-	if (p_chmod(path_out->ptr, (mode & ~mask))) {
+#ifdef GIT_WIN32
+	r = p_chmod(path_out->ptr, (mode & ~mask));
+#else
+	r = p_fchmod(fd, (mode & ~mask));
+#endif
+	if (r != 0) {
 		git_error_set(GIT_ERROR_OS,
 			"failed to set permissions on file '%s'", path_out->ptr);
 		return -1;

--- a/src/unix/posix.h
+++ b/src/unix/posix.h
@@ -73,8 +73,10 @@ GIT_INLINE(int) p_fsync(int fd)
  */
 #ifdef __ANDROID__
 # define p_chmod(p,m) 0
+# define p_fchmod(fd,m) 0
 #else
 # define p_chmod(p,m) chmod(p, m)
+# define p_fchmod(fd,m) fchmod(fd, m)
 #endif
 
 /* see win32/posix.h for explanation about why this exists */


### PR DESCRIPTION
Using fchmod in cases where we have a filehandle allows PosixLib to work around the issue with being unable to change mode on open files on AmigaOS.
It also seems to me like it would be the better option for other systems too.
Unfortunately it seems like Windows doesn't have a direct equivalent?
