### PR TITLE
diff: do not autoexpand unmodified trees while calculating tree to tree diff

### DIFF
--- a/src/libgit2/diff_generate.c
+++ b/src/libgit2/diff_generate.c
@@ -1355,6 +1355,7 @@ int git_diff__from_iterators(
 					if ((error = iterator_advance(&info.oitem, info.old_iter)) < 0 ||
 					    (error = iterator_advance(&info.nitem, info.new_iter)) < 0)
 						goto cleanup;
+					continue;
 				} else {
 					git_diff_delta *last = git_vector_last(&diff->base.deltas);
 					git_vector_pop(&diff->base.deltas);


### PR DESCRIPTION
During the process of calculating the tree-to-tree diff, all trees are expanded and leaf entries are compared. This can be a performance hit because the algorithm complexity becomes O(all files in the repository) instead of O(modified files between the compared trees).

I have made an attempt to improve the performance of this process by introducing a check. The check applies only to trees that have the same name. If the trees are in an unmodified state compared to each other, they are skipped. Other trees are expanded as usual.

This modification applies only to the tree-to-tree diff and doesn't have influence on other kinds of diff. 