### PR TITLE
remote: always populate old id in update tips

### DIFF
--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -1733,7 +1733,7 @@ static int update_ref(
 	const git_remote_callbacks *callbacks)
 {
 	git_reference *ref;
-	git_oid old_id;
+	git_oid old_id = GIT_OID_SHA1_ZERO;
 	int error;
 
 	error = git_reference_name_to_id(&old_id, remote->repo, ref_name);


### PR DESCRIPTION
In b1e83cca1bbc255627950b4e8d4fdb1174bf7a12 we erroneously stopped setting the old ID to zero; correct that.