### PR TITLE
ssh: fix known_hosts leak in _git_ssh_setup_conn

### DIFF
--- a/src/libgit2/transports/ssh.c
+++ b/src/libgit2/transports/ssh.c
@@ -877,11 +877,12 @@ static int _git_ssh_setup_conn(
 	t->current_stream = s;
 
 done:
+	if (known_hosts)
+		libssh2_knownhost_free(known_hosts);
+
 	if (error < 0) {
 		ssh_stream_free(*stream);
 
-		if (known_hosts)
-			libssh2_knownhost_free(known_hosts);
 		if (session)
 			libssh2_session_free(session);
 	}


### PR DESCRIPTION
In _git_ssh_setup_conn, known_hosts is allocated by _git_ssh_session_create. However, known_hosts is only cleaned up in the case of error.

This moves the cleanup code for known_hosts so that its run in the error an success case.

Fixes #6598