### PR TITLE
Use `git_clone__submodule` to avoid file checks in workdir

### DIFF
--- a/src/libgit2/submodule.c
+++ b/src/libgit2/submodule.c
@@ -1393,7 +1393,7 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 		 */
 		clone_options.checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;
 
-		if ((error = git_clone(&sub_repo, submodule_url, sm->path, &clone_options)) < 0 ||
+		if ((error = git_clone__submodule(&sub_repo, submodule_url, sm->path, &clone_options)) < 0 ||
 			(error = git_repository_set_head_detached(sub_repo, git_submodule_index_id(sm))) < 0 ||
 			(error = git_checkout_head(sub_repo, &update_options.checkout_opts)) != 0)
 			goto done;


### PR DESCRIPTION
`git_clone` checks for existence of (non-empty) directories that would clash with what is about to be cloned.

This is problematic when cloning submodules since they make sense in the context of a parent module, so they should not use the current working dir.

Since in `git_submodule_update` we clone the submodule only when it is not yet initialized we do not need to perform directory checks.

Fixes #5830 