### PR TITLE
push: use resolved oid as the source

### DIFF
--- a/src/libgit2/push.c
+++ b/src/libgit2/push.c
@@ -395,7 +395,7 @@ static int calculate_work(git_push *push)
 				return -1;
 			}
 
-			git_oid_cpy(git_object_id(obj), &spec->loid);
+			git_oid_cpy(&spec->loid, git_object_id(obj));
 			git_object_free(obj);
 		}
 


### PR DESCRIPTION
211c97195e2ebcf68e27782715eb756823ad5a91 attempts to use the parsed OID but inverted the arguments to `git_oid_cpy`.