### PR TITLE
transport: do not filter tags based on ref dir in local

### DIFF
--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -108,10 +108,6 @@ static int add_ref(transport_local *t, const char *name)
 		return error;
 	}
 
-	/* If it's not a tag, we don't need to try to peel it */
-	if (git__prefixcmp(name, GIT_REFS_TAGS_DIR))
-		return 0;
-
 	if ((error = git_object_lookup(&obj, t->repo, &head->oid, GIT_OBJECT_ANY)) < 0)
 		return error;
 

--- a/tests/libgit2/network/remote/local.c
+++ b/tests/libgit2/network/remote/local.c
@@ -61,7 +61,7 @@ void test_network_remote_local__retrieve_advertised_references(void)
 
 	cl_git_pass(git_remote_ls(&refs, &refs_len, remote));
 
-	cl_assert_equal_i(refs_len, 30);
+	cl_assert_equal_i(refs_len, 31);
 }
 
 void test_network_remote_local__retrieve_advertised_before_connect(void)
@@ -85,7 +85,7 @@ void test_network_remote_local__retrieve_advertised_references_after_disconnect(
 
 	cl_git_pass(git_remote_ls(&refs, &refs_len, remote));
 
-	cl_assert_equal_i(refs_len, 30);
+	cl_assert_equal_i(refs_len, 31);
 }
 
 void test_network_remote_local__retrieve_advertised_references_from_spaced_repository(void)
@@ -100,7 +100,7 @@ void test_network_remote_local__retrieve_advertised_references_from_spaced_repos
 
 	cl_git_pass(git_remote_ls(&refs, &refs_len, remote));
 
-	cl_assert_equal_i(refs_len, 30);
+	cl_assert_equal_i(refs_len, 31);
 
 	git_remote_free(remote);	/* Disconnect from the "spaced repo" before the cleanup */
 	remote = NULL;


### PR DESCRIPTION
Let `git_object_type()` do the filtering instead.

Fixes: https://github.com/libgit2/libgit2/issues/6275