### PR TITLE
#6366: When a worktree is missing, return GIT_ENOTFOUND.

### DIFF
--- a/src/libgit2/worktree.c
+++ b/src/libgit2/worktree.c
@@ -187,6 +187,11 @@ int git_worktree_lookup(git_worktree **out, git_repository *repo, const char *na
 	if ((error = git_str_join3(&path, '/', repo->commondir, "worktrees", name)) < 0)
 		goto out;
 
+	if (!git_fs_path_isdir(path.ptr)) {
+		error = GIT_ENOTFOUND;
+		goto out;
+	}
+
 	if ((error = (open_worktree_dir(out, git_repository_workdir(repo), path.ptr, name))) < 0)
 		goto out;
 

--- a/tests/libgit2/worktree/worktree.c
+++ b/tests/libgit2/worktree/worktree.c
@@ -120,7 +120,7 @@ void test_worktree_worktree__lookup_nonexistent_worktree(void)
 {
 	git_worktree *wt;
 
-	cl_git_fail(git_worktree_lookup(&wt, fixture.repo, "nonexistent"));
+	cl_git_fail_with(GIT_ENOTFOUND, git_worktree_lookup(&wt, fixture.repo, "nonexistent"));
 	cl_assert_equal_p(wt, NULL);
 }
 


### PR DESCRIPTION
Rationale: I preferred to not touch the function I mention in #6366 since that check mostly assumes the directory exists and is checking its contents (for corrupted worktrees, etc). So I added an additional check specific to the lookup function. If the directory does not exist, it means the worktree does not exist as well.