### PR TITLE
stransport: macOS: replace errSSLNetworkTimeout, with hard-coded value

### DIFF
--- a/src/libgit2/streams/stransport.c
+++ b/src/libgit2/streams/stransport.c
@@ -162,7 +162,7 @@ static OSStatus write_cb(SSLConnectionRef conn, const void *data, size_t *len)
 	if (ret < 0) {
 		st->error = ret;
 		return (ret == GIT_TIMEOUT) ?
-		       errSSLNetworkTimeout :
+		       -9853 /* errSSLNetworkTimeout */:
 		       -36 /* ioErr */;
 	}
 
@@ -214,7 +214,7 @@ static OSStatus read_cb(SSLConnectionRef conn, void *data, size_t *len)
 		if (ret < 0) {
 			st->error = ret;
 			error = (ret == GIT_TIMEOUT) ?
-			        errSSLNetworkTimeout :
+			        -9853 /* errSSLNetworkTimeout */:
 			        -36 /* ioErr */;
 			break;
 		} else if (ret == 0) {


### PR DESCRIPTION
- Constant only available in 10.13+, causing build failures for older macOS releases
- Fixes: [Issue 6606 - Use of macOS constant errSSLNetworkTimeout causes build failures for macOS 10.8 thru 10.12](https://github.com/libgit2/libgit2/issues/6606)