### PR TITLE
URL parsing for google-compatible URLs

### DIFF
--- a/src/util/net.c
+++ b/src/util/net.c
@@ -93,121 +93,360 @@ int git_net_url_dup(git_net_url *out, git_net_url *in)
 	return 0;
 }
 
+static int url_invalid(const char *message)
+{
+	git_error_set(GIT_ERROR_NET, "invalid url: %s", message);
+	return GIT_EINVALIDSPEC;
+}
+
+static int url_parse_authority(
+	const char **user_start, size_t *user_len,
+	const char **password_start, size_t *password_len,
+	const char **host_start, size_t *host_len,
+	const char **port_start, size_t *port_len,
+	const char *authority_start, size_t len)
+{
+	const char *c, *hostport_end, *host_end = NULL,
+	           *userpass_end, *user_end = NULL;
+
+	enum {
+		HOSTPORT, HOST, IPV6, HOST_END, USERPASS, USER
+	} state = HOSTPORT;
+
+	if (len == 0)
+		return 0;
+
+	/*
+	 * walk the authority backwards so that we can parse google code's
+	 * ssh urls that are not rfc compliant and allow @ in the username
+	 */
+	for (hostport_end = authority_start + len, c = hostport_end - 1;
+	     c >= authority_start && !user_end;
+	     c--) {
+		switch (state) {
+		case HOSTPORT:
+			if (*c == ':') {
+				*port_start = c + 1;
+				*port_len = hostport_end - *port_start;
+				host_end = c;
+				state = HOST;
+				break;
+			}
+
+			/*
+			 * if we've only seen digits then we don't know
+			 * if we're parsing just a host or a host and port.
+			 * if we see a non-digit, then we're in a host,
+			 * otherwise, fall through to possibly match the
+			 * "@" (user/host separator).
+			 */
+
+			if (*c < '0' || *c > '9') {
+				host_end = hostport_end;
+				state = HOST;
+			}
+
+			/* fall through */
+
+		case HOST:
+			if (*c == ']' && host_end == c + 1) {
+				host_end = c;
+				state = IPV6;
+			}
+
+			else if (*c == '@') {
+				*host_start = c + 1;
+				*host_len = host_end ? host_end - *host_start :
+				                       hostport_end - *host_start;
+				userpass_end = c;
+				state = USERPASS;
+			}
+
+			else if (*c == '[' || *c == ']' || *c == ':') {
+				return url_invalid("malformed hostname");
+			}
+
+			break;
+
+		case IPV6:
+			if (*c == '[') {
+				*host_start = c + 1;
+				*host_len = host_end - *host_start;
+				state = HOST_END;
+			}
+
+			else if ((*c < '0' || *c > '9') &&
+			         (*c < 'a' || *c > 'f') &&
+			         (*c < 'A' || *c > 'F') &&
+			         (*c != ':')) {
+				return url_invalid("malformed hostname");
+			}
+
+			break;
+
+		case HOST_END:
+			if (*c == '@') {
+				userpass_end = c;
+				state = USERPASS;
+				break;
+			}
+
+			return url_invalid("malformed hostname");
+
+		case USERPASS:
+			if (*c == ':') {
+				*password_start = c + 1;
+				*password_len = userpass_end - *password_start;
+				user_end = c;
+				state = USER;
+				break;
+			}
+
+			break;
+
+		default:
+			GIT_ASSERT(!"unhandled state");
+		}
+	}
+
+	switch (state) {
+		case HOSTPORT:
+			*host_start = authority_start;
+			*host_len = (hostport_end - *host_start);
+			break;
+		case HOST:
+			*host_start = authority_start;
+			*host_len = (host_end - *host_start);
+			break;
+		case IPV6:
+			return url_invalid("malformed hostname");
+		case HOST_END:
+			break;
+		case USERPASS:
+			*user_start = authority_start;
+			*user_len = (userpass_end - *user_start);
+			break;
+		case USER:
+			*user_start = authority_start;
+			*user_len = (user_end - *user_start);
+			break;
+		default:
+			GIT_ASSERT(!"unhandled state");
+	}
+
+	return 0;
+}
+
 int git_net_url_parse(git_net_url *url, const char *given)
 {
-	struct http_parser_url u = {0};
-	bool has_scheme, has_host, has_port, has_path, has_query, has_userinfo;
-	git_str scheme = GIT_STR_INIT,
-		host = GIT_STR_INIT,
-		port = GIT_STR_INIT,
-		path = GIT_STR_INIT,
-		username = GIT_STR_INIT,
-		password = GIT_STR_INIT,
-		query = GIT_STR_INIT;
-	int error = GIT_EINVALIDSPEC;
+	const char *c, *scheme_start, *authority_start, *user_start,
+	           *password_start, *host_start, *port_start, *path_start,
+	           *query_start, *fragment_start, *default_port;
+	git_str scheme = GIT_STR_INIT, user = GIT_STR_INIT,
+	        password = GIT_STR_INIT, host = GIT_STR_INIT,
+	        port = GIT_STR_INIT, path = GIT_STR_INIT,
+	        query = GIT_STR_INIT, fragment = GIT_STR_INIT;
+	size_t scheme_len = 0, user_len = 0, password_len = 0, host_len = 0,
+	       port_len = 0, path_len = 0, query_len = 0, fragment_len = 0;
+	bool hierarchical = false;
+	int error = 0;
 
-	if (http_parser_parse_url(given, strlen(given), false, &u)) {
-		git_error_set(GIT_ERROR_NET, "malformed URL '%s'", given);
-		goto done;
+	enum {
+		SCHEME,
+		AUTHORITY_START, AUTHORITY,
+		PATH_START, PATH,
+		QUERY,
+		FRAGMENT
+	} state = SCHEME;
+
+	memset(url, 0, sizeof(git_net_url));
+
+	for (c = scheme_start = given; *c; c++) {
+		switch (state) {
+		case SCHEME:
+			if (*c == ':') {
+				scheme_len = (c - scheme_start);
+
+				if (*(c+1) == '/' && *(c+2) == '/') {
+					c += 2;
+					hierarchical = true;
+					state = AUTHORITY_START;
+				} else {
+					state = PATH_START;
+				}
+			} else if ((*c < 'A' || *c > 'Z') &&
+			           (*c < 'a' || *c > 'z') &&
+			           (*c < '0' || *c > '9') &&
+			           (*c != '+' && *c != '-' && *c != '.')) {
+				/*
+				 * an illegal scheme character means that we
+				 * were just given a relative path
+				 */
+				path_start = given;
+				state = PATH;
+				break;
+			}
+			break;
+
+		case AUTHORITY_START:
+			authority_start = c;
+			state = AUTHORITY;
+
+			/* fall through */
+
+		case AUTHORITY:
+			if (*c != '/')
+				break;
+
+			/*
+			 * authority is sufficiently complex that we parse
+			 * it separately
+			 */
+			if ((error = url_parse_authority(
+					&user_start, &user_len,
+					&password_start,&password_len,
+					&host_start, &host_len,
+					&port_start, &port_len,
+					authority_start, (c - authority_start))) < 0)
+				goto done;
+
+			/* fall through */
+
+		case PATH_START:
+			path_start = c;
+			state = PATH;
+			/* fall through */
+
+		case PATH:
+			switch (*c) {
+			case '?':
+				path_len = (c - path_start);
+				query_start = c + 1;
+				state = QUERY;
+				break;
+			case '#':
+				path_len = (c - path_start);
+				fragment_start = c + 1;
+				state = FRAGMENT;
+				break;
+			}
+			break;
+
+		case QUERY:
+			if (*c == '#') {
+				query_len = (c - query_start);
+				fragment_start = c + 1;
+				state = FRAGMENT;
+			}
+			break;
+
+		case FRAGMENT:
+			break;
+
+		default:
+			GIT_ASSERT(!"unhandled state");
+		}
 	}
 
-	has_scheme = !!(u.field_set & (1 << UF_SCHEMA));
-	has_host = !!(u.field_set & (1 << UF_HOST));
-	has_port = !!(u.field_set & (1 << UF_PORT));
-	has_path = !!(u.field_set & (1 << UF_PATH));
-	has_query = !!(u.field_set & (1 << UF_QUERY));
-	has_userinfo = !!(u.field_set & (1 << UF_USERINFO));
-
-	if (has_scheme) {
-		const char *url_scheme = given + u.field_data[UF_SCHEMA].off;
-		size_t url_scheme_len = u.field_data[UF_SCHEMA].len;
-		git_str_put(&scheme, url_scheme, url_scheme_len);
-		git__strntolower(scheme.ptr, scheme.size);
-	} else {
-		git_error_set(GIT_ERROR_NET, "malformed URL '%s'", given);
-		goto done;
-	}
-
-	if (has_host) {
-		const char *url_host = given + u.field_data[UF_HOST].off;
-		size_t url_host_len = u.field_data[UF_HOST].len;
-		git_str_decode_percent(&host, url_host, url_host_len);
-	}
-
-	if (has_port) {
-		const char *url_port = given + u.field_data[UF_PORT].off;
-		size_t url_port_len = u.field_data[UF_PORT].len;
-		git_str_put(&port, url_port, url_port_len);
-	} else {
-		const char *default_port = default_port_for_scheme(scheme.ptr);
-
-		if (default_port == NULL) {
-			git_error_set(GIT_ERROR_NET, "unknown scheme for URL '%s'", given);
+	switch (state) {
+	case SCHEME:
+		/*
+		 * if we never saw a ':' then we were given a relative
+		 * path, not a bare scheme
+		 */
+		path_start = given;
+		path_len = (c - scheme_start);
+		break;
+	case AUTHORITY_START:
+		break;
+	case AUTHORITY:
+		if ((error = url_parse_authority(
+				&user_start, &user_len,
+				&password_start,&password_len,
+				&host_start, &host_len,
+				&port_start, &port_len,
+				authority_start, (c - authority_start))) < 0)
 			goto done;
-		}
-
-		git_str_puts(&port, default_port);
+		break;
+	case PATH_START:
+		break;
+	case PATH:
+		path_len = (c - path_start);
+		break;
+	case QUERY:
+		query_len = (c - query_start);
+		break;
+	case FRAGMENT:
+		fragment_len = (c - fragment_start);
+		break;
+	default:
+		GIT_ASSERT(!"unhandled state");
 	}
 
-	if (has_path) {
-		const char *url_path = given + u.field_data[UF_PATH].off;
-		size_t url_path_len = u.field_data[UF_PATH].len;
-		git_str_put(&path, url_path, url_path_len);
-	} else {
-		git_str_puts(&path, "/");
+	if (scheme_len) {
+		if ((error = git_str_put(&scheme, scheme_start, scheme_len)) < 0)
+			goto done;
+
+		git__strntolower(scheme.ptr, scheme.size);
 	}
 
-	if (has_query) {
-		const char *url_query = given + u.field_data[UF_QUERY].off;
-		size_t url_query_len = u.field_data[UF_QUERY].len;
-		git_str_decode_percent(&query, url_query, url_query_len);
-	}
+	if (user_len &&
+	    (error = git_str_decode_percent(&user, user_start, user_len)) < 0)
+		goto done;
 
-	if (has_userinfo) {
-		const char *url_userinfo = given + u.field_data[UF_USERINFO].off;
-		size_t url_userinfo_len = u.field_data[UF_USERINFO].len;
-		const char *colon = memchr(url_userinfo, ':', url_userinfo_len);
+	if (password_len &&
+	    (error = git_str_decode_percent(&password, password_start, password_len)) < 0)
+		goto done;
 
-		if (colon) {
-			const char *url_username = url_userinfo;
-			size_t url_username_len = colon - url_userinfo;
-			const char *url_password = colon + 1;
-			size_t url_password_len = url_userinfo_len - (url_username_len + 1);
+	if (host_len &&
+	    (error = git_str_decode_percent(&host, host_start, host_len)) < 0)
+		goto done;
 
-			git_str_decode_percent(&username, url_username, url_username_len);
-			git_str_decode_percent(&password, url_password, url_password_len);
-		} else {
-			git_str_decode_percent(&username, url_userinfo, url_userinfo_len);
-		}
-	}
+	if (port_len)
+		error = git_str_put(&port, port_start, port_len);
+	else if (scheme_len && (default_port = default_port_for_scheme(scheme.ptr)) != NULL)
+		error = git_str_puts(&port, default_port);
 
-	if (git_str_oom(&scheme) ||
-	    git_str_oom(&host) ||
-	    git_str_oom(&port) ||
-	    git_str_oom(&path) ||
-	    git_str_oom(&query) ||
-	    git_str_oom(&username) ||
-	    git_str_oom(&password))
-		return -1;
+	if (error < 0)
+		goto done;
+
+	if (path_len)
+		error = git_str_put(&path, path_start, path_len);
+	else if (hierarchical)
+		error = git_str_puts(&path, "/");
+
+	if (error < 0)
+		goto done;
+
+	if (query_len &&
+	    (error = git_str_decode_percent(&query, query_start, query_len)) < 0)
+		goto done;
+
+	if (fragment_len &&
+	    (error = git_str_decode_percent(&fragment, fragment_start, fragment_len)) < 0)
+		goto done;
 
 	url->scheme = git_str_detach(&scheme);
 	url->host = git_str_detach(&host);
 	url->port = git_str_detach(&port);
 	url->path = git_str_detach(&path);
 	url->query = git_str_detach(&query);
-	url->username = git_str_detach(&username);
+	url->fragment = git_str_detach(&fragment);
+	url->username = git_str_detach(&user);
 	url->password = git_str_detach(&password);
 
 	error = 0;
 
 done:
 	git_str_dispose(&scheme);
+	git_str_dispose(&user);
+	git_str_dispose(&password);
 	git_str_dispose(&host);
 	git_str_dispose(&port);
 	git_str_dispose(&path);
 	git_str_dispose(&query);
-	git_str_dispose(&username);
-	git_str_dispose(&password);
+	git_str_dispose(&fragment);
+
 	return error;
 }
 
@@ -374,7 +613,7 @@ int git_net_url_parse_scp(git_net_url *url, const char *given)
 			break;
 
 		default:
-			GIT_ASSERT("unhandled state");
+			GIT_ASSERT(!"unhandled state");
 		}
 	}
 
@@ -588,7 +827,7 @@ bool git_net_url_is_default_port(git_net_url *url)
 {
 	const char *default_port;
 
-	if ((default_port = default_port_for_scheme(url->scheme)) != NULL)
+	if (url->scheme && (default_port = default_port_for_scheme(url->scheme)) != NULL)
 		return (strcmp(url->port, default_port) == 0);
 	else
 		return false;
@@ -744,6 +983,7 @@ void git_net_url_dispose(git_net_url *url)
 	git__free(url->port); url->port = NULL;
 	git__free(url->path); url->path = NULL;
 	git__free(url->query); url->query = NULL;
+	git__free(url->fragment); url->fragment = NULL;
 	git__free(url->username); url->username = NULL;
 	git__free(url->password); url->password = NULL;
 }

--- a/src/util/net.c
+++ b/src/util/net.c
@@ -104,7 +104,8 @@ static int url_parse_authority(
 	const char **password_start, size_t *password_len,
 	const char **host_start, size_t *host_len,
 	const char **port_start, size_t *port_len,
-	const char *authority_start, size_t len)
+	const char *authority_start, size_t len,
+	const char *scheme_start, size_t scheme_len)
 {
 	const char *c, *hostport_end, *host_end = NULL,
 	           *userpass_end, *user_end = NULL;
@@ -194,6 +195,10 @@ static int url_parse_authority(
 			return url_invalid("malformed hostname");
 
 		case USERPASS:
+			if (*c == '@' &&
+			    strncasecmp(scheme_start, "ssh", scheme_len))
+				return url_invalid("malformed hostname");
+
 			if (*c == ':') {
 				*password_start = c + 1;
 				*password_len = userpass_end - *password_start;
@@ -307,7 +312,8 @@ int git_net_url_parse(git_net_url *url, const char *given)
 					&password_start,&password_len,
 					&host_start, &host_len,
 					&port_start, &port_len,
-					authority_start, (c - authority_start))) < 0)
+					authority_start, (c - authority_start),
+					scheme_start, scheme_len)) < 0)
 				goto done;
 
 			/* fall through */
@@ -365,7 +371,8 @@ int git_net_url_parse(git_net_url *url, const char *given)
 				&password_start,&password_len,
 				&host_start, &host_len,
 				&port_start, &port_len,
-				authority_start, (c - authority_start))) < 0)
+				authority_start, (c - authority_start),
+				scheme_start, scheme_len)) < 0)
 			goto done;
 		break;
 	case PATH_START:

--- a/src/util/net.h
+++ b/src/util/net.h
@@ -15,6 +15,7 @@ typedef struct git_net_url {
 	char *port;
 	char *path;
 	char *query;
+	char *fragment;
 	char *username;
 	char *password;
 } git_net_url;

--- a/tests/util/url/joinpath.c
+++ b/tests/util/url/joinpath.c
@@ -4,19 +4,19 @@
 
 static git_net_url source, target;
 
-void test_network_url_joinpath__initialize(void)
+void test_url_joinpath__initialize(void)
 {
 	memset(&source, 0, sizeof(source));
 	memset(&target, 0, sizeof(target));
 }
 
-void test_network_url_joinpath__cleanup(void)
+void test_url_joinpath__cleanup(void)
 {
 	git_net_url_dispose(&source);
 	git_net_url_dispose(&target);
 }
 
-void test_network_url_joinpath__target_paths_and_queries(void)
+void test_url_joinpath__target_paths_and_queries(void)
 {
 	cl_git_pass(git_net_url_parse(&source, "http://example.com/a/b"));
 
@@ -31,7 +31,7 @@ void test_network_url_joinpath__target_paths_and_queries(void)
 	git_net_url_dispose(&target);
 }
 
-void test_network_url_joinpath__source_query_removed(void)
+void test_url_joinpath__source_query_removed(void)
 {
 	cl_git_pass(git_net_url_parse(&source, "http://example.com/a/b?query&one&two"));
 
@@ -46,7 +46,7 @@ void test_network_url_joinpath__source_query_removed(void)
 	git_net_url_dispose(&target);
 }
 
-void test_network_url_joinpath__source_lacks_path(void)
+void test_url_joinpath__source_lacks_path(void)
 {
 	cl_git_pass(git_net_url_parse(&source, "http://example.com"));
 
@@ -91,7 +91,7 @@ void test_network_url_joinpath__source_lacks_path(void)
 	git_net_url_dispose(&target);
 }
 
-void test_network_url_joinpath__source_is_slash(void)
+void test_url_joinpath__source_is_slash(void)
 {
 	cl_git_pass(git_net_url_parse(&source, "http://example.com/"));
 
@@ -137,7 +137,7 @@ void test_network_url_joinpath__source_is_slash(void)
 }
 
 
-void test_network_url_joinpath__source_has_query(void)
+void test_url_joinpath__source_has_query(void)
 {
 	cl_git_pass(git_net_url_parse(&source, "http://example.com?query"));
 
@@ -183,7 +183,7 @@ void test_network_url_joinpath__source_has_query(void)
 }
 
 
-void test_network_url_joinpath__empty_query_ignored(void)
+void test_url_joinpath__empty_query_ignored(void)
 {
 	cl_git_pass(git_net_url_parse(&source, "http://example.com/foo"));
 

--- a/tests/util/url/parse.c
+++ b/tests/util/url/parse.c
@@ -555,3 +555,15 @@ void test_url_parse__ipv6_invalid_addresses(void)
 	/* Invalid character inside address */
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata, "http://[fe8o::dcad:beff:fe00:0001]/resource"));
 }
+
+void test_url_parse__spaces_in_the_name(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "https://libgit2@dev.azure.com/libgit2/test/_git/spaces%20in%20the%20name"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "dev.azure.com");
+	cl_assert_equal_s(conndata.port, "443");
+	cl_assert_equal_s(conndata.path, "/libgit2/test/_git/spaces%20in%20the%20name");
+	cl_assert_equal_s(conndata.username, "libgit2");
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}

--- a/tests/util/url/parse.c
+++ b/tests/util/url/parse.c
@@ -749,6 +749,11 @@ void test_url_parse__empty_path_with_empty_authority(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
+void test_url_parse__http_follows_the_rfc(void)
+{
+	cl_git_fail(git_net_url_parse(&conndata, "https://my.email.address@gmail.com@source.developers.google.com:4433/p/my-project/r/my-repository"));
+}
+
 void test_url_parse__ssh_from_terrible_google_rfc_violating_products(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "ssh://my.email.address@gmail.com@source.developers.google.com:2022/p/my-project/r/my-repository"));

--- a/tests/util/url/parse.c
+++ b/tests/util/url/parse.c
@@ -24,6 +24,8 @@ void test_url_parse__hostname_trivial(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -36,6 +38,8 @@ void test_url_parse__hostname_root(void)
 	cl_assert_equal_s(conndata.path, "/");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -48,6 +52,22 @@ void test_url_parse__hostname_implied_root(void)
 	cl_assert_equal_s(conndata.path, "/");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_url_parse__hostname_numeric(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://8888888/"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "8888888");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -60,6 +80,8 @@ void test_url_parse__hostname_implied_root_custom_port(void)
 	cl_assert_equal_s(conndata.path, "/");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
@@ -72,6 +94,8 @@ void test_url_parse__hostname_implied_root_empty_port(void)
 	cl_assert_equal_s(conndata.path, "/");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -85,6 +109,8 @@ void test_url_parse__hostname_encoded_password(void)
 	cl_assert_equal_s(conndata.path, "/");
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass/is@bad");
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
@@ -98,6 +124,8 @@ void test_url_parse__hostname_user(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -112,6 +140,8 @@ void test_url_parse__hostname_user_pass(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -126,6 +156,8 @@ void test_url_parse__hostname_port(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
@@ -138,6 +170,8 @@ void test_url_parse__hostname_empty_port(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
@@ -152,6 +186,8 @@ void test_url_parse__hostname_user_port(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
@@ -166,6 +202,72 @@ void test_url_parse__hostname_user_pass_port(void)
 	cl_assert_equal_s(conndata.path, "/resource");
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__hostname_user_pass_port_query(void)
+{
+	/* user:pass@hostname.tld:port/resource */
+	cl_git_pass(git_net_url_parse(&conndata,
+				"https://user:pass@example.com:9191/resource?query=q&foo=bar&z=asdf"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "example.com");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_s(conndata.query, "query=q&foo=bar&z=asdf");
+	cl_assert_equal_p(conndata.fragment, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__hostname_user_pass_port_fragment(void)
+{
+	/* user:pass@hostname.tld:port/resource */
+	cl_git_pass(git_net_url_parse(&conndata,
+				"https://user:pass@example.com:9191/resource#fragment"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "example.com");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_s(conndata.fragment, "fragment");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__hostname_user_pass_port_query_fragment(void)
+{
+	/* user:pass@hostname.tld:port/resource */
+	cl_git_pass(git_net_url_parse(&conndata,
+				"https://user:pass@example.com:9191/resource?query=q&foo=bar&z=asdf#fragment"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "example.com");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_s(conndata.query, "query=q&foo=bar&z=asdf");
+	cl_assert_equal_s(conndata.fragment, "fragment");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__fragment_with_question_mark(void)
+{
+	/* user:pass@hostname.tld:port/resource */
+	cl_git_pass(git_net_url_parse(&conndata,
+				"https://user:pass@example.com:9191/resource#fragment_with?question_mark"));
+	cl_assert_equal_s(conndata.scheme, "https");
+	cl_assert_equal_s(conndata.host, "example.com");
+	cl_assert_equal_s(conndata.port, "9191");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_s(conndata.username, "user");
+	cl_assert_equal_s(conndata.password, "pass");
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_s(conndata.fragment, "fragment_with?question_mark");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
@@ -526,6 +628,7 @@ void test_url_parse__ipv6_invalid_addresses(void)
 		"https://user@[fe80::dcad:beff:fe00:0001:9191/resource"));
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
 		"https://user:pass@[fe80::dcad:beff:fe00:0001:9191/resource"));
+
 	/* Both brackets missing */
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
 		"http://fe80::dcad:beff:fe00:0001/resource"));
@@ -554,6 +657,120 @@ void test_url_parse__ipv6_invalid_addresses(void)
 
 	/* Invalid character inside address */
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata, "http://[fe8o::dcad:beff:fe00:0001]/resource"));
+
+	/* Characters before/after braces */
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://fe80::[dcad:beff:fe00:0001]/resource"));
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://cafe[fe80::dcad:beff:fe00:0001]/resource"));
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
+		"http://[fe80::dcad:beff:fe00:0001]cafe/resource"));
+}
+
+/* Oddities */
+
+void test_url_parse__invalid_scheme_is_relative(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "foo!bar://host:42/path/to/project?query_string=yes"));
+	cl_assert_equal_p(conndata.scheme, NULL);
+	cl_assert_equal_p(conndata.host, NULL);
+	cl_assert_equal_p(conndata.port, NULL);
+	cl_assert_equal_s(conndata.path, "foo!bar://host:42/path/to/project");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_s(conndata.query, "query_string=yes");
+	cl_assert_equal_p(conndata.fragment, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__scheme_case_is_normalized(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "GIT+SSH://host:42/path/to/project"));
+	cl_assert_equal_s(conndata.scheme, "git+ssh");
+}
+
+void test_url_parse__nonhierarchical_scheme(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "mailto:foobar@example.com"));
+	cl_assert_equal_s(conndata.scheme, "mailto");
+	cl_assert_equal_p(conndata.host, NULL);
+	cl_assert_equal_p(conndata.port, NULL);
+	cl_assert_equal_s(conndata.path, "foobar@example.com");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__no_scheme_relative_path(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "path"));
+	cl_assert_equal_p(conndata.scheme, NULL);
+	cl_assert_equal_p(conndata.host, NULL);
+	cl_assert_equal_p(conndata.port, NULL);
+	cl_assert_equal_s(conndata.path, "path");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__no_scheme_absolute_path(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "/path"));
+	cl_assert_equal_p(conndata.scheme, NULL);
+	cl_assert_equal_p(conndata.host, NULL);
+	cl_assert_equal_p(conndata.port, NULL);
+	cl_assert_equal_s(conndata.path, "/path");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__empty_path(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "mailto:"));
+	cl_assert_equal_s(conndata.scheme, "mailto");
+	cl_assert_equal_p(conndata.host, NULL);
+	cl_assert_equal_p(conndata.port, NULL);
+	cl_assert_equal_s(conndata.path, NULL);
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__empty_path_with_empty_authority(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_p(conndata.host, NULL);
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+}
+
+void test_url_parse__ssh_from_terrible_google_rfc_violating_products(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "ssh://my.email.address@gmail.com@source.developers.google.com:2022/p/my-project/r/my-repository"));
+	cl_assert_equal_s(conndata.scheme, "ssh");
+	cl_assert_equal_s(conndata.host, "source.developers.google.com");
+	cl_assert_equal_s(conndata.port, "2022");
+	cl_assert_equal_s(conndata.path, "/p/my-project/r/my-repository");
+	cl_assert_equal_s(conndata.username, "my.email.address@gmail.com");
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+}
+
+void test_url_parse__ssh_with_password_from_terrible_google_rfc_violating_products(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "ssh://my.email.address@gmail.com:seekret@source.developers.google.com:2022/p/my-project/r/my-repository"));
+	cl_assert_equal_s(conndata.scheme, "ssh");
+	cl_assert_equal_s(conndata.host, "source.developers.google.com");
+	cl_assert_equal_s(conndata.port, "2022");
+	cl_assert_equal_s(conndata.path, "/p/my-project/r/my-repository");
+	cl_assert_equal_s(conndata.username, "my.email.address@gmail.com");
+	cl_assert_equal_s(conndata.password, "seekret");
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
 void test_url_parse__spaces_in_the_name(void)

--- a/tests/util/url/parse.c
+++ b/tests/util/url/parse.c
@@ -3,19 +3,19 @@
 
 static git_net_url conndata;
 
-void test_network_url_parse__initialize(void)
+void test_url_parse__initialize(void)
 {
 	memset(&conndata, 0, sizeof(conndata));
 }
 
-void test_network_url_parse__cleanup(void)
+void test_url_parse__cleanup(void)
 {
 	git_net_url_dispose(&conndata);
 }
 
 /* Hostname */
 
-void test_network_url_parse__hostname_trivial(void)
+void test_url_parse__hostname_trivial(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com/resource"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -27,7 +27,7 @@ void test_network_url_parse__hostname_trivial(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_root(void)
+void test_url_parse__hostname_root(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com/"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -39,7 +39,7 @@ void test_network_url_parse__hostname_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_implied_root(void)
+void test_url_parse__hostname_implied_root(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -51,7 +51,7 @@ void test_network_url_parse__hostname_implied_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_implied_root_custom_port(void)
+void test_url_parse__hostname_implied_root_custom_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com:42"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -63,7 +63,7 @@ void test_network_url_parse__hostname_implied_root_custom_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__hostname_implied_root_empty_port(void)
+void test_url_parse__hostname_implied_root_empty_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com:"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -75,7 +75,7 @@ void test_network_url_parse__hostname_implied_root_empty_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_encoded_password(void)
+void test_url_parse__hostname_encoded_password(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 				"https://user:pass%2fis%40bad@hostname.com:1234/"));
@@ -88,7 +88,7 @@ void test_network_url_parse__hostname_encoded_password(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__hostname_user(void)
+void test_url_parse__hostname_user(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 				"https://user@example.com/resource"));
@@ -101,7 +101,7 @@ void test_network_url_parse__hostname_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_user_pass(void)
+void test_url_parse__hostname_user_pass(void)
 {
 	/* user:pass@hostname.tld/resource */
 	cl_git_pass(git_net_url_parse(&conndata,
@@ -115,7 +115,7 @@ void test_network_url_parse__hostname_user_pass(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_port(void)
+void test_url_parse__hostname_port(void)
 {
 	/* hostname.tld:port/resource */
 	cl_git_pass(git_net_url_parse(&conndata,
@@ -129,7 +129,7 @@ void test_network_url_parse__hostname_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__hostname_empty_port(void)
+void test_url_parse__hostname_empty_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://example.com:/resource"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -141,7 +141,7 @@ void test_network_url_parse__hostname_empty_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__hostname_user_port(void)
+void test_url_parse__hostname_user_port(void)
 {
 	/* user@hostname.tld:port/resource */
 	cl_git_pass(git_net_url_parse(&conndata,
@@ -155,7 +155,7 @@ void test_network_url_parse__hostname_user_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__hostname_user_pass_port(void)
+void test_url_parse__hostname_user_pass_port(void)
 {
 	/* user:pass@hostname.tld:port/resource */
 	cl_git_pass(git_net_url_parse(&conndata,
@@ -171,7 +171,7 @@ void test_network_url_parse__hostname_user_pass_port(void)
 
 /* IPv4 addresses */
 
-void test_network_url_parse__ipv4_trivial(void)
+void test_url_parse__ipv4_trivial(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1/resource"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -183,7 +183,7 @@ void test_network_url_parse__ipv4_trivial(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_root(void)
+void test_url_parse__ipv4_root(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1/"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -195,7 +195,7 @@ void test_network_url_parse__ipv4_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_implied_root(void)
+void test_url_parse__ipv4_implied_root(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -207,7 +207,7 @@ void test_network_url_parse__ipv4_implied_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_implied_root_custom_port(void)
+void test_url_parse__ipv4_implied_root_custom_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1:42"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -219,7 +219,7 @@ void test_network_url_parse__ipv4_implied_root_custom_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv4_implied_root_empty_port(void)
+void test_url_parse__ipv4_implied_root_empty_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1:"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -231,7 +231,7 @@ void test_network_url_parse__ipv4_implied_root_empty_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_encoded_password(void)
+void test_url_parse__ipv4_encoded_password(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user:pass%2fis%40bad@192.168.1.1:1234/"));
@@ -244,7 +244,7 @@ void test_network_url_parse__ipv4_encoded_password(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv4_user(void)
+void test_url_parse__ipv4_user(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user@192.168.1.1/resource"));
@@ -257,7 +257,7 @@ void test_network_url_parse__ipv4_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_user_pass(void)
+void test_url_parse__ipv4_user_pass(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user:pass@192.168.1.1/resource"));
@@ -270,7 +270,7 @@ void test_network_url_parse__ipv4_user_pass(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_port(void)
+void test_url_parse__ipv4_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://192.168.1.1:9191/resource"));
@@ -283,7 +283,7 @@ void test_network_url_parse__ipv4_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv4_empty_port(void)
+void test_url_parse__ipv4_empty_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://192.168.1.1:/resource"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -295,7 +295,7 @@ void test_network_url_parse__ipv4_empty_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv4_user_port(void)
+void test_url_parse__ipv4_user_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user@192.168.1.1:9191/resource"));
@@ -308,7 +308,7 @@ void test_network_url_parse__ipv4_user_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv4_user_pass_port(void)
+void test_url_parse__ipv4_user_pass_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user:pass@192.168.1.1:9191/resource"));
@@ -323,7 +323,7 @@ void test_network_url_parse__ipv4_user_pass_port(void)
 
 /* IPv6 addresses */
 
-void test_network_url_parse__ipv6_trivial(void)
+void test_url_parse__ipv6_trivial(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]/resource"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -335,7 +335,7 @@ void test_network_url_parse__ipv6_trivial(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_root(void)
+void test_url_parse__ipv6_root(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]/"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -347,7 +347,7 @@ void test_network_url_parse__ipv6_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_implied_root(void)
+void test_url_parse__ipv6_implied_root(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -359,7 +359,7 @@ void test_network_url_parse__ipv6_implied_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_implied_root_custom_port(void)
+void test_url_parse__ipv6_implied_root_custom_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]:42"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -371,7 +371,7 @@ void test_network_url_parse__ipv6_implied_root_custom_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv6_implied_root_empty_port(void)
+void test_url_parse__ipv6_implied_root_empty_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]:"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -383,7 +383,7 @@ void test_network_url_parse__ipv6_implied_root_empty_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_encoded_password(void)
+void test_url_parse__ipv6_encoded_password(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user:pass%2fis%40bad@[fe80::dcad:beff:fe00:0001]:1234/"));
@@ -396,7 +396,7 @@ void test_network_url_parse__ipv6_encoded_password(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv6_user(void)
+void test_url_parse__ipv6_user(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user@[fe80::dcad:beff:fe00:0001]/resource"));
@@ -409,7 +409,7 @@ void test_network_url_parse__ipv6_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_user_pass(void)
+void test_url_parse__ipv6_user_pass(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user:pass@[fe80::dcad:beff:fe00:0001]/resource"));
@@ -422,7 +422,7 @@ void test_network_url_parse__ipv6_user_pass(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_port(void)
+void test_url_parse__ipv6_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://[fe80::dcad:beff:fe00:0001]:9191/resource"));
@@ -435,7 +435,7 @@ void test_network_url_parse__ipv6_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv6_empty_port(void)
+void test_url_parse__ipv6_empty_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "http://[fe80::dcad:beff:fe00:0001]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "http");
@@ -447,7 +447,7 @@ void test_network_url_parse__ipv6_empty_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_parse__ipv6_user_port(void)
+void test_url_parse__ipv6_user_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user@[fe80::dcad:beff:fe00:0001]:9191/resource"));
@@ -460,7 +460,7 @@ void test_network_url_parse__ipv6_user_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv6_user_pass_port(void)
+void test_url_parse__ipv6_user_pass_port(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user:pass@[fe80::dcad:beff:fe00:0001]:9191/resource"));
@@ -473,7 +473,7 @@ void test_network_url_parse__ipv6_user_pass_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_parse__ipv6_invalid_addresses(void)
+void test_url_parse__ipv6_invalid_addresses(void)
 {
 	/* Opening bracket missing */
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,

--- a/tests/util/url/pattern.c
+++ b/tests/util/url/pattern.c
@@ -7,7 +7,7 @@ struct url_pattern {
 	bool matches;
 };
 
-void test_network_url_pattern__single(void)
+void test_url_pattern__single(void)
 {
 	git_net_url url;
 	size_t i;
@@ -53,7 +53,7 @@ void test_network_url_pattern__single(void)
 	}
 }
 
-void test_network_url_pattern__list(void)
+void test_url_pattern__list(void)
 {
 	git_net_url url;
 	size_t i;

--- a/tests/util/url/redirect.c
+++ b/tests/util/url/redirect.c
@@ -4,17 +4,17 @@
 
 static git_net_url conndata;
 
-void test_network_url_redirect__initialize(void)
+void test_url_redirect__initialize(void)
 {
 	memset(&conndata, 0, sizeof(conndata));
 }
 
-void test_network_url_redirect__cleanup(void)
+void test_url_redirect__cleanup(void)
 {
 	git_net_url_dispose(&conndata);
 }
 
-void test_network_url_redirect__redirect_http(void)
+void test_url_redirect__redirect_http(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"http://example.com/foo/bar/baz"));
@@ -28,7 +28,7 @@ void test_network_url_redirect__redirect_http(void)
 	cl_assert_equal_p(conndata.password, NULL);
 }
 
-void test_network_url_redirect__redirect_ssl(void)
+void test_url_redirect__redirect_ssl(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://example.com/foo/bar/baz"));
@@ -42,7 +42,7 @@ void test_network_url_redirect__redirect_ssl(void)
 	cl_assert_equal_p(conndata.password, NULL);
 }
 
-void test_network_url_redirect__redirect_leaves_root_path(void)
+void test_url_redirect__redirect_leaves_root_path(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://example.com/foo/bar/baz"));
@@ -56,7 +56,7 @@ void test_network_url_redirect__redirect_leaves_root_path(void)
 	cl_assert_equal_p(conndata.password, NULL);
 }
 
-void test_network_url_redirect__redirect_encoded_username_password(void)
+void test_url_redirect__redirect_encoded_username_password(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://user%2fname:pass%40word%zyx%v@example.com/foo/bar/baz"));
@@ -70,7 +70,7 @@ void test_network_url_redirect__redirect_encoded_username_password(void)
 	cl_assert_equal_s(conndata.password, "pass@word%zyx%v");
 }
 
-void test_network_url_redirect__redirect_cross_host_allowed(void)
+void test_url_redirect__redirect_cross_host_allowed(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://bar.com/bar/baz"));
@@ -84,7 +84,7 @@ void test_network_url_redirect__redirect_cross_host_allowed(void)
 	cl_assert_equal_p(conndata.password, NULL);
 }
 
-void test_network_url_redirect__redirect_cross_host_denied(void)
+void test_url_redirect__redirect_cross_host_denied(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://bar.com/bar/baz"));
@@ -92,7 +92,7 @@ void test_network_url_redirect__redirect_cross_host_denied(void)
 		"https://foo.com/bar/baz", false, NULL), -1);
 }
 
-void test_network_url_redirect__redirect_http_downgrade_denied(void)
+void test_url_redirect__redirect_http_downgrade_denied(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://foo.com/bar/baz"));
@@ -100,7 +100,7 @@ void test_network_url_redirect__redirect_http_downgrade_denied(void)
 		"http://foo.com/bar/baz", true, NULL), -1);
 }
 
-void test_network_url_redirect__redirect_relative(void)
+void test_url_redirect__redirect_relative(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"http://foo.com/bar/baz/biff"));
@@ -114,7 +114,7 @@ void test_network_url_redirect__redirect_relative(void)
 	cl_assert_equal_p(conndata.password, NULL);
 }
 
-void test_network_url_redirect__redirect_relative_ssl(void)
+void test_url_redirect__redirect_relative_ssl(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://foo.com/bar/baz/biff"));
@@ -128,7 +128,7 @@ void test_network_url_redirect__redirect_relative_ssl(void)
 	cl_assert_equal_p(conndata.password, NULL);
 }
 
-void test_network_url_redirect__service_query_no_query_params_in_location(void)
+void test_url_redirect__service_query_no_query_params_in_location(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://foo.com/bar/info/refs?service=git-upload-pack"));
@@ -137,7 +137,7 @@ void test_network_url_redirect__service_query_no_query_params_in_location(void)
 	cl_assert_equal_s(conndata.path, "/baz");
 }
 
-void test_network_url_redirect__service_query_with_query_params_in_location(void)
+void test_url_redirect__service_query_with_query_params_in_location(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata,
 		"https://foo.com/bar/info/refs?service=git-upload-pack"));

--- a/tests/util/url/scp.c
+++ b/tests/util/url/scp.c
@@ -314,8 +314,4 @@ void test_url_scp__invalid_addresses(void)
 		"[git@[fe80::dcad:beff:fe00:0001]:42:/resource"));
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse_scp(&conndata,
 		"[git@[fe80::dcad:beff:fe00:0001:42]:/resource"));
-
-	/* Invalid character inside address */
-	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse(&conndata,
-		"[fe8o::dcad:beff:fe00:0001]:/resource"));
 }

--- a/tests/util/url/scp.c
+++ b/tests/util/url/scp.c
@@ -3,19 +3,19 @@
 
 static git_net_url conndata;
 
-void test_network_url_scp__initialize(void)
+void test_url_scp__initialize(void)
 {
 	memset(&conndata, 0, sizeof(conndata));
 }
 
-void test_network_url_scp__cleanup(void)
+void test_url_scp__cleanup(void)
 {
 	git_net_url_dispose(&conndata);
 }
 
 /* Hostname */
 
-void test_network_url_scp__hostname_trivial(void)
+void test_url_scp__hostname_trivial(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "example.com:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -27,7 +27,7 @@ void test_network_url_scp__hostname_trivial(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__hostname_bracketed(void)
+void test_url_scp__hostname_bracketed(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[example.com]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -39,7 +39,7 @@ void test_network_url_scp__hostname_bracketed(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__hostname_root(void)
+void test_url_scp__hostname_root(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "example.com:/"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -51,7 +51,7 @@ void test_network_url_scp__hostname_root(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__hostname_user(void)
+void test_url_scp__hostname_user(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "git@example.com:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -63,7 +63,7 @@ void test_network_url_scp__hostname_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__hostname_user_bracketed(void)
+void test_url_scp__hostname_user_bracketed(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[git@example.com]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -75,7 +75,7 @@ void test_network_url_scp__hostname_user_bracketed(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__hostname_port(void)
+void test_url_scp__hostname_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[example.com:42]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -87,7 +87,7 @@ void test_network_url_scp__hostname_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_scp__hostname_user_port(void)
+void test_url_scp__hostname_user_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[git@example.com:42]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -99,7 +99,7 @@ void test_network_url_scp__hostname_user_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_scp__ipv4_trivial(void)
+void test_url_scp__ipv4_trivial(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "192.168.99.88:/resource/a/b/c"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -111,7 +111,7 @@ void test_network_url_scp__ipv4_trivial(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__ipv4_bracketed(void)
+void test_url_scp__ipv4_bracketed(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[192.168.99.88]:/resource/a/b/c"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -123,7 +123,7 @@ void test_network_url_scp__ipv4_bracketed(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__ipv4_user(void)
+void test_url_scp__ipv4_user(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "git@192.168.99.88:/resource/a/b/c"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -135,7 +135,7 @@ void test_network_url_scp__ipv4_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__ipv4_port(void)
+void test_url_scp__ipv4_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[192.168.99.88:1111]:/resource/a/b/c"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -147,7 +147,7 @@ void test_network_url_scp__ipv4_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_scp__ipv4_user_port(void)
+void test_url_scp__ipv4_user_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[git@192.168.99.88:1111]:/resource/a/b/c"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -159,7 +159,7 @@ void test_network_url_scp__ipv4_user_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_scp__ipv6_trivial(void)
+void test_url_scp__ipv6_trivial(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[fe80::dcad:beff:fe00:0001]:/resource/foo"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -171,7 +171,7 @@ void test_network_url_scp__ipv6_trivial(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__ipv6_user(void)
+void test_url_scp__ipv6_user(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "git@[fe80::dcad:beff:fe00:0001]:/resource/foo"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -183,7 +183,7 @@ void test_network_url_scp__ipv6_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__ipv6_port(void)
+void test_url_scp__ipv6_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[[fe80::dcad:beff:fe00:0001]:99]:/resource/foo"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -195,7 +195,7 @@ void test_network_url_scp__ipv6_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_scp__ipv6_user_port(void)
+void test_url_scp__ipv6_user_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[git@[fe80::dcad:beff:fe00:0001]:99]:/resource/foo"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -207,7 +207,7 @@ void test_network_url_scp__ipv6_user_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
 }
 
-void test_network_url_scp__hexhost_and_port(void)
+void test_url_scp__hexhost_and_port(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[fe:22]:/resource/foo"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -219,7 +219,7 @@ void test_network_url_scp__hexhost_and_port(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__malformed_ipv6_one(void)
+void test_url_scp__malformed_ipv6_one(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "fe80::dcad:beff:fe00:0001]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -231,7 +231,7 @@ void test_network_url_scp__malformed_ipv6_one(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__malformed_ipv6_two(void)
+void test_url_scp__malformed_ipv6_two(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "[fe80::dcad:beff:fe00:0001]:42]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -243,7 +243,7 @@ void test_network_url_scp__malformed_ipv6_two(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__malformed_ipv6_with_user(void)
+void test_url_scp__malformed_ipv6_with_user(void)
 {
 	cl_git_pass(git_net_url_parse_scp(&conndata, "git@[fe80::dcad:beff:fe00:0001]:42]:/resource"));
 	cl_assert_equal_s(conndata.scheme, "ssh");
@@ -255,7 +255,7 @@ void test_network_url_scp__malformed_ipv6_with_user(void)
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
 }
 
-void test_network_url_scp__invalid_addresses(void)
+void test_url_scp__invalid_addresses(void)
 {
 	/* Path is required */
 	cl_git_fail_with(GIT_EINVALIDSPEC, git_net_url_parse_scp(&conndata,

--- a/tests/util/url/valid.c
+++ b/tests/util/url/valid.c
@@ -1,7 +1,7 @@
 #include "clar_libgit2.h"
 #include "net.h"
 
-void test_network_url_valid__test(void)
+void test_url_valid__test(void)
 {
 	cl_assert(git_net_str_is_url("http://example.com/"));
 	cl_assert(git_net_str_is_url("file://localhost/tmp/foo/"));


### PR DESCRIPTION
Google Code allows you to put `@` in usernames, and git supports urls like `ssh://user@domain@host/...` because - fuck you, RFCs. Add our own URL parsing so that we can cope with this madness. 😭 

Fixes #6199