### PR TITLE
Set GIT_EOWNER when safe.directory is not configured

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -580,9 +580,13 @@ static int validate_ownership(git_repository *repo)
 			break;
 	}
 
-	if (is_safe ||
-	    (error = validate_ownership_config(&is_safe, validation_paths[0])) < 0)
+	if (is_safe)
 		goto done;
+
+	error = validate_ownership_config(&is_safe, validation_paths[0]);
+	if (error < 0 && error != GIT_ENOTFOUND)
+		goto done;
+	error = 0;
 
 	if (!is_safe) {
 		git_error_set(GIT_ERROR_CONFIG,

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -543,7 +543,7 @@ void test_repo_open__can_allowlist_dirs_with_problematic_ownership(void)
 	cl_git_pass(cl_rename("empty_standard_repo/.gitted", "empty_standard_repo/.git"));
 
 	git_fs_path__set_owner(GIT_FS_PATH_OWNER_OTHER);
-	cl_git_fail(git_repository_open(&repo, "empty_standard_repo"));
+	cl_git_fail_with(GIT_EOWNER, git_repository_open(&repo, "empty_standard_repo"));
 
 	/* Add safe.directory options to the global configuration */
 	git_str_joinpath(&config_path, clar_sandbox_path(), "__global_config");


### PR DESCRIPTION
When there is an ownership violation, and `safe.directory` is not configured, libgit2 will return a somewhat confusing GIT_ENOTFOUND message with `config value 'safe.directory' was not found`. I'm not sure if this was intentional, but I think it is helpful to instead return GIT_EOWNER to indicate the actual underlying error.
