### PR TITLE
chunk-format: create an API from common code

### DIFF
--- a/src/libgit2/chunk_format.c
+++ b/src/libgit2/chunk_format.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "chunk_format.h"
+
+int write_offset(off64_t offset, chunk_format_write_cb write_cb, void *cb_data)
+{
+	int error;
+	uint32_t word;
+
+	word = htonl((uint32_t)((offset >> 32) & 0xffffffffu));
+	error = write_cb((const char *)&word, sizeof(word), cb_data);
+	if (error < 0)
+		return error;
+	word = htonl((uint32_t)((offset >> 0) & 0xffffffffu));
+	error = write_cb((const char *)&word, sizeof(word), cb_data);
+	if (error < 0)
+		return error;
+
+	return 0;
+}
+
+int write_chunk_header(
+		int chunk_id,
+		off64_t offset,
+		chunk_format_write_cb write_cb,
+		void *cb_data)
+{
+	uint32_t word = htonl(chunk_id);
+	int error = write_cb((const char *)&word, sizeof(word), cb_data);
+	if (error < 0)
+		return error;
+	return write_offset(offset, write_cb, cb_data);
+}

--- a/src/libgit2/chunk_format.h
+++ b/src/libgit2/chunk_format.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_chunk_format_h__
+#define INCLUDE_chunk_format_h__
+
+#include "common.h"
+
+#include "git2/types.h"
+
+/*
+ * The chunk format is a common set of substructures in some Git formats.
+ * This file declares some helpful methods for writing and reading these
+ * formats to help share code across different file types.
+ *
+ * See https://git-scm.com/docs/chunk-format for details on the chunk
+ * format, including how it uses a table of contents to describe distinct
+ * sections of structured data within a file.
+ */
+
+typedef int (*chunk_format_write_cb)(const char *buf, size_t size, void *cb_data);
+
+int write_offset(off64_t offset, chunk_format_write_cb write_cb, void *cb_data);
+
+int write_chunk_header(
+		int chunk_id,
+		off64_t offset,
+		chunk_format_write_cb write_cb,
+		void *cb_data);
+
+#endif


### PR DESCRIPTION
The commit-graph and multi-pack-index file formats use common substructures. This is so much the case that commit_graph.c and midx.c have some common code that can be extracted into its own API.

Start by pulling out the write_offset() and write_chunk_header() methods. Later changes will update the API with the reading half of the API.

There are similar changes in the Git project in git/git:chunk-format.[c|h] that could be used as an example for future abstractions, such as populating a struct with the full list of chunks, then letting the chunk API write each of the chunks using callbacks to the specifics within each chunk.

This is a super-simple refactoring. There are more complicated things we could do if we want to mimic [the full chunk-format API in `git/git`](https://github.com/git/git/compare/5a3b130cad0d5c770f766e3af6d32b41766374c0...c4ff24bbb354377a6a7937744fbbef2898243fc7), which has been helpful when quickly prototyping new file formats. I wanted to keep my first contribution small so I could learn about contributing to this community.