### PR TITLE
process: don't try to close the status

### DIFF
--- a/src/util/unix/process.c
+++ b/src/util/unix/process.c
@@ -556,7 +556,6 @@ int git_process_close(git_process *process)
 	CLOSE_FD(process->child_in);
 	CLOSE_FD(process->child_out);
 	CLOSE_FD(process->child_err);
-	CLOSE_FD(process->status);
 
 	return 0;
 }


### PR DESCRIPTION
`process->status` is a status value; we were mistakenly trying to close it as a file descriptor, as if it were the `status` self-pipe that we open during process creation.

Instead, don't try to close it, as it's not a file descriptor.

Fixes #6686 