### PR TITLE
commit-graph: only verify csum on git_commit_graph_open().

### DIFF
--- a/src/libgit2/commit_graph.c
+++ b/src/libgit2/commit_graph.c
@@ -200,7 +200,7 @@ int git_commit_graph_file_parse(
 	const unsigned char *chunk_hdr;
 	struct git_commit_graph_chunk *last_chunk;
 	uint32_t i;
-	off64_t last_chunk_offset, chunk_offset, trailer_offset;
+	uint64_t last_chunk_offset, chunk_offset, trailer_offset;
 	size_t checksum_size;
 	int error;
 	struct git_commit_graph_chunk chunk_oid_fanout = {0}, chunk_oid_lookup = {0},
@@ -236,8 +236,8 @@ int git_commit_graph_file_parse(
 	chunk_hdr = data + sizeof(struct git_commit_graph_header);
 	last_chunk = NULL;
 	for (i = 0; i < hdr->chunks; ++i, chunk_hdr += 12) {
-		chunk_offset = ((off64_t)ntohl(*((uint32_t *)(chunk_hdr + 4)))) << 32
-				| ((off64_t)ntohl(*((uint32_t *)(chunk_hdr + 8))));
+		chunk_offset = ((uint64_t)ntohl(*((uint32_t *)(chunk_hdr + 4)))) << 32
+				| ((uint64_t)ntohl(*((uint32_t *)(chunk_hdr + 8))));
 		if (chunk_offset < last_chunk_offset)
 			return commit_graph_error("chunks are non-monotonic");
 		if (chunk_offset >= trailer_offset)

--- a/src/libgit2/commit_graph.h
+++ b/src/libgit2/commit_graph.h
@@ -106,6 +106,9 @@ struct git_commit_graph {
 /** Create a new commit-graph, optionally opening the underlying file. */
 int git_commit_graph_new(git_commit_graph **cgraph_out, const char *objects_dir, bool open_file);
 
+/** Validate the checksum of a commit graph */
+int git_commit_graph_validate(git_commit_graph *cgraph);
+
 /** Open and validate a commit-graph file. */
 int git_commit_graph_file_open(git_commit_graph_file **file_out, const char *path);
 


### PR DESCRIPTION
It is expensive to compute the sha1 of the entire commit-graph file each time we open it. Git only does this if it is re-writing the file.

This patch will only verify the checksum when calling the external API git_commit_graph_open(), which explicitly says it opens and verifies the commit graph in the documentation.

For internal library calls, we call git_commit_graph_get_file(), which mmaps the commit-graph file in read-only mode. Therefore it is safe to skip the validation check there.

Tests were added to check that the validation works in the happy path, and prevents us from opening the file when validation fails.

(Note from Derrick Stolee: This patch was applied internally at GitHub after we recognized the performance impact it had during an upgrade of libgit2. The original author left the company before we remembered to send it upstream.)

cc/ @ccstolley 
cc/ @carlosmn 