### PR TITLE
ci: don't run Windows SHA256 gitdaemon tests

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -55,6 +55,8 @@ jobs:
             CMAKE_OPTIONS: -A x64 -DWIN32_LEAKCHECK=ON -DDEPRECATE_HARD=ON -DEXPERIMENTAL_SHA256=ON
             SKIP_SSH_TESTS: true
             SKIP_NEGOTIATE_TESTS: true
+            # TODO: this is a temporary removal
+            SKIP_GITDAEMON_TESTS: true
       fail-fast: false
     env: ${{ matrix.platform.env }}
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
The Windows SHA256 gitdaemon seems to crash; remove from CI while we troubleshoot.