### PR TITLE
Support setting oid type for in-memory repositories

### DIFF
--- a/include/git2/sys/repository.h
+++ b/include/git2/sys/repository.h
@@ -9,6 +9,7 @@
 
 #include "git2/common.h"
 #include "git2/types.h"
+#include "git2/oid.h"
 
 /**
  * @file git2/sys/repository.h
@@ -32,7 +33,11 @@ GIT_BEGIN_DECL
  * @param out The blank repository
  * @return 0 on success, or an error code
  */
+#ifdef GIT_EXPERIMENTAL_SHA256
+GIT_EXTERN(int) git_repository_new(git_repository **out, git_oid_t oid_type);
+#else
 GIT_EXTERN(int) git_repository_new(git_repository **out);
+#endif
 
 /**
  * Reset all the internal state in a repository.

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -328,7 +328,7 @@ on_error:
 	return NULL;
 }
 
-int git_repository_new(git_repository **out)
+int git_repository__new(git_repository **out, git_oid_t oid_type)
 {
 	git_repository *repo;
 
@@ -337,9 +337,22 @@ int git_repository_new(git_repository **out)
 
 	repo->is_bare = 1;
 	repo->is_worktree = 0;
+	repo->oid_type = oid_type;
 
 	return 0;
 }
+
+#ifdef GIT_EXPERIMENTAL_SHA256
+int git_repository_new(git_repository **out, git_oid_t oid_type)
+{
+	return git_repository__new(out, oid_type);
+}
+#else
+int git_repository_new(git_repository** out)
+{
+	return git_repository__new(out, GIT_OID_SHA1);
+}
+#endif
 
 static int load_config_data(git_repository *repo, const git_config *config)
 {

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -280,4 +280,7 @@ int git_repository__set_objectformat(
 	git_repository *repo,
 	git_oid_t oid_type);
 
+/* SHA256-aware internal functions */
+int git_repository__new(git_repository **out, git_oid_t oid_type);
+
 #endif

--- a/tests/libgit2/network/remote/local.c
+++ b/tests/libgit2/network/remote/local.c
@@ -473,7 +473,11 @@ void test_network_remote_local__anonymous_remote_inmemory_repo(void)
 
 	git_str_sets(&file_path_buf, cl_git_path_url(cl_fixture("testrepo.git")));
 
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_repository_new(&inmemory, GIT_OID_SHA1));
+#else
 	cl_git_pass(git_repository_new(&inmemory));
+#endif
 	cl_git_pass(git_remote_create_anonymous(&remote, inmemory, git_str_cstr(&file_path_buf)));
 	cl_git_pass(git_remote_connect(remote, GIT_DIRECTION_FETCH, NULL, NULL, NULL));
 	cl_assert(git_remote_connected(remote));

--- a/tests/libgit2/odb/backend/nobackend.c
+++ b/tests/libgit2/odb/backend/nobackend.c
@@ -11,7 +11,11 @@ void test_odb_backend_nobackend__initialize(void)
 	git_odb *odb;
 	git_refdb *refdb;
 
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_repository_new(&_repo, GIT_OID_SHA1));
+#else
 	cl_git_pass(git_repository_new(&_repo));
+#endif
 	cl_git_pass(git_config_new(&config));
 	cl_git_pass(git_odb__new(&odb, NULL));
 	cl_git_pass(git_refdb_new(&refdb, _repo));

--- a/tests/libgit2/repo/new.c
+++ b/tests/libgit2/repo/new.c
@@ -5,7 +5,11 @@ void test_repo_new__has_nothing(void)
 {
 	git_repository *repo;
 
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_repository_new(&repo, GIT_OID_SHA1));
+#else
 	cl_git_pass(git_repository_new(&repo));
+#endif
 	cl_assert_equal_b(true, git_repository_is_bare(repo));
 	cl_assert_equal_p(NULL, git_repository_path(repo));
 	cl_assert_equal_p(NULL, git_repository_workdir(repo));
@@ -16,7 +20,11 @@ void test_repo_new__is_bare_until_workdir_set(void)
 {
 	git_repository *repo;
 
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_repository_new(&repo, GIT_OID_SHA1));
+#else
 	cl_git_pass(git_repository_new(&repo));
+#endif
 	cl_assert_equal_b(true, git_repository_is_bare(repo));
 
 	cl_git_pass(git_repository_set_workdir(repo, clar_sandbox_path(), 0));
@@ -25,3 +33,30 @@ void test_repo_new__is_bare_until_workdir_set(void)
 	git_repository_free(repo);
 }
 
+void test_repo_new__sha1(void)
+{
+	git_repository *repo;
+
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_repository_new(&repo, GIT_OID_SHA1));
+#else
+	cl_git_pass(git_repository_new(&repo));
+#endif
+	cl_assert_equal_i(GIT_OID_SHA1, git_repository_oid_type(repo));
+
+	git_repository_free(repo);
+}
+
+void test_repo_new__sha256(void)
+{
+#ifndef GIT_EXPERIMENTAL_SHA256
+	cl_skip();
+#else
+	git_repository *repo;
+
+	cl_git_pass(git_repository_new(&repo, GIT_OID_SHA256));
+	cl_assert_equal_i(GIT_OID_SHA256, git_repository_oid_type(repo));
+
+	git_repository_free(repo);
+#endif
+}


### PR DESCRIPTION
This change adds support for setting oid type when creating an in-memory repository using git_repository_new (in conjunction with using custom backends).

Needed to prevent "ambiguous lookup - OID prefix is too short" error during git_object_lookup_prefix.
