### PR TITLE
repository: Return EOWNER when repository permission validation fails

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -680,6 +680,7 @@ static int validate_ownership(git_repository *repo)
 			&is_safe, validation_paths[0], repo->use_env)) < 0)
 		goto done;
 
+done:
 	if (!is_safe) {
 		git_error_set(GIT_ERROR_CONFIG,
 			"repository path '%s' is not owned by current user",
@@ -687,7 +688,6 @@ static int validate_ownership(git_repository *repo)
 		error = GIT_EOWNER;
 	}
 
-done:
 	return error;
 }
 


### PR DESCRIPTION
Should prevent libgit claiming that repository does not exist when it does.

:~> git ls-remote /srv/git/kernel-source.git | head -n3
41037b9c54949ab7df9d32e8bc753c059b27c66c        HEAD
7a68c4c0c640ac07b89722271f866287b9047459        refs/heads/ALP-current
4993d1b0a96a0fa7fb0e87d3b1725bc775162283        refs/heads/ALP-current-RT
:~> python3
Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pygit2
>>> pygit2.Repository("/srv/git/kernel-source.git")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.6/site-packages/pygit2/repository.py", line 1498, in __init__
    path_backend = init_file_backend(path, flags)
_pygit2.GitError: Repository not found at /srv/git/kernel-source.git
>>>

TBD: tests