### PR TITLE
process.c: fix environ for macOS

### DIFF
--- a/src/util/unix/process.c
+++ b/src/util/unix/process.c
@@ -15,7 +15,12 @@
 #include "process.h"
 #include "strlist.h"
 
-extern char **environ;
+#ifdef __APPLE__
+	#include <crt_externs.h>
+	#define environ (*_NSGetEnviron())
+#else
+	extern char **environ;
+#endif
 
 struct git_process {
 	char **args;


### PR DESCRIPTION
https://github.com/libgit2/libgit2/commit/bc97d01c039f004a05a5457bace11f3c3e26beb5 commit introduced `environ` usage which is not compatible with some version of macOS. In result `libgit2` cannot be built.

Fix that: use a MacOS-specific symbol on macOS.