### PR TITLE
revparse: ensure bare '@' is truly bare

### DIFF
--- a/src/libgit2/revparse.c
+++ b/src/libgit2/revparse.c
@@ -941,7 +941,7 @@ int git_revparse(
 		 * allowed.
 		 */
 		if (!git__strcmp(spec, "..")) {
-			git_error_set(GIT_ERROR_INVALID, "Invalid pattern '..'");
+			git_error_set(GIT_ERROR_INVALID, "invalid pattern '..'");
 			return GIT_EINVALIDSPEC;
 		}
 

--- a/src/libgit2/revparse.c
+++ b/src/libgit2/revparse.c
@@ -817,6 +817,12 @@ static int revparse(
 					base_rev = temp_object;
 				break;
 			} else if (spec[pos+1] == '\0') {
+				if (pos) {
+					git_error_set(GIT_ERROR_REFERENCE, "invalid revspec");
+					error = GIT_EINVALIDSPEC;
+					goto cleanup;
+				}
+
 				spec = "HEAD";
 				identifier_len = 4;
 				parsed = true;

--- a/tests/libgit2/refs/revparse.c
+++ b/tests/libgit2/refs/revparse.c
@@ -889,3 +889,15 @@ void test_refs_revparse__parses_at_head(void)
 	test_id("@{0}", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVSPEC_SINGLE);
 	test_id("@", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750", NULL, GIT_REVSPEC_SINGLE);
 }
+
+void test_refs_revparse__rejects_bogus_at(void)
+{
+	git_repository *repo;
+	git_object *target;
+
+	repo = cl_git_sandbox_init("testrepo.git");
+
+	cl_git_fail_with(GIT_EINVALIDSPEC, git_revparse_single(&target, repo, "foo@"));
+
+	cl_git_sandbox_cleanup();
+}


### PR DESCRIPTION
Support a revspec of '@' to mean 'HEAD', but ensure that it's at the start of the revspec. Previously we were erroneously allowing 'foo@' to mean 'HEAD' as well. Instead, 'foo@' should be rejected.

Fixes #6735 