### PR TITLE
refs: fix missing error message

### DIFF
--- a/src/libgit2/refdb_fs.c
+++ b/src/libgit2/refdb_fs.c
@@ -740,7 +740,7 @@ static int packed_lookup(
 			return 0;
 		}
 	}
-	return GIT_ENOTFOUND;
+	return ref_error_notfound(ref_name);
 
 parse_failed:
 	git_error_set(GIT_ERROR_REFERENCE, "corrupted packed references file");


### PR DESCRIPTION
Super minor but it appears the packed ref lookup rewrite(#6138) didn't set the "not found" error message correctly and it broke a test in nodegit :sweat_smile:

I haven't checked for other missing errors in this file but when I get some time I can look it over just in case