### PR TITLE
fix: Add missing include for oidarray.

### DIFF
--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -9,6 +9,7 @@
 #define INCLUDE_sys_git_transport_h
 
 #include "git2/net.h"
+#include "git2/oidarray.h"
 #include "git2/proxy.h"
 #include "git2/remote.h"
 #include "git2/strarray.h"


### PR DESCRIPTION
Add a missing include for `git2/oidarray.h` so build doesn't fail on using `git_oidarray` when using custom transports.

Fixes #6607