### PR TITLE
strarray: remove deprecated declaration

### DIFF
--- a/include/git2/strarray.h
+++ b/include/git2/strarray.h
@@ -36,19 +36,6 @@ typedef struct git_strarray {
  */
 GIT_EXTERN(void) git_strarray_dispose(git_strarray *array);
 
-/**
- * Copy a string array object from source to target.
- *
- * Note: target is overwritten and hence should be empty, otherwise its
- * contents are leaked.  Call git_strarray_free() if necessary.
- *
- * @param tgt target
- * @param src source
- * @return 0 on success, < 0 on allocation failure
- */
-GIT_EXTERN(int) git_strarray_copy(git_strarray *tgt, const git_strarray *src);
-
-
 /** @} */
 GIT_END_DECL
 

--- a/src/libgit2/describe.c
+++ b/src/libgit2/describe.c
@@ -8,7 +8,6 @@
 #include "common.h"
 
 #include "git2/describe.h"
-#include "git2/strarray.h"
 #include "git2/diff.h"
 #include "git2/status.h"
 
@@ -19,6 +18,7 @@
 #include "refs.h"
 #include "repository.h"
 #include "revwalk.h"
+#include "strarray.h"
 #include "tag.h"
 #include "vector.h"
 #include "wildmatch.h"

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -17,6 +17,7 @@
 #include "fetchhead.h"
 #include "push.h"
 #include "proxy.h"
+#include "strarray.h"
 
 #include "git2/config.h"
 #include "git2/types.h"

--- a/src/libgit2/strarray.c
+++ b/src/libgit2/strarray.c
@@ -8,6 +8,7 @@
 #include "util.h"
 
 #include "common.h"
+#include "strarray.h"
 
 int git_strarray_copy(git_strarray *tgt, const git_strarray *src)
 {

--- a/src/libgit2/strarray.h
+++ b/src/libgit2/strarray.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_strarray_h__
+#define INCLUDE_strarray_h__
+
+#include "common.h"
+#include "git2/strarray.h"
+
+/**
+ * Copy a string array object from source to target.
+ *
+ * Note: target is overwritten and hence should be empty, otherwise its
+ * contents are leaked.  Call git_strarray_free() if necessary.
+ *
+ * @param tgt target
+ * @param src source
+ * @return 0 on success, < 0 on allocation failure
+ */
+extern int git_strarray_copy(git_strarray *tgt, const git_strarray *src);
+
+#endif


### PR DESCRIPTION
`git_strarray_copy` is deprecated (and has been included in `deprecated.h` for some time). It should not have remained in the public `strarray.h`. Remove it.