### PR TITLE
C90: add inline macro to xdiff and mbedtls

### DIFF
--- a/src/streams/mbedtls.c
+++ b/src/streams/mbedtls.c
@@ -23,12 +23,14 @@
 #endif
 
 /* Work around C90-conformance issues */
-#if defined(_MSC_VER)
-# define inline __inline
-#elif defined(__GNUC__)
-# define inline __inline__
-#else
-# define inline
+#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
+# if defined(_MSC_VER)
+#  define inline __inline
+# elif defined(__GNUC__)
+#  define inline __inline__
+# else
+#  define inline
+# endif
 #endif
 
 #include <mbedtls/config.h>

--- a/src/xdiff/git-xdiff.h
+++ b/src/xdiff/git-xdiff.h
@@ -16,6 +16,17 @@
 
 #include "regexp.h"
 
+/* Work around C90-conformance issues */
+#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
+# if defined(_MSC_VER)
+#  define inline __inline
+# elif defined(__GNUC__)
+#  define inline __inline__
+# else
+#  define inline
+# endif
+#endif
+
 #define xdl_malloc(x) git__malloc(x)
 #define xdl_free(ptr) git__free(ptr)
 #define xdl_realloc(ptr, x) git__realloc(ptr, x)


### PR DESCRIPTION
To be able to use unmodified xdiff code together with git-xdiff.h we need to make sure that `inline` exists with C90 (Or switch to C99)
This PR does the former.

deps/ntmlclient is left alone for now but it has the same problem.

We could consider doing something similar with the `GIT_INLINE(type)` macro but that would be a lot of changes for no particular benefit.
