### PR TITLE
Leak in truncate_racily_clean in index.c

### DIFF
--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -90,7 +90,7 @@ struct entry_common {
 		uint16_t flags_extended;             \
 		char path[1]; /* arbitrary length */ \
 	}
-C
+
 typedef entry_short(GIT_OID_SHA1_SIZE) index_entry_short_sha1;
 typedef entry_long(GIT_OID_SHA1_SIZE) index_entry_long_sha1;
 
@@ -784,7 +784,7 @@ static int truncate_racily_clean(git_index *index)
 		goto done;
 
 	diff_opts.pathspec.count = paths.length;
-    	diff_opts.pathspec.strings = (char **)paths.contents;
+	diff_opts.pathspec.strings = (char **)paths.contents;
 
     	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
         	git_vector_free(&paths);

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -90,7 +90,7 @@ struct entry_common {
 		uint16_t flags_extended;             \
 		char path[1]; /* arbitrary length */ \
 	}
-
+C
 typedef entry_short(GIT_OID_SHA1_SIZE) index_entry_short_sha1;
 typedef entry_long(GIT_OID_SHA1_SIZE) index_entry_long_sha1;
 
@@ -784,12 +784,12 @@ static int truncate_racily_clean(git_index *index)
 		goto done;
 
 	diff_opts.pathspec.count = paths.length;
-    diff_opts.pathspec.strings = (char **)paths.contents;
+    	diff_opts.pathspec.strings = (char **)paths.contents;
 
-    if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
-        git_vector_free(&paths);
-        return error;
-    }
+    	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
+        	git_vector_free(&paths);
+        	return error;
+    	}
 
 	git_vector_foreach(&diff->deltas, i, delta) {
 		entry = (git_index_entry *)git_index_get_bypath(index, delta->old_file.path, 0);

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -784,11 +784,11 @@ static int truncate_racily_clean(git_index *index)
 		goto done;
 
 	diff_opts.pathspec.count = paths.length;
-	diff_opts.pathspec.strings = (char **)paths.contents;
+    diff_opts.pathspec.strings = (char **)paths.contents;
 
-	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
+    if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
         git_vector_free(&paths);
-		return error;
+        return error;
     }
 
 	git_vector_foreach(&diff->deltas, i, delta) {

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -786,8 +786,10 @@ static int truncate_racily_clean(git_index *index)
 	diff_opts.pathspec.count = paths.length;
 	diff_opts.pathspec.strings = (char **)paths.contents;
 
-	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0)
+	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
+        git_vector_free(&paths);
 		return error;
+    }
 
 	git_vector_foreach(&diff->deltas, i, delta) {
 		entry = (git_index_entry *)git_index_get_bypath(index, delta->old_file.path, 0);


### PR DESCRIPTION
In truncate_racily_clean, when git_diff_index_to_workdir fails, we leak the local variable git_vector paths.