### PR TITLE
remote: Delete a now-inexistent API declaration

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -260,16 +260,6 @@ GIT_EXTERN(int) git_transport_smart_certificate_check(git_transport *transport, 
  */
 GIT_EXTERN(int) git_transport_smart_credentials(git_credential **out, git_transport *transport, const char *user, int methods);
 
-/**
- * Get a copy of the proxy options
- *
- * The url is copied and must be freed by the caller.
- *
- * @param out options struct to fill
- * @param transport the transport to extract the data from.
- */
-GIT_EXTERN(int) git_transport_smart_proxy_options(git_proxy_options *out, git_transport *transport);
-
 /*
  *** End of base transport interface ***
  *** Begin interface for subtransports for the smart transport ***


### PR DESCRIPTION
6fc6eeb66c40310086c8f059cae41de69ad4c6da replaced the remote options
with `git_remote_connect_options`. The function definitions were
removed, but one function declaration remained, causing linker errors if
one tried to use it.

This change removes the declaration of
`git_transport_smart_proxy_option` to better reflect reality.