### PR TITLE
Make failure to connect to ssh-agent non-fatal

### DIFF
--- a/src/libgit2/transports/ssh.c
+++ b/src/libgit2/transports/ssh.c
@@ -246,8 +246,10 @@ static int ssh_agent_auth(LIBSSH2_SESSION *session, git_credential_ssh_key *c) {
 
 	rc = libssh2_agent_connect(agent);
 
-	if (rc != LIBSSH2_ERROR_NONE)
+	if (rc != LIBSSH2_ERROR_NONE) {
+		rc = LIBSSH2_ERROR_AUTHENTICATION_FAILED;
 		goto shutdown;
+	}
 
 	rc = libssh2_agent_list_identities(agent);
 


### PR DESCRIPTION
Fixes https://github.com/libgit2/libgit2/issues/3866

Has been applied in all Julia builds since 2017:
https://github.com/JuliaLang/julia/pull/17459

Authored-by: Keno Fischer <kfischer@college.harvard.edu>