### PR TITLE
midx: fix large offset table check.

### DIFF
--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -431,7 +431,7 @@ int git_midx_entry_find(
 
 	object_offset = idx->object_offsets + pos * 8;
 	offset = ntohl(*((uint32_t *)(object_offset + 4)));
-	if (offset & 0x80000000) {
+	if (idx->object_large_offsets && offset & 0x80000000) {
 		uint32_t object_large_offsets_pos = offset & 0x7fffffff;
 		const unsigned char *object_large_offsets_index = idx->object_large_offsets;
 

--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -432,7 +432,7 @@ int git_midx_entry_find(
 	object_offset = idx->object_offsets + pos * 8;
 	offset = ntohl(*((uint32_t *)(object_offset + 4)));
 	if (idx->object_large_offsets && offset & 0x80000000) {
-		uint32_t object_large_offsets_pos = offset & 0x7fffffff;
+		uint32_t object_large_offsets_pos = (uint32_t) (offset ^ 0x80000000);
 		const unsigned char *object_large_offsets_index = idx->object_large_offsets;
 
 		/* Make sure we're not being sent out of bounds */


### PR DESCRIPTION
It's insufficient to only check if the offset high order bit is set, as some object offsets may have their high order bit set but still not use the large offsets table.

We must also check to see if object_large_offsets are in use.

This can cause libgit2 to falsely claim objects do not exist when they actually do, because it is unable to find the object in the index.

cc: @lhchavez as the original author of MIDX support.