### PR TITLE
repo: allow administrator to own the configuration

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -512,7 +512,7 @@ static int validate_ownership(const char *repo_path)
 	bool is_safe;
 	int error;
 
-	if ((error = git_fs_path_owner_is_current_user(&is_safe, repo_path)) < 0) {
+	if ((error = git_fs_path_owner_is_system_or_current_user(&is_safe, repo_path)) < 0) {
 		if (error == GIT_ENOTFOUND)
 			error = 0;
 

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -484,9 +484,10 @@ void test_repo_open__validates_dir_ownership(void)
 	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
 	git_repository_free(repo);
 
-	/* When the system user owns the repo config, fail */
+	/* When the system user owns the repo config, also acceptable */
 	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_SYSTEM);
-	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
+	cl_git_pass(git_repository_open(&repo, "empty_standard_repo"));
+	git_repository_free(repo);
 
 	/* When an unknown user owns the repo config, fail */
 	git_fs_path__set_owner(GIT_FS_PATH_MOCK_OWNER_OTHER);


### PR DESCRIPTION
Update our ownership checks that were introduced in libgit2 v1.4.3
(to combat CVE 2022-24765). These were not compatible with git's; git
itself allows administrators to own the path. Our checks now match
this behavior.

Fixes #6279 