### PR TITLE
Make `GIT_WIN32` an internal declaration

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -73,11 +73,6 @@ typedef size_t size_t;
 # define GIT_FORMAT_PRINTF(a,b) /* empty */
 #endif
 
-/** Defined when building on Windows (but not via cygwin) */
-#if (defined(_WIN32)) && !defined(__CYGWIN__)
-#define GIT_WIN32 1
-#endif
-
 #ifdef __amigaos4__
 #include <netinet/in.h>
 #endif
@@ -101,10 +96,10 @@ GIT_BEGIN_DECL
  * environment variable). A semi-colon ";" is used on Windows and
  * AmigaOS, and a colon ":" for all other systems.
  */
-#if defined(GIT_WIN32) || defined(AMIGA)
-#define GIT_PATH_LIST_SEPARATOR ';'
+#if (defined(_WIN32) && !defined(__CYGWIN__)) || defined(AMIGA)
+# define GIT_PATH_LIST_SEPARATOR ';'
 #else
-#define GIT_PATH_LIST_SEPARATOR ':'
+# define GIT_PATH_LIST_SEPARATOR ':'
 #endif
 
 /**

--- a/src/libgit2/odb_mempack.c
+++ b/src/libgit2/odb_mempack.c
@@ -213,15 +213,9 @@ int git_mempack_new(git_odb_backend **out)
 int git_mempack_object_count(size_t *out, git_odb_backend *_backend)
 {
 	struct memory_packer_db *db = (struct memory_packer_db *)_backend;
-	uint32_t count;
 
 	GIT_ASSERT_ARG(_backend);
 
-	count = git_odb_mempack_oidmap_size(&db->objects);
-
-	if (count < 0)
-		return count;
-
-	*out = (size_t)count;
+	*out = (size_t)git_odb_mempack_oidmap_size(&db->objects);
 	return 0;
 }

--- a/src/util/git2_util.h
+++ b/src/util/git2_util.h
@@ -49,6 +49,10 @@ typedef struct git_str git_str;
 # define GIT_WARN_UNUSED_RESULT
 #endif
 
+#if (defined(_WIN32)) && !defined(__CYGWIN__)
+# define GIT_WIN32 1
+#endif
+
 #include <assert.h>
 #include <errno.h>
 #include <limits.h>

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -7,14 +7,14 @@
 #ifndef INCLUDE_util_h__
 #define INCLUDE_util_h__
 
-#ifndef GIT_WIN32
-# include <ctype.h>
-#endif
-
 #include "str.h"
 #include "git2_util.h"
 #include "strnlen.h"
 #include "thread.h"
+
+#ifndef GIT_WIN32
+# include <ctype.h>
+#endif
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 #define bitsizeof(x) (CHAR_BIT * sizeof(x))


### PR DESCRIPTION
The `GIT_WIN32` macro should only be used internally; keep it as such.