### PR TITLE
fetch: fail on depth for local transport

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -60,7 +60,8 @@ typedef enum {
 	GIT_EAPPLYFAIL      = -35,	/**< Patch application failed */
 	GIT_EOWNER          = -36,	/**< The object is not owned by the current user */
 	GIT_TIMEOUT         = -37,	/**< The operation timed out */
-	GIT_EUNCHANGED      = -38	/**< There were no changes */
+	GIT_EUNCHANGED      = -38,	/**< There were no changes */
+	GIT_ENOTSUPPORTED   = -39	/**< An option is not supported */
 } git_error_code;
 
 /**

--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -303,6 +303,11 @@ static int local_negotiate_fetch(
 
 	GIT_UNUSED(wants);
 
+	if (wants->depth) {
+		git_error_set(GIT_ERROR_NET, "shallow fetch is not supported by the local transport");
+		return GIT_ENOTSUPPORTED;
+	}
+
 	/* Fill in the loids */
 	git_vector_foreach(&t->refs, i, rhead) {
 		git_object *obj;

--- a/tests/libgit2/clone/local.c
+++ b/tests/libgit2/clone/local.c
@@ -210,3 +210,14 @@ void test_clone_local__git_style_unc_paths(void)
 	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
 #endif
 }
+
+void test_clone_local__shallow_fails(void)
+{
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.depth = 4;
+
+	cl_git_fail_with(GIT_ENOTSUPPORTED, git_clone(&repo, cl_fixture("testrepo.git"), "./clone.git", &opts));
+	git_repository_free(repo);
+}


### PR DESCRIPTION
We don't support shallow clones for the local transport, currently. Fail, instead of silently ignoring the depth option.