### PR TITLE
Add new PHP bindings project to language bindings section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Here are the bindings to libgit2 that are currently available:
 * Pharo Smalltalk
     * libgit2-pharo-bindings <https://github.com/pharo-vcs/libgit2-pharo-bindings>
 * PHP
-    * php-git <https://github.com/libgit2/php-git>
+    * php-git2 <https://github.com/RogerGee/php-git2>
 * Python
     * pygit2 <https://github.com/libgit2/pygit2>
 * R


### PR DESCRIPTION
Updates the README.md language binding section to include an additional project providing PHP bindings at https://github.com/RogerGee/php-git2.

I've been working on PHP language bindings for `libgit2` since late 2016. I started the project because the existing support for PHP was incomplete, and I wanted to create more complete, full-featured and stable support for PHP. Since then, the project has really come a long way, and I'd like to incorporate it into the list of PHP language bindings in the `libgit2` README so others can more easily find it.

I plan on maintaining this project in the future as much as possible. Here are a few highlights:
- Coverage of the `libgit2` API (`v1.5.0`) is around 70% at the time of this writing
- The extension provides reference-counting functionality to prevent crashes due to low-level concerns
- The extension provides object-oriented abstractions in PHP userspace for implementing custom backends (e.g. ODB backend)
- PHP 8 support is under active development
  - I've recently published a development branch providing experimental PHP 8 support

Thanks for your consideration!