### PR TITLE
Correct the definition of "empty" in the docs for `git_repository_is_empty`

### DIFF
--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -465,7 +465,9 @@ GIT_EXTERN(int) git_repository_head_unborn(git_repository *repo);
  * Check if a repository is empty
  *
  * An empty repository has just been initialized and contains no references
- * apart from HEAD, which must be pointing to the unborn master branch.
+ * apart from HEAD, which must be pointing to the unborn master branch,
+ * or the branch specified for the repository in the `init.defaultBranch`
+ * configuration variable.
  *
  * @param repo Repo to test
  * @return 1 if the repository is empty, 0 if it isn't, error code


### PR DESCRIPTION
This improves the documentation for `git_repository_is_empty` which currently does not accurately describe libgit2's definition of "empty".

It says that HEAD must point to the "unborn master branch", when in fact, this is not the case if the repo's `init.defaultBranch` configuration is set. If it is set, it will check that HEAD points there. Only if it is not set does it fall back to `master`.