### PR TITLE
revparse: Remove error-prone, redundant test

### DIFF
--- a/tests/libgit2/refs/revparse.c
+++ b/tests/libgit2/refs/revparse.c
@@ -399,8 +399,6 @@ void test_refs_revparse__date(void)
 	 * a65fedf HEAD@{1335806603 -0900}: commit:
 	 * be3563a HEAD@{1335806563 -0700}: clone: from /Users/ben/src/libgit2/tests/resour
 	 */
-	test_object("HEAD@{11 years ago}", "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
-
 	test_object("HEAD@{1 second}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	test_object("HEAD@{1 second ago}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	test_object("HEAD@{2 days ago}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");


### PR DESCRIPTION
Originally introduced in: 776a6a8e5f8e258d31aded73c0ce38df6ac7bdc4

This test case has recently been fixed in bdab22384cc61d315005a65456a9f9563bb27c8f, but that fix will only last for a year. Next year the same problem will crop up and the test will need to be re-edited.

This is not ideal as
- This test case becomes an unnecessary burden for developers
- Downstream distros or even just users who want to build older versions of libgit2 are guaranteed to have this test fail

Furthermore, this test case is entirely unnecessary, as the functionality that was originally (see 776a6a8e5f8e258d31aded73c0ce38df6ac7bdc4) intended to be tested is well-covered by subsequent tests which specify a date instead of a "x ago" specification.