### PR TITLE
vector: free is now dispose

### DIFF
--- a/fuzzers/standalone_driver.c
+++ b/fuzzers/standalone_driver.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 	fprintf(stderr, "Done %d runs\n", i);
 
 exit:
-	git_vector_free_deep(&corpus_files);
+	git_vector_dispose_deep(&corpus_files);
 	git_libgit2_shutdown();
 	return error;
 }

--- a/src/cli/common.c
+++ b/src/cli/common.c
@@ -105,7 +105,7 @@ done:
 	if (error && backend)
 		backend->free(backend);
 	git_config_free(config);
-	git_vector_free_deep(&cmdline);
+	git_vector_dispose_deep(&cmdline);
 	return error;
 }
 

--- a/src/libgit2/apply.c
+++ b/src/libgit2/apply.c
@@ -96,7 +96,7 @@ static void patch_image_free(patch_image *image)
 		return;
 
 	git_pool_clear(&image->pool);
-	git_vector_free(&image->lines);
+	git_vector_dispose(&image->lines);
 }
 
 static bool match_hunk(
@@ -730,7 +730,7 @@ static int git_apply__to_workdir(
 	error = git_checkout_index(repo, postimage, &checkout_opts);
 
 done:
-	git_vector_free(&paths);
+	git_vector_dispose(&paths);
 	return error;
 }
 

--- a/src/libgit2/attr.c
+++ b/src/libgit2/attr.c
@@ -618,7 +618,7 @@ static void release_attr_files(git_vector *files)
 		git_attr_file__free(file);
 		files->contents[i] = NULL;
 	}
-	git_vector_free(files);
+	git_vector_dispose(files);
 }
 
 static int collect_attr_files(

--- a/src/libgit2/attr_file.c
+++ b/src/libgit2/attr_file.c
@@ -69,7 +69,7 @@ int git_attr_file__clear_rules(git_attr_file *file, bool need_lock)
 
 	git_vector_foreach(&file->rules, i, rule)
 		git_attr_rule__free(rule);
-	git_vector_free(&file->rules);
+	git_vector_dispose(&file->rules);
 
 	if (need_lock)
 		git_mutex_unlock(&file->lock);
@@ -996,7 +996,7 @@ static void git_attr_rule__clear(git_attr_rule *rule)
 	if (!(rule->match.flags & GIT_ATTR_FNMATCH_IGNORE)) {
 		git_vector_foreach(&rule->assigns, i, assign)
 			GIT_REFCOUNT_DEC(assign, git_attr_assignment__free);
-		git_vector_free(&rule->assigns);
+		git_vector_dispose(&rule->assigns);
 	}
 
 	/* match.pattern is stored in a git_pool, so no need to free */

--- a/src/libgit2/blame.c
+++ b/src/libgit2/blame.c
@@ -165,9 +165,9 @@ void git_blame_free(git_blame *blame)
 
 	git_vector_foreach(&blame->hunks, i, hunk)
 		free_hunk(hunk);
-	git_vector_free(&blame->hunks);
+	git_vector_dispose(&blame->hunks);
 
-	git_vector_free_deep(&blame->paths);
+	git_vector_dispose_deep(&blame->paths);
 
 	git_array_clear(blame->line_index);
 

--- a/src/libgit2/checkout.c
+++ b/src/libgit2/checkout.c
@@ -2316,11 +2316,11 @@ static void checkout_data_clear(checkout_data *data)
 		data->opts.baseline = NULL;
 	}
 
-	git_vector_free(&data->removes);
+	git_vector_dispose(&data->removes);
 	git_pool_clear(&data->pool);
 
-	git_vector_free_deep(&data->remove_conflicts);
-	git_vector_free_deep(&data->update_conflicts);
+	git_vector_dispose_deep(&data->remove_conflicts);
+	git_vector_dispose_deep(&data->update_conflicts);
 
 	git__free(data->pfx);
 	data->pfx = NULL;

--- a/src/libgit2/commit_graph.c
+++ b/src/libgit2/commit_graph.c
@@ -730,7 +730,7 @@ void git_commit_graph_writer_free(git_commit_graph_writer *w)
 
 	git_vector_foreach (&w->commits, i, packed_commit)
 		packed_commit_free(packed_commit);
-	git_vector_free(&w->commits);
+	git_vector_dispose(&w->commits);
 	git_str_dispose(&w->objects_info_dir);
 	git__free(w);
 }

--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -78,8 +78,8 @@ static void config_free(git_config *config)
 		git__free(entry);
 	}
 
-	git_vector_free(&config->readers);
-	git_vector_free(&config->writers);
+	git_vector_dispose(&config->readers);
+	git_vector_dispose(&config->writers);
 	git__free(config);
 }
 

--- a/src/libgit2/describe.c
+++ b/src/libgit2/describe.c
@@ -627,7 +627,7 @@ cleanup:
 			git__free(match);
 		}
 	}
-	git_vector_free(&all_matches);
+	git_vector_dispose(&all_matches);
 	git_pqueue_free(&list);
 	git_revwalk_free(walk);
 	return error;

--- a/src/libgit2/diff_generate.c
+++ b/src/libgit2/diff_generate.c
@@ -429,7 +429,7 @@ static void diff_generated_free(git_diff *d)
 	git_diff_generated *diff = (git_diff_generated *)d;
 
 	git_attr_session__free(&diff->base.attrsession);
-	git_vector_free_deep(&diff->base.deltas);
+	git_vector_dispose_deep(&diff->base.deltas);
 
 	git_pathspec__vfree(&diff->pathspec);
 	git_pool_clear(&diff->base.pool);

--- a/src/libgit2/diff_parse.c
+++ b/src/libgit2/diff_parse.c
@@ -20,9 +20,9 @@ static void diff_parsed_free(git_diff *d)
 	git_vector_foreach(&diff->patches, i, patch)
 		git_patch_free(patch);
 
-	git_vector_free(&diff->patches);
+	git_vector_dispose(&diff->patches);
 
-	git_vector_free(&diff->base.deltas);
+	git_vector_dispose(&diff->base.deltas);
 	git_pool_clear(&diff->base.pool);
 
 	git__memzero(diff, sizeof(*diff));

--- a/src/libgit2/diff_tform.c
+++ b/src/libgit2/diff_tform.c
@@ -190,7 +190,7 @@ int git_diff__merge(
 			git_pool_strdup_safe(&onto->pool, onto->opts.new_prefix);
 	}
 
-	git_vector_free_deep(&onto_new);
+	git_vector_dispose_deep(&onto_new);
 	git_pool_clear(&onto_pool);
 
 	return error;
@@ -424,13 +424,13 @@ static int apply_splits_and_deletes(
 
 	/* swap new delta list into place */
 	git_vector_swap(&diff->deltas, &onto);
-	git_vector_free(&onto);
+	git_vector_dispose(&onto);
 	git_vector_sort(&diff->deltas);
 
 	return 0;
 
 on_error:
-	git_vector_free_deep(&onto);
+	git_vector_dispose_deep(&onto);
 
 	return -1;
 }

--- a/src/libgit2/filter.c
+++ b/src/libgit2/filter.c
@@ -239,7 +239,7 @@ static void git_filter_global_shutdown(void)
 		git__free(fdef);
 	}
 
-	git_vector_free(&filter_registry.filters);
+	git_vector_dispose(&filter_registry.filters);
 
 	git_rwlock_wrunlock(&filter_registry.lock);
 	git_rwlock_free(&filter_registry.lock);
@@ -1106,7 +1106,7 @@ static void filter_streams_free(git_vector *streams)
 
 	git_vector_foreach(streams, i, stream)
 		stream->free(stream);
-	git_vector_free(streams);
+	git_vector_dispose(streams);
 }
 
 int git_filter_list_stream_file(

--- a/src/libgit2/graph.c
+++ b/src/libgit2/graph.c
@@ -243,7 +243,7 @@ int git_graph_reachable_from_any(
 
 done:
 	git_commit_list_free(&result);
-	git_vector_free(&list);
+	git_vector_dispose(&list);
 	git_revwalk_free(walk);
 	return error;
 }

--- a/src/libgit2/ignore.c
+++ b/src/libgit2/ignore.c
@@ -428,13 +428,13 @@ void git_ignore__free(git_ignores *ignores)
 		git_attr_file__free(file);
 		ignores->ign_path.contents[i] = NULL;
 	}
-	git_vector_free(&ignores->ign_path);
+	git_vector_dispose(&ignores->ign_path);
 
 	git_vector_foreach(&ignores->ign_global, i, file) {
 		git_attr_file__free(file);
 		ignores->ign_global.contents[i] = NULL;
 	}
-	git_vector_free(&ignores->ign_global);
+	git_vector_dispose(&ignores->ign_global);
 
 	git_str_dispose(&ignores->dir);
 }

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -503,10 +503,10 @@ static void index_free(git_index *index)
 
 	git_index_clear(index);
 	git_idxmap_free(index->entries_map);
-	git_vector_free(&index->entries);
-	git_vector_free(&index->names);
-	git_vector_free(&index->reuc);
-	git_vector_free(&index->deleted);
+	git_vector_dispose(&index->entries);
+	git_vector_dispose(&index->names);
+	git_vector_dispose(&index->reuc);
+	git_vector_dispose(&index->deleted);
 
 	git__free(index->index_file_path);
 
@@ -786,10 +786,10 @@ static int truncate_racily_clean(git_index *index)
 	diff_opts.pathspec.count = paths.length;
 	diff_opts.pathspec.strings = (char **)paths.contents;
 
-    	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
-        	git_vector_free(&paths);
-        	return error;
-    	}
+	if ((error = git_diff_index_to_workdir(&diff, INDEX_OWNER(index), index, &diff_opts)) < 0) {
+		git_vector_dispose(&paths);
+		return error;
+	}
 
 	git_vector_foreach(&diff->deltas, i, delta) {
 		entry = (git_index_entry *)git_index_get_bypath(index, delta->old_file.path, 0);
@@ -805,7 +805,7 @@ static int truncate_racily_clean(git_index *index)
 
 done:
 	git_diff_free(diff);
-	git_vector_free(&paths);
+	git_vector_dispose(&paths);
 	return 0;
 }
 
@@ -3091,7 +3091,7 @@ static int write_entries(git_index *index, git_filebuf *file)
 	}
 
 done:
-	git_vector_free(&case_sorted);
+	git_vector_dispose(&case_sorted);
 	return error;
 }
 
@@ -3414,7 +3414,7 @@ int git_index_read_tree(git_index *index, const git_tree *tree)
 	index->dirty = 1;
 
 cleanup:
-	git_vector_free(&entries);
+	git_vector_dispose(&entries);
 	git_idxmap_free(entries_map);
 	if (error < 0)
 		return error;
@@ -3558,8 +3558,8 @@ static int git_index_read_iterator(
 
 done:
 	git_idxmap_free(new_entries_map);
-	git_vector_free(&new_entries);
-	git_vector_free(&remove_entries);
+	git_vector_dispose(&new_entries);
+	git_vector_dispose(&remove_entries);
 	git_iterator_free(index_iterator);
 	return error;
 }
@@ -3860,7 +3860,7 @@ int git_index_snapshot_new(git_vector *snap, git_index *index)
 
 void git_index_snapshot_release(git_vector *snap, git_index *index)
 {
-	git_vector_free(snap);
+	git_vector_dispose(snap);
 
 	git_atomic32_dec(&index->readers);
 

--- a/src/libgit2/indexer.c
+++ b/src/libgit2/indexer.c
@@ -1456,7 +1456,7 @@ void git_indexer_free(git_indexer *idx)
 	if (idx->have_stream)
 		git_packfile_stream_dispose(&idx->stream);
 
-	git_vector_free_deep(&idx->objects);
+	git_vector_dispose_deep(&idx->objects);
 
 	if (idx->pack->idx_cache) {
 		struct git_pack_entry *pentry;
@@ -1467,7 +1467,7 @@ void git_indexer_free(git_indexer *idx)
 		git_oidmap_free(idx->pack->idx_cache);
 	}
 
-	git_vector_free_deep(&idx->deltas);
+	git_vector_dispose_deep(&idx->deltas);
 
 	git_packfile_free(idx->pack, !idx->pack_committed);
 

--- a/src/libgit2/iterator.c
+++ b/src/libgit2/iterator.c
@@ -696,7 +696,7 @@ static int tree_iterator_frame_pop(tree_iterator *iter)
 
 	frame = git_array_pop(iter->frames);
 
-	git_vector_free(&frame->entries);
+	git_vector_dispose(&frame->entries);
 	git_tree_free(frame->tree);
 
 	do {
@@ -709,7 +709,7 @@ static int tree_iterator_frame_pop(tree_iterator *iter)
 	git_vector_foreach(&frame->similar_trees, i, tree)
 		git_tree_free(tree);
 
-	git_vector_free(&frame->similar_trees);
+	git_vector_dispose(&frame->similar_trees);
 
 	git_str_dispose(&frame->path);
 
@@ -1501,7 +1501,7 @@ GIT_INLINE(int) filesystem_iterator_frame_pop(filesystem_iterator *iter)
 	filesystem_iterator_frame_pop_ignores(iter);
 
 	git_pool_clear(&frame->entry_pool);
-	git_vector_free(&frame->entries);
+	git_vector_dispose(&frame->entries);
 
 	return 0;
 }
@@ -2336,7 +2336,7 @@ void git_iterator_free(git_iterator *iter)
 
 	iter->cb->free(iter);
 
-	git_vector_free(&iter->pathlist);
+	git_vector_dispose(&iter->pathlist);
 	git__free(iter->start);
 	git__free(iter->end);
 

--- a/src/libgit2/mailmap.c
+++ b/src/libgit2/mailmap.c
@@ -173,7 +173,7 @@ void git_mailmap_free(git_mailmap *mm)
 	git_vector_foreach(&mm->entries, idx, entry)
 		mailmap_entry_free(entry);
 
-	git_vector_free(&mm->entries);
+	git_vector_dispose(&mm->entries);
 	git__free(mm);
 }
 

--- a/src/libgit2/merge.c
+++ b/src/libgit2/merge.c
@@ -124,11 +124,11 @@ static int merge_bases_many(git_commit_list **out, git_revwalk **walk_out, git_r
 	*out = result;
 	*walk_out = walk;
 
-	git_vector_free(&list);
+	git_vector_dispose(&list);
 	return 0;
 
 on_error:
-	git_vector_free(&list);
+	git_vector_dispose(&list);
 	git_revwalk_free(walk);
 	return error;
 }
@@ -511,7 +511,7 @@ static int remove_redundant(git_revwalk *walk, git_vector *commits, uint32_t min
 done:
 	git__free(redundant);
 	git__free(filled_index);
-	git_vector_free(&work);
+	git_vector_dispose(&work);
 	return error;
 }
 
@@ -570,7 +570,7 @@ int git_merge__bases_many(
 		if ((error = clear_commit_marks(one, ALL_FLAGS)) < 0 ||
 		    (error = clear_commit_marks_many(twos, ALL_FLAGS)) < 0 ||
 		    (error = remove_redundant(walk, &redundant, minimum_generation)) < 0) {
-			git_vector_free(&redundant);
+			git_vector_dispose(&redundant);
 			return error;
 		}
 
@@ -579,7 +579,7 @@ int git_merge__bases_many(
 				git_commit_list_insert_by_date(two, &result);
 		}
 
-		git_vector_free(&redundant);
+		git_vector_dispose(&redundant);
 	}
 
 	*out = result;
@@ -1866,9 +1866,9 @@ void git_merge_diff_list__free(git_merge_diff_list *diff_list)
 	if (!diff_list)
 		return;
 
-	git_vector_free(&diff_list->staged);
-	git_vector_free(&diff_list->conflicts);
-	git_vector_free(&diff_list->resolved);
+	git_vector_dispose(&diff_list->staged);
+	git_vector_dispose(&diff_list->conflicts);
+	git_vector_dispose(&diff_list->resolved);
 	git_pool_clear(&diff_list->pool);
 	git__free(diff_list);
 }
@@ -2836,7 +2836,7 @@ cleanup:
 
 	git_str_dispose(&file_path);
 
-	git_vector_free(&matching);
+	git_vector_dispose(&matching);
 	git__free(entries);
 
 	return error;
@@ -3015,7 +3015,7 @@ done:
 	git_iterator_free(iter_new);
 	git_diff_free(staged_diff_list);
 	git_diff_free(index_diff_list);
-	git_vector_free(&staged_paths);
+	git_vector_dispose(&staged_paths);
 
 	return error;
 }
@@ -3112,7 +3112,7 @@ int git_merge__check_result(git_repository *repo, git_index *index_new)
 	}
 
 done:
-	git_vector_free(&paths);
+	git_vector_dispose(&paths);
 	git_tree_free(head_tree);
 	git_iterator_free(iter_head);
 	git_iterator_free(iter_new);

--- a/src/libgit2/merge_driver.c
+++ b/src/libgit2/merge_driver.c
@@ -218,7 +218,7 @@ int git_merge_driver_global_init(void)
 
 done:
 	if (error < 0)
-		git_vector_free_deep(&merge_driver_registry.drivers);
+		git_vector_dispose_deep(&merge_driver_registry.drivers);
 
 	return error;
 }
@@ -238,7 +238,7 @@ static void git_merge_driver_global_shutdown(void)
 		git__free(entry);
 	}
 
-	git_vector_free(&merge_driver_registry.drivers);
+	git_vector_dispose(&merge_driver_registry.drivers);
 
 	git_rwlock_wrunlock(&merge_driver_registry.lock);
 	git_rwlock_free(&merge_driver_registry.lock);

--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -484,7 +484,7 @@ int git_midx_close(git_midx_file *idx)
 	if (idx->index_map.data)
 		git_futils_mmap_free(&idx->index_map);
 
-	git_vector_free(&idx->packfile_names);
+	git_vector_dispose(&idx->packfile_names);
 
 	return 0;
 }
@@ -554,7 +554,7 @@ void git_midx_writer_free(git_midx_writer *w)
 
 	git_vector_foreach (&w->packs, i, p)
 		git_mwindow_put_pack(p);
-	git_vector_free(&w->packs);
+	git_vector_dispose(&w->packs);
 	git_str_dispose(&w->pack_dir);
 	git__free(w);
 }
@@ -869,7 +869,7 @@ static int midx_write(
 
 cleanup:
 	git_array_clear(object_entries_array);
-	git_vector_free(&object_entries);
+	git_vector_dispose(&object_entries);
 	git_str_dispose(&packfile_names);
 	git_str_dispose(&oid_lookup);
 	git_str_dispose(&object_offsets);

--- a/src/libgit2/mwindow.c
+++ b/src/libgit2/mwindow.c
@@ -152,7 +152,7 @@ static int git_mwindow_free_all_locked(git_mwindow_file *mwf)
 	}
 
 	if (ctl->windowfiles.length == 0) {
-		git_vector_free(&ctl->windowfiles);
+		git_vector_dispose(&ctl->windowfiles);
 		ctl->windowfiles.contents = NULL;
 	}
 
@@ -505,7 +505,7 @@ int git_mwindow_file_register(git_mwindow_file *mwf)
 	}
 
 cleanup:
-	git_vector_free(&closed_files);
+	git_vector_dispose(&closed_files);
 	return error;
 }
 

--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -915,7 +915,7 @@ static void odb_free(git_odb *db)
 		git_mutex_unlock(&db->lock);
 
 	git_commit_graph_free(db->cgraph);
-	git_vector_free(&db->backends);
+	git_vector_dispose(&db->backends);
 	git_cache_dispose(&db->own_cache);
 	git_mutex_free(&db->lock);
 
@@ -1609,7 +1609,7 @@ int git_odb_foreach(git_odb *db, git_odb_foreach_cb cb, void *payload)
 	}
 
 cleanup:
-	git_vector_free(&backends);
+	git_vector_dispose(&backends);
 
 	return error;
 }

--- a/src/libgit2/odb_pack.c
+++ b/src/libgit2/odb_pack.c
@@ -863,8 +863,8 @@ static void pack_backend__free(git_odb_backend *_backend)
 		git_mwindow_put_pack(p);
 
 	git_midx_free(backend->midx);
-	git_vector_free(&backend->midx_packs);
-	git_vector_free(&backend->packs);
+	git_vector_dispose(&backend->midx_packs);
+	git_vector_dispose(&backend->packs);
 	git__free(backend->pack_folder);
 	git__free(backend);
 }
@@ -883,7 +883,7 @@ static int pack_backend__alloc(
 	}
 
 	if (git_vector_init(&backend->packs, initial_size, packfile_sort__cb) < 0) {
-		git_vector_free(&backend->midx_packs);
+		git_vector_dispose(&backend->midx_packs);
 		git__free(backend);
 		return -1;
 	}

--- a/src/libgit2/pack.c
+++ b/src/libgit2/pack.c
@@ -1351,7 +1351,7 @@ int git_pack_foreach_entry(
 				git_vector_insert(&oids, (void*)&current[4]);
 		}
 
-		git_vector_free(&offsets);
+		git_vector_dispose(&offsets);
 		p->ids = (unsigned char **)git_vector_detach(NULL, NULL, &oids);
 	}
 

--- a/src/libgit2/pathspec.c
+++ b/src/libgit2/pathspec.c
@@ -105,7 +105,7 @@ int git_pathspec__vinit(
 /* free data from the pathspec vector */
 void git_pathspec__vfree(git_vector *vspec)
 {
-	git_vector_free_deep(vspec);
+	git_vector_dispose_deep(vspec);
 }
 
 struct pathspec_match_context {

--- a/src/libgit2/push.c
+++ b/src/libgit2/push.c
@@ -56,22 +56,22 @@ int git_push_new(git_push **out, git_remote *remote, const git_push_options *opt
 	}
 
 	if (git_vector_init(&p->status, 0, push_status_ref_cmp) < 0) {
-		git_vector_free(&p->specs);
+		git_vector_dispose(&p->specs);
 		git__free(p);
 		return -1;
 	}
 
 	if (git_vector_init(&p->updates, 0, NULL) < 0) {
-		git_vector_free(&p->status);
-		git_vector_free(&p->specs);
+		git_vector_dispose(&p->status);
+		git_vector_dispose(&p->specs);
 		git__free(p);
 		return -1;
 	}
 
 	if (git_vector_init(&p->remote_push_options, 0, git__strcmp_cb) < 0) {
-		git_vector_free(&p->status);
-		git_vector_free(&p->specs);
-		git_vector_free(&p->updates);
+		git_vector_dispose(&p->status);
+		git_vector_dispose(&p->specs);
+		git_vector_dispose(&p->updates);
 		git__free(p);
 		return -1;
 	}
@@ -568,24 +568,24 @@ void git_push_free(git_push *push)
 	git_vector_foreach(&push->specs, i, spec) {
 		free_refspec(spec);
 	}
-	git_vector_free(&push->specs);
+	git_vector_dispose(&push->specs);
 
 	git_vector_foreach(&push->status, i, status) {
 		git_push_status_free(status);
 	}
-	git_vector_free(&push->status);
+	git_vector_dispose(&push->status);
 
 	git_vector_foreach(&push->updates, i, update) {
 		git__free(update->src_refname);
 		git__free(update->dst_refname);
 		git__free(update);
 	}
-	git_vector_free(&push->updates);
+	git_vector_dispose(&push->updates);
 
 	git_vector_foreach(&push->remote_push_options, i, option) {
 		git__free(option);
 	}
-	git_vector_free(&push->remote_push_options);
+	git_vector_dispose(&push->remote_push_options);
 
 	git__free(push);
 }

--- a/src/libgit2/refdb_fs.c
+++ b/src/libgit2/refdb_fs.c
@@ -801,7 +801,7 @@ static void refdb_fs_backend__iterator_free(git_reference_iterator *_iter)
 {
 	refdb_fs_iter *iter = GIT_CONTAINER_OF(_iter, refdb_fs_iter, parent);
 
-	git_vector_free(&iter->loose);
+	git_vector_dispose(&iter->loose);
 	git_pool_clear(&iter->pool);
 	git_sortedcache_free(iter->cache);
 	git__free(iter);

--- a/src/libgit2/reflog.c
+++ b/src/libgit2/reflog.c
@@ -40,7 +40,7 @@ void git_reflog_free(git_reflog *reflog)
 		git_reflog_entry__free(entry);
 	}
 
-	git_vector_free(&reflog->entries);
+	git_vector_dispose(&reflog->entries);
 	git__free(reflog->ref_name);
 	git__free(reflog);
 }

--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -808,7 +808,7 @@ int git_reference_list(
 
 	if (git_reference_foreach_name(
 			repo, &cb__reflist_add, (void *)&ref_list) < 0) {
-		git_vector_free(&ref_list);
+		git_vector_dispose(&ref_list);
 		return -1;
 	}
 

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -1293,9 +1293,9 @@ static int git_remote__download(
 	free_refspecs(&remote->active_refspecs);
 	error = dwim_refspecs(&remote->active_refspecs, to_active, &refs);
 
-	git_vector_free(&refs);
+	git_vector_dispose(&refs);
 	free_refspecs(&specs);
-	git_vector_free(&specs);
+	git_vector_dispose(&specs);
 
 	if (error < 0)
 		goto on_error;
@@ -1311,9 +1311,9 @@ static int git_remote__download(
 	error = git_fetch_download_pack(remote);
 
 on_error:
-	git_vector_free(&refs);
+	git_vector_dispose(&refs);
 	free_refspecs(&specs);
-	git_vector_free(&specs);
+	git_vector_dispose(&specs);
 	return error;
 }
 
@@ -1589,7 +1589,7 @@ cleanup:
 	for (i = 0; i < fetchhead_refs.length; ++i)
 		git_fetchhead_ref_free(fetchhead_refs.contents[i]);
 
-	git_vector_free(&fetchhead_refs);
+	git_vector_dispose(&fetchhead_refs);
 	git_reference_free(head_ref);
 
 	return error;
@@ -1735,8 +1735,8 @@ int git_remote_prune(git_remote *remote, const git_remote_callbacks *callbacks)
 	}
 
 cleanup:
-	git_vector_free(&remote_refs);
-	git_vector_free_deep(&candidates);
+	git_vector_dispose(&remote_refs);
+	git_vector_dispose_deep(&candidates);
 	return error;
 }
 
@@ -1947,12 +1947,12 @@ static int update_tips_for_spec(
 		goto on_error;
 
 	git_refspec__dispose(&tagspec);
-	git_vector_free(&update_heads);
+	git_vector_dispose(&update_heads);
 	return 0;
 
 on_error:
 	git_refspec__dispose(&tagspec);
-	git_vector_free(&update_heads);
+	git_vector_dispose(&update_heads);
 	return -1;
 
 }
@@ -2123,7 +2123,7 @@ int git_remote_update_tips(
 		error = opportunistic_updates(remote, callbacks, &refs, reflog_message);
 
 out:
-	git_vector_free(&refs);
+	git_vector_dispose(&refs);
 	git_refspec__dispose(&tagspec);
 	return error;
 }
@@ -2182,19 +2182,19 @@ void git_remote_free(git_remote *remote)
 		remote->transport = NULL;
 	}
 
-	git_vector_free(&remote->refs);
+	git_vector_dispose(&remote->refs);
 
 	free_refspecs(&remote->refspecs);
-	git_vector_free(&remote->refspecs);
+	git_vector_dispose(&remote->refspecs);
 
 	free_refspecs(&remote->active_refspecs);
-	git_vector_free(&remote->active_refspecs);
+	git_vector_dispose(&remote->active_refspecs);
 
 	free_refspecs(&remote->passive_refspecs);
-	git_vector_free(&remote->passive_refspecs);
+	git_vector_dispose(&remote->passive_refspecs);
 
 	free_heads(&remote->local_heads);
-	git_vector_free(&remote->local_heads);
+	git_vector_dispose(&remote->local_heads);
 
 	git_push_free(remote->push);
 	git__free(remote->url);
@@ -2237,7 +2237,7 @@ int git_remote_list(git_strarray *remotes_list, git_repository *repo)
 		cfg, "^remote\\..*\\.(push)?url$", remote_list_cb, &list);
 
 	if (error < 0) {
-		git_vector_free_deep(&list);
+		git_vector_dispose_deep(&list);
 		return error;
 	}
 
@@ -2518,7 +2518,7 @@ static int rename_fetch_refspecs(git_vector *problems, git_remote *remote, const
 		git_vector_foreach(problems, i, str)
 			git__free(str);
 
-		git_vector_free(problems);
+		git_vector_dispose(problems);
 	}
 
 	return error;
@@ -2558,7 +2558,7 @@ int git_remote_rename(git_strarray *out, git_repository *repo, const char *name,
 
 cleanup:
 	if (error < 0)
-		git_vector_free(&problem_refspecs);
+		git_vector_dispose(&problem_refspecs);
 
 	git_remote_free(remote);
 	return error;
@@ -2665,7 +2665,7 @@ static int copy_refspecs(git_strarray *array, const git_remote *remote, unsigned
 	return 0;
 
 on_error:
-	git_vector_free_deep(&refspecs);
+	git_vector_dispose_deep(&refspecs);
 
 	return -1;
 }
@@ -2813,7 +2813,7 @@ cleanup:
 	git_vector_foreach(&refs, i, dup) {
 		git__free(dup);
 	}
-	git_vector_free(&refs);
+	git_vector_dispose(&refs);
 	return error;
 }
 

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -2107,7 +2107,7 @@ int git_repository__set_extensions(const char **extensions, size_t len)
 
 void git_repository__free_extensions(void)
 {
-	git_vector_free_deep(&user_extensions);
+	git_vector_dispose_deep(&user_extensions);
 }
 
 int git_repository_create_head(const char *git_dir, const char *ref_name)

--- a/src/libgit2/status.c
+++ b/src/libgit2/status.c
@@ -414,7 +414,7 @@ void git_status_list_free(git_status_list *status)
 	git_diff_free(status->head2idx);
 	git_diff_free(status->idx2wd);
 
-	git_vector_free_deep(&status->paired);
+	git_vector_dispose_deep(&status->paired);
 
 	git__memzero(status, sizeof(*status));
 	git__free(status);

--- a/src/libgit2/submodule.c
+++ b/src/libgit2/submodule.c
@@ -668,7 +668,7 @@ int git_submodule_foreach(
 done:
 	git_vector_foreach(&snapshot, i, sm)
 		git_submodule_free(sm);
-	git_vector_free(&snapshot);
+	git_vector_dispose(&snapshot);
 
 	git_strmap_foreach_value(submodules, sm, {
 		git_submodule_free(sm);
@@ -1338,11 +1338,11 @@ int git_submodule_update(git_submodule *sm, int init, git_submodule_update_optio
 	/* Get the status of the submodule to determine if it is already initialized  */
 	if ((error = git_submodule_status(&submodule_status, sm->repo, sm->name, GIT_SUBMODULE_IGNORE_UNSPECIFIED)) < 0)
 		goto done;
-	
+
 	/* If the submodule is configured but hasn't been added, skip it */
 	if (submodule_status == GIT_SUBMODULE_STATUS_IN_CONFIG)
 	        goto done;
-	
+
 	/*
 	 * If submodule work dir is not already initialized, check to see
 	 * what we need to do (initialize, clone, return error...)

--- a/src/libgit2/tag.c
+++ b/src/libgit2/tag.c
@@ -548,7 +548,7 @@ int git_tag_list_match(git_strarray *tag_names, const char *pattern, git_reposit
 	error = git_tag_foreach(repo, &tag_list_cb, (void *)&filter);
 
 	if (error < 0)
-		git_vector_free(&taglist);
+		git_vector_dispose(&taglist);
 
 	tag_names->strings =
 		(char **)git_vector_detach(&tag_names->count, NULL, &taglist);

--- a/src/libgit2/transport.c
+++ b/src/libgit2/transport.c
@@ -203,7 +203,7 @@ int git_transport_unregister(const char *scheme)
 			git__free(d);
 
 			if (!custom_transports.length)
-				git_vector_free(&custom_transports);
+				git_vector_dispose(&custom_transports);
 
 			error = 0;
 			goto done;

--- a/src/libgit2/transports/httpclient.c
+++ b/src/libgit2/transports/httpclient.c
@@ -1442,9 +1442,9 @@ int git_http_client_read_response(
 	git_http_response_dispose(response);
 
 	if (client->current_server == PROXY) {
-		git_vector_free_deep(&client->proxy.auth_challenges);
+		git_vector_dispose_deep(&client->proxy.auth_challenges);
 	} else if(client->current_server == SERVER) {
-		git_vector_free_deep(&client->server.auth_challenges);
+		git_vector_dispose_deep(&client->server.auth_challenges);
 	}
 
 	client->state = READING_RESPONSE;
@@ -1605,7 +1605,7 @@ GIT_INLINE(void) http_server_close(git_http_server *server)
 
 	git_net_url_dispose(&server->url);
 
-	git_vector_free_deep(&server->auth_challenges);
+	git_vector_dispose_deep(&server->auth_challenges);
 	free_auth_context(server);
 }
 

--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -58,7 +58,7 @@ static void free_heads(git_vector *heads)
 	git_vector_foreach(heads, i, head)
 		free_head(head);
 
-	git_vector_free(heads);
+	git_vector_dispose(heads);
 }
 
 static int add_ref(transport_local *t, const char *name)
@@ -182,7 +182,7 @@ static int store_refs(transport_local *t)
 	return 0;
 
 on_error:
-	git_vector_free(&t->refs);
+	git_vector_dispose(&t->refs);
 	git_strarray_dispose(&ref_names);
 	return -1;
 }

--- a/src/libgit2/transports/smart.c
+++ b/src/libgit2/transports/smart.c
@@ -124,7 +124,7 @@ static void free_symrefs(git_vector *symrefs)
 		git__free(spec);
 	}
 
-	git_vector_free(symrefs);
+	git_vector_dispose(symrefs);
 }
 
 static int git_smart__connect(
@@ -402,7 +402,7 @@ static int git_smart__close(git_transport *transport)
 	git_vector_foreach(common, i, p)
 		git_pkt_free(p);
 
-	git_vector_free(common);
+	git_vector_dispose(common);
 
 	if (t->url) {
 		git__free(t->url);
@@ -427,11 +427,11 @@ static void git_smart__free(git_transport *transport)
 	/* Free the subtransport */
 	t->wrapped->free(t->wrapped);
 
-	git_vector_free(&t->heads);
+	git_vector_dispose(&t->heads);
 	git_vector_foreach(refs, i, p)
 		git_pkt_free(p);
 
-	git_vector_free(refs);
+	git_vector_dispose(refs);
 
 	git_remote_connect_options_dispose(&t->connect_opts);
 
@@ -524,8 +524,8 @@ int git_transport_smart(git_transport **out, git_remote *owner, void *param)
 	if (git_vector_init(&t->refs, 16, ref_name_cmp) < 0 ||
 	    git_vector_init(&t->heads, 16, ref_name_cmp) < 0 ||
 	    definition->callback(&t->wrapped, &t->parent, definition->param) < 0) {
-		git_vector_free(&t->refs);
-		git_vector_free(&t->heads);
+		git_vector_dispose(&t->refs);
+		git_vector_dispose(&t->heads);
 		git__free(t);
 		return -1;
 	}

--- a/src/libgit2/tree.c
+++ b/src/libgit2/tree.c
@@ -547,7 +547,7 @@ static int git_treebuilder__write_with_buffer(
 		error = git_odb_write(oid, odb, buf->ptr, buf->size, GIT_OBJECT_TREE);
 
 out:
-	git_vector_free(&entries);
+	git_vector_dispose(&entries);
 
 	return error;
 }
@@ -1312,7 +1312,7 @@ cleanup:
 
 	git_str_dispose(&component);
 	git_array_clear(stack);
-	git_vector_free(&entries);
+	git_vector_dispose(&entries);
 	return error;
 }
 

--- a/src/util/pool.c
+++ b/src/util/pool.c
@@ -144,7 +144,7 @@ int git_pool_init(git_pool *pool, size_t item_size)
 
 void git_pool_clear(git_pool *pool)
 {
-	git_vector_free_deep(&pool->allocations);
+	git_vector_dispose_deep(&pool->allocations);
 }
 
 static void *pool_alloc(git_pool *pool, size_t size) {

--- a/src/util/pqueue.h
+++ b/src/util/pqueue.h
@@ -33,7 +33,7 @@ extern int git_pqueue_init(
 	size_t init_size,
 	git_vector_cmp cmp);
 
-#define git_pqueue_free  git_vector_free
+#define git_pqueue_free  git_vector_dispose
 #define git_pqueue_clear git_vector_clear
 #define git_pqueue_size  git_vector_length
 #define git_pqueue_get   git_vector_get

--- a/src/util/sortedcache.c
+++ b/src/util/sortedcache.c
@@ -47,7 +47,7 @@ int git_sortedcache_new(
 
 fail:
 	git_strmap_free(sc->map);
-	git_vector_free(&sc->items);
+	git_vector_dispose(&sc->items);
 	git_pool_clear(&sc->pool);
 	git__free(sc);
 	return -1;
@@ -88,7 +88,7 @@ static void sortedcache_free(git_sortedcache *sc)
 		return;
 
 	sortedcache_clear(sc);
-	git_vector_free(&sc->items);
+	git_vector_dispose(&sc->items);
 	git_strmap_free(sc->map);
 
 	git_sortedcache_wunlock(sc);

--- a/src/util/unix/process.c
+++ b/src/util/unix/process.c
@@ -104,7 +104,7 @@ static int merge_env(
 	return 0;
 
 on_error:
-	git_vector_free_deep(&merged);
+	git_vector_dispose_deep(&merged);
 	return error;
 }
 

--- a/src/util/vector.c
+++ b/src/util/vector.c
@@ -76,7 +76,7 @@ int git_vector_dup(git_vector *v, const git_vector *src, git_vector_cmp cmp)
 	return 0;
 }
 
-void git_vector_free(git_vector *v)
+void git_vector_dispose(git_vector *v)
 {
 	if (!v)
 		return;
@@ -88,7 +88,7 @@ void git_vector_free(git_vector *v)
 	v->_alloc_size = 0;
 }
 
-void git_vector_free_deep(git_vector *v)
+void git_vector_dispose_deep(git_vector *v)
 {
 	size_t i;
 
@@ -100,7 +100,7 @@ void git_vector_free_deep(git_vector *v)
 		v->contents[i] = NULL;
 	}
 
-	git_vector_free(v);
+	git_vector_dispose(v);
 }
 
 int git_vector_init(git_vector *v, size_t initial_size, git_vector_cmp cmp)

--- a/src/util/vector.h
+++ b/src/util/vector.h
@@ -28,8 +28,8 @@ typedef struct git_vector {
 
 GIT_WARN_UNUSED_RESULT int git_vector_init(
 	git_vector *v, size_t initial_size, git_vector_cmp cmp);
-void git_vector_free(git_vector *v);
-void git_vector_free_deep(git_vector *v); /* free each entry and self */
+void git_vector_dispose(git_vector *v);
+void git_vector_dispose_deep(git_vector *v); /* free each entry and self */
 void git_vector_clear(git_vector *v);
 GIT_WARN_UNUSED_RESULT int git_vector_dup(
 	git_vector *v, const git_vector *src, git_vector_cmp cmp);

--- a/tests/libgit2/checkout/conflict.c
+++ b/tests/libgit2/checkout/conflict.c
@@ -1141,5 +1141,5 @@ void test_checkout_conflict__report_progress(void)
 	git_vector_foreach(&paths, i, path)
 		git__free(path);
 
-	git_vector_free(&paths);
+	git_vector_dispose(&paths);
 }

--- a/tests/libgit2/checkout/crlf.c
+++ b/tests/libgit2/checkout/crlf.c
@@ -197,7 +197,7 @@ static void empty_workdir(const char *name)
 		if (cmp)
 			cl_git_pass(p_unlink(fn));
 	}
-	git_vector_free_deep(&contents);
+	git_vector_dispose_deep(&contents);
 }
 
 void test_checkout_crlf__matches_core_git(void)

--- a/tests/libgit2/diff/drivers.c
+++ b/tests/libgit2/diff/drivers.c
@@ -249,7 +249,7 @@ void test_diff_drivers__builtins(void)
 	git_buf_dispose(&actual);
 	git_str_dispose(&file);
 	git_str_dispose(&expected);
-	git_vector_free(&files);
+	git_vector_dispose(&files);
 }
 
 void test_diff_drivers__invalid_pattern(void)

--- a/tests/libgit2/diff/workdir.c
+++ b/tests/libgit2/diff/workdir.c
@@ -2136,7 +2136,7 @@ void test_diff_workdir__to_index_pathlist(void)
 	git_diff_free(diff);
 
 	git_index_free(index);
-	git_vector_free(&pathlist);
+	git_vector_dispose(&pathlist);
 }
 
 void test_diff_workdir__symlink_changed_on_non_symlink_platform(void)
@@ -2198,7 +2198,7 @@ void test_diff_workdir__symlink_changed_on_non_symlink_platform(void)
 	cl_git_pass(git_futils_rmdir_r("symlink", NULL, GIT_RMDIR_REMOVE_FILES));
 
 	git_tree_free(tree);
-	git_vector_free(&pathlist);
+	git_vector_dispose(&pathlist);
 }
 
 void test_diff_workdir__order(void)

--- a/tests/libgit2/fetchhead/nonetwork.c
+++ b/tests/libgit2/fetchhead/nonetwork.c
@@ -106,7 +106,7 @@ void test_fetchhead_nonetwork__write(void)
 		git_fetchhead_ref_free(fetchhead_ref);
 	}
 
-	git_vector_free(&fetchhead_vector);
+	git_vector_dispose(&fetchhead_vector);
 
 	cl_assert(equals);
 }
@@ -166,7 +166,7 @@ void test_fetchhead_nonetwork__read(void)
 		git_fetchhead_ref_free(fetchhead_ref);
 	}
 
-	git_vector_free(&fetchhead_vector);
+	git_vector_dispose(&fetchhead_vector);
 }
 
 static int read_old_style_cb(const char *name, const char *url,

--- a/tests/libgit2/graph/reachable_from_any.c
+++ b/tests/libgit2/graph/reachable_from_any.c
@@ -231,6 +231,6 @@ void test_graph_reachable_from_any__exhaustive(void)
 	git_vector_foreach (&mc.commits, child_idx, child_commit)
 		git_commit_free(child_commit);
 	git_bitvec_free(&reachable);
-	git_vector_free(&mc.commits);
+	git_vector_dispose(&mc.commits);
 	git_odb_free(mc.db);
 }

--- a/tests/libgit2/index/crlf.c
+++ b/tests/libgit2/index/crlf.c
@@ -190,7 +190,7 @@ static void set_up_workingdir(const char *name)
 			continue;
 		p_unlink(fn);
 	}
-	git_vector_free_deep(&contents);
+	git_vector_dispose_deep(&contents);
 
 	/* copy input files */
 	git_fs_path_dirload(&contents, cl_fixture("crlf"), 0, 0);
@@ -207,7 +207,7 @@ static void set_up_workingdir(const char *name)
 		git__free(basename);
 		git_str_dispose(&dest_filename);
 	}
-	git_vector_free_deep(&contents);
+	git_vector_dispose_deep(&contents);
 }
 
 void test_index_crlf__matches_core_git(void)

--- a/tests/libgit2/iterator/index.c
+++ b/tests/libgit2/iterator/index.c
@@ -627,7 +627,7 @@ void test_iterator_index__pathlist(void)
 	}
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_with_dirs(void)
@@ -728,7 +728,7 @@ void test_iterator_index__pathlist_with_dirs(void)
 	}
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_with_dirs_include_trees(void)
@@ -759,7 +759,7 @@ void test_iterator_index__pathlist_with_dirs_include_trees(void)
 	git_iterator_free(i);
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_1(void)
@@ -799,7 +799,7 @@ void test_iterator_index__pathlist_1(void)
 	git_iterator_free(i);
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_2(void)
@@ -841,7 +841,7 @@ void test_iterator_index__pathlist_2(void)
 	git_iterator_free(i);
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_four(void)
@@ -883,7 +883,7 @@ void test_iterator_index__pathlist_four(void)
 	git_iterator_free(i);
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_icase(void)
@@ -946,7 +946,7 @@ void test_iterator_index__pathlist_icase(void)
 
 	cl_git_pass(git_index_set_caps(index, caps));
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__pathlist_with_directory(void)
@@ -973,7 +973,7 @@ void test_iterator_index__pathlist_with_directory(void)
 
 	git_index_free(index);
 	git_tree_free(tree);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 static void create_paths(git_index *index, const char *root, int depth)
@@ -1131,7 +1131,7 @@ void test_iterator_index__pathlist_for_deeply_nested_item(void)
 	}
 
 	git_index_free(index);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_index__advance_over(void)

--- a/tests/libgit2/iterator/tree.c
+++ b/tests/libgit2/iterator/tree.c
@@ -911,7 +911,7 @@ void test_iterator_tree__pathlist(void)
 	expect_iterator_items(i, expect, NULL, expect, NULL);
 	git_iterator_free(i);
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 	git_tree_free(tree);
 }
 
@@ -968,7 +968,7 @@ void test_iterator_tree__pathlist_icase(void)
 	expect_iterator_items(i, 2, NULL, 2, NULL);
 	git_iterator_free(i);
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 	git_tree_free(tree);
 }
 
@@ -1021,7 +1021,7 @@ void test_iterator_tree__pathlist_with_directory(void)
 	git_iterator_free(i);
 
 	git_tree_free(tree);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_tree__pathlist_with_directory_include_tree_nodes(void)
@@ -1050,7 +1050,7 @@ void test_iterator_tree__pathlist_with_directory_include_tree_nodes(void)
 	git_iterator_free(i);
 
 	git_tree_free(tree);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_tree__pathlist_no_match(void)
@@ -1075,6 +1075,6 @@ void test_iterator_tree__pathlist_no_match(void)
 	git_iterator_free(i);
 
 	git_tree_free(tree);
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 

--- a/tests/libgit2/iterator/workdir.c
+++ b/tests/libgit2/iterator/workdir.c
@@ -917,7 +917,7 @@ void test_iterator_workdir__pathlist(void)
 		git_iterator_free(i);
 	}
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_workdir__pathlist_with_dirs(void)
@@ -1014,7 +1014,7 @@ void test_iterator_workdir__pathlist_with_dirs(void)
 		git_iterator_free(i);
 	}
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 static void create_paths(const char *root, int depth)
@@ -1175,7 +1175,7 @@ void test_iterator_workdir__pathlist_for_deeply_nested_item(void)
 		git_iterator_free(i);
 	}
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_workdir__bounded_submodules(void)
@@ -1258,7 +1258,7 @@ void test_iterator_workdir__bounded_submodules(void)
 		git_iterator_free(i);
 	}
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 	git_index_free(index);
 	git_tree_free(head);
 }
@@ -1380,7 +1380,7 @@ void test_iterator_workdir__advance_over_with_pathlist(void)
 
 	cl_git_fail_with(GIT_ITEROVER, git_iterator_advance(NULL, i));
 	git_iterator_free(i);
-	git_vector_free(&pathlist);
+	git_vector_dispose(&pathlist);
 }
 
 void test_iterator_workdir__advance_into(void)
@@ -1447,7 +1447,7 @@ void test_iterator_workdir__pathlist_with_directory(void)
 	expect_iterator_items(i, expected_len, expected, expected_len, expected);
 	git_iterator_free(i);
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_workdir__pathlist_with_directory_include_trees(void)
@@ -1473,7 +1473,7 @@ void test_iterator_workdir__pathlist_with_directory_include_trees(void)
 	expect_iterator_items(i, expected_len, expected, expected_len, expected);
 	git_iterator_free(i);
 
-	git_vector_free(&filelist);
+	git_vector_dispose(&filelist);
 }
 
 void test_iterator_workdir__hash_when_requested(void)

--- a/tests/libgit2/network/remote/rename.c
+++ b/tests/libgit2/network/remote/rename.c
@@ -238,7 +238,7 @@ void test_network_remote_rename__symref_head(void)
 	cl_assert_equal_s("be3563ae3f795b2b4353bcce3a527ad0a4f7f644", idstr);
 	git_reference_free(ref);
 
-	git_vector_free(&refs);
+	git_vector_dispose(&refs);
 
 	cl_git_fail_with(GIT_ITEROVER, git_branch_next(&ref, &btype, iter));
 	git_branch_iterator_free(iter);

--- a/tests/libgit2/online/push.c
+++ b/tests/libgit2/online/push.c
@@ -165,7 +165,7 @@ static void do_verify_push_status(record_callbacks_data *data, const push_status
 		git__free(s);
 	}
 
-	git_vector_free(actual);
+	git_vector_dispose(actual);
 }
 
 /**
@@ -272,7 +272,7 @@ failed:
 	git_vector_foreach(&actual_refs, i, actual_ref)
 		git__free(actual_ref);
 
-	git_vector_free(&actual_refs);
+	git_vector_dispose(&actual_refs);
 	git_str_dispose(&msg);
 	git_buf_dispose(&ref_name);
 }
@@ -416,7 +416,7 @@ void test_online_push__initialize(void)
 	}
 
 	git_remote_disconnect(_remote);
-	git_vector_free_deep(&delete_specs);
+	git_vector_dispose_deep(&delete_specs);
 
 	/* Now that we've deleted everything, fetch from the remote */
 	memcpy(&fetch_opts.callbacks, &_record_cbs, sizeof(git_remote_callbacks));

--- a/tests/libgit2/online/push_util.c
+++ b/tests/libgit2/online/push_util.c
@@ -24,12 +24,12 @@ void record_callbacks_data_clear(record_callbacks_data *data)
 	git_vector_foreach(&data->updated_tips, i, tip)
 		updated_tip_free(tip);
 
-	git_vector_free(&data->updated_tips);
+	git_vector_dispose(&data->updated_tips);
 
 	git_vector_foreach(&data->statuses, i, status)
 		push_status_free(status);
 
-	git_vector_free(&data->statuses);
+	git_vector_dispose(&data->statuses);
 
 	data->pack_progress_calls = 0;
 	data->transfer_progress_calls = 0;

--- a/tests/libgit2/pack/packbuilder.c
+++ b/tests/libgit2/pack/packbuilder.c
@@ -42,7 +42,7 @@ void test_pack_packbuilder__cleanup(void)
 		git_vector_foreach(&_commits, i, o) {
 			git__free(o);
 		}
-		git_vector_free(&_commits);
+		git_vector_dispose(&_commits);
 	}
 
 	git_packbuilder_free(_packbuilder);

--- a/tests/libgit2/refs/iterator.c
+++ b/tests/libgit2/refs/iterator.c
@@ -96,7 +96,7 @@ static void assert_all_refnames_match(const char **expected, git_vector *names)
 	}
 	cl_assert(expected[i] == NULL);
 
-	git_vector_free(names);
+	git_vector_dispose(names);
 }
 
 void test_refs_iterator__list(void)
@@ -222,7 +222,7 @@ void test_refs_iterator__foreach_name(void)
 		git__free(name);
 	}
 
-	git_vector_free(&output);
+	git_vector_dispose(&output);
 }
 
 static int refs_foreach_name_cancel_cb(const char *name, void *payload)

--- a/tests/util/process/env.c
+++ b/tests/util/process/env.c
@@ -19,7 +19,7 @@ void test_process_env__initialize(void)
 
 void test_process_env__cleanup(void)
 {
-	git_vector_free(&env_result);
+	git_vector_dispose(&env_result);
 	git_str_dispose(&accumulator);
 	git_str_dispose(&env_cmd);
 }

--- a/tests/util/vector.c
+++ b/tests/util/vector.c
@@ -12,7 +12,7 @@ void test_vector__0(void)
 	for (i = 0; i < 10; ++i) {
 		git_vector_insert(&x, (void*) 0xabc);
 	}
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 
@@ -27,7 +27,7 @@ void test_vector__1(void)
 	git_vector_insert(&x, (void*) 0x123);
 
 	git_vector_remove(&x, 0); /* used to read past array bounds. */
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 
@@ -59,7 +59,7 @@ void test_vector__2(void)
 	git_vector_uniq(&x, NULL);
 	cl_assert(x.length == 2);
 
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 
 	git__free(ptrs[0]);
 	git__free(ptrs[1]);
@@ -91,7 +91,7 @@ void test_vector__3(void)
 		cl_assert(git_vector_get(&x, i) == (void*)(i + 1));
 	}
 
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 /* insert_sorted with duplicates */
@@ -122,7 +122,7 @@ void test_vector__4(void)
 		cl_assert(git_vector_get(&x, i) == (void*)(i / 2 + 1));
 	}
 
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 typedef struct {
@@ -189,7 +189,7 @@ void test_vector__5(void)
 		_struct_count--;
 	}
 
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 static int remove_ones(const git_vector *v, size_t idx, void *p)
@@ -274,7 +274,7 @@ void test_vector__remove_matching(void)
 	git_vector_remove_matching(&x, remove_ones, NULL);
 	cl_assert(x.length == 4);
 
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 static void assert_vector(git_vector *x, void *expected[], size_t len)
@@ -376,7 +376,7 @@ void test_vector__grow_and_shrink(void)
 	git_vector_remove_range(&x, 0, 1);
 	assert_vector(&x, NULL, 0);
 
-	git_vector_free(&x);
+	git_vector_dispose(&x);
 }
 
 void test_vector__reverse(void)
@@ -407,7 +407,7 @@ void test_vector__reverse(void)
 	for (i = 0; i < 5; i++)
 		cl_assert_equal_p(out2[i], git_vector_get(&v, i));
 
-	git_vector_free(&v);
+	git_vector_dispose(&v);
 }
 
 void test_vector__dup_empty_vector(void)
@@ -426,5 +426,5 @@ void test_vector__dup_empty_vector(void)
 	cl_assert_equal_i(8, dup._alloc_size);
 	cl_assert_equal_i(1, dup.length);
 
-	git_vector_free(&dup);
+	git_vector_dispose(&dup);
 }


### PR DESCRIPTION
In keeping with the libgit2 pattern, we _dispose_ a structure that is not heap allocated, and _free_ a structure's contents _and the structure itself_.