### PR TITLE
pack: use 64 bits for the number of objects

### DIFF
--- a/src/libgit2/pack.c
+++ b/src/libgit2/pack.c
@@ -200,7 +200,8 @@ static void pack_index_free(struct git_pack_file *p)
 static int pack_index_check_locked(const char *path, struct git_pack_file *p)
 {
 	struct git_pack_idx_header *hdr;
-	uint32_t version, nr, i, *index;
+	uint32_t version, i, *index;
+	uint64_t nr = 0;
 	void *idx_map;
 	size_t idx_size;
 	struct stat st;
@@ -246,7 +247,6 @@ static int pack_index_check_locked(const char *path, struct git_pack_file *p)
 		version = 1;
 	}
 
-	nr = 0;
 	index = idx_map;
 
 	if (version > 1)
@@ -287,8 +287,8 @@ static int pack_index_check_locked(const char *path, struct git_pack_file *p)
 		 * variable sized table containing 8-byte entries
 		 * for offsets larger than 2^31.
 		 */
-		unsigned long min_size = 8 + (4 * 256) + (nr * (p->oid_size + 4 + 4)) + (p->oid_size * 2);
-		unsigned long max_size = min_size;
+		uint64_t min_size = 8 + (4 * 256) + (nr * (p->oid_size + 4 + 4)) + (p->oid_size * 2);
+		uint64_t max_size = min_size;
 
 		if (nr)
 			max_size += (nr - 1)*8;

--- a/src/libgit2/pack.c
+++ b/src/libgit2/pack.c
@@ -200,8 +200,7 @@ static void pack_index_free(struct git_pack_file *p)
 static int pack_index_check_locked(const char *path, struct git_pack_file *p)
 {
 	struct git_pack_idx_header *hdr;
-	uint32_t version, i, *index;
-	uint64_t nr = 0;
+	uint32_t version, nr = 0, i, *index;
 	void *idx_map;
 	size_t idx_size;
 	struct stat st;
@@ -269,7 +268,7 @@ static int pack_index_check_locked(const char *path, struct git_pack_file *p)
 		 * - 20/32-byte SHA of the packfile
 		 * - 20/32-byte SHA file checksum
 		 */
-		if (idx_size != (4 * 256 + (nr * (p->oid_size + 4)) + (p->oid_size * 2))) {
+		if (idx_size != (4 * 256 + ((uint64_t) nr * (p->oid_size + 4)) + (p->oid_size * 2))) {
 			git_futils_mmap_free(&p->index_map);
 			return packfile_error("index is corrupted");
 		}
@@ -287,7 +286,7 @@ static int pack_index_check_locked(const char *path, struct git_pack_file *p)
 		 * variable sized table containing 8-byte entries
 		 * for offsets larger than 2^31.
 		 */
-		uint64_t min_size = 8 + (4 * 256) + (nr * (p->oid_size + 4 + 4)) + (p->oid_size * 2);
+		uint64_t min_size = 8 + (4 * 256) + ((uint64_t)nr * (p->oid_size + 4 + 4)) + (p->oid_size * 2);
 		uint64_t max_size = min_size;
 
 		if (nr)


### PR DESCRIPTION
Keeping it as a 32-bit value means the min size calculation overflows or gets truncated which can lead to issues with large packfiles.

--

It's a bit disappointing that the compiler doesn't seem to care that we've been cutting off this value when we have a lot of objects.