### PR TITLE
Push options

### DIFF
--- a/ci/hooks/pre-receive
+++ b/ci/hooks/pre-receive
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf "$GIT_PUSH_OPTION_0$GIT_PUSH_OPTION_1$GIT_PUSH_OPTION_2" > %file%

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -812,9 +812,14 @@ typedef struct {
 	 * Extra headers for this push operation
 	 */
 	git_strarray custom_headers;
+
+	/**
+	 * Push options to pass to git server hooks
+	 */
+	git_strarray arguments;
 } git_push_options;
 
-#define GIT_PUSH_OPTIONS_VERSION 1
+#define GIT_PUSH_OPTIONS_VERSION 2
 #define GIT_PUSH_OPTIONS_INIT { GIT_PUSH_OPTIONS_VERSION, 1, GIT_REMOTE_CALLBACKS_INIT, GIT_PROXY_OPTIONS_INIT }
 
 /**

--- a/src/libgit2/push.h
+++ b/src/libgit2/push.h
@@ -42,6 +42,7 @@ struct git_push {
 	/* options */
 	unsigned pb_parallelism;
 	git_remote_callbacks callbacks;
+	git_strarray *arguments;
 };
 
 /**

--- a/src/libgit2/transports/smart.h
+++ b/src/libgit2/transports/smart.h
@@ -32,6 +32,7 @@
 #define GIT_CAP_SYMREF "symref"
 #define GIT_CAP_WANT_TIP_SHA1 "allow-tip-sha1-in-want"
 #define GIT_CAP_WANT_REACHABLE_SHA1 "allow-reachable-sha1-in-want"
+#define GIT_CAP_PUSH_ARGUMENTS "push-options"
 
 extern bool git_smart__ofs_delta_enabled;
 
@@ -132,7 +133,8 @@ typedef struct transport_smart_caps {
 	             report_status:1,
 	             thin_pack:1,
 	             want_tip_sha1:1,
-	             want_reachable_sha1:1;
+	             want_reachable_sha1:1,
+	             push_arguments:1;
 } transport_smart_caps;
 
 typedef int (*packetsize_cb)(size_t received, void *payload);

--- a/src/libgit2/transports/smart_pkt.c
+++ b/src/libgit2/transports/smart_pkt.c
@@ -545,6 +545,9 @@ static int buffer_want_with_caps(const git_remote_head *head, transport_smart_ca
 	else if (caps->side_band)
 		git_str_printf(&str, "%s ", GIT_CAP_SIDE_BAND);
 
+	if (caps->push_arguments)
+		git_str_puts(&str, GIT_CAP_PUSH_ARGUMENTS " ");
+
 	if (caps->include_tag)
 		git_str_puts(&str, GIT_CAP_INCLUDE_TAG " ");
 

--- a/src/libgit2/transports/smart_protocol.c
+++ b/src/libgit2/transports/smart_protocol.c
@@ -196,6 +196,12 @@ int git_smart__detect_caps(git_pkt_ref *pkt, transport_smart_caps *caps, git_vec
 			continue;
 		}
 
+		if (!git__prefixcmp(ptr, GIT_CAP_PUSH_ARGUMENTS)) {
+			caps->common = caps->push_arguments = 1;
+			ptr += strlen(GIT_CAP_PUSH_ARGUMENTS);
+			continue;
+		}
+
 		if (!git__prefixcmp(ptr, GIT_CAP_SYMREF)) {
 			int error;
 
@@ -639,7 +645,7 @@ done:
 	return error;
 }
 
-static int gen_pktline(git_str *buf, git_push *push)
+static int gen_pktline(git_str *buf, git_push *push, const transport_smart_caps *caps)
 {
 	push_spec *spec;
 	size_t i, len;
@@ -655,6 +661,9 @@ static int gen_pktline(git_str *buf, git_push *push)
 			if (push->report_status)
 				len += strlen(GIT_CAP_REPORT_STATUS) + 1;
 			len += strlen(GIT_CAP_SIDE_BAND_64K) + 1;
+
+			if (caps->push_arguments && push->arguments != NULL)
+				len += strlen(GIT_CAP_PUSH_ARGUMENTS) + 1;
 		}
 
 		git_oid_fmt(old_id, &spec->roid);
@@ -671,12 +680,27 @@ static int gen_pktline(git_str *buf, git_push *push)
 			}
 			git_str_putc(buf, ' ');
 			git_str_printf(buf, GIT_CAP_SIDE_BAND_64K);
+
+			if (caps->push_arguments && push->arguments != NULL) {
+				git_str_putc(buf, ' ');
+				git_str_printf(buf, GIT_CAP_PUSH_ARGUMENTS);
+			}
 		}
 
 		git_str_putc(buf, '\n');
 	}
 
 	git_str_puts(buf, "0000");
+
+	if (caps->push_arguments && push->arguments != NULL) {
+		for (i = 0; i < push->arguments->count; i++) {
+			const char *argument = push->arguments->strings[i];
+			git_str_printf(buf, "%04"PRIxZ"%s", strlen(argument) + 4, argument);
+		}
+		/* must include if push options is enabled (even if empty string) */
+		git_str_puts(buf, "0000");
+	}
+
 	return git_str_oom(buf) ? -1 : 0;
 }
 
@@ -1053,7 +1077,7 @@ int git_smart__push(git_transport *transport, git_push *push)
 		goto done;
 
 	if ((error = git_smart__get_push_stream(t, &packbuilder_payload.stream)) < 0 ||
-		(error = gen_pktline(&pktline, push)) < 0 ||
+		(error = gen_pktline(&pktline, push, &t->caps)) < 0 ||
 		(error = packbuilder_payload.stream->write(packbuilder_payload.stream, git_str_cstr(&pktline), git_str_len(&pktline))) < 0)
 		goto done;
 


### PR DESCRIPTION
My classmates and I, with help from someone on the GitKraken team, implemented a way to upload push options.

A refresher on what push options are: https://git-scm.com/docs/git-push#Documentation/git-push.txt--oltoptiongt

Justification: Push options are a popular way to specify additional parameters for Git hosting services. GitLab uses them to specify CI variables in their CI pipeline (https://docs.gitlab.com/ee/user/project/push_options.html), for instance. With the advent of Git GUIs using libgit2 to implement their Git support, we feel it important to reduce the functionality gap between the Git CLI and libgit2.

---

Intended use:
```c
git_remote *remote = ...;
git_strarray refspecs = ...;
git_push_options options;
const char *args[2] = {
    "Lorem Ipsum es simplemente el texto",
    "That still only counts as one!"
};
options.arguments = (git_strarray){
    args,
    2
};

git_remote_push(remote, &refspecs, &options);
```
Should be noted that the way we designed this potentially breaks ABI compatibility. Open to suggestions on how to re-implement if this is not desired.

Let me know if there are any questions on the implementation. Tests ended up being a little weird because there didn't seem to be a nice way to implement them in the normal `ctest` suite, so we implemented our tests as CI tests. The changes we made aren't super complicated, so I'm hoping the code should be more-or-less self-explanatory but I of course could be wrong about that. 