### PR TITLE
tests: support flaky stat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,7 @@ jobs:
               -e CMAKE_GENERATOR \
               -e CMAKE_OPTIONS \
               -e GITTEST_NEGOTIATE_PASSWORD \
+              -e GITTEST_FLAKY_STAT \
               -e PKG_CONFIG_PATH \
               -e SKIP_NEGOTIATE_TESTS \
               -e SKIP_SSH_TESTS \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -247,6 +247,7 @@ jobs:
             CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DDEPRECATE_HARD=ON -DUSE_GSSAPI=ON -DUSE_SSH=ON
             RUN_INVASIVE_TESTS: true
             SKIP_PROXY_TESTS: true
+            GITTEST_FLAKY_STAT: true
           os: ubuntu-latest
         - name: "Linux (arm64, Bionic, GCC, OpenSSL)"
           container:
@@ -305,6 +306,7 @@ jobs:
               -e CMAKE_GENERATOR \
               -e CMAKE_OPTIONS \
               -e GITTEST_NEGOTIATE_PASSWORD \
+              -e GITTEST_FLAKY_STAT \
               -e PKG_CONFIG_PATH \
               -e SKIP_NEGOTIATE_TESTS \
               -e SKIP_SSH_TESTS \

--- a/tests/libgit2/diff/workdir.c
+++ b/tests/libgit2/diff/workdir.c
@@ -1238,6 +1238,7 @@ void test_diff_workdir__can_diff_empty_file(void)
 	git_tree *tree;
 	git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
 	git_patch *patch;
+	struct stat st = {0};
 
 	g_repo = cl_git_sandbox_init("attr_index");
 
@@ -1252,13 +1253,10 @@ void test_diff_workdir__can_diff_empty_file(void)
 	/* empty contents of file */
 	cl_git_rewritefile("attr_index/README.txt", "");
 
-#if !defined(__arm__) || !defined(GIT_ARCH_32)
-	{
-		struct stat st;
-		cl_git_pass(git_fs_path_lstat("attr_index/README.txt", &st));
-		cl_assert(st.st_size == 0);
-	}
-#endif
+	cl_git_pass(git_fs_path_lstat("attr_index/README.txt", &st));
+
+	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
+		cl_assert_equal_sz(0, st.st_size);
 
 	cl_git_pass(git_diff_tree_to_workdir(&diff, g_repo, tree, &opts));
 	cl_assert_equal_i(3, (int)git_diff_num_deltas(diff));

--- a/tests/util/copy.c
+++ b/tests/util/copy.c
@@ -4,7 +4,7 @@
 
 void test_copy__file(void)
 {
-	struct stat st;
+	struct stat st = {0};
 	const char *content = "This is some stuff to copy\n";
 
 	cl_git_mkfile("copy_me", content);
@@ -13,7 +13,9 @@ void test_copy__file(void)
 
 	cl_git_pass(git_fs_path_lstat("copy_me_two", &st));
 	cl_assert(S_ISREG(st.st_mode));
-	cl_assert(strlen(content) == (size_t)st.st_size);
+
+	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
+		cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
 
 	cl_git_pass(p_unlink("copy_me_two"));
 	cl_git_pass(p_unlink("copy_me"));
@@ -21,7 +23,7 @@ void test_copy__file(void)
 
 void test_copy__file_in_dir(void)
 {
-	struct stat st;
+	struct stat st = {0};
 	const char *content = "This is some other stuff to copy\n";
 
 	cl_git_pass(git_futils_mkdir("an_dir/in_a_dir", 0775, GIT_MKDIR_PATH));
@@ -38,7 +40,9 @@ void test_copy__file_in_dir(void)
 
 	cl_git_pass(git_fs_path_lstat("an_dir/second_dir/and_more/copy_me_two", &st));
 	cl_assert(S_ISREG(st.st_mode));
-	cl_assert(strlen(content) == (size_t)st.st_size);
+
+	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
+		cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
 
 	cl_git_pass(git_futils_rmdir_r("an_dir", NULL, GIT_RMDIR_REMOVE_FILES));
 	cl_assert(!git_fs_path_isdir("an_dir"));
@@ -97,11 +101,15 @@ void test_copy__tree(void)
 	cl_assert(git_fs_path_isfile("t1/c/d/f4"));
 	cl_assert(!git_fs_path_isfile("t1/c/d/.f5"));
 
+	memset(&st, 0, sizeof(struct stat));
 	cl_git_pass(git_fs_path_lstat("t1/c/f3", &st));
 	cl_assert(S_ISREG(st.st_mode));
-	cl_assert(strlen(content) == (size_t)st.st_size);
+
+	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
+		cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
 
 #ifndef GIT_WIN32
+	memset(&st, 0, sizeof(struct stat));
 	cl_git_pass(git_fs_path_lstat("t1/c/d/l1", &st));
 	cl_assert(S_ISLNK(st.st_mode));
 #endif
@@ -127,6 +135,7 @@ void test_copy__tree(void)
 	cl_assert(git_fs_path_isfile("t2/c/d/.f5"));
 
 #ifndef GIT_WIN32
+	memset(&st, 0, sizeof(struct stat));
 	cl_git_fail(git_fs_path_lstat("t2/c/d/l1", &st));
 #endif
 


### PR DESCRIPTION
The 32-bit ARM QEMU builds are flaky when running `lstat`. Disable those
testing `lstat`'s `st_size` temporarily.