### PR TITLE
meta: configure pkg-config .pc correctly

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -103,10 +103,10 @@ if(SONAME)
 	endif()
 endif()
 
-pkg_build_config(NAME "${LIBGIT2_FILENAME}"
+pkg_build_config(NAME "lib${LIBGIT2_FILENAME}"
 	VERSION ${libgit2_VERSION}
 	DESCRIPTION "The git library, take 2"
-	LIBS_SELF git2
+	LIBS_SELF ${LIBGIT2_FILENAME}
 	PRIVATE_LIBS ${LIBGIT2_PC_LIBS}
 	REQUIRES ${LIBGIT2_PC_REQUIRES})
 


### PR DESCRIPTION
The library name is correctly libgit2 (not git2) or libgit2-experimental depending on configuration.

Fixes #6507 