### PR TITLE
Rename bundled xdiff symbols to avoid conflicts

### DIFF
--- a/src/libgit2/blame_git.c
+++ b/src/libgit2/blame_git.c
@@ -385,7 +385,7 @@ static int diff_hunks(mmfile_t file_a, mmfile_t file_b, void *cb_data, git_blame
 		return -1;
 	}
 
-	return xdl_diff(&file_a, &file_b, &xpp, &xecfg, &ecb);
+	return git_xdl_diff(&file_a, &file_b, &xpp, &xecfg, &ecb);
 }
 
 static void fill_origin_blob(git_blame__origin *o, mmfile_t *file)

--- a/src/libgit2/diff_xdiff.c
+++ b/src/libgit2/diff_xdiff.c
@@ -223,7 +223,7 @@ static int git_xdiff(git_patch_generated_output *output, git_patch_generated *pa
 	    git_patch_generated_new_data(&info.xd_new_data.ptr, &info.xd_new_data.size, patch) < 0)
 		return -1;
 
-	xdl_diff(&info.xd_old_data, &info.xd_new_data,
+	git_xdl_diff(&info.xd_old_data, &info.xd_new_data,
 		&xo->params, &xo->config, &xo->callback);
 
 	git_diff_find_context_clear(&findctxt);

--- a/src/libgit2/merge_file.c
+++ b/src/libgit2/merge_file.c
@@ -77,7 +77,7 @@ static int merge_file__xdiff(
 	mmbuffer_t mmbuffer;
 	git_merge_file_options options = GIT_MERGE_FILE_OPTIONS_INIT;
 	const char *path;
-	int xdl_result;
+	int git_xdl_result;
 	int error = 0;
 
 	memset(out, 0x0, sizeof(git_merge_file_result));
@@ -141,7 +141,7 @@ static int merge_file__xdiff(
 
 	xmparam.marker_size = options.marker_size;
 
-	if ((xdl_result = xdl_merge(&ancestor_mmfile, &our_mmfile,
+	if ((git_xdl_result = git_xdl_merge(&ancestor_mmfile, &our_mmfile,
 		&their_mmfile, &xmparam, &mmbuffer)) < 0) {
 		git_error_set(GIT_ERROR_MERGE, "failed to merge files");
 		error = -1;
@@ -158,7 +158,7 @@ static int merge_file__xdiff(
 		goto done;
 	}
 
-	out->automergeable = (xdl_result == 0);
+	out->automergeable = (git_xdl_result == 0);
 	out->ptr = (const char *)mmbuffer.ptr;
 	out->len = mmbuffer.size;
 	out->mode = git_merge_file__best_mode(

--- a/src/libgit2/xdiff/git-xdiff.h
+++ b/src/libgit2/xdiff/git-xdiff.h
@@ -27,18 +27,18 @@
 # endif
 #endif
 
-#define xdl_malloc(x) git__malloc(x)
-#define xdl_free(ptr) git__free(ptr)
-#define xdl_realloc(ptr, x) git__realloc(ptr, x)
+#define git_xdl_malloc(x) git__malloc(x)
+#define git_xdl_free(ptr) git__free(ptr)
+#define git_xdl_realloc(ptr, x) git__realloc(ptr, x)
 
 #define XDL_BUG(msg) GIT_ASSERT(msg)
 
-#define xdl_regex_t git_regexp
-#define xdl_regmatch_t git_regmatch
+#define git_xdl_regex_t git_regexp
+#define git_xdl_regmatch_t git_regmatch
 
-GIT_INLINE(int) xdl_regexec_buf(
-	const xdl_regex_t *preg, const char *buf, size_t size,
-	size_t nmatch, xdl_regmatch_t pmatch[], int eflags)
+GIT_INLINE(int) git_xdl_regexec_buf(
+	const git_xdl_regex_t *preg, const char *buf, size_t size,
+	size_t nmatch, git_xdl_regmatch_t pmatch[], int eflags)
 {
 	GIT_UNUSED(preg);
 	GIT_UNUSED(buf);

--- a/src/libgit2/xdiff/xdiff.h
+++ b/src/libgit2/xdiff/xdiff.h
@@ -84,7 +84,7 @@ typedef struct s_xpparam {
 	unsigned long flags;
 
 	/* -I<regex> */
-	xdl_regex_t **ignore_regex;
+	git_xdl_regex_t **ignore_regex;
 	size_t ignore_regex_nr;
 
 	/* See Documentation/diff-options.txt. */
@@ -103,7 +103,7 @@ typedef struct s_xdemitcb {
 
 typedef long (*find_func_t)(const char *line, long line_len, char *buffer, long buffer_size, void *priv);
 
-typedef int (*xdl_emit_hunk_consume_func_t)(long start_a, long count_a,
+typedef int (*git_xdl_emit_hunk_consume_func_t)(long start_a, long count_a,
 					    long start_b, long count_b,
 					    void *cb_data);
 
@@ -113,7 +113,7 @@ typedef struct s_xdemitconf {
 	unsigned long flags;
 	find_func_t find_func;
 	void *find_func_priv;
-	xdl_emit_hunk_consume_func_t hunk_func;
+	git_xdl_emit_hunk_consume_func_t hunk_func;
 } xdemitconf_t;
 
 typedef struct s_bdiffparam {
@@ -121,10 +121,10 @@ typedef struct s_bdiffparam {
 } bdiffparam_t;
 
 
-void *xdl_mmfile_first(mmfile_t *mmf, long *size);
-long xdl_mmfile_size(mmfile_t *mmf);
+void *git_xdl_mmfile_first(mmfile_t *mmf, long *size);
+long git_xdl_mmfile_size(mmfile_t *mmf);
 
-int xdl_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
+int git_xdl_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	     xdemitconf_t const *xecfg, xdemitcb_t *ecb);
 
 typedef struct s_xmparam {
@@ -140,7 +140,7 @@ typedef struct s_xmparam {
 
 #define DEFAULT_CONFLICT_MARKER_SIZE 7
 
-int xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
+int git_xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
 		xmparam_t const *xmp, mmbuffer_t *result);
 
 #ifdef __cplusplus

--- a/src/libgit2/xdiff/xdiffi.h
+++ b/src/libgit2/xdiff/xdiffi.h
@@ -46,19 +46,19 @@ typedef struct s_xdchange {
 
 
 
-int xdl_recs_cmp(diffdata_t *dd1, long off1, long lim1,
+int git_xdl_recs_cmp(diffdata_t *dd1, long off1, long lim1,
 		 diffdata_t *dd2, long off2, long lim2,
 		 long *kvdf, long *kvdb, int need_min, xdalgoenv_t *xenv);
-int xdl_do_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
+int git_xdl_do_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 		xdfenv_t *xe);
-int xdl_change_compact(xdfile_t *xdf, xdfile_t *xdfo, long flags);
-int xdl_build_script(xdfenv_t *xe, xdchange_t **xscr);
-void xdl_free_script(xdchange_t *xscr);
-int xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
+int git_xdl_change_compact(xdfile_t *xdf, xdfile_t *xdfo, long flags);
+int git_xdl_build_script(xdfenv_t *xe, xdchange_t **xscr);
+void git_xdl_free_script(xdchange_t *xscr);
+int git_xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
 		  xdemitconf_t const *xecfg);
-int xdl_do_patience_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
+int git_xdl_do_patience_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 		xdfenv_t *env);
-int xdl_do_histogram_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
+int git_xdl_do_histogram_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 		xdfenv_t *env);
 
 #endif /* #if !defined(XDIFFI_H) */

--- a/src/libgit2/xdiff/xemit.c
+++ b/src/libgit2/xdiff/xemit.c
@@ -22,7 +22,7 @@
 
 #include "xinclude.h"
 
-static long xdl_get_rec(xdfile_t *xdf, long ri, char const **rec) {
+static long git_xdl_get_rec(xdfile_t *xdf, long ri, char const **rec) {
 
 	*rec = xdf->recs[ri]->ptr;
 
@@ -30,12 +30,12 @@ static long xdl_get_rec(xdfile_t *xdf, long ri, char const **rec) {
 }
 
 
-static int xdl_emit_record(xdfile_t *xdf, long ri, char const *pre, xdemitcb_t *ecb) {
+static int git_xdl_emit_record(xdfile_t *xdf, long ri, char const *pre, xdemitcb_t *ecb) {
 	long size, psize = strlen(pre);
 	char const *rec;
 
-	size = xdl_get_rec(xdf, ri, &rec);
-	if (xdl_emit_diffrec(rec, size, pre, psize, ecb) < 0) {
+	size = git_xdl_get_rec(xdf, ri, &rec);
+	if (git_xdl_emit_diffrec(rec, size, pre, psize, ecb) < 0) {
 
 		return -1;
 	}
@@ -49,7 +49,7 @@ static int xdl_emit_record(xdfile_t *xdf, long ri, char const *pre, xdemitcb_t *
  * inside the differential hunk according to the specified configuration.
  * Also advance xscr if the first changes must be discarded.
  */
-xdchange_t *xdl_get_hunk(xdchange_t **xscr, xdemitconf_t const *xecfg)
+xdchange_t *git_xdl_get_hunk(xdchange_t **xscr, xdemitconf_t const *xecfg)
 {
 	xdchange_t *xch, *xchp, *lxch;
 	long max_common = 2 * xecfg->ctxlen + xecfg->interhunkctxlen;
@@ -115,7 +115,7 @@ static long match_func_rec(xdfile_t *xdf, xdemitconf_t const *xecfg, long ri,
 			   char *buf, long sz)
 {
 	const char *rec;
-	long len = xdl_get_rec(xdf, ri, &rec);
+	long len = git_xdl_get_rec(xdf, ri, &rec);
 	if (!xecfg->find_func)
 		return def_ff(rec, len, buf, sz, xecfg->find_func_priv);
 	return xecfg->find_func(rec, len, buf, sz, xecfg->find_func_priv);
@@ -155,7 +155,7 @@ static long get_func_line(xdfenv_t *xe, xdemitconf_t const *xecfg,
 static int is_empty_rec(xdfile_t *xdf, long ri)
 {
 	const char *rec;
-	long len = xdl_get_rec(xdf, ri, &rec);
+	long len = git_xdl_get_rec(xdf, ri, &rec);
 
 	while (len > 0 && XDL_ISSPACE(*rec)) {
 		rec++;
@@ -164,7 +164,7 @@ static int is_empty_rec(xdfile_t *xdf, long ri)
 	return !len;
 }
 
-int xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
+int git_xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
 		  xdemitconf_t const *xecfg) {
 	long s1, s2, e1, e2, lctx;
 	xdchange_t *xch, *xche;
@@ -173,7 +173,7 @@ int xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
 
 	for (xch = xscr; xch; xch = xche->next) {
 		xdchange_t *xchp = xch;
-		xche = xdl_get_hunk(&xch, xecfg);
+		xche = git_xdl_get_hunk(&xch, xecfg);
 		if (!xch)
 			break;
 
@@ -279,7 +279,7 @@ pre_context_calculation:
 			funclineprev = s1 - 1;
 		}
 		if (!(xecfg->flags & XDL_EMIT_NO_HUNK_HDR) &&
-		    xdl_emit_hunk_hdr(s1 + 1, e1 - s1, s2 + 1, e2 - s2,
+		    git_xdl_emit_hunk_hdr(s1 + 1, e1 - s1, s2 + 1, e2 - s2,
 				      func_line.buf, func_line.len, ecb) < 0)
 			return -1;
 
@@ -287,7 +287,7 @@ pre_context_calculation:
 		 * Emit pre-context.
 		 */
 		for (; s2 < xch->i2; s2++)
-			if (xdl_emit_record(&xe->xdf2, s2, " ", ecb) < 0)
+			if (git_xdl_emit_record(&xe->xdf2, s2, " ", ecb) < 0)
 				return -1;
 
 		for (s1 = xch->i1, s2 = xch->i2;; xch = xch->next) {
@@ -295,21 +295,21 @@ pre_context_calculation:
 			 * Merge previous with current change atom.
 			 */
 			for (; s1 < xch->i1 && s2 < xch->i2; s1++, s2++)
-				if (xdl_emit_record(&xe->xdf2, s2, " ", ecb) < 0)
+				if (git_xdl_emit_record(&xe->xdf2, s2, " ", ecb) < 0)
 					return -1;
 
 			/*
 			 * Removes lines from the first file.
 			 */
 			for (s1 = xch->i1; s1 < xch->i1 + xch->chg1; s1++)
-				if (xdl_emit_record(&xe->xdf1, s1, "-", ecb) < 0)
+				if (git_xdl_emit_record(&xe->xdf1, s1, "-", ecb) < 0)
 					return -1;
 
 			/*
 			 * Adds lines from the second file.
 			 */
 			for (s2 = xch->i2; s2 < xch->i2 + xch->chg2; s2++)
-				if (xdl_emit_record(&xe->xdf2, s2, "+", ecb) < 0)
+				if (git_xdl_emit_record(&xe->xdf2, s2, "+", ecb) < 0)
 					return -1;
 
 			if (xch == xche)
@@ -322,7 +322,7 @@ pre_context_calculation:
 		 * Emit post-context.
 		 */
 		for (s2 = xche->i2 + xche->chg2; s2 < e2; s2++)
-			if (xdl_emit_record(&xe->xdf2, s2, " ", ecb) < 0)
+			if (git_xdl_emit_record(&xe->xdf2, s2, " ", ecb) < 0)
 				return -1;
 	}
 

--- a/src/libgit2/xdiff/xemit.h
+++ b/src/libgit2/xdiff/xemit.h
@@ -27,8 +27,8 @@
 typedef int (*emit_func_t)(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
 			   xdemitconf_t const *xecfg);
 
-xdchange_t *xdl_get_hunk(xdchange_t **xscr, xdemitconf_t const *xecfg);
-int xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
+xdchange_t *git_xdl_get_hunk(xdchange_t **xscr, xdemitconf_t const *xecfg);
+int git_xdl_emit_diff(xdfenv_t *xe, xdchange_t *xscr, xdemitcb_t *ecb,
 		  xdemitconf_t const *xecfg);
 
 

--- a/src/libgit2/xdiff/xhistogram.c
+++ b/src/libgit2/xdiff/xhistogram.c
@@ -138,7 +138,7 @@ static int scanA(struct histindex *index, int line1, int count1)
 		 * This is the first time we have ever seen this particular
 		 * element in the sequence. Construct a new chain for it.
 		 */
-		if (!(rec = xdl_cha_alloc(&index->rcha)))
+		if (!(rec = git_xdl_cha_alloc(&index->rcha)))
 			return -1;
 		rec->ptr = ptr;
 		rec->cnt = 1;
@@ -234,16 +234,16 @@ static int fall_back_to_classic_diff(xpparam_t const *xpp, xdfenv_t *env,
 	memset(&xpparam, 0, sizeof(xpparam));
 	xpparam.flags = xpp->flags & ~XDF_DIFF_ALGORITHM_MASK;
 
-	return xdl_fall_back_diff(env, &xpparam,
+	return git_xdl_fall_back_diff(env, &xpparam,
 				  line1, count1, line2, count2);
 }
 
 static inline void free_index(struct histindex *index)
 {
-	xdl_free(index->records);
-	xdl_free(index->line_map);
-	xdl_free(index->next_ptrs);
-	xdl_cha_free(&index->rcha);
+	git_xdl_free(index->records);
+	git_xdl_free(index->line_map);
+	git_xdl_free(index->next_ptrs);
+	git_xdl_cha_free(&index->rcha);
 }
 
 static int find_lcs(xpparam_t const *xpp, xdfenv_t *env,
@@ -261,30 +261,30 @@ static int find_lcs(xpparam_t const *xpp, xdfenv_t *env,
 
 	index.records = NULL;
 	index.line_map = NULL;
-	/* in case of early xdl_cha_free() */
+	/* in case of early git_xdl_cha_free() */
 	index.rcha.head = NULL;
 
-	index.table_bits = xdl_hashbits(count1);
+	index.table_bits = git_xdl_hashbits(count1);
 	sz = index.records_size = 1 << index.table_bits;
 	sz *= sizeof(struct record *);
-	if (!(index.records = (struct record **) xdl_malloc(sz)))
+	if (!(index.records = (struct record **) git_xdl_malloc(sz)))
 		goto cleanup;
 	memset(index.records, 0, sz);
 
 	sz = index.line_map_size = count1;
 	sz *= sizeof(struct record *);
-	if (!(index.line_map = (struct record **) xdl_malloc(sz)))
+	if (!(index.line_map = (struct record **) git_xdl_malloc(sz)))
 		goto cleanup;
 	memset(index.line_map, 0, sz);
 
 	sz = index.line_map_size;
 	sz *= sizeof(unsigned int);
-	if (!(index.next_ptrs = (unsigned int *) xdl_malloc(sz)))
+	if (!(index.next_ptrs = (unsigned int *) git_xdl_malloc(sz)))
 		goto cleanup;
 	memset(index.next_ptrs, 0, sz);
 
-	/* lines / 4 + 1 comes from xprepare.c:xdl_prepare_ctx() */
-	if (xdl_cha_init(&index.rcha, sizeof(struct record), count1 / 4 + 1) < 0)
+	/* lines / 4 + 1 comes from xprepare.c:git_xdl_prepare_ctx() */
+	if (git_xdl_cha_init(&index.rcha, sizeof(struct record), count1 / 4 + 1) < 0)
 		goto cleanup;
 
 	index.ptr_shift = line1;
@@ -369,10 +369,10 @@ out:
 	return result;
 }
 
-int xdl_do_histogram_diff(mmfile_t *file1, mmfile_t *file2,
+int git_xdl_do_histogram_diff(mmfile_t *file1, mmfile_t *file2,
 	xpparam_t const *xpp, xdfenv_t *env)
 {
-	if (xdl_prepare_env(file1, file2, xpp, env) < 0)
+	if (git_xdl_prepare_env(file1, file2, xpp, env) < 0)
 		return -1;
 
 	return histogram_diff(xpp, env,

--- a/src/libgit2/xdiff/xmacros.h
+++ b/src/libgit2/xdiff/xmacros.h
@@ -34,7 +34,7 @@
 #define XDL_ADDBITS(v,b)	((v) + ((v) >> (b)))
 #define XDL_MASKBITS(b)		((1UL << (b)) - 1)
 #define XDL_HASHLONG(v,b)	(XDL_ADDBITS((unsigned long)(v), b) & XDL_MASKBITS(b))
-#define XDL_PTRFREE(p) do { if (p) { xdl_free(p); (p) = NULL; } } while (0)
+#define XDL_PTRFREE(p) do { if (p) { git_xdl_free(p); (p) = NULL; } } while (0)
 #define XDL_LE32_PUT(p, v) \
 do { \
 	unsigned char *__p = (unsigned char *) (p); \

--- a/src/libgit2/xdiff/xmerge.c
+++ b/src/libgit2/xdiff/xmerge.c
@@ -47,7 +47,7 @@ typedef struct s_xdmerge {
 	long chg0;
 } xdmerge_t;
 
-static int xdl_append_merge(xdmerge_t **merge, int mode,
+static int git_xdl_append_merge(xdmerge_t **merge, int mode,
 			    long i0, long chg0,
 			    long i1, long chg1,
 			    long i2, long chg2)
@@ -60,7 +60,7 @@ static int xdl_append_merge(xdmerge_t **merge, int mode,
 		m->chg1 = i1 + chg1 - m->i1;
 		m->chg2 = i2 + chg2 - m->i2;
 	} else {
-		m = xdl_malloc(sizeof(xdmerge_t));
+		m = git_xdl_malloc(sizeof(xdmerge_t));
 		if (!m)
 			return -1;
 		m->next = NULL;
@@ -78,7 +78,7 @@ static int xdl_append_merge(xdmerge_t **merge, int mode,
 	return 0;
 }
 
-static int xdl_cleanup_merge(xdmerge_t *c)
+static int git_xdl_cleanup_merge(xdmerge_t *c)
 {
 	int count = 0;
 	xdmerge_t *next_c;
@@ -88,12 +88,12 @@ static int xdl_cleanup_merge(xdmerge_t *c)
 		if (c->mode == 0)
 			count++;
 		next_c = c->next;
-		xdl_free(c);
+		git_xdl_free(c);
 	}
 	return count;
 }
 
-static int xdl_merge_cmp_lines(xdfenv_t *xe1, int i1, xdfenv_t *xe2, int i2,
+static int git_xdl_merge_cmp_lines(xdfenv_t *xe1, int i1, xdfenv_t *xe2, int i2,
 		int line_count, long flags)
 {
 	int i;
@@ -101,7 +101,7 @@ static int xdl_merge_cmp_lines(xdfenv_t *xe1, int i1, xdfenv_t *xe2, int i2,
 	xrecord_t **rec2 = xe2->xdf2.recs + i2;
 
 	for (i = 0; i < line_count; i++) {
-		int result = xdl_recmatch(rec1[i]->ptr, rec1[i]->size,
+		int result = git_xdl_recmatch(rec1[i]->ptr, rec1[i]->size,
 			rec2[i]->ptr, rec2[i]->size, flags);
 		if (!result)
 			return -1;
@@ -109,7 +109,7 @@ static int xdl_merge_cmp_lines(xdfenv_t *xe1, int i1, xdfenv_t *xe2, int i2,
 	return 0;
 }
 
-static int xdl_recs_copy_0(int use_orig, xdfenv_t *xe, int i, int count, int needs_cr, int add_nl, char *dest)
+static int git_xdl_recs_copy_0(int use_orig, xdfenv_t *xe, int i, int count, int needs_cr, int add_nl, char *dest)
 {
 	xrecord_t **recs;
 	int size = 0;
@@ -139,14 +139,14 @@ static int xdl_recs_copy_0(int use_orig, xdfenv_t *xe, int i, int count, int nee
 	return size;
 }
 
-static int xdl_recs_copy(xdfenv_t *xe, int i, int count, int needs_cr, int add_nl, char *dest)
+static int git_xdl_recs_copy(xdfenv_t *xe, int i, int count, int needs_cr, int add_nl, char *dest)
 {
-	return xdl_recs_copy_0(0, xe, i, count, needs_cr, add_nl, dest);
+	return git_xdl_recs_copy_0(0, xe, i, count, needs_cr, add_nl, dest);
 }
 
-static int xdl_orig_copy(xdfenv_t *xe, int i, int count, int needs_cr, int add_nl, char *dest)
+static int git_xdl_orig_copy(xdfenv_t *xe, int i, int count, int needs_cr, int add_nl, char *dest)
 {
-	return xdl_recs_copy_0(1, xe, i, count, needs_cr, add_nl, dest);
+	return git_xdl_recs_copy_0(1, xe, i, count, needs_cr, add_nl, dest);
 }
 
 /*
@@ -208,7 +208,7 @@ static int fill_conflict_hunk(xdfenv_t *xe1, const char *name1,
 		marker_size = DEFAULT_CONFLICT_MARKER_SIZE;
 
 	/* Before conflicting part */
-	size += xdl_recs_copy(xe1, i, m->i1 - i, 0, 0,
+	size += git_xdl_recs_copy(xe1, i, m->i1 - i, 0, 0,
 			      dest ? dest + size : NULL);
 
 	if (!dest) {
@@ -227,7 +227,7 @@ static int fill_conflict_hunk(xdfenv_t *xe1, const char *name1,
 	}
 
 	/* Postimage from side #1 */
-	size += xdl_recs_copy(xe1, m->i1, m->chg1, needs_cr, 1,
+	size += git_xdl_recs_copy(xe1, m->i1, m->chg1, needs_cr, 1,
 			      dest ? dest + size : NULL);
 
 	if (style == XDL_MERGE_DIFF3 || style == XDL_MERGE_ZEALOUS_DIFF3) {
@@ -246,7 +246,7 @@ static int fill_conflict_hunk(xdfenv_t *xe1, const char *name1,
 				dest[size++] = '\r';
 			dest[size++] = '\n';
 		}
-		size += xdl_orig_copy(xe1, m->i0, m->chg0, needs_cr, 1,
+		size += git_xdl_orig_copy(xe1, m->i0, m->chg0, needs_cr, 1,
 				      dest ? dest + size : NULL);
 	}
 
@@ -261,7 +261,7 @@ static int fill_conflict_hunk(xdfenv_t *xe1, const char *name1,
 	}
 
 	/* Postimage from side #2 */
-	size += xdl_recs_copy(xe2, m->i2, m->chg2, needs_cr, 1,
+	size += git_xdl_recs_copy(xe2, m->i2, m->chg2, needs_cr, 1,
 			      dest ? dest + size : NULL);
 	if (!dest) {
 		size += marker_size + 1 + needs_cr + marker2_size;
@@ -280,7 +280,7 @@ static int fill_conflict_hunk(xdfenv_t *xe1, const char *name1,
 	return size;
 }
 
-static int xdl_fill_merge_buffer(xdfenv_t *xe1, const char *name1,
+static int git_xdl_fill_merge_buffer(xdfenv_t *xe1, const char *name1,
 				 xdfenv_t *xe2, const char *name2,
 				 const char *ancestor_name,
 				 int favor,
@@ -300,38 +300,38 @@ static int xdl_fill_merge_buffer(xdfenv_t *xe1, const char *name1,
 						  marker_size);
 		else if (m->mode & 3) {
 			/* Before conflicting part */
-			size += xdl_recs_copy(xe1, i, m->i1 - i, 0, 0,
+			size += git_xdl_recs_copy(xe1, i, m->i1 - i, 0, 0,
 					      dest ? dest + size : NULL);
 			/* Postimage from side #1 */
 			if (m->mode & 1) {
 				int needs_cr = is_cr_needed(xe1, xe2, m);
 
-				size += xdl_recs_copy(xe1, m->i1, m->chg1, needs_cr, (m->mode & 2),
+				size += git_xdl_recs_copy(xe1, m->i1, m->chg1, needs_cr, (m->mode & 2),
 						      dest ? dest + size : NULL);
 			}
 			/* Postimage from side #2 */
 			if (m->mode & 2)
-				size += xdl_recs_copy(xe2, m->i2, m->chg2, 0, 0,
+				size += git_xdl_recs_copy(xe2, m->i2, m->chg2, 0, 0,
 						      dest ? dest + size : NULL);
 		} else
 			continue;
 		i = m->i1 + m->chg1;
 	}
-	size += xdl_recs_copy(xe1, i, xe1->xdf2.nrec - i, 0, 0,
+	size += git_xdl_recs_copy(xe1, i, xe1->xdf2.nrec - i, 0, 0,
 			      dest ? dest + size : NULL);
 	return size;
 }
 
 static int recmatch(xrecord_t *rec1, xrecord_t *rec2, unsigned long flags)
 {
-	return xdl_recmatch(rec1->ptr, rec1->size,
+	return git_xdl_recmatch(rec1->ptr, rec1->size,
 			    rec2->ptr, rec2->size, flags);
 }
 
 /*
  * Remove any common lines from the beginning and end of the conflicted region.
  */
-static void xdl_refine_zdiff3_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
+static void git_xdl_refine_zdiff3_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
 		xpparam_t const *xpp)
 {
 	xrecord_t **rec1 = xe1->xdf2.recs, **rec2 = xe2->xdf2.recs;
@@ -360,7 +360,7 @@ static void xdl_refine_zdiff3_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t 
  * Sometimes, changes are not quite identical, but differ in only a few
  * lines. Try hard to show only these few lines as conflicting.
  */
-static int xdl_refine_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
+static int git_xdl_refine_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
 		xpparam_t const *xpp)
 {
 	for (; m; m = m->next) {
@@ -387,17 +387,17 @@ static int xdl_refine_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
 		t2.ptr = (char *)xe2->xdf2.recs[m->i2]->ptr;
 		t2.size = xe2->xdf2.recs[m->i2 + m->chg2 - 1]->ptr
 			+ xe2->xdf2.recs[m->i2 + m->chg2 - 1]->size - t2.ptr;
-		if (xdl_do_diff(&t1, &t2, xpp, &xe) < 0)
+		if (git_xdl_do_diff(&t1, &t2, xpp, &xe) < 0)
 			return -1;
-		if (xdl_change_compact(&xe.xdf1, &xe.xdf2, xpp->flags) < 0 ||
-		    xdl_change_compact(&xe.xdf2, &xe.xdf1, xpp->flags) < 0 ||
-		    xdl_build_script(&xe, &xscr) < 0) {
-			xdl_free_env(&xe);
+		if (git_xdl_change_compact(&xe.xdf1, &xe.xdf2, xpp->flags) < 0 ||
+		    git_xdl_change_compact(&xe.xdf2, &xe.xdf1, xpp->flags) < 0 ||
+		    git_xdl_build_script(&xe, &xscr) < 0) {
+			git_xdl_free_env(&xe);
 			return -1;
 		}
 		if (!xscr) {
 			/* If this happens, the changes are identical. */
-			xdl_free_env(&xe);
+			git_xdl_free_env(&xe);
 			m->mode = 4;
 			continue;
 		}
@@ -407,10 +407,10 @@ static int xdl_refine_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
 		m->i2 = xscr->i2 + i2;
 		m->chg2 = xscr->chg2;
 		while (xscr->next) {
-			xdmerge_t *m2 = xdl_malloc(sizeof(xdmerge_t));
+			xdmerge_t *m2 = git_xdl_malloc(sizeof(xdmerge_t));
 			if (!m2) {
-				xdl_free_env(&xe);
-				xdl_free_script(x);
+				git_xdl_free_env(&xe);
+				git_xdl_free_script(x);
 				return -1;
 			}
 			xscr = xscr->next;
@@ -423,8 +423,8 @@ static int xdl_refine_conflicts(xdfenv_t *xe1, xdfenv_t *xe2, xdmerge_t *m,
 			m->i2 = xscr->i2 + i2;
 			m->chg2 = xscr->chg2;
 		}
-		xdl_free_env(&xe);
-		xdl_free_script(x);
+		git_xdl_free_env(&xe);
+		git_xdl_free_script(x);
 	}
 	return 0;
 }
@@ -450,13 +450,13 @@ static int lines_contain_alnum(xdfenv_t *xe, int i, int chg)
  * This function merges m and m->next, marking everything between those hunks
  * as conflicting, too.
  */
-static void xdl_merge_two_conflicts(xdmerge_t *m)
+static void git_xdl_merge_two_conflicts(xdmerge_t *m)
 {
 	xdmerge_t *next_m = m->next;
 	m->chg1 = next_m->i1 + next_m->chg1 - m->i1;
 	m->chg2 = next_m->i2 + next_m->chg2 - m->i2;
 	m->next = next_m->next;
-	xdl_free(next_m);
+	git_xdl_free(next_m);
 }
 
 /*
@@ -464,7 +464,7 @@ static void xdl_merge_two_conflicts(xdmerge_t *m)
  * it appears simpler -- because it takes up less (or as many) lines --
  * if the lines are moved into the conflicts.
  */
-static int xdl_simplify_non_conflicts(xdfenv_t *xe1, xdmerge_t *m,
+static int git_xdl_simplify_non_conflicts(xdfenv_t *xe1, xdmerge_t *m,
 				      int simplify_if_no_alnum)
 {
 	int result = 0;
@@ -488,7 +488,7 @@ static int xdl_simplify_non_conflicts(xdfenv_t *xe1, xdmerge_t *m,
 			m = next_m;
 		} else {
 			result++;
-			xdl_merge_two_conflicts(m);
+			git_xdl_merge_two_conflicts(m);
 		}
 	}
 }
@@ -502,7 +502,7 @@ static int xdl_simplify_non_conflicts(xdfenv_t *xe1, xdmerge_t *m,
  *
  * returns < 0 on error, == 0 for no conflicts, else number of conflicts
  */
-static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
+static int git_xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 		xdfenv_t *xe2, xdchange_t *xscr2,
 		xmparam_t const *xmp, mmbuffer_t *result)
 {
@@ -552,9 +552,9 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 			chg0 = xscr1->chg1;
 			chg1 = xscr1->chg2;
 			chg2 = xscr1->chg1;
-			if (xdl_append_merge(&c, 1,
+			if (git_xdl_append_merge(&c, 1,
 					     i0, chg0, i1, chg1, i2, chg2)) {
-				xdl_cleanup_merge(changes);
+				git_xdl_cleanup_merge(changes);
 				return -1;
 			}
 			xscr1 = xscr1->next;
@@ -567,9 +567,9 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 			chg0 = xscr2->chg1;
 			chg1 = xscr2->chg1;
 			chg2 = xscr2->chg2;
-			if (xdl_append_merge(&c, 2,
+			if (git_xdl_append_merge(&c, 2,
 					     i0, chg0, i1, chg1, i2, chg2)) {
-				xdl_cleanup_merge(changes);
+				git_xdl_cleanup_merge(changes);
 				return -1;
 			}
 			xscr2 = xscr2->next;
@@ -578,7 +578,7 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 		if (level == XDL_MERGE_MINIMAL || xscr1->i1 != xscr2->i1 ||
 				xscr1->chg1 != xscr2->chg1 ||
 				xscr1->chg2 != xscr2->chg2 ||
-				xdl_merge_cmp_lines(xe1, xscr1->i2,
+				git_xdl_merge_cmp_lines(xe1, xscr1->i2,
 					xe2, xscr2->i2,
 					xscr1->chg2, xpp->flags)) {
 			/* conflict */
@@ -602,9 +602,9 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 				chg1 -= ffo;
 			} else
 				chg2 += ffo;
-			if (xdl_append_merge(&c, 0,
+			if (git_xdl_append_merge(&c, 0,
 					     i0, chg0, i1, chg1, i2, chg2)) {
-				xdl_cleanup_merge(changes);
+				git_xdl_cleanup_merge(changes);
 				return -1;
 			}
 		}
@@ -626,9 +626,9 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 		chg0 = xscr1->chg1;
 		chg1 = xscr1->chg2;
 		chg2 = xscr1->chg1;
-		if (xdl_append_merge(&c, 1,
+		if (git_xdl_append_merge(&c, 1,
 				     i0, chg0, i1, chg1, i2, chg2)) {
-			xdl_cleanup_merge(changes);
+			git_xdl_cleanup_merge(changes);
 			return -1;
 		}
 		xscr1 = xscr1->next;
@@ -642,9 +642,9 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 		chg0 = xscr2->chg1;
 		chg1 = xscr2->chg1;
 		chg2 = xscr2->chg2;
-		if (xdl_append_merge(&c, 2,
+		if (git_xdl_append_merge(&c, 2,
 				     i0, chg0, i1, chg1, i2, chg2)) {
-			xdl_cleanup_merge(changes);
+			git_xdl_cleanup_merge(changes);
 			return -1;
 		}
 		xscr2 = xscr2->next;
@@ -653,35 +653,35 @@ static int xdl_do_merge(xdfenv_t *xe1, xdchange_t *xscr1,
 		changes = c;
 	/* refine conflicts */
 	if (style == XDL_MERGE_ZEALOUS_DIFF3) {
-		xdl_refine_zdiff3_conflicts(xe1, xe2, changes, xpp);
+		git_xdl_refine_zdiff3_conflicts(xe1, xe2, changes, xpp);
 	} else if (XDL_MERGE_ZEALOUS <= level &&
-		   (xdl_refine_conflicts(xe1, xe2, changes, xpp) < 0 ||
-		    xdl_simplify_non_conflicts(xe1, changes,
+		   (git_xdl_refine_conflicts(xe1, xe2, changes, xpp) < 0 ||
+		    git_xdl_simplify_non_conflicts(xe1, changes,
 					       XDL_MERGE_ZEALOUS < level) < 0)) {
-		xdl_cleanup_merge(changes);
+		git_xdl_cleanup_merge(changes);
 		return -1;
 	}
 	/* output */
 	if (result) {
 		int marker_size = xmp->marker_size;
-		int size = xdl_fill_merge_buffer(xe1, name1, xe2, name2,
+		int size = git_xdl_fill_merge_buffer(xe1, name1, xe2, name2,
 						 ancestor_name,
 						 favor, changes, NULL, style,
 						 marker_size);
-		result->ptr = xdl_malloc(size);
+		result->ptr = git_xdl_malloc(size);
 		if (!result->ptr) {
-			xdl_cleanup_merge(changes);
+			git_xdl_cleanup_merge(changes);
 			return -1;
 		}
 		result->size = size;
-		xdl_fill_merge_buffer(xe1, name1, xe2, name2,
+		git_xdl_fill_merge_buffer(xe1, name1, xe2, name2,
 				      ancestor_name, favor, changes,
 				      result->ptr, style, marker_size);
 	}
-	return xdl_cleanup_merge(changes);
+	return git_xdl_cleanup_merge(changes);
 }
 
-int xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
+int git_xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
 		xmparam_t const *xmp, mmbuffer_t *result)
 {
 	xdchange_t *xscr1, *xscr2;
@@ -692,46 +692,46 @@ int xdl_merge(mmfile_t *orig, mmfile_t *mf1, mmfile_t *mf2,
 	result->ptr = NULL;
 	result->size = 0;
 
-	if (xdl_do_diff(orig, mf1, xpp, &xe1) < 0) {
+	if (git_xdl_do_diff(orig, mf1, xpp, &xe1) < 0) {
 		return -1;
 	}
-	if (xdl_do_diff(orig, mf2, xpp, &xe2) < 0) {
-		xdl_free_env(&xe1);
+	if (git_xdl_do_diff(orig, mf2, xpp, &xe2) < 0) {
+		git_xdl_free_env(&xe1);
 		return -1;
 	}
-	if (xdl_change_compact(&xe1.xdf1, &xe1.xdf2, xpp->flags) < 0 ||
-	    xdl_change_compact(&xe1.xdf2, &xe1.xdf1, xpp->flags) < 0 ||
-	    xdl_build_script(&xe1, &xscr1) < 0) {
-		xdl_free_env(&xe1);
+	if (git_xdl_change_compact(&xe1.xdf1, &xe1.xdf2, xpp->flags) < 0 ||
+	    git_xdl_change_compact(&xe1.xdf2, &xe1.xdf1, xpp->flags) < 0 ||
+	    git_xdl_build_script(&xe1, &xscr1) < 0) {
+		git_xdl_free_env(&xe1);
 		return -1;
 	}
-	if (xdl_change_compact(&xe2.xdf1, &xe2.xdf2, xpp->flags) < 0 ||
-	    xdl_change_compact(&xe2.xdf2, &xe2.xdf1, xpp->flags) < 0 ||
-	    xdl_build_script(&xe2, &xscr2) < 0) {
-		xdl_free_script(xscr1);
-		xdl_free_env(&xe1);
-		xdl_free_env(&xe2);
+	if (git_xdl_change_compact(&xe2.xdf1, &xe2.xdf2, xpp->flags) < 0 ||
+	    git_xdl_change_compact(&xe2.xdf2, &xe2.xdf1, xpp->flags) < 0 ||
+	    git_xdl_build_script(&xe2, &xscr2) < 0) {
+		git_xdl_free_script(xscr1);
+		git_xdl_free_env(&xe1);
+		git_xdl_free_env(&xe2);
 		return -1;
 	}
 	status = 0;
 	if (!xscr1) {
-		result->ptr = xdl_malloc(mf2->size);
+		result->ptr = git_xdl_malloc(mf2->size);
 		memcpy(result->ptr, mf2->ptr, mf2->size);
 		result->size = mf2->size;
 	} else if (!xscr2) {
-		result->ptr = xdl_malloc(mf1->size);
+		result->ptr = git_xdl_malloc(mf1->size);
 		memcpy(result->ptr, mf1->ptr, mf1->size);
 		result->size = mf1->size;
 	} else {
-		status = xdl_do_merge(&xe1, xscr1,
+		status = git_xdl_do_merge(&xe1, xscr1,
 				      &xe2, xscr2,
 				      xmp, result);
 	}
-	xdl_free_script(xscr1);
-	xdl_free_script(xscr2);
+	git_xdl_free_script(xscr1);
+	git_xdl_free_script(xscr2);
 
-	xdl_free_env(&xe1);
-	xdl_free_env(&xe2);
+	git_xdl_free_env(&xe1);
+	git_xdl_free_env(&xe2);
 
 	return status;
 }

--- a/src/libgit2/xdiff/xpatience.c
+++ b/src/libgit2/xdiff/xpatience.c
@@ -92,8 +92,8 @@ static void insert_record(xpparam_t const *xpp, int line, struct hashmap *map,
 		map->env->xdf1.recs : map->env->xdf2.recs;
 	xrecord_t *record = records[line - 1];
 	/*
-	 * After xdl_prepare_env() (or more precisely, due to
-	 * xdl_classify_record()), the "ha" member of the records (AKA lines)
+	 * After git_xdl_prepare_env() (or more precisely, due to
+	 * git_xdl_classify_record()), the "ha" member of the records (AKA lines)
 	 * is _not_ the hash anymore, but a linearized version of it.  In
 	 * other words, the "ha" member is guaranteed to start with 0 and
 	 * the second record's ha can only be 0 or 1, etc.
@@ -137,7 +137,7 @@ static void insert_record(xpparam_t const *xpp, int line, struct hashmap *map,
  * parts, as previously non-unique lines can become unique when being
  * restricted to a smaller part of the files.
  *
- * It is assumed that env has been prepared using xdl_prepare().
+ * It is assumed that env has been prepared using git_xdl_prepare().
  */
 static int fill_hashmap(mmfile_t *file1, mmfile_t *file2,
 		xpparam_t const *xpp, xdfenv_t *env,
@@ -152,7 +152,7 @@ static int fill_hashmap(mmfile_t *file1, mmfile_t *file2,
 	/* We know exactly how large we want the hash map */
 	result->alloc = count1 * 2;
 	result->entries = (struct entry *)
-		xdl_malloc(result->alloc * sizeof(struct entry));
+		git_xdl_malloc(result->alloc * sizeof(struct entry));
 	if (!result->entries)
 		return -1;
 	memset(result->entries, 0, result->alloc * sizeof(struct entry));
@@ -200,7 +200,7 @@ static int binary_search(struct entry **sequence, int longest,
  */
 static struct entry *find_longest_common_sequence(struct hashmap *map)
 {
-	struct entry **sequence = xdl_malloc(map->nr * sizeof(struct entry *));
+	struct entry **sequence = git_xdl_malloc(map->nr * sizeof(struct entry *));
 	int longest = 0, i;
 	struct entry *entry;
 
@@ -230,7 +230,7 @@ static struct entry *find_longest_common_sequence(struct hashmap *map)
 
 	/* No common unique lines were found */
 	if (!longest) {
-		xdl_free(sequence);
+		git_xdl_free(sequence);
 		return NULL;
 	}
 
@@ -241,7 +241,7 @@ static struct entry *find_longest_common_sequence(struct hashmap *map)
 		entry->previous->next = entry;
 		entry = entry->previous;
 	}
-	xdl_free(sequence);
+	git_xdl_free(sequence);
 	return entry;
 }
 
@@ -314,15 +314,15 @@ static int fall_back_to_classic_diff(struct hashmap *map,
 	memset(&xpp, 0, sizeof(xpp));
 	xpp.flags = map->xpp->flags & ~XDF_DIFF_ALGORITHM_MASK;
 
-	return xdl_fall_back_diff(map->env, &xpp,
+	return git_xdl_fall_back_diff(map->env, &xpp,
 				  line1, count1, line2, count2);
 }
 
 /*
  * Recursively find the longest common sequence of unique lines,
- * and if none was found, ask xdl_do_diff() to do the job.
+ * and if none was found, ask git_xdl_do_diff() to do the job.
  *
- * This function assumes that env was prepared with xdl_prepare_env().
+ * This function assumes that env was prepared with git_xdl_prepare_env().
  */
 static int patience_diff(mmfile_t *file1, mmfile_t *file2,
 		xpparam_t const *xpp, xdfenv_t *env,
@@ -354,7 +354,7 @@ static int patience_diff(mmfile_t *file1, mmfile_t *file2,
 			env->xdf1.rchg[line1++ - 1] = 1;
 		while(count2--)
 			env->xdf2.rchg[line2++ - 1] = 1;
-		xdl_free(map.entries);
+		git_xdl_free(map.entries);
 		return 0;
 	}
 
@@ -366,17 +366,17 @@ static int patience_diff(mmfile_t *file1, mmfile_t *file2,
 		result = fall_back_to_classic_diff(&map,
 			line1, count1, line2, count2);
 
-	xdl_free(map.entries);
+	git_xdl_free(map.entries);
 	return result;
 }
 
-int xdl_do_patience_diff(mmfile_t *file1, mmfile_t *file2,
+int git_xdl_do_patience_diff(mmfile_t *file1, mmfile_t *file2,
 		xpparam_t const *xpp, xdfenv_t *env)
 {
-	if (xdl_prepare_env(file1, file2, xpp, env) < 0)
+	if (git_xdl_prepare_env(file1, file2, xpp, env) < 0)
 		return -1;
 
-	/* environment is cleaned up in xdl_diff() */
+	/* environment is cleaned up in git_xdl_diff() */
 	return patience_diff(file1, file2, xpp, env,
 			1, env->xdf1.nrec, 1, env->xdf2.nrec);
 }

--- a/src/libgit2/xdiff/xprepare.c
+++ b/src/libgit2/xdiff/xprepare.c
@@ -53,43 +53,43 @@ typedef struct s_xdlclassifier {
 
 
 
-static int xdl_init_classifier(xdlclassifier_t *cf, long size, long flags);
-static void xdl_free_classifier(xdlclassifier_t *cf);
-static int xdl_classify_record(unsigned int pass, xdlclassifier_t *cf, xrecord_t **rhash,
+static int git_xdl_init_classifier(xdlclassifier_t *cf, long size, long flags);
+static void git_xdl_free_classifier(xdlclassifier_t *cf);
+static int git_xdl_classify_record(unsigned int pass, xdlclassifier_t *cf, xrecord_t **rhash,
 			       unsigned int hbits, xrecord_t *rec);
-static int xdl_prepare_ctx(unsigned int pass, mmfile_t *mf, long narec, xpparam_t const *xpp,
+static int git_xdl_prepare_ctx(unsigned int pass, mmfile_t *mf, long narec, xpparam_t const *xpp,
 			   xdlclassifier_t *cf, xdfile_t *xdf);
-static void xdl_free_ctx(xdfile_t *xdf);
-static int xdl_clean_mmatch(char const *dis, long i, long s, long e);
-static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2);
-static int xdl_trim_ends(xdfile_t *xdf1, xdfile_t *xdf2);
-static int xdl_optimize_ctxs(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2);
+static void git_xdl_free_ctx(xdfile_t *xdf);
+static int git_xdl_clean_mmatch(char const *dis, long i, long s, long e);
+static int git_xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2);
+static int git_xdl_trim_ends(xdfile_t *xdf1, xdfile_t *xdf2);
+static int git_xdl_optimize_ctxs(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2);
 
 
 
 
-static int xdl_init_classifier(xdlclassifier_t *cf, long size, long flags) {
+static int git_xdl_init_classifier(xdlclassifier_t *cf, long size, long flags) {
 	cf->flags = flags;
 
-	cf->hbits = xdl_hashbits((unsigned int) size);
+	cf->hbits = git_xdl_hashbits((unsigned int) size);
 	cf->hsize = 1 << cf->hbits;
 
-	if (xdl_cha_init(&cf->ncha, sizeof(xdlclass_t), size / 4 + 1) < 0) {
+	if (git_xdl_cha_init(&cf->ncha, sizeof(xdlclass_t), size / 4 + 1) < 0) {
 
 		return -1;
 	}
-	if (!(cf->rchash = (xdlclass_t **) xdl_malloc(cf->hsize * sizeof(xdlclass_t *)))) {
+	if (!(cf->rchash = (xdlclass_t **) git_xdl_malloc(cf->hsize * sizeof(xdlclass_t *)))) {
 
-		xdl_cha_free(&cf->ncha);
+		git_xdl_cha_free(&cf->ncha);
 		return -1;
 	}
 	memset(cf->rchash, 0, cf->hsize * sizeof(xdlclass_t *));
 
 	cf->alloc = size;
-	if (!(cf->rcrecs = (xdlclass_t **) xdl_malloc(cf->alloc * sizeof(xdlclass_t *)))) {
+	if (!(cf->rcrecs = (xdlclass_t **) git_xdl_malloc(cf->alloc * sizeof(xdlclass_t *)))) {
 
-		xdl_free(cf->rchash);
-		xdl_cha_free(&cf->ncha);
+		git_xdl_free(cf->rchash);
+		git_xdl_cha_free(&cf->ncha);
 		return -1;
 	}
 
@@ -99,15 +99,15 @@ static int xdl_init_classifier(xdlclassifier_t *cf, long size, long flags) {
 }
 
 
-static void xdl_free_classifier(xdlclassifier_t *cf) {
+static void git_xdl_free_classifier(xdlclassifier_t *cf) {
 
-	xdl_free(cf->rcrecs);
-	xdl_free(cf->rchash);
-	xdl_cha_free(&cf->ncha);
+	git_xdl_free(cf->rcrecs);
+	git_xdl_free(cf->rchash);
+	git_xdl_cha_free(&cf->ncha);
 }
 
 
-static int xdl_classify_record(unsigned int pass, xdlclassifier_t *cf, xrecord_t **rhash,
+static int git_xdl_classify_record(unsigned int pass, xdlclassifier_t *cf, xrecord_t **rhash,
 			       unsigned int hbits, xrecord_t *rec) {
 	long hi;
 	char const *line;
@@ -118,19 +118,19 @@ static int xdl_classify_record(unsigned int pass, xdlclassifier_t *cf, xrecord_t
 	hi = (long) XDL_HASHLONG(rec->ha, cf->hbits);
 	for (rcrec = cf->rchash[hi]; rcrec; rcrec = rcrec->next)
 		if (rcrec->ha == rec->ha &&
-				xdl_recmatch(rcrec->line, rcrec->size,
+				git_xdl_recmatch(rcrec->line, rcrec->size,
 					rec->ptr, rec->size, cf->flags))
 			break;
 
 	if (!rcrec) {
-		if (!(rcrec = xdl_cha_alloc(&cf->ncha))) {
+		if (!(rcrec = git_xdl_cha_alloc(&cf->ncha))) {
 
 			return -1;
 		}
 		rcrec->idx = cf->count++;
 		if (cf->count > cf->alloc) {
 			cf->alloc *= 2;
-			if (!(rcrecs = (xdlclass_t **) xdl_realloc(cf->rcrecs, cf->alloc * sizeof(xdlclass_t *)))) {
+			if (!(rcrecs = (xdlclass_t **) git_xdl_realloc(cf->rcrecs, cf->alloc * sizeof(xdlclass_t *)))) {
 
 				return -1;
 			}
@@ -157,7 +157,7 @@ static int xdl_classify_record(unsigned int pass, xdlclassifier_t *cf, xrecord_t
 }
 
 
-static int xdl_prepare_ctx(unsigned int pass, mmfile_t *mf, long narec, xpparam_t const *xpp,
+static int git_xdl_prepare_ctx(unsigned int pass, mmfile_t *mf, long narec, xpparam_t const *xpp,
 			   xdlclassifier_t *cf, xdfile_t *xdf) {
 	unsigned int hbits;
 	long nrec, hsize, bsize;
@@ -176,48 +176,48 @@ static int xdl_prepare_ctx(unsigned int pass, mmfile_t *mf, long narec, xpparam_
 	rhash = NULL;
 	recs = NULL;
 
-	if (xdl_cha_init(&xdf->rcha, sizeof(xrecord_t), narec / 4 + 1) < 0)
+	if (git_xdl_cha_init(&xdf->rcha, sizeof(xrecord_t), narec / 4 + 1) < 0)
 		goto abort;
-	if (!(recs = (xrecord_t **) xdl_malloc(narec * sizeof(xrecord_t *))))
+	if (!(recs = (xrecord_t **) git_xdl_malloc(narec * sizeof(xrecord_t *))))
 		goto abort;
 
-	hbits = xdl_hashbits((unsigned int) narec);
+	hbits = git_xdl_hashbits((unsigned int) narec);
 	hsize = 1 << hbits;
-	if (!(rhash = (xrecord_t **) xdl_malloc(hsize * sizeof(xrecord_t *))))
+	if (!(rhash = (xrecord_t **) git_xdl_malloc(hsize * sizeof(xrecord_t *))))
 		goto abort;
 	memset(rhash, 0, hsize * sizeof(xrecord_t *));
 
 	nrec = 0;
-	if ((cur = blk = xdl_mmfile_first(mf, &bsize)) != NULL) {
+	if ((cur = blk = git_xdl_mmfile_first(mf, &bsize)) != NULL) {
 		for (top = blk + bsize; cur < top; ) {
 			prev = cur;
-			hav = xdl_hash_record(&cur, top, xpp->flags);
+			hav = git_xdl_hash_record(&cur, top, xpp->flags);
 			if (nrec >= narec) {
 				narec *= 2;
-				if (!(rrecs = (xrecord_t **) xdl_realloc(recs, narec * sizeof(xrecord_t *))))
+				if (!(rrecs = (xrecord_t **) git_xdl_realloc(recs, narec * sizeof(xrecord_t *))))
 					goto abort;
 				recs = rrecs;
 			}
-			if (!(crec = xdl_cha_alloc(&xdf->rcha)))
+			if (!(crec = git_xdl_cha_alloc(&xdf->rcha)))
 				goto abort;
 			crec->ptr = prev;
 			crec->size = (long) (cur - prev);
 			crec->ha = hav;
 			recs[nrec++] = crec;
-			if (xdl_classify_record(pass, cf, rhash, hbits, crec) < 0)
+			if (git_xdl_classify_record(pass, cf, rhash, hbits, crec) < 0)
 				goto abort;
 		}
 	}
 
-	if (!(rchg = (char *) xdl_malloc((nrec + 2) * sizeof(char))))
+	if (!(rchg = (char *) git_xdl_malloc((nrec + 2) * sizeof(char))))
 		goto abort;
 	memset(rchg, 0, (nrec + 2) * sizeof(char));
 
 	if ((XDF_DIFF_ALG(xpp->flags) != XDF_PATIENCE_DIFF) &&
 	    (XDF_DIFF_ALG(xpp->flags) != XDF_HISTOGRAM_DIFF)) {
-		if (!(rindex = xdl_malloc((nrec + 1) * sizeof(*rindex))))
+		if (!(rindex = git_xdl_malloc((nrec + 1) * sizeof(*rindex))))
 			goto abort;
-		if (!(ha = xdl_malloc((nrec + 1) * sizeof(*ha))))
+		if (!(ha = git_xdl_malloc((nrec + 1) * sizeof(*ha))))
 			goto abort;
 	}
 
@@ -235,28 +235,28 @@ static int xdl_prepare_ctx(unsigned int pass, mmfile_t *mf, long narec, xpparam_
 	return 0;
 
 abort:
-	xdl_free(ha);
-	xdl_free(rindex);
-	xdl_free(rchg);
-	xdl_free(rhash);
-	xdl_free(recs);
-	xdl_cha_free(&xdf->rcha);
+	git_xdl_free(ha);
+	git_xdl_free(rindex);
+	git_xdl_free(rchg);
+	git_xdl_free(rhash);
+	git_xdl_free(recs);
+	git_xdl_cha_free(&xdf->rcha);
 	return -1;
 }
 
 
-static void xdl_free_ctx(xdfile_t *xdf) {
+static void git_xdl_free_ctx(xdfile_t *xdf) {
 
-	xdl_free(xdf->rhash);
-	xdl_free(xdf->rindex);
-	xdl_free(xdf->rchg - 1);
-	xdl_free(xdf->ha);
-	xdl_free(xdf->recs);
-	xdl_cha_free(&xdf->rcha);
+	git_xdl_free(xdf->rhash);
+	git_xdl_free(xdf->rindex);
+	git_xdl_free(xdf->rchg - 1);
+	git_xdl_free(xdf->ha);
+	git_xdl_free(xdf->recs);
+	git_xdl_cha_free(&xdf->rcha);
 }
 
 
-int xdl_prepare_env(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
+int git_xdl_prepare_env(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 		    xdfenv_t *xe) {
 	long enl1, enl2, sample;
 	xdlclassifier_t cf;
@@ -268,53 +268,53 @@ int xdl_prepare_env(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	 * thus a poorer estimate of the number of lines, as the hash
 	 * table (rhash) won't be filled up/grown. The number of lines
 	 * (nrecs) will be updated correctly anyway by
-	 * xdl_prepare_ctx().
+	 * git_xdl_prepare_ctx().
 	 */
 	sample = (XDF_DIFF_ALG(xpp->flags) == XDF_HISTOGRAM_DIFF
 		  ? XDL_GUESS_NLINES2 : XDL_GUESS_NLINES1);
 
-	enl1 = xdl_guess_lines(mf1, sample) + 1;
-	enl2 = xdl_guess_lines(mf2, sample) + 1;
+	enl1 = git_xdl_guess_lines(mf1, sample) + 1;
+	enl2 = git_xdl_guess_lines(mf2, sample) + 1;
 
-	if (xdl_init_classifier(&cf, enl1 + enl2 + 1, xpp->flags) < 0)
+	if (git_xdl_init_classifier(&cf, enl1 + enl2 + 1, xpp->flags) < 0)
 		return -1;
 
-	if (xdl_prepare_ctx(1, mf1, enl1, xpp, &cf, &xe->xdf1) < 0) {
+	if (git_xdl_prepare_ctx(1, mf1, enl1, xpp, &cf, &xe->xdf1) < 0) {
 
-		xdl_free_classifier(&cf);
+		git_xdl_free_classifier(&cf);
 		return -1;
 	}
-	if (xdl_prepare_ctx(2, mf2, enl2, xpp, &cf, &xe->xdf2) < 0) {
+	if (git_xdl_prepare_ctx(2, mf2, enl2, xpp, &cf, &xe->xdf2) < 0) {
 
-		xdl_free_ctx(&xe->xdf1);
-		xdl_free_classifier(&cf);
+		git_xdl_free_ctx(&xe->xdf1);
+		git_xdl_free_classifier(&cf);
 		return -1;
 	}
 
 	if ((XDF_DIFF_ALG(xpp->flags) != XDF_PATIENCE_DIFF) &&
 	    (XDF_DIFF_ALG(xpp->flags) != XDF_HISTOGRAM_DIFF) &&
-	    xdl_optimize_ctxs(&cf, &xe->xdf1, &xe->xdf2) < 0) {
+	    git_xdl_optimize_ctxs(&cf, &xe->xdf1, &xe->xdf2) < 0) {
 
-		xdl_free_ctx(&xe->xdf2);
-		xdl_free_ctx(&xe->xdf1);
-		xdl_free_classifier(&cf);
+		git_xdl_free_ctx(&xe->xdf2);
+		git_xdl_free_ctx(&xe->xdf1);
+		git_xdl_free_classifier(&cf);
 		return -1;
 	}
 
-	xdl_free_classifier(&cf);
+	git_xdl_free_classifier(&cf);
 
 	return 0;
 }
 
 
-void xdl_free_env(xdfenv_t *xe) {
+void git_xdl_free_env(xdfenv_t *xe) {
 
-	xdl_free_ctx(&xe->xdf2);
-	xdl_free_ctx(&xe->xdf1);
+	git_xdl_free_ctx(&xe->xdf2);
+	git_xdl_free_ctx(&xe->xdf1);
 }
 
 
-static int xdl_clean_mmatch(char const *dis, long i, long s, long e) {
+static int git_xdl_clean_mmatch(char const *dis, long i, long s, long e) {
 	long r, rdis0, rpdis0, rdis1, rpdis1;
 
 	/*
@@ -377,13 +377,13 @@ static int xdl_clean_mmatch(char const *dis, long i, long s, long e) {
  * matches on the other file. Also, lines that have multiple matches
  * might be potentially discarded if they happear in a run of discardable.
  */
-static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2) {
+static int git_xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2) {
 	long i, nm, nreff, mlim;
 	xrecord_t **recs;
 	xdlclass_t *rcrec;
 	char *dis, *dis1, *dis2;
 
-	if (!(dis = (char *) xdl_malloc(xdf1->nrec + xdf2->nrec + 2))) {
+	if (!(dis = (char *) git_xdl_malloc(xdf1->nrec + xdf2->nrec + 2))) {
 
 		return -1;
 	}
@@ -391,7 +391,7 @@ static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xd
 	dis1 = dis;
 	dis2 = dis1 + xdf1->nrec + 1;
 
-	if ((mlim = xdl_bogosqrt(xdf1->nrec)) > XDL_MAX_EQLIMIT)
+	if ((mlim = git_xdl_bogosqrt(xdf1->nrec)) > XDL_MAX_EQLIMIT)
 		mlim = XDL_MAX_EQLIMIT;
 	for (i = xdf1->dstart, recs = &xdf1->recs[xdf1->dstart]; i <= xdf1->dend; i++, recs++) {
 		rcrec = cf->rcrecs[(*recs)->ha];
@@ -399,7 +399,7 @@ static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xd
 		dis1[i] = (nm == 0) ? 0: (nm >= mlim) ? 2: 1;
 	}
 
-	if ((mlim = xdl_bogosqrt(xdf2->nrec)) > XDL_MAX_EQLIMIT)
+	if ((mlim = git_xdl_bogosqrt(xdf2->nrec)) > XDL_MAX_EQLIMIT)
 		mlim = XDL_MAX_EQLIMIT;
 	for (i = xdf2->dstart, recs = &xdf2->recs[xdf2->dstart]; i <= xdf2->dend; i++, recs++) {
 		rcrec = cf->rcrecs[(*recs)->ha];
@@ -410,7 +410,7 @@ static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xd
 	for (nreff = 0, i = xdf1->dstart, recs = &xdf1->recs[xdf1->dstart];
 	     i <= xdf1->dend; i++, recs++) {
 		if (dis1[i] == 1 ||
-		    (dis1[i] == 2 && !xdl_clean_mmatch(dis1, i, xdf1->dstart, xdf1->dend))) {
+		    (dis1[i] == 2 && !git_xdl_clean_mmatch(dis1, i, xdf1->dstart, xdf1->dend))) {
 			xdf1->rindex[nreff] = i;
 			xdf1->ha[nreff] = (*recs)->ha;
 			nreff++;
@@ -422,7 +422,7 @@ static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xd
 	for (nreff = 0, i = xdf2->dstart, recs = &xdf2->recs[xdf2->dstart];
 	     i <= xdf2->dend; i++, recs++) {
 		if (dis2[i] == 1 ||
-		    (dis2[i] == 2 && !xdl_clean_mmatch(dis2, i, xdf2->dstart, xdf2->dend))) {
+		    (dis2[i] == 2 && !git_xdl_clean_mmatch(dis2, i, xdf2->dstart, xdf2->dend))) {
 			xdf2->rindex[nreff] = i;
 			xdf2->ha[nreff] = (*recs)->ha;
 			nreff++;
@@ -431,7 +431,7 @@ static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xd
 	}
 	xdf2->nreff = nreff;
 
-	xdl_free(dis);
+	git_xdl_free(dis);
 
 	return 0;
 }
@@ -440,7 +440,7 @@ static int xdl_cleanup_records(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xd
 /*
  * Early trim initial and terminal matching records.
  */
-static int xdl_trim_ends(xdfile_t *xdf1, xdfile_t *xdf2) {
+static int git_xdl_trim_ends(xdfile_t *xdf1, xdfile_t *xdf2) {
 	long i, lim;
 	xrecord_t **recs1, **recs2;
 
@@ -466,10 +466,10 @@ static int xdl_trim_ends(xdfile_t *xdf1, xdfile_t *xdf2) {
 }
 
 
-static int xdl_optimize_ctxs(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2) {
+static int git_xdl_optimize_ctxs(xdlclassifier_t *cf, xdfile_t *xdf1, xdfile_t *xdf2) {
 
-	if (xdl_trim_ends(xdf1, xdf2) < 0 ||
-	    xdl_cleanup_records(cf, xdf1, xdf2) < 0) {
+	if (git_xdl_trim_ends(xdf1, xdf2) < 0 ||
+	    git_xdl_cleanup_records(cf, xdf1, xdf2) < 0) {
 
 		return -1;
 	}

--- a/src/libgit2/xdiff/xprepare.h
+++ b/src/libgit2/xdiff/xprepare.h
@@ -25,9 +25,9 @@
 
 
 
-int xdl_prepare_env(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
+int git_xdl_prepare_env(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 		    xdfenv_t *xe);
-void xdl_free_env(xdfenv_t *xe);
+void git_xdl_free_env(xdfenv_t *xe);
 
 
 

--- a/src/libgit2/xdiff/xutils.c
+++ b/src/libgit2/xdiff/xutils.c
@@ -23,7 +23,7 @@
 #include "xinclude.h"
 
 
-long xdl_bogosqrt(long n) {
+long git_xdl_bogosqrt(long n) {
 	long i;
 
 	/*
@@ -36,7 +36,7 @@ long xdl_bogosqrt(long n) {
 }
 
 
-int xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
+int git_xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
 		     xdemitcb_t *ecb) {
 	int i = 2;
 	mmbuffer_t mb[3];
@@ -58,20 +58,20 @@ int xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
 	return 0;
 }
 
-void *xdl_mmfile_first(mmfile_t *mmf, long *size)
+void *git_xdl_mmfile_first(mmfile_t *mmf, long *size)
 {
 	*size = mmf->size;
 	return mmf->ptr;
 }
 
 
-long xdl_mmfile_size(mmfile_t *mmf)
+long git_xdl_mmfile_size(mmfile_t *mmf)
 {
 	return mmf->size;
 }
 
 
-int xdl_cha_init(chastore_t *cha, long isize, long icount) {
+int git_xdl_cha_init(chastore_t *cha, long isize, long icount) {
 
 	cha->head = cha->tail = NULL;
 	cha->isize = isize;
@@ -83,22 +83,22 @@ int xdl_cha_init(chastore_t *cha, long isize, long icount) {
 }
 
 
-void xdl_cha_free(chastore_t *cha) {
+void git_xdl_cha_free(chastore_t *cha) {
 	chanode_t *cur, *tmp;
 
 	for (cur = cha->head; (tmp = cur) != NULL;) {
 		cur = cur->next;
-		xdl_free(tmp);
+		git_xdl_free(tmp);
 	}
 }
 
 
-void *xdl_cha_alloc(chastore_t *cha) {
+void *git_xdl_cha_alloc(chastore_t *cha) {
 	chanode_t *ancur;
 	void *data;
 
 	if (!(ancur = cha->ancur) || ancur->icurr == cha->nsize) {
-		if (!(ancur = (chanode_t *) xdl_malloc(sizeof(chanode_t) + cha->nsize))) {
+		if (!(ancur = (chanode_t *) git_xdl_malloc(sizeof(chanode_t) + cha->nsize))) {
 
 			return NULL;
 		}
@@ -118,11 +118,11 @@ void *xdl_cha_alloc(chastore_t *cha) {
 	return data;
 }
 
-long xdl_guess_lines(mmfile_t *mf, long sample) {
+long git_xdl_guess_lines(mmfile_t *mf, long sample) {
 	long nl = 0, size, tsize = 0;
 	char const *data, *cur, *top;
 
-	if ((cur = data = xdl_mmfile_first(mf, &size)) != NULL) {
+	if ((cur = data = git_xdl_mmfile_first(mf, &size)) != NULL) {
 		for (top = data + size; nl < sample && cur < top; ) {
 			nl++;
 			if (!(cur = memchr(cur, '\n', top - cur)))
@@ -134,12 +134,12 @@ long xdl_guess_lines(mmfile_t *mf, long sample) {
 	}
 
 	if (nl && tsize)
-		nl = xdl_mmfile_size(mf) / (tsize / nl);
+		nl = git_xdl_mmfile_size(mf) / (tsize / nl);
 
 	return nl + 1;
 }
 
-int xdl_blankline(const char *line, long size, long flags)
+int git_xdl_blankline(const char *line, long size, long flags)
 {
 	long i;
 
@@ -170,7 +170,7 @@ static int ends_with_optional_cr(const char *l, long s, long i)
 	return 0;
 }
 
-int xdl_recmatch(const char *l1, long s1, const char *l2, long s2, long flags)
+int git_xdl_recmatch(const char *l1, long s1, const char *l2, long s2, long flags)
 {
 	int i1, i2;
 
@@ -249,7 +249,7 @@ int xdl_recmatch(const char *l1, long s1, const char *l2, long s2, long flags)
 	return 1;
 }
 
-static unsigned long xdl_hash_record_with_whitespace(char const **data,
+static unsigned long git_xdl_hash_record_with_whitespace(char const **data,
 		char const *top, long flags) {
 	unsigned long ha = 5381;
 	char const *ptr = *data;
@@ -294,12 +294,12 @@ static unsigned long xdl_hash_record_with_whitespace(char const **data,
 	return ha;
 }
 
-unsigned long xdl_hash_record(char const **data, char const *top, long flags) {
+unsigned long git_xdl_hash_record(char const **data, char const *top, long flags) {
 	unsigned long ha = 5381;
 	char const *ptr = *data;
 
 	if (flags & XDF_WHITESPACE_FLAGS)
-		return xdl_hash_record_with_whitespace(data, top, flags);
+		return git_xdl_hash_record_with_whitespace(data, top, flags);
 
 	for (; ptr < top && *ptr != '\n'; ptr++) {
 		ha += (ha << 5);
@@ -310,7 +310,7 @@ unsigned long xdl_hash_record(char const **data, char const *top, long flags) {
 	return ha;
 }
 
-unsigned int xdl_hashbits(unsigned int size) {
+unsigned int git_xdl_hashbits(unsigned int size) {
 	unsigned int val = 1, bits = 0;
 
 	for (; val < size && bits < CHAR_BIT * sizeof(unsigned int); val <<= 1, bits++);
@@ -318,7 +318,7 @@ unsigned int xdl_hashbits(unsigned int size) {
 }
 
 
-int xdl_num_out(char *out, long val) {
+int git_xdl_num_out(char *out, long val) {
 	char *ptr, *str = out;
 	char buf[32];
 
@@ -340,7 +340,7 @@ int xdl_num_out(char *out, long val) {
 	return str - out;
 }
 
-static int xdl_format_hunk_hdr(long s1, long c1, long s2, long c2,
+static int git_xdl_format_hunk_hdr(long s1, long c1, long s2, long c2,
 			       const char *func, long funclen,
 			       xdemitcb_t *ecb) {
 	int nb = 0;
@@ -350,25 +350,25 @@ static int xdl_format_hunk_hdr(long s1, long c1, long s2, long c2,
 	memcpy(buf, "@@ -", 4);
 	nb += 4;
 
-	nb += xdl_num_out(buf + nb, c1 ? s1: s1 - 1);
+	nb += git_xdl_num_out(buf + nb, c1 ? s1: s1 - 1);
 
 	if (c1 != 1) {
 		memcpy(buf + nb, ",", 1);
 		nb += 1;
 
-		nb += xdl_num_out(buf + nb, c1);
+		nb += git_xdl_num_out(buf + nb, c1);
 	}
 
 	memcpy(buf + nb, " +", 2);
 	nb += 2;
 
-	nb += xdl_num_out(buf + nb, c2 ? s2: s2 - 1);
+	nb += git_xdl_num_out(buf + nb, c2 ? s2: s2 - 1);
 
 	if (c2 != 1) {
 		memcpy(buf + nb, ",", 1);
 		nb += 1;
 
-		nb += xdl_num_out(buf + nb, c2);
+		nb += git_xdl_num_out(buf + nb, c2);
 	}
 
 	memcpy(buf + nb, " @@", 3);
@@ -389,11 +389,11 @@ static int xdl_format_hunk_hdr(long s1, long c1, long s2, long c2,
 	return 0;
 }
 
-int xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
+int git_xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
 		      const char *func, long funclen,
 		      xdemitcb_t *ecb) {
 	if (!ecb->out_hunk)
-		return xdl_format_hunk_hdr(s1, c1, s2, c2, func, funclen, ecb);
+		return git_xdl_format_hunk_hdr(s1, c1, s2, c2, func, funclen, ecb);
 	if (ecb->out_hunk(ecb->priv,
 			  c1 ? s1 : s1 - 1, c1,
 			  c2 ? s2 : s2 - 1, c2,
@@ -402,7 +402,7 @@ int xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
 	return 0;
 }
 
-int xdl_fall_back_diff(xdfenv_t *diff_env, xpparam_t const *xpp,
+int git_xdl_fall_back_diff(xdfenv_t *diff_env, xpparam_t const *xpp,
 		int line1, int count1, int line2, int count2)
 {
 	/*
@@ -422,13 +422,13 @@ int xdl_fall_back_diff(xdfenv_t *diff_env, xpparam_t const *xpp,
 	subfile2.ptr = (char *)diff_env->xdf2.recs[line2 - 1]->ptr;
 	subfile2.size = diff_env->xdf2.recs[line2 + count2 - 2]->ptr +
 		diff_env->xdf2.recs[line2 + count2 - 2]->size - subfile2.ptr;
-	if (xdl_do_diff(&subfile1, &subfile2, xpp, &env) < 0)
+	if (git_xdl_do_diff(&subfile1, &subfile2, xpp, &env) < 0)
 		return -1;
 
 	memcpy(diff_env->xdf1.rchg + line1 - 1, env.xdf1.rchg, count1);
 	memcpy(diff_env->xdf2.rchg + line2 - 1, env.xdf2.rchg, count2);
 
-	xdl_free_env(&env);
+	git_xdl_free_env(&env);
 
 	return 0;
 }

--- a/src/libgit2/xdiff/xutils.h
+++ b/src/libgit2/xdiff/xutils.h
@@ -25,21 +25,21 @@
 
 
 
-long xdl_bogosqrt(long n);
-int xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
+long git_xdl_bogosqrt(long n);
+int git_xdl_emit_diffrec(char const *rec, long size, char const *pre, long psize,
 		     xdemitcb_t *ecb);
-int xdl_cha_init(chastore_t *cha, long isize, long icount);
-void xdl_cha_free(chastore_t *cha);
-void *xdl_cha_alloc(chastore_t *cha);
-long xdl_guess_lines(mmfile_t *mf, long sample);
-int xdl_blankline(const char *line, long size, long flags);
-int xdl_recmatch(const char *l1, long s1, const char *l2, long s2, long flags);
-unsigned long xdl_hash_record(char const **data, char const *top, long flags);
-unsigned int xdl_hashbits(unsigned int size);
-int xdl_num_out(char *out, long val);
-int xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
+int git_xdl_cha_init(chastore_t *cha, long isize, long icount);
+void git_xdl_cha_free(chastore_t *cha);
+void *git_xdl_cha_alloc(chastore_t *cha);
+long git_xdl_guess_lines(mmfile_t *mf, long sample);
+int git_xdl_blankline(const char *line, long size, long flags);
+int git_xdl_recmatch(const char *l1, long s1, const char *l2, long s2, long flags);
+unsigned long git_xdl_hash_record(char const **data, char const *top, long flags);
+unsigned int git_xdl_hashbits(unsigned int size);
+int git_xdl_num_out(char *out, long val);
+int git_xdl_emit_hunk_hdr(long s1, long c1, long s2, long c2,
 		      const char *func, long funclen, xdemitcb_t *ecb);
-int xdl_fall_back_diff(xdfenv_t *diff_env, xpparam_t const *xpp,
+int git_xdl_fall_back_diff(xdfenv_t *diff_env, xpparam_t const *xpp,
 		       int line1, int count1, int line2, int count2);
 
 


### PR DESCRIPTION
At the time both mercurial and libgit2 projects bundle xdiff.
When they are linked statically, a duplicated symbol error is raised by the linker.

Rename these symbols to avoid conflicts.