### PR TITLE
futils_mktmp: don't use umask

### DIFF
--- a/src/posix.h
+++ b/src/posix.h
@@ -9,6 +9,7 @@
 
 #include "common.h"
 
+#include <stdlib.h>
 #include <fcntl.h>
 #include <time.h>
 
@@ -130,6 +131,7 @@ extern ssize_t p_pwrite(int fd, const void *data, size_t size, off64_t offset);
 
 #define p_close(fd) close(fd)
 #define p_umask(m) umask(m)
+#define p_mktemp(p) mktemp(p)
 
 extern int p_open(const char *path, int flags, ...);
 extern int p_creat(const char *path, mode_t mode);

--- a/tests/core/futils.c
+++ b/tests/core/futils.c
@@ -87,3 +87,29 @@ void test_core_futils__recursive_rmdir_keeps_symlink_targets(void)
 	cl_must_pass(p_rmdir("dir-target"));
 	cl_must_pass(p_unlink("file-target"));
 }
+
+void test_core_futils__mktmp_umask(void)
+{
+#ifdef GIT_WIN32
+	cl_skip();
+#else
+	git_str path = GIT_STR_INIT;
+	struct stat st;
+	int fd;
+
+	umask(0);
+	cl_assert((fd = git_futils_mktmp(&path, "foo", 0777)) >= 0);
+	cl_must_pass(p_fstat(fd, &st));
+	cl_assert_equal_i(st.st_mode & 0777, 0777);
+	cl_must_pass(p_unlink(path.ptr));
+	close(fd);
+
+	umask(077);
+	cl_assert((fd = git_futils_mktmp(&path, "foo", 0777)) >= 0);
+	cl_must_pass(p_fstat(fd, &st));
+	cl_assert_equal_i(st.st_mode & 0777, 0700);
+	cl_must_pass(p_unlink(path.ptr));
+	close(fd);
+	git_str_dispose(&path);
+#endif
+}


### PR DESCRIPTION
Modification of  #5350 with ~~tempnam()~~ mktemp() since tempnam() isn't supported on the macos and windows builds.

For some reason the test doesn't fail when used on its own. Maybe something have changed since then?

~~[The Open Group Base Specifications Issue 7](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tempnam.html) marks tempnam() as obsolescent and states that "The tempnam() function may be removed in a future version."
It also limits the prefix to 5 bytes so appending "\_git2\_" to the prefix is a bit pointless.~~
