### PR TITLE
Fix leak in git_tag_create_from_buffer

### DIFF
--- a/src/libgit2/tag.c
+++ b/src/libgit2/tag.c
@@ -299,8 +299,10 @@ static int git_tag_create__internal(
 	}
 
 	if (create_tag_annotation) {
-		if (write_tag_annotation(oid, repo, tag_name, target, tagger, message) < 0)
+		if (write_tag_annotation(oid, repo, tag_name, target, tagger, message) < 0) {
+			git_str_dispose(&ref_name);
 			return -1;
+		}
 	} else
 		git_oid_cpy(oid, git_object_id(target));
 

--- a/src/libgit2/tag.c
+++ b/src/libgit2/tag.c
@@ -397,6 +397,7 @@ int git_tag_create_from_buffer(git_oid *oid, git_repository *repo, const char *b
 	/** Ensure the tag name doesn't conflict with an already existing
 	 *	reference unless overwriting has explicitly been requested **/
 	if (error == 0 && !allow_ref_overwrite) {
+		git_str_dispose(&ref_name);
 		git_error_set(GIT_ERROR_TAG, "tag already exists");
 		return GIT_EEXISTS;
 	}

--- a/src/libgit2/tag.c
+++ b/src/libgit2/tag.c
@@ -404,8 +404,10 @@ int git_tag_create_from_buffer(git_oid *oid, git_repository *repo, const char *b
 
 	/* write the buffer */
 	if ((error = git_odb_open_wstream(
-			&stream, odb, strlen(buffer), GIT_OBJECT_TAG)) < 0)
+			&stream, odb, strlen(buffer), GIT_OBJECT_TAG)) < 0) {
+		git_str_dispose(&ref_name);
 		return error;
+	}
 
 	if (!(error = git_odb_stream_write(stream, buffer, strlen(buffer))))
 		error = git_odb_stream_finalize_write(oid, stream);


### PR DESCRIPTION
If the tag already exists and we are not forcing overwrite we need to free ref_name buffer before return the "tag already exists" error.