### PR TITLE
Fix potential null dereference

### DIFF
--- a/tests/libgit2/merge/merge_helpers.c
+++ b/tests/libgit2/merge/merge_helpers.c
@@ -145,7 +145,7 @@ void merge__dump_reuc(git_index *index)
 
 	printf ("\nREUC:\n");
 	for (i = 0; i < git_index_reuc_entrycount(index); i++) {
-		reuc = git_index_reuc_get_byindex(index, i);
+		cl_assert(reuc = git_index_reuc_get_byindex(index, i));
 
 		printf("%s ", reuc->path);
 		printf("%o ", reuc->mode[0]);


### PR DESCRIPTION
**Description**
Fix the null dereference warning detected by static analyse tool infer@facebook

**Warning Type**
Null Dereference

**omponent Name**
libgit2/tests/libgit2/merge/merge_helpers.c (line:148)

**Additional Information**
pointer `reuc` last assigned on line 148 could be null and is dereferenced at line 150.