### PR TITLE
Do not register fake repository as owner of ODB

### DIFF
--- a/include/git2/sys/repository.h
+++ b/include/git2/sys/repository.h
@@ -97,9 +97,10 @@ GIT_EXTERN(int) git_repository_set_config(git_repository *repo, git_config *conf
  *
  * @param repo A repository object
  * @param odb An ODB object
+ * @param set_owner Register repository as owner of ODB
  * @return 0 on success, or an error code
  */
-GIT_EXTERN(int) git_repository_set_odb(git_repository *repo, git_odb *odb);
+GIT_EXTERN(int) git_repository_set_odb(git_repository *repo, git_odb *odb, bool set_owner);
 
 /**
  * Set the Reference Database Backend for this repository

--- a/tests/libgit2/odb/backend/nobackend.c
+++ b/tests/libgit2/odb/backend/nobackend.c
@@ -17,7 +17,7 @@ void test_odb_backend_nobackend__initialize(void)
 	cl_git_pass(git_refdb_new(&refdb, _repo));
 
 	git_repository_set_config(_repo, config);
-	git_repository_set_odb(_repo, odb);
+	git_repository_set_odb(_repo, odb, /*set_owner=*/true);
 	git_repository_set_refdb(_repo, refdb);
 
 	/* The set increases the refcount and we don't want them anymore */

--- a/tests/libgit2/repo/setters.c
+++ b/tests/libgit2/repo/setters.c
@@ -94,7 +94,28 @@ void test_repo_setters__setting_a_new_odb_on_a_repo_which_already_loaded_one_pro
 	cl_git_pass(git_odb__open(&new_odb, "./testrepo.git/objects", NULL));
 	cl_assert(((git_refcount *)new_odb)->refcount.val == 1);
 
-	git_repository_set_odb(repo, new_odb);
+	git_repository_set_odb(repo, new_odb, /*set_owner=*/true);
+	cl_assert(((git_refcount *)new_odb)->refcount.val == 2);
+
+	git_repository_free(repo);
+	cl_assert(((git_refcount *)new_odb)->refcount.val == 1);
+
+	git_odb_free(new_odb);
+
+	/*
+	 * Ensure the cleanup method won't try to free the repo as it's already been taken care of
+	 */
+	repo = NULL;
+}
+
+void test_repo_setters__setting_a_new_odb_on_a_non_owner_repo_which_already_loaded_one_properly_honors_the_refcount(void)
+{
+	git_odb *new_odb;
+
+	cl_git_pass(git_odb__open(&new_odb, "./testrepo.git/objects", NULL));
+	cl_assert(((git_refcount *)new_odb)->refcount.val == 1);
+
+	git_repository_set_odb(repo, new_odb, /*set_owner=*/false);
 	cl_assert(((git_refcount *)new_odb)->refcount.val == 2);
 
 	git_repository_free(repo);


### PR DESCRIPTION
Accessing ODB is guaranteed to be thread-safe. Registering a fake repository (created via git_repository_wrap_odb()) may not register itself as owner of the ODB in order to maintain that guarantee. Otherwise, accessing objects from ODB will try to obtain the cache from the owning repository (via odb_cache()) and produce a race if this ODB is concurrently used to create fake repositories in other threads. Consequently, operations on fake repositories will interact with the ODB's cache instead of the repository's cache.