### PR TITLE
Swap `GIT_DIFF_LINE_(ADD|DEL)_EOFNL` to match other Diffs

### DIFF
--- a/src/libgit2/patch_parse.c
+++ b/src/libgit2/patch_parse.c
@@ -558,9 +558,9 @@ fail:
 
 static int eof_for_origin(int origin) {
 	if (origin == GIT_DIFF_LINE_ADDITION)
-		return GIT_DIFF_LINE_ADD_EOFNL;
-	if (origin == GIT_DIFF_LINE_DELETION)
 		return GIT_DIFF_LINE_DEL_EOFNL;
+	if (origin == GIT_DIFF_LINE_DELETION)
+		return GIT_DIFF_LINE_ADD_EOFNL;
 	return GIT_DIFF_LINE_CONTEXT_EOFNL;
 }
 

--- a/tests/libgit2/diff/parse.c
+++ b/tests/libgit2/diff/parse.c
@@ -279,6 +279,31 @@ static int file_cb(const git_diff_delta *delta, float progress, void *payload)
     return 0;
 }
 
+void test_diff_parse__eof_nl_missing(void)
+{
+	const char patch[] =
+		"diff --git a/.env b/.env\n"
+        "index f89e4c0..7c56eb7 100644\n"
+        "--- a/.env\n"
+        "+++ b/.env\n"
+        "@@ -1 +1 @@\n"
+        "-hello=12345\n"
+        "+hello=123456\n"
+		"\\ No newline at end of file\n";
+	git_diff *diff;
+	git_patch *ret_patch;
+	git_diff_line *line;
+
+	cl_git_pass(git_diff_from_buffer(&diff, patch, strlen(patch)));
+	cl_git_pass(git_patch_from_diff(&ret_patch, diff, 0));
+
+	cl_assert((line = git_array_get(ret_patch->lines, 2)) != NULL);
+	cl_assert(line->origin == GIT_DIFF_LINE_DEL_EOFNL);
+
+	git_diff_free(diff);
+	git_patch_free(ret_patch);
+}
+
 void test_diff_parse__foreach_works_with_parsed_patch(void)
 {
 	const char patch[] =


### PR DESCRIPTION
Generating a diff using `git_diff_tree_to_tree` and `git_diff_from_buffer` return different result for the same patch of:
```
$ git diff 17ec0f3 394a717
diff --git a/.env b/.env
index f9fb22f..ed7b51e 100644
--- a/.env
+++ b/.env
@@ -1 +1 @@
-hello=12345
+hello=123456
\ No newline at end of file
```
Diff:
```
from repo:::
- hello=12345
+ hello=123456<                // Notice missing \n and `<` origin, meaning deletion
\ No newline at end of file
.
from buff:::
- hello=12345
+ hello=123456
> \ No newline at end of file
```

We didn't add the LF, we deleted it!