### PR TITLE
util: suppress some uninitialized variable warnings

### DIFF
--- a/src/util/errors.c
+++ b/src/util/errors.c
@@ -376,6 +376,9 @@ void git_error_system_set(int code)
 /* Deprecated error values and functions */
 
 #ifndef GIT_DEPRECATE_HARD
+
+#include "git2/deprecated.h"
+
 const git_error *giterr_last(void)
 {
 	return git_error_last();

--- a/src/util/fs_path.c
+++ b/src/util/fs_path.c
@@ -1938,12 +1938,13 @@ static int sudo_uid_lookup(uid_t *out)
 {
 	git_str uid_str = GIT_STR_INIT;
 	int64_t uid;
-	int error;
+	int error = -1;
 
-	if ((error = git__getenv(&uid_str, "SUDO_UID")) == 0 &&
-	    (error = git__strntol64(&uid, uid_str.ptr, uid_str.size, NULL, 10)) == 0 &&
-	    uid == (int64_t)((uid_t)uid)) {
+	if (git__getenv(&uid_str, "SUDO_UID") == 0 &&
+		git__strntol64(&uid, uid_str.ptr, uid_str.size, NULL, 10) == 0 &&
+		uid == (int64_t)((uid_t)uid)) {
 		*out = (uid_t)uid;
+		error = 0;
 	}
 
 	git_str_dispose(&uid_str);

--- a/src/util/futils.h
+++ b/src/util/futils.h
@@ -25,7 +25,7 @@ extern int git_futils_readbuffer(git_str *obj, const char *path);
 extern int git_futils_readbuffer_updated(
 	git_str *obj,
 	const char *path,
-	unsigned char checksum[GIT_HASH_SHA1_SIZE],
+	unsigned char checksum[GIT_HASH_SHA256_SIZE],
 	int *updated);
 extern int git_futils_readbuffer_fd_full(git_str *obj, git_file fd);
 extern int git_futils_readbuffer_fd(git_str *obj, git_file fd, size_t len);

--- a/src/util/net.c
+++ b/src/util/net.c
@@ -657,7 +657,7 @@ static bool has_at(const char *str)
 int git_net_url_parse_scp(git_net_url *url, const char *given)
 {
 	const char *default_port = default_port_for_scheme("ssh");
-	const char *c, *user, *host, *port, *path = NULL;
+	const char *c, *user, *host, *port = NULL, *path = NULL;
 	size_t user_len = 0, host_len = 0, port_len = 0;
 	unsigned short bracket = 0;
 

--- a/src/util/regexp.c
+++ b/src/util/regexp.c
@@ -125,7 +125,7 @@ int git_regexp_search(const git_regexp *r, const char *string, size_t nmatches, 
 
 	if ((data = pcre2_match_data_create(nmatches, NULL)) == NULL) {
 		git_error_set_oom();
-		goto out;
+		return -1;
 	}
 
 	if ((error = pcre2_match(*r, (const unsigned char *) string, strlen(string),

--- a/src/util/unix/process.c
+++ b/src/util/unix/process.c
@@ -37,7 +37,7 @@ struct git_process {
 
 GIT_INLINE(bool) is_delete_env(const char *env)
 {
-	char *c = index(env, '=');
+	char *c = strchr(env, '=');
 
 	if (c == NULL)
 		return false;


### PR DESCRIPTION
A couple of warnings were uncovered in #6655
This should take care of the easy ones.

The larger problem is the ctype warnings where we have a bit of a mix between using the proper `isalnum()` and rolling our own with `git__isalnum()`
The posix versions take an integer in to be able to handle EOF from `fgetc()` so when a char is passed it has to be casted to unsigned so that 128-255 isn't extended to negative integers.
The `git__isalnum()` function takes care of it by simply not handling characters outside of the ascii set and will behave incorrectly on systems using ISO-8859-1 or other charsets using more than 7 bits.

I'm not entirely sure why we have the `git__isalnum()` functions. I assume it is to support systems where `ctype.h` isn't available?
In that case I think the current implementation should be used only when ctype doesn't exists.
There is also the thing where casting characters to unsigned everywhere is a bit tedious, so maybe we should change the functions to take an unsigned char in?