### PR TITLE
cmake: Fix package name for system http-parser

### DIFF
--- a/cmake/SelectHTTPParser.cmake
+++ b/cmake/SelectHTTPParser.cmake
@@ -1,6 +1,6 @@
 # Optional external dependency: http-parser
 if(USE_HTTP_PARSER STREQUAL "system")
-	find_package(HTTP_Parser)
+	find_package(HTTPParser)
 
 	if(HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
 		list(APPEND LIBGIT2_SYSTEM_INCLUDES ${HTTP_PARSER_INCLUDE_DIRS})


### PR DESCRIPTION
Fix building against system http-parser library by fixing
the find_package() argument.  It seems to have been accidentally changed
from HTTPParser to HTTP_Parser in de178d36f, effectively making
the build against system library fail to find it:

```
CMake Warning at cmake/SelectHTTPParser.cmake:3 (find_package):
  By not providing "FindHTTP_Parser.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "HTTP_Parser", but CMake did not find one.

  Could not find a package configuration file provided by "HTTP_Parser" with
  any of the following names:

    HTTP_ParserConfig.cmake
    http_parser-config.cmake

  Add the installation prefix of "HTTP_Parser" to CMAKE_PREFIX_PATH or set
  "HTTP_Parser_DIR" to a directory containing one of the above files.  If
  "HTTP_Parser" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  src/CMakeLists.txt:97 (include)

CMake Error at cmake/SelectHTTPParser.cmake:11 (message):
  http-parser support was requested but not found
Call Stack (most recent call first):
  src/CMakeLists.txt:97 (include)
```