### PR TITLE
commit: introduce git_commit_create_from_stage

### DIFF
--- a/examples/merge.c
+++ b/examples/merge.c
@@ -263,7 +263,7 @@ static int create_merge_commit(git_repository *repo, git_index *index, struct me
 	                        sign, sign,
 	                        NULL, msg,
 	                        tree,
-	                        opts->annotated_count + 1, (const git_commit **)parents);
+	                        opts->annotated_count + 1, parents);
 	check_lg2(err, "failed to create commit", NULL);
 
 	/* We're done merging, cleanup the repository state */

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -394,6 +394,36 @@ GIT_EXTERN(int) git_commit_create_v(
 	size_t parent_count,
 	...);
 
+typedef struct {
+	unsigned int version;
+
+	unsigned int allow_empty_commit : 1;
+
+	const git_signature *author;
+	const git_signature *committer;
+} git_commit_create_options;
+
+#define GIT_COMMIT_CREATE_OPTIONS_VERSION 1
+#define GIT_COMMIT_CREATE_OPTIONS_INIT { GIT_COMMIT_CREATE_OPTIONS_VERSION }
+
+/**
+ * Commits the staged changes in the repository; this is a near analog to
+ * `git commit -m message`.
+ *
+ * By default, empty commits are not allowed.
+ *
+ * @param id pointer to store the new commit's object id
+ * @param repo repository to commit changes in
+ * @param message the commit message
+ * @param opts options for creating the commit
+ * @return 0 on success, GIT_EUNCHANGED if there were no changes to commit, or an error code
+ */
+GIT_EXTERN(int) git_commit_create_from_stage(
+	git_oid *id,
+	git_repository *repo,
+	const char *message,
+	const git_commit_create_options *opts);
+
 /**
  * Amend an existing commit by replacing only non-NULL values.
  *

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -397,10 +397,23 @@ GIT_EXTERN(int) git_commit_create_v(
 typedef struct {
 	unsigned int version;
 
+	/**
+	 * Flags for creating the commit.
+	 *
+	 * If `allow_empty_commit` is specified, a commit with no changes
+	 * from the prior commit (and "empty" commit) is allowed. Otherwise,
+	 * commit creation will be stopped.
+	 */
 	unsigned int allow_empty_commit : 1;
 
+	/** The commit author, or NULL for the default. */
 	const git_signature *author;
+
+	/** The committer, or NULL for the default. */
 	const git_signature *committer;
+
+	/** Encoding for the commit message; leave NULL for default. */
+	const char *message_encoding;
 } git_commit_create_options;
 
 #define GIT_COMMIT_CREATE_OPTIONS_VERSION 1

--- a/include/git2/commit.h
+++ b/include/git2/commit.h
@@ -366,7 +366,7 @@ GIT_EXTERN(int) git_commit_create(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[]);
+	git_commit * const parents[]);
 
 /**
  * Create new commit in the repository using a variable argument list.
@@ -469,7 +469,7 @@ GIT_EXTERN(int) git_commit_create_buffer(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[]);
+	git_commit * const parents[]);
 
 /**
  * Create a commit object from the given buffer and signature
@@ -538,7 +538,7 @@ typedef int (*git_commit_create_cb)(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[],
+	git_commit * const parents[],
 	void *payload);
 
 /** An array of commits returned from the library */

--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -59,7 +59,8 @@ typedef enum {
 	GIT_EINDEXDIRTY     = -34,	/**< Unsaved changes in the index would be overwritten */
 	GIT_EAPPLYFAIL      = -35,	/**< Patch application failed */
 	GIT_EOWNER          = -36,	/**< The object is not owned by the current user */
-	GIT_TIMEOUT         = -37	/**< The operation timed out */
+	GIT_TIMEOUT         = -37,	/**< The operation timed out */
+	GIT_EUNCHANGED      = -38	/**< There were no changes */
 } git_error_code;
 
 /**

--- a/src/libgit2/commit.c
+++ b/src/libgit2/commit.c
@@ -281,7 +281,7 @@ int git_commit_create_from_ids(
 
 typedef struct {
 	size_t total;
-	const git_commit **parents;
+	git_commit * const *parents;
 	git_repository *repo;
 } commit_parent_data;
 
@@ -307,7 +307,7 @@ int git_commit_create(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[])
+	git_commit * const parents[])
 {
 	commit_parent_data data = { parent_count, parents, repo };
 
@@ -945,7 +945,7 @@ int git_commit_create_buffer(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[])
+	git_commit * const parents[])
 {
 	GIT_BUF_WRAP_PRIVATE(out, git_commit__create_buffer, repo,
 	                     author, committer, message_encoding, message,
@@ -961,7 +961,7 @@ int git_commit__create_buffer(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[])
+	git_commit * const parents[])
 {
 	int error;
 	commit_parent_data data = { parent_count, parents, repo };

--- a/src/libgit2/commit.c
+++ b/src/libgit2/commit.c
@@ -1147,7 +1147,8 @@ int git_commit_create_from_stage(
 		goto done;
 
 	error = git_commit_create(out, repo, "HEAD", author, committer,
-			NULL, message, tree, parents.count, parents.commits);
+			opts.message_encoding, message,
+			tree, parents.count, parents.commits);
 
 done:
 	git_commitarray_dispose(&parents);

--- a/src/libgit2/commit.h
+++ b/src/libgit2/commit.h
@@ -64,7 +64,7 @@ int git_commit__create_buffer(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[]);
+	git_commit * const parents[]);
 
 int git_commit__parse(
 	void *commit,

--- a/src/libgit2/notes.c
+++ b/src/libgit2/notes.c
@@ -303,7 +303,7 @@ static int note_write(
 
 	error = git_commit_create(&oid, repo, notes_ref, author, committer,
 				  NULL, GIT_NOTES_DEFAULT_MSG_ADD,
-				  tree, *parents == NULL ? 0 : 1, (const git_commit **) parents);
+				  tree, *parents == NULL ? 0 : 1, parents);
 
 	if (notes_commit_out)
 		git_oid_cpy(notes_commit_out, &oid);
@@ -394,7 +394,7 @@ static int note_remove(
 	  NULL, GIT_NOTES_DEFAULT_MSG_RM,
 	  tree_after_removal,
 	  *parents == NULL ? 0 : 1,
-	  (const git_commit **) parents);
+	  parents);
 
 	if (error < 0)
 		goto cleanup;

--- a/src/libgit2/rebase.c
+++ b/src/libgit2/rebase.c
@@ -952,7 +952,7 @@ static int create_signed(
 	const char *message,
 	git_tree *tree,
 	size_t parent_count,
-	const git_commit **parents)
+	git_commit * const *parents)
 {
 	git_str commit_content = GIT_STR_INIT;
 	git_buf commit_signature = { NULL, 0, 0 },
@@ -1040,8 +1040,7 @@ static int rebase_commit__create(
 	if (rebase->options.commit_create_cb) {
 		error = rebase->options.commit_create_cb(&commit_id,
 			author, committer, message_encoding, message,
-			tree, 1, (const git_commit **)&parent_commit,
-			rebase->options.payload);
+			tree, 1, &parent_commit, rebase->options.payload);
 
 		git_error_set_after_callback_function(error,
 			"commit_create_cb");
@@ -1050,14 +1049,14 @@ static int rebase_commit__create(
 	else if (rebase->options.signing_cb) {
 		error = create_signed(&commit_id, rebase, author,
 			committer, message_encoding, message, tree,
-			1, (const git_commit **)&parent_commit);
+			1, &parent_commit);
 	}
 #endif
 
 	if (error == GIT_PASSTHROUGH)
 		error = git_commit_create(&commit_id, rebase->repo, NULL,
 			author, committer, message_encoding, message,
-			tree, 1, (const git_commit **)&parent_commit);
+			tree, 1, &parent_commit);
 
 	if (error)
 		goto done;

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -3314,6 +3314,25 @@ int git_repository_set_bare(git_repository *repo)
 	return 0;
 }
 
+int git_repository_head_commit(git_commit **commit, git_repository *repo)
+{
+	git_reference *head;
+	git_object *obj;
+	int error;
+
+	if ((error = git_repository_head(&head, repo)) < 0)
+		return error;
+
+	if ((error = git_reference_peel(&obj, head, GIT_OBJECT_COMMIT)) < 0)
+		goto cleanup;
+
+	*commit = (git_commit *)obj;
+
+cleanup:
+	git_reference_free(head);
+	return error;
+}
+
 int git_repository_head_tree(git_tree **tree, git_repository *repo)
 {
 	git_reference *head;

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -173,6 +173,7 @@ GIT_INLINE(git_attr_cache *) git_repository_attr_cache(git_repository *repo)
 	return repo->attrcache;
 }
 
+int git_repository_head_commit(git_commit **commit, git_repository *repo);
 int git_repository_head_tree(git_tree **tree, git_repository *repo);
 int git_repository_create_head(const char *git_dir, const char *ref_name);
 

--- a/src/libgit2/stash.c
+++ b/src/libgit2/stash.c
@@ -124,7 +124,7 @@ static int commit_index(
 	git_index *index,
 	const git_signature *stasher,
 	const char *message,
-	const git_commit *parent)
+	git_commit *parent)
 {
 	git_tree *i_tree = NULL;
 	git_oid i_commit_oid;
@@ -423,7 +423,7 @@ static int build_stash_commit_from_tree(
 	git_commit *u_commit,
 	const git_tree *tree)
 {
-	const git_commit *parents[] = {	NULL, NULL, NULL };
+	git_commit *parents[] = { NULL, NULL, NULL };
 
 	parents[0] = b_commit;
 	parents[1] = i_commit;

--- a/tests/clar/clar_libgit2.h
+++ b/tests/clar/clar_libgit2.h
@@ -166,9 +166,26 @@ GIT_INLINE(void) clar__assert_equal_oid(
 	}
 }
 
+GIT_INLINE(void) clar__assert_equal_oidstr(
+	const char *file, const char *func, int line, const char *desc,
+	const char *one_str, const git_oid *two)
+{
+	git_oid one;
+
+	if (git_oid__fromstr(&one, one_str, git_oid_type(two)) < 0) {
+		clar__fail(file, func, line, desc, "could not parse oid string", 1);
+	} else {
+		clar__assert_equal_oid(file, func, line, desc, &one, two);
+	}
+}
+
 #define cl_assert_equal_oid(one, two) \
 	clar__assert_equal_oid(__FILE__, __func__, __LINE__, \
 		"OID mismatch: " #one " != " #two, (one), (two))
+
+#define cl_assert_equal_oidstr(one_str, two) \
+	clar__assert_equal_oidstr(__FILE__, __func__, __LINE__, \
+		"OID mismatch: " #one_str " != " #two, (one_str), (two))
 
 /*
  * Some utility macros for building long strings

--- a/tests/libgit2/checkout/tree.c
+++ b/tests/libgit2/checkout/tree.c
@@ -1235,7 +1235,7 @@ void test_checkout_tree__case_changing_rename(void)
 
 	cl_git_pass(git_signature_new(&signature, "Renamer", "rename@contoso.com", time(NULL), 0));
 
-	cl_git_pass(git_commit_create(&commit_id, g_repo, "refs/heads/dir", signature, signature, NULL, "case-changing rename", tree, 1, (const git_commit **)&dir_commit));
+	cl_git_pass(git_commit_create(&commit_id, g_repo, "refs/heads/dir", signature, signature, NULL, "case-changing rename", tree, 1, &dir_commit));
 
 	cl_assert(git_fs_path_isfile("testrepo/readme"));
 	if (case_sensitive)

--- a/tests/libgit2/cherrypick/workdir.c
+++ b/tests/libgit2/cherrypick/workdir.c
@@ -77,7 +77,7 @@ void test_cherrypick_workdir__automerge(void)
 		cl_git_pass(git_index_write_tree(&cherrypicked_tree_oid, repo_index));
 		cl_git_pass(git_tree_lookup(&cherrypicked_tree, repo, &cherrypicked_tree_oid));
 		cl_git_pass(git_commit_create(&cherrypicked_oid, repo, "HEAD", signature, signature, NULL,
-			"Cherry picked!", cherrypicked_tree, 1, (const git_commit **)&head));
+			"Cherry picked!", cherrypicked_tree, 1, &head));
 
 		cl_assert(merge_test_index(repo_index, merge_index_entries + i * 3, 3));
 

--- a/tests/libgit2/commit/commit.c
+++ b/tests/libgit2/commit/commit.c
@@ -36,11 +36,11 @@ void test_commit_commit__create_unexisting_update_ref(void)
 
 	cl_git_fail(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
 	cl_git_pass(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
-				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+				      NULL, "some msg", tree, 1, &commit));
 
 	/* fail because the parent isn't the tip of the branch anymore */
 	cl_git_fail(git_commit_create(&oid, _repo, "refs/heads/foo/bar", s, s,
-				      NULL, "some msg", tree, 1, (const git_commit **) &commit));
+				      NULL, "some msg", tree, 1, &commit));
 
 	cl_git_pass(git_reference_lookup(&ref, _repo, "refs/heads/foo/bar"));
 	cl_assert_equal_oid(&oid, git_reference_target(ref));

--- a/tests/libgit2/commit/create.c
+++ b/tests/libgit2/commit/create.c
@@ -1,0 +1,112 @@
+#include "clar_libgit2.h"
+#include "repository.h"
+
+/* Fixture setup */
+static git_repository *g_repo;
+static git_signature *g_author, *g_committer;
+
+void test_commit_create__initialize(void)
+{
+	g_repo = cl_git_sandbox_init("testrepo2");
+	cl_git_pass(git_signature_new(&g_author, "Edward Thomson", "ethomson@edwardthomson.com", 123456789, 60));
+	cl_git_pass(git_signature_new(&g_committer, "libgit2 user", "nobody@noreply.libgit2.org", 987654321, 90));
+}
+
+void test_commit_create__cleanup(void)
+{
+	git_signature_free(g_committer);
+	git_signature_free(g_author);
+	cl_git_sandbox_cleanup();
+}
+
+
+void test_commit_create__from_stage_simple(void)
+{
+	git_commit_create_options opts = GIT_COMMIT_CREATE_OPTIONS_INIT;
+	git_index *index;
+	git_oid commit_id;
+	git_tree *tree;
+
+	opts.author = g_author;
+	opts.committer = g_committer;
+
+	cl_git_rewritefile("testrepo2/newfile.txt", "This is a new file.\n");
+	cl_git_rewritefile("testrepo2/newfile2.txt", "This is a new file.\n");
+	cl_git_rewritefile("testrepo2/README", "hello, world.\n");
+	cl_git_rewritefile("testrepo2/new.txt", "hi there.\n");
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_add_bypath(index, "newfile2.txt"));
+	cl_git_pass(git_index_add_bypath(index, "README"));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_commit_create_from_stage(&commit_id, g_repo, "This is the message.", &opts));
+
+	cl_git_pass(git_repository_head_tree(&tree, g_repo));
+
+	cl_assert_equal_oidstr("241b5b04e847bc38dd7b4b9f49f21e55da40f3a6", &commit_id);
+	cl_assert_equal_oidstr("b27210772d0633870b4f486d04ed3eb5ebbef5e7", git_tree_id(tree));
+
+	git_index_free(index);
+	git_tree_free(tree);
+}
+
+void test_commit_create__from_stage_nochanges(void)
+{
+	git_commit_create_options opts = GIT_COMMIT_CREATE_OPTIONS_INIT;
+	git_oid commit_id;
+	git_tree *tree;
+
+	opts.author = g_author;
+	opts.committer = g_committer;
+
+	cl_git_fail_with(GIT_EUNCHANGED, git_commit_create_from_stage(&commit_id, g_repo, "Message goes here.", &opts));
+
+	opts.allow_empty_commit = 1;
+
+	cl_git_pass(git_commit_create_from_stage(&commit_id, g_repo, "Message goes here.", &opts));
+
+	cl_git_pass(git_repository_head_tree(&tree, g_repo));
+
+	cl_assert_equal_oidstr("f776dc4c7fd8164b7127dc8e4f9b44421cb01b56", &commit_id);
+	cl_assert_equal_oidstr("c4dc1555e4d4fa0e0c9c3fc46734c7c35b3ce90b", git_tree_id(tree));
+
+	git_tree_free(tree);
+}
+
+void test_commit_create__from_stage_newrepo(void)
+{
+	git_commit_create_options opts = GIT_COMMIT_CREATE_OPTIONS_INIT;
+	git_repository *newrepo;
+	git_index *index;
+	git_commit *commit;
+	git_tree *tree;
+	git_oid commit_id;
+
+	opts.author = g_author;
+	opts.committer = g_committer;
+
+	git_repository_init(&newrepo, "newrepo", false);
+	cl_git_pass(git_repository_index(&index, newrepo));
+
+	cl_git_rewritefile("newrepo/hello.txt", "hello, world.\n");
+	cl_git_rewritefile("newrepo/hi.txt", "hi there.\n");
+	cl_git_rewritefile("newrepo/foo.txt", "bar.\n");
+
+	cl_git_pass(git_index_add_bypath(index, "hello.txt"));
+	cl_git_pass(git_index_add_bypath(index, "foo.txt"));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_commit_create_from_stage(&commit_id, newrepo, "Initial commit.", &opts));
+	cl_git_pass(git_repository_head_commit(&commit, newrepo));
+	cl_git_pass(git_repository_head_tree(&tree, newrepo));
+
+	cl_assert_equal_oid(&commit_id, git_commit_id(commit));
+	cl_assert_equal_oidstr("b2fa96a4f191c76eb172437281c66aa29609dcaa", git_commit_tree_id(commit));
+
+	git_tree_free(tree);
+	git_commit_free(commit);
+	git_index_free(index);
+	git_repository_free(newrepo);
+	cl_fixture_cleanup("newrepo");
+}

--- a/tests/libgit2/commit/write.c
+++ b/tests/libgit2/commit/write.c
@@ -118,7 +118,7 @@ void test_commit_write__into_buf(void)
 	cl_git_pass(git_commit_lookup(&parent, g_repo, &parent_id));
 
 	cl_git_pass(git_commit_create_buffer(&commit, g_repo, author, committer,
-					     NULL, root_commit_message, tree, 1, (const git_commit **) &parent));
+					     NULL, root_commit_message, tree, 1, &parent));
 
 	cl_assert_equal_s(commit.ptr,
 			  "tree 1810dff58d8a660512d4832e740f692884338ccd\n\

--- a/tests/libgit2/diff/rename.c
+++ b/tests/libgit2/diff/rename.c
@@ -424,7 +424,7 @@ void test_diff_rename__test_small_files(void)
 	cl_git_pass(git_index_write_tree(&oid, index));
 	cl_git_pass(git_tree_lookup(&commit_tree, g_repo, &oid));
 	cl_git_pass(git_signature_new(&signature, "Rename", "rename@example.com", 1404157834, 0));
-	cl_git_pass(git_commit_create(&oid, g_repo, "HEAD", signature, signature, NULL, "Test commit", commit_tree, 1, (const git_commit**)&head_commit));
+	cl_git_pass(git_commit_create(&oid, g_repo, "HEAD", signature, signature, NULL, "Test commit", commit_tree, 1, &head_commit));
 
 	cl_git_mkfile("renames/copy.txt", "Hello World!\n");
 	cl_git_rmfile("renames/small.txt");

--- a/tests/libgit2/odb/freshen.c
+++ b/tests/libgit2/odb/freshen.c
@@ -125,7 +125,7 @@ void test_odb_freshen__tree_during_commit(void)
 
 	cl_git_pass(git_commit_create(&commit_id, repo, NULL,
 		signature, signature, NULL, "New commit pointing to old tree",
-		tree, 1, (const git_commit **)&parent));
+		tree, 1, &parent));
 
 	/* make sure we freshen the tree the commit points to */
 	cl_must_pass(p_lstat("testrepo.git/objects/" LOOSE_TREE_FN, &after));

--- a/tests/libgit2/rebase/sign.c
+++ b/tests/libgit2/rebase/sign.c
@@ -26,7 +26,7 @@ static int create_cb_passthrough(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[],
+	git_commit * const parents[],
 	void *payload)
 {
 	GIT_UNUSED(out);
@@ -94,7 +94,7 @@ static int create_cb_signed_gpg(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[],
+	git_commit * const parents[],
 	void *payload)
 {
 	git_buf commit_content = GIT_BUF_INIT;
@@ -202,7 +202,7 @@ static int create_cb_error(
 	const char *message,
 	const git_tree *tree,
 	size_t parent_count,
-	const git_commit *parents[],
+	git_commit * const parents[],
 	void *payload)
 {
 	GIT_UNUSED(out);

--- a/tests/libgit2/refs/reflog/messages.c
+++ b/tests/libgit2/refs/reflog/messages.c
@@ -233,7 +233,7 @@ void test_refs_reflog_messages__show_merge_for_merge_commits(void)
 	cl_git_pass(git_commit_create(&merge_commit_oid,
 		g_repo, "HEAD", s, s, NULL,
 		"Merge commit", tree,
-		2, (const struct git_commit **) parent_commits));
+		2, parent_commits));
 
 	cl_reflog_check_entry(g_repo, GIT_HEAD_FILE, 0,
 		NULL,

--- a/tests/libgit2/revert/workdir.c
+++ b/tests/libgit2/revert/workdir.c
@@ -188,7 +188,7 @@ void test_revert_workdir__again(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
+	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, &orig_head));
 
 	cl_git_pass(git_revert(repo, orig_head, NULL));
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));
@@ -238,7 +238,7 @@ void test_revert_workdir__again_after_automerge(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&head));
+	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, &head));
 
 	cl_git_pass(git_revert(repo, commit, NULL));
 	cl_assert(merge_test_index(repo_index, second_revert_entries, 6));
@@ -287,7 +287,7 @@ void test_revert_workdir__again_after_edit(void)
 	cl_git_pass(git_tree_lookup(&reverted_tree, repo, &reverted_tree_oid));
 
 	cl_git_pass(git_signature_new(&signature, "Reverter", "reverter@example.org", time(NULL), 0));
-	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, (const git_commit **)&orig_head));
+	cl_git_pass(git_commit_create(&reverted_commit_oid, repo, "HEAD", signature, signature, NULL, "Reverted!", reverted_tree, 1, &orig_head));
 
 	cl_git_pass(git_revert(repo, commit, NULL));
 	cl_assert(merge_test_index(repo_index, merge_index_entries, 4));

--- a/tests/libgit2/revwalk/basic.c
+++ b/tests/libgit2/revwalk/basic.c
@@ -550,8 +550,7 @@ void test_revwalk_basic__big_timestamp(void)
 	cl_git_pass(git_signature_new(&sig, "Joe", "joe@example.com", INT64_C(2399662595), 0));
 	cl_git_pass(git_commit_tree(&tree, tip));
 
-	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1,
-		(const git_commit **)&tip));
+	cl_git_pass(git_commit_create(&id, _repo, "HEAD", sig, sig, NULL, "some message", tree, 1, &tip));
 
 	cl_git_pass(git_revwalk_push_head(_walk));
 


### PR DESCRIPTION
Provide a simple helper method that allows users to create a commit from
the current index with minimal information.