### PR TITLE
push: Prepare pack before sending pack header.

### DIFF
--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1308,7 +1308,7 @@ static int ll_find_deltas(git_packbuilder *pb, git_pobject **list,
 #define ll_find_deltas(pb, l, ls, w, d) find_deltas(pb, l, &ls, w, d)
 #endif
 
-int prepare_pack(git_packbuilder *pb)
+int git_packbuilder__prepare(git_packbuilder *pb)
 {
 	git_pobject **delta_list;
 	size_t i, n = 0;
@@ -1353,7 +1353,7 @@ int prepare_pack(git_packbuilder *pb)
 	return 0;
 }
 
-#define PREPARE_PACK if (prepare_pack(pb) < 0) { return -1; }
+#define PREPARE_PACK if (git_packbuilder__prepare(pb) < 0) { return -1; }
 
 int git_packbuilder_foreach(git_packbuilder *pb, int (*cb)(void *buf, size_t size, void *payload), void *payload)
 {

--- a/src/pack-objects.c
+++ b/src/pack-objects.c
@@ -1308,7 +1308,7 @@ static int ll_find_deltas(git_packbuilder *pb, git_pobject **list,
 #define ll_find_deltas(pb, l, ls, w, d) find_deltas(pb, l, &ls, w, d)
 #endif
 
-static int prepare_pack(git_packbuilder *pb)
+int prepare_pack(git_packbuilder *pb)
 {
 	git_pobject **delta_list;
 	size_t i, n = 0;

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -97,5 +97,7 @@ struct git_packbuilder {
 };
 
 int git_packbuilder__write_buf(git_str *buf, git_packbuilder *pb);
+int prepare_pack(git_packbuilder *pb);
+
 
 #endif

--- a/src/pack-objects.h
+++ b/src/pack-objects.h
@@ -97,7 +97,7 @@ struct git_packbuilder {
 };
 
 int git_packbuilder__write_buf(git_str *buf, git_packbuilder *pb);
-int prepare_pack(git_packbuilder *pb);
+int git_packbuilder__prepare(git_packbuilder *pb);
 
 
 #endif

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -1034,6 +1034,10 @@ int git_smart__push(git_transport *transport, git_push *push, const git_remote_c
 		}
 	}
 
+	/* prepare pack before sending pack header to avoid timeouts */
+	if (need_pack && ((error = prepare_pack(push->pb))) < 0)
+		goto done;
+
 	if ((error = git_smart__get_push_stream(t, &packbuilder_payload.stream)) < 0 ||
 		(error = gen_pktline(&pktline, push)) < 0 ||
 		(error = packbuilder_payload.stream->write(packbuilder_payload.stream, git_str_cstr(&pktline), git_str_len(&pktline))) < 0)

--- a/src/transports/smart_protocol.c
+++ b/src/transports/smart_protocol.c
@@ -1035,7 +1035,7 @@ int git_smart__push(git_transport *transport, git_push *push, const git_remote_c
 	}
 
 	/* prepare pack before sending pack header to avoid timeouts */
-	if (need_pack && ((error = prepare_pack(push->pb))) < 0)
+	if (need_pack && ((error = git_packbuilder__prepare(push->pb))) < 0)
 		goto done;
 
 	if ((error = git_smart__get_push_stream(t, &packbuilder_payload.stream)) < 0 ||


### PR DESCRIPTION
For large pushes, preparing the pack can take a while. Currently we send the pack header first, followed by preparing the pack and then finally sending the pack. Unfortunately github.com will terminate a git-receive-pack command over http if it is idle for more than 10 seconds. This is easily exceeded for a large push, and so the push is rejected with a Broken Pipe error.

This patch moves the pack preparation ahead of sending the pack header, so that the timeout is avoided.

`prepare_pack()` can be called multiple times but will only do the work once, so the original `PREPARE_PACK` call inside `git_packbuilder_foreach()` remains.

Resolves https://github.com/libgit2/libgit2/issues/5905 .