### PR TITLE
commit: add support to take ENV variables for commit info

### DIFF
--- a/src/libgit2/commit.c
+++ b/src/libgit2/commit.c
@@ -139,6 +139,8 @@ static int git_commit__create_internal(
 	git_str buf = GIT_STR_INIT;
 	const git_oid *current_id = NULL;
 	git_array_oid_t parents = GIT_ARRAY_INIT;
+	git_signature *env_author = NULL;
+	git_signature *env_committer = NULL;
 
 	if (update_ref) {
 		error = git_reference_lookup_resolved(&ref, repo, update_ref, 10);
@@ -152,6 +154,14 @@ static int git_commit__create_internal(
 
 	if ((error = validate_tree_and_parents(&parents, repo, tree, parent_cb, parent_payload, current_id, validate)) < 0)
 		goto cleanup;
+
+	error = git_signature_author_env(&env_author, author);
+	if (!error)
+		author = env_author;
+
+	error = git_signature_committer_env(&env_committer, committer);
+	if (!error)
+		committer = env_committer;
 
 	error = git_commit__create_buffer_internal(&buf, author, committer,
 		message_encoding, message, tree,
@@ -177,6 +187,8 @@ static int git_commit__create_internal(
 	}
 
 cleanup:
+	git_signature_free(env_author);
+	git_signature_free(env_committer);
 	git_array_clear(parents);
 	git_reference_free(ref);
 	git_str_dispose(&buf);

--- a/src/libgit2/signature.c
+++ b/src/libgit2/signature.c
@@ -337,3 +337,79 @@ bool git_signature__equal(const git_signature *one, const git_signature *two)
 		one->when.sign == two->when.sign;
 }
 
+int git_signature_from_env(git_signature **out,
+		const git_signature *sig,
+		const char *env_var_name,
+		const char *env_var_email)
+{
+	int error = 0;
+	git_str env_value = GIT_STR_INIT;
+	char *env_name_value = NULL;
+	char *env_email_value = NULL;
+	git_signature *p = NULL;
+	bool is_env_name_set = false;
+	bool is_env_email_set = false;
+	bool is_any_value_set = false;
+
+	GIT_ASSERT_ARG(sig);
+	GIT_ASSERT_ARG(env_var_name);
+
+	error = git__getenv(&env_value, env_var_name);
+	if (!error) {
+		env_name_value = strdup(git_str_cstr(&env_value));
+
+		is_env_name_set = true;
+		if (strlen(env_name_value) == 0) {
+			is_env_name_set = false;
+		}
+	}
+
+	error = git__getenv(&env_value, env_var_email);
+	if (!error) {
+		env_email_value = strdup(git_str_cstr(&env_value));
+
+		is_env_email_set = true;
+		if (strlen(env_email_value) == 0) {
+			is_env_email_set = false;
+		}
+	}
+	is_any_value_set = is_env_name_set || is_env_email_set;
+
+	if (is_any_value_set) {
+		if ((error = git_signature_new(&p,
+			((is_env_name_set) ? env_name_value : sig->name),
+			((is_env_email_set) ? env_email_value : sig->email),
+			sig->when.time, 0)) < 0) {
+			*out = NULL;
+			error = -1;
+		}
+		else {
+			*out = p;
+			error = 0;
+		}
+	}
+	else {
+		*out = NULL;
+		error = GIT_ENOTFOUND;
+	}
+
+	if (is_env_name_set) {
+		free(env_name_value);
+	}
+	if (is_env_email_set) {
+		free(env_email_value);
+	}
+	return error;
+}
+
+int git_signature_author_env(git_signature **out, const git_signature *sig)
+{
+	return git_signature_from_env(out, sig,
+			"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL");
+}
+
+int git_signature_committer_env(git_signature **out, const git_signature *sig)
+{
+	return git_signature_from_env(out, sig,
+			"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL");
+}

--- a/src/libgit2/signature.h
+++ b/src/libgit2/signature.h
@@ -18,6 +18,13 @@ int git_signature__parse(git_signature *sig, const char **buffer_out, const char
 void git_signature__writebuf(git_str *buf, const char *header, const git_signature *sig);
 bool git_signature__equal(const git_signature *one, const git_signature *two);
 
+int git_signature_from_env(git_signature **out,
+		const git_signature *sig,
+		const char *env_var_name,
+		const char *env_var_email);
+int git_signature_author_env(git_signature **out, const git_signature *sig);
+int git_signature_committer_env(git_signature **out, const git_signature *sig);
+
 int git_signature__pdup(git_signature **dest, const git_signature *source, git_pool *pool);
 
 #endif


### PR DESCRIPTION
Fixes issue: https://github.com/libgit2/libgit2/issues/3751

This will add support for git_commit__create_internal() for getting AUTHOR and COMMITTER information from the ENVIRONMENT.
variables considered as follows,
           GIT_AUTHOR_NAME
           GIT_AUTHOR_EMAIL // for AUTHOR information
and
           GIT_COMMITTER_NAME
           GIT_COMMITTER_EMAIL // for  information

if one of the env variable in a set(AUTHOR env pair)
and other is not set or set to empty string(eg.: GIT_AUTHOR_NAME is set and GIT_AUTHOR_EMAIL is set to empty string or not setted at all) this patch will
defaults to global values for the empty string value or unsetted ENV variable and takes the properly set ENV variable with non-empty string and stores as a `git_signature` structure in `git_commit__create_internal`, but in git CLI the commit will fail instead of defaulting to
global defaults for empty string value for a ENV variable such as GIT_AUTHOR_EMAIL.

on the other hand if one of a variable in pair is not set(eg. GIT_AUTHOR_NAME is set and GIT_AUTHOR_EMAIL is not set) and other one is set to valid value ENV git CLI sets global defaults values for unsetted ENV variable.
I'm using git version 2.36.0.