### PR TITLE
util/rand: Fix unused variable warning when building without threads

### DIFF
--- a/src/util/rand.c
+++ b/src/util/rand.c
@@ -15,7 +15,9 @@ See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 #endif
 
 static uint64_t state[4];
+#if defined(GIT_THREADS)
 static git_mutex state_lock;
+#endif
 
 typedef union {
 	double f;


### PR DESCRIPTION
When building with USE_THREADS=OFF (GIT_THREADS not defined), the
state_lock variable was still defined, but never used, causing a
warning.