### PR TITLE
revparse: support bare '@'

### DIFF
--- a/src/revparse.c
+++ b/src/revparse.c
@@ -799,6 +799,9 @@ static int revparse(
 				if (temp_object != NULL)
 					base_rev = temp_object;
 				break;
+			} else if (spec[pos+1] == '\0') {
+				spec = "HEAD";
+				break;
 			}
 			/* fall through */
 

--- a/tests/refs/revparse.c
+++ b/tests/refs/revparse.c
@@ -881,3 +881,10 @@ void test_refs_revparse__uneven_sizes(void)
 	test_object("a65fedf39aefe402d3bb6e24df4d",
 				"a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 }
+
+void test_refs_revparse__parses_at_head(void)
+{
+	test_id("HEAD", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVSPEC_SINGLE);
+	test_id("@{0}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVSPEC_SINGLE);
+	test_id("@", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVSPEC_SINGLE);
+}


### PR DESCRIPTION
A bare '@' revision syntax represents HEAD.  Support it as such.

Fixes #6123 