### PR TITLE
cmake: don't include `include/git2`

### DIFF
--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(CLI_INCLUDES
 	"${libgit2_BINARY_DIR}/src/util"
 	"${libgit2_BINARY_DIR}/include"
-	"${libgit2_BINARY_DIR}/include/git2"
 	"${libgit2_SOURCE_DIR}/src/util"
 	"${libgit2_SOURCE_DIR}/src/cli"
 	"${libgit2_SOURCE_DIR}/include"

--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -10,7 +10,6 @@ include(PkgBuildConfig)
 set(LIBGIT2_INCLUDES
 	"${PROJECT_BINARY_DIR}/src/util"
 	"${PROJECT_BINARY_DIR}/include"
-	"${PROJECT_BINARY_DIR}/include/git2"
 	"${PROJECT_SOURCE_DIR}/src/libgit2"
 	"${PROJECT_SOURCE_DIR}/src/util"
 	"${PROJECT_SOURCE_DIR}/include")

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -9,7 +9,6 @@ configure_file(git2_features.h.in git2_features.h)
 set(UTIL_INCLUDES
 	"${PROJECT_BINARY_DIR}/src/util"
 	"${PROJECT_BINARY_DIR}/include"
-	"${PROJECT_BINARY_DIR}/include/git2"
 	"${PROJECT_SOURCE_DIR}/src/util"
 	"${PROJECT_SOURCE_DIR}/include")
 


### PR DESCRIPTION
Including the `include/git2` build path is a seemingly unnecessary oversight to include the generated `experimental.h` file.