### PR TITLE
cmake: remove workaround that isn't compatible with Windows on ARM

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -65,12 +65,6 @@ set_target_properties(libgit2package PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJE
 set_target_properties(libgit2package PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 set_target_properties(libgit2package PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 
-# Workaround for Cmake bug #0011240 (see http://public.kitware.com/Bug/view.php?id=11240)
-# Win64+MSVC+static libs = linker error
-if(MSVC AND GIT_ARCH_64 AND NOT BUILD_SHARED_LIBS)
-	set_target_properties(libgit2package PROPERTIES STATIC_LIBRARY_FLAGS "/MACHINE:x64")
-endif()
-
 ide_split_sources(libgit2package)
 
 if(SONAME)


### PR DESCRIPTION
Attempting to build static libraries with the ARM MSVC command prompt fails because of this old workaround. According to the bug report linked in the comment (http://public.kitware.com/Bug/view.php?id=11240), the bug was fixed in CMake 3.4. This *should* no longer be necessary now that the required CMake version is 3.5.1.