### PR TITLE
Add assert

### DIFF
--- a/src/libgit2/object.c
+++ b/src/libgit2/object.c
@@ -281,6 +281,7 @@ int git_object_lookup_prefix(
 }
 
 int git_object_lookup(git_object **object_out, git_repository *repo, const git_oid *id, git_object_t type) {
+	GIT_ASSERT_ARG(repo);
 	return git_object_lookup_prefix(object_out,
 		repo, id, git_oid_hexsize(repo->oid_type), type);
 }


### PR DESCRIPTION
Description: In an older version of libgit2 in git_object_lookup_prefix was a check that repo is valid, but now there is repo->oid_type in the git_object_lookup and must be checked as well