### PR TITLE
Remove check for empty email or name

### DIFF
--- a/src/libgit2/signature.c
+++ b/src/libgit2/signature.c
@@ -90,11 +90,6 @@ int git_signature_new(git_signature **sig_out, const char *name, const char *ema
 	p->email = extract_trimmed(email, strlen(email));
 	GIT_ERROR_CHECK_ALLOC(p->email);
 
-	if (p->name[0] == '\0' || p->email[0] == '\0') {
-		git_signature_free(p);
-		return signature_error("Signature cannot have an empty name or email");
-	}
-
 	p->when.time = time;
 	p->when.offset = offset;
 	p->when.sign = (offset < 0) ? '-' : '+';


### PR DESCRIPTION
Some commits in public repos have no name or email and we cant re-create them with this check

	$ git clone https://github.com/ClickHouse/ClickHouse.git
	$ cd ClickHouse
	$ git cat-file -p 8b0d48f4789b8f54a19c25cecd9205e2ecca88e8
	$ git cat-file -p 54e7115ead8661bad33f8be879548270b4bdb400