### PR TITLE
Add `git_odb_backend_loose` back

### DIFF
--- a/src/libgit2/odb_loose.c
+++ b/src/libgit2/odb_loose.c
@@ -1204,3 +1204,37 @@ int git_odb__backend_loose(
 	*backend_out = (git_odb_backend *)backend;
 	return 0;
 }
+
+
+#ifdef GIT_EXPERIMENTAL_SHA256
+int git_odb_backend_loose(
+	git_odb_backend **backend_out,
+	const char *objects_dir,
+	git_odb_backend_loose_options *opts)
+{
+	return git_odb__backend_loose(backend_out, objects_dir, opts);
+}
+#else
+int git_odb_backend_loose(
+	git_odb_backend **backend_out,
+	const char *objects_dir,
+	int compression_level,
+	int do_fsync,
+	unsigned int dir_mode,
+	unsigned int file_mode)
+{
+	git_odb_backend_loose_flag_t flags = 0;
+	git_odb_backend_loose_options opts = GIT_ODB_BACKEND_LOOSE_OPTIONS_INIT;
+
+	if (do_fsync)
+		flags |= GIT_ODB_BACKEND_LOOSE_FSYNC;
+
+	opts.flags = flags;
+	opts.compression_level = compression_level;
+	opts.dir_mode = dir_mode;
+	opts.file_mode = file_mode;
+	opts.oid_type = GIT_OID_DEFAULT;
+
+	return git_odb__backend_loose(backend_out, objects_dir, &opts);
+}
+#endif

--- a/tests/libgit2/odb/backend/loose.c
+++ b/tests/libgit2/odb/backend/loose.c
@@ -1,0 +1,43 @@
+#include "clar_libgit2.h"
+#include "repository.h"
+#include "odb.h"
+#include "backend_helpers.h"
+#include "git2/sys/mempack.h"
+
+static git_repository *_repo;
+static git_odb *_odb;
+
+void test_odb_backend_loose__initialize(void)
+{
+	git_odb_backend *backend;
+
+	cl_fixture_sandbox("testrepo.git");
+
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_odb_backend_loose(&backend, "testrepo.git/objects", NULL));
+#else
+	cl_git_pass(git_odb_backend_loose(&backend, "testrepo.git/objects", 0, 0, 0, 0));
+#endif
+
+	cl_git_pass(git_odb__new(&_odb, NULL));
+	cl_git_pass(git_odb_add_backend(_odb, backend, 10));
+	cl_git_pass(git_repository_wrap_odb(&_repo, _odb));
+}
+
+void test_odb_backend_loose__cleanup(void)
+{
+	git_odb_free(_odb);
+	git_repository_free(_repo);
+
+	cl_fixture_cleanup("testrepo.git");
+}
+
+void test_odb_backend_loose__read(void)
+{
+	git_oid oid;
+	git_odb_object *obj;
+
+	cl_git_pass(git_oid__fromstr(&oid, "1385f264afb75a56a5bec74243be9b367ba4ca08", GIT_OID_SHA1));
+	cl_git_pass(git_odb_read(&obj, _odb, &oid));
+	git_odb_object_free(obj);
+}


### PR DESCRIPTION
`git_odb_backend_loose` was erroneously removed during a refactoring; add it back.

Fixes #6509 