### PR TITLE
refs: make `git_reference_cmp` consider the name

### DIFF
--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -1054,9 +1054,13 @@ int git_reference_cmp(
 	const git_reference *ref2)
 {
 	git_reference_t type1, type2;
+	int ret;
 
 	GIT_ASSERT_ARG(ref1);
 	GIT_ASSERT_ARG(ref2);
+
+	if ((ret = strcmp(ref1->name, ref2->name)) != 0)
+		return ret;
 
 	type1 = git_reference_type(ref1);
 	type2 = git_reference_type(ref2);

--- a/tests/libgit2/refs/cmp.c
+++ b/tests/libgit2/refs/cmp.c
@@ -1,0 +1,27 @@
+#include "clar_libgit2.h"
+#include "refs.h"
+
+static git_repository *g_repo;
+
+void test_refs_cmp__initialize(void)
+{
+	g_repo = cl_git_sandbox_init("testrepo2");
+}
+
+void test_refs_cmp__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_refs_cmp__symbolic(void)
+{
+	git_reference *one, *two;
+
+	cl_git_pass(git_reference_lookup(&one, g_repo, "refs/heads/symbolic-one"));
+	cl_git_pass(git_reference_lookup(&two, g_repo, "refs/heads/symbolic-two"));
+
+	cl_assert(git_reference_cmp(one, two) != 0);
+
+	git_reference_free(one);
+	git_reference_free(two);
+}

--- a/tests/resources/testrepo2/.gitted/refs/heads/symbolic-one
+++ b/tests/resources/testrepo2/.gitted/refs/heads/symbolic-one
@@ -1,0 +1,1 @@
+ref: refs/heads/master

--- a/tests/resources/testrepo2/.gitted/refs/heads/symbolic-two
+++ b/tests/resources/testrepo2/.gitted/refs/heads/symbolic-two
@@ -1,0 +1,1 @@
+ref: refs/heads/master


### PR DESCRIPTION
`git_reference_cmp` only considers the target of a reference, and
ignores the name. Meaning that a reference `foo` and reference `bar`
pointing to the same commit will compare equal.

Correct this, comparing the name _and_ target of a reference.

This appears to be an oversight, as [`git_reference_cmp`](https://github.com/libgit2/libgit2/commit/f201d613a80f7ad6f54d90eb7a7a0d8b8c72676b) was added as a helper method. Despite that, this is a breaking API change. We'll target libgit2 2.0 for this change.

Fixes #6337 