### PR TITLE
midx: do not try to look at every object in the index

### DIFF
--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -114,8 +114,6 @@ static int midx_parse_oid_lookup(
 		const unsigned char *data,
 		struct git_midx_chunk *chunk_oid_lookup)
 {
-	uint32_t i;
-	unsigned char *oid, *prev_oid, zero_oid[GIT_OID_MAX_SIZE] = {0};
 	size_t oid_size = git_oid_size(idx->oid_type);
 
 	if (chunk_oid_lookup->offset == 0)
@@ -125,13 +123,7 @@ static int midx_parse_oid_lookup(
 	if (chunk_oid_lookup->length != idx->num_objects * oid_size)
 		return midx_error("OID Lookup chunk has wrong length");
 
-	idx->oid_lookup = oid = (unsigned char *)(data + chunk_oid_lookup->offset);
-	prev_oid = zero_oid;
-	for (i = 0; i < idx->num_objects; ++i, oid += oid_size) {
-		if (git_oid_raw_cmp(prev_oid, oid, oid_size) >= 0)
-			return midx_error("OID Lookup index is non-monotonic");
-		prev_oid = oid;
-	}
+	idx->oid_lookup = (unsigned char *)(data + chunk_oid_lookup->offset);
 
 	return 0;
 }


### PR DESCRIPTION
Similar to previous issues around doing way too much verification at loading time, checking whether the object index chunk is monotonic is better left for git-fsck instead of every single time we want to look at something in the repository.

As midx files grow, this starts taking more and more times. As an example, I went looking for this because it's taking about 1.5s to do a single object lookup in a repository that's ended up with a 7G multi-pack-index file.

----

For comparison without this loop we're down to 40ms. There's another loop for the fanout that I've left since `perf` didn't show pretty much any of `git2 cat-file` and it's not that terrible to have a little bit of checking to see that we didn't load complete nonsense.