### PR TITLE
sha256: refactoring in preparation for sha256

### DIFF
--- a/fuzzers/packfile_fuzzer.c
+++ b/fuzzers/packfile_fuzzer.c
@@ -94,7 +94,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 			fprintf(stderr, "Failed to compute the SHA1 hash\n");
 			abort();
 		}
-		if (git_indexer_append(indexer, &oid, sizeof(oid), &stats) < 0) {
+		if (git_indexer_append(indexer, &oid.id, GIT_OID_RAWSZ, &stats) < 0) {
 			goto cleanup;
 		}
 	}

--- a/src/libgit2/commit_graph.c
+++ b/src/libgit2/commit_graph.c
@@ -147,10 +147,10 @@ static int commit_graph_parse_oid_lookup(
 	if (chunk_oid_lookup->length != file->num_commits * GIT_OID_RAWSZ)
 		return commit_graph_error("OID Lookup chunk has wrong length");
 
-	file->oid_lookup = oid = (git_oid *)(data + chunk_oid_lookup->offset);
+	file->oid_lookup = oid = (git_oid_raw *)(data + chunk_oid_lookup->offset);
 	prev_oid = &zero_oid;
 	for (i = 0; i < file->num_commits; ++i, ++oid) {
-		if (git_oid_cmp(prev_oid, oid) >= 0)
+		if (git_oid_raw_cmp(prev_oid, oid) >= 0)
 			return commit_graph_error("OID Lookup index is non-monotonic");
 		prev_oid = oid;
 	}

--- a/src/libgit2/commit_graph.h
+++ b/src/libgit2/commit_graph.h
@@ -36,7 +36,7 @@ typedef struct git_commit_graph_file {
 	uint32_t num_commits;
 
 	/* The OID Lookup table. */
-	git_oid *oid_lookup;
+	unsigned char *oid_lookup;
 
 	/*
 	 * The Commit Data table. Each entry contains the OID of the commit followed

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -74,7 +74,7 @@ struct entry_short {
 	uint32_t uid;
 	uint32_t gid;
 	uint32_t file_size;
-	git_oid oid;
+	unsigned char oid[GIT_OID_RAWSZ];
 	uint16_t flags;
 	char path[1]; /* arbitrary length */
 };
@@ -88,7 +88,7 @@ struct entry_long {
 	uint32_t uid;
 	uint32_t gid;
 	uint32_t file_size;
-	git_oid oid;
+	unsigned char oid[GIT_OID_RAWSZ];
 	uint16_t flags;
 	uint16_t flags_extended;
 	char path[1]; /* arbitrary length */
@@ -2480,8 +2480,10 @@ static int read_entry(
 	entry.uid = ntohl(source.uid);
 	entry.gid = ntohl(source.gid);
 	entry.file_size = ntohl(source.file_size);
-	git_oid_cpy(&entry.id, &source.oid);
 	entry.flags = ntohs(source.flags);
+
+	if (git_oid_fromraw(&entry.id, source.oid) < 0)
+		return -1;
 
 	if (entry.flags & GIT_INDEX_ENTRY_EXTENDED) {
 		uint16_t flags_raw;
@@ -2803,9 +2805,7 @@ static int write_disk_entry(git_filebuf *file, git_index_entry *entry, const cha
 	ondisk.uid = htonl(entry->uid);
 	ondisk.gid = htonl(entry->gid);
 	ondisk.file_size = htonl((uint32_t)entry->file_size);
-
-	git_oid_cpy(&ondisk.oid, &entry->id);
-
+	git_oid_raw_cpy(ondisk.oid, entry->id.id);
 	ondisk.flags = htons(entry->flags);
 
 	if (entry->flags & GIT_INDEX_ENTRY_EXTENDED) {

--- a/src/libgit2/indexer.c
+++ b/src/libgit2/indexer.c
@@ -1269,7 +1269,7 @@ int git_indexer_commit(git_indexer *idx, git_indexer_progress *stats)
 
 	/* Write out the object names (SHA-1 hashes) */
 	git_vector_foreach(&idx->objects, i, entry) {
-		git_filebuf_write(&index_file, &entry->oid, sizeof(git_oid));
+		git_filebuf_write(&index_file, &entry->oid.id, GIT_OID_RAWSZ);
 	}
 
 	/* Write out the CRC32 values */

--- a/src/libgit2/indexer.c
+++ b/src/libgit2/indexer.c
@@ -385,7 +385,7 @@ static int check_object_connectivity(git_indexer *idx, const git_rawobj *obj)
 			size_t i;
 
 			git_array_foreach(tree->entries, i, entry)
-				if (add_expected_oid(idx, entry->oid) < 0)
+				if (add_expected_oid(idx, &entry->oid) < 0)
 					goto out;
 
 			break;

--- a/src/libgit2/iterator.c
+++ b/src/libgit2/iterator.c
@@ -613,7 +613,7 @@ GIT_INLINE(int) tree_iterator_frame_push_neighbors(
 			break;
 
 		if ((error = git_tree_lookup(&tree,
-			iter->base.repo, entry->tree_entry->oid)) < 0)
+			iter->base.repo, &entry->tree_entry->oid)) < 0)
 			break;
 
 		if (git_vector_insert(&parent_frame->similar_trees, tree) < 0)
@@ -659,7 +659,7 @@ GIT_INLINE(int) tree_iterator_frame_push(
 	int error;
 
 	if ((error = git_tree_lookup(&tree,
-			iter->base.repo, entry->tree_entry->oid)) < 0 ||
+			iter->base.repo, &entry->tree_entry->oid)) < 0 ||
 		(error = tree_iterator_frame_init(iter, tree, entry)) < 0)
 		goto done;
 
@@ -740,7 +740,7 @@ static void tree_iterator_set_current(
 
 	iter->entry.mode = tree_entry->attr;
 	iter->entry.path = iter->entry_path.ptr;
-	git_oid_cpy(&iter->entry.id, tree_entry->oid);
+	git_oid_cpy(&iter->entry.id, &tree_entry->oid);
 }
 
 static int tree_iterator_advance(const git_index_entry **out, git_iterator *i)

--- a/src/libgit2/midx.h
+++ b/src/libgit2/midx.h
@@ -17,6 +17,7 @@
 #include "map.h"
 #include "mwindow.h"
 #include "odb.h"
+#include "oid.h"
 
 /*
  * A multi-pack-index file.
@@ -40,7 +41,7 @@ typedef struct git_midx_file {
 	uint32_t num_objects;
 
 	/* The OID Lookup table. */
-	git_oid *oid_lookup;
+	unsigned char *oid_lookup;
 
 	/* The Object Offsets table. Each entry has two 4-byte fields with the pack index and the offset. */
 	const unsigned char *object_offsets;

--- a/src/libgit2/oid.c
+++ b/src/libgit2/oid.c
@@ -203,25 +203,7 @@ int git_oid_equal(const git_oid *a, const git_oid *b)
 
 int git_oid_ncmp(const git_oid *oid_a, const git_oid *oid_b, size_t len)
 {
-	const unsigned char *a = oid_a->id;
-	const unsigned char *b = oid_b->id;
-
-	if (len > GIT_OID_HEXSZ)
-		len = GIT_OID_HEXSZ;
-
-	while (len > 1) {
-		if (*a != *b)
-			return 1;
-		a++;
-		b++;
-		len -= 2;
-	};
-
-	if (len)
-		if ((*a ^ *b) & 0xf0)
-			return 1;
-
-	return 0;
+	return git_oid_raw_ncmp(oid_a->id, oid_b->id, len);
 }
 
 int git_oid_strcmp(const git_oid *oid_a, const char *str)

--- a/src/libgit2/oid.c
+++ b/src/libgit2/oid.c
@@ -187,8 +187,7 @@ int git_oid_fromraw(git_oid *out, const unsigned char *raw)
 
 int git_oid_cpy(git_oid *out, const git_oid *src)
 {
-	memcpy(out->id, src->id, sizeof(out->id));
-	return 0;
+	return git_oid_raw_cpy(out->id, src->id);
 }
 
 int git_oid_cmp(const git_oid *a, const git_oid *b)

--- a/src/libgit2/oid.h
+++ b/src/libgit2/oid.h
@@ -25,6 +25,29 @@ extern const git_oid git_oid__empty_tree_sha1;
  */
 char *git_oid_allocfmt(const git_oid *id);
 
+GIT_INLINE(int) git_oid_raw_ncmp(
+	const unsigned char *sha1,
+	const unsigned char *sha2,
+	size_t len)
+{
+	if (len > GIT_OID_HEXSZ)
+		len = GIT_OID_HEXSZ;
+
+	while (len > 1) {
+		if (*sha1 != *sha2)
+			return 1;
+		sha1++;
+		sha2++;
+		len -= 2;
+	};
+
+	if (len)
+		if ((*sha1 ^ *sha2) & 0xf0)
+			return 1;
+
+	return 0;
+}
+
 GIT_INLINE(int) git_oid_raw_cmp(
 	const unsigned char *sha1,
 	const unsigned char *sha2)

--- a/src/libgit2/oid.h
+++ b/src/libgit2/oid.h
@@ -55,6 +55,14 @@ GIT_INLINE(int) git_oid_raw_cmp(
 	return memcmp(sha1, sha2, GIT_OID_RAWSZ);
 }
 
+GIT_INLINE(int) git_oid_raw_cpy(
+	unsigned char *dst,
+	const unsigned char *src)
+{
+	memcpy(dst, src, GIT_OID_RAWSZ);
+	return 0;
+}
+
 /*
  * Compare two oid structures.
  *

--- a/src/libgit2/oid.h
+++ b/src/libgit2/oid.h
@@ -25,7 +25,9 @@ extern const git_oid git_oid__empty_tree_sha1;
  */
 char *git_oid_allocfmt(const git_oid *id);
 
-GIT_INLINE(int) git_oid__hashcmp(const unsigned char *sha1, const unsigned char *sha2)
+GIT_INLINE(int) git_oid_raw_cmp(
+	const unsigned char *sha1,
+	const unsigned char *sha2)
 {
 	return memcmp(sha1, sha2, GIT_OID_RAWSZ);
 }
@@ -39,7 +41,7 @@ GIT_INLINE(int) git_oid__hashcmp(const unsigned char *sha1, const unsigned char 
  */
 GIT_INLINE(int) git_oid__cmp(const git_oid *a, const git_oid *b)
 {
-	return git_oid__hashcmp(a->id, b->id);
+	return git_oid_raw_cmp(a->id, b->id);
 }
 
 GIT_INLINE(void) git_oid__cpy_prefix(

--- a/src/libgit2/oidmap.c
+++ b/src/libgit2/oidmap.c
@@ -19,7 +19,7 @@ __KHASH_TYPE(oid, const git_oid *, void *)
 GIT_INLINE(khint_t) git_oidmap_hash(const git_oid *oid)
 {
 	khint_t h;
-	memcpy(&h, oid, sizeof(khint_t));
+	memcpy(&h, oid->id, sizeof(khint_t));
 	return h;
 }
 

--- a/src/libgit2/pack.c
+++ b/src/libgit2/pack.c
@@ -1451,7 +1451,7 @@ int git_pack__lookup_sha1(const void *oid_lookup_table, size_t stride, unsigned 
 
 	while (lo < hi) {
 		unsigned mi = (lo + hi) / 2;
-		int cmp = git_oid__hashcmp(base + mi * stride, oid_prefix);
+		int cmp = git_oid_raw_cmp(base + mi * stride, oid_prefix);
 
 		if (!cmp)
 			return mi;

--- a/src/libgit2/pack.h
+++ b/src/libgit2/pack.h
@@ -19,6 +19,7 @@
 #include "offmap.h"
 #include "oidmap.h"
 #include "zstream.h"
+#include "oid.h"
 
 /**
  * Function type for callbacks from git_pack_foreach_entry_offset.
@@ -104,7 +105,7 @@ struct git_pack_file {
 	git_time_t mtime;
 	unsigned pack_local:1, pack_keep:1, has_cache:1;
 	git_oidmap *idx_cache;
-	git_oid **oids;
+	unsigned char **oids;
 
 	git_pack_cache bases; /* delta base cache */
 

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -1830,7 +1830,7 @@ static int update_one_tip(
 	}
 
 	if (error == GIT_ENOTFOUND) {
-		memset(&old, 0, GIT_OID_RAWSZ);
+		memset(&old, 0, sizeof(git_oid));
 		error = 0;
 
 		if (autotag && (error = git_vector_insert(update_heads, head)) < 0)

--- a/src/libgit2/tree-cache.c
+++ b/src/libgit2/tree-cache.c
@@ -263,7 +263,7 @@ static void write_tree(git_str *out, git_tree_cache *tree)
 	git_str_printf(out, "%s%c%"PRIdZ" %"PRIuZ"\n", tree->name, 0, tree->entry_count, tree->children_count);
 
 	if (tree->entry_count != -1)
-		git_str_put(out, (const char *) &tree->oid, GIT_OID_RAWSZ);
+		git_str_put(out, (char *)&tree->oid.id, GIT_OID_RAWSZ);
 
 	for (i = 0; i < tree->children_count; i++)
 		write_tree(out, tree->children[i]);

--- a/src/libgit2/tree.h
+++ b/src/libgit2/tree.h
@@ -19,7 +19,7 @@
 struct git_tree_entry {
 	uint16_t attr;
 	uint16_t filename_len;
-	const git_oid *oid;
+	git_oid oid;
 	const char *filename;
 };
 

--- a/tests/libgit2/iterator/tree.c
+++ b/tests/libgit2/iterator/tree.c
@@ -268,7 +268,7 @@ static void check_tree_entry(
 
 	cl_git_pass(git_iterator_current_tree_entry(&te, i));
 	cl_assert(te);
-	cl_assert(git_oid_streq(te->oid, oid) == 0);
+	cl_assert(git_oid_streq(&te->oid, oid) == 0);
 
 	cl_git_pass(git_iterator_current(&ie, i));
 

--- a/tests/libgit2/object/raw/hash.c
+++ b/tests/libgit2/object/raw/hash.c
@@ -24,20 +24,23 @@ static char *bye_text = "bye world\n";
 void test_object_raw_hash__hash_by_blocks(void)
 {
 	git_hash_ctx ctx;
+	unsigned char hash[GIT_HASH_SHA1_SIZE];
 	git_oid id1, id2;
 
 	cl_git_pass(git_hash_ctx_init(&ctx, GIT_HASH_ALGORITHM_SHA1));
 
 	/* should already be init'd */
 	cl_git_pass(git_hash_update(&ctx, hello_text, strlen(hello_text)));
-	cl_git_pass(git_hash_final(id2.id, &ctx));
+	cl_git_pass(git_hash_final(hash, &ctx));
+	cl_git_pass(git_oid_fromraw(&id2, hash));
 	cl_git_pass(git_oid_fromstr(&id1, hello_id));
 	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 
 	/* reinit should permit reuse */
 	cl_git_pass(git_hash_init(&ctx));
 	cl_git_pass(git_hash_update(&ctx, bye_text, strlen(bye_text)));
-	cl_git_pass(git_hash_final(id2.id, &ctx));
+	cl_git_pass(git_hash_final(hash, &ctx));
+	cl_git_pass(git_oid_fromraw(&id2, hash));
 	cl_git_pass(git_oid_fromstr(&id1, bye_id));
 	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 
@@ -47,9 +50,11 @@ void test_object_raw_hash__hash_by_blocks(void)
 void test_object_raw_hash__hash_buffer_in_single_call(void)
 {
 	git_oid id1, id2;
+	unsigned char hash[GIT_HASH_SHA1_SIZE];
 
 	cl_git_pass(git_oid_fromstr(&id1, hello_id));
-	git_hash_buf(id2.id, hello_text, strlen(hello_text), GIT_HASH_ALGORITHM_SHA1);
+	cl_git_pass(git_hash_buf(hash, hello_text, strlen(hello_text), GIT_HASH_ALGORITHM_SHA1));
+	cl_git_pass(git_oid_fromraw(&id2, hash));
 	cl_assert(git_oid_cmp(&id1, &id2) == 0);
 }
 

--- a/tests/libgit2/object/raw/short.c
+++ b/tests/libgit2/object/raw/short.c
@@ -28,12 +28,15 @@ static int insert_sequential_oids(
 	int i, min_len = 0;
 	char numbuf[16];
 	git_oid oid;
+	unsigned char hashbuf[GIT_HASH_SHA1_SIZE];
 	char **oids = git__calloc(n, sizeof(char *));
 	cl_assert(oids != NULL);
 
 	for (i = 0; i < n; ++i) {
 		p_snprintf(numbuf, sizeof(numbuf), "%u", (unsigned int)i);
-		git_hash_buf(oid.id, numbuf, strlen(numbuf), GIT_HASH_ALGORITHM_SHA1);
+		git_hash_buf(hashbuf, numbuf, strlen(numbuf), GIT_HASH_ALGORITHM_SHA1);
+
+		git_oid_fromraw(&oid, hashbuf);
 
 		oids[i] = git__malloc(GIT_OID_HEXSZ + 1);
 		cl_assert(oids[i]);

--- a/tests/libgit2/object/tree/parse.c
+++ b/tests/libgit2/object/tree/parse.c
@@ -40,7 +40,7 @@ static void assert_tree_parses(const char *data, size_t datalen,
 		cl_assert(entry = git_tree_entry_byname(tree, expected->filename));
 		cl_assert_equal_s(expected->filename, entry->filename);
 		cl_assert_equal_i(expected->attr, entry->attr);
-		cl_assert_equal_oid(&oid, entry->oid);
+		cl_assert_equal_oid(&oid, &entry->oid);
 	}
 
 	git_object_free(&tree->object);

--- a/tests/libgit2/pack/packbuilder.c
+++ b/tests/libgit2/pack/packbuilder.c
@@ -68,7 +68,7 @@ static void seed_packbuilder(void)
 	cl_git_pass(git_revwalk_push_ref(_revwalker, "HEAD"));
 
 	while (git_revwalk_next(&oid, _revwalker) == 0) {
-		o = git__malloc(GIT_OID_RAWSZ);
+		o = git__malloc(sizeof(git_oid));
 		cl_assert(o != NULL);
 		git_oid_cpy(o, &oid);
 		cl_git_pass(git_vector_insert(&_commits, o));


### PR DESCRIPTION
Instead of treating `git_oid` as if it's simply an array of bytes, actually look at the internal byte array member. This is critical if we add additional data to the `git_oid` (like a type enum).

(This is broken out of #6191.)