### PR TITLE
diff_file: Fix crash when freeing a patch representing an empty untracked file

### DIFF
--- a/src/libgit2/diff_file.c
+++ b/src/libgit2/diff_file.c
@@ -348,6 +348,13 @@ static int diff_file_content_load_workdir_file(
 		goto cleanup;
 	}
 
+	/* if file is empty, don't attempt to mmap or readbuffer */
+	if (fc->file->size == 0) {
+		fc->map.len = 0;
+		fc->map.data = git_str__initstr;
+		goto cleanup;
+	}
+
 	if ((diff_opts->flags & GIT_DIFF_SHOW_BINARY) == 0 &&
 		diff_file_content_binary_by_size(fc))
 		goto cleanup;


### PR DESCRIPTION
This PR fixes a crash and a failed assert in the following scenario:
1. create an **empty** untracked file in a repo;
2. call `git_diff_index_to_workdir`;
3. feed the diff to `git_patch_from_diff`;
4. free the resulting patch.

Currently, this use case raises two issues:
- `git_diff_file_content__unload` may attempt to free `git_str__initstr` (a statically-allocated array)
- or, `GIT_MMAP_VALIDATE` may fail

The outcome depends on whether or not filters (such as “core.crlf”) were installed:

- With filters, [`fc->map.data` ultimately points to `git_str__initstr`](https://github.com/libgit2/libgit2/blob/v1.5.1/src/libgit2/diff_file.c#L371-L381) because the file is empty (convert_buf doesn’t touch “out”). However, `GIT_DIFF_FLAG__FREE_DATA` is set; so, when time comes to free the patch, `git_diff_file_content__unload` attempts to free `git_str__initstr`, resulting in a crash.

- Without any filters, [`diff_file_content_load_workdir_file` attempts to mmap a 0-length file](https://github.com/libgit2/libgit2/blob/v1.5.1/src/libgit2/diff_file.c#L359-L369), causing GIT_MMAP_VALIDATE to fail. 

The fix I’m suggesting here is: in `diff_file_content_load_workdir_file`, if we know the file is empty, then don’t bother with mmap or readbuffer.

I’m not the most familiar with libgit2’s codebase so feel free to edit the PR if there’s a better solution!

—

PS: Incidentally, this PR fixes 2 other tests when assertions are enabled:
test_diff_rename__empty_files_renamed
test_diff_workdir__can_diff_empty_file