### PR TITLE
push: report a push status even the push has failed

### DIFF
--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -2998,6 +2998,14 @@ int git_remote_upload(
 	    (error = git_push_status_foreach(push, connect_opts.callbacks.push_update_reference, connect_opts.callbacks.payload)) < 0)
 		goto cleanup;
 
+	error = git_push_finish(push);
+
+	if (connect_opts.callbacks.push_update_reference) {
+		const int cb_error = git_push_status_foreach(push, connect_opts.callbacks.push_update_reference, connect_opts.callbacks.payload);
+		if (!error) 
+			error = cb_error;
+	}
+
 cleanup:
 	git_remote_connect_options_dispose(&connect_opts);
 	return error;

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -2991,13 +2991,6 @@ int git_remote_upload(
 				goto cleanup;
 		}
 
-	if ((error = git_push_finish(push)) < 0)
-		goto cleanup;
-
-	if (connect_opts.callbacks.push_update_reference &&
-	    (error = git_push_status_foreach(push, connect_opts.callbacks.push_update_reference, connect_opts.callbacks.payload)) < 0)
-		goto cleanup;
-
 	error = git_push_finish(push);
 
 	if (connect_opts.callbacks.push_update_reference) {


### PR DESCRIPTION
In case when `unpack_ok` is false push status can be non-empty and contains important information about unpacking failure cause. For example, Azure DevOps git server behave like that. 
There is an example of error message is provided by Azure:
"The blob object e4f9f86ce8fcaa697809bcb6efbd91eddc50b04a was rejected: VS403658: The object is 1074200997 bytes, which is greater than the 10485760 byte limit for objects in this repository." 
If we go to cleanup immediately it will be no information about the cause for client.