### PR TITLE
Handle Win32 shares

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -547,6 +547,9 @@ static int validate_ownership_path(bool *is_safe, const char *path)
 	if (error == GIT_ENOTFOUND) {
 		*is_safe = true;
 		error = 0;
+	} else if (error == GIT_EINVALID) {
+		*is_safe = false;
+		error = 0;
 	}
 
 	return error;

--- a/src/util/fs_path.c
+++ b/src/util/fs_path.c
@@ -1855,7 +1855,7 @@ static int file_owner_sid(PSID *out, const char *path)
 	PSECURITY_DESCRIPTOR descriptor = NULL;
 	PSID owner_sid;
 	DWORD ret;
-	int error = -1;
+	int error = GIT_EINVALID;
 
 	if (git_win32_path_from_utf8(path_w32, path) < 0)
 		return -1;


### PR DESCRIPTION
With some paths on Win32, we cannot identify the owner because it's on a file share (WSL2 or UNC). In that case, don't fail, but identify that the current user does not own the path. This matches Git for Windows behavior.

Fixes #6468 