### PR TITLE
config: return `GIT_ENOTFOUND` for missing programdata

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1174,9 +1174,12 @@ int git_config__find_programdata(git_str *path)
 		GIT_FS_PATH_OWNER_CURRENT_USER |
 		GIT_FS_PATH_OWNER_ADMINISTRATOR;
 	bool is_safe;
+	int error;
 
-	if (git_sysdir_find_programdata_file(path, GIT_CONFIG_FILENAME_PROGRAMDATA) < 0 ||
-	    git_fs_path_owner_is(&is_safe, path->ptr, owner_level) < 0)
+	if ((error = git_sysdir_find_programdata_file(path, GIT_CONFIG_FILENAME_PROGRAMDATA)) < 0)
+		return error;
+
+	if (git_fs_path_owner_is(&is_safe, path->ptr, owner_level) < 0)
 		return -1;
 
 	if (!is_safe) {

--- a/tests/libgit2/config/find.c
+++ b/tests/libgit2/config/find.c
@@ -1,0 +1,11 @@
+#include "clar_libgit2.h"
+
+void test_config_find__one(void)
+{
+	git_buf buf = GIT_BUF_INIT;
+
+	cl_git_fail_with(GIT_ENOTFOUND, git_config_find_global(&buf));
+	cl_git_fail_with(GIT_ENOTFOUND, git_config_find_xdg(&buf));
+	cl_git_fail_with(GIT_ENOTFOUND, git_config_find_system(&buf));
+	cl_git_fail_with(GIT_ENOTFOUND, git_config_find_programdata(&buf));
+}


### PR DESCRIPTION
When the programdata path is missing, ensure that we pass down the `GIT_ENOTFOUND` error to the caller instead of converting it to a generic `-1`.