### PR TITLE
meta: update version number to v1.5.0-alpha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.5.1)
 
-project(libgit2 VERSION "1.4.0" LANGUAGES C)
+project(libgit2 VERSION "1.5.0" LANGUAGES C)
 
 # Add find modules to the path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")

--- a/include/git2/version.h
+++ b/include/git2/version.h
@@ -7,12 +7,13 @@
 #ifndef INCLUDE_git_version_h__
 #define INCLUDE_git_version_h__
 
-#define LIBGIT2_VERSION "1.4.0"
-#define LIBGIT2_VER_MAJOR 1
-#define LIBGIT2_VER_MINOR 4
-#define LIBGIT2_VER_REVISION 0
-#define LIBGIT2_VER_PATCH 0
+#define LIBGIT2_VERSION        "1.5.0-alpha"
+#define LIBGIT2_VER_MAJOR      1
+#define LIBGIT2_VER_MINOR      5
+#define LIBGIT2_VER_REVISION   0
+#define LIBGIT2_VER_PATCH      0
+#define LIBGIT2_VER_PRERELEASE "alpha"
 
-#define LIBGIT2_SOVERSION "1.4"
+#define LIBGIT2_SOVERSION      "1.5"
 
 #endif

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libgit2",
-  "version": "1.4.0",
+  "version": "1.5.0-alpha",
   "repo": "https://github.com/libgit2/libgit2",
   "description": " A cross-platform, linkable library implementation of Git that you can use in your application.",
   "install": "mkdir build && cd build && cmake .. && cmake --build ."


### PR DESCRIPTION
Update the version number in main to v1.5.0-alpha.  This helps people
understand that the main builds are not part of the v1.4.0 release
train.

We use "alpha" to indicate builds out of main (or nightlies) as semver
v2 requires the prerelease component is compared lexicographically.
Thus, our "beta" and "rc" releases should follow.

Closes #6210 