### PR TITLE
config: properly delete or rename section containing multivars

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1509,19 +1509,36 @@ static int rename_config_entries_cb(
 	int error = 0;
 	struct rename_data *data = (struct rename_data *)payload;
 	size_t base_len = git_str_len(data->name);
+	git_str raw_value = GIT_STR_INIT, value = GIT_STR_INIT;
 
 	if (base_len > 0 &&
 		!(error = git_str_puts(data->name, entry->name + data->old_len)))
 	{
-		error = git_config_set_string(
-			data->config, git_str_cstr(data->name), entry->value);
-
-		git_str_truncate(data->name, base_len);
+		error = git_config_set_multivar(
+		        data->config, git_str_cstr(data->name), "^$",
+		        entry->value);
 	}
 
-	if (!error)
-		error = git_config_delete_entry(data->config, entry->name);
+	if (!error) {
+		if ((error = git_str_puts_escape_regex(
+		             &raw_value, entry->value)))
+			goto cleanup;
+		git_str_grow(&value, git_str_len(&raw_value) + 2);
+		git_str_putc(&value, '^');
+		git_str_puts(&value, git_str_cstr(&raw_value));
+		git_str_putc(&value, '$');
+		if (git_str_oom(&value)) {
+			error = -1;
+			goto cleanup;
+		}
+		error = git_config_delete_multivar(
+		        data->config, entry->name, git_str_cstr(&value));
+	}
 
+ cleanup:
+	git_str_truncate(data->name, base_len);
+	git_str_dispose(&raw_value);
+	git_str_dispose(&value);
 	return error;
 }
 

--- a/tests/libgit2/refs/branches/delete.c
+++ b/tests/libgit2/refs/branches/delete.c
@@ -92,6 +92,21 @@ void test_refs_branches_delete__can_delete_a_local_branch(void)
 	git_reference_free(branch);
 }
 
+void test_refs_branches_delete__can_delete_a_local_branch_with_multivar(void)
+{
+	git_reference *branch;
+	git_config *cfg;
+
+	cl_git_pass(git_repository_config(&cfg, repo));
+	cl_git_pass(git_config_set_multivar(
+	        cfg, "branch.br2.gitpublishto", "^$", "example1@example.com"));
+	cl_git_pass(git_config_set_multivar(
+	        cfg, "branch.br2.gitpublishto", "^$", "example2@example.com"));
+	cl_git_pass(git_branch_lookup(&branch, repo, "br2", GIT_BRANCH_LOCAL));
+	cl_git_pass(git_branch_delete(branch));
+	git_reference_free(branch);
+}
+
 void test_refs_branches_delete__can_delete_a_remote_branch(void)
 {
 	git_reference *branch;


### PR DESCRIPTION
Renaming a config section or deleting its content removes each entry after copying it in its new place if needed. However, since each entry may be part of a multivar, deletion must only remove the exact entry that has just been copied.

Fix #6722
