### PR TITLE
util: add fallback for non-standard getloadavg()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,12 @@ check_prototype_definition(qsort_r
 
 check_function_exists(qsort_s GIT_QSORT_S)
 
+# util/rand: getentropy and getloadavg
+
+check_function_exists(getentropy GIT_RAND_GETENTROPY)
+
+check_function_exists(getloadavg GIT_RAND_GETLOADAVG)
+
 # determine architecture of the machine
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -116,8 +122,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)")
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Haiku")
-	list(APPEND LIBGIT2_SYSTEM_LIBS network)
-	list(APPEND LIBGIT2_PC_LIBS "-lnetwork")
+	list(APPEND LIBGIT2_SYSTEM_LIBS gnu network)
+	list(APPEND LIBGIT2_PC_LIBS "-lgnu -lnetwork")
 endif()
 
 if(AMIGA)

--- a/src/features.h.in
+++ b/src/features.h.in
@@ -49,5 +49,6 @@
 #cmakedefine GIT_SHA1_MBEDTLS 1
 
 #cmakedefine GIT_RAND_GETENTROPY 1
+#cmakedefine GIT_RAND_GETLOADAVG 1
 
 #endif

--- a/src/util/rand.c
+++ b/src/util/rand.c
@@ -106,7 +106,13 @@ GIT_INLINE(int) getseed(uint64_t *seed)
 		return -1;
 	}
 
+# if defined(GIT_RAND_GETLOADAVG)
 	getloadavg(loadavg, 3);
+# else
+	loadavg[0] = drand48();
+	loadavg[1] = drand48();
+	loadavg[2] = drand48();
+# endif
 
 	*seed = 0;
 	*seed |= ((uint64_t)tv.tv_usec << 40);


### PR DESCRIPTION
The getloadavg() function is not part of the POSIX specification. While it is
implemented on *BSD and Linux, it is not available on the Haiku platform.
This causes linking errors when using libgit2. This commit adds a check if
the function is available while building for the target platform, and if it
is not, it will fall back to drand48() which is part of the POSIX standard
and should be available on all platforms.

While the drand48() function does not provide the same guarantee of
randomness as using system data, it does allow libgit2 continue to work on
more platforms.

This change also reintroduces the check for getentropy(), which seems to have
fallen through the cracks in the refactoring to the structure done in ef4ab29
and c3b7ace.

Finally, when building on Haiku, it now links to libgnu.so, which provides
the qsort_r symbol.