### PR TITLE
git_diff_find_similar doesn't always remove unmodified deltas

### DIFF
--- a/src/libgit2/diff_tform.c
+++ b/src/libgit2/diff_tform.c
@@ -718,8 +718,15 @@ static bool is_rename_source(
 	git_diff_delta *delta = GIT_VECTOR_GET(&diff->deltas, delta_idx);
 
 	/* skip things that aren't blobs */
-	if (!GIT_MODE_ISBLOB(delta->old_file.mode))
+	if (!GIT_MODE_ISBLOB(delta->old_file.mode)) {
+
+		/* but still honor "remove unmodified" flag */
+		if (delta->status == GIT_DELTA_UNMODIFIED &&
+			FLAG_SET(opts, GIT_DIFF_FIND_REMOVE_UNMODIFIED))
+			delta->flags |= GIT_DIFF_FLAG__TO_DELETE;
+
 		return false;
+	}
 
 	switch (delta->status) {
 	case GIT_DELTA_ADDED:

--- a/tests/libgit2/diff/rename.c
+++ b/tests/libgit2/diff/rename.c
@@ -1441,6 +1441,47 @@ void test_diff_rename__can_delete_unmodified_deltas(void)
 	git_str_dispose(&c1);
 }
 
+void test_diff_rename__can_delete_unmodified_deltas_without_changes(void)
+{
+	git_str c1 = GIT_STR_INIT;
+	git_index *index;
+	git_tree *tree;
+	git_diff *diff;
+	git_diff_options diffopts = GIT_DIFF_OPTIONS_INIT;
+	git_diff_find_options opts = GIT_DIFF_FIND_OPTIONS_INIT;
+	diff_expects exp;
+
+	cl_git_pass(
+		git_revparse_single((git_object **)&tree, g_repo, "HEAD^{tree}"));
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_read_tree(index, tree));
+
+	diffopts.flags = GIT_DIFF_INCLUDE_UNMODIFIED;
+
+	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, tree, index, &diffopts));
+
+	memset(&exp, 0, sizeof(exp));
+	cl_git_pass(git_diff_foreach(
+		diff, diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &exp));
+	cl_assert_equal_i(4, exp.files);
+	cl_assert_equal_i(4, exp.file_status[GIT_DELTA_UNMODIFIED]);
+
+	opts.flags = GIT_DIFF_FIND_ALL | GIT_DIFF_FIND_REMOVE_UNMODIFIED;
+	cl_git_pass(git_diff_find_similar(diff, &opts));
+
+	memset(&exp, 0, sizeof(exp));
+	cl_git_pass(git_diff_foreach(
+		diff, diff_file_cb, diff_binary_cb, diff_hunk_cb, diff_line_cb, &exp));
+	cl_assert_equal_i(0, exp.files);
+
+	git_diff_free(diff);
+	git_tree_free(tree);
+	git_index_free(index);
+
+	git_str_dispose(&c1);
+}
+
 void test_diff_rename__matches_config_behavior(void)
 {
 	const char *sha0 = INITIAL_COMMIT;


### PR DESCRIPTION
Unmodified deltas are not always removed by git_diff_find_similar() when GIT_DIFF_FIND_REMOVE_UNMODIFIED is set. It only works correctly when a rename or copy is found in the diff. Somewhat understandably, this is the only case covered by the unit tests.

Non-blob deltas also avoid removal because of the way they are excluded as rename candidates. I've added a test for this using the "submodules" fixture. Maybe there's a simpler way to test for non-blob deltas?