### PR TITLE
Do not normalize safe.directory paths

### DIFF
--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -555,6 +555,25 @@ void test_repo_open__can_allowlist_dirs_with_problematic_ownership(void)
 
 	git_str_joinpath(&config_filename, config_path.ptr, ".gitconfig");
 
+	// Test with incorrect exception (slash at the end)
+	git_str_printf(&config_data,
+		"[foo]\n" \
+		"\tbar = Foobar\n" \
+		"\tbaz = Baz!\n" \
+		"[safe]\n" \
+		"\tdirectory = /non/existent/path\n" \
+		"\tdirectory = /\n" \
+		"\tdirectory = c:\\\\temp\n" \
+		"\tdirectory = %s/%s/\n" \
+		"\tdirectory = /tmp\n" \
+		"[bar]\n" \
+		"\tfoo = barfoo\n",
+		clar_sandbox_path(), "empty_standard_repo");
+	cl_git_rewritefile(config_filename.ptr, config_data.ptr);
+	cl_git_fail_with(GIT_EOWNER, git_repository_open(&repo, "empty_standard_repo"));
+
+	// Test with correct exception
+	git_str_clear(&config_data);
 	git_str_printf(&config_data,
 		"[foo]\n" \
 		"\tbar = Foobar\n" \


### PR DESCRIPTION
Vanilla Git does not do it either (cf. https://github.com/gitster/git/blob/master/setup.c#L1150) and calling git_fs_path_prettify_dir can cause performance issues (cf. issue #6649).

Still needed: expansion of "~/"... (but not this PR)