### PR TITLE
Fix missing include

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -9,6 +9,7 @@
 #define INCLUDE_sys_git_transport_h
 
 #include "git2/net.h"
+#include "git2/remote.h"
 #include "git2/transport.h"
 #include "git2/types.h"
 #include "git2/strarray.h"


### PR DESCRIPTION
`#include <git2/sys/transport.h>` leads to the following error message:

```
compiling test.c
In file included from test.c:2:
/opt/homebrew/Cellar/libgit2/1.4.2_1/include/git2/sys/transport.h:38:9: error: unknown type name 'git_remote_connect_options'
                const git_remote_connect_options *connect_opts);
                      ^
```

`git_remote_connect_options` is defined in `git2/remote.h`

Including `"git2/remote.h"` in `include/git2/sys/transport.h` fixes the issue