### PR TITLE
Yet more CI improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,25 @@ jobs:
       matrix:
         platform:
         # All builds: core platforms
-        - name: "Linux (Xenial, GCC, OpenSSL, libssh2)"
+        - name: "Linux (Noble, GCC, OpenSSL, libssh2)"
+          id: noble-gcc-openssl
+          os: ubuntu-latest
+          container:
+            name: noble
+          env:
+            CC: gcc
+            CMAKE_GENERATOR: Ninja
+            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2 -DDEBUG_STRICT_ALLOC=ON -DDEBUG_STRICT_OPEN=ON
+        - name: "Linux (Noble, Clang, mbedTLS, OpenSSH)"
+          id: noble-clang-mbedtls
+          os: ubuntu-latest
+          container:
+            name: noble
+          env:
+            CC: clang
+            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec
+            CMAKE_GENERATOR: Ninja
+        - name: "Linux (Xenial, GCC, OpenSSL, OpenSSH)"
           id: xenial-gcc-openssl
           os: ubuntu-latest
           container:
@@ -38,34 +56,16 @@ jobs:
           env:
             CC: gcc
             CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2 -DDEBUG_STRICT_ALLOC=ON -DDEBUG_STRICT_OPEN=ON
-        - name: Linux (Xenial, GCC, mbedTLS, OpenSSH)
+            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec -DDEBUG_STRICT_ALLOC=ON -DDEBUG_STRICT_OPEN=ON
+        - name: "Linux (Xenial, Clang, mbedTLS, libssh2)"
           id: xenial-gcc-mbedtls
           os: ubuntu-latest
           container:
             name: xenial
           env:
-            CC: gcc
-            CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec
-        - name: "Linux (Xenial, Clang, OpenSSL, OpenSSH)"
-          id: xenial-clang-openssl
-          os: ubuntu-latest
-          container:
-            name: xenial
-          env:
             CC: clang
             CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec
-        - name: "Linux (Xenial, Clang, mbedTLS, libssh2)"
-          id: xenial-clang-mbedtls
-          os: ubuntu-latest
-          container:
-            name: xenial
-          env:
-            CC: clang
-            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2
-            CMAKE_GENERATOR: Ninja
+            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2
         - name: "macOS"
           id: macos
           os: macos-12
@@ -130,9 +130,9 @@ jobs:
         - name: "Sanitizer (Memory)"
           id: sanitizer-memory
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: clang
             CFLAGS: -fsanitize=memory -fsanitize-memory-track-origins=2 -fsanitize-blacklist=/home/libgit2/source/script/sanitizers.supp -fno-optimize-sibling-calls -fno-omit-frame-pointer
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local/msan -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_BUNDLED_ZLIB=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja
@@ -145,9 +145,9 @@ jobs:
           id: sanitizer-ub
           os: ubuntu-latest
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: clang
             CFLAGS: -fsanitize=undefined,nullability -fno-sanitize-recover=undefined,nullability -fsanitize-blacklist=/home/libgit2/source/script/sanitizers.supp -fno-optimize-sibling-calls -fno-omit-frame-pointer
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local -DUSE_HTTPS=OpenSSL -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_BUNDLED_ZLIB=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja
@@ -159,9 +159,9 @@ jobs:
           id: sanitizer-thread
           os: ubuntu-latest
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: clang
             CFLAGS: -fsanitize=thread -fno-optimize-sibling-calls -fno-omit-frame-pointer
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local -DUSE_HTTPS=OpenSSL -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_BUNDLED_ZLIB=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,25 @@ jobs:
       matrix:
         platform:
         # All builds: core platforms
-        - name: "Linux (Xenial, GCC, OpenSSL, libssh2)"
+        - name: "Linux (Noble, GCC, OpenSSL, libssh2)"
+          id: noble-gcc-openssl
+          os: ubuntu-latest
+          container:
+            name: noble
+          env:
+            CC: gcc
+            CMAKE_GENERATOR: Ninja
+            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2 -DDEBUG_STRICT_ALLOC=ON -DDEBUG_STRICT_OPEN=ON
+        - name: "Linux (Noble, Clang, mbedTLS, OpenSSH)"
+          id: noble-clang-mbedtls
+          os: ubuntu-latest
+          container:
+            name: noble
+          env:
+            CC: clang
+            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec
+            CMAKE_GENERATOR: Ninja
+        - name: "Linux (Xenial, GCC, OpenSSL, OpenSSH)"
           id: xenial-gcc-openssl
           os: ubuntu-latest
           container:
@@ -35,34 +53,16 @@ jobs:
           env:
             CC: gcc
             CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2 -DDEBUG_STRICT_ALLOC=ON -DDEBUG_STRICT_OPEN=ON
-        - name: Linux (Xenial, GCC, mbedTLS, OpenSSH)
+            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DREGEX_BACKEND=builtin -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec -DDEBUG_STRICT_ALLOC=ON -DDEBUG_STRICT_OPEN=ON
+        - name: "Linux (Xenial, Clang, mbedTLS, libssh2)"
           id: xenial-gcc-mbedtls
           os: ubuntu-latest
           container:
             name: xenial
           env:
-            CC: gcc
-            CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec
-        - name: "Linux (Xenial, Clang, OpenSSL, OpenSSH)"
-          id: xenial-clang-openssl
-          os: ubuntu-latest
-          container:
-            name: xenial
-          env:
             CC: clang
             CMAKE_GENERATOR: Ninja
-            CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=exec
-        - name: "Linux (Xenial, Clang, mbedTLS, libssh2)"
-          id: xenial-clang-mbedtls
-          os: ubuntu-latest
-          container:
-            name: xenial
-          env:
-            CC: clang
-            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2
-            CMAKE_GENERATOR: Ninja
+            CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2
         - name: "macOS"
           id: macos
           os: macos-12
@@ -127,9 +127,9 @@ jobs:
         - name: "Sanitizer (Memory)"
           id: memorysanitizer
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: clang-17
             CFLAGS: -fsanitize=memory -fsanitize-memory-track-origins=2 -fsanitize-blacklist=/home/libgit2/source/script/sanitizers.supp -fno-optimize-sibling-calls -fno-omit-frame-pointer
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local/msan -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_BUNDLED_ZLIB=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja
@@ -142,9 +142,9 @@ jobs:
           id: ubsanitizer
           os: ubuntu-latest
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: clang-17
             CFLAGS: -fsanitize=undefined,nullability -fno-sanitize-recover=undefined,nullability -fsanitize-blacklist=/home/libgit2/source/script/sanitizers.supp -fno-optimize-sibling-calls -fno-omit-frame-pointer
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local -DUSE_HTTPS=OpenSSL -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_BUNDLED_ZLIB=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja
@@ -156,9 +156,9 @@ jobs:
           id: threadsanitizer
           os: ubuntu-latest
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: clang-17
             CFLAGS: -fsanitize=thread -fno-optimize-sibling-calls -fno-omit-frame-pointer
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local -DUSE_HTTPS=OpenSSL -DUSE_SHA1=HTTPS -DREGEX_BACKEND=pcre -DDEPRECATE_HARD=ON -DUSE_BUNDLED_ZLIB=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja
@@ -277,12 +277,12 @@ jobs:
             CMAKE_OPTIONS: -DTHREADSAFE=OFF -DDEPRECATE_HARD=ON -DUSE_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=ON
             CMAKE_GENERATOR: Ninja
         - name: "Linux (no mmap)"
-          id: focal-nommap
+          id: noble-nommap
           os: ubuntu-latest
           container:
-            name: focal
+            name: noble
           env:
-            CC: clang-10
+            CC: gcc
             CFLAGS: -DNO_MMAP
             CMAKE_OPTIONS: -DCMAKE_PREFIX_PATH=/usr/local
             CMAKE_GENERATOR: Ninja

--- a/ci/docker/centos7
+++ b/ci/docker/centos7
@@ -18,13 +18,13 @@ RUN yum install -y \
 
 FROM yum AS libssh2
 RUN cd /tmp && \
-    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.8.0.tar.gz | tar -xz && \
-    cd libssh2-1.8.0 && \
+    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.11.0.tar.gz | tar -xz && \
+    cd libssh2-1.11.0 && \
     ./configure && \
     make && \
     make install && \
     cd .. && \
-    rm -rf libssh-1.8.0
+    rm -rf libssh-1.11.0
 
 FROM libssh2 AS valgrind
 RUN cd /tmp && \

--- a/ci/docker/centos8
+++ b/ci/docker/centos8
@@ -24,13 +24,13 @@ RUN yum install -y \
 
 FROM yum AS libssh2
 RUN cd /tmp && \
-    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.8.0.tar.gz | tar -xz && \
-    cd libssh2-1.8.0 && \
+    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.11.0.tar.gz | tar -xz && \
+    cd libssh2-1.11.0 && \
     ./configure && \
     make && \
     make install && \
     cd .. && \
-    rm -rf libssh2-1.8.0
+    rm -rf libssh2-1.11.0
 
 FROM libssh2 AS valgrind
 RUN cd /tmp && \

--- a/ci/docker/focal
+++ b/ci/docker/focal
@@ -53,7 +53,7 @@ RUN cd /tmp && \
     cd libssh2-1.9.0 && \
     mkdir build build-msan && \
     cd build && \
-    CC=clang-10 CFLAGS="-fPIC" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=Libgcrypt -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    CC=clang-10 CFLAGS="-fPIC" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
     ninja install && \
     cd ../build-msan && \
     CC=clang-10 CFLAGS="-fPIC -fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer" LDFLAGS="-fsanitize=memory" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=mbedTLS -DCMAKE_PREFIX_PATH=/usr/local/msan -DCMAKE_INSTALL_PREFIX=/usr/local/msan .. && \

--- a/ci/docker/noble
+++ b/ci/docker/noble
@@ -1,0 +1,88 @@
+ARG BASE=ubuntu:noble
+
+FROM ${BASE} AS apt
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        clang \
+        cmake \
+        curl \
+        gcc \
+        git \
+        krb5-user \
+        libclang-rt-17-dev \
+        libcurl4-gnutls-dev \
+        libgcrypt20-dev \
+        libkrb5-dev \
+        libpcre3-dev \
+        libssl-dev \
+        libz-dev \
+        llvm-17 \
+        make \
+        ninja-build \
+        openjdk-8-jre-headless \
+        openssh-server \
+        openssl \
+        pkgconf \
+        python3 \
+        sudo \
+        valgrind \
+        && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /usr/local/msan
+
+FROM apt AS mbedtls
+RUN cd /tmp && \
+    curl --location --silent --show-error https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-2.28.6.tar.gz | \
+        tar -xz && \
+    cd mbedtls-mbedtls-2.28.6 && \
+    scripts/config.pl unset MBEDTLS_AESNI_C && \
+    scripts/config.pl set MBEDTLS_MD4_C 1 && \
+    mkdir build build-msan && \
+    cd build && \
+    CC=clang-17 CFLAGS="-fPIC" cmake -G Ninja -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    ninja install && \
+    cd ../build-msan && \
+    CC=clang-17 CFLAGS="-fPIC" cmake -G Ninja -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDTLS_LIBRARY=OFF -DCMAKE_BUILD_TYPE=MemSanDbg -DCMAKE_INSTALL_PREFIX=/usr/local/msan .. && \
+    ninja install && \
+    cd .. && \
+    rm -rf mbedtls-mbedtls-2.28.6
+
+FROM mbedtls AS libssh2
+RUN cd /tmp && \
+    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.11.0.tar.gz | tar -xz && \
+    cd libssh2-1.11.0 && \
+    mkdir build build-msan && \
+    cd build && \
+    CC=clang-17 CFLAGS="-fPIC" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
+    ninja install && \
+    cd ../build-msan && \
+    CC=clang-17 CFLAGS="-fPIC -fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer" LDFLAGS="-fsanitize=memory" cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=mbedTLS -DCMAKE_PREFIX_PATH=/usr/local/msan -DCMAKE_INSTALL_PREFIX=/usr/local/msan .. && \
+    ninja install && \
+    cd .. && \
+    rm -rf libssh2-1.11.0
+
+FROM libssh2 AS valgrind
+RUN cd /tmp && \
+    curl --insecure --location --silent --show-error https://sourceware.org/pub/valgrind/valgrind-3.22.0.tar.bz2 | \
+        tar -xj && \
+    cd valgrind-3.22.0 && \
+    CC=clang-17 ./configure && \
+    make MAKEFLAGS="-j -l$(grep -c ^processor /proc/cpuinfo)" && \
+    make install && \
+    cd .. && \
+    rm -rf valgrind-3.22.0
+
+FROM valgrind AS adduser
+ARG UID=""
+ARG GID=""
+RUN if [ "${UID}" != "" ]; then USER_ARG="--uid ${UID}"; fi && \
+    if [ "${GID}" != "" ]; then GROUP_ARG="--gid ${GID}"; fi && \
+    groupadd ${GROUP_ARG} libgit2 && \
+    useradd ${USER_ARG} --gid libgit2 --shell /bin/bash --create-home libgit2
+
+FROM adduser AS ldconfig
+RUN ldconfig
+
+FROM ldconfig AS configure
+RUN mkdir /var/run/sshd

--- a/ci/docker/xenial
+++ b/ci/docker/xenial
@@ -53,12 +53,12 @@ RUN cd /tmp && \
 
 FROM mbedtls AS libssh2
 RUN cd /tmp && \
-    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.8.2.tar.gz | tar -xz && \
-    cd libssh2-1.8.2 && \
-    CFLAGS=-fPIC cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCRYPTO_BACKEND=Libgcrypt . && \
+    curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.11.0.tar.gz | tar -xz && \
+    cd libssh2-1.11.0 && \
+    CFLAGS=-fPIC cmake -G Ninja -DBUILD_SHARED_LIBS=ON . && \
     ninja install && \
     cd .. && \
-    rm -rf libssh2-1.8.2
+    rm -rf libssh2-1.11.0
 
 FROM libssh2 AS valgrind
 RUN cd /tmp && \


### PR DESCRIPTION
This makes several changes to our CI builds:

1. Our sanitizer builds are now running in Ubuntu Noble (24.04), which has newer GCC and Clang versions. This has already caught several problems!
2. All platforms are now building libssh2 v1.11.0. Generally, our Xenial builds are meant to run _the oldest possible_ versions of things for compatibility testing. But given the weak cipher compatibility in libssh2, it's simply not possible to use older versions with modern OpenSSH or hosting providers.
2. We now run a mix of newest Ubuntu (Noble) and oldest supported Ubuntu (Xenial) for our CI builds. This helps us use newer compilers, toolchains, etc, in addition to older ones, to catch a broader set of problems.