### PR TITLE
remote: add update_refs with git_refspec

### DIFF
--- a/tests/libgit2/online/clone.c
+++ b/tests/libgit2/online/clone.c
@@ -319,10 +319,10 @@ void test_online_clone__clone_mirror(void)
 	cl_fixture_cleanup("./foo.git");
 }
 
-static int update_tips(const char *refname, const git_oid *a, const git_oid *b, void *payload)
+static int update_refs(const char *refname, const git_oid *a, const git_oid *b, git_refspec *spec, void *payload)
 {
 	int *callcount = (int*)payload;
-	GIT_UNUSED(refname); GIT_UNUSED(a); GIT_UNUSED(b);
+	GIT_UNUSED(refname); GIT_UNUSED(a); GIT_UNUSED(b); GIT_UNUSED(spec);
 	*callcount = *callcount + 1;
 	return 0;
 }
@@ -331,7 +331,7 @@ void test_online_clone__custom_remote_callbacks(void)
 {
 	int callcount = 0;
 
-	g_options.fetch_opts.callbacks.update_tips = update_tips;
+	g_options.fetch_opts.callbacks.update_refs = update_refs;
 	g_options.fetch_opts.callbacks.payload = &callcount;
 
 	cl_git_pass(git_clone(&g_repo, LIVE_REPO_URL, "./foo", &g_options));

--- a/tests/libgit2/online/fetch.c
+++ b/tests/libgit2/online/fetch.c
@@ -39,9 +39,13 @@ void test_online_fetch__cleanup(void)
 	git__free(_remote_redirect_subsequent);
 }
 
-static int update_tips(const char *refname, const git_oid *a, const git_oid *b, void *data)
+static int update_refs(const char *refname, const git_oid *a, const git_oid *b, git_refspec *spec, void *data)
 {
-	GIT_UNUSED(refname); GIT_UNUSED(a); GIT_UNUSED(b); GIT_UNUSED(data);
+	GIT_UNUSED(refname);
+	GIT_UNUSED(a);
+	GIT_UNUSED(b);
+	GIT_UNUSED(spec);
+	GIT_UNUSED(data);
 
 	++counter;
 
@@ -62,7 +66,7 @@ static void do_fetch(const char *url, git_remote_autotag_option_t flag, int n)
 	size_t bytes_received = 0;
 
 	options.callbacks.transfer_progress = progress;
-	options.callbacks.update_tips = update_tips;
+	options.callbacks.update_refs = update_refs;
 	options.callbacks.payload = &bytes_received;
 	options.download_tags = flag;
 	counter = 0;
@@ -163,7 +167,7 @@ void test_online_fetch__doesnt_retrieve_a_pack_when_the_repository_is_up_to_date
 
 	options.callbacks.transfer_progress = &transferProgressCallback;
 	options.callbacks.payload = &invoked;
-	options.callbacks.update_tips = update_tips;
+	options.callbacks.update_refs = update_refs;
 	cl_git_pass(git_remote_download(remote, NULL, &options));
 
 	cl_assert_equal_i(false, invoked);
@@ -201,7 +205,7 @@ void test_online_fetch__report_unchanged_tips(void)
 
 	options.callbacks.transfer_progress = &transferProgressCallback;
 	options.callbacks.payload = &invoked;
-	options.callbacks.update_tips = update_tips;
+	options.callbacks.update_refs = update_refs;
 	cl_git_pass(git_remote_download(remote, NULL, &options));
 
 	cl_assert_equal_i(false, invoked);

--- a/tests/libgit2/online/push_util.c
+++ b/tests/libgit2/online/push_util.c
@@ -35,10 +35,12 @@ void record_callbacks_data_clear(record_callbacks_data *data)
 	data->transfer_progress_calls = 0;
 }
 
-int record_update_tips_cb(const char *refname, const git_oid *a, const git_oid *b, void *data)
+int record_update_refs_cb(const char *refname, const git_oid *a, const git_oid *b, git_refspec *spec, void *data)
 {
 	updated_tip *t;
 	record_callbacks_data *record_data = (record_callbacks_data *)data;
+
+	GIT_UNUSED(spec);
 
 	cl_assert(t = git__calloc(1, sizeof(*t)));
 

--- a/tests/libgit2/online/push_util.h
+++ b/tests/libgit2/online/push_util.h
@@ -12,7 +12,7 @@ extern const git_oid OID_ZERO;
  * @param data pointer to a record_callbacks_data instance
  */
 #define RECORD_CALLBACKS_INIT(data) \
-	{ GIT_REMOTE_CALLBACKS_VERSION, NULL, NULL, cred_acquire_cb, NULL, NULL, record_update_tips_cb, NULL, NULL, NULL, NULL, NULL, NULL, data, NULL }
+	{ GIT_REMOTE_CALLBACKS_VERSION, NULL, NULL, cred_acquire_cb, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, data, NULL, record_update_refs_cb }
 
 typedef struct {
 	char *name;
@@ -50,7 +50,7 @@ void record_callbacks_data_clear(record_callbacks_data *data);
  *
  * @param data (git_vector *) of updated_tip instances
  */
-int record_update_tips_cb(const char *refname, const git_oid *a, const git_oid *b, void *data);
+int record_update_refs_cb(const char *refname, const git_oid *a, const git_oid *b, git_refspec *spec, void *data);
 
 /**
  * Create a set of refspecs that deletes each of the inputs

--- a/tests/libgit2/submodule/update.c
+++ b/tests/libgit2/submodule/update.c
@@ -30,7 +30,7 @@ void test_submodule_update__uninitialized_submodule_no_init(void)
 }
 
 struct update_submodule_cb_payload {
-	int update_tips_called;
+	int update_refs_called;
 	int checkout_progress_called;
 	int checkout_notify_called;
 };
@@ -71,15 +71,16 @@ static int checkout_notify_cb(
 	return 0;
 }
 
-static int update_tips(const char *refname, const git_oid *a, const git_oid *b, void *data)
+static int update_refs(const char *refname, const git_oid *a, const git_oid *b, git_refspec *spec, void *data)
 {
 	struct update_submodule_cb_payload *update_payload = data;
 
 	GIT_UNUSED(refname);
 	GIT_UNUSED(a);
 	GIT_UNUSED(b);
+	GIT_UNUSED(spec);
 
-	update_payload->update_tips_called = 1;
+	update_payload->update_refs_called = 1;
 
 	return 1;
 }
@@ -96,7 +97,7 @@ void test_submodule_update__update_submodule(void)
 	update_options.checkout_opts.progress_cb = checkout_progress_cb;
 	update_options.checkout_opts.progress_payload = &update_payload;
 
-	update_options.fetch_opts.callbacks.update_tips = update_tips;
+	update_options.fetch_opts.callbacks.update_refs = update_refs;
 	update_options.fetch_opts.callbacks.payload = &update_payload;
 
 	/* get the submodule */
@@ -126,7 +127,7 @@ void test_submodule_update__update_submodule(void)
 
 	/* verify that the expected callbacks have been called. */
 	cl_assert_equal_i(1, update_payload.checkout_progress_called);
-	cl_assert_equal_i(1, update_payload.update_tips_called);
+	cl_assert_equal_i(1, update_payload.update_refs_called);
 
 	git_submodule_free(sm);
 }
@@ -143,7 +144,7 @@ void test_submodule_update__update_submodule_with_path(void)
 	update_options.checkout_opts.progress_cb = checkout_progress_cb;
 	update_options.checkout_opts.progress_payload = &update_payload;
 
-	update_options.fetch_opts.callbacks.update_tips = update_tips;
+	update_options.fetch_opts.callbacks.update_refs = update_refs;
 	update_options.fetch_opts.callbacks.payload = &update_payload;
 
 	/* get the submodule */
@@ -173,7 +174,7 @@ void test_submodule_update__update_submodule_with_path(void)
 
 	/* verify that the expected callbacks have been called. */
 	cl_assert_equal_i(1, update_payload.checkout_progress_called);
-	cl_assert_equal_i(1, update_payload.update_tips_called);
+	cl_assert_equal_i(1, update_payload.update_refs_called);
 
 	git_submodule_free(sm);
 }


### PR DESCRIPTION
`git` shows the _remote_ and _local_ ref information during a fetch. For example:

```
 * [new branch]          ethomson/nonblocking   -> origin/ethomson/nonblocking
```

This is not information that users of libgit2 can currently surface since our `update_tips` callback includes only src/dest OIDs, and the _local_ ref name. Nor can one reliably reverse engineer the remote branch name, since a remote configuration could map two remote specs to a local spec. For example:

```
        fetch = +refs/pull/*/head:refs/remotes/asdf/*
        fetch = +refs/heads/*:refs/remotes/asdf/*
```

In this case, given `refs/remotes/asdf/foo` in the `update_tips`, a caller would have no idea whether the remote was `refs/pull/foo/head` or `refs/heads/foo`.

Provide the matching remote `git_refspec` so that callers can `rtransform` themselves into the remote.