### PR TITLE
New checkout option: disabled_filters

### DIFF
--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -342,6 +342,8 @@ typedef struct git_checkout_options {
 
 	/** Payload passed to perfdata_cb */
 	void *perfdata_payload;
+
+	git_strarray disabled_filters; /**< don’t apply these specific filters */
 } git_checkout_options;
 
 #define GIT_CHECKOUT_OPTIONS_VERSION 1

--- a/src/libgit2/checkout.c
+++ b/src/libgit2/checkout.c
@@ -1538,6 +1538,7 @@ static int blob_content_to_file(
 
 	filter_session.attr_session = &data->attr_session;
 	filter_session.temp_buf = &data->tmp;
+	filter_session.disabled_filters = &data->opts.disabled_filters;
 
 	if (!data->opts.disable_filters &&
 		(error = git_filter_list__load(
@@ -2119,6 +2120,7 @@ static int checkout_write_merge(
 
 		filter_session.attr_session = &data->attr_session;
 		filter_session.temp_buf = &data->tmp;
+		filter_session.disabled_filters = &data->opts.disabled_filters;
 
 		if ((error = git_filter_list__load(
 				&fl, data->repo, NULL, result.path,

--- a/src/libgit2/filter.c
+++ b/src/libgit2/filter.c
@@ -516,6 +516,8 @@ int git_filter_list__load(
 	git_filter_session *filter_session)
 {
 	int error = 0;
+	int i;
+	int disabled_filter_found;
 	git_filter_list *fl = NULL;
 	git_filter_source src = { 0 };
 	git_filter_entry *fe;
@@ -542,6 +544,19 @@ int git_filter_list__load(
 
 		if (!fdef || !fdef->filter)
 			continue;
+
+		if (filter_session->disabled_filters) {
+			disabled_filter_found = 0;
+			for (i = 0; i < filter_session->disabled_filters->count; ++i) {
+				char *filter = filter_session->disabled_filters->strings[i];
+				if (!strcmp(filter, fdef->filter_name)) {
+					disabled_filter_found = 1;
+					break;
+				}
+			}
+			if (disabled_filter_found)
+				continue;
+		}
 
 		if (fdef->nattrs > 0) {
 			error = filter_list_check_attributes(

--- a/src/libgit2/filter.h
+++ b/src/libgit2/filter.h
@@ -20,6 +20,7 @@ typedef struct {
 	git_filter_options options;
 	git_attr_session *attr_session;
 	git_str *temp_buf;
+	git_strarray *disabled_filters;
 } git_filter_session;
 
 #define GIT_FILTER_SESSION_INIT {GIT_FILTER_OPTIONS_INIT, 0}


### PR DESCRIPTION
Add the possibility of disabling specific filters instead of disabling all of them.

For example we can disable LFS filter during checkout, so we can execute `git lfs checkout` after checkout to improve performance in LFS repos.

Special thanks to @AlexaXs for helping me