### PR TITLE
Update documentation generation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,9 @@ on:
   release:
   workflow_dispatch:
 
+concurrency:
+  group: documentation
+
 permissions:
   contents: read
 
@@ -29,7 +32,11 @@ jobs:
         ssh-key: ${{ secrets.DOCS_PUBLISH_KEY }}
     - name: Prepare branches
       run: |
-        for a in main $(git branch -r --list 'origin/maint/*' | sed -e "s/^  origin\///"); do
+        if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
+          git branch --track main origin/main
+        fi
+
+        for a in $(git branch -r --list 'origin/maint/*' | sed -e "s/^  origin\///"); do
           git branch --track "$a" "origin/$a"
         done
       working-directory: source


### PR DESCRIPTION
Ensure that workflows where the main branch exists (eg, anything except PR workflows) don't try to recreate the main branch. Add a concurrency token so that we don't have conflicts generating documentation.