### PR TITLE
win32: `find_system_dirs` does not return `GIT_ENOTFOUND`

### DIFF
--- a/src/win32/findfile.c
+++ b/src/win32/findfile.c
@@ -222,7 +222,7 @@ int git_win32__find_system_dirs(git_str *out, const char *subdir)
 	has_regdir = (find_sysdir_in_registry(regdir) == 0);
 
 	if (!has_pathdir && !has_regdir)
-		return GIT_ENOTFOUND;
+		return 0;
 
 	/*
 	 * Usually the git in the path is the same git in the registry,

--- a/tests/win32/systemdir.c
+++ b/tests/win32/systemdir.c
@@ -326,3 +326,13 @@ void test_win32_systemdir__prefers_path_to_registry(void)
 	git_config_free(cfg);
 #endif
 }
+
+void test_win32_systemdir__no_git_installed(void)
+{
+#ifdef GIT_WIN32
+	git_str out = GIT_STR_INIT;
+
+	cl_git_pass(git_win32__find_system_dirs(&out, "etc"));
+	cl_assert_equal_s(out.ptr, "");
+#endif
+}


### PR DESCRIPTION
Allow for no Git for Windows installation.  When there is no GfW found
in the path or registry, `git_win32__find_system_dirs` would return a
`GIT_ENOTFOUND`.  Callers were not expecting this.  Since this is no
error, we simply return `0` so that callers can move on with their
lives.

Fixed #6225 