### PR TITLE
tree: avoid mixed signedness comparison

### DIFF
--- a/src/libgit2/tree.c
+++ b/src/libgit2/tree.c
@@ -381,7 +381,7 @@ static int parse_mode(uint16_t *mode_out, const char *buffer, size_t buffer_len,
 	if ((error = git__strntol32(&mode, buffer, buffer_len, buffer_out, 8)) < 0)
 		return error;
 
-	if (mode < 0 || mode > UINT16_MAX)
+	if (mode < 0 || (uint32_t)mode > UINT16_MAX)
 		return -1;
 
 	*mode_out = mode;


### PR DESCRIPTION
Promote mode to `uint32_t` before comparing it to an `uint16_t` to avoid mixed signed comparison warnings.