### PR TITLE
A couple of simplications around mwindow

### DIFF
--- a/src/libgit2/mwindow.c
+++ b/src/libgit2/mwindow.c
@@ -240,9 +240,7 @@ static bool git_mwindow_scan_recently_used(
 		 * store it in the output parameter. If lru_window is NULL,
 		 * it's the first loop, so store it as well.
 		 */
-		if (!lru_window ||
-				(comparison_sign == GIT_MWINDOW__LRU && lru_window->last_used > w->last_used) ||
-				(comparison_sign == GIT_MWINDOW__MRU && lru_window->last_used < w->last_used)) {
+		if (!lru_window || (comparison_sign * w->last_used) > lru_window->last_used) {
 			lru_window = w;
 			lru_last = w_last;
 			found = true;

--- a/src/libgit2/mwindow.c
+++ b/src/libgit2/mwindow.c
@@ -186,13 +186,16 @@ int git_mwindow_free_all(git_mwindow_file *mwf)
 }
 
 /*
- * Check if a window 'win' contains the address 'offset'
+ * Check if a window 'win' contains both the address 'offset' and 'extra'.
+ *
+ * 'extra' is the size of the hash we're using as we always want to make sure
+ * that it's contained.
  */
-int git_mwindow_contains(git_mwindow *win, off64_t offset)
+int git_mwindow_contains(git_mwindow *win, off64_t offset, off64_t extra)
 {
 	off64_t win_off = win->offset;
 	return win_off <= offset
-		&& offset <= (off64_t)(win_off + win->window_map.len);
+		&& (offset + extra) <= (off64_t)(win_off + win->window_map.len);
 }
 
 #define GIT_MWINDOW__LRU -1
@@ -406,14 +409,13 @@ unsigned char *git_mwindow_open(
 		return NULL;
 	}
 
-	if (!w || !(git_mwindow_contains(w, offset) && git_mwindow_contains(w, offset + extra))) {
+	if (!w || !(git_mwindow_contains(w, offset, extra))) {
 		if (w) {
 			w->inuse_cnt--;
 		}
 
 		for (w = mwf->windows; w; w = w->next) {
-			if (git_mwindow_contains(w, offset) &&
-				git_mwindow_contains(w, offset + extra))
+			if (git_mwindow_contains(w, offset, extra))
 				break;
 		}
 

--- a/src/libgit2/mwindow.h
+++ b/src/libgit2/mwindow.h
@@ -38,7 +38,7 @@ typedef struct git_mwindow_ctl {
 	git_vector windowfiles;
 } git_mwindow_ctl;
 
-int git_mwindow_contains(git_mwindow *win, off64_t offset);
+int git_mwindow_contains(git_mwindow *win, off64_t offset, off64_t extra);
 int git_mwindow_free_all(git_mwindow_file *mwf); /* locks */
 unsigned char *git_mwindow_open(git_mwindow_file *mwf, git_mwindow **cursor, off64_t offset, size_t extra, unsigned int *left);
 int git_mwindow_file_register(git_mwindow_file *mwf);


### PR DESCRIPTION
I was looking at this code and found a couple of places where we've way too verbose for what we're doing and figured we can make this easier to read.

The first change makes us include the hash/extra size in the window "contains" check as we only ever use them (and would want to use them) in pairs.

The second change eliminates some rather verbose comparisons in favour of maths. The values are already `1` and `-1` so we can multiply instead of chaining several comparisons. This is likely to be gentler on the branch predictor due to fewer conditional jumps but that's unlikely to be measurable.