### PR TITLE
odb: restore `git_odb_open`

### DIFF
--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -856,6 +856,25 @@ int git_odb__open(
 	return 0;
 }
 
+#ifdef GIT_EXPERIMENTAL_SHA256
+
+int git_odb_open(
+	git_odb **out,
+	const char *objects_dir,
+	const git_odb_options *opts)
+{
+	return git_odb__open(out, objects_dir, opts);
+}
+
+#else
+
+int git_odb_open(git_odb **out, const char *objects_dir)
+{
+	return git_odb__open(out, objects_dir, NULL);
+}
+
+#endif
+
 int git_odb__set_caps(git_odb *odb, int caps)
 {
 	if (caps == GIT_ODB_CAP_FROM_OWNER) {

--- a/tests/libgit2/odb/open.c
+++ b/tests/libgit2/odb/open.c
@@ -1,0 +1,34 @@
+#include "clar_libgit2.h"
+
+void test_odb_open__initialize(void)
+{
+	cl_fixture_sandbox("testrepo.git");
+}
+
+void test_odb_open__cleanup(void)
+{
+	cl_fixture_cleanup("testrepo.git");
+}
+
+void test_odb_open__exists(void)
+{
+	git_odb *odb;
+	git_oid one, two;
+
+#ifdef GIT_EXPERIMENTAL_SHA256
+	git_odb_options opts = GIT_ODB_OPTIONS_INIT;
+
+	cl_git_pass(git_odb_open(&odb, "testrepo.git/objects", &opts));
+	cl_git_pass(git_oid_fromstr(&one, "1385f264afb75a56a5bec74243be9b367ba4ca08", GIT_OID_SHA1));
+	cl_git_pass(git_oid_fromstr(&two, "00112233445566778899aabbccddeeff00112233", GIT_OID_SHA1));
+#else
+	cl_git_pass(git_odb_open(&odb, "testrepo.git/objects"));
+	cl_git_pass(git_oid_fromstr(&one, "1385f264afb75a56a5bec74243be9b367ba4ca08"));
+	cl_git_pass(git_oid_fromstr(&two, "00112233445566778899aabbccddeeff00112233"));
+#endif
+
+	cl_assert(git_odb_exists(odb, &one));
+	cl_assert(!git_odb_exists(odb, &two));
+
+	git_odb_free(odb);
+}


### PR DESCRIPTION
`git_odb_open` was erroneously removed during a refactoring; add it back.

Fixes #6519 