### PR TITLE
Do not trim dots from usernames

### DIFF
--- a/src/libgit2/signature.c
+++ b/src/libgit2/signature.c
@@ -43,7 +43,6 @@ static bool contains_angle_brackets(const char *input)
 static bool is_crud(unsigned char c)
 {
 	return  c <= 32  ||
-		c == '.' ||
 		c == ',' ||
 		c == ':' ||
 		c == ';' ||

--- a/tests/libgit2/commit/signature.c
+++ b/tests/libgit2/commit/signature.c
@@ -39,7 +39,7 @@ void test_commit_signature__leading_and_trailing_spaces_are_trimmed(void)
 void test_commit_signature__leading_and_trailing_crud_is_trimmed(void)
 {
 	assert_name_and_email("nulltoken", "emeric.fermas@gmail.com", "\"nulltoken\"", "\"emeric.fermas@gmail.com\"");
-	assert_name_and_email("nulltoken w", "emeric.fermas@gmail.com", "nulltoken w.", "emeric.fermas@gmail.com");
+	assert_name_and_email("nulltoken w", "emeric.fermas@gmail.com", "nulltoken w;", "emeric.fermas@gmail.com");
 	assert_name_and_email("nulltoken \xe2\x98\xba", "emeric.fermas@gmail.com", "nulltoken \xe2\x98\xba", "emeric.fermas@gmail.com");
 }
 


### PR DESCRIPTION
`Sammy Davis Jr. Jr.` is a valid name and the dot shoud not be trimmed.

This makes libgit2 a bit more compatible with the git parsing.
See: https://github.com/git/git/blob/master/ident.c#L275