### PR TITLE
Fix examples/CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/examples/build/
 .DS_Store
 *~
 .*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /tags
 CMakeSettings.json
 .vs
+.vscode
 .idea

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,18 +1,48 @@
 # examples: code usage examples of libgit2
+cmake_minimum_required(VERSION 3.5.1)
+project(libgit2examples LANGUAGES C)
 
-file(GLOB SRC_EXAMPLES *.c *.h)
+set(SRC_EXAMPLES 
+  add.c
+  args.c
+  args.h
+  blame.c
+  cat-file.c
+  checkout.c
+  clone.c
+  commit.c
+  common.c
+  common.h
+  config.c
+  describe.c
+  diff.c
+  fetch.c
+  for-each-ref.c
+  general.c
+  index-pack.c
+  init.c
+  lg2.c
+  log.c
+  ls-files.c
+  ls-remote.c
+  merge.c
+  push.c
+  remote.c
+  rev-list.c
+  rev-parse.c
+  show-index.c
+  stash.c
+  status.c
+  tag.c
+)
 
 add_executable(lg2 ${SRC_EXAMPLES})
 set_target_properties(lg2 PROPERTIES C_STANDARD 90)
 
 # Ensure that we do not use deprecated functions internally
-add_definitions(-DGIT_DEPRECATE_HARD)
+target_compile_definitions(lg2 PRIVATE GIT_DEPRECATE_HARD)
 
-target_include_directories(lg2 PRIVATE ${LIBGIT2_INCLUDES} ${LIBGIT2_DEPENDENCY_INCLUDES})
-target_include_directories(lg2 SYSTEM PRIVATE ${LIBGIT2_SYSTEM_INCLUDES})
-
-if(WIN32 OR ANDROID)
-	target_link_libraries(lg2 libgit2package)
-else()
-	target_link_libraries(lg2 libgit2package pthread)
-endif()
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBGIT2 REQUIRED libgit2)
+target_include_directories(lg2 SYSTEM PRIVATE ${LIBGIT2_INCLUDE_DIRS})
+target_link_libraries(lg2 ${LIBGIT2_LINK_LIBRARIES})

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,3 +20,17 @@ For annotated HTML versions, see the "Examples" section of:
 such as:
 
     http://libgit2.github.com/libgit2/ex/HEAD/general.html
+
+Prerequisites for examples
+--------------------------
+1. [CMake](https://cmake.org/), and is recommended to be installed into your `PATH`.
+2. `libgit2`, it is assumed you have already built [and installed](../README.md#installation), to the default system path (don't specify `CMAKE_INSTALL_PREFIX`).
+3. [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) is used by `examples/CMakeLists.txt` to determine the necessary include and link paths.  In this way, it is also an example of how an external project might include `libgit2` as a dependency using cmake.
+
+Build
+-----
+Similarly to `libgit2` itself, the examples can be built with cmake using the following commands
+
+        $ mkdir examples/build && cd examples/build
+        $ cmake ..
+        $ cmake --build .


### PR DESCRIPTION
This fixes issue #6241.  

`examples/CMakeListst.txt` has been made independent of the rest of libgit2's build.  
This is done by making use of pkg-config, since a `libgit2.pc` file is provided during installation.

Source files have been listed explicitly, as `file(GLOB ...)` is [discouraged for setting sources](https://cmake.org/cmake/help/latest/command/file.html?highlight=file%20glob#glob).
> Note We do not recommend using GLOB to collect a list of source files from your source tree. If no CMakeLists.txt file changes when a source is added or removed then the generated build system cannot know when to ask CMake to regenerate. ...

Some build instructions have also been added to the examples readme.
