### PR TITLE
Fix a string concatenation bug when validating extensions

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -1462,6 +1462,7 @@ static int check_valid_extension(const git_config_entry *entry, void *payload)
 	}
 
 	for (i = 0; i < ARRAY_SIZE(builtin_extensions); i++) {
+		git_str_clear(&cfg);
 		extension = builtin_extensions[i];
 
 		if ((error = git_str_printf(&cfg, "extensions.%s", extension)) < 0)


### PR DESCRIPTION
As builtin extensions are evaluated in the latter half of `check_valid_extension`, a string `cfg` is concatenated with the static string 'extension.' and the value from `builtin_extension`, before being compared with the configured value. This string is not being cleared while iterating through the names of the extensions. Because there is currently only one extension (`noop`), the bug was never noticeable.

This patch corrects the behavior by clearing the string on each iteration, as is done in for user extensions in the preceding block.