### PR TITLE
ci: always create test summaries, even on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,6 +323,7 @@ jobs:
   test_results:
     name: Test results
     needs: [ build ]
+    if: always()
     runs-on: ubuntu-latest
     steps:
     - name: Download test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -329,7 +329,7 @@ jobs:
     - name: Download test results
       uses: actions/download-artifact@v3
     - name: Generate test summary
-      uses: test-summary/action@v1
+      uses: test-summary/action@v2
       with:
         paths: 'test-results-*/*.xml'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -365,7 +365,7 @@ jobs:
             cm doc api.docurium
         git checkout gh-pages
         zip --exclude .git/\* --exclude .gitignore --exclude .gitattributes -r api-documentation.zip .
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       name: Upload artifact
       with:
         name: api-documentation


### PR DESCRIPTION
When the dependent jobs fail -- possibly due to test failures -- we should still produce the job summary that shows those test failures.