### PR TITLE
http: Initialize ‘on_status’ when using the http-parser backend.

### DIFF
--- a/src/libgit2/transports/httpparser.c
+++ b/src/libgit2/transports/httpparser.c
@@ -71,7 +71,8 @@ size_t git_http_parser_execute(
 {
 	struct http_parser_settings settings_proxy;
 
-	settings_proxy.on_status = NULL;
+	memset(&settings_proxy, 0, sizeof(struct http_parser_settings));
+
 	settings_proxy.on_message_begin = parser->settings.on_message_begin ? on_message_begin : NULL;
 	settings_proxy.on_url = parser->settings.on_url ? on_url : NULL;
 	settings_proxy.on_header_field = parser->settings.on_header_field ? on_header_field : NULL;
@@ -79,8 +80,6 @@ size_t git_http_parser_execute(
 	settings_proxy.on_headers_complete = parser->settings.on_headers_complete ? on_headers_complete : NULL;
 	settings_proxy.on_body = parser->settings.on_body ? on_body : NULL;
 	settings_proxy.on_message_complete = parser->settings.on_message_complete ? on_message_complete : NULL;
-	settings_proxy.on_chunk_header = NULL;
-	settings_proxy.on_chunk_complete = NULL;
 
 	return http_parser_execute(&parser->parser, &settings_proxy, data, len);
 }

--- a/src/libgit2/transports/httpparser.c
+++ b/src/libgit2/transports/httpparser.c
@@ -71,6 +71,7 @@ size_t git_http_parser_execute(
 {
 	struct http_parser_settings settings_proxy;
 
+	settings_proxy.on_status = NULL;
 	settings_proxy.on_message_begin = parser->settings.on_message_begin ? on_message_begin : NULL;
 	settings_proxy.on_url = parser->settings.on_url ? on_url : NULL;
 	settings_proxy.on_header_field = parser->settings.on_header_field ? on_header_field : NULL;
@@ -78,6 +79,8 @@ size_t git_http_parser_execute(
 	settings_proxy.on_headers_complete = parser->settings.on_headers_complete ? on_headers_complete : NULL;
 	settings_proxy.on_body = parser->settings.on_body ? on_body : NULL;
 	settings_proxy.on_message_complete = parser->settings.on_message_complete ? on_message_complete : NULL;
+	settings_proxy.on_chunk_header = NULL;
+	settings_proxy.on_chunk_complete = NULL;
 
 	return http_parser_execute(&parser->parser, &settings_proxy, data, len);
 }


### PR DESCRIPTION
Fixes a bug likely introduced in
d396819101a67c652af0fa0ae65cda19a2c0430a (in **1.8.1**) whereby `proxy_settings.on_status` would be left uninitialized when using the ‘http-parser’ backend (`-DUSE_HTTP_PARSER=http-parser`), eventually leading to a segfault in `http_parser_execute`.  Valgrind would report use of the uninitialized value like so:

```
   Conditional jump or move depends on uninitialised value(s)
      at 0x50CD533: http_parser_execute (http_parser.c:910)
      by 0x4928504: git_http_parser_execute (httpparser.c:82)
      by 0x4925C42: client_read_and_parse (httpclient.c:1178)
      by 0x4926F27: git_http_client_read_response (httpclient.c:1458)
      by 0x49255FE: http_stream_read (http.c:427)
      by 0x4929B90: git_smart__recv (smart.c:29)
      by 0x492C147: git_smart__store_refs (smart_protocol.c:58)
      by 0x4929F6C: git_smart__connect (smart.c:171)
      by 0x4904DCE: git_remote_connect_ext (remote.c:963)
      by 0x48A15D2: clone_into (clone.c:449)
      by 0x48A15D2: git__clone (clone.c:546)
      by 0x4010E9: main (libgit2-proxy.c:20)
```

A simple reproducer is this program:

```c
#include <git2.h>
#include <assert.h>
#include <stdio.h>

int
main ()
{
  int err;
  err = git_libgit2_init ();
  assert (err == 1);

  git_clone_options opts;
  err = git_clone_init_options (&opts, GIT_CLONE_OPTIONS_VERSION);
  assert (err == 0);

  opts.fetch_opts.proxy_opts.type = GIT_PROXY_SPECIFIED;
  opts.fetch_opts.proxy_opts.url = "http://example.org/";

  git_repository *repo;
  err = git_clone (&repo, "http://example.org/whatever.git", "/tmp/example",
		   &opts);
  assert (err != 0);

  const git_error *gerr;
  gerr = giterr_last ();
  fprintf (stderr, "last error: %s\n", gerr->message);

  return 0;
}
```

Note that this bug does not exist when building libgit2 with `-DUSE_HTTP_PARSER=llhttp`.