### PR TITLE
GIT_RAND_GETENTROPY: do not include sys/random.h

### DIFF
--- a/src/util/rand.c
+++ b/src/util/rand.c
@@ -10,10 +10,6 @@ See <http://creativecommons.org/publicdomain/zero/1.0/>. */
 #include "rand.h"
 #include "runtime.h"
 
-#if defined(GIT_RAND_GETENTROPY)
-# include <sys/random.h>
-#endif
-
 #if defined(GIT_WIN32)
 # include <wincrypt.h>
 #endif


### PR DESCRIPTION
CMakeLists.txt is looking for `unistd.h` (where the `getentropy` function is present for at least Linux and OpenBSD).

It isn't necessary to include `sys/random.h` (which is Linux only).

It unbreak the build on OpenBSD.