### PR TITLE
Fix message trailer parsing

### DIFF
--- a/src/libgit2/trailer.c
+++ b/src/libgit2/trailer.c
@@ -158,7 +158,7 @@ static size_t find_patch_start(const char *str)
 	const char *s;
 
 	for (s = str; *s; s = next_line(s)) {
-		if (git__prefixcmp(s, "---") == 0)
+		if (git__prefixcmp(s, "---") == 0 && git__isspace(s[3]))
 			return s - str;
 	}
 

--- a/tests/libgit2/message/trailer.c
+++ b/tests/libgit2/message/trailer.c
@@ -3,18 +3,21 @@
 static void assert_trailers(const char *message, git_message_trailer *trailers)
 {
 	git_message_trailer_array arr;
-	size_t i;
+	size_t i, count;
 
 	int rc = git_message_trailers(&arr, message);
 
 	cl_assert_equal_i(0, rc);
 
-	for(i=0; i<arr.count; i++) {
+	for (i = 0, count = 0; trailers[i].key != NULL; i++, count++)
+		;
+
+	cl_assert_equal_sz(arr.count, count);
+
+	for (i=0; i < count; i++) {
 		cl_assert_equal_s(arr.trailers[i].key, trailers[i].key);
 		cl_assert_equal_s(arr.trailers[i].value, trailers[i].value);
 	}
-
-	cl_assert_equal_i(0, rc);
 
 	git_message_trailer_array_free(&arr);
 }

--- a/tests/libgit2/message/trailer.c
+++ b/tests/libgit2/message/trailer.c
@@ -165,3 +165,23 @@ void test_message_trailer__invalid(void)
 		"Another: trailer\n"
 	, trailers);
 }
+
+void test_message_trailer__ignores_dashes(void)
+{
+	git_message_trailer trailers[] = {
+		{ "Signed-off-by", "some@one.com" },
+		{ "Another", "trailer" },
+		{ NULL, NULL },
+	};
+
+	assert_trailers(
+		"Message\n"
+		"\n"
+		"Markdown header\n"
+		"---------------\n"
+		"Lorem ipsum\n"
+		"\n"
+		"Signed-off-by: some@one.com\n"
+		"Another: trailer\n"
+	, trailers);
+}


### PR DESCRIPTION
Update message trailer parsing to match git behavior for ignoring patch attachments.

Fixes #6760 