### PR TITLE
Fix handling of paths with white spaces on diff parsing

### DIFF
--- a/tests/libgit2/diff/parse.c
+++ b/tests/libgit2/diff/parse.c
@@ -422,8 +422,8 @@ void test_diff_parse__new_file_with_space(void)
 	cl_git_pass(diff_from_buffer(&diff, content, strlen(content)));
 	cl_git_pass(git_patch_from_diff((git_patch **) &patch, diff, 0));
 
-	cl_assert_equal_p(patch->diff_opts.old_prefix, NULL);
-	cl_assert_equal_p(patch->delta->old_file.path, NULL);
+	cl_assert_equal_s(patch->diff_opts.old_prefix, "a/");
+	cl_assert_equal_s(patch->delta->old_file.path, "sp ace.txt");
 	cl_assert_equal_s(patch->diff_opts.new_prefix, "b/");
 	cl_assert_equal_s(patch->delta->new_file.path, "sp ace.txt");
 
@@ -470,6 +470,31 @@ void test_diff_parse__crlf(void)
 
 	cl_assert_equal_s(delta->old_file.path, "test-file");
 	cl_assert_equal_s(delta->new_file.path, "test-file");
+
+	git_patch_free(patch);
+	git_diff_free(diff);
+}
+
+void test_diff_parse__delete_file_with_space(void)
+{
+	const char *text = "diff --git a/x y.xml b/x y.xml\n"
+	"deleted file mode 100644\n"
+	"index 48a7354..0000000\n"
+	"--- a/x y.xml\n"
+	"+++ /dev/null\n"
+	"@@ -1,1 +0,0 @@\n"
+	"-x\n";
+
+	git_diff *diff;
+	git_patch *patch;
+	const git_diff_delta *delta;
+
+	cl_git_pass(diff_from_buffer(&diff, text, strlen(text)));
+	cl_git_pass(git_patch_from_diff(&patch, diff, 0));
+	delta = git_patch_get_delta(patch);
+
+	cl_assert_equal_s(delta->old_file.path, "x y.xml");
+	cl_assert_equal_s(delta->new_file.path, "x y.xml");
 
 	git_patch_free(patch);
 	git_diff_free(diff);


### PR DESCRIPTION
## Context

While I was using [pygit2](https://github.com/libgit2/pygit2) I got a _segmentation fault_ when trying to use [`pygit2.Repository.apply`](https://www.pygit2.org/repository.html#pygit2.Repository.apply) with a diff obtained by using [`parse_diff`](https://www.pygit2.org/diff.html#pygit2.Diff.parse_diff). The diff contained a removal of a file with spaces on its path and the path was not quoted: 

`diff --git a/.run/Run IDE with Plugin.run.xml b/.run/Run IDE with Plugin.run.xml`

What I found was that when I transformed the diff obtained from [`parse_diff`](https://www.pygit2.org/diff.html#pygit2.Diff.parse_diff) back to a string, the previous line was changed to:

`diff --git a/.run/Run IDE with Plugin.run.xml /dev/null`

For some reason that I still don't fully understand, but that makes some sense to me, the `/dev/null` created a _segmentation fault_ on the apply. I looked into [pygit2](https://github.com/libgit2/pygit2) and found out that the problem probably was on `libgit2`.

## Changes

I was able to debug and find out that the function `header_path_len` was the culprit. Since previously this function stopped on a white space if the path is not quoted, then the header I gave as example would be incorrectly parsed. Given this, I changed the function so it only stops when it reaches ` b/` or ` "b/`. This still has a problem if a folder called ` b` (white space followed by b) or ` "b` is used but it seems pretty unlikely.

## Tests

I created a test for delete mode since a test for create mode already existed. However I found it weird that the tests expected that on create mode the result for the old file path was NULL. The reason I found it weird is that for "normal" paths, i.e. paths without spaces, the result was the path of the file instead of NULL. For this reason, I also changed the test for create mode to go accordingly with the behavior of "normal" paths.