### PR TITLE
Revert #6503

### DIFF
--- a/src/libgit2/transports/ssh.c
+++ b/src/libgit2/transports/ssh.c
@@ -651,8 +651,6 @@ static int check_against_known_hosts(
 	return ret;
 }
 
-#define SSH_DEFAULT_PORT 22
-
 /*
  * Perform the check for the session's certificate against known hosts if
  * possible and then ask the user if they have a callback.
@@ -750,16 +748,9 @@ static int check_certificate(
 	if (check_cb != NULL) {
 		git_cert_hostkey *cert_ptr = &cert;
 		git_error_state previous_error = {0};
-		const char *host_ptr = host;
-		git_str host_and_port = GIT_STR_INIT;
-
-		if (port != SSH_DEFAULT_PORT) {
-			git_str_printf(&host_and_port, "%s:%d", host, port);
-			host_ptr = host_and_port.ptr;
-		}
 
 		git_error_state_capture(&previous_error, error);
-		error = check_cb((git_cert *) cert_ptr, cert_valid, host_ptr, check_cb_payload);
+		error = check_cb((git_cert *) cert_ptr, cert_valid, host, check_cb_payload);
 		if (error == GIT_PASSTHROUGH) {
 			error = git_error_state_restore(&previous_error);
 		} else if (error < 0 && !git_error_last()) {
@@ -767,11 +758,12 @@ static int check_certificate(
 		}
 
 		git_error_state_free(&previous_error);
-		git_str_dispose(&host_and_port);
 	}
 
 	return error;
 }
+
+#define SSH_DEFAULT_PORT "22"
 
 static int _git_ssh_setup_conn(
 	ssh_subtransport *t,

--- a/tests/libgit2/online/clone.c
+++ b/tests/libgit2/online/clone.c
@@ -787,18 +787,9 @@ static int ssh_certificate_check(git_cert *cert, int valid, const char *host, vo
 {
 	git_cert_hostkey *key;
 	git_oid expected = GIT_OID_SHA1_ZERO, actual = GIT_OID_SHA1_ZERO;
-	git_str expected_host = GIT_STR_INIT;
-	git_net_url parsed_url = GIT_NET_URL_INIT;
 
 	GIT_UNUSED(valid);
 	GIT_UNUSED(payload);
-
-	cl_git_pass(git_net_url_parse_standard_or_scp(&parsed_url, _remote_url));
-	cl_git_pass(git_str_printf(&expected_host, "%s%s%s",
-		parsed_url.host,
-		git_net_url_is_default_port(&parsed_url) ? "" : ":",
-		git_net_url_is_default_port(&parsed_url) ? "" : parsed_url.port));
-	cl_assert_equal_s(expected_host.ptr, host);
 
 	cl_assert(_remote_ssh_fingerprint);
 
@@ -821,8 +812,7 @@ static int ssh_certificate_check(git_cert *cert, int valid, const char *host, vo
 
 	cl_assert(!memcmp(&expected, &actual, 20));
 
-	git_net_url_dispose(&parsed_url);
-	git_str_dispose(&expected_host);
+	cl_assert_equal_s("localhost", host);
 
 	return GIT_EUSER;
 }


### PR DESCRIPTION
Introducing #6503 regrettably meant that host:port was ambiguous with IPv6 addresses. (See #6510.) Revert until we can sort out a proper path forward in v1.7.