### PR TITLE
ci: allow workflows to read and write packages

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,9 +10,10 @@ permissions:
   contents: read
 
 jobs:
-  # Run our nightly builds.  We build a matrix with the various build
-  # targets and their details.  Then we build either in a docker container
-  # (Linux) or on the actual hosts (macOS, Windows).
+  # Run our benchmarks. We build a matrix with the various build
+  # targets and their details. Unlike our CI builds, we run these
+  # directly on the VM instead of in containers since we do not
+  # need the breadth of platform diversity.
   build:
     # Only run scheduled workflows on the main repository; prevents people
     # from using build minutes on their forks.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ env:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   containers:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,7 @@ env:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   # Run our nightly builds.  We build a matrix with the various build


### PR DESCRIPTION
Our CI workflows consume and will automatically generate their build containers. Ensure that they can do so.