### PR TITLE
ctype: cast characters to unsigned when classifying characters

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1447,7 +1447,7 @@ static int normalize_section(char *start, char *end)
 	for (scan = start; *scan; ++scan) {
 		if (end && scan >= end)
 			break;
-		if (isalnum(*scan))
+		if (isalnum((unsigned char)*scan))
 			*scan = (char)git__tolower(*scan);
 		else if (*scan != '-' || scan == start)
 			return GIT_EINVALIDSPEC;

--- a/src/libgit2/config_parse.c
+++ b/src/libgit2/config_parse.c
@@ -25,9 +25,9 @@ static void set_parse_error(git_config_parser *reader, int col, const char *erro
 }
 
 
-GIT_INLINE(int) config_keychar(int c)
+GIT_INLINE(int) config_keychar(char c)
 {
-	return isalnum(c) || c == '-';
+	return isalnum((unsigned char)c) || c == '-';
 }
 
 static int strip_comments(char *line, int in_quotes)
@@ -158,9 +158,10 @@ end_error:
 static int parse_section_header(git_config_parser *reader, char **section_out)
 {
 	char *name, *name_end;
-	int name_length, c, pos;
+	int name_length, pos;
 	int result;
 	char *line;
+	char c;
 	size_t line_len;
 
 	git_parse_advance_ws(&reader->ctx);
@@ -382,7 +383,7 @@ out:
 
 GIT_INLINE(bool) is_namechar(char c)
 {
-	return isalnum(c) || c == '-';
+	return isalnum((unsigned char)c) || c == '-';
 }
 
 static int parse_name(

--- a/src/libgit2/path.c
+++ b/src/libgit2/path.c
@@ -202,7 +202,7 @@ GIT_INLINE(size_t) common_prefix_icase(const char *str, size_t len, const char *
 {
 	size_t count = 0;
 
-	while (len > 0 && tolower(*str) == tolower(*prefix)) {
+	while (len > 0 && tolower((unsigned char)*str) == tolower((unsigned char)*prefix)) {
 		count++;
 		str++;
 		prefix++;

--- a/src/libgit2/trailer.c
+++ b/src/libgit2/trailer.c
@@ -24,7 +24,7 @@ static const char *const git_generated_prefixes[] = {
 static int is_blank_line(const char *str)
 {
 	const char *s = str;
-	while (*s && *s != '\n' && isspace(*s))
+	while (*s && *s != '\n' && isspace((unsigned char)*s))
 		s++;
 	return !*s || *s == '\n';
 }
@@ -93,7 +93,7 @@ static bool find_separator(size_t *out, const char *line, const char *separators
 			return true;
 		}
 
-		if (!whitespace_found && (isalnum(*c) || *c == '-'))
+		if (!whitespace_found && (isalnum((unsigned char)*c) || *c == '-'))
 			continue;
 		if (c != line && (*c == ' ' || *c == '\t')) {
 			whitespace_found = 1;
@@ -233,12 +233,12 @@ static size_t find_trailer_start(const char *buf, size_t len)
 		}
 
 		find_separator(&separator_pos, bol, TRAILER_SEPARATORS);
-		if (separator_pos >= 1 && !isspace(bol[0])) {
+		if (separator_pos >= 1 && !isspace((unsigned char)bol[0])) {
 			trailer_lines++;
 			possible_continuation_lines = 0;
 			if (recognized_prefix)
 				continue;
-		} else if (isspace(bol[0]))
+		} else if (isspace((unsigned char)bol[0]))
 			possible_continuation_lines++;
 		else {
 			non_trailer_lines++;
@@ -323,7 +323,7 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 					goto ret;
 				}
 
-				if (isalnum(*ptr) || *ptr == '-') {
+				if (isalnum((unsigned char)*ptr) || *ptr == '-') {
 					/* legal key character */
 					NEXT(S_KEY);
 				}

--- a/src/libgit2/transports/smart_pkt.c
+++ b/src/libgit2/transports/smart_pkt.c
@@ -535,10 +535,10 @@ static int parse_len(size_t *out, const char *line, size_t linelen)
 	num[PKT_LEN_SIZE] = '\0';
 
 	for (i = 0; i < PKT_LEN_SIZE; ++i) {
-		if (!isxdigit(num[i])) {
+		if (!isxdigit((unsigned char)num[i])) {
 			/* Make sure there are no special characters before passing to error message */
 			for (k = 0; k < PKT_LEN_SIZE; ++k) {
-				if(!isprint(num[k])) {
+				if(!isprint((unsigned char)num[k])) {
 					num[k] = '.';
 				}
 			}

--- a/src/util/date.c
+++ b/src/util/date.c
@@ -129,9 +129,9 @@ static size_t match_string(const char *date, const char *str)
 	for (i = 0; *date; date++, str++, i++) {
 		if (*date == *str)
 			continue;
-		if (toupper(*date) == toupper(*str))
+		if (toupper((unsigned char)*date) == toupper((unsigned char)*str))
 			continue;
-		if (!isalnum(*date))
+		if (!isalnum((unsigned char)*date))
 			break;
 		return 0;
 	}
@@ -143,7 +143,7 @@ static int skip_alpha(const char *date)
 	int i = 0;
 	do {
 		i++;
-	} while (isalpha(date[i]));
+	} while (isalpha((unsigned char)date[i]));
 	return i;
 }
 
@@ -251,7 +251,7 @@ static size_t match_multi_number(unsigned long num, char c, const char *date, ch
 
 	num2 = strtol(end+1, &end, 10);
 	num3 = -1;
-	if (*end == c && isdigit(end[1]))
+	if (*end == c && isdigit((unsigned char)end[1]))
 		num3 = strtol(end+1, &end, 10);
 
 	/* Time? Date? */
@@ -349,7 +349,7 @@ static size_t match_digit(const char *date, struct tm *tm, int *offset, int *tm_
 	case '.':
 	case '/':
 	case '-':
-		if (isdigit(end[1])) {
+		if (isdigit((unsigned char)end[1])) {
 			size_t match = match_multi_number(num, *end, date, end, tm);
 			if (match)
 				return match;
@@ -364,7 +364,7 @@ static size_t match_digit(const char *date, struct tm *tm, int *offset, int *tm_
 	n = 0;
 	do {
 		n++;
-	} while (isdigit(date[n]));
+	} while (isdigit((unsigned char)date[n]));
 
 	/* Four-digit year or a timezone? */
 	if (n == 4) {
@@ -518,7 +518,7 @@ static int parse_date_basic(const char *date, git_time_t *timestamp, int *offset
 			match = match_alpha(date, &tm, offset);
 		else if (isdigit(c))
 			match = match_digit(date, &tm, offset, &tm_gmt);
-		else if ((c == '-' || c == '+') && isdigit(date[1]))
+		else if ((c == '-' || c == '+') && isdigit((unsigned char)date[1]))
 			match = match_tz(date, offset);
 
 		if (!match) {
@@ -682,7 +682,7 @@ static const char *approxidate_alpha(const char *date, struct tm *tm, struct tm 
 	const char *end = date;
 	int i;
 
-	while (isalpha(*++end))
+	while (isalpha((unsigned char)*++end))
 		/* scan to non-alpha */;
 
 	for (i = 0; i < 12; i++) {
@@ -783,7 +783,7 @@ static const char *approxidate_digit(const char *date, struct tm *tm, int *num)
 	case '.':
 	case '/':
 	case '-':
-		if (isdigit(end[1])) {
+		if (isdigit((unsigned char)end[1])) {
 			size_t match = match_multi_number(number, *end, date, end, tm);
 			if (match)
 				return date + match;

--- a/src/util/str.c
+++ b/src/util/str.c
@@ -485,8 +485,8 @@ int git_str_decode_percent(
 	for (str_pos = 0; str_pos < str_len; buf->size++, str_pos++) {
 		if (str[str_pos] == '%' &&
 			str_len > str_pos + 2 &&
-			isxdigit(str[str_pos + 1]) &&
-			isxdigit(str[str_pos + 2])) {
+			isxdigit((unsigned char)str[str_pos + 1]) &&
+			isxdigit((unsigned char)str[str_pos + 2])) {
 			buf->ptr[buf->size] = (HEX_DECODE(str[str_pos + 1]) << 4) +
 				HEX_DECODE(str[str_pos + 2]);
 			str_pos += 2;

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -89,7 +89,7 @@ GIT_INLINE(int) git__tolower(int c)
 	return (c >= 'A' && c <= 'Z') ? (c + 32) : c;
 }
 #else
-# define git__tolower(a) tolower(a)
+# define git__tolower(a) tolower((unsigned char)(a))
 #endif
 
 extern size_t git__linenlen(const char *buffer, size_t buffer_len);

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -316,7 +316,7 @@ static void unposix_path(git_str *path)
 	src = tgt = path->ptr;
 
 	/* convert "/d/..." to "d:\..." */
-	if (src[0] == '/' && isalpha(src[1]) && src[2] == '/') {
+	if (src[0] == '/' && isalpha((unsigned char)src[1]) && src[2] == '/') {
 		*tgt++ = src[1];
 		*tgt++ = ':';
 		*tgt++ = '\\';


### PR DESCRIPTION
ctype classification takes an integer in as returned from getc() if we just sign extend characters to integers 128-255 will be misclassified. (255 will become EOF)
Newlib in particular doesn't like this since they uses the value as an index in a lookup table.