### PR TITLE
Work In Progress: load config from environment variables if present

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1145,6 +1145,24 @@ int git_config__find_xdg(git_str *path)
 	return git_sysdir_find_xdg_file(path, GIT_CONFIG_FILENAME_XDG);
 }
 
+int git_config__find_global_and_xdg(
+	git_str *global_buf,
+	git_str *xdg_buf) {
+	int error;
+	error = git__getenv(global_buf, "GIT_CONFIG_GLOBAL");
+
+	/* Only read the $HOME/.gitconfig or $XDG_CONFIG_HOME/git/config files if
+	GIT_CONFIG_GLOBAL is not set, per
+	https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode */
+	if (error == GIT_ENOTFOUND) {
+		git_error_clear();
+		git_config__find_global(global_buf);
+		git_config__find_xdg(xdg_buf);
+		return 0;
+	}
+	return error;
+}
+
 int git_config_find_system(git_buf *path)
 {
 	GIT_BUF_WRAP_PRIVATE(path, git_sysdir_find_system_file, GIT_CONFIG_FILENAME_SYSTEM);

--- a/src/libgit2/config.h
+++ b/src/libgit2/config.h
@@ -29,8 +29,9 @@ struct git_config {
 
 extern int git_config__global_location(git_str *buf);
 
-extern int git_config__find_global(git_str *path);
-extern int git_config__find_xdg(git_str *path);
+extern int git_config__find_global_and_xdg(
+	git_str *global_buf,
+	git_str *xdg_buf);
 extern int git_config__find_system(git_str *path);
 extern int git_config__find_programdata(git_str *path);
 

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -1191,8 +1191,7 @@ int git_repository_config__weakptr(git_config **out, git_repository *repo)
 		git_str programdata_buf = GIT_STR_INIT;
 		git_config *config;
 
-		git_config__find_global(&global_buf);
-		git_config__find_xdg(&xdg_buf);
+		git_config__find_global_and_xdg(&global_buf, &xdg_buf);
 		git_config__find_system(&system_buf);
 		git_config__find_programdata(&programdata_buf);
 
@@ -1732,14 +1731,14 @@ static bool is_filesystem_case_insensitive(const char *gitdir_path)
  */
 static int load_global_config(git_config **config)
 {
+	git_str global_buf_from_env = GIT_STR_INIT;
 	git_str global_buf = GIT_STR_INIT;
 	git_str xdg_buf = GIT_STR_INIT;
 	git_str system_buf = GIT_STR_INIT;
 	git_str programdata_buf = GIT_STR_INIT;
 	int error;
 
-	git_config__find_global(&global_buf);
-	git_config__find_xdg(&xdg_buf);
+	git_config__find_global_and_xdg(&global_buf, &xdg_buf);
 	git_config__find_system(&system_buf);
 	git_config__find_programdata(&programdata_buf);
 


### PR DESCRIPTION
This is a first attempt at having libgit2 use environment variables for config paths, to address https://github.com/libgit2/libgit2/issues/6182.

This PR modifies the original code to read the config at the path specified by the `GIT_CONFIG_GLOBAL` environment variable, and to avoid reading the `$HOME/.gitconfig` and `$XDG_CONFIG_HOME/git/config` files if `GIT_CONFIG_GLOBAL` is set, as specified in the [git-scm](https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode) documentation.

In addition to unit tests, I've created a minimal example to show that this code change indeed picks up the value from the environment variable: https://github.com/clnoll/libgit2-config-env-var. It can be run by:
```
git clone https://github.com/clnoll/libgit2-config-env-var.git
cd libgit2-config-env-var
cargo build --release
GIT_CONFIG_GLOBAL=.gitconfig_test_env_var ./target/release/libgit2-config-env-var  # prints "In custom config section" to stdout
./target/release/libgit2-config-env-var  # prints "Error: config value 'myconfigsection.custom' was not found" to stdout
```
Output: 
<img width="787" alt="image" src="https://user-images.githubusercontent.com/5257313/188963385-c30d1ddf-b580-4d15-b3fd-c546e877d099.png">

If this implementation looks good I can also add handling for `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_NOSYSTEM` following a similar pattern.