### PR TITLE
meta: add a release configuration file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+  - title: New features
+    labels:
+    - feature
+  - title: Bug fixes
+    labels:
+    - bug
+  - title: Code cleanups
+    labels:
+    - cleanup
+  - title: CI improvements
+    labels:
+    - build
+  - title: Documentation improvements
+    labels:
+    - documentation
+  - title: Other Changes
+    labels:
+      - '*'


### PR DESCRIPTION
Let's let GitHub handle our release notes as much as possible:
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes