### PR TITLE
cmake: export libraries needed to compile against libgit2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,14 @@ if(BUILD_FUZZERS)
 endif()
 
 
+# Export for people who use us as a dependency
+
+if(NOT "${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+	set(LIBGIT2_DEPENDENCY_OBJECTS ${LIBGIT2_DEPENDENCY_OBJECTS} PARENT_SCOPE)
+	set(LIBGIT2_SYSTEM_LIBS ${LIBGIT2_SYSTEM_LIBS} PARENT_SCOPE)
+endif()
+
+
 # Summary
 
 feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")


### PR DESCRIPTION
If users are using us as a direct dependency (via `add_subdirectory`)
then they may want to know the libraries to link to; tell them.