### PR TITLE
filter: Fix Segfault

### DIFF
--- a/src/libgit2/filter.c
+++ b/src/libgit2/filter.c
@@ -902,6 +902,16 @@ static int buffered_stream_close(git_writestream *s)
 
 	GIT_ASSERT_ARG(buffered_stream);
 
+#ifndef GIT_DEPRECATE_HARD
+	if(buffered_stream->write_fn == NULL) {
+		error = buffered_stream->legacy_write_fn(
+			buffered_stream->filter,
+			buffered_stream->payload,
+			(git_buf *)buffered_stream->output,
+			(git_buf *)&buffered_stream->input,
+			buffered_stream->source);
+	} else
+#endif
 	error = buffered_stream->write_fn(
 		buffered_stream->filter,
 		buffered_stream->payload,

--- a/src/libgit2/filter.c
+++ b/src/libgit2/filter.c
@@ -904,13 +904,15 @@ static int buffered_stream_close(git_writestream *s)
 
 #ifndef GIT_DEPRECATE_HARD
 	if (buffered_stream->write_fn == NULL) {
-		 git_buf legacy_output = GIT_BUF_INIT,
-		         legacy_input = GIT_BUF_INIT;
+		git_buf legacy_output = GIT_BUF_INIT,
+		        legacy_input = GIT_BUF_INIT;
 
-		 legacy_output.ptr = buffered_stream->output->ptr;
-		 legacy_output.size = buffered_stream->output->size;
-		 legacy_input.ptr = buffered_stream->input.ptr;
-		 legacy_input.size = buffered_stream->input.size;
+		legacy_output.ptr = buffered_stream->output->ptr;
+		legacy_output.size = buffered_stream->output->size;
+		legacy_output.reserved = buffered_stream->output->asize;
+		legacy_input.ptr = buffered_stream->input.ptr;
+		legacy_input.size = buffered_stream->input.size;
+		legacy_input.reserved = buffered_stream->input.asize;
 
 		error = buffered_stream->legacy_write_fn(
 			buffered_stream->filter,

--- a/src/libgit2/filter.c
+++ b/src/libgit2/filter.c
@@ -903,12 +903,20 @@ static int buffered_stream_close(git_writestream *s)
 	GIT_ASSERT_ARG(buffered_stream);
 
 #ifndef GIT_DEPRECATE_HARD
-	if(buffered_stream->write_fn == NULL) {
+	if (buffered_stream->write_fn == NULL) {
+		 git_buf legacy_output = GIT_BUF_INIT,
+		         legacy_input = GIT_BUF_INIT;
+
+		 legacy_output.ptr = buffered_stream->output->ptr;
+		 legacy_output.size = buffered_stream->output->size;
+		 legacy_input.ptr = buffered_stream->input.ptr;
+		 legacy_input.size = buffered_stream->input.size;
+
 		error = buffered_stream->legacy_write_fn(
 			buffered_stream->filter,
 			buffered_stream->payload,
-			(git_buf *)buffered_stream->output,
-			(git_buf *)&buffered_stream->input,
+			&legacy_output,
+			&legacy_input,
 			buffered_stream->source);
 	} else
 #endif


### PR DESCRIPTION
Registering a git_filter without setting the `stream` callback causes the git_filter_list_apply_* functions(which eventually call filter.c:setup_stream) to call buffered_legacy_stream_new which sets the legacy_write_fn callback instead of the write_fn callback. but buffered_stream_close will only ever call write_fn callback...thus the segfault.

This appears to have been introduced with the git_buf/git_str split.
Hopefully I've taken the right approach here? I ran this against the nodegit test suite(which hasn't implemented filter streaming yet) and it fixed the crashes I was experiencing.