### PR TITLE
Make refdb_fs (hopefully) fully aware of per worktree refs

### DIFF
--- a/src/libgit2/refdb_fs.c
+++ b/src/libgit2/refdb_fs.c
@@ -403,7 +403,9 @@ static const char *loose_parse_symbolic(git_str *file_content)
 static bool is_per_worktree_ref(const char *ref_name)
 {
 	return git__prefixcmp(ref_name, "refs/") != 0 ||
-	    git__prefixcmp(ref_name, "refs/bisect/") == 0;
+	       git__prefixcmp(ref_name, "refs/bisect/") == 0 ||
+	       git__prefixcmp(ref_name, "refs/worktree/") == 0 ||
+	       git__prefixcmp(ref_name, "refs/rewritten/") == 0;
 }
 
 static int loose_lookup(

--- a/tests/libgit2/worktree/refs.c
+++ b/tests/libgit2/worktree/refs.c
@@ -20,7 +20,7 @@ void test_worktree_refs__cleanup(void)
 	cleanup_fixture_worktree(&fixture);
 }
 
-void test_worktree_refs__list(void)
+void test_worktree_refs__list_no_difference_in_worktree(void)
 {
 	git_strarray refs, wtrefs;
 	unsigned i, j;
@@ -56,6 +56,74 @@ void test_worktree_refs__list(void)
 	}
 
 exit:
+	git_strarray_dispose(&refs);
+	git_strarray_dispose(&wtrefs);
+	cl_git_pass(error);
+}
+
+void test_worktree_refs__list_worktree_specific(void)
+{
+	git_strarray refs, wtrefs;
+	git_reference *ref, *new_branch;
+	int error = 0;
+	git_oid oid;
+
+	cl_git_pass(git_reference_name_to_id(&oid, fixture.repo, "refs/heads/dir"));
+	cl_git_fail(git_reference_lookup(&ref, fixture.repo, "refs/bisect/a-bisect-ref"));
+	cl_git_pass(git_reference_create(
+	        &new_branch, fixture.worktree, "refs/bisect/a-bisect-ref", &oid,
+	        0, "test"));
+
+	cl_git_fail(git_reference_lookup(&ref, fixture.repo, "refs/bisect/a-bisect-ref"));
+	cl_git_pass(git_reference_lookup(&ref, fixture.worktree, "refs/bisect/a-bisect-ref"));
+
+	cl_git_pass(git_reference_list(&refs, fixture.repo));
+	cl_git_pass(git_reference_list(&wtrefs, fixture.worktree));
+
+	if (refs.count + 1 != wtrefs.count) {
+		error = GIT_ERROR;
+		goto exit;
+	}
+
+exit:
+	git_reference_free(ref);
+	git_reference_free(new_branch);
+	git_strarray_dispose(&refs);
+	git_strarray_dispose(&wtrefs);
+	cl_git_pass(error);
+}
+
+void test_worktree_refs__list_worktree_specific_hidden_in_main_repo(void)
+{
+	git_strarray refs, wtrefs;
+	git_reference *ref, *new_branch;
+	int error = 0;
+	git_oid oid;
+
+	cl_git_pass(
+	        git_reference_name_to_id(&oid, fixture.repo, "refs/heads/dir"));
+	cl_git_fail(git_reference_lookup(
+	        &ref, fixture.worktree, "refs/bisect/a-bisect-ref"));
+	cl_git_pass(git_reference_create(
+	        &new_branch, fixture.repo, "refs/bisect/a-bisect-ref", &oid,
+	        0, "test"));
+
+	cl_git_fail(git_reference_lookup(
+	        &ref, fixture.worktree, "refs/bisect/a-bisect-ref"));
+	cl_git_pass(git_reference_lookup(
+	        &ref, fixture.repo, "refs/bisect/a-bisect-ref"));
+
+	cl_git_pass(git_reference_list(&refs, fixture.repo));
+	cl_git_pass(git_reference_list(&wtrefs, fixture.worktree));
+
+	if (refs.count != wtrefs.count + 1) {
+		error = GIT_ERROR;
+		goto exit;
+	}
+
+exit:
+	git_reference_free(ref);
+	git_reference_free(new_branch);
 	git_strarray_dispose(&refs);
 	git_strarray_dispose(&wtrefs);
 	cl_git_pass(error);


### PR DESCRIPTION
This makes refdb_fs fully aware of per worktree refs (fixes issue #5492).

The code has some duplication but does the trick.