### PR TITLE
midx: allow unknown chunk ids in multi-pack index files

### DIFF
--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -185,7 +185,8 @@ int git_midx_parse(
 					 chunk_oid_fanout = {0},
 					 chunk_oid_lookup = {0},
 					 chunk_object_offsets = {0},
-					 chunk_object_large_offsets = {0};
+					 chunk_object_large_offsets = {0},
+					 chunk_unknown = {0};
 
 	GIT_ASSERT_ARG(idx);
 
@@ -264,7 +265,9 @@ int git_midx_parse(
 			break;
 
 		default:
-			return midx_error("unrecognized chunk ID");
+			chunk_unknown.offset = last_chunk_offset;
+			last_chunk = &chunk_unknown;
+			break;
 		}
 	}
 	last_chunk->length = (size_t)(trailer_offset - last_chunk_offset);


### PR DESCRIPTION
These chunks work like extensions where it's fine not to know what one means. We can skip over it and keep processing the file instead of erroring out.

---

I think there's probably a different bug here as well where erroring out of the midx means we don't really keep looking, as the bug I found here is that having a midx with REIDX, aka reverse index meant that we couldn't find an object, but IIUC we should have been able to fall back on to the per-pack index there.