### PR TITLE
Do not include headers bearing OpenSSL copyrights by default

### DIFF
--- a/src/libgit2/streams/openssl.c
+++ b/src/libgit2/streams/openssl.c
@@ -6,8 +6,6 @@
  */
 
 #include "streams/openssl.h"
-#include "streams/openssl_legacy.h"
-#include "streams/openssl_dynamic.h"
 
 #ifdef GIT_OPENSSL
 

--- a/src/libgit2/streams/openssl.h
+++ b/src/libgit2/streams/openssl.h
@@ -8,8 +8,14 @@
 #define INCLUDE_streams_openssl_h__
 
 #include "common.h"
-#include "streams/openssl_legacy.h"
-#include "streams/openssl_dynamic.h"
+
+#if defined(GIT_OPENSSL_LEGACY)
+# include "streams/openssl_legacy.h"
+#endif
+
+#if defined(GIT_OPENSSL_DYNAMIC)
+# include "streams/openssl_dynamic.h"
+#endif
 
 #include "git2/sys/stream.h"
 

--- a/src/libgit2/streams/openssl_dynamic.c
+++ b/src/libgit2/streams/openssl_dynamic.c
@@ -6,7 +6,6 @@
  */
 
 #include "streams/openssl.h"
-#include "streams/openssl_dynamic.h"
 
 #if defined(GIT_OPENSSL) && defined(GIT_OPENSSL_DYNAMIC)
 

--- a/src/libgit2/streams/openssl_legacy.c
+++ b/src/libgit2/streams/openssl_legacy.c
@@ -6,7 +6,8 @@
  */
 
 #include "streams/openssl.h"
-#include "streams/openssl_legacy.h"
+
+#if defined(GIT_OPENSSL_LEGACY) || defined(GIT_OPENSSL_DYNAMIC)
 
 #include "runtime.h"
 #include "git2/sys/openssl.h"
@@ -17,8 +18,6 @@
 # include <openssl/x509v3.h>
 # include <openssl/bio.h>
 #endif
-
-#if defined(GIT_OPENSSL_LEGACY) || defined(GIT_OPENSSL_DYNAMIC)
 
 /*
  * OpenSSL 1.1 made BIO opaque so we have to use functions to interact with it


### PR DESCRIPTION
We use automatic license analysis and automatic source tracking when we import the code.

At the time license report for libgit2 is overcomplicated.
This PR reorganizes include schema in order to avoid #include-ing openssl_dynamic.h from default build.

It would be nice to add an option disabling `openssl_dynamic.c` and `openssl_legacy.c` compilation at all.

This is yet TBD.