### PR TITLE
Fix crash when regenerating a patch with unquoted spaces in filename

### DIFF
--- a/src/libgit2/diff_print.c
+++ b/src/libgit2/diff_print.c
@@ -316,10 +316,9 @@ static int diff_print_oid_range(
 static int diff_delta_format_path(
 	git_str *out, const char *prefix, const char *filename)
 {
-	if (!filename)
-	{
+	if (!filename) {
 		/* don't prefix "/dev/null" */
-		return git_str_puts(out, "/dev/null");
+ 		return git_str_puts(out, "/dev/null");
 	}
 
 	if (git_str_joinpath(out, prefix, filename) < 0)

--- a/src/libgit2/diff_print.c
+++ b/src/libgit2/diff_print.c
@@ -316,6 +316,12 @@ static int diff_print_oid_range(
 static int diff_delta_format_path(
 	git_str *out, const char *prefix, const char *filename)
 {
+	if (!filename)
+	{
+		/* don't prefix "/dev/null" */
+		return git_str_puts(out, "/dev/null");
+	}
+
 	if (git_str_joinpath(out, prefix, filename) < 0)
 		return -1;
 

--- a/tests/libgit2/diff/parse.c
+++ b/tests/libgit2/diff/parse.c
@@ -431,6 +431,32 @@ void test_diff_parse__new_file_with_space(void)
 	git_diff_free(diff);
 }
 
+void test_diff_parse__new_file_with_space_and_regenerate_patch(void)
+{
+	const char *content = PATCH_ORIGINAL_NEW_FILE_WITH_SPACE;
+	git_diff *diff = NULL;
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_pass(git_diff_from_buffer(&diff, content, strlen(content)));
+	cl_git_pass(git_diff_to_buf(&buf, diff, GIT_DIFF_FORMAT_PATCH));
+
+	git_buf_dispose(&buf);
+	git_diff_free(diff);
+}
+
+void test_diff_parse__delete_file_with_space_and_regenerate_patch(void)
+{
+	const char *content = PATCH_DELETE_FILE_WITH_SPACE;
+	git_diff *diff = NULL;
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_pass(git_diff_from_buffer(&diff, content, strlen(content)));
+	cl_git_pass(git_diff_to_buf(&buf, diff, GIT_DIFF_FORMAT_PATCH));
+
+	git_buf_dispose(&buf);
+	git_diff_free(diff);
+}
+
 void test_diff_parse__crlf(void)
 {
 	const char *text = PATCH_CRLF;

--- a/tests/libgit2/patch/patch_common.h
+++ b/tests/libgit2/patch/patch_common.h
@@ -933,6 +933,15 @@
 	"@@ -0,0 +1 @@\n" \
 	"+a\n"
 
+#define PATCH_DELETE_FILE_WITH_SPACE \
+	"diff --git a/sp ace.txt b/sp ace.txt\n" \
+	"deleted file mode 100644\n" \
+	"index 789819226..000000000\n" \
+	"--- a/sp ace.txt\n" \
+	"+++ /dev/null\n" \
+	"@@ -1 +0,0 @@\n" \
+	"-a\n"
+
 #define PATCH_CRLF \
 	"diff --git a/test-file b/test-file\r\n" \
 	"new file mode 100644\r\n" \


### PR DESCRIPTION
This PR fixes a null pointer deref in the following scenario:

1. Write a patch that creates or deletes a file (with `new file mode ...` or `delete file mode ...`), **and** has unquoted filenames with spaces in the 1st line of the header.
For example, take PATCH_ORIGINAL_NEW_FILE_WITH_SPACE in patch_common.h:
    ```patch
    diff --git a/sp ace.txt b/sp ace.txt
    new file mode 100644
    index 000000000..789819226
    --- /dev/null
    +++ b/sp ace.txt
    @@ -0,0 +1 @@
    +a
    ```
2. Get a `git_diff` from the patch with `git_diff_from_buffer`
3. Regenerate a patch with `git_diff_to_buf`

I'm not sure the proposed fix is optimal, since it doesn't reproduce the same `diff --git` header line. But, it at least prevents the crash, and vanilla `git apply` accepts the resulting patch.