### PR TITLE
Fix missing oid type for "fake" repositories

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -1152,6 +1152,8 @@ int git_repository_wrap_odb(git_repository **repo_out, git_odb *odb)
 	repo = repository_alloc();
 	GIT_ERROR_CHECK_ALLOC(repo);
 
+	repo->oid_type = GIT_OID_DEFAULT;
+
 	git_repository_set_odb(repo, odb);
 	*repo_out = repo;
 


### PR DESCRIPTION
... otherwise git_tree__parse_raw() will fail to obtain the correct oid size, which causes the entire parse to fail.

Fixes issue https://github.com/libgit2/libgit2/issues/6553.