### PR TITLE
Fix parsing rev with reflog of HEAD (e.g., HEAD@{3})

### DIFF
--- a/src/libgit2/revparse.c
+++ b/src/libgit2/revparse.c
@@ -268,7 +268,11 @@ static int retrieve_revobject_from_reflog(git_object **out, git_reference **base
 	int error = -1;
 
 	if (*base_ref == NULL) {
-		if ((error = git_reference_dwim(&ref, repo, identifier)) < 0)
+		if (position > 0 &&
+		    (!strcmp(identifier, "HEAD"))) {
+			if ((error = git_reference_lookup(&ref, repo, "HEAD")) < 0)
+				return error;
+		} else if ((error = git_reference_dwim(&ref, repo, identifier)) < 0)
 			return error;
 	} else {
 		ref = *base_ref;

--- a/tests/libgit2/refs/revparse.c
+++ b/tests/libgit2/refs/revparse.c
@@ -304,6 +304,9 @@ void test_refs_revparse__ordinal(void)
 	test_object("@{0}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	test_object("@{1}", "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
 
+	test_object("HEAD@{0}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
+	test_object("HEAD@{4}", "5b5b025afb0b4c913b4c338a42934a3863bf3644");
+
 	test_object("master@{0}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 	test_object("master@{1}", "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");
 	test_object("heads/master@{1}", "be3563ae3f795b2b4353bcce3a527ad0a4f7f644");


### PR DESCRIPTION
git_revparse_single for the reflog entries of HEAD wrongly return the reflog entries of the current branch

Refers to issue #6156