### PR TITLE
Fix some bugs caught by UBscan

### DIFF
--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -1080,6 +1080,12 @@ int git_reference_cmp(
 	return git_oid__cmp(&ref1->target.oid, &ref2->target.oid);
 }
 
+int git_reference__cmp_cb(const void *a, const void *b)
+{
+	return git_reference_cmp(
+		(const git_reference *)a, (const git_reference *)b);
+}
+
 /*
  * Starting with the reference given by `ref_name`, follows symbolic
  * references until a direct reference is found and updated the OID

--- a/src/libgit2/refs.h
+++ b/src/libgit2/refs.h
@@ -92,6 +92,12 @@ int git_reference__is_tag(const char *ref_name);
 int git_reference__is_note(const char *ref_name);
 const char *git_reference__shorthand(const char *name);
 
+/*
+ * A `git_reference_cmp` wrapper suitable for passing to generic
+ * comparators, like `vector_cmp` / `tsort` / etc.
+ */
+int git_reference__cmp_cb(const void *a, const void *b);
+
 /**
  * Lookup a reference by name and try to resolve to an OID.
  *

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -623,12 +623,12 @@ int git__bsearch_r(
  */
 int git__strcmp_cb(const void *a, const void *b)
 {
-	return strcmp((const char *)a, (const char *)b);
+	return git__strcmp((const char *)a, (const char *)b);
 }
 
 int git__strcasecmp_cb(const void *a, const void *b)
 {
-	return strcasecmp((const char *)a, (const char *)b);
+	return git__strcasecmp((const char *)a, (const char *)b);
 }
 
 int git__parse_bool(int *out, const char *value)

--- a/tests/libgit2/iterator/workdir.c
+++ b/tests/libgit2/iterator/workdir.c
@@ -585,9 +585,9 @@ void test_iterator_workdir__filesystem(void)
 	expect_iterator_items(i, 5, expect_noauto, 18, expect_trees);
 	git_iterator_free(i);
 
-	git__tsort((void **)expect_base, 8, (git__tsort_cmp)git__strcasecmp);
-	git__tsort((void **)expect_trees, 18, (git__tsort_cmp)git__strcasecmp);
-	git__tsort((void **)expect_noauto, 5, (git__tsort_cmp)git__strcasecmp);
+	git__tsort((void **)expect_base, 8, git__strcasecmp_cb);
+	git__tsort((void **)expect_trees, 18, git__strcasecmp_cb);
+	git__tsort((void **)expect_noauto, 5, git__strcasecmp_cb);
 
 	i_opts.flags = GIT_ITERATOR_IGNORE_CASE;
 	cl_git_pass(git_iterator_for_filesystem(&i, "status/subdir", &i_opts));

--- a/tests/libgit2/network/remote/rename.c
+++ b/tests/libgit2/network/remote/rename.c
@@ -216,7 +216,7 @@ void test_network_remote_rename__symref_head(void)
 	cl_assert_equal_i(0, problems.count);
 	git_strarray_dispose(&problems);
 
-	cl_git_pass(git_vector_init(&refs, 2, (git_vector_cmp) git_reference_cmp));
+	cl_git_pass(git_vector_init(&refs, 2, git_reference__cmp_cb));
 	cl_git_pass(git_branch_iterator_new(&iter, _repo, GIT_BRANCH_REMOTE));
 
 	while ((error = git_branch_next(&ref, &btype, iter)) == 0) {

--- a/tests/libgit2/odb/sorting.c
+++ b/tests/libgit2/odb/sorting.c
@@ -7,6 +7,11 @@ typedef struct {
 	size_t position;
 } fake_backend;
 
+static void odb_backend_free(git_odb_backend *odb)
+{
+	git__free(odb);
+}
+
 static git_odb_backend *new_backend(size_t position)
 {
 	fake_backend *b;
@@ -15,7 +20,7 @@ static git_odb_backend *new_backend(size_t position)
 	if (b == NULL)
 		return NULL;
 
-	b->base.free = (void (*)(git_odb_backend *)) git__free;
+	b->base.free = odb_backend_free;
 	b->base.version = GIT_ODB_BACKEND_VERSION;
 	b->position = position;
 	return (git_odb_backend *)b;

--- a/tests/libgit2/remote/fetch.c
+++ b/tests/libgit2/remote/fetch.c
@@ -75,6 +75,7 @@ static void do_time_travelling_fetch(git_oid *commit1id, git_oid *commit2id,
 	/* create two commits in repo 1 and a reference to them */
 	{
 		git_oid empty_tree_id;
+		git_commit *commit1;
 		git_tree *empty_tree;
 		git_signature *sig;
 		git_treebuilder *tb;
@@ -84,10 +85,12 @@ static void do_time_travelling_fetch(git_oid *commit1id, git_oid *commit2id,
 		cl_git_pass(git_signature_default(&sig, repo1));
 		cl_git_pass(git_commit_create(commit1id, repo1, REPO1_REFNAME, sig,
 					sig, NULL, "one", empty_tree, 0, NULL));
+		cl_git_pass(git_commit_lookup(&commit1, repo1, commit1id));
 		cl_git_pass(git_commit_create_v(commit2id, repo1, REPO1_REFNAME, sig,
-					sig, NULL, "two", empty_tree, 1, commit1id));
+					sig, NULL, "two", empty_tree, 1, commit1));
 
 		git_tree_free(empty_tree);
+		git_commit_free(commit1);
 		git_signature_free(sig);
 		git_treebuilder_free(tb);
 	}


### PR DESCRIPTION
After upgrading the undefined behavior scanner to LLVM 14, we see some warnings reported. These warnings are correct; this PR fixes them.