### PR TITLE
Fix degraded performance using GIT_USE_NSEC on repos cloned with GIT_USE_NSEC disabled

### DIFF
--- a/src/libgit2/index.h
+++ b/src/libgit2/index.h
@@ -84,6 +84,8 @@ GIT_INLINE(bool) git_index_time_eq(const git_index_time *one, const git_index_ti
 		return false;
 
 #ifdef GIT_USE_NSEC
+	if (one->nanoseconds == 0 || two->nanoseconds == 0)
+		return true;
 	if (one->nanoseconds != two->nanoseconds)
 		return false;
 #endif
@@ -109,6 +111,8 @@ GIT_INLINE(bool) git_index_entry_newer_than_index(
 		return true;
 	else if ((int32_t)index->stamp.mtime.tv_sec > entry->mtime.seconds)
 		return false;
+	else if (entry->mtime.nanoseconds == 0 || index->stamp.mtime.tv_nsec == 0)
+		return true;
 	else
 		return (uint32_t)index->stamp.mtime.tv_nsec <= entry->mtime.nanoseconds;
 #else


### PR DESCRIPTION
Fix degrade performance using GIT_USE_NSEC on repos cloned with GIT_USE_NSEC disabled.
We just mimic the GIT_USE_NSEC disabled behavior when nanoseconds are 0.
There is a edge case when nanoseconds is 0 in a repo cloned with GIT_USE_NSEC enabled, never found it but anyway that file will be handle fine just the sha1 will be generated to check if has changed.
