### PR TITLE
Support OpenSSL 3 in dynamic loading mode

### DIFF
--- a/src/libgit2/streams/openssl.c
+++ b/src/libgit2/streams/openssl.c
@@ -198,7 +198,7 @@ static int openssl_ensure_initialized(void)
 		if ((error = git_openssl_stream_dynamic_init()) == 0)
 			error = openssl_init();
 
-		openssl_initialized = true;
+		openssl_initialized = !error;
 	}
 
 	error |= git_mutex_unlock(&openssl_mutex);

--- a/src/util/hash/openssl.c
+++ b/src/util/hash/openssl.c
@@ -10,8 +10,8 @@
 #ifdef GIT_OPENSSL_DYNAMIC
 # include <dlfcn.h>
 
-int handle_count;
-void *openssl_handle;
+static int handle_count;
+static void *openssl_handle;
 
 static int git_hash_openssl_global_shutdown(void)
 {
@@ -30,7 +30,8 @@ static int git_hash_openssl_global_init(void)
 		    (openssl_handle = dlopen("libssl.1.1.dylib", RTLD_NOW)) == NULL &&
 		    (openssl_handle = dlopen("libssl.so.1.0.0", RTLD_NOW)) == NULL &&
 		    (openssl_handle = dlopen("libssl.1.0.0.dylib", RTLD_NOW)) == NULL &&
-		    (openssl_handle = dlopen("libssl.so.10", RTLD_NOW)) == NULL) {
+		    (openssl_handle = dlopen("libssl.so.10", RTLD_NOW)) == NULL &&
+		    (openssl_handle = dlopen("libssl.so.3", RTLD_NOW)) == NULL) {
 			git_error_set(GIT_ERROR_SSL, "could not load ssl libraries");
 			return -1;
 		}


### PR DESCRIPTION
Try to load OpenSSL 3 libraries when compiled with OpenSSL-Dynamic
support.

Handle the deprecated symbol renaming of SSL_get_peer_certificate to
SSL_get1_peer_certificate -- try to load the old name and if it fails,
use the new one.