### PR TITLE
odb: conditional git_hash_ctx_cleanup in git_odb_stream

### DIFF
--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -1796,7 +1796,8 @@ void git_odb_stream_free(git_odb_stream *stream)
 	if (stream == NULL)
 		return;
 
-	git_hash_ctx_cleanup(stream->hash_ctx);
+	if (stream->hash_ctx)
+		git_hash_ctx_cleanup(stream->hash_ctx);
 	git__free(stream->hash_ctx);
 	stream->free(stream);
 }


### PR DESCRIPTION
As discussed in https://github.com/libgit2/libgit2/discussions/6835

When `git_odb_stream` is a read stream, `hash_ctx` is not used. Therefore, check if `hash_ctx` can be freed during the release. This allows implementers of custom ODB backends to not worry about the creation of `hash_ctx` for now.