### PR TITLE
remote: do store the update_tips callback error value

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -1852,7 +1852,7 @@ static int update_one_tip(
 	}
 
 	if (callbacks && callbacks->update_tips != NULL &&
-	    callbacks->update_tips(refname.ptr, &old, &head->oid, callbacks->payload) < 0)
+	    (error = callbacks->update_tips(refname.ptr, &old, &head->oid, callbacks->payload)) < 0)
 		git_error_set_after_callback_function(error, "git_remote_fetch");
 
 done:


### PR DESCRIPTION
We use `git_error_set_after_callback_function` to determine whether
`update_tips` returned an error but do not store its return value making us
think it always returns 0.

Fix it by adding the common patter of storing it inside the `if` when calling it.

---

I have verified this fixes the rugged tests when updating to v1.4.1 and am somewhat surprised that the libgit2 tests did not catch this. It looks like this broke in the refactoring in b523776785e542792bd22f185ed0a678ab07c872 which is part of #6203 as the previous code would hard-code a `goto` to an error exit rather than use any of these fancy functions.