### PR TITLE
odb: initialize `object` before use

### DIFF
--- a/src/odb.c
+++ b/src/odb.c
@@ -1067,7 +1067,7 @@ int git_odb_expand_ids(
 int git_odb_read_header(size_t *len_p, git_object_t *type_p, git_odb *db, const git_oid *id)
 {
 	int error;
-	git_odb_object *object;
+	git_odb_object *object = NULL;
 
 	error = git_odb__read_header_or_object(&object, len_p, type_p, db, id);
 


### PR DESCRIPTION
Newer gcc is complaining about `object` being potentially not
initialized; initialize it.