### PR TITLE
[cmake] allow C_STANDARD to be set from commandline

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -2,7 +2,12 @@
 # git library functionality.
 
 add_library(libgit2 OBJECT)
-set_target_properties(libgit2 PROPERTIES C_STANDARD 90)
+
+set(CSTD 90)
+if(C_STANDARD)
+	set(CSTD ${C_STANDARD})
+endif()
+set_target_properties(libgit2 PROPERTIES C_STANDARD ${CSTD})
 set_target_properties(libgit2 PROPERTIES C_EXTENSIONS OFF)
 
 include(PkgBuildConfig)
@@ -85,7 +90,7 @@ set(LIBGIT2_SYSTEM_LIBS ${LIBGIT2_SYSTEM_LIBS} PARENT_SCOPE)
 add_library(libgit2package ${SRC_RC} ${LIBGIT2_OBJECTS})
 target_link_libraries(libgit2package ${LIBGIT2_SYSTEM_LIBS})
 
-set_target_properties(libgit2package PROPERTIES C_STANDARD 90)
+set_target_properties(libgit2package PROPERTIES C_STANDARD ${CSTD})
 set_target_properties(libgit2package PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 set_target_properties(libgit2package PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 set_target_properties(libgit2package PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,7 +1,11 @@
 # util: a shared library for common utility functions for libgit2 projects
 
 add_library(util OBJECT)
-set_target_properties(util PROPERTIES C_STANDARD 90)
+set(CSTD 90)
+if(C_STANDARD)
+	set(CSTD ${C_STANDARD})
+endif()
+set_target_properties(util PROPERTIES C_STANDARD ${CSTD})
 set_target_properties(util PROPERTIES C_EXTENSIONS OFF)
 
 set(UTIL_INCLUDES


### PR DESCRIPTION
without this, cross-compiling for Android with `ExternalProject_Add()`,
where targets are not available to the *SuperProject* for setting
propeties on them, build fails. this will allow said *SueprPorject* to
set the C_STANDARD vi CMAKE_ARGS.