### PR TITLE
Pass hostkey & port to host verify callback

### DIFF
--- a/src/libgit2/transports/ssh.c
+++ b/src/libgit2/transports/ssh.c
@@ -651,6 +651,8 @@ static int check_against_known_hosts(
 	return ret;
 }
 
+#define SSH_DEFAULT_PORT 22
+
 /*
  * Perform the check for the session's certificate against known hosts if
  * possible and then ask the user if they have a callback.
@@ -748,9 +750,16 @@ static int check_certificate(
 	if (check_cb != NULL) {
 		git_cert_hostkey *cert_ptr = &cert;
 		git_error_state previous_error = {0};
+		const char *host_ptr = host;
+		git_str host_and_port = GIT_STR_INIT;
+
+		if (port != SSH_DEFAULT_PORT) {
+			git_str_printf(&host_and_port, "%s:%d", host, port);
+			host_ptr = host_and_port.ptr;
+		}
 
 		git_error_state_capture(&previous_error, error);
-		error = check_cb((git_cert *) cert_ptr, cert_valid, host, check_cb_payload);
+		error = check_cb((git_cert *) cert_ptr, cert_valid, host_ptr, check_cb_payload);
 		if (error == GIT_PASSTHROUGH) {
 			error = git_error_state_restore(&previous_error);
 		} else if (error < 0 && !git_error_last()) {
@@ -758,12 +767,11 @@ static int check_certificate(
 		}
 
 		git_error_state_free(&previous_error);
+		git_str_dispose(&host_and_port);
 	}
 
 	return error;
 }
-
-#define SSH_DEFAULT_PORT "22"
 
 static int _git_ssh_setup_conn(
 	ssh_subtransport *t,

--- a/src/util/net.c
+++ b/src/util/net.c
@@ -646,6 +646,13 @@ int git_net_url_parse_scp(git_net_url *url, const char *given)
 	return 0;
 }
 
+int git_net_url_parse_standard_or_scp(git_net_url *url, const char *given)
+{
+	return git_net_str_is_url(given) ?
+	       git_net_url_parse(url, given) :
+	       git_net_url_parse_scp(url, given);
+}
+
 int git_net_url_joinpath(
 	git_net_url *out,
 	git_net_url *one,

--- a/src/util/net.h
+++ b/src/util/net.h
@@ -34,6 +34,12 @@ extern int git_net_url_parse(git_net_url *url, const char *str);
 /** Parses a string containing an SCP style path into a URL structure. */
 extern int git_net_url_parse_scp(git_net_url *url, const char *str);
 
+/**
+ * Parses a string containing a standard URL or an SCP style path into
+ * a URL structure.
+ */
+extern int git_net_url_parse_standard_or_scp(git_net_url *url, const char *str);
+
 /** Appends a path and/or query string to the given URL */
 extern int git_net_url_joinpath(
 	git_net_url *out,


### PR DESCRIPTION
This is a patch that has been applied for 2 years in Julia. Quoting from @StefanKarpinski in his original pull request:

> It seems that no one actually verifies SSH host identity with libgit2 because the callback doesn't give enough information do so correctly:
> 
> * It doesn't give the actual host key fingerprint, but rather three
>   different hashes thereof. This means we cannot distinguish a known
>   hosts entry that has a different type (`ssh-rsa`, `ssh-dsa`, etc.)
>   from an entry with a matching type and a fingerprint mismatch: the
>   former should be treated as an unknown host whereas the latter is a
>   host key mismatch; they cannot be distinguished without this patch.
> * If the user connects on a non-default port (i.e. not 22), this is not
>   passed to the callback in any way. Since there can be different known
>   host entries for different ports and they should be treated as
>   distinct, this also means the current API cannot be used to verify
>   hosts serving SSH on non-standard ports. This patch passes the port.
> 
> I will try to upstream some version of this patch to libgit2.

I have adapted the patch slightly. I do not know libgit2 internals enough to know whether `snprintf` and `alloca` are the best way to handle the memory allocation/string printing in that place.


- Original PR at Julia: https://github.com/JuliaLang/julia/pull/39324
- Example of bug created by the current situation: https://github.com/JuliaLang/julia/issues/38777 “Host verification failure for packages in SSH remotes at a non-standard port”