### PR TITLE
transport: provide a useful error message during cancellation

### DIFF
--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -458,7 +458,7 @@ static int local_push(
 			default:
 				last = git_error_last();
 
-				if (last && last->message)
+				if (last->klass != GIT_ERROR_NONE)
 					status->msg = git__strdup(last->message);
 				else
 					status->msg = git__strdup("Unspecified error encountered");

--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -375,8 +375,8 @@ static int _git_ssh_authenticate_session(
 			return GIT_EAUTH;
 
 	if (rc != LIBSSH2_ERROR_NONE) {
-		if (!git_error_last())
-			ssh_error(session, "Failed to authenticate SSH session");
+		if (git_error_last()->klass == GIT_ERROR_NONE)
+			ssh_error(session, "failed to authenticate SSH session");
 		return -1;
 	}
 

--- a/src/libgit2/transports/winhttp.c
+++ b/src/libgit2/transports/winhttp.c
@@ -293,7 +293,7 @@ static int certificate_check(winhttp_stream *s, int valid)
 
 	/* If there is no override, we should fail if WinHTTP doesn't think it's fine */
 	if (t->owner->connect_opts.callbacks.certificate_check == NULL && !valid) {
-		if (!git_error_last())
+		if (git_error_last()->klass == GIT_ERROR_NONE)
 			git_error_set(GIT_ERROR_HTTP, "unknown certificate check failure");
 
 		return GIT_ECERTIFICATE;
@@ -317,7 +317,7 @@ static int certificate_check(winhttp_stream *s, int valid)
 	if (error == GIT_PASSTHROUGH)
 		error = valid ? 0 : GIT_ECERTIFICATE;
 
-	if (error < 0 && !git_error_last())
+	if (error < 0 && git_error_last()->klass == GIT_ERROR_NONE)
 		git_error_set(GIT_ERROR_HTTP, "user cancelled certificate check");
 
 	return error;
@@ -961,7 +961,7 @@ static int send_request(winhttp_stream *s, size_t len, bool chunked)
 			(!request_failed && s->status_sending_request_reached)) {
 			git_error_clear();
 			if ((error = certificate_check(s, cert_valid)) < 0) {
-				if (!git_error_last())
+				if (git_error_last()->klass == GIT_ERROR_NONE)
 					git_error_set(GIT_ERROR_OS, "user cancelled certificate check");
 
 				return error;


### PR DESCRIPTION
Since 3618a2a, `git_error_last` does not return NULL when there was no error. Adapt to this when testing for a user cancelling a callback but not setting an error message, testing for `klass` of `GIT_ERROR_NONE`.