### PR TITLE
Fix docs for git_odb_stream_read return value.

### DIFF
--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -382,7 +382,7 @@ GIT_EXTERN(int) git_odb_stream_finalize_write(git_oid *out, git_odb_stream *stre
  * @param stream the stream
  * @param buffer a user-allocated buffer to store the data in.
  * @param len the buffer's length
- * @return 0 if the read succeeded, error code otherwise
+ * @return the number of bytes read if succeeded, error code otherwise
  */
 GIT_EXTERN(int) git_odb_stream_read(git_odb_stream *stream, char *buffer, size_t len);
 


### PR DESCRIPTION
I believe the original docs for the return value of `git_odb_stream_read` might be incorrect. It currently says that it returns 0 on success. However, that means there would be no way to know how many bytes were actually saved to the buffer. `loose_backend__readstream_read` appears to return the total number of bytes read. I don't know if there are any other backends that implement readstream (I don't see any).
