### PR TITLE
experimental.h: allow building without CMake-generated experimental header

### DIFF
--- a/include/git2.h
+++ b/include/git2.h
@@ -28,7 +28,9 @@
 #include "git2/diff.h"
 #include "git2/email.h"
 #include "git2/errors.h"
-#include "git2/experimental.h"
+#ifndef LIBGIT2_NO_EXPERIMENTAL_H
+# include "git2/experimental.h"
+#endif
 #include "git2/filter.h"
 #include "git2/global.h"
 #include "git2/graph.h"

--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -9,7 +9,9 @@
 
 #include "common.h"
 #include "types.h"
-#include "experimental.h"
+#ifndef LIBGIT2_NO_EXPERIMENTAL_H
+# include "experimental.h"
+#endif
 
 /**
  * @file git2/oid.h

--- a/src/libgit2/oid.h
+++ b/src/libgit2/oid.h
@@ -9,7 +9,9 @@
 
 #include "common.h"
 
-#include "git2/experimental.h"
+#ifndef LIBGIT2_NO_EXPERIMENTAL_H
+# include "git2/experimental.h"
+#endif
 #include "git2/oid.h"
 #include "hash.h"
 


### PR DESCRIPTION
Not all libgit2 users use cmake.

Issue introduced in: #6191

Similar fix for features.h: #4346

Maybe a more generic flag should be introduced.