### PR TITLE
url: track whether url explicitly specified a port

### DIFF
--- a/src/util/net.h
+++ b/src/util/net.h
@@ -35,6 +35,8 @@ typedef struct git_net_url {
 	char *fragment;
 	char *username;
 	char *password;
+
+	unsigned int port_specified;
 } git_net_url;
 
 #define GIT_NET_URL_INIT { NULL }

--- a/tests/util/url/parse.c
+++ b/tests/util/url/parse.c
@@ -27,6 +27,7 @@ void test_url_parse__hostname_trivial(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_root(void)
@@ -41,6 +42,7 @@ void test_url_parse__hostname_root(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_implied_root(void)
@@ -55,6 +57,7 @@ void test_url_parse__hostname_implied_root(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_numeric(void)
@@ -69,6 +72,7 @@ void test_url_parse__hostname_numeric(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_implied_root_custom_port(void)
@@ -83,6 +87,22 @@ void test_url_parse__hostname_implied_root_custom_port(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
+}
+
+void test_url_parse__specified_default_port(void)
+{
+	cl_git_pass(git_net_url_parse(&conndata, "http://example.com:80/"));
+	cl_assert_equal_s(conndata.scheme, "http");
+	cl_assert_equal_s(conndata.host, "example.com");
+	cl_assert_equal_s(conndata.port, "80");
+	cl_assert_equal_s(conndata.path, "/");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_p(conndata.query, NULL);
+	cl_assert_equal_p(conndata.fragment, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_implied_root_empty_port(void)
@@ -97,6 +117,7 @@ void test_url_parse__hostname_implied_root_empty_port(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_encoded_password(void)
@@ -112,6 +133,7 @@ void test_url_parse__hostname_encoded_password(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_user(void)
@@ -127,6 +149,7 @@ void test_url_parse__hostname_user(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_user_pass(void)
@@ -143,6 +166,7 @@ void test_url_parse__hostname_user_pass(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_port(void)
@@ -159,6 +183,7 @@ void test_url_parse__hostname_port(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_empty_port(void)
@@ -173,6 +198,7 @@ void test_url_parse__hostname_empty_port(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__hostname_user_port(void)
@@ -189,6 +215,7 @@ void test_url_parse__hostname_user_port(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_user_pass_port(void)
@@ -205,6 +232,7 @@ void test_url_parse__hostname_user_pass_port(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_user_pass_port_query(void)
@@ -221,6 +249,7 @@ void test_url_parse__hostname_user_pass_port_query(void)
 	cl_assert_equal_s(conndata.query, "query=q&foo=bar&z=asdf");
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_user_pass_port_fragment(void)
@@ -237,6 +266,7 @@ void test_url_parse__hostname_user_pass_port_fragment(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_s(conndata.fragment, "fragment");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__hostname_user_pass_port_query_fragment(void)
@@ -253,6 +283,7 @@ void test_url_parse__hostname_user_pass_port_query_fragment(void)
 	cl_assert_equal_s(conndata.query, "query=q&foo=bar&z=asdf");
 	cl_assert_equal_s(conndata.fragment, "fragment");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__fragment_with_question_mark(void)
@@ -269,6 +300,7 @@ void test_url_parse__fragment_with_question_mark(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_s(conndata.fragment, "fragment_with?question_mark");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 /* IPv4 addresses */
@@ -283,6 +315,7 @@ void test_url_parse__ipv4_trivial(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_root(void)
@@ -295,6 +328,7 @@ void test_url_parse__ipv4_root(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_implied_root(void)
@@ -307,6 +341,7 @@ void test_url_parse__ipv4_implied_root(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_implied_root_custom_port(void)
@@ -319,6 +354,7 @@ void test_url_parse__ipv4_implied_root_custom_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv4_implied_root_empty_port(void)
@@ -331,6 +367,7 @@ void test_url_parse__ipv4_implied_root_empty_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_encoded_password(void)
@@ -344,6 +381,7 @@ void test_url_parse__ipv4_encoded_password(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass/is@bad");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv4_user(void)
@@ -357,6 +395,7 @@ void test_url_parse__ipv4_user(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_user_pass(void)
@@ -370,6 +409,7 @@ void test_url_parse__ipv4_user_pass(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_port(void)
@@ -383,6 +423,7 @@ void test_url_parse__ipv4_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv4_empty_port(void)
@@ -395,6 +436,7 @@ void test_url_parse__ipv4_empty_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv4_user_port(void)
@@ -408,6 +450,7 @@ void test_url_parse__ipv4_user_port(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv4_user_pass_port(void)
@@ -421,6 +464,7 @@ void test_url_parse__ipv4_user_pass_port(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 /* IPv6 addresses */
@@ -435,6 +479,7 @@ void test_url_parse__ipv6_trivial(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_root(void)
@@ -447,6 +492,7 @@ void test_url_parse__ipv6_root(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_implied_root(void)
@@ -459,6 +505,7 @@ void test_url_parse__ipv6_implied_root(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_implied_root_custom_port(void)
@@ -471,6 +518,7 @@ void test_url_parse__ipv6_implied_root_custom_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv6_implied_root_empty_port(void)
@@ -483,6 +531,7 @@ void test_url_parse__ipv6_implied_root_empty_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_encoded_password(void)
@@ -496,6 +545,7 @@ void test_url_parse__ipv6_encoded_password(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass/is@bad");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv6_user(void)
@@ -509,6 +559,7 @@ void test_url_parse__ipv6_user(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_user_pass(void)
@@ -522,6 +573,7 @@ void test_url_parse__ipv6_user_pass(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_port(void)
@@ -535,6 +587,7 @@ void test_url_parse__ipv6_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv6_empty_port(void)
@@ -547,6 +600,7 @@ void test_url_parse__ipv6_empty_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__ipv6_user_port(void)
@@ -560,6 +614,7 @@ void test_url_parse__ipv6_user_port(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv6_user_pass_port(void)
@@ -573,6 +628,7 @@ void test_url_parse__ipv6_user_pass_port(void)
 	cl_assert_equal_s(conndata.username, "user");
 	cl_assert_equal_s(conndata.password, "pass");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ipv6_invalid_addresses(void)
@@ -681,6 +737,7 @@ void test_url_parse__empty_scheme(void)
 	cl_assert_equal_p(conndata.query, NULL);
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__invalid_scheme_is_relative(void)
@@ -695,12 +752,14 @@ void test_url_parse__invalid_scheme_is_relative(void)
 	cl_assert_equal_s(conndata.query, "query_string=yes");
 	cl_assert_equal_p(conndata.fragment, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__scheme_case_is_normalized(void)
 {
 	cl_git_pass(git_net_url_parse(&conndata, "GIT+SSH://host:42/path/to/project"));
 	cl_assert_equal_s(conndata.scheme, "git+ssh");
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__nonhierarchical_scheme(void)
@@ -713,6 +772,7 @@ void test_url_parse__nonhierarchical_scheme(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__no_scheme_relative_path(void)
@@ -725,6 +785,7 @@ void test_url_parse__no_scheme_relative_path(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__no_scheme_absolute_path(void)
@@ -737,6 +798,7 @@ void test_url_parse__no_scheme_absolute_path(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__empty_path(void)
@@ -749,6 +811,7 @@ void test_url_parse__empty_path(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__empty_path_with_empty_authority(void)
@@ -761,6 +824,7 @@ void test_url_parse__empty_path_with_empty_authority(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_parse__http_follows_the_rfc(void)
@@ -778,6 +842,7 @@ void test_url_parse__ssh_from_terrible_google_rfc_violating_products(void)
 	cl_assert_equal_s(conndata.username, "my.email.address@gmail.com");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__ssh_with_password_from_terrible_google_rfc_violating_products(void)
@@ -790,6 +855,7 @@ void test_url_parse__ssh_with_password_from_terrible_google_rfc_violating_produc
 	cl_assert_equal_s(conndata.username, "my.email.address@gmail.com");
 	cl_assert_equal_s(conndata.password, "seekret");
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_parse__spaces_in_the_name(void)
@@ -802,4 +868,5 @@ void test_url_parse__spaces_in_the_name(void)
 	cl_assert_equal_s(conndata.username, "libgit2");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }

--- a/tests/util/url/scp.c
+++ b/tests/util/url/scp.c
@@ -25,6 +25,7 @@ void test_url_scp__hostname_trivial(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__hostname_bracketed(void)
@@ -37,6 +38,7 @@ void test_url_scp__hostname_bracketed(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__hostname_root(void)
@@ -49,6 +51,7 @@ void test_url_scp__hostname_root(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__hostname_user(void)
@@ -61,6 +64,7 @@ void test_url_scp__hostname_user(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__hostname_user_bracketed(void)
@@ -73,6 +77,7 @@ void test_url_scp__hostname_user_bracketed(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__hostname_port(void)
@@ -85,6 +90,20 @@ void test_url_scp__hostname_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
+}
+
+void test_url_scp__hostname_specified_default_port(void)
+{
+	cl_git_pass(git_net_url_parse_scp(&conndata, "[example.com:22]:/resource"));
+	cl_assert_equal_s(conndata.scheme, "ssh");
+	cl_assert_equal_s(conndata.host, "example.com");
+	cl_assert_equal_s(conndata.port, "22");
+	cl_assert_equal_s(conndata.path, "/resource");
+	cl_assert_equal_p(conndata.username, NULL);
+	cl_assert_equal_p(conndata.password, NULL);
+	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__hostname_user_port(void)
@@ -97,6 +116,7 @@ void test_url_scp__hostname_user_port(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__ipv4_trivial(void)
@@ -109,6 +129,7 @@ void test_url_scp__ipv4_trivial(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__ipv4_bracketed(void)
@@ -121,6 +142,7 @@ void test_url_scp__ipv4_bracketed(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__ipv4_user(void)
@@ -133,6 +155,7 @@ void test_url_scp__ipv4_user(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__ipv4_port(void)
@@ -145,6 +168,7 @@ void test_url_scp__ipv4_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__ipv4_user_port(void)
@@ -157,6 +181,7 @@ void test_url_scp__ipv4_user_port(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__ipv6_trivial(void)
@@ -169,6 +194,7 @@ void test_url_scp__ipv6_trivial(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__ipv6_user(void)
@@ -181,6 +207,7 @@ void test_url_scp__ipv6_user(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__ipv6_port(void)
@@ -193,6 +220,7 @@ void test_url_scp__ipv6_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__ipv6_user_port(void)
@@ -205,6 +233,7 @@ void test_url_scp__ipv6_user_port(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 0);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__hexhost_and_port(void)
@@ -217,6 +246,7 @@ void test_url_scp__hexhost_and_port(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 1);
 }
 
 void test_url_scp__malformed_ipv6_one(void)
@@ -229,6 +259,7 @@ void test_url_scp__malformed_ipv6_one(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__malformed_ipv6_two(void)
@@ -241,6 +272,7 @@ void test_url_scp__malformed_ipv6_two(void)
 	cl_assert_equal_p(conndata.username, NULL);
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__malformed_ipv6_with_user(void)
@@ -253,6 +285,7 @@ void test_url_scp__malformed_ipv6_with_user(void)
 	cl_assert_equal_s(conndata.username, "git");
 	cl_assert_equal_p(conndata.password, NULL);
 	cl_assert_equal_i(git_net_url_is_default_port(&conndata), 1);
+	cl_assert_equal_i(conndata.port_specified, 0);
 }
 
 void test_url_scp__invalid_addresses(void)


### PR DESCRIPTION
When parsing URLs, track whether the port number was explicitly specified or not. We track this separately from whether the port is the _default_ port. This is so that we can discern between URLs that have the default port explicitly specified or not.

For example: scp://host:22/foo and scp://host/foo are equivalent in terms of functionality, but are not semantically equivalent.

A user might wish to specify scp://host:22/foo in order to explicitly ensure that we connect on port 22, which might override (for example) a different configuration option.