### PR TITLE
pack: cast the number of objects to size_t

### DIFF
--- a/src/libgit2/pack.c
+++ b/src/libgit2/pack.c
@@ -1268,13 +1268,13 @@ static off64_t nth_packed_object_offset_locked(struct git_pack_file *p, uint32_t
 	end = index + p->index_map.len;
 	index += 4 * 256;
 	if (p->index_version == 1)
-		return ntohl(*((uint32_t *)(index + (p->oid_size + 4) * n)));
+		return ntohl(*((uint32_t *)(index + (p->oid_size + 4) * (size_t) n)));
 
-	index += 8 + p->num_objects * (p->oid_size + 4);
+	index += 8 + (size_t) p->num_objects * (p->oid_size + 4);
 	off32 = ntohl(*((uint32_t *)(index + 4 * n)));
 	if (!(off32 & 0x80000000))
 		return off32;
-	index += p->num_objects * 4 + (off32 & 0x7fffffff) * 8;
+	index += (size_t) p->num_objects * 4 + (off32 & 0x7fffffff) * 8;
 
 	/* Make sure we're not being sent out of bounds */
 	if (index >= end - 8)


### PR DESCRIPTION
Similar to a previous change where we had to change the casting when loading the index file, we also need to make sure we don't restrict the numbers to 32-bit when looking up objects in packfiles.

This was done about three years ago in git itself, but we never got he update in this library.

---

This is the potential bug I mention in #6583 where failing to parse the multi-pack index we then failed to parse the regular index as well. This is what git did in https://github.com/git/git/commit/f86f769550ef7fb5162a9cd4be5e2be7981d063b