### PR TITLE
ssh: Include rsa-sha2-256 and rsa-sha2-512 in the list of hostkey types

### DIFF
--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -515,6 +515,8 @@ static void find_hostkey_preference(
 	add_hostkey_pref_if_avail(known_hosts, hostname, port, prefs, LIBSSH2_KNOWNHOST_KEY_ECDSA_384, "ecdsa-sha2-nistp384");
 	add_hostkey_pref_if_avail(known_hosts, hostname, port, prefs, LIBSSH2_KNOWNHOST_KEY_ECDSA_521, "ecdsa-sha2-nistp521");
 #endif
+	add_hostkey_pref_if_avail(known_hosts, hostname, port, prefs, LIBSSH2_KNOWNHOST_KEY_SSHRSA, "rsa-sha2-512");
+	add_hostkey_pref_if_avail(known_hosts, hostname, port, prefs, LIBSSH2_KNOWNHOST_KEY_SSHRSA, "rsa-sha2-256");
 	add_hostkey_pref_if_avail(known_hosts, hostname, port, prefs, LIBSSH2_KNOWNHOST_KEY_SSHRSA, "ssh-rsa");
 }
 


### PR DESCRIPTION
User sees this error when trying to clone a repository using SSH:

failed to start SSH session: Unable to exchange encryption keys (-1x23)

This particular server only accepts these host key algorithms (output from ssh executable):

debug2: host key algorithms: rsa-sha2-256,rsa-sha2-512

"Normally" you might see others but what causes the error is the absence of "ssh-rsa" from the accepted list of host key algorithms.

Calling libssh2_session_method_pref with a list of methodsunfortunately isn't just preferring those methods, it means it accepts ONLY those methods. This pull request fixes that by adding rsa-sha2-256 and rsa-sha2-512 to the list.

This could be optimised by only calling libssh2_knownhost_checkp once for LIBSSH2_KNOWNHOST_KEY_SSHRSA and appending all of rsa-sha2-256, rsa-sha2-512. and ssh-rsa if mismatch is returned.