### PR TITLE
fix compile on Windows with -DWIN32_LEAN_AND_MEAN

### DIFF
--- a/src/util/rand.c
+++ b/src/util/rand.c
@@ -14,6 +14,10 @@ See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 # include <sys/random.h>
 #endif
 
+#if defined(GIT_WIN32)
+#include <wincrypt.h>
+#endif
+
 static uint64_t state[4];
 static git_mutex state_lock;
 

--- a/src/util/rand.c
+++ b/src/util/rand.c
@@ -15,7 +15,7 @@ See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 #endif
 
 #if defined(GIT_WIN32)
-#include <wincrypt.h>
+# include <wincrypt.h>
 #endif
 
 static uint64_t state[4];


### PR DESCRIPTION
Ensure the needed wincrypt.h is included.

Without this, rand.c will not compile if -DWIN32_LEAN_AND_MEAN is set in the compile flags.