### PR TITLE
schannel: Fix certificate error reporting and ignore some trust errors by default

### DIFF
--- a/src/libgit2/streams/schannel.c
+++ b/src/libgit2/streams/schannel.c
@@ -369,8 +369,9 @@ static int check_certificate(schannel_stream* st)
 	st->x509.len = st->certificate->cbCertEncoded;
 
 	/* Handle initial certificate validation */
-
-	if (st->cert_chain->TrustStatus.dwErrorStatus != CERT_TRUST_NO_ERROR)
+	if ((st->cert_chain->TrustStatus.dwErrorStatus &
+	     ~(DWORD)(CERT_TRUST_REVOCATION_STATUS_UNKNOWN |
+	              CERT_TRUST_IS_OFFLINE_REVOCATION)) != CERT_TRUST_NO_ERROR)
 		return set_certificate_lookup_error(st->cert_chain->TrustStatus.dwErrorStatus);
 
 	ssl_policy_parameters.cbSize = sizeof(SSL_EXTRA_CERT_CHAIN_POLICY_PARA);

--- a/src/libgit2/streams/schannel.c
+++ b/src/libgit2/streams/schannel.c
@@ -185,53 +185,86 @@ static int connect_context(schannel_stream *st)
 	return error;
 }
 
+static void
+certificate_error_append_message(int *error, git_str *msg, const char *error_msg)
+{
+	if (*error != -1)
+		git_str_puts(msg, ", ");
+	git_str_puts(msg, error_msg);
+}
+
 static int set_certificate_lookup_error(DWORD status)
 {
-	switch (status) {
-	case CERT_TRUST_IS_NOT_TIME_VALID:
-		git_error_set(GIT_ERROR_SSL,
-			"certificate is expired or not yet valid");
-		break;
-	case CERT_TRUST_IS_REVOKED:
-		git_error_set(GIT_ERROR_SSL, "certificate is revoked");
-		break;
-	case CERT_TRUST_IS_NOT_SIGNATURE_VALID:
-	case CERT_TRUST_IS_NOT_VALID_FOR_USAGE:
-	case CERT_TRUST_INVALID_EXTENSION:
-	case CERT_TRUST_INVALID_POLICY_CONSTRAINTS:
-	case CERT_TRUST_INVALID_BASIC_CONSTRAINTS:
-	case CERT_TRUST_INVALID_NAME_CONSTRAINTS:
-	case CERT_TRUST_HAS_NOT_SUPPORTED_NAME_CONSTRAINT:
-	case CERT_TRUST_HAS_NOT_DEFINED_NAME_CONSTRAINT:
-	case CERT_TRUST_HAS_NOT_PERMITTED_NAME_CONSTRAINT:
-	case CERT_TRUST_HAS_EXCLUDED_NAME_CONSTRAINT:
-	case CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY:
-	case CERT_TRUST_HAS_NOT_SUPPORTED_CRITICAL_EXT:
-		git_error_set(GIT_ERROR_SSL, "certificate is not valid");
-		break;
-	case CERT_TRUST_IS_UNTRUSTED_ROOT:
-	case CERT_TRUST_IS_CYCLIC:
-	case CERT_TRUST_IS_EXPLICIT_DISTRUST:
-		git_error_set(GIT_ERROR_SSL, "certificate is not trusted");
-		break;
-	case CERT_TRUST_REVOCATION_STATUS_UNKNOWN:
-		git_error_set(GIT_ERROR_SSL,
-			"certificate revocation status could not be verified");
-		break;
-	case CERT_TRUST_IS_OFFLINE_REVOCATION:
-		git_error_set(GIT_ERROR_SSL,
-			"certificate revocation is offline or stale");
-		break;
-	case CERT_TRUST_HAS_WEAK_SIGNATURE:
-		git_error_set(GIT_ERROR_SSL, "certificate has a weak signature");
-		break;
-	default:
-		git_error_set(GIT_ERROR_SSL,
-			"unknown certificate lookup failure: %d", status);
-		return -1;
+	int error = -1;
+	git_str msg = GIT_STR_INIT;
+
+	git_str_printf(&msg, "certificate error (%d): ", status);
+
+	if (status & CERT_TRUST_IS_NOT_TIME_VALID) {
+		certificate_error_append_message(
+		        &error, &msg,
+		        "certificate is expired or not yet valid");
+		error = GIT_ECERTIFICATE;
 	}
 
-	return GIT_ECERTIFICATE;
+	if (status & CERT_TRUST_IS_REVOKED) {
+		certificate_error_append_message(
+		        &error, &msg, "certificate is revoked");
+		error = GIT_ECERTIFICATE;
+	}
+
+	if (status &
+	    (CERT_TRUST_IS_NOT_SIGNATURE_VALID |
+	     CERT_TRUST_IS_NOT_VALID_FOR_USAGE | CERT_TRUST_INVALID_EXTENSION |
+	     CERT_TRUST_INVALID_POLICY_CONSTRAINTS |
+	     CERT_TRUST_INVALID_BASIC_CONSTRAINTS |
+	     CERT_TRUST_INVALID_NAME_CONSTRAINTS |
+	     CERT_TRUST_HAS_NOT_SUPPORTED_NAME_CONSTRAINT |
+	     CERT_TRUST_HAS_NOT_DEFINED_NAME_CONSTRAINT |
+	     CERT_TRUST_HAS_NOT_PERMITTED_NAME_CONSTRAINT |
+	     CERT_TRUST_HAS_EXCLUDED_NAME_CONSTRAINT |
+	     CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY |
+	     CERT_TRUST_HAS_NOT_SUPPORTED_CRITICAL_EXT)) {
+		certificate_error_append_message(
+		        &error, &msg, "certificate is not valid");
+		error = GIT_ECERTIFICATE;
+	}
+
+	if (status & (CERT_TRUST_IS_UNTRUSTED_ROOT | CERT_TRUST_IS_CYCLIC |
+	              CERT_TRUST_IS_EXPLICIT_DISTRUST)) {
+		certificate_error_append_message(
+		        &error, &msg, "certificate is not trusted");
+		error = GIT_ECERTIFICATE;
+	}
+
+	if (status & CERT_TRUST_HAS_WEAK_SIGNATURE) {
+		certificate_error_append_message(
+		        &error, &msg, "certificate has a weak signature");
+		error = GIT_ECERTIFICATE;
+	}
+
+	if (status & CERT_TRUST_REVOCATION_STATUS_UNKNOWN) {
+		certificate_error_append_message(
+		        &error, &msg,
+		        "certificate revocation status could not be verified");
+		error = GIT_ECERTIFICATE;
+	}
+
+	if (status & CERT_TRUST_IS_OFFLINE_REVOCATION) {
+		certificate_error_append_message(
+		        &error, &msg,
+		        "certificate revocation is offline or stale");
+		error = GIT_ECERTIFICATE;
+	}
+
+	if (error == -1)
+		git_str_printf(
+		        &msg, "unknown certificate lookup failure: %d", status);
+
+	git_error_set(GIT_ERROR_SSL, git_str_cstr(&msg));
+	git_str_dispose(&msg);
+
+	return error;
 }
 
 static int set_certificate_validation_error(DWORD status)

--- a/src/libgit2/streams/schannel.c
+++ b/src/libgit2/streams/schannel.c
@@ -341,6 +341,9 @@ static int check_certificate(schannel_stream* st)
 
 	memset(&cert_chain_parameters, 0, sizeof(CERT_CHAIN_PARA));
 	cert_chain_parameters.cbSize = sizeof(CERT_CHAIN_PARA);
+	
+	memset(&cert_policy_status, 0, sizeof(CERT_CHAIN_POLICY_STATUS));
+	cert_policy_status.cbSize = sizeof(CERT_CHAIN_POLICY_STATUS);
 
 	if (QueryContextAttributesW(&st->context,
 			SECPKG_ATTR_REMOTE_CERT_CONTEXT,

--- a/tests/libgit2/online/badssl.c
+++ b/tests/libgit2/online/badssl.c
@@ -86,7 +86,7 @@ void test_online_badssl__untrusted(void)
 	        GIT_ECERTIFICATE,
 	        git_clone(
 	                &g_repo, "https://untrusted-root.badssl.com/fake.git",
-	                "./fake", NULL));
+	                "./fake", &opts));
 	cl_assert_equal_i(git_error_last()->klass, GIT_ERROR_SSL);
 	cl_assert(strstr(git_error_last()->message, "certificate is not trusted") != NULL);
 	cl_assert(

--- a/tests/libgit2/online/badssl.c
+++ b/tests/libgit2/online/badssl.c
@@ -73,3 +73,28 @@ void test_online_badssl__old_cipher(void)
 	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
 	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", &opts));
 }
+
+void test_online_badssl__untrusted(void)
+{
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+	opts.fetch_opts.callbacks.certificate_check = cert_check_assert_invalid;
+
+	if (!g_has_ssl)
+		cl_skip();
+
+	cl_git_fail_with(
+	        GIT_ECERTIFICATE,
+	        git_clone(
+	                &g_repo, "https://untrusted-root.badssl.com/fake.git",
+	                "./fake", NULL));
+	cl_assert_equal_i(git_error_last()->klass, GIT_ERROR_SSL);
+	const char *message = git_error_last()->message;
+	cl_assert(strstr(message, "certificate is not trusted") != NULL);
+	cl_assert(
+	        strstr(message,
+	               "certificate revocation status could not be verified") !=
+	        NULL);
+	cl_assert(
+	        strstr(message, "certificate revocation is offline or stale") !=
+	        NULL);
+}

--- a/tests/libgit2/online/badssl.c
+++ b/tests/libgit2/online/badssl.c
@@ -73,24 +73,3 @@ void test_online_badssl__old_cipher(void)
 	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", NULL));
 	cl_git_fail(git_clone(&g_repo, "https://rc4.badssl.com/fake.git", "./fake", &opts));
 }
-
-void test_online_badssl__untrusted(void)
-{
-	if (!g_has_ssl)
-		cl_skip();
-
-	cl_git_fail_with(
-	        GIT_ECERTIFICATE,
-	        git_clone(
-	                &g_repo, "https://untrusted-root.badssl.com/fake.git",
-	                "./fake", NULL));
-	cl_assert_equal_i(git_error_last()->klass, GIT_ERROR_SSL);
-	cl_assert(strstr(git_error_last()->message, "certificate is not trusted") != NULL);
-	cl_assert(
-	        strstr(git_error_last()->message,
-	               "certificate revocation status could not be verified") !=
-	        NULL);
-	cl_assert(
-	        strstr(git_error_last()->message, "certificate revocation is offline or stale") !=
-	        NULL);
-}

--- a/tests/libgit2/online/badssl.c
+++ b/tests/libgit2/online/badssl.c
@@ -76,9 +76,6 @@ void test_online_badssl__old_cipher(void)
 
 void test_online_badssl__untrusted(void)
 {
-	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
-	opts.fetch_opts.callbacks.certificate_check = cert_check_assert_invalid;
-
 	if (!g_has_ssl)
 		cl_skip();
 
@@ -86,7 +83,7 @@ void test_online_badssl__untrusted(void)
 	        GIT_ECERTIFICATE,
 	        git_clone(
 	                &g_repo, "https://untrusted-root.badssl.com/fake.git",
-	                "./fake", &opts));
+	                "./fake", NULL));
 	cl_assert_equal_i(git_error_last()->klass, GIT_ERROR_SSL);
 	cl_assert(strstr(git_error_last()->message, "certificate is not trusted") != NULL);
 	cl_assert(

--- a/tests/libgit2/online/badssl.c
+++ b/tests/libgit2/online/badssl.c
@@ -88,13 +88,12 @@ void test_online_badssl__untrusted(void)
 	                &g_repo, "https://untrusted-root.badssl.com/fake.git",
 	                "./fake", NULL));
 	cl_assert_equal_i(git_error_last()->klass, GIT_ERROR_SSL);
-	const char *message = git_error_last()->message;
-	cl_assert(strstr(message, "certificate is not trusted") != NULL);
+	cl_assert(strstr(git_error_last()->message, "certificate is not trusted") != NULL);
 	cl_assert(
-	        strstr(message,
+	        strstr(git_error_last()->message,
 	               "certificate revocation status could not be verified") !=
 	        NULL);
 	cl_assert(
-	        strstr(message, "certificate revocation is offline or stale") !=
+	        strstr(git_error_last()->message, "certificate revocation is offline or stale") !=
 	        NULL);
 }


### PR DESCRIPTION
This is a partial fix for #6724.

1) dwErrorStatus is a bitmask and so I've attempted to concatenate the error strings.
2) libgit2 now uses the same defaults as Git for Windows, ignoring CERT_TRUST_REVOCATION_STATUS_UNKNOWN and CERT_TRUST_IS_OFFLINE_REVOCATION.

I would add support for querying "http.schannelcheckrevoke", but am not sure how to get a repository config snapshot in this function. Or could just get the global config. I didn't see any stream implementations that query the config.