### PR TITLE
Make packbuilder interruptible using progress callback

### DIFF
--- a/include/git2/pack.h
+++ b/include/git2/pack.h
@@ -247,6 +247,9 @@ typedef int GIT_CALLBACK(git_packbuilder_progress)(
  * @param progress_cb Function to call with progress information during
  * pack building. Be aware that this is called inline with pack building
  * operations, so performance may be affected.
+ * When progress_cb returns an error, the pack building process will be
+ * aborted and the error will be returned from the invoked function.
+ * `pb` must then be freed.
  * @param progress_cb_payload Payload for progress callback.
  * @return 0 or an error code
  */

--- a/src/libgit2/pack-objects.h
+++ b/src/libgit2/pack-objects.h
@@ -100,6 +100,10 @@ struct git_packbuilder {
 	uint64_t last_progress_report_time;
 
 	bool done;
+
+	/* A non-zero error code in failure causes all threads to shut themselves
+	   down. Some functions will return this error code.  */
+	volatile int failure;
 };
 
 int git_packbuilder__write_buf(git_str *buf, git_packbuilder *pb);


### PR DESCRIPTION
Specifically, forward errors from `packbuilder->progress_cb`

This allows the callback to gracefully terminate long-running operations when the application is interrupted.

Interruption could be `^C` in the terminal, but this could be any other condition or event, as this is up to the callback function to implement.

My specific motivation for this is to improve the responsiveness of the Nix package manager to interrupts in the terminal, in the context of https://github.com/NixOS/nix/pull/11330, which proposes to write packfiles instead of loose objects for performance.