### PR TITLE
cmake: drop posix dependency from pcre* detection

### DIFF
--- a/cmake/FindPCRE.cmake
+++ b/cmake/FindPCRE.cmake
@@ -16,19 +16,18 @@
 # PCRE_FOUND	- True if pcre found.
 
 # Look for the header file.
-find_path(PCRE_INCLUDE_DIR NAMES pcreposix.h)
+find_path(PCRE_INCLUDE_DIR NAMES pcre.h)
 
 # Look for the library.
 find_library(PCRE_LIBRARY NAMES pcre)
-find_library(PCRE_POSIX_LIBRARY NAMES pcreposix)
 
 # Handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PCRE DEFAULT_MSG PCRE_LIBRARY PCRE_POSIX_LIBRARY PCRE_INCLUDE_DIR)
+find_package_handle_standard_args(PCRE DEFAULT_MSG PCRE_LIBRARY PCRE_INCLUDE_DIR)
 
 # Copy the results to the output variables.
 if(PCRE_FOUND)
-	set(PCRE_LIBRARIES ${PCRE_LIBRARY} ${PCRE_POSIX_LIBRARY})
+	set(PCRE_LIBRARIES ${PCRE_LIBRARY})
 	set(PCRE_INCLUDE_DIRS ${PCRE_INCLUDE_DIR})
 else(PCRE_FOUND)
 	set(PCRE_LIBRARIES)

--- a/cmake/FindPCRE2.cmake
+++ b/cmake/FindPCRE2.cmake
@@ -16,7 +16,7 @@
 # PCRE2_FOUND	- True if pcre found.
 
 # Look for the header file.
-find_path(PCRE2_INCLUDE_DIR NAMES pcre2posix.h)
+find_path(PCRE2_INCLUDE_DIR NAMES pcre2.h)
 
 # Look for the library.
 find_library(PCRE2_LIBRARY NAMES pcre2-8)


### PR DESCRIPTION
since f585b12 neither PCRE nor PCRE2 backends rely on POSIX regex, so
reflect it in library detection logic