### PR TITLE
merge: comment conflicts lines in MERGE_MSG

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -3126,7 +3126,7 @@ int git_merge__append_conflicts_to_merge_msg(
 		(error = git_filebuf_open(&file, file_path.ptr, GIT_FILEBUF_APPEND, GIT_MERGE_FILE_MODE)) < 0)
 		goto cleanup;
 
-	git_filebuf_printf(&file, "\nConflicts:\n");
+	git_filebuf_printf(&file, "\n#Conflicts:\n");
 
 	for (i = 0; i < git_index_entrycount(index); i++) {
 		const git_index_entry *e = git_index_get_byindex(index, i);
@@ -3135,7 +3135,7 @@ int git_merge__append_conflicts_to_merge_msg(
 			continue;
 
 		if (last == NULL || strcmp(e->path, last) != 0)
-			git_filebuf_printf(&file, "\t%s\n", e->path);
+			git_filebuf_printf(&file, "#\t%s\n", e->path);
 
 		last = e->path;
 	}

--- a/tests/cherrypick/workdir.c
+++ b/tests/cherrypick/workdir.c
@@ -170,9 +170,9 @@ void test_cherrypick_workdir__conflicts(void)
 	cl_assert(strcmp(git_str_cstr(&mergemsg_buf),
 		"Change all files\n" \
 		"\n" \
-		"Conflicts:\n" \
-		"\tfile2.txt\n" \
-		"\tfile3.txt\n") == 0);
+		"#Conflicts:\n" \
+		"#\tfile2.txt\n" \
+		"#\tfile3.txt\n") == 0);
 
 	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
 		TEST_REPO_PATH "/file2.txt"));
@@ -352,10 +352,10 @@ void test_cherrypick_workdir__both_renamed(void)
 	cl_assert(strcmp(git_str_cstr(&mergemsg_buf),
 		"Renamed file3.txt -> file3.txt.renamed\n" \
 		"\n" \
-		"Conflicts:\n" \
-		"\tfile3.txt\n" \
-		"\tfile3.txt.renamed\n" \
-		"\tfile3.txt.renamed_on_branch\n") == 0);
+		"#Conflicts:\n" \
+		"#\tfile3.txt\n" \
+		"#\tfile3.txt.renamed\n" \
+		"#\tfile3.txt.renamed_on_branch\n") == 0);
 
 	git_str_dispose(&mergemsg_buf);
 	git_commit_free(commit);

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -278,8 +278,8 @@ void test_merge_workdir_simple__mergefile(void)
 	cl_assert(strcmp(git_str_cstr(&mergemsg_buf),
 		"Merge commit '7cb63eed597130ba4abb87b3e544b85021905520'\n" \
 		"\n" \
-		"Conflicts:\n" \
-		"\tconflicting.txt\n") == 0);
+		"#Conflicts:\n" \
+		"#\tconflicting.txt\n") == 0);
 	git_str_dispose(&conflicting_buf);
 	git_str_dispose(&mergemsg_buf);
 

--- a/tests/revert/workdir.c
+++ b/tests/revert/workdir.c
@@ -119,8 +119,8 @@ void test_revert_workdir__conflicts(void)
 		"\n" \
 		"This reverts commit 72333f47d4e83616630ff3b0ffe4c0faebcc3c45.\n"
 		"\n" \
-		"Conflicts:\n" \
-		"\tfile1.txt\n") == 0);
+		"#Conflicts:\n" \
+		"#\tfile1.txt\n") == 0);
 
 	git_commit_free(commit);
 	git_commit_free(head);


### PR DESCRIPTION
git has started adding comment markers to its conflict lines in `MERGE_MSG`.  Match that behavior.

Fixes #6131 