### PR TITLE
http: support empty http.proxy config setting

### DIFF
--- a/src/libgit2/transports/http.c
+++ b/src/libgit2/transports/http.c
@@ -334,7 +334,7 @@ static int lookup_proxy(
 		return 0;
 	}
 
-	if (!proxy ||
+	if (!proxy || !*proxy ||
 	    (error = git_net_url_parse_http(&transport->proxy.url, proxy)) < 0)
 		goto done;
 

--- a/src/libgit2/transports/winhttp.c
+++ b/src/libgit2/transports/winhttp.c
@@ -436,7 +436,7 @@ static int winhttp_stream_connect(winhttp_stream *s)
 		GIT_ERROR_CHECK_ALLOC(proxy_url);
 	}
 
-	if (proxy_url) {
+	if (proxy_url && *proxy_url) {
 		git_str processed_url = GIT_STR_INIT;
 		WINHTTP_PROXY_INFO proxy_info;
 		wchar_t *proxy_wide;

--- a/tests/libgit2/online/fetch.c
+++ b/tests/libgit2/online/fetch.c
@@ -110,6 +110,26 @@ void test_online_fetch__fetch_twice(void)
 	git_remote_free(remote);
 }
 
+void test_online_fetch__fetch_with_empty_http_proxy(void)
+{
+	git_remote *remote;
+	git_config *config;
+	git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;
+
+	opts.proxy_opts.type = GIT_PROXY_AUTO;
+
+	cl_git_pass(git_repository_config(&config, _repo));
+	cl_git_pass(git_config_set_string(config, "http.proxy", ""));
+
+	cl_git_pass(git_remote_create(&remote, _repo, "test",
+		"https://github.com/libgit2/TestGitRepository"));
+	cl_git_pass(git_remote_fetch(remote, NULL, &opts, NULL));
+
+	git_remote_disconnect(remote);
+	git_remote_free(remote);
+	git_config_free(config);
+}
+
 static int transferProgressCallback(const git_indexer_progress *stats, void *payload)
 {
 	bool *invoked = (bool *)payload;


### PR DESCRIPTION
An empty `http.proxy` config setting should be treated like a missing `http.proxy` config setting.

Fixes #5220