### PR TITLE
SHA256: early preparation

### DIFF
--- a/examples/index-pack.c
+++ b/examples/index-pack.c
@@ -17,7 +17,6 @@ int lg2_index_pack(git_repository *repo, int argc, char **argv)
 	git_indexer *idx;
 	git_indexer_progress stats = {0, 0};
 	int error;
-	char hash[GIT_OID_HEXSZ + 1] = {0};
 	int fd;
 	ssize_t read_bytes;
 	char buf[512];
@@ -61,8 +60,7 @@ int lg2_index_pack(git_repository *repo, int argc, char **argv)
 
 	printf("\rIndexing %u of %u\n", stats.indexed_objects, stats.total_objects);
 
-	git_oid_fmt(hash, git_indexer_hash(idx));
-	puts(hash);
+	puts(git_indexer_name(idx));
 
  cleanup:
 	close(fd);

--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -101,13 +101,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if (git_indexer_commit(indexer, &stats) < 0)
 		goto cleanup;
 
-	if (git_str_printf(&path, "pack-%s.idx", git_oid_tostr_s(git_indexer_hash(indexer))) < 0)
+	if (git_str_printf(&path, "pack-%s.idx", git_indexer_name(indexer)) < 0)
 		goto cleanup;
 	p_unlink(git_str_cstr(&path));
 
 	git_str_clear(&path);
 
-	if (git_str_printf(&path, "pack-%s.pack", git_oid_tostr_s(git_indexer_hash(indexer))) < 0)
+	if (git_str_printf(&path, "pack-%s.pack", git_indexer_name(indexer)) < 0)
 		goto cleanup;
 	p_unlink(git_str_cstr(&path));
 

--- a/include/git2/index.h
+++ b/include/git2/index.h
@@ -296,6 +296,7 @@ GIT_EXTERN(int) git_index_write(git_index *index);
  */
 GIT_EXTERN(const char *) git_index_path(const git_index *index);
 
+#ifndef GIT_DEPRECATE_HARD
 /**
  * Get the checksum of the index
  *
@@ -303,10 +304,12 @@ GIT_EXTERN(const char *) git_index_path(const git_index *index);
  * last 20 bytes which are the checksum itself). In cases where the
  * index does not exist on-disk, it will be zeroed out.
  *
+ * @deprecated this function is deprecated with no replacement
  * @param index an existing index object
  * @return a pointer to the checksum of the index
  */
 GIT_EXTERN(const git_oid *) git_index_checksum(git_index *index);
+#endif
 
 /**
  * Read a tree into the index file with stats

--- a/include/git2/indexer.h
+++ b/include/git2/indexer.h
@@ -129,16 +129,30 @@ GIT_EXTERN(int) git_indexer_append(git_indexer *idx, const void *data, size_t si
  */
 GIT_EXTERN(int) git_indexer_commit(git_indexer *idx, git_indexer_progress *stats);
 
+#ifndef GIT_DEPRECATE_HARD
 /**
  * Get the packfile's hash
  *
  * A packfile's name is derived from the sorted hashing of all object
  * names. This is only correct after the index has been finalized.
  *
+ * @deprecated use git_indexer_name
  * @param idx the indexer instance
  * @return the packfile's hash
  */
 GIT_EXTERN(const git_oid *) git_indexer_hash(const git_indexer *idx);
+#endif
+
+/**
+ * Get the unique name for the resulting packfile.
+ *
+ * The packfile's name is derived from the packfile's content.
+ * This is only correct after the index has been finalized.
+ *
+ * @param idx the indexer instance
+ * @return a NUL terminated string for the packfile name
+ */
+GIT_EXTERN(const char *) git_indexer_name(const git_indexer *idx);
 
 /**
  * Free the indexer and its resources

--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -170,16 +170,30 @@ GIT_EXTERN(int) git_packbuilder_write(
 	git_indexer_progress_cb progress_cb,
 	void *progress_cb_payload);
 
+#ifndef GIT_DEPRECATE_HARD
 /**
-* Get the packfile's hash
-*
-* A packfile's name is derived from the sorted hashing of all object
-* names. This is only correct after the packfile has been written.
-*
-* @param pb The packbuilder object
+ * Get the packfile's hash
+ *
+ * A packfile's name is derived from the sorted hashing of all object
+ * names. This is only correct after the packfile has been written.
+ *
+ * @deprecated use git_packbuilder_name
+ * @param pb The packbuilder object
  * @return 0 or an error code
-*/
+ */
 GIT_EXTERN(const git_oid *) git_packbuilder_hash(git_packbuilder *pb);
+#endif
+
+/**
+ * Get the unique name for the resulting packfile.
+ *
+ * The packfile's name is derived from the packfile's content.
+ * This is only correct after the packfile has been written.
+ *
+ * @param pb the packbuilder instance
+ * @return a NUL terminated string for the packfile name
+ */
+GIT_EXTERN(const char *) git_packbuilder_name(git_packbuilder *pb);
 
 /**
  * Callback used to iterate over packed objects

--- a/src/branch.c
+++ b/src/branch.c
@@ -123,7 +123,10 @@ int git_branch_create(
 	const git_commit *commit,
 	int force)
 {
-	return create_branch(ref_out, repository, branch_name, commit, git_oid_tostr_s(git_commit_id(commit)), force);
+	char commit_id[GIT_OID_HEXSZ + 1];
+
+	git_oid_tostr(commit_id, GIT_OID_HEXSZ + 1, git_commit_id(commit));
+	return create_branch(ref_out, repository, branch_name, commit, commit_id, force);
 }
 
 int git_branch_create_from_annotated(

--- a/src/commit_graph.h
+++ b/src/commit_graph.h
@@ -15,6 +15,8 @@
 
 #include "map.h"
 #include "vector.h"
+#include "oid.h"
+#include "hash.h"
 
 /**
  * A commit-graph file.
@@ -55,7 +57,7 @@ typedef struct git_commit_graph_file {
 	size_t num_extra_edge_list;
 
 	/* The trailer of the file. Contains the SHA1-checksum of the whole file. */
-	git_oid checksum;
+	unsigned char checksum[GIT_HASH_SHA1_SIZE];
 } git_commit_graph_file;
 
 /**

--- a/src/hash.c
+++ b/src/hash.c
@@ -124,3 +124,19 @@ done:
 
 	return error;
 }
+
+int git_hash_fmt(char *out, unsigned char *hash, size_t hash_len)
+{
+	static char hex[] = "0123456789abcdef";
+	char *str = out;
+	size_t i;
+
+	for (i = 0; i < hash_len; i++) {
+		*str++ = hex[hash[i] >> 4];
+		*str++ = hex[hash[i] & 0x0f];
+	}
+
+	*str++ = '\0';
+
+	return 0;
+}

--- a/src/hash.h
+++ b/src/hash.h
@@ -41,4 +41,6 @@ int git_hash_final(unsigned char *out, git_hash_ctx *c);
 int git_hash_buf(unsigned char *out, const void *data, size_t len, git_hash_algorithm_t algorithm);
 int git_hash_vec(unsigned char *out, git_str_vec *vec, size_t n, git_hash_algorithm_t algorithm);
 
+int git_hash_fmt(char *out, unsigned char *hash, size_t hash_len);
+
 #endif

--- a/src/index.h
+++ b/src/index.h
@@ -27,7 +27,7 @@ struct git_index {
 
 	char *index_file_path;
 	git_futils_filestamp stamp;
-	git_oid checksum;   /* checksum at the end of the file */
+	unsigned char checksum[GIT_HASH_SHA1_SIZE];
 
 	git_vector entries;
 	git_idxmap *entries_map;
@@ -133,10 +133,13 @@ extern unsigned int git_index__create_mode(unsigned int mode);
 
 GIT_INLINE(const git_futils_filestamp *) git_index__filestamp(git_index *index)
 {
-   return &index->stamp;
+	return &index->stamp;
 }
 
-extern int git_index__changed_relative_to(git_index *index, const git_oid *checksum);
+GIT_INLINE(unsigned char *) git_index__checksum(git_index *index)
+{
+	return index->checksum;
+}
 
 /* Copy the current entries vector *and* increment the index refcount.
  * Call `git_index__release_snapshot` when done.

--- a/src/midx.h
+++ b/src/midx.h
@@ -51,7 +51,7 @@ typedef struct git_midx_file {
 	size_t num_object_large_offsets;
 
 	/* The trailer of the file. Contains the SHA1-checksum of the whole file. */
-	git_oid checksum;
+	unsigned char checksum[GIT_HASH_SHA1_SIZE];
 
 	/* something like ".git/objects/pack/multi-pack-index". */
 	git_str filename;

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1422,7 +1422,12 @@ int git_packbuilder_write(
 	if ((error = git_indexer_commit(indexer, &stats)) < 0)
 		goto cleanup;
 
+#ifndef GIT_DEPRECATE_HARD
 	git_oid_cpy(&pb->pack_oid, git_indexer_hash(indexer));
+#endif
+
+	pb->pack_name = git__strdup(git_indexer_name(indexer));
+	GIT_ERROR_CHECK_ALLOC(pb->pack_name);
 
 cleanup:
 	git_indexer_free(indexer);
@@ -1432,9 +1437,16 @@ cleanup:
 
 #undef PREPARE_PACK
 
+#ifndef GIT_DEPRECATE_HARD
 const git_oid *git_packbuilder_hash(git_packbuilder *pb)
 {
 	return &pb->pack_oid;
+}
+#endif
+
+const char *git_packbuilder_name(git_packbuilder *pb)
+{
+	return pb->pack_name;
 }
 
 
@@ -1802,6 +1814,8 @@ void git_packbuilder_free(git_packbuilder *pb)
 
 	git_hash_ctx_cleanup(&pb->ctx);
 	git_zstream_free(&pb->zstream);
+
+	git__free(pb->pack_name);
 
 	git__free(pb);
 }

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -73,7 +73,10 @@ struct git_packbuilder {
 	git_oidmap *walk_objects;
 	git_pool object_pool;
 
+#ifndef GIT_DEPRECATE_HARD
 	git_oid pack_oid; /* hash of written pack */
+#endif
+	char *pack_name; /* name of written pack */
 
 	/* synchronization objects */
 	git_mutex cache_mutex;

--- a/src/reset.c
+++ b/src/reset.c
@@ -188,7 +188,10 @@ int git_reset(
 	git_reset_t reset_type,
 	const git_checkout_options *checkout_opts)
 {
-	return reset(repo, target, git_oid_tostr_s(git_object_id(target)), reset_type, checkout_opts);
+	char to[GIT_OID_HEXSZ + 1];
+
+	git_oid_tostr(to, GIT_OID_HEXSZ + 1, git_object_id(target));
+	return reset(repo, target, to, reset_type, checkout_opts);
 }
 
 int git_reset_from_annotated(

--- a/tests/checkout/crlf.c
+++ b/tests/checkout/crlf.c
@@ -239,10 +239,10 @@ void test_checkout_crlf__autocrlf_false_index_size_is_unfiltered_size(void)
 
 	cl_repo_set_bool(g_repo, "core.autocrlf", false);
 
-	git_repository_index(&index, g_repo);
+	cl_git_pass(git_repository_index(&index, g_repo));
 	tick_index(index);
 
-	git_checkout_head(g_repo, &opts);
+	cl_git_pass(git_checkout_head(g_repo, &opts));
 
 	cl_assert((entry = git_index_get_bypath(index, "all-lf", 0)) != NULL);
 	cl_assert(entry->file_size == strlen(ALL_LF_TEXT_RAW));

--- a/tests/graph/commitgraph.c
+++ b/tests/graph/commitgraph.c
@@ -6,7 +6,7 @@
 #include "commit_graph.h"
 #include "futils.h"
 
-void test_graph_commit_graph__parse(void)
+void test_graph_commitgraph__parse(void)
 {
 	git_repository *repo;
 	struct git_commit_graph_file *file;
@@ -50,7 +50,7 @@ void test_graph_commit_graph__parse(void)
 	git_str_dispose(&commit_graph_path);
 }
 
-void test_graph_commit_graph__parse_octopus_merge(void)
+void test_graph_commitgraph__parse_octopus_merge(void)
 {
 	git_repository *repo;
 	struct git_commit_graph_file *file;
@@ -91,7 +91,7 @@ void test_graph_commit_graph__parse_octopus_merge(void)
 	git_str_dispose(&commit_graph_path);
 }
 
-void test_graph_commit_graph__writer(void)
+void test_graph_commitgraph__writer(void)
 {
 	git_repository *repo;
 	git_commit_graph_writer *w = NULL;

--- a/tests/pack/indexer.c
+++ b/tests/pack/indexer.c
@@ -169,8 +169,7 @@ void test_pack_indexer__fix_thin(void)
 	cl_assert_equal_i(stats.indexed_objects, 2);
 	cl_assert_equal_i(stats.local_objects, 1);
 
-	git_oid_fromstr(&should_id, "fefdb2d740a3a6b6c03a0c7d6ce431c6d5810e13");
-	cl_assert_equal_oid(&should_id, git_indexer_hash(idx));
+	cl_assert_equal_s("fefdb2d740a3a6b6c03a0c7d6ce431c6d5810e13", git_indexer_name(idx));
 
 	git_indexer_free(idx);
 	git_odb_free(odb);

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -138,16 +138,12 @@ void test_pack_packbuilder__create_pack(void)
 	cl_assert_equal_s(hex, "5d410bdf97cf896f9007681b92868471d636954b");
 }
 
-void test_pack_packbuilder__get_hash(void)
+void test_pack_packbuilder__get_name(void)
 {
-	char hex[GIT_OID_HEXSZ+1]; hex[GIT_OID_HEXSZ] = '\0';
-
 	seed_packbuilder();
 
 	cl_git_pass(git_packbuilder_write(_packbuilder, ".", 0, NULL, NULL));
-	git_oid_fmt(hex, git_packbuilder_hash(_packbuilder));
-
-	cl_assert_equal_s(hex, "7f5fa362c664d68ba7221259be1cbd187434b2f0");
+	cl_assert_equal_s("7f5fa362c664d68ba7221259be1cbd187434b2f0", git_packbuilder_name(_packbuilder));
 }
 
 void test_pack_packbuilder__write_default_path(void)

--- a/tests/pack/packbuilder.c
+++ b/tests/pack/packbuilder.c
@@ -5,6 +5,7 @@
 #include "iterator.h"
 #include "vector.h"
 #include "posix.h"
+#include "hash.h"
 
 static git_repository *_repo;
 static git_revwalk *_revwalker;
@@ -98,8 +99,8 @@ void test_pack_packbuilder__create_pack(void)
 	git_indexer_progress stats;
 	git_str buf = GIT_STR_INIT, path = GIT_STR_INIT;
 	git_hash_ctx ctx;
-	git_oid hash;
-	char hex[GIT_OID_HEXSZ+1]; hex[GIT_OID_HEXSZ] = '\0';
+	unsigned char hash[GIT_HASH_SHA1_SIZE];
+	char hex[(GIT_HASH_SHA1_SIZE * 2) + 1];
 
 	seed_packbuilder();
 
@@ -107,8 +108,7 @@ void test_pack_packbuilder__create_pack(void)
 	cl_git_pass(git_packbuilder_foreach(_packbuilder, feed_indexer, &stats));
 	cl_git_pass(git_indexer_commit(_indexer, &stats));
 
-	git_oid_fmt(hex, git_indexer_hash(_indexer));
-	git_str_printf(&path, "pack-%s.pack", hex);
+	git_str_printf(&path, "pack-%s.pack", git_indexer_name(_indexer));
 
 	/*
 	 * By default, packfiles are created with only one thread.
@@ -128,14 +128,13 @@ void test_pack_packbuilder__create_pack(void)
 
 	cl_git_pass(git_hash_ctx_init(&ctx, GIT_HASH_ALGORITHM_SHA1));
 	cl_git_pass(git_hash_update(&ctx, buf.ptr, buf.size));
-	cl_git_pass(git_hash_final(hash.id, &ctx));
+	cl_git_pass(git_hash_final(hash, &ctx));
 	git_hash_ctx_cleanup(&ctx);
 
 	git_str_dispose(&path);
 	git_str_dispose(&buf);
 
-	git_oid_fmt(hex, &hash);
-
+	git_hash_fmt(hex, hash, GIT_HASH_SHA1_SIZE);
 	cl_assert_equal_s(hex, "5d410bdf97cf896f9007681b92868471d636954b");
 }
 


### PR DESCRIPTION
This splits out some of the early grounding work in #6191 so that we can include it in the next minor release.

Notably, this makes our checksums simple byte arrays instead of them being `git_oid`s.  (Our file checksums are _not_ object IDs, after all).  It's important to get this in to the next release to mark functions like `git_index_checksum` as deprecated for their eventual removal.