### PR TITLE
repo: support the preciousObjects extension

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -1881,6 +1881,7 @@ static const char *builtin_extensions[] = {
 	"noop",
 	"objectformat",
 	"worktreeconfig",
+	"preciousobjects"
 };
 
 static git_vector user_extensions = { 0, git__strcmp_cb };

--- a/tests/libgit2/core/opts.c
+++ b/tests/libgit2/core/opts.c
@@ -34,10 +34,11 @@ void test_core_opts__extensions_query(void)
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 3);
+	cl_assert_equal_sz(out.count, 4);
 	cl_assert_equal_s("noop", out.strings[0]);
 	cl_assert_equal_s("objectformat", out.strings[1]);
-	cl_assert_equal_s("worktreeconfig", out.strings[2]);
+	cl_assert_equal_s("preciousobjects", out.strings[2]);
+	cl_assert_equal_s("worktreeconfig", out.strings[3]);
 
 	git_strarray_dispose(&out);
 }
@@ -50,11 +51,12 @@ void test_core_opts__extensions_add(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 4);
+	cl_assert_equal_sz(out.count, 5);
 	cl_assert_equal_s("foo", out.strings[0]);
 	cl_assert_equal_s("noop", out.strings[1]);
 	cl_assert_equal_s("objectformat", out.strings[2]);
-	cl_assert_equal_s("worktreeconfig", out.strings[3]);
+	cl_assert_equal_s("preciousobjects", out.strings[3]);
+	cl_assert_equal_s("worktreeconfig", out.strings[4]);
 
 	git_strarray_dispose(&out);
 }
@@ -67,11 +69,12 @@ void test_core_opts__extensions_remove(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 4);
+	cl_assert_equal_sz(out.count, 5);
 	cl_assert_equal_s("bar", out.strings[0]);
 	cl_assert_equal_s("baz", out.strings[1]);
 	cl_assert_equal_s("objectformat", out.strings[2]);
-	cl_assert_equal_s("worktreeconfig", out.strings[3]);
+	cl_assert_equal_s("preciousobjects", out.strings[3]);
+	cl_assert_equal_s("worktreeconfig", out.strings[4]);
 
 	git_strarray_dispose(&out);
 }
@@ -84,12 +87,13 @@ void test_core_opts__extensions_uniq(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 5);
+	cl_assert_equal_sz(out.count, 6);
 	cl_assert_equal_s("bar", out.strings[0]);
 	cl_assert_equal_s("foo", out.strings[1]);
 	cl_assert_equal_s("noop", out.strings[2]);
 	cl_assert_equal_s("objectformat", out.strings[3]);
-	cl_assert_equal_s("worktreeconfig", out.strings[4]);
+	cl_assert_equal_s("preciousobjects", out.strings[4]);
+	cl_assert_equal_s("worktreeconfig", out.strings[5]);
 
 	git_strarray_dispose(&out);
 }

--- a/tests/libgit2/repo/extensions.c
+++ b/tests/libgit2/repo/extensions.c
@@ -70,3 +70,13 @@ void test_repo_extensions__adds_extension(void)
 	cl_assert(git__suffixcmp(git_repository_path(extended), "/") == 0);
 	git_repository_free(extended);
 }
+
+void test_repo_extensions__preciousobjects(void)
+{
+	git_repository *extended = NULL;
+
+	cl_repo_set_string(repo, "extensions.preciousObjects", "true");
+
+	cl_git_pass(git_repository_open(&extended, "empty_bare.git"));
+	git_repository_free(extended);
+}


### PR DESCRIPTION
libgit2 implicitly supports precious objects, since there's no gc command, nor even any option in our object database functionality to delete an object from the odb.

In the future, when we support deleting objects, or a gc functionality, we will need to honor the preciousObjects extension and reject those APIs when it is set. In the meantime, since users cannot use libgit2 (directly) to delete an object, we can simply add this to our allowlist.