### PR TITLE
odb: don't unconditionally add oid_type to stream

### DIFF
--- a/include/git2/odb_backend.h
+++ b/include/git2/odb_backend.h
@@ -171,7 +171,9 @@ struct git_odb_stream {
 	unsigned int mode;
 	void *hash_ctx;
 
+#ifdef GIT_EXPERIMENTAL_SHA256
 	git_oid_t oid_type;
+#endif
 
 	git_object_size_t declared_size;
 	git_object_size_t received_bytes;

--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -1704,7 +1704,9 @@ int git_odb_open_wstream(
 	    (error = hash_header(ctx, size, type)) < 0)
 		goto done;
 
+#ifdef GIT_EXPERIMENTAL_SHA256
 	(*stream)->oid_type = db->options.oid_type;
+#endif
 	(*stream)->hash_ctx = ctx;
 	(*stream)->declared_size = size;
 	(*stream)->received_bytes = 0;


### PR DESCRIPTION
`git_odb_stream` should have an `oid_type` to disambiguate; that's not necessary on non-experimental SHA256 builds. Avoid unnecessary ABI breakage for consumers and hide it behind an ifdef for now.