### PR TITLE
Fix 'path cannot exist in repository' during diff for in-memory repository

### DIFF
--- a/src/libgit2/attr.c
+++ b/src/libgit2/attr.c
@@ -424,8 +424,12 @@ static int attr_setup(
 			goto out;
 
 	if ((error = git_repository_index__weakptr(&idx, repo)) < 0 ||
-	    (error = preload_attr_source(repo, attr_session, &index_source)) < 0)
+	    (error = preload_attr_source(repo, attr_session, &index_source)) < 0) {
+		if (error != GIT_ENOTFOUND)
 			goto out;
+
+		error = 0;
+	}
 
 	if ((opts && (opts->flags & GIT_ATTR_CHECK_INCLUDE_HEAD) != 0) &&
 	    (error = preload_attr_source(repo, attr_session, &head_source)) < 0)

--- a/tests/libgit2/attr/repo.c
+++ b/tests/libgit2/attr/repo.c
@@ -309,6 +309,31 @@ void test_attr_repo__bare_repo_with_index(void)
 	cl_assert(GIT_ATTR_IS_UNSPECIFIED(values[3]));
 }
 
+void test_attr_repo__inmemory_repo_without_index(void)
+{
+	const char *names[1] = { "fake" };
+	const char *values[1];
+	git_repository *inmemory;
+	git_index *index = NULL;
+
+	/* setup bare in-memory repo without index */
+#ifdef GIT_EXPERIMENTAL_SHA256
+	cl_git_pass(git_repository_new(&inmemory, GIT_OID_SHA1));
+#else
+	cl_git_pass(git_repository_new(&inmemory));
+#endif
+	cl_assert(git_repository_is_bare(inmemory));
+
+	/* verify repo isn't given an index upfront in future */
+	git_repository_index(&index, inmemory);
+	cl_assert(!index);
+
+	/* check attributes can be queried without error due to missing index */
+	cl_git_pass(git_attr_get_many(values, inmemory, 0, "fake.txt", 1, names));
+
+	git_repository_free(inmemory);
+}
+
 void test_attr_repo__sysdir(void)
 {
 	git_str sysdir = GIT_STR_INIT;


### PR DESCRIPTION
Fixes obscure bug caused by change shown below in 54a22f536557b9a25752c6b59829dff4cbee99e0.

![image](https://github.com/libgit2/libgit2/assets/17040909/ba4382b9-ad15-4b10-ad52-93efdf0865f9)

For an in-memory repository without an index setup, nor any directory on-disk, git_repository_index_weakptr can now fail with a not found error returned by repository_index_path, as a consequence of this, attr_setup returns the not found error in this scenario, which then results in an error when attempting to lookup the driver for comparing a file during a diff.

Elsewhere, the not found errors are ignored within attr_setup directly, or indirectly by callers of that, but error is escaping via the diff driver lookup, hence fix added to ignore it directly within attr_setup.