### PR TITLE
 object: git_object_short_id fails with core.abbrev string values

### DIFF
--- a/src/libgit2/config_cache.c
+++ b/src/libgit2/config_cache.c
@@ -65,8 +65,8 @@ static git_configmap _configmap_logallrefupdates[] = {
 };
 
 static git_configmap _configmap_abbrev[] = {
-	{GIT_CONFIGMAP_FALSE, NULL, GIT_ABBREV_FALSE},
 	{GIT_CONFIGMAP_INT32, NULL, 0},
+	{GIT_CONFIGMAP_FALSE, NULL, GIT_ABBREV_FALSE},
 	{GIT_CONFIGMAP_STRING, "auto", GIT_ABBREV_DEFAULT}
 };
 

--- a/src/libgit2/config_cache.c
+++ b/src/libgit2/config_cache.c
@@ -65,10 +65,15 @@ static git_configmap _configmap_logallrefupdates[] = {
 };
 
 /*
- * Generic map for integer values
- */
-static git_configmap _configmap_int[] = {
+Set the length object names are abbreviated to. If unspecified or set to "auto",
+an appropriate value is computed based on the approximate number of packed objects in your repository,
+which hopefully is enough for abbreviated object names to stay unique for some time. If set to "no",
+no abbreviation is made and the object names are shown in their full length. The minimum length is 4.
+*/
+static git_configmap _configmap_abbrev[] = {
+	{GIT_CONFIGMAP_FALSE, NULL, GIT_ABBREV_FALSE},
 	{GIT_CONFIGMAP_INT32, NULL, 0},
+	{GIT_CONFIGMAP_STRING, "auto", GIT_ABBREV_DEFAULT}
 };
 
 static struct map_data _configmaps[] = {
@@ -79,7 +84,7 @@ static struct map_data _configmaps[] = {
 	{"core.filemode", NULL, 0, GIT_FILEMODE_DEFAULT },
 	{"core.ignorestat", NULL, 0, GIT_IGNORESTAT_DEFAULT },
 	{"core.trustctime", NULL, 0, GIT_TRUSTCTIME_DEFAULT },
-	{"core.abbrev", _configmap_int, 1, GIT_ABBREV_DEFAULT },
+	{"core.abbrev", _configmap_abbrev, ARRAY_SIZE(_configmap_abbrev), GIT_ABBREV_DEFAULT },
 	{"core.precomposeunicode", NULL, 0, GIT_PRECOMPOSE_DEFAULT },
 	{"core.safecrlf", _configmap_safecrlf, ARRAY_SIZE(_configmap_safecrlf), GIT_SAFE_CRLF_DEFAULT},
 	{"core.logallrefupdates", _configmap_logallrefupdates, ARRAY_SIZE(_configmap_logallrefupdates), GIT_LOGALLREFUPDATES_DEFAULT},

--- a/src/libgit2/config_cache.c
+++ b/src/libgit2/config_cache.c
@@ -64,12 +64,6 @@ static git_configmap _configmap_logallrefupdates[] = {
 	{GIT_CONFIGMAP_STRING, "always", GIT_LOGALLREFUPDATES_ALWAYS},
 };
 
-/*
-Set the length object names are abbreviated to. If unspecified or set to "auto",
-an appropriate value is computed based on the approximate number of packed objects in your repository,
-which hopefully is enough for abbreviated object names to stay unique for some time. If set to "no",
-no abbreviation is made and the object names are shown in their full length. The minimum length is 4.
-*/
 static git_configmap _configmap_abbrev[] = {
 	{GIT_CONFIGMAP_FALSE, NULL, GIT_ABBREV_FALSE},
 	{GIT_CONFIGMAP_INT32, NULL, 0},

--- a/src/libgit2/diff_print.c
+++ b/src/libgit2/diff_print.c
@@ -53,13 +53,9 @@ static int diff_print_info_init__common(
 	if (!pi->id_strlen) {
 		if (!repo)
 			pi->id_strlen = GIT_ABBREV_DEFAULT;
-		else if (git_repository__configmap_lookup(&pi->id_strlen, repo, GIT_CONFIGMAP_ABBREV) < 0)
+		else if (git_object__abbrev_length(&pi->id_strlen, repo) < 0)
 			return -1;
 	}
-
-	if (pi->id_strlen > 0 &&
-	    (size_t)pi->id_strlen > git_oid_hexsize(pi->oid_type))
-		pi->id_strlen = (int)git_oid_hexsize(pi->oid_type);
 
 	memset(&pi->line, 0, sizeof(pi->line));
 	pi->line.old_lineno = -1;

--- a/src/libgit2/diff_print.c
+++ b/src/libgit2/diff_print.c
@@ -15,6 +15,7 @@
 #include "zstream.h"
 #include "blob.h"
 #include "delta.h"
+#include "repository.h"
 #include "git2/sys/diff.h"
 
 typedef struct {
@@ -53,7 +54,7 @@ static int diff_print_info_init__common(
 	if (!pi->id_strlen) {
 		if (!repo)
 			pi->id_strlen = GIT_ABBREV_DEFAULT;
-		else if (git_object__abbrev_length(&pi->id_strlen, repo) < 0)
+		else if (git_repository__abbrev_length(&pi->id_strlen, repo) < 0)
 			return -1;
 	}
 

--- a/src/libgit2/object.c
+++ b/src/libgit2/object.c
@@ -520,31 +520,6 @@ cleanup:
 	return error;
 }
 
-int git_object__abbrev_length(int *out, git_repository *repo)
-{
-	size_t oid_hexsize;
-	int len;
-	int error;
-
-	oid_hexsize = git_oid_hexsize(repo->oid_type);
-
-	if ((error = git_repository__configmap_lookup(&len, repo, GIT_CONFIGMAP_ABBREV)) < 0)
-		return error;
-
-	if (len == GIT_ABBREV_FALSE) {
-		len = (int)oid_hexsize;
-	}
-
-	if (len < GIT_ABBREV_MINIMUM || (size_t)len > oid_hexsize) {
-		git_error_set(GIT_ERROR_CONFIG, "invalid oid abbreviation setting: '%d'", len);
-		return -1;
-	}
-
-	*out = len;
-
-	return error;
-}
-
 static int git_object__short_id(git_str *out, const git_object *obj)
 {
 	git_repository *repo;
@@ -561,7 +536,7 @@ static int git_object__short_id(git_str *out, const git_object *obj)
 	git_oid_clear(&id, repo->oid_type);
 	oid_hexsize = git_oid_hexsize(repo->oid_type);
 
-	if ((error = git_object__abbrev_length(&len, repo)) < 0)
+	if ((error = git_repository__abbrev_length(&len, repo)) < 0)
 		return error;
 
 	if ((size_t)len == oid_hexsize) {

--- a/src/libgit2/object.c
+++ b/src/libgit2/object.c
@@ -532,7 +532,7 @@ int git_object__abbrev_length(int *out, git_repository *repo)
 		return error;
 
 	if (len == GIT_ABBREV_FALSE) {
-		len = oid_hexsize;
+		len = (int)oid_hexsize;
 	}
 
 	if (len < GIT_ABBREV_MINIMUM || (size_t)len > oid_hexsize) {

--- a/src/libgit2/object.c
+++ b/src/libgit2/object.c
@@ -520,13 +520,38 @@ cleanup:
 	return error;
 }
 
+int git_object__abbrev_length(int *out, git_repository *repo)
+{
+	size_t oid_hexsize;
+	int len;
+	int error;
+
+	oid_hexsize = git_oid_hexsize(repo->oid_type);
+
+	if ((error = git_repository__configmap_lookup(&len, repo, GIT_CONFIGMAP_ABBREV)) < 0)
+		return error;
+
+	if (len == GIT_ABBREV_FALSE) {
+		len = oid_hexsize;
+	}
+
+	if (len < GIT_ABBREV_MINIMUM || (size_t)len > oid_hexsize) {
+		git_error_set(GIT_ERROR_CONFIG, "invalid oid abbreviation setting: '%d'", len);
+		return -1;
+	}
+
+	*out = len;
+
+	return error;
+}
+
 static int git_object__short_id(git_str *out, const git_object *obj)
 {
 	git_repository *repo;
 	git_oid id;
 	git_odb *odb;
 	size_t oid_hexsize;
-	int len = GIT_ABBREV_DEFAULT, error;
+	int len, error;
 
 	GIT_ASSERT_ARG(out);
 	GIT_ASSERT_ARG(obj);
@@ -536,12 +561,13 @@ static int git_object__short_id(git_str *out, const git_object *obj)
 	git_oid_clear(&id, repo->oid_type);
 	oid_hexsize = git_oid_hexsize(repo->oid_type);
 
-	if ((error = git_repository__configmap_lookup(&len, repo, GIT_CONFIGMAP_ABBREV)) < 0)
+	if ((error = git_object__abbrev_length(&len, repo)) < 0)
 		return error;
 
-	if (len < 0 || (size_t)len > oid_hexsize) {
-		git_error_set(GIT_ERROR_CONFIG, "invalid oid abbreviation setting: '%d'", len);
-		return -1;
+	if ((size_t)len == oid_hexsize) {
+		if ((error = git_oid_cpy(&id, &obj->cached.oid)) < 0) {
+			return error;
+		}
 	}
 
 	if ((error = git_repository_odb(&odb, repo)) < 0)

--- a/src/libgit2/object.h
+++ b/src/libgit2/object.h
@@ -83,4 +83,6 @@ GIT_INLINE(git_object_t) git_object__type_from_filemode(git_filemode_t mode)
 	}
 }
 
+int git_object__abbrev_length(int *out, git_repository *repo);
+
 #endif

--- a/src/libgit2/object.h
+++ b/src/libgit2/object.h
@@ -83,6 +83,4 @@ GIT_INLINE(git_object_t) git_object__type_from_filemode(git_filemode_t mode)
 	}
 }
 
-int git_object__abbrev_length(int *out, git_repository *repo);
-
 #endif

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -4021,14 +4021,13 @@ int git_repository__abbrev_length(int *out, git_repository *repo)
 	if ((error = git_repository__configmap_lookup(&len, repo, GIT_CONFIGMAP_ABBREV)) < 0)
 		return error;
 
-	if (len == GIT_ABBREV_FALSE) {
-		len = (int)oid_hexsize;
-	}
-
-	if (len < GIT_ABBREV_MINIMUM || (size_t)len > oid_hexsize) {
+	if (len < GIT_ABBREV_MINIMUM) {
 		git_error_set(GIT_ERROR_CONFIG, "invalid oid abbreviation setting: '%d'", len);
 		return -1;
 	}
+
+	if (len == GIT_ABBREV_FALSE || (size_t)len > oid_hexsize)
+		len = (int)oid_hexsize;
 
 	*out = len;
 

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -4009,3 +4009,28 @@ done:
 	git_reference_free(head_ref);
 	return error;
 }
+
+int git_repository__abbrev_length(int *out, git_repository *repo)
+{
+	size_t oid_hexsize;
+	int len;
+	int error;
+
+	oid_hexsize = git_oid_hexsize(repo->oid_type);
+
+	if ((error = git_repository__configmap_lookup(&len, repo, GIT_CONFIGMAP_ABBREV)) < 0)
+		return error;
+
+	if (len == GIT_ABBREV_FALSE) {
+		len = (int)oid_hexsize;
+	}
+
+	if (len < GIT_ABBREV_MINIMUM || (size_t)len > oid_hexsize) {
+		git_error_set(GIT_ERROR_CONFIG, "invalid oid abbreviation setting: '%d'", len);
+		return -1;
+	}
+
+	*out = len;
+
+	return error;
+}

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -102,7 +102,7 @@ typedef enum {
 	/* core.trustctime */
 	GIT_TRUSTCTIME_DEFAULT = GIT_CONFIGMAP_TRUE,
 	/* core.abbrev */
-	GIT_ABBREV_FALSE = GIT_CONFIGMAP_FALSE,
+	GIT_ABBREV_FALSE = GIT_OID_MAX_HEXSIZE,
 	GIT_ABBREV_MINIMUM = 4,
 	GIT_ABBREV_DEFAULT = 7,
 	/* core.precomposeunicode */

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -102,6 +102,8 @@ typedef enum {
 	/* core.trustctime */
 	GIT_TRUSTCTIME_DEFAULT = GIT_CONFIGMAP_TRUE,
 	/* core.abbrev */
+	GIT_ABBREV_FALSE = GIT_CONFIGMAP_FALSE,
+	GIT_ABBREV_MINIMUM = 4,
 	GIT_ABBREV_DEFAULT = 7,
 	/* core.precomposeunicode */
 	GIT_PRECOMPOSE_DEFAULT = GIT_CONFIGMAP_FALSE,

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -213,6 +213,9 @@ int git_repository__wrap_odb(
 int git_repository__configmap_lookup(int *out, git_repository *repo, git_configmap_item item);
 void git_repository__configmap_lookup_cache_clear(git_repository *repo);
 
+/** Return the length that object names will be abbreviated to. */
+int git_repository__abbrev_length(int *out, git_repository *repo);
+
 int git_repository__item_path(git_str *out, const git_repository *repo, git_repository_item_t item);
 
 GIT_INLINE(int) git_repository__ensure_not_bare(

--- a/tests/libgit2/object/shortid.c
+++ b/tests/libgit2/object/shortid.c
@@ -70,14 +70,24 @@ void test_object_shortid__core_abbrev(void)
 	cl_assert_equal_i(40, shorty.size);
 	cl_assert_equal_s("ce013625030ba8dba906f756967f9e9ca394464a", shorty.ptr);
 
+	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "false"));
+	cl_git_pass(git_object_short_id(&shorty, obj));
+	cl_assert_equal_i(40, shorty.size);
+	cl_assert_equal_s("ce013625030ba8dba906f756967f9e9ca394464a", shorty.ptr);
+
+	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "99"));
+	cl_git_pass(git_object_short_id(&shorty, obj));
+	cl_assert_equal_i(40, shorty.size);
+	cl_assert_equal_s("ce013625030ba8dba906f756967f9e9ca394464a", shorty.ptr);
+
 	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "4"));
 	cl_git_pass(git_object_short_id(&shorty, obj));
 	cl_assert_equal_i(4, shorty.size);
 	cl_assert_equal_s("ce01", shorty.ptr);
 
-	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "3"));
+	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "0"));
 	cl_git_fail(git_object_short_id(&shorty, obj));
-	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "41"));
+	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "3"));
 	cl_git_fail(git_object_short_id(&shorty, obj));
 	cl_git_pass(git_config_set_string(cfg, "core.abbrev", "invalid"));
 	cl_git_fail(git_object_short_id(&shorty, obj));


### PR DESCRIPTION
Fixes #6878.

Not sure if I went to far here, I noticed core.abbrev was used by diff_print.c. If the user sets core.abbrev to an integer outside of the allowed range that will now error.

I also added GIT_ABBREV_MINIMUM, which Git sets to 4. libgit2 was allowing anything above zero.