### PR TITLE
Limit .gitattributes and .gitignore files to 100 MiB

### DIFF
--- a/src/libgit2/attr_file.c
+++ b/src/libgit2/attr_file.c
@@ -143,6 +143,8 @@ int git_attr_file__load(
 		blobsize = git_blob_rawsize(blob);
 
 		GIT_ERROR_CHECK_BLOBSIZE(blobsize);
+		if (blobsize > GIT_ATTR_MAX_FILE_SIZE) /* TODO: issue warning when warning API is available */
+			goto cleanup;
 		git_str_put(&content, git_blob_rawcontent(blob), (size_t)blobsize);
 		break;
 	}
@@ -155,6 +157,7 @@ int git_attr_file__load(
 		if (p_stat(entry->fullpath, &st) < 0 ||
 			S_ISDIR(st.st_mode) ||
 			(fd = git_futils_open_ro(entry->fullpath)) < 0 ||
+			(st.st_size > GIT_ATTR_MAX_FILE_SIZE) ||
 			(error = git_futils_readbuffer_fd(&content, fd, (size_t)st.st_size)) < 0)
 			nonexistent = true;
 
@@ -198,6 +201,8 @@ int git_attr_file__load(
 		blobsize = git_blob_rawsize(blob);
 
 		GIT_ERROR_CHECK_BLOBSIZE(blobsize);
+		if (blobsize > GIT_ATTR_MAX_FILE_SIZE) /* TODO: issue warning when warning API is available */
+			goto cleanup;
 		if ((error = git_str_put(&content,
 			git_blob_rawcontent(blob), (size_t)blobsize)) < 0)
 			goto cleanup;

--- a/src/libgit2/attr_file.h
+++ b/src/libgit2/attr_file.h
@@ -21,6 +21,8 @@
 #define GIT_ATTR_FILE_SYSTEM	"gitattributes"
 #define GIT_ATTR_FILE_XDG		"attributes"
 
+#define GIT_ATTR_MAX_FILE_SIZE	100 * 1024 * 1024
+
 #define GIT_ATTR_FNMATCH_NEGATIVE	(1U << 0)
 #define GIT_ATTR_FNMATCH_DIRECTORY	(1U << 1)
 #define GIT_ATTR_FNMATCH_FULLPATH	(1U << 2)


### PR DESCRIPTION
Git introduced this 100 MiB limit in commits https://github.com/gitster/git/commit/3c50032ff528 (attr: ignore overly large gitattributes files, 2022-12-01) and https://github.com/gitster/git/commit/e7c3d1ddba0b (dir.c: reduce max pattern file size to 100MB, 2024-06-05).