### PR TITLE
Avoid macro redefinition of ENABLE_INTSAFE_SIGNED_FUNCTIONS

### DIFF
--- a/src/util/integer.h
+++ b/src/util/integer.h
@@ -89,7 +89,9 @@ GIT_INLINE(int) git__is_int(int64_t p)
 /* Use Microsoft's safe integer handling functions where available */
 #elif defined(_MSC_VER)
 
-# define ENABLE_INTSAFE_SIGNED_FUNCTIONS
+# if !defined(ENABLE_INTSAFE_SIGNED_FUNCTIONS)
+#  define ENABLE_INTSAFE_SIGNED_FUNCTIONS
+# endif
 # include <intsafe.h>
 
 # define git__add_sizet_overflow(out, one, two) \


### PR DESCRIPTION
In some projects ENABLE_INTSAFE_SIGNED_FUNCTIONS might already be defined...