### PR TITLE
Add `git_repository_commit_parents` to identify the parents of the next commit given the repository state

### DIFF
--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -541,6 +541,24 @@ typedef int (*git_commit_create_cb)(
 	const git_commit *parents[],
 	void *payload);
 
+/** An array of commits returned from the library */
+typedef struct git_commitarray {
+	git_commit **commits;
+	size_t count;
+} git_commitarray;
+
+/**
+ * Free the commits contained in a commit array.  This method should
+ * be called on `git_commitarray` objects that were provided by the
+ * library.  Not doing so will result in a memory leak.
+ *
+ * This does not free the `git_commitarray` itself, since the library
+ * will never allocate that object directly itself.
+ *
+ * @param array The git_commitarray that contains commits to free
+ */
+GIT_EXTERN(void) git_commitarray_dispose(git_commitarray *array);
+
 /** @} */
 GIT_END_DECL
 #endif

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -543,7 +543,7 @@ typedef int (*git_commit_create_cb)(
 
 /** An array of commits returned from the library */
 typedef struct git_commitarray {
-	git_commit **commits;
+	git_commit *const *commits;
 	size_t count;
 } git_commitarray;
 

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -11,6 +11,7 @@
 #include "types.h"
 #include "oid.h"
 #include "buffer.h"
+#include "commit.h"
 
 /**
  * @file git2/repository.h
@@ -977,6 +978,17 @@ GIT_EXTERN(int) git_repository_set_ident(git_repository *repo, const char *name,
  * @return the object id type
  */
 GIT_EXTERN(git_oid_t) git_repository_oid_type(git_repository *repo);
+
+/**
+ * Gets the parents of the next commit, given the current repository state.
+ * Generally, this is the HEAD commit, except when performing a merge, in
+ * which case it is two or more commits.
+ *
+ * @param commits a `git_commitarray` that will contain the commit parents
+ * @param repo the repository
+ * @return 0 or an error code
+ */
+GIT_EXTERN(int) git_repository_commit_parents(git_commitarray *commits, git_repository *repo);
 
 /** @} */
 GIT_END_DECL

--- a/src/libgit2/commit.c
+++ b/src/libgit2/commit.c
@@ -1097,3 +1097,18 @@ int git_commit_author_with_mailmap(
 {
 	return git_mailmap_resolve_signature(out, mailmap, commit->author);
 }
+
+void git_commitarray_dispose(git_commitarray *array)
+{
+	size_t i;
+
+	if (array == NULL)
+		return;
+
+	for (i = 0; i < array->count; i++)
+		git_commit_free(array->commits[i]);
+
+	git__free(array->commits);
+
+	memset(array, 0, sizeof(*array));
+}

--- a/src/libgit2/commit.c
+++ b/src/libgit2/commit.c
@@ -1108,7 +1108,7 @@ void git_commitarray_dispose(git_commitarray *array)
 	for (i = 0; i < array->count; i++)
 		git_commit_free(array->commits[i]);
 
-	git__free(array->commits);
+	git__free((git_commit **)array->commits);
 
 	memset(array, 0, sizeof(*array));
 }

--- a/tests/libgit2/repo/getters.c
+++ b/tests/libgit2/repo/getters.c
@@ -51,3 +51,63 @@ void test_repo_getters__retrieving_the_odb_honors_the_refcount(void)
 
 	git_odb_free(odb);
 }
+
+void test_repo_getters__commit_parents(void)
+{
+	git_repository *repo;
+	git_commitarray parents;
+	git_oid first_parent;
+	git_oid merge_parents[4];
+
+	git_oid__fromstr(&first_parent, "099fabac3a9ea935598528c27f866e34089c2eff", GIT_OID_SHA1);
+
+	/* A commit on a new repository has no parents */
+
+	cl_git_pass(git_repository_init(&repo, "new_repo", false));
+	cl_git_pass(git_repository_commit_parents(&parents, repo));
+
+	cl_assert_equal_sz(0, parents.count);
+	cl_assert_equal_p(NULL, parents.commits);
+
+	git_commitarray_dispose(&parents);
+	git_repository_free(repo);
+
+	/* A standard commit has one parent */
+
+	repo = cl_git_sandbox_init("testrepo");
+	cl_git_pass(git_repository_commit_parents(&parents, repo));
+
+	cl_assert_equal_sz(1, parents.count);
+	cl_assert_equal_oid(&first_parent, git_commit_id(parents.commits[0]));
+
+	git_commitarray_dispose(&parents);
+
+	/* A merge commit has multiple parents */
+
+	cl_git_rewritefile("testrepo/.git/MERGE_HEAD",
+		"8496071c1b46c854b31185ea97743be6a8774479\n"
+		"5b5b025afb0b4c913b4c338a42934a3863bf3644\n"
+		"4a202b346bb0fb0db7eff3cffeb3c70babbd2045\n"
+		"9fd738e8f7967c078dceed8190330fc8648ee56a\n");
+
+	cl_git_pass(git_repository_commit_parents(&parents, repo));
+
+	cl_assert_equal_sz(5, parents.count);
+
+	cl_assert_equal_oid(&first_parent, git_commit_id(parents.commits[0]));
+
+	git_oid__fromstr(&merge_parents[0], "8496071c1b46c854b31185ea97743be6a8774479", GIT_OID_SHA1);
+	cl_assert_equal_oid(&merge_parents[0], git_commit_id(parents.commits[1]));
+	git_oid__fromstr(&merge_parents[1], "5b5b025afb0b4c913b4c338a42934a3863bf3644", GIT_OID_SHA1);
+	cl_assert_equal_oid(&merge_parents[1], git_commit_id(parents.commits[2]));
+	git_oid__fromstr(&merge_parents[2], "4a202b346bb0fb0db7eff3cffeb3c70babbd2045", GIT_OID_SHA1);
+	cl_assert_equal_oid(&merge_parents[2], git_commit_id(parents.commits[3]));
+	git_oid__fromstr(&merge_parents[3], "9fd738e8f7967c078dceed8190330fc8648ee56a", GIT_OID_SHA1);
+	cl_assert_equal_oid(&merge_parents[3], git_commit_id(parents.commits[4]));
+
+	git_commitarray_dispose(&parents);
+
+	git_repository_free(repo);
+
+	cl_fixture_cleanup("testrepo");
+}


### PR DESCRIPTION
* Emulating `git commit` is clunky - identifying your commit's parents is part of the problem. Provide a helper to give you the parents given the current repository state.