### PR TITLE
tests: remove test for strcasecmp

### DIFF
--- a/src/util/unix/posix.h
+++ b/src/util/unix/posix.h
@@ -54,8 +54,6 @@ GIT_INLINE(int) p_fsync(int fd)
 #define p_send(s,b,l,f) send(s,b,l,f)
 #define p_inet_pton(a, b, c) inet_pton(a, b, c)
 
-#define p_strcasecmp(s1, s2) strcasecmp(s1, s2)
-#define p_strncasecmp(s1, s2, c) strncasecmp(s1, s2, c)
 #define p_vsnprintf(b, c, f, a) vsnprintf(b, c, f, a)
 #define p_snprintf snprintf
 #define p_chdir(p) chdir(p)

--- a/tests/clar/clar.c
+++ b/tests/clar/clar.c
@@ -41,9 +41,6 @@
 #	ifndef strdup
 #		define strdup(str) _strdup(str)
 #	endif
-#	ifndef strcasecmp
-#		define strcasecmp(a,b) _stricmp(a,b)
-#	endif
 
 #	ifndef __MINGW32__
 #		pragma comment(lib, "shell32")

--- a/tests/util/string.c
+++ b/tests/util/string.c
@@ -111,12 +111,6 @@ void test_string__strcasecmp(void)
 	cl_assert(git__strcasecmp("foo", "FOO") == 0);
 	cl_assert(git__strcasecmp("foo", "fOO") == 0);
 
-	cl_assert(strcasecmp("rt\303\202of", "rt dev\302\266h") > 0);
-	cl_assert(strcasecmp("e\342\202\254ghi=", "et") > 0);
-	cl_assert(strcasecmp("rt dev\302\266h", "rt\303\202of") < 0);
-	cl_assert(strcasecmp("et", "e\342\202\254ghi=") < 0);
-	cl_assert(strcasecmp("\303\215", "\303\255") < 0);
-
 	cl_assert(git__strcasecmp("rt\303\202of", "rt dev\302\266h") > 0);
 	cl_assert(git__strcasecmp("e\342\202\254ghi=", "et") > 0);
 	cl_assert(git__strcasecmp("rt dev\302\266h", "rt\303\202of") < 0);


### PR DESCRIPTION
strcasecmp is a posix function, testing it doesn't make sense.
Functions that needs unsigned compare should use git__strcasecmp()

If people are using signed chars then they will probably run into some issue where sorted strings end up in a different order but this is a problem with the functions calling strcasecmp instead of git__strcasecmp, not strcasecmp itself.
