### PR TITLE
Fix crashes in example programs on Windows (sprintf_s not compatible with snprintf)

### DIFF
--- a/examples/common.h
+++ b/examples/common.h
@@ -45,7 +45,7 @@
 #endif
 
 #ifdef _MSC_VER
-#define snprintf sprintf_s
+#define snprintf _snprintf
 #define strcasecmp strcmpi
 #endif
 


### PR DESCRIPTION
When building with Visual C++, the example programs crash in some instances because they expect `snprintf` to allow NULL buffers to be passed with a length argument of 0 to retrieve the required length of output buffer (as in C99 spec). However, `common.h` defines `snprintf` as `sprintf_s` for MS C and MingW and the latter does not accept NULL buffers raising an assert.

Fix is simply to define `snprintf` as `_snprintf` for instead of `sprintf_s`.