### PR TITLE
config: remove `free` ptr from `git_config_entry`

### DIFF
--- a/include/git2/config.h
+++ b/include/git2/config.h
@@ -97,12 +97,6 @@ typedef struct git_config_entry {
 
 	/** Configuration level for the file this was found in */
 	git_config_level_t level;
-
-	/**
-	 * Free function for this entry; for internal purposes. Callers
-	 * should call `git_config_entry_free` to free data.
-	 */
-	void GIT_CALLBACK(free)(struct git_config_entry *entry);
 } git_config_entry;
 
 /**

--- a/include/git2/sys/config.h
+++ b/include/git2/sys/config.h
@@ -20,6 +20,16 @@
  */
 GIT_BEGIN_DECL
 
+typedef struct git_config_backend_entry {
+	struct git_config_entry entry;
+
+	/**
+	 * Free function for this entry; for internal purposes. Callers
+	 * should call `git_config_entry_free` to free data.
+	 */
+	void GIT_CALLBACK(free)(struct git_config_backend_entry *entry);
+} git_config_backend_entry;
+
 /**
  * Every iterator must have this struct as its first element, so the
  * API can talk to it. You'd define your iterator as
@@ -39,7 +49,7 @@ struct git_config_iterator {
 	 * Return the current entry and advance the iterator. The
 	 * memory belongs to the library.
 	 */
-	int GIT_CALLBACK(next)(git_config_entry **entry, git_config_iterator *iter);
+	int GIT_CALLBACK(next)(git_config_backend_entry **entry, git_config_iterator *iter);
 
 	/**
 	 * Free the iterator
@@ -59,7 +69,7 @@ struct git_config_backend {
 
 	/* Open means open the file/database and parse if necessary */
 	int GIT_CALLBACK(open)(struct git_config_backend *, git_config_level_t level, const git_repository *repo);
-	int GIT_CALLBACK(get)(struct git_config_backend *, const char *key, git_config_entry **entry);
+	int GIT_CALLBACK(get)(struct git_config_backend *, const char *key, git_config_backend_entry **entry);
 	int GIT_CALLBACK(set)(struct git_config_backend *, const char *key, const char *value);
 	int GIT_CALLBACK(set_multivar)(git_config_backend *cfg, const char *name, const char *regexp, const char *value);
 	int GIT_CALLBACK(del)(struct git_config_backend *, const char *key);

--- a/src/libgit2/config_backend.h
+++ b/src/libgit2/config_backend.h
@@ -51,7 +51,14 @@ GIT_INLINE(void) git_config_backend_free(git_config_backend *cfg)
 GIT_INLINE(int) git_config_backend_get_string(
 	git_config_entry **out, git_config_backend *cfg, const char *name)
 {
-	return cfg->get(cfg, name, out);
+	git_config_backend_entry *be;
+	int error;
+
+	if ((error = cfg->get(cfg, name, &be)) < 0)
+		return error;
+
+	*out = &be->entry;
+	return 0;
 }
 
 GIT_INLINE(int) git_config_backend_set_string(

--- a/src/libgit2/config_file.c
+++ b/src/libgit2/config_file.c
@@ -310,8 +310,8 @@ static int config_file_set(git_config_backend *cfg, const char *name, const char
 		if (error != GIT_ENOTFOUND)
 			goto out;
 		error = 0;
-	} else if ((!existing->base.value && !value) ||
-		   (existing->base.value && value && !strcmp(existing->base.value, value))) {
+	} else if ((!existing->base.entry.value && !value) ||
+		   (existing->base.entry.value && value && !strcmp(existing->base.entry.value, value))) {
 		/* don't update if old and new values already match */
 		error = 0;
 		goto out;
@@ -336,7 +336,10 @@ out:
 /*
  * Internal function that actually gets the value in string form
  */
-static int config_file_get(git_config_backend *cfg, const char *key, git_config_entry **out)
+static int config_file_get(
+	git_config_backend *cfg,
+	const char *key,
+	git_config_backend_entry **out)
 {
 	config_file_backend *h = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_list *config_list = NULL;
@@ -407,7 +410,7 @@ static int config_file_delete(git_config_backend *cfg, const char *name)
 		goto out;
 	}
 
-	if ((error = config_file_write(b, name, entry->base.name, NULL, NULL)) < 0)
+	if ((error = config_file_write(b, name, entry->base.entry.name, NULL, NULL)) < 0)
 		goto out;
 
 out:
@@ -795,22 +798,22 @@ static int read_on_variable(
 	entry = git__calloc(1, sizeof(git_config_list_entry));
 	GIT_ERROR_CHECK_ALLOC(entry);
 
-	entry->base.name = git_str_detach(&buf);
-	GIT_ERROR_CHECK_ALLOC(entry->base.name);
+	entry->base.entry.name = git_str_detach(&buf);
+	GIT_ERROR_CHECK_ALLOC(entry->base.entry.name);
 
 	if (var_value) {
-		entry->base.value = git__strdup(var_value);
-		GIT_ERROR_CHECK_ALLOC(entry->base.value);
+		entry->base.entry.value = git__strdup(var_value);
+		GIT_ERROR_CHECK_ALLOC(entry->base.entry.value);
 	}
 
-	entry->base.backend_type = git_config_list_add_string(parse_data->config_list, CONFIG_FILE_TYPE);
-	GIT_ERROR_CHECK_ALLOC(entry->base.backend_type);
+	entry->base.entry.backend_type = git_config_list_add_string(parse_data->config_list, CONFIG_FILE_TYPE);
+	GIT_ERROR_CHECK_ALLOC(entry->base.entry.backend_type);
 
-	entry->base.origin_path = git_config_list_add_string(parse_data->config_list, parse_data->file->path);
-	GIT_ERROR_CHECK_ALLOC(entry->base.origin_path);
+	entry->base.entry.origin_path = git_config_list_add_string(parse_data->config_list, parse_data->file->path);
+	GIT_ERROR_CHECK_ALLOC(entry->base.entry.origin_path);
 
-	entry->base.level = parse_data->level;
-	entry->base.include_depth = parse_data->depth;
+	entry->base.entry.level = parse_data->level;
+	entry->base.entry.include_depth = parse_data->depth;
 	entry->base.free = git_config_list_entry_free;
 	entry->config_list = parse_data->config_list;
 
@@ -820,11 +823,11 @@ static int read_on_variable(
 	result = 0;
 
 	/* Add or append the new config option */
-	if (!git__strcmp(entry->base.name, "include.path"))
-		result = parse_include(parse_data, entry->base.value);
-	else if (!git__prefixcmp(entry->base.name, "includeif.") &&
-	         !git__suffixcmp(entry->base.name, ".path"))
-		result = parse_conditional_include(parse_data, entry->base.name, entry->base.value);
+	if (!git__strcmp(entry->base.entry.name, "include.path"))
+		result = parse_include(parse_data, entry->base.entry.value);
+	else if (!git__prefixcmp(entry->base.entry.name, "includeif.") &&
+	         !git__suffixcmp(entry->base.entry.name, ".path"))
+		result = parse_conditional_include(parse_data, entry->base.entry.name, entry->base.entry.value);
 
 	return result;
 }

--- a/src/libgit2/config_list.h
+++ b/src/libgit2/config_list.h
@@ -13,7 +13,7 @@
 typedef struct git_config_list git_config_list;
 
 typedef struct {
-	git_config_entry base;
+	git_config_backend_entry base;
 	git_config_list *config_list;
 } git_config_list_entry;
 
@@ -29,4 +29,4 @@ int git_config_list_get_unique(git_config_list_entry **out, git_config_list *lis
 int git_config_list_iterator_new(git_config_iterator **out, git_config_list *list);
 const char *git_config_list_add_string(git_config_list *list, const char *str);
 
-void git_config_list_entry_free(git_config_entry *entry);
+void git_config_list_entry_free(git_config_backend_entry *entry);

--- a/src/libgit2/config_mem.c
+++ b/src/libgit2/config_mem.c
@@ -77,12 +77,12 @@ static int read_variable_cb(
 
 	entry = git__calloc(1, sizeof(git_config_list_entry));
 	GIT_ERROR_CHECK_ALLOC(entry);
-	entry->base.name = git_str_detach(&buf);
-	entry->base.value = var_value ? git__strdup(var_value) : NULL;
-	entry->base.level = parse_data->level;
-	entry->base.include_depth = 0;
-	entry->base.backend_type = parse_data->backend_type;
-	entry->base.origin_path = parse_data->origin_path;
+	entry->base.entry.name = git_str_detach(&buf);
+	entry->base.entry.value = var_value ? git__strdup(var_value) : NULL;
+	entry->base.entry.level = parse_data->level;
+	entry->base.entry.include_depth = 0;
+	entry->base.entry.backend_type = parse_data->backend_type;
+	entry->base.entry.origin_path = parse_data->origin_path;
 	entry->base.free = git_config_list_entry_free;
 	entry->config_list = parse_data->config_list;
 
@@ -151,18 +151,18 @@ static int parse_values(
 		entry = git__calloc(1, sizeof(git_config_list_entry));
 		GIT_ERROR_CHECK_ALLOC(entry);
 
-		entry->base.name = git__strndup(memory_backend->values[i], name_len);
-		GIT_ERROR_CHECK_ALLOC(entry->base.name);
+		entry->base.entry.name = git__strndup(memory_backend->values[i], name_len);
+		GIT_ERROR_CHECK_ALLOC(entry->base.entry.name);
 
 		if (eql) {
-			entry->base.value = git__strdup(eql + 1);
-			GIT_ERROR_CHECK_ALLOC(entry->base.value);
+			entry->base.entry.value = git__strdup(eql + 1);
+			GIT_ERROR_CHECK_ALLOC(entry->base.entry.value);
 		}
 
-		entry->base.level = level;
-		entry->base.include_depth = 0;
-		entry->base.backend_type = backend_type;
-		entry->base.origin_path = origin_path;
+		entry->base.entry.level = level;
+		entry->base.entry.include_depth = 0;
+		entry->base.entry.backend_type = backend_type;
+		entry->base.entry.origin_path = origin_path;
 		entry->base.free = git_config_list_entry_free;
 		entry->config_list = memory_backend->config_list;
 
@@ -190,7 +190,7 @@ static int config_memory_open(git_config_backend *backend, git_config_level_t le
 	return 0;
 }
 
-static int config_memory_get(git_config_backend *backend, const char *key, git_config_entry **out)
+static int config_memory_get(git_config_backend *backend, const char *key, git_config_backend_entry **out)
 {
 	config_memory_backend *memory_backend = (config_memory_backend *) backend;
 	git_config_list_entry *entry;

--- a/src/libgit2/config_snapshot.c
+++ b/src/libgit2/config_snapshot.c
@@ -41,7 +41,10 @@ out:
 	return error;
 }
 
-static int config_snapshot_get(git_config_backend *cfg, const char *key, git_config_entry **out)
+static int config_snapshot_get(
+	git_config_backend *cfg,
+	const char *key,
+	git_config_backend_entry **out)
 {
 	config_snapshot_backend *b = GIT_CONTAINER_OF(cfg, config_snapshot_backend, parent);
 	git_config_list *config_list = NULL;


### PR DESCRIPTION
While looking at the documentation, it became clear that the `git_config_entry` function was strange...

This is a leftover leaky abstraction. If consumers aren't meant to _call_ the `free` function then they shouldn't _see_ the free function. Move it out into a `git_config_backend_entry` that is, well, produced by the config backends.

This makes our code messier but is an improvement for consumers.