### PR TITLE
Validate repository directory ownership

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -225,7 +225,9 @@ typedef enum {
 	GIT_OPT_SET_ODB_PACKED_PRIORITY,
 	GIT_OPT_SET_ODB_LOOSE_PRIORITY,
 	GIT_OPT_GET_EXTENSIONS,
-	GIT_OPT_SET_EXTENSIONS
+	GIT_OPT_SET_EXTENSIONS,
+	GIT_OPT_GET_OWNER_VALIDATION,
+	GIT_OPT_SET_OWNER_VALIDATION
 } git_libgit2_opt_t;
 
 /**
@@ -462,6 +464,14 @@ typedef enum {
  *      > { "!noop", "newext" } indicates that the caller does not want
  *      > to support repositories with the `noop` extension but does want
  *      > to support repositories with the `newext` extension.
+ *
+ *   opts(GIT_OPT_GET_OWNER_VALIDATION, int *enabled)
+ *      > Gets the owner validation setting for repository
+ *      > directories.
+ *
+ *   opts(GIT_OPT_SET_OWNER_VALIDATION, int enabled)
+ *      > Set that repository directories should be owned by the current
+ *      > user. The default is to validate ownership.
  *
  * @param option Option key
  * @param ... value to set the option

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -57,7 +57,8 @@ typedef enum {
 	GIT_RETRY           = -32,	/**< Internal only */
 	GIT_EMISMATCH       = -33,	/**< Hashsum mismatch in object */
 	GIT_EINDEXDIRTY     = -34,	/**< Unsaved changes in the index would be overwritten */
-	GIT_EAPPLYFAIL      = -35	/**< Patch application failed */
+	GIT_EAPPLYFAIL      = -35,	/**< Patch application failed */
+	GIT_EOWNER          = -36	/**< The object is not owned by the current user */
 } git_error_code;
 
 /**

--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1170,14 +1170,18 @@ int git_config_find_programdata(git_buf *path)
 
 int git_config__find_programdata(git_str *path)
 {
-	int ret;
+	bool is_safe;
 
-	ret = git_sysdir_find_programdata_file(path, GIT_CONFIG_FILENAME_PROGRAMDATA);
+	if (git_sysdir_find_programdata_file(path, GIT_CONFIG_FILENAME_PROGRAMDATA) < 0 ||
+	    git_fs_path_owner_is_system_or_current_user(&is_safe, path->ptr) < 0)
+		return -1;
 
-	if (ret != GIT_OK)
-		return ret;
+	if (!is_safe) {
+		git_error_set(GIT_ERROR_CONFIG, "programdata path has invalid ownership");
+		return -1;
+	}
 
-	return git_fs_path_validate_system_file_ownership(path->ptr);
+	return 0;
 }
 
 int git_config__global_location(git_str *buf)

--- a/src/libgit2/libgit2.c
+++ b/src/libgit2/libgit2.c
@@ -406,6 +406,14 @@ int git_libgit2_opts(int key, ...)
 		}
 		break;
 
+	case GIT_OPT_GET_OWNER_VALIDATION:
+		*(va_arg(ap, int *)) = git_repository__validate_ownership;
+		break;
+
+	case GIT_OPT_SET_OWNER_VALIDATION:
+		git_repository__validate_ownership = (va_arg(ap, int) != 0);
+		break;
+
 	default:
 		git_error_set(GIT_ERROR_INVALID, "invalid option key");
 		error = -1;

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -1632,13 +1632,40 @@ static bool is_filesystem_case_insensitive(const char *gitdir_path)
 	return is_insensitive;
 }
 
-static bool are_symlinks_supported(const char *wd_path)
+/*
+ * Return a configuration object with only the global and system
+ * configurations; no repository-level configuration.
+ */
+static int load_global_config(git_config **config)
 {
-	git_config *config = NULL;
 	git_str global_buf = GIT_STR_INIT;
 	git_str xdg_buf = GIT_STR_INIT;
 	git_str system_buf = GIT_STR_INIT;
 	git_str programdata_buf = GIT_STR_INIT;
+	int error;
+
+	git_config__find_global(&global_buf);
+	git_config__find_xdg(&xdg_buf);
+	git_config__find_system(&system_buf);
+	git_config__find_programdata(&programdata_buf);
+
+	error = load_config(config, NULL,
+	                    path_unless_empty(&global_buf),
+	                    path_unless_empty(&xdg_buf),
+	                    path_unless_empty(&system_buf),
+	                    path_unless_empty(&programdata_buf));
+
+	git_str_dispose(&global_buf);
+	git_str_dispose(&xdg_buf);
+	git_str_dispose(&system_buf);
+	git_str_dispose(&programdata_buf);
+
+	return error;
+}
+
+static bool are_symlinks_supported(const char *wd_path)
+{
+	git_config *config = NULL;
 	int symlinks = 0;
 
 	/*
@@ -1649,19 +1676,9 @@ static bool are_symlinks_supported(const char *wd_path)
 	 * _not_ set, then we do not test or enable symlink support.
 	 */
 #ifdef GIT_WIN32
-	git_config__find_global(&global_buf);
-	git_config__find_xdg(&xdg_buf);
-	git_config__find_system(&system_buf);
-	git_config__find_programdata(&programdata_buf);
-
-	if (load_config(&config, NULL,
-	    path_unless_empty(&global_buf),
-	    path_unless_empty(&xdg_buf),
-	    path_unless_empty(&system_buf),
-	    path_unless_empty(&programdata_buf)) < 0)
-		goto done;
-
-	if (git_config_get_bool(&symlinks, config, "core.symlinks") < 0 || !symlinks)
+	if (load_global_config(&config) < 0 ||
+	    git_config_get_bool(&symlinks, config, "core.symlinks") < 0 ||
+	    !symlinks)
 		goto done;
 #endif
 
@@ -1669,10 +1686,6 @@ static bool are_symlinks_supported(const char *wd_path)
 		goto done;
 
 done:
-	git_str_dispose(&global_buf);
-	git_str_dispose(&xdg_buf);
-	git_str_dispose(&system_buf);
-	git_str_dispose(&programdata_buf);
 	git_config_free(config);
 	return symlinks != 0;
 }

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -39,6 +39,7 @@
 # include "win32/w32_util.h"
 #endif
 
+bool git_repository__validate_ownership = true;
 bool git_repository__fsync_gitdir = false;
 
 static const struct {
@@ -977,7 +978,8 @@ int git_repository_open_ext(
 	 */
 	validation_path = repo->is_bare ? repo->gitdir : repo->workdir;
 
-	if ((error = validate_ownership(validation_path)) < 0)
+	if (git_repository__validate_ownership &&
+	    (error = validate_ownership(validation_path)) < 0)
 		goto cleanup;
 
 cleanup:

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -65,6 +65,7 @@ static const struct {
 
 static int check_repositoryformatversion(int *version, git_config *config);
 static int check_extensions(git_config *config, int version);
+static int load_global_config(git_config **config);
 
 #define GIT_COMMONDIR_FILE "commondir"
 #define GIT_GITDIR_FILE "gitdir"
@@ -483,21 +484,61 @@ static int read_gitfile(git_str *path_out, const char *file_path)
 	return error;
 }
 
+typedef struct {
+	const char *repo_path;
+	git_str tmp;
+	bool is_safe;
+} validate_ownership_data;
+
+static int validate_ownership_cb(const git_config_entry *entry, void *payload)
+{
+	validate_ownership_data *data = payload;
+
+	if (strcmp(entry->value, "") == 0)
+		data->is_safe = false;
+
+	if (git_fs_path_prettify_dir(&data->tmp, entry->value, NULL) == 0 &&
+	    strcmp(data->tmp.ptr, data->repo_path) == 0)
+		data->is_safe = true;
+
+	return 0;
+}
+
 static int validate_ownership(const char *repo_path)
 {
+	git_config *config = NULL;
+	validate_ownership_data data = { repo_path, GIT_STR_INIT, false };
 	bool is_safe;
 	int error;
 
-	if ((error = git_fs_path_owner_is_current_user(&is_safe, repo_path)) < 0)
-		return (error == GIT_ENOTFOUND) ? 0 : error;
+	if ((error = git_fs_path_owner_is_current_user(&is_safe, repo_path)) < 0) {
+		if (error == GIT_ENOTFOUND)
+			error = 0;
 
-	if (is_safe)
-		return 0;
+		goto done;
+	}
+
+	if (is_safe) {
+		error = 0;
+		goto done;
+	}
+
+	if (load_global_config(&config) == 0) {
+		error = git_config_get_multivar_foreach(config, "safe.directory", NULL, validate_ownership_cb, &data);
+
+		if (!error && data.is_safe)
+			goto done;
+	}
 
 	git_error_set(GIT_ERROR_CONFIG,
 		"repository path '%s' is not owned by current user",
 		repo_path);
-	return GIT_EOWNER;
+	error = GIT_EOWNER;
+
+done:
+	git_config_free(config);
+	git_str_dispose(&data.tmp);
+	return error;
 }
 
 static int find_repo(

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -34,6 +34,7 @@
 #define GIT_DIR_SHORTNAME "GIT~1"
 
 extern bool git_repository__fsync_gitdir;
+extern bool git_repository__validate_ownership;
 
 /** Cvar cache identifiers */
 typedef enum {

--- a/src/util/fs_path.c
+++ b/src/util/fs_path.c
@@ -1785,81 +1785,198 @@ done:
 	return supported;
 }
 
-int git_fs_path_validate_system_file_ownership(const char *path)
+#ifdef GIT_WIN32
+static PSID *sid_dup(PSID sid)
 {
-#ifndef GIT_WIN32
-	GIT_UNUSED(path);
-	return GIT_OK;
-#else
-	git_win32_path buf;
-	PSID owner_sid;
-	PSECURITY_DESCRIPTOR descriptor = NULL;
-	HANDLE token;
-	TOKEN_USER *info = NULL;
-	DWORD err, len;
-	int ret;
+	DWORD len;
+	PSID dup;
 
-	if (git_win32_path_from_utf8(buf, path) < 0)
+	len = GetLengthSid(sid);
+
+	if ((dup = git__malloc(len)) == NULL)
+		return NULL;
+
+	if (!CopySid(len, dup, sid)) {
+		git_error_set(GIT_ERROR_OS, "could not duplicate sid");
+		git__free(dup);
+		return NULL;
+	}
+
+	return dup;
+}
+
+static int current_user_sid(PSID *out)
+{
+	TOKEN_USER *info = NULL;
+	HANDLE token = NULL;
+	DWORD len = 0;
+	int error = -1;
+
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+		git_error_set(GIT_ERROR_OS, "could not lookup process information");
+		goto done;
+	}
+
+	if (GetTokenInformation(token, TokenUser, NULL, 0, &len) ||
+		GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+		git_error_set(GIT_ERROR_OS, "could not lookup token metadata");
+		goto done;
+	}
+
+	info = git__malloc(len);
+	GIT_ERROR_CHECK_ALLOC(info);
+
+	if (!GetTokenInformation(token, TokenUser, info, len, &len)) {
+		git_error_set(GIT_ERROR_OS, "could not lookup current user");
+		goto done;
+	}
+
+	if ((*out = sid_dup(info->User.Sid)))
+		error = 0;
+
+done:
+	if (token)
+		CloseHandle(token);
+
+	git__free(info);
+	return error;
+}
+
+static int file_owner_sid(PSID *out, const char *path)
+{
+	git_win32_path path_w32;
+	PSECURITY_DESCRIPTOR descriptor = NULL;
+	PSID owner_sid;
+	DWORD ret;
+	int error = -1;
+
+	if (git_win32_path_from_utf8(path_w32, path) < 0)
 		return -1;
 
-	err = GetNamedSecurityInfoW(buf, SE_FILE_OBJECT,
-				    OWNER_SECURITY_INFORMATION |
-					    DACL_SECURITY_INFORMATION,
-				    &owner_sid, NULL, NULL, NULL, &descriptor);
+	ret = GetNamedSecurityInfoW(path_w32, SE_FILE_OBJECT,
+		OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+		&owner_sid, NULL, NULL, NULL, &descriptor);
 
-	if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
-		ret = GIT_ENOTFOUND;
-		goto cleanup;
-	}
-
-	if (err != ERROR_SUCCESS) {
+	if (ret == ERROR_FILE_NOT_FOUND || ret == ERROR_PATH_NOT_FOUND)
+		error = GIT_ENOTFOUND;
+	else if (ret != ERROR_SUCCESS)
 		git_error_set(GIT_ERROR_OS, "failed to get security information");
-		ret = GIT_ERROR;
-		goto cleanup;
-	}
+	else if (!IsValidSid(owner_sid))
+		git_error_set(GIT_ERROR_OS, "file owner is not valid");
+	else if ((*out = sid_dup(owner_sid)))
+		error = 0;
 
-	if (!IsValidSid(owner_sid)) {
-		git_error_set(GIT_ERROR_INVALID, "programdata configuration file owner is unknown");
-		ret = GIT_ERROR;
-		goto cleanup;
-	}
-
-	if (IsWellKnownSid(owner_sid, WinBuiltinAdministratorsSid) ||
-	    IsWellKnownSid(owner_sid, WinLocalSystemSid)) {
-		ret = GIT_OK;
-		goto cleanup;
-	}
-
-	/* Obtain current user's SID */
-	if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token) &&
-	    !GetTokenInformation(token, TokenUser, NULL, 0, &len)) {
-		info = git__malloc(len);
-		GIT_ERROR_CHECK_ALLOC(info);
-		if (!GetTokenInformation(token, TokenUser, info, len, &len)) {
-			git__free(info);
-			info = NULL;
-		}
-	}
-
-	/*
-	 * If the file is owned by the same account that is running the current
-	 * process, it's okay to read from that file.
-	 */
-	if (info && EqualSid(owner_sid, info->User.Sid))
-		ret = GIT_OK;
-	else {
-		git_error_set(GIT_ERROR_INVALID, "programdata configuration file owner is not valid");
-		ret = GIT_ERROR;
-	}
-	git__free(info);
-
-cleanup:
 	if (descriptor)
 		LocalFree(descriptor);
 
-	return ret;
-#endif
+	return error;
 }
+
+int git_fs_path_owner_is_current_user(bool *out, const char *path)
+{
+	PSID owner_sid = NULL, user_sid = NULL;
+	int error = -1;
+
+	if ((error = file_owner_sid(&owner_sid, path)) < 0 ||
+	    (error = current_user_sid(&user_sid)) < 0)
+		goto done;
+
+	*out = EqualSid(owner_sid, user_sid);
+	error = 0;
+
+done:
+	git__free(owner_sid);
+	git__free(user_sid);
+	return error;
+}
+
+int git_fs_path_owner_is_system(bool *out, const char *path)
+{
+	PSID owner_sid;
+
+	if (file_owner_sid(&owner_sid, path) < 0)
+		return -1;
+
+	*out = IsWellKnownSid(owner_sid, WinBuiltinAdministratorsSid) ||
+	       IsWellKnownSid(owner_sid, WinLocalSystemSid);
+
+	git__free(owner_sid);
+	return 0;
+}
+
+int git_fs_path_owner_is_system_or_current_user(bool *out, const char *path)
+{
+	PSID owner_sid = NULL, user_sid = NULL;
+	int error = -1;
+
+	if (file_owner_sid(&owner_sid, path) < 0)
+		goto done;
+
+	if (IsWellKnownSid(owner_sid, WinBuiltinAdministratorsSid) ||
+	    IsWellKnownSid(owner_sid, WinLocalSystemSid)) {
+		*out = 1;
+		error = 0;
+		goto done;
+	}
+
+	if (current_user_sid(&user_sid) < 0)
+		goto done;
+
+	*out = EqualSid(owner_sid, user_sid);
+	error = 0;
+
+done:
+	git__free(owner_sid);
+	git__free(user_sid);
+	return error;
+}
+
+#else
+
+static int fs_path_owner_is(bool *out, const char *path, uid_t *uids, size_t uids_len)
+{
+	struct stat st;
+	size_t i;
+
+	*out = false;
+
+	if (p_lstat(path, &st) != 0) {
+		if (errno == ENOENT)
+			return GIT_ENOTFOUND;
+
+		git_error_set(GIT_ERROR_OS, "could not stat '%s'", path);
+		return -1;
+	}
+
+	for (i = 0; i < uids_len; i++) {
+		if (uids[i] == st.st_uid) {
+			*out = true;
+			break;
+		}
+	}
+
+	return 0;
+}
+
+int git_fs_path_owner_is_current_user(bool *out, const char *path)
+{
+	uid_t userid = geteuid();
+	return fs_path_owner_is(out, path, &userid, 1);
+}
+
+int git_fs_path_owner_is_system(bool *out, const char *path)
+{
+	uid_t userid = 0;
+	return fs_path_owner_is(out, path, &userid, 1);
+}
+
+int git_fs_path_owner_is_system_or_current_user(bool *out, const char *path)
+{
+	uid_t userids[2] = { geteuid(), 0 };
+	return fs_path_owner_is(out, path, userids, 2);
+}
+
+#endif
 
 int git_fs_path_find_executable(git_str *fullpath, const char *executable)
 {

--- a/src/util/fs_path.h
+++ b/src/util/fs_path.h
@@ -731,6 +731,20 @@ int git_fs_path_normalize_slashes(git_str *out, const char *path);
 
 bool git_fs_path_supports_symlinks(const char *dir);
 
+typedef enum {
+	GIT_FS_PATH_MOCK_OWNER_NONE = 0, /* do filesystem lookups as normal */
+	GIT_FS_PATH_MOCK_OWNER_SYSTEM = 1,
+	GIT_FS_PATH_MOCK_OWNER_CURRENT_USER = 2,
+	GIT_FS_PATH_MOCK_OWNER_OTHER = 3
+} git_fs_path__mock_owner_t;
+
+/**
+ * Sets the mock ownership for files; subsequent calls to
+ * `git_fs_path_owner_is_*` functions will return this data until cleared
+ * with `GIT_FS_PATH_MOCK_OWNER_NONE`.
+ */
+void git_fs_path__set_owner(git_fs_path__mock_owner_t owner);
+
 /**
  * Verify that the file in question is owned by an administrator or system
  * account.

--- a/src/util/fs_path.h
+++ b/src/util/fs_path.h
@@ -732,16 +732,22 @@ int git_fs_path_normalize_slashes(git_str *out, const char *path);
 bool git_fs_path_supports_symlinks(const char *dir);
 
 /**
- * Validate a system file's ownership
- *
  * Verify that the file in question is owned by an administrator or system
- * account, or at least by the current user.
- *
- * This function returns 0 if successful. If the file is not owned by any of
- * these, or any other if there have been problems determining the file
- * ownership, it returns -1.
+ * account.
  */
-int git_fs_path_validate_system_file_ownership(const char *path);
+int git_fs_path_owner_is_system(bool *out, const char *path);
+
+/**
+ * Verify that the file in question is owned by the current user;
+ */
+
+int git_fs_path_owner_is_current_user(bool *out, const char *path);
+
+/**
+ * Verify that the file in question is owned by an administrator or system
+ * account _or_ the current user;
+ */
+int git_fs_path_owner_is_system_or_current_user(bool *out, const char *path);
 
 /**
  * Search the current PATH for the given executable, returning the full

--- a/tests/clar/clar_libgit2.c
+++ b/tests/clar/clar_libgit2.c
@@ -599,6 +599,11 @@ void cl_sandbox_set_search_path_defaults(void)
 	git_str_dispose(&path);
 }
 
+void cl_sandbox_disable_ownership_validation(void)
+{
+	git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, 0);
+}
+
 #ifdef GIT_WIN32
 bool cl_sandbox_supports_8dot3(void)
 {

--- a/tests/clar/clar_libgit2.h
+++ b/tests/clar/clar_libgit2.h
@@ -222,6 +222,7 @@ void cl_fake_home(void);
 void cl_fake_home_cleanup(void *);
 
 void cl_sandbox_set_search_path_defaults(void);
+void cl_sandbox_disable_ownership_validation(void);
 
 #ifdef GIT_WIN32
 # define cl_msleep(x) Sleep(x)

--- a/tests/clar/main.c
+++ b/tests/clar/main.c
@@ -26,6 +26,7 @@ int main(int argc, char *argv[])
 
 	cl_global_trace_register();
 	cl_sandbox_set_search_path_defaults();
+	cl_sandbox_disable_ownership_validation();
 
 	/* Run the test suite */
 	res = clar_test_run();

--- a/tests/libgit2/repo/config.c
+++ b/tests/libgit2/repo/config.c
@@ -28,7 +28,6 @@ void test_repo_config__cleanup(void)
 	cl_assert(!git_fs_path_isdir("alternate"));
 
 	cl_fixture_cleanup("empty_standard_repo");
-
 }
 
 void test_repo_config__can_open_global_when_there_is_no_file(void)

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -7,9 +7,12 @@
 void test_repo_open__cleanup(void)
 {
 	cl_git_sandbox_cleanup();
+	cl_fixture_cleanup("empty_standard_repo");
 
 	if (git_fs_path_isdir("alternate"))
 		git_futils_rmdir_r("alternate", NULL, GIT_RMDIR_REMOVE_FILES);
+
+	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_NONE);
 }
 
 void test_repo_open__bare_empty_repo(void)
@@ -453,3 +456,35 @@ void test_repo_open__force_bare(void)
 	git_repository_free(barerepo);
 }
 
+void test_repo_open__validates_dir_ownership(void)
+{
+	git_repository *repo;
+
+	cl_fixture_sandbox("empty_standard_repo");
+	cl_git_pass(cl_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
+
+	/* When the current user owns the repo config, that's acceptable */
+	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_CURRENT_USER);
+	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
+	git_repository_free(repo);
+
+	/* When the system user owns the repo config, fail */
+	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_SYSTEM);
+	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
+
+	/* When an unknown user owns the repo config, fail */
+	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_OTHER);
+	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
+}
+
+void test_repo_open__can_allowlist_dirs_with_problematic_ownership(void)
+{
+	git_repository *repo;
+
+	cl_fixture_sandbox("empty_standard_repo");
+	cl_git_pass(cl_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
+
+	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_OTHER);
+	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
+
+}

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -3,11 +3,13 @@
 #include "sysdir.h"
 #include <ctype.h>
 
+static int validate_ownership = 0;
 static git_buf config_path = GIT_BUF_INIT;
 
 void test_repo_open__initialize(void)
 {
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, &config_path));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_OWNER_VALIDATION, &validate_ownership));
 }
 
 void test_repo_open__cleanup(void)
@@ -23,6 +25,8 @@ void test_repo_open__cleanup(void)
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_SEARCH_PATH, GIT_CONFIG_LEVEL_GLOBAL, config_path.ptr));
 	git_buf_dispose(&config_path);
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, validate_ownership));
 }
 
 void test_repo_open__bare_empty_repo(void)
@@ -470,6 +474,8 @@ void test_repo_open__validates_dir_ownership(void)
 {
 	git_repository *repo;
 
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, 1));
+
 	cl_fixture_sandbox("empty_standard_repo");
 	cl_git_pass(cl_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
 
@@ -493,6 +499,8 @@ void test_repo_open__can_allowlist_dirs_with_problematic_ownership(void)
 	git_str config_path = GIT_STR_INIT,
 	        config_filename = GIT_STR_INIT,
 	        config_data = GIT_STR_INIT;
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, 1));
 
 	cl_fixture_sandbox("empty_standard_repo");
 	cl_git_pass(cl_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
@@ -536,6 +544,8 @@ void test_repo_open__can_reset_safe_directory_list(void)
 	git_str config_path = GIT_STR_INIT,
 	        config_filename = GIT_STR_INIT,
 	        config_data = GIT_STR_INIT;
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, 1));
 
 	cl_fixture_sandbox("empty_standard_repo");
 	cl_git_pass(cl_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));

--- a/tests/util/path.c
+++ b/tests/util/path.c
@@ -737,3 +737,28 @@ void test_path__find_exe_in_path(void)
 	git_str_dispose(&sandbox_path);
 	git__free(orig_path);
 }
+
+void test_path__validate_current_user_ownership(void)
+{
+	bool is_cur;
+
+	cl_must_pass(p_mkdir("testdir", 0777));
+	cl_git_pass(git_fs_path_owner_is_current_user(&is_cur, "testdir"));
+	cl_assert_equal_i(is_cur, 1);
+
+	cl_git_rewritefile("testfile", "This is a test file.");
+	cl_git_pass(git_fs_path_owner_is_current_user(&is_cur, "testfile"));
+	cl_assert_equal_i(is_cur, 1);
+
+#ifdef GIT_WIN32
+	cl_git_pass(git_fs_path_owner_is_current_user(&is_cur, "C:\\"));
+	cl_assert_equal_i(is_cur, 0);
+
+	cl_git_fail(git_fs_path_owner_is_current_user(&is_cur, "c:\\path\\does\\not\\exist"));
+#else
+	cl_git_pass(git_fs_path_owner_is_current_user(&is_cur, "/"));
+	cl_assert_equal_i(is_cur, 0);
+
+	cl_git_fail(git_fs_path_owner_is_current_user(&is_cur, "/path/does/not/exist"));
+#endif
+}


### PR DESCRIPTION
Validate that the repository (the `.git` folder for bare repositories, or its parent, the working directory, for non-bare repositories) is owned by the current user. This prevents a class of attacks where an attacker creates a `.git` directory in a shared folder (eg `/tmp`) with a malicious configuration. Other users on the system who run git commands in `/tmp` would then be vulnerable.