### PR TITLE
Introduce a stricter debugging allocator for testing

### DIFF
--- a/src/util/alloc.c
+++ b/src/util/alloc.c
@@ -8,8 +8,9 @@
 #include "alloc.h"
 #include "runtime.h"
 
-#include "allocators/failalloc.h"
 #include "allocators/stdalloc.h"
+#include "allocators/debugalloc.h"
+#include "allocators/failalloc.h"
 #include "allocators/win32_leakcheck.h"
 
 /* Fail any allocation until git_libgit2_init is called. */
@@ -88,6 +89,8 @@ static int setup_default_allocator(void)
 {
 #if defined(GIT_WIN32_LEAKCHECK)
 	return git_win32_leakcheck_init_allocator(&git__allocator);
+#elif defined(GIT_DEBUG_STRICT_ALLOC)
+	return git_debugalloc_init_allocator(&git__allocator);
 #else
 	return git_stdalloc_init_allocator(&git__allocator);
 #endif

--- a/src/util/allocators/debugalloc.c
+++ b/src/util/allocators/debugalloc.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "debugalloc.h"
+
+static void *debugalloc__malloc(size_t len, const char *file, int line)
+{
+	void *ptr;
+	size_t total = len + sizeof(size_t);
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	if (!len || (ptr = malloc(total)) == NULL)
+		return NULL;
+
+	memcpy(ptr, &len, sizeof(size_t));
+	return ptr + sizeof(size_t);
+}
+
+static void *debugalloc__realloc(void *ptr, size_t len, const char *file, int line)
+{
+	void *newptr;
+	size_t original_len;
+	size_t total = len + sizeof(size_t);
+
+	GIT_UNUSED(file);
+	GIT_UNUSED(line);
+
+	if (!len && !ptr)
+		return NULL;
+
+	if (!len) {
+		free(ptr - sizeof(size_t));
+		return NULL;
+	}
+
+	if ((newptr = malloc(total)) == NULL)
+		return NULL;
+
+	if (ptr) {
+		memcpy(&original_len, ptr - sizeof(size_t), sizeof(size_t));
+		memcpy(newptr + sizeof(size_t), ptr, min(len, original_len));
+
+		memset(ptr - sizeof(size_t), 0xfd, original_len + sizeof(size_t));
+		free(ptr - sizeof(size_t));
+	}
+
+	memcpy(newptr, &len, sizeof(size_t));
+	return newptr + sizeof(size_t);
+}
+
+static void debugalloc__free(void *ptr)
+{
+	if (!ptr)
+		return;
+
+	free(ptr - sizeof(size_t));
+}
+
+int git_debugalloc_init_allocator(git_allocator *allocator)
+{
+	allocator->gmalloc = debugalloc__malloc;
+	allocator->grealloc = debugalloc__realloc;
+	allocator->gfree = debugalloc__free;
+	return 0;
+}

--- a/src/util/allocators/debugalloc.c
+++ b/src/util/allocators/debugalloc.c
@@ -9,7 +9,7 @@
 
 static void *debugalloc__malloc(size_t len, const char *file, int line)
 {
-	void *ptr;
+	unsigned char *ptr;
 	size_t total = len + sizeof(size_t);
 
 	GIT_UNUSED(file);
@@ -22,9 +22,9 @@ static void *debugalloc__malloc(size_t len, const char *file, int line)
 	return ptr + sizeof(size_t);
 }
 
-static void *debugalloc__realloc(void *ptr, size_t len, const char *file, int line)
+static void *debugalloc__realloc(void *_ptr, size_t len, const char *file, int line)
 {
-	void *newptr;
+	unsigned char *ptr = _ptr, *newptr;
 	size_t original_len;
 	size_t total = len + sizeof(size_t);
 
@@ -54,8 +54,10 @@ static void *debugalloc__realloc(void *ptr, size_t len, const char *file, int li
 	return newptr + sizeof(size_t);
 }
 
-static void debugalloc__free(void *ptr)
+static void debugalloc__free(void *_ptr)
 {
+	unsigned char *ptr = _ptr;
+
 	if (!ptr)
 		return;
 

--- a/src/util/allocators/debugalloc.h
+++ b/src/util/allocators/debugalloc.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_allocators_debugalloc_h__
+#define INCLUDE_allocators_debugalloc_h__
+
+#include "git2_util.h"
+
+#include "alloc.h"
+
+int git_debugalloc_init_allocator(git_allocator *allocator);
+
+#endif

--- a/src/util/allocators/stdalloc.c
+++ b/src/util/allocators/stdalloc.c
@@ -12,11 +12,6 @@ static void *stdalloc__malloc(size_t len, const char *file, int line)
 	GIT_UNUSED(file);
 	GIT_UNUSED(line);
 
-#ifdef GIT_DEBUG_STRICT_ALLOC
-	if (!len)
-		return NULL;
-#endif
-
 	return malloc(len);
 }
 
@@ -24,11 +19,6 @@ static void *stdalloc__realloc(void *ptr, size_t size, const char *file, int lin
 {
 	GIT_UNUSED(file);
 	GIT_UNUSED(line);
-
-#ifdef GIT_DEBUG_STRICT_ALLOC
-	if (!size)
-		return NULL;
-#endif
 
 	return realloc(ptr, size);
 }

--- a/tests/clar/clar_libgit2_alloc.c
+++ b/tests/clar/clar_libgit2_alloc.c
@@ -104,7 +104,5 @@ void cl_alloc_limit(size_t bytes)
 
 void cl_alloc_reset(void)
 {
-	git_allocator stdalloc;
-	git_stdalloc_init_allocator(&stdalloc);
-	git_allocator_setup(&stdalloc);
+	git_allocator_setup(NULL);
 }

--- a/tests/libgit2/checkout/conflict.c
+++ b/tests/libgit2/checkout/conflict.c
@@ -1095,7 +1095,7 @@ static void collect_progress(
 	if (path == NULL)
 		return;
 
-	git_vector_insert(paths, strdup(path));
+	git_vector_insert(paths, git__strdup(path));
 }
 
 void test_checkout_conflict__report_progress(void)

--- a/tests/libgit2/checkout/icase.c
+++ b/tests/libgit2/checkout/icase.c
@@ -89,7 +89,7 @@ static void assert_name_is(const char *expected)
 	if (start)
 		cl_assert_equal_strn("/", actual + (start - 1), 1);
 
-	free(actual);
+	git__free(actual);
 }
 
 static int symlink_or_fake(git_repository *repo, const char *a, const char *b)

--- a/tests/libgit2/remote/fetch.c
+++ b/tests/libgit2/remote/fetch.c
@@ -40,10 +40,10 @@ void test_remote_fetch__cleanup(void) {
 	git_repository_free(repo2);
 
 	cl_git_pass(git_futils_rmdir_r(repo1_path, NULL, GIT_RMDIR_REMOVE_FILES));
-	free(repo1_path);
+	git__free(repo1_path);
 
 	cl_git_pass(git_futils_rmdir_r(repo2_path, NULL, GIT_RMDIR_REMOVE_FILES));
-	free(repo2_path);
+	git__free(repo2_path);
 }
 
 


### PR DESCRIPTION
Introduce a new debugging allocator that:

1) internally tracks allocation size — this is helpful both to be able to track internally, but also to ensure that the pointer returned from the custom `malloc` is _not_ the same pointer that the underlying system `malloc` used, and is therefore incompatible with the system `free`. This helps catch inconsistent use of system malloc and the libgit2-configured malloc.
2) forces `realloc` to always reallocate (it will explicitly `malloc`, `memcpy`, and `free` the previous pointer)

Also, update some inconsistent use of allocators caught by 1.