### PR TITLE
Bug #6272 - fix crash in git_describe_commit.

### DIFF
--- a/src/describe.c
+++ b/src/describe.c
@@ -652,7 +652,7 @@ int git_describe_commit(
 {
 	struct get_name_data data;
 	struct commit_name *name;
-	git_commit *commit;
+	git_commit *commit = NULL;
 	int error = -1;
 	git_describe_options normalized;
 
@@ -698,7 +698,8 @@ int git_describe_commit(
 		goto cleanup;
 
 cleanup:
-	git_commit_free(commit);
+	if (commit != NULL)
+		git_commit_free(commit);
 
 	git_oidmap_foreach_value(data.names, name, {
 		git_tag_free(name->tag);

--- a/src/describe.c
+++ b/src/describe.c
@@ -698,8 +698,7 @@ int git_describe_commit(
 		goto cleanup;
 
 cleanup:
-	if (commit != NULL)
-		git_commit_free(commit);
+	git_commit_free(commit);
 
 	git_oidmap_foreach_value(data.names, name, {
 		git_tag_free(name->tag);


### PR DESCRIPTION
When the passed object fails to be peeled into a commit pointer,
the cleanup code still tries to free the (uninitialized) pointer.

See #6272 