### PR TITLE
diff: always print the file header on GIT_DIFF_FORMAT_PATCH_HEADER 

### DIFF
--- a/src/libgit2/diff_print.c
+++ b/src/libgit2/diff_print.c
@@ -580,8 +580,12 @@ static int diff_print_patch_file_binary(
 	return error;
 }
 
-GIT_INLINE(int) should_force_header(const git_diff_delta *delta)
+GIT_INLINE(int) should_force_header(const diff_print_info *pi, const git_diff_delta *delta)
 {
+	if (pi->format == GIT_DIFF_FORMAT_PATCH_HEADER) {
+		return 1;
+	}
+
 	if (delta->old_file.mode != delta->new_file.mode)
 		return 1;
 
@@ -646,7 +650,7 @@ static int diff_print_patch_file(
 	 * should queue it to send when we see the first hunk. This prevents
 	 * us from sending a header when all hunks were ignored.
 	 */
-	if (should_force_header(delta) && (error = flush_file_header(delta, pi)) < 0)
+	if (should_force_header(pi, delta) && (error = flush_file_header(delta, pi)) < 0)
 		return error;
 
 	return 0;

--- a/tests/libgit2/diff/header.c
+++ b/tests/libgit2/diff/header.c
@@ -1,0 +1,69 @@
+#include "clar_libgit2.h"
+#include "git2/sys/repository.h"
+
+#include "diff_helpers.h"
+#include "diff.h"
+#include "repository.h"
+
+static git_repository *g_repo = NULL;
+
+void test_diff_header__initialize(void)
+{
+}
+
+void test_diff_header__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+#define EXPECTED_HEADER "diff --git a/subdir.txt b/subdir.txt\n"	\
+	"deleted file mode 100644\n"					\
+	"index e8ee89e..0000000\n"					\
+	"--- a/subdir.txt\n"						\
+	"+++ /dev/null\n"
+
+static int check_header_cb(
+	const git_diff_delta *delta,
+	const git_diff_hunk *hunk,
+	const git_diff_line *line,
+	void *payload)
+{
+	int *counter = (int *) payload;
+
+	GIT_UNUSED(delta);
+
+	switch (line->origin) {
+	case GIT_DIFF_LINE_FILE_HDR:
+		cl_assert(hunk == NULL);
+		(*counter)++;
+		break;
+	default:
+		/* unexpected code path */
+		return -1;
+	}
+
+	return 0;
+}
+
+void test_diff_header__can_print_just_headers(void)
+{
+	const char *one_sha = "26a125e";
+	git_tree *one;
+	git_diff *diff;
+	int counter = 0;
+
+	g_repo = cl_git_sandbox_init("status");
+
+	one = resolve_commit_oid_to_tree(g_repo, one_sha);
+
+	cl_git_pass(git_diff_tree_to_index(&diff, g_repo, one, NULL, NULL));
+
+	cl_git_pass(git_diff_print(
+			    diff, GIT_DIFF_FORMAT_PATCH_HEADER, check_header_cb, &counter));
+
+	cl_assert_equal_i(8, counter);
+
+	git_diff_free(diff);
+
+	git_tree_free(one);
+}


### PR DESCRIPTION
In `diff_print_patch_file` we try to avoid printing the file if we're not sure
that there will be some content. This works fine if we have any later functions
that might get called as part of printing. But when given the format
`GIT_DIFF_FORMAT_PATCH_HEADER`, this is the only function to get called.

Force us to print the diff header for the file in such a situation. This may
still print the header where e.g. `GIT_DIFF_FORMAT_PATCH` wouldn't, but it's
better than this option not working at all.

This fixes a regression introduced in #5893 that's making the rugged tests fail to pass. This sort of regresses that fix by sending out the header more than we'd like, but this is a fix I could make quickly.

An alternative might be to still call the hunk function but have it return early if the format is just asking for the header (that might require teaching a few of these functions though as we could still instead land in the binary function).