### PR TITLE
xdiff: use xdl_free not free

### DIFF
--- a/src/xdiff/xdiff.h
+++ b/src/xdiff/xdiff.h
@@ -23,11 +23,11 @@
 #if !defined(XDIFF_H)
 #define XDIFF_H
 
-#include "git-xdiff.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* #ifdef __cplusplus */
+
+#include "git-xdiff.h"
 
 /* xpparm_t.flags */
 #define XDF_NEED_MINIMAL (1 << 0)

--- a/src/xdiff/xmerge.c
+++ b/src/xdiff/xmerge.c
@@ -88,7 +88,7 @@ static int xdl_cleanup_merge(xdmerge_t *c)
 		if (c->mode == 0)
 			count++;
 		next_c = c->next;
-		free(c);
+		xdl_free(c);
 	}
 	return count;
 }
@@ -456,7 +456,7 @@ static void xdl_merge_two_conflicts(xdmerge_t *m)
 	m->chg1 = next_m->i1 + next_m->chg1 - m->i1;
 	m->chg2 = next_m->i2 + next_m->chg2 - m->i2;
 	m->next = next_m->next;
-	free(next_m);
+	xdl_free(next_m);
 }
 
 /*


### PR DESCRIPTION
We've added a lovely abstraction layer in xdiff so that it can call our
allocation functions.  But it also needs to call our free functions.  We
missed some `free` calls in `xmerge.c`.  Update them to use `xdl_free`.
Without this, we will pass a pointer allocated with a custom allocator
to the system free function.  :bomb: