### PR TITLE
repo: ensure we can initialize win32 paths

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -2676,6 +2676,8 @@ static int repo_init_directories(
 	if (git_str_joinpath(repo_path, given_repo, add_dotgit ? GIT_DIR : "") < 0)
 		return -1;
 
+	git_fs_path_mkposix(repo_path->ptr);
+
 	has_dotgit = (git__suffixcmp(repo_path->ptr, "/" GIT_DIR) == 0);
 	if (has_dotgit)
 		opts->flags |= GIT_REPOSITORY_INIT__HAS_DOTGIT;

--- a/tests/libgit2/repo/init.c
+++ b/tests/libgit2/repo/init.c
@@ -755,3 +755,28 @@ void test_repo_init__longpath(void)
 	git_str_dispose(&path);
 #endif
 }
+
+void test_repo_init__absolute_path_with_backslashes(void)
+{
+#ifdef GIT_WIN32
+	git_repository_init_options initopts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
+	git_str path = GIT_STR_INIT;
+	char *c;
+
+	cl_set_cleanup(&cleanup_repository, "path");
+
+	cl_git_pass(git_str_joinpath(&path, clar_sandbox_path(), "path/to/newrepo"));
+
+	for (c = path.ptr; *c; c++) {
+		if (*c == '/')
+			*c = '\\';
+	}
+
+	initopts.flags |= GIT_REPOSITORY_INIT_MKDIR | GIT_REPOSITORY_INIT_MKPATH;
+
+	cl_git_pass(git_repository_init_ext(&g_repo, path.ptr, &initopts));
+	git_str_dispose(&path);
+#else
+	clar__skip();
+#endif
+}


### PR DESCRIPTION
Given a win32 path, ensure that we can initialize it. This involves a posix-style path conversion at the beginning of our initialization.

Fixes #5241 