### PR TITLE
sysdir: Do not declare win32 functions on non-win32 platforms

### DIFF
--- a/src/libgit2/sysdir.h
+++ b/src/libgit2/sysdir.h
@@ -134,10 +134,12 @@ extern int git_sysdir_set(git_sysdir_t which, const char *paths);
  */
 extern int git_sysdir_reset(void);
 
+#ifdef GIT_WIN32
 /** Sets the registry system dir to a mock; for testing.  */
 extern int git_win32__set_registry_system_dir(const wchar_t *mock_sysdir);
 
 /** Find the given system dir; for testing. */
 extern int git_win32__find_system_dirs(git_str *out, const char *subdir);
+#endif
 
 #endif


### PR DESCRIPTION
These declaration poses problems on some embedded or retro Linux systems that deliberately disable support for wchar_t from their libc.

```
<overlong path>/libgit2-1.6.2/src/libgit2/sysdir.h:138:53: error: unknown type name ‘wchar_t’
  138 | extern int git_win32__set_registry_system_dir(const wchar_t *mock_sysdir);
      |                                                     ^~~~~~~
```