### PR TITLE
repo: don't allow repeated extensions

### DIFF
--- a/tests/libgit2/core/opts.c
+++ b/tests/libgit2/core/opts.c
@@ -50,9 +50,9 @@ void test_core_opts__extensions_add(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
 	cl_assert_equal_sz(out.count, 3);
-	cl_assert_equal_s("noop", out.strings[0]);
-	cl_assert_equal_s("objectformat", out.strings[1]);
-	cl_assert_equal_s("foo", out.strings[2]);
+	cl_assert_equal_s("foo", out.strings[0]);
+	cl_assert_equal_s("noop", out.strings[1]);
+	cl_assert_equal_s("objectformat", out.strings[2]);
 
 	git_strarray_dispose(&out);
 }
@@ -66,9 +66,26 @@ void test_core_opts__extensions_remove(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
 	cl_assert_equal_sz(out.count, 3);
-	cl_assert_equal_s("objectformat", out.strings[0]);
-	cl_assert_equal_s("bar", out.strings[1]);
-	cl_assert_equal_s("baz", out.strings[2]);
+	cl_assert_equal_s("bar", out.strings[0]);
+	cl_assert_equal_s("baz", out.strings[1]);
+	cl_assert_equal_s("objectformat", out.strings[2]);
+
+	git_strarray_dispose(&out);
+}
+
+void test_core_opts__extensions_uniq(void)
+{
+	const char *in[] = { "foo", "noop", "bar", "bar", "foo", "objectformat" };
+	git_strarray out = { 0 };
+
+	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
+
+	cl_assert_equal_sz(out.count, 4);
+	cl_assert_equal_s("bar", out.strings[0]);
+	cl_assert_equal_s("foo", out.strings[1]);
+	cl_assert_equal_s("noop", out.strings[2]);
+	cl_assert_equal_s("objectformat", out.strings[3]);
 
 	git_strarray_dispose(&out);
 }


### PR DESCRIPTION
If a user attempts to add a custom extension that the system already supports, or that is already in their list of custom extensions, de-dup it.