### PR TITLE
 Define correct off64_t for AIX

### DIFF
--- a/src/util/posix.h
+++ b/src/util/posix.h
@@ -104,6 +104,8 @@ typedef __int64 off64_t;
 typedef __haiku_std_int64 off64_t;
 #elif defined(__APPLE__)
 typedef __int64_t off64_t;
+#elif defined(_AIX)
+typedef long long off64_t;
 #else
 typedef int64_t off64_t;
 #endif

--- a/src/util/posix.h
+++ b/src/util/posix.h
@@ -9,7 +9,6 @@
 
 #include "git2_util.h"
 
-#include <stdint.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <time.h>
@@ -105,6 +104,8 @@ typedef __int64 off64_t;
 typedef __haiku_std_int64 off64_t;
 #elif defined(__APPLE__)
 typedef __int64_t off64_t;
+#elif defined(_AIX)
+typedef long long off64_t;
 #else
 typedef int64_t off64_t;
 #endif

--- a/src/util/posix.h
+++ b/src/util/posix.h
@@ -9,6 +9,7 @@
 
 #include "git2_util.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <time.h>
@@ -104,8 +105,6 @@ typedef __int64 off64_t;
 typedef __haiku_std_int64 off64_t;
 #elif defined(__APPLE__)
 typedef __int64_t off64_t;
-#elif defined(_AIX)
-typedef long long off64_t;
 #else
 typedef int64_t off64_t;
 #endif


### PR DESCRIPTION
`off64_t` is `long long` on AIX, see `/usr/include/sys/types.h` on AIX.