### PR TITLE
clar: remove ftrunacte from libgit2 tests

### DIFF
--- a/tests/libgit2/CMakeLists.txt
+++ b/tests/libgit2/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 
 include(AddClarTest)
 add_clar_test(libgit2_tests offline             -v -xonline)
-add_clar_test(libgit2_tests invasive            -v -score::ftruncate -sfilter::stream::bigfile -sodb::largefiles -siterator::workdir::filesystem_gunk -srepo::init -srepo::init::at_filesystem_root)
+add_clar_test(libgit2_tests invasive            -v -sfilter::stream::bigfile -sodb::largefiles -siterator::workdir::filesystem_gunk -srepo::init -srepo::init::at_filesystem_root)
 add_clar_test(libgit2_tests online              -v -sonline -xonline::customcert)
 add_clar_test(libgit2_tests online_customcert   -v -sonline::customcert)
 add_clar_test(libgit2_tests gitdaemon           -v -sonline::push)


### PR DESCRIPTION
The ftruncate test have been moved to util and shouldn't/can't be done from the libgit2 tests anymore