### PR TITLE
remote: drop bitfields in git_remote_fetch_options

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -746,8 +746,7 @@ typedef struct {
 	/**
 	 * How to handle reference updates; see `git_remote_update_flags`.
 	 */
-	unsigned int update_fetchhead : 1,
-	             report_unchanged : 1;
+	unsigned int update_fetchhead;
 
 	/**
 	 * Determines how to behave regarding tags on the remote, such
@@ -790,8 +789,7 @@ typedef struct {
 	GIT_FETCH_OPTIONS_VERSION, \
 	GIT_REMOTE_CALLBACKS_INIT, \
 	GIT_FETCH_PRUNE_UNSPECIFIED, \
-	1, \
-	0, \
+	GIT_REMOTE_UPDATE_FETCHHEAD, \
 	GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED, \
 	GIT_PROXY_OPTIONS_INIT }
 

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -1376,12 +1376,7 @@ int git_remote_fetch(
 		return error;
 
 	if (opts) {
-		if (opts->update_fetchhead)
-			update_flags |= GIT_REMOTE_UPDATE_FETCHHEAD;
-
-		if (opts->report_unchanged)
-			update_flags |= GIT_REMOTE_UPDATE_REPORT_UNCHANGED;
-
+		update_flags = opts->update_fetchhead;
 		tagopt = opts->download_tags;
 	}
 


### PR DESCRIPTION
In attempting to make a clever change that added fetch options as flags, while keeping ABI and API compatibility, we screwed up. Bitfields in structs are implementation-specific and are not necessarily ABI compatible across compilers.

Make `update_fetchhead` a flags value which is weirdly named, but that's a future problem. This removes the `report_unchanged` option from API.