### PR TITLE
util: detect all possible qsort_r and qsort_s variants

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,15 +58,29 @@ add_feature_info(futimens GIT_USE_FUTIMENS "futimens support")
 
 # qsort
 
+# old-style FreeBSD qsort_r() has the 'context' parameter as the first argument
+# of the comparison function:
 check_prototype_definition(qsort_r
-	"void qsort_r(void *base, size_t nmemb, size_t size, void *thunk, int (*compar)(void *, const void *, const void *))"
+	"void (qsort_r)(void *base, size_t nmemb, size_t size, void *context, int (*compar)(void *, const void *, const void *))"
 	"" "stdlib.h" GIT_QSORT_R_BSD)
 
+# GNU or POSIX qsort_r() has the 'context' parameter as the last argument of the
+# comparison function:
 check_prototype_definition(qsort_r
-	"void qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *, void *), void *arg)"
+	"void (qsort_r)(void *base, size_t nmemb, size_t size, int (*compar)(const void *, const void *, void *), void *context)"
 	"" "stdlib.h" GIT_QSORT_R_GNU)
 
-check_function_exists(qsort_s GIT_QSORT_S)
+# C11 qsort_s() has the 'context' parameter as the last argument of the
+# comparison function, and returns an error status:
+check_prototype_definition(qsort_s
+	"errno_t (qsort_s)(void *base, rsize_t nmemb, rsize_t size, int (*compar)(const void *, const void *, void *), void *context)"
+	"0" "stdlib.h" GIT_QSORT_S_C11)
+
+# MSC qsort_s() has the 'context' parameter as the first argument of the
+# comparison function, and as the last argument of qsort_s():
+check_prototype_definition(qsort_s
+	"void (qsort_s)(void *base, size_t num, size_t width, int (*compare )(void *, const void *, const void *), void *context)"
+	"" "stdlib.h" GIT_QSORT_S_MSC)
 
 # random / entropy data
 

--- a/src/util/git2_features.h.in
+++ b/src/util/git2_features.h.in
@@ -26,7 +26,8 @@
 
 #cmakedefine GIT_QSORT_R_BSD
 #cmakedefine GIT_QSORT_R_GNU
-#cmakedefine GIT_QSORT_S
+#cmakedefine GIT_QSORT_S_C11
+#cmakedefine GIT_QSORT_S_MSC
 
 #cmakedefine GIT_SSH 1
 #cmakedefine GIT_SSH_MEMORY_CREDENTIALS 1


### PR DESCRIPTION
As reported in https://bugs.freebsd.org/271234, recent versions of FreeBSD have adjusted the prototype for `qsort_r()` to match the POSIX interface. This causes libgit2's CMake configuration check to fail to detect `qsort_r()`, making it fall back to `qsort_s()`, which in libgit2 also has an incompatible interface. With recent versions of clang this results in a "incompatible function pointer types" compile error.

Summarizing, there are four variations of 'qsort-with-context':
* old style BSD `qsort_r()`, used in FreeBSD 13 and earlier, where the comparison function has the context parameter first
* GNU or POSIX `qsort_r()`, also used in FreeBSD 14 and later, where the comparison function has the context parameter last
* C11 `qsort_s()`, where the comparison function has the context parameter last
* Microsoft `qsort_s()`, where the comparison function has the context parameter first

Add explicit detections for all these variants, so they get detected as (in the same order as above):

* `GIT_QSORT_R_BSD`
* `GIT_QSORT_R_GNU`
* `GIT_QSORT_S_C11`
* `GIT_QSORT_S_MSC`

An additional complication is that on FreeBSD 14 and later, `<stdlib.h>` uses the C11 `_Generic()` macro mechanism to automatically select the correct `qsort_r()` prototype, depending on the caller's comparison function argument. This breaks CMake's `check_prototype_definition()` functionality, since it tries to redefine the function, and the _Generic macro is expanded inline causing a compile error.

Work around that problem by putting the function names in parentheses, to prevent the preprocessor from using a macro to replace the function name.
