### PR TITLE
repository: make cleanup safe for re-use with grafts

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -153,7 +153,9 @@ int git_repository__cleanup(git_repository *repo)
 	git_cache_clear(&repo->objects);
 	git_attr_cache_flush(repo);
 	git_grafts_free(repo->grafts);
+	repo->grafts = NULL;
 	git_grafts_free(repo->shallow_grafts);
+	repo->shallow_grafts = NULL;
 
 	set_config(repo, NULL);
 	set_index(repo, NULL);


### PR DESCRIPTION
We are allowed to call `git_repository__cleanup` multiple times, and this happens e.g. in rugged if we want to free up resources before GC gets around to them.

This means that we cannot leave dangling pointers in it, which we were doing with the grafts. Fix this by setting the pointers to NULL after freeing the resources.

---

I discovered this while working on libgit2/rugged#964 trying to update the bindings.