### PR TITLE
cmake: disable some gnu extensions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(git2internal OBJECT)
 set_target_properties(git2internal PROPERTIES C_STANDARD 90)
+set_target_properties(git2internal PROPERTIES C_EXTENSIONS OFF)
 
 
 if(DEPRECATE_HARD)

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -521,7 +521,6 @@ int git_smart__download_pack(
 	int error = 0;
 	struct network_packetsize_payload npp = {0};
 
-	// TODO
 	git_indexer_progress_cb progress_cb = t->connect_opts.callbacks.transfer_progress;
 	void *progress_payload = t->connect_opts.callbacks.payload;
 


### PR DESCRIPTION
Setting `C_EXTENSIONS` to `OFF` turns off some extensions and will catch the C++ comments. Probably some more things, but nothing that we currently use.

Since it is on the git2internal target it won't apply do deps/
I guess anything in deps is currently compiled with whatever `CMAKE_C_STANDARD` and `CMAKE_C_EXTENSIONS` defaults to.

A side point here is that we should probably set `C_STANDARD` to `99` when building for release.
Otherwise `__STDC_VERSION__` wont be set to `199901` and we need to rely on rely on "hacky" `__GNUC__` checks to get flexible arrays and inline to work.
C90 is still nice for syntax checking.