### PR TITLE
Fix broken regexp that matches submodule names containing ".path"

### DIFF
--- a/src/libgit2/submodule.c
+++ b/src/libgit2/submodule.c
@@ -196,7 +196,7 @@ static void free_submodule_names(git_strmap *names)
  */
 static int load_submodule_names(git_strmap **out, git_repository *repo, git_config *cfg)
 {
-	const char *key = "submodule\\..*\\.path";
+	const char *key = "^submodule\\..*\\.path$";
 	git_config_iterator *iter = NULL;
 	git_config_entry *entry;
 	git_str buf = GIT_STR_INIT;
@@ -332,7 +332,7 @@ int git_submodule__lookup_with_cache(
 	/* If it's not configured or we're looking by path  */
 	if (location == 0 || location == GIT_SUBMODULE_STATUS_IN_WD) {
 		git_config_backend *mods;
-		const char *pattern = "submodule\\..*\\.path";
+		const char *pattern = "^submodule\\..*\\.path$";
 		git_str path = GIT_STR_INIT;
 		fbp_data data = { NULL, NULL };
 

--- a/tests/libgit2/submodule/lookup.c
+++ b/tests/libgit2/submodule/lookup.c
@@ -401,6 +401,24 @@ void test_submodule_lookup__prefix_name(void)
 	git_submodule_free(sm);
 }
 
+/* ".path" in name of submodule */
+void test_submodule_lookup__dotpath_in_name(void)
+{
+	sm_lookup_data data;
+
+	cl_git_rewritefile(
+	        "submod2/.gitmodules", "[submodule \"kwb.pathdict\"]\n"
+	                               "    path = kwb.pathdict\n"
+	                               "    url = ../Test_App\n"
+	                               "[submodule \"fakin.path.app\"]\n"
+	                               "    path = fakin.path.app\n"
+	                               "    url = ../Test_App\n");
+
+	memset(&data, 0, sizeof(data));
+	cl_git_pass(git_submodule_foreach(g_repo, sm_lookup_cb, &data));
+	cl_assert_equal_i(9, data.count);
+}
+
 void test_submodule_lookup__renamed(void)
 {
 	const char *newpath = "sm_actually_changed";


### PR DESCRIPTION
fixes #6580