### PR TITLE
midx: do not verify the checksum on load

### DIFF
--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -179,7 +179,6 @@ int git_midx_parse(
 	uint32_t i;
 	off64_t last_chunk_offset, chunk_offset, trailer_offset;
 	size_t checksum_size;
-	unsigned char checksum[GIT_HASH_SHA1_SIZE];
 	int error;
 	struct git_midx_chunk chunk_packfile_names = {0},
 					 chunk_oid_fanout = {0},
@@ -216,11 +215,6 @@ int git_midx_parse(
 	if (trailer_offset < last_chunk_offset)
 		return midx_error("wrong index size");
 	memcpy(idx->checksum, data + trailer_offset, checksum_size);
-
-	if (git_hash_buf(checksum, data, (size_t)trailer_offset, GIT_HASH_ALGORITHM_SHA1) < 0)
-		return midx_error("could not calculate signature");
-	if (memcmp(checksum, idx->checksum, checksum_size) != 0)
-		return midx_error("index signature mismatch");
 
 	chunk_hdr = data + sizeof(struct git_midx_header);
 	last_chunk = NULL;


### PR DESCRIPTION
This is something we only want to do during explicit verification rather than on
every load.

Verifying does not seem like a big deal when we're running with test workloads
but once your `multi-pack-index` reaches gigabytes, we spend more time hashing
this than doing any work.

This is basically what we do for single-pack index files as well. We trust that he checksum is fine while running regularly.

cc @lhchavez as author of our implementation