### PR TITLE
ssh: Omit port option from ssh command unless specified in remote url

### DIFF
--- a/src/libgit2/transports/ssh_exec.c
+++ b/src/libgit2/transports/ssh_exec.c
@@ -158,9 +158,10 @@ static int get_ssh_cmdline(
 	else if ((error = git_config__get_string_buf(&ssh_cmd, cfg, "core.sshcommand")) < 0 && error != GIT_ENOTFOUND)
 		goto done;
 
-	error = git_str_printf(out, "%s -p %s \"%s%s%s\" \"%s\" \"%s\"",
+	error = git_str_printf(out, "%s %s %s \"%s%s%s\" \"%s\" \"%s\"",
 		ssh_cmd.size > 0 ? ssh_cmd.ptr : default_ssh_cmd,
-		url->port,
+		url->port_specified ? "-p" : "",
+		url->port_specified ? url->port : "",
 		url->username ? url->username : "",
 		url->username ? "@" : "",
 		url->host,


### PR DESCRIPTION
Currently, when using `GIT_SSH_EXEC` feature, `libgit2` doen't respect a `Port` config in ssh config because it always insert `-p 22` option to a ssh command if there is no port value in a git remote url (e.g. `git@my-custom-domain.org:user/path`). I've experienced this for my company's GHE.

~One caveat of this implementation is that if you specify port `22` in a remote url despite a different port in ssh config, it will be ignored.~
~For example, in `~/.ssh/config`:~
```
Host my-custom-domain.org
  Port 1234
```
~and if you try to fetch or push with a remote url `ssh://git@my-custom-domain.org:22/user/path`, the port `1234` will be used.~
~It would be unlikely someone tries to do this though, I guess.~

EDITED:
Now `-p <port>` option is added only when the port is specified in a remote url.