### PR TITLE
readme: add OpenSSF best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 libgit2 - the Git linkable library
 ==================================
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9609/badge)](https://www.bestpractices.dev/projects/9609)
 
 | Build Status | |
 | ------------ | - |


### PR DESCRIPTION
I was curious about how we fair against OpenSSF Best Practices. Pretty good, which I'm proud of but not particularly surprised by. Let's add the badge to our README so that we can track conformance.