### PR TITLE
docs: Add instructions to build examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ On most systems you can build the library using the following commands
 	$ cmake ..
 	$ cmake --build .
 
+To include the examples in the build, use `cmake -DBUILD_EXAMPLES=True ..` instead of `cmake ..`.
+
+The built executable for the examples can then be found in `build/examples`, relative to the toplevel directory.
+
 Alternatively you can point the CMake GUI tool to the CMakeLists.txt file and generate platform specific build project or IDE workspace.
 
 If you're not familiar with CMake, [a more detailed explanation](https://preshing.com/20170511/how-to-build-a-cmake-based-project/) may be helpful.


### PR DESCRIPTION
To build the examples, they must be included in the main build using the following command:

    cmake -DBUILD_EXAMPLES=True ..