### PR TITLE
fetch: enable deepening/shortening shallow clones

### DIFF
--- a/src/libgit2/fetch.c
+++ b/src/libgit2/fetch.c
@@ -60,9 +60,11 @@ static int mark_local(git_remote *remote)
 
 	git_vector_foreach(&remote->refs, i, head) {
 		/* If we have the object, mark it so we don't ask for it.
-		   However if we are unshallowing, we need to ask for it
-		   even though the head exists locally. */
-		if (remote->nego.depth != INT_MAX && git_odb_exists(odb, &head->oid))
+		   However if we are unshallowing or changing history
+		   depth, we need to ask for it even though the head
+		   exists locally. */
+		if (remote->nego.depth == GIT_FETCH_DEPTH_FULL &&
+		    git_odb_exists(odb, &head->oid))
 			head->local = 1;
 		else
 			remote->need_pack = 1;


### PR DESCRIPTION
A shallow repository can currently only be completely unshallowed, which is caused by mark_local() only marking locally-existing objects as wanted if the fetch depth is set to `INT_MAX` (`GIT_FETCH_DEPTH_UNSHALLOW`). This prevents deepening the history of a shallow clone to an arbitrary number of commits, which may be preferable over full unshallowing for large repositories.

Enable deepening and shortening shallow clones by marking locally-existing objects as wanted whenever the fetch depth is set to any non-default value (either `GIT_FETCH_DEPTH_UNSHALLOW` or an arbitrary positive integer).