### PR TITLE
Removed Content-Type checks

### DIFF
--- a/src/libgit2/transports/http.c
+++ b/src/libgit2/transports/http.c
@@ -284,17 +284,10 @@ static int handle_response(
 		return -1;
 	}
 
-	/* The response must contain a Content-Type header. */
-	if (!response->content_type) {
-		git_error_set(GIT_ERROR_HTTP, "no content-type header in response");
-		return -1;
-	}
-
-	/* The Content-Type header must match our expectation. */
-	if (strcmp(response->content_type, stream->service->response_type) != 0) {
-		git_error_set(GIT_ERROR_HTTP, "invalid content-type: '%s'", response->content_type);
-		return -1;
-	}
+	/* 
+	 * Here were Context-Type related checks, that were too restrict.
+	 * Somewhere in the year 2025 can this reminder be removed.
+	 */
 
 	*complete = true;
 	stream->state = HTTP_STATE_RECEIVING_RESPONSE;


### PR DESCRIPTION
git doesn't enforce them, now neither do we.

Git commit hashes, date, line number and content of the removed lines:
  $ git blame src/libgit2/transports/http.c | sed --silent -e 287,297p | cut -b 1-11,42,64-73,89-
  b9c5b15a79 (2019-12-22 287) 	/* The response must contain a Content-Type header. */
  b9c5b15a79 (2019-12-22 288) 	if (!response->content_type) {
  e9cef7c4b1 (2020-01-11 289) 		git_error_set(GIT_ERROR_HTTP, "no content-type header in response");
  b9c5b15a79 (2019-12-22 290) 		return -1;
  ce72ae9527 (2019-03-22 291) 	}
  5d4e1e040f (2018-10-28 292)
  b9c5b15a79 (2019-12-22 293) 	/* The Content-Type header must match our expectation. */
  b9c5b15a79 (2019-12-22 294) 	if (strcmp(response->content_type, stream->service->response_type) != 0) {
  e9cef7c4b1 (2020-01-11 295) 		git_error_set(GIT_ERROR_HTTP, "invalid content-type: '%s'", response->content_type);
  b9c5b15a79 (2019-12-22 296) 		return -1;
  5d4e1e040f (2018-10-28 297) 	}
  $