### PR TITLE
util/win32: Continue if access is denied when deleting a folder.

### DIFF
--- a/src/util/win32/posix_w32.c
+++ b/src/util/win32/posix_w32.c
@@ -770,6 +770,7 @@ int p_rmdir(const char *path)
 			 * handle to the directory."  This sounds like what everybody else calls
 			 * EBUSY.  Let's convert appropriate error codes.
 			 */
+			case ERROR_ACCESS_DENIED:
 			case ERROR_SHARING_VIOLATION:
 				errno = EBUSY;
 				break;


### PR DESCRIPTION
I'm afraid people do put Git repos on OneDrive... It seems to like to prevent folders from being deleted, causing libgit2 operations to handle ERROR_ACCESS_DENIED, and preventing us from switching branches/merging etc.

I think this change brings libgit2 in line with the behaviour of Git for Windows. The rmdir function is located [here](https://github.com/git-for-windows/git/blame/85dac07b93425aba69537d42ef036aa8413ae37c/compat/mingw.c#L593). The function is_file_in_use_error not only checks for ERROR_SHARING_VIOLATION, but also ERROR_ACCESS_DENIED:

```cpp
static inline int is_file_in_use_error(DWORD errcode)
{
	switch (errcode) {
	case ERROR_SHARING_VIOLATION:
	case ERROR_ACCESS_DENIED:
		return 1;
	}

	return 0;
}
```

Completely understand any hesitation about merging this, but thought it might be useful to at least raise it so others can search for it. I've tried it out and it seems to work ok.

Of course, it means empty folders can end up lying around in your local Git repository which is also confusing. But Git for Windows is the same.