### PR TITLE
v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ libgit2 - the Git linkable library
 | Build Status | |
 | ------------ | - |
 | **main** branch CI builds | [![CI Build](https://github.com/libgit2/libgit2/workflows/CI%20Build/badge.svg?event=push)](https://github.com/libgit2/libgit2/actions?query=workflow%3A%22CI+Build%22+event%3Apush) |
-| **v1.2 branch** CI builds | [![CI Build](https://github.com/libgit2/libgit2/workflows/CI%20Build/badge.svg?branch=maint%2Fv1.2&event=push)](https://github.com/libgit2/libgit2/actions?query=workflow%3A%22CI+Build%22+event%3Apush+branch%3Amaint%2Fv1.2) |
-| **v1.1 branch** CI builds | [![CI Build](https://github.com/libgit2/libgit2/workflows/CI%20Build/badge.svg?branch=maint%2Fv1.1&event=push)](https://github.com/libgit2/libgit2/actions?query=workflow%3A%22CI+Build%22+event%3Apush+branch%3Amaint%2Fv1.1) |
+| **v1.4 branch** CI builds | [![CI Build](https://github.com/libgit2/libgit2/workflows/CI%20Build/badge.svg?branch=maint%2Fv1.4&event=push)](https://github.com/libgit2/libgit2/actions?query=workflow%3A%22CI+Build%22+event%3Apush+branch%3Amaint%2Fv1.4) |
+| **v1.3 branch** CI builds | [![CI Build](https://github.com/libgit2/libgit2/workflows/CI%20Build/badge.svg?branch=maint%2Fv1.3&event=push)](https://github.com/libgit2/libgit2/actions?query=workflow%3A%22CI+Build%22+event%3Apush+branch%3Amaint%2Fv1.3) |
 | **Nightly** builds | [![Nightly Build](https://github.com/libgit2/libgit2/workflows/Nightly%20Build/badge.svg)](https://github.com/libgit2/libgit2/actions?query=workflow%3A%22Nightly+Build%22) [![Coverity Scan Status](https://scan.coverity.com/projects/639/badge.svg)](https://scan.coverity.com/projects/639) |
 
 `libgit2` is a portable, pure C implementation of the Git core methods

--- a/cmake/SelectHTTPParser.cmake
+++ b/cmake/SelectHTTPParser.cmake
@@ -1,6 +1,6 @@
 # Optional external dependency: http-parser
 if(USE_HTTP_PARSER STREQUAL "system")
-	find_package(HTTP_Parser)
+	find_package(HTTPParser)
 
 	if(HTTP_PARSER_FOUND AND HTTP_PARSER_VERSION_MAJOR EQUAL 2)
 		list(APPEND LIBGIT2_SYSTEM_INCLUDES ${HTTP_PARSER_INCLUDE_DIRS})

--- a/examples/commit.c
+++ b/examples/commit.c
@@ -26,7 +26,7 @@
  * This does have:
  *
  * - Example of performing a git commit with a comment
- * 
+ *
  */
 int lg2_commit(git_repository *repo, int argc, char **argv)
 {
@@ -36,10 +36,10 @@ int lg2_commit(git_repository *repo, int argc, char **argv)
 
 	git_oid commit_oid,tree_oid;
 	git_tree *tree;
-	git_index *index;	
+	git_index *index;
 	git_object *parent = NULL;
 	git_reference *ref = NULL;
-	git_signature *signature;	
+	git_signature *signature;
 
 	/* Validate args */
 	if (argc < 3 || strcmp(opt, "-m") != 0) {
@@ -62,9 +62,9 @@ int lg2_commit(git_repository *repo, int argc, char **argv)
 	check_lg2(git_index_write(index), "Could not write index", NULL);;
 
 	check_lg2(git_tree_lookup(&tree, repo, &tree_oid), "Error looking up tree", NULL);
-	
+
 	check_lg2(git_signature_default(&signature, repo), "Error creating signature", NULL);
-	
+
 	check_lg2(git_commit_create_v(
 		&commit_oid,
 		repo,
@@ -78,7 +78,9 @@ int lg2_commit(git_repository *repo, int argc, char **argv)
 
 	git_index_free(index);
 	git_signature_free(signature);
-	git_tree_free(tree);	
+	git_tree_free(tree);
+	git_object_free(parent);
+	git_reference_free(ref);
 
 	return error;
 }

--- a/include/git2/version.h
+++ b/include/git2/version.h
@@ -7,10 +7,10 @@
 #ifndef INCLUDE_git_version_h__
 #define INCLUDE_git_version_h__
 
-#define LIBGIT2_VERSION "1.4.0"
+#define LIBGIT2_VERSION "1.4.1"
 #define LIBGIT2_VER_MAJOR 1
 #define LIBGIT2_VER_MINOR 4
-#define LIBGIT2_VER_REVISION 0
+#define LIBGIT2_VER_REVISION 1
 #define LIBGIT2_VER_PATCH 0
 
 #define LIBGIT2_SOVERSION "1.4"

--- a/src/xdiff/xdiff.h
+++ b/src/xdiff/xdiff.h
@@ -23,11 +23,11 @@
 #if !defined(XDIFF_H)
 #define XDIFF_H
 
-#include "git-xdiff.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* #ifdef __cplusplus */
+
+#include "git-xdiff.h"
 
 /* xpparm_t.flags */
 #define XDF_NEED_MINIMAL (1 << 0)

--- a/src/xdiff/xmerge.c
+++ b/src/xdiff/xmerge.c
@@ -88,7 +88,7 @@ static int xdl_cleanup_merge(xdmerge_t *c)
 		if (c->mode == 0)
 			count++;
 		next_c = c->next;
-		free(c);
+		xdl_free(c);
 	}
 	return count;
 }
@@ -456,7 +456,7 @@ static void xdl_merge_two_conflicts(xdmerge_t *m)
 	m->chg1 = next_m->i1 + next_m->chg1 - m->i1;
 	m->chg2 = next_m->i2 + next_m->chg2 - m->i2;
 	m->next = next_m->next;
-	free(next_m);
+	xdl_free(next_m);
 }
 
 /*


### PR DESCRIPTION
Backports some critical fixes for the v1.4 branch in preparation for a v1.4.1 release.

* [Free parent and ref in lg2_commit before returning](https://github.com/libgit2/libgit2/pull/6219) by @apnadkarni
* [cmake: Fix package name for system http-parser](https://github.com/libgit2/libgit2/pull/6217) by @mgorny 
* [xdiff: use xdl_free not free](https://github.com/libgit2/libgit2/pull/6223) by @ethomson 

In addition, this updates the README and version number to v1.4.1.