### PR TITLE
ci: update nightly workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,7 +89,7 @@ jobs:
   publish:
     name: Publish results
     needs: [ build ]
-    if: always()
+    if: ${{ always() && github.repository == 'libgit2/libgit2' }}
     runs-on: ubuntu-latest
     steps:
     - name: Check out benchmark repository
@@ -100,7 +100,7 @@ jobs:
         fetch-depth: 0
         ssh-key: ${{ secrets.BENCHMARKS_PUBLISH_KEY }}
     - name: Download test results
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
     - name: Publish API
       run: |
        # Move today's benchmark run into the right place

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -401,7 +401,7 @@ jobs:
   test_results:
     name: Test results
     needs: [ build ]
-    if: always()
+    if: ${{ always() && github.repository == 'libgit2/libgit2' }}
     runs-on: ubuntu-latest
     steps:
     - name: Download test results


### PR DESCRIPTION
Update the nightly and benchmark workflows to only run steps in libgit2/libgit2 by default. Also update the benchmark workflow to use the latest download-artifact version.