### PR TITLE
Fix internal git_sysdir_find* function usage within public git_config_find* functions

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1137,7 +1137,7 @@ int git_config__find_global(git_str *path)
 
 int git_config_find_xdg(git_buf *path)
 {
-	GIT_BUF_WRAP_PRIVATE(path, git_sysdir_find_global_file, GIT_CONFIG_FILENAME_XDG);
+	GIT_BUF_WRAP_PRIVATE(path, git_sysdir_find_xdg_file, GIT_CONFIG_FILENAME_XDG);
 }
 
 int git_config__find_xdg(git_str *path)
@@ -1147,7 +1147,7 @@ int git_config__find_xdg(git_str *path)
 
 int git_config_find_system(git_buf *path)
 {
-	GIT_BUF_WRAP_PRIVATE(path, git_sysdir_find_global_file, GIT_CONFIG_FILENAME_SYSTEM);
+	GIT_BUF_WRAP_PRIVATE(path, git_sysdir_find_system_file, GIT_CONFIG_FILENAME_SYSTEM);
 }
 
 int git_config__find_system(git_str *path)


### PR DESCRIPTION
This change is intended to fix what appears to be a regression introduced as part of changes to distinguish git_buf/str.

I discovered the public git_config_find_system_file function wasn't working as advertised while attempting to this to find/use the system configuration file in combination with a custom config backend I use otherwise (in conjunction with a custom ODB backend).

When looking into the history of the code changes, I noticed both the git_config_find_system_file & git_config_find_xdg_file previously used corresponding git_sysdir_find* functions, but when change was made to use GIT_BUF_WRAP_PRIVATE, they've ended up using git_sysdir_find_global_file, which this change should hopefully correct for both scenarios (this at least worked in my case when looking for the system configuration file).