### PR TITLE
Add more robust reporting to SecureTransport errors on macos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,4 +75,5 @@ Tim Clem
 Tim Harder
 Torsten Bögershausen
 Trent Mick
+Venus Xeon-Blonde
 Vicent Marti

--- a/src/libgit2/streams/stransport.c
+++ b/src/libgit2/streams/stransport.c
@@ -41,7 +41,7 @@ static int stransport_error(OSStatus ret)
 		In these cases, it's more valuable to print the actual error message than to be cheap/efficient.
 		Call the (more expensive) 
 	*/
-	if (message_c_str == NULL) {
+	if (( must_free = (message_c_str == NULL) )) {
 		/* 
 			Before we allocate a buffer, get the size of the buffer we need to allocate (in bytes). 
 			CFStringGetLength gives us the number of UTF-16 code-pairs (16 bit characters) in the string. 

--- a/src/libgit2/streams/stransport.c
+++ b/src/libgit2/streams/stransport.c
@@ -15,6 +15,8 @@
 
 #include "git2/transport.h"
 
+#include "../util/alloc.h"
+
 #include "streams/socket.h"
 
 static int stransport_error(OSStatus ret)
@@ -50,7 +52,8 @@ static int stransport_error(OSStatus ret)
 		long buffer_size = CFStringGetLength(message) * 2 + 1;
 
 		/* Allocate the buffer. */
-		message_c_str = malloc((size_t) buffer_size);
+		message_c_str = git__malloc((size_t) buffer_size);
+		GIT_ERROR_CHECK_ALLOC(message_c_str);
 		
 		/* 
 			Convert the string into a C string using the buffer. 
@@ -59,7 +62,7 @@ static int stransport_error(OSStatus ret)
 		*/
 		if (!CFStringGetCString(message, message_c_str, buffer_size, kCFStringEncodingUTF8)) {
 			git_error_set(GIT_ERROR_NET, "CFStringGetCString error while handling a SecureTransport error");
-			free(message_c_str);
+			git__free(message_c_str);
 			CFRelease(message);
 			return -1;
 		}
@@ -69,7 +72,7 @@ static int stransport_error(OSStatus ret)
 
 	/* If we decided earlier that we would have to free the buffer allocation, do that. */
 	if (must_free) {
-		free(message_c_str);
+		git__free(message_c_str);
 	}
 
 	CFRelease(message);


### PR DESCRIPTION
This pull request ensures errors from `SecureTransport` on macos are handled properly when `CFStringGetCStringPtr` returns `null`. This occurs when the string encoding conversion is not cheap/efficient. 

I am making this pull request after encountering a `SecureTransport error: (null); class=Net (12)` while working on https://github.com/mitre/hipcheck. With these changes, I now get an error message from macos instead of `(null)`.