### PR TITLE
Make xdiff independent from regexp.h

### DIFF
--- a/deps/xdiff/git-xdiff.h
+++ b/deps/xdiff/git-xdiff.h
@@ -14,7 +14,11 @@
 #ifndef INCLUDE_git_xdiff_h__
 #define INCLUDE_git_xdiff_h__
 
-#include "regexp.h"
+#include "git2_util.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stddef.h>
 
 /* Work around C90-conformance issues */
 #if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
@@ -35,22 +39,5 @@
 #define xdl_realloc(ptr, x) git__realloc(ptr, x)
 
 #define XDL_BUG(msg) GIT_ASSERT(!msg)
-
-#define xdl_regex_t git_regexp
-#define xdl_regmatch_t git_regmatch
-
-GIT_INLINE(int) xdl_regexec_buf(
-	const xdl_regex_t *preg, const char *buf, size_t size,
-	size_t nmatch, xdl_regmatch_t pmatch[], int eflags)
-{
-	GIT_UNUSED(preg);
-	GIT_UNUSED(buf);
-	GIT_UNUSED(size);
-	GIT_UNUSED(nmatch);
-	GIT_UNUSED(pmatch);
-	GIT_UNUSED(eflags);
-	GIT_ASSERT("not implemented");
-	return -1;
-}
 
 #endif

--- a/deps/xdiff/xdiff.h
+++ b/deps/xdiff/xdiff.h
@@ -83,10 +83,6 @@ typedef struct s_mmbuffer {
 typedef struct s_xpparam {
 	unsigned long flags;
 
-	/* -I<regex> */
-	xdl_regex_t **ignore_regex;
-	size_t ignore_regex_nr;
-
 	/* See Documentation/diff-options.txt. */
 	char **anchors;
 	size_t anchors_nr;

--- a/deps/xdiff/xdiffi.c
+++ b/deps/xdiff/xdiffi.c
@@ -1011,46 +1011,6 @@ static void xdl_mark_ignorable_lines(xdchange_t *xscr, xdfenv_t *xe, long flags)
 	}
 }
 
-static int record_matches_regex(xrecord_t *rec, xpparam_t const *xpp) {
-	xdl_regmatch_t regmatch;
-	int i;
-
-	for (i = 0; i < xpp->ignore_regex_nr; i++)
-		if (!xdl_regexec_buf(xpp->ignore_regex[i], rec->ptr, rec->size, 1,
-				 &regmatch, 0))
-			return 1;
-
-	return 0;
-}
-
-static void xdl_mark_ignorable_regex(xdchange_t *xscr, const xdfenv_t *xe,
-				     xpparam_t const *xpp)
-{
-	xdchange_t *xch;
-
-	for (xch = xscr; xch; xch = xch->next) {
-		xrecord_t **rec;
-		int ignore = 1;
-		long i;
-
-		/*
-		 * Do not override --ignore-blank-lines.
-		 */
-		if (xch->ignore)
-			continue;
-
-		rec = &xe->xdf1.recs[xch->i1];
-		for (i = 0; i < xch->chg1 && ignore; i++)
-			ignore = record_matches_regex(rec[i], xpp);
-
-		rec = &xe->xdf2.recs[xch->i2];
-		for (i = 0; i < xch->chg2 && ignore; i++)
-			ignore = record_matches_regex(rec[i], xpp);
-
-		xch->ignore = ignore;
-	}
-}
-
 int xdl_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	     xdemitconf_t const *xecfg, xdemitcb_t *ecb) {
 	xdchange_t *xscr;
@@ -1071,9 +1031,6 @@ int xdl_diff(mmfile_t *mf1, mmfile_t *mf2, xpparam_t const *xpp,
 	if (xscr) {
 		if (xpp->flags & XDF_IGNORE_BLANK_LINES)
 			xdl_mark_ignorable_lines(xscr, &xe, xpp->flags);
-
-		if (xpp->ignore_regex)
-			xdl_mark_ignorable_regex(xscr, &xe, xpp);
 
 		if (ef(&xe, xscr, ecb, xecfg) < 0) {
 


### PR DESCRIPTION
I will backport these to libgit2/xdiff later on.