### PR TITLE
refs: Handle normalizing negative refspecs

### DIFF
--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -835,17 +835,20 @@ static int is_valid_ref_char(char ch)
 	}
 }
 
-static int ensure_segment_validity(const char *name, char may_contain_glob)
+static int ensure_segment_validity(const char *name, char may_contain_glob, bool allow_caret_prefix)
 {
 	const char *current = name;
+	const char *start = current;
 	char prev = '\0';
 	const int lock_len = (int)strlen(GIT_FILELOCK_EXTENSION);
 	int segment_len;
 
 	if (*current == '.')
 		return -1; /* Refname starts with "." */
+	if (allow_caret_prefix && *current == '^')
+		start++;
 
-	for (current = name; ; current++) {
+	for (current = start; ; current++) {
 		if (*current == '\0' || *current == '/')
 			break;
 
@@ -877,7 +880,7 @@ static int ensure_segment_validity(const char *name, char may_contain_glob)
 	return segment_len;
 }
 
-static bool is_all_caps_and_underscore(const char *name, size_t len)
+static bool is_valid_normalized_name(const char *name, size_t len)
 {
 	size_t i;
 	char c;
@@ -888,6 +891,9 @@ static bool is_all_caps_and_underscore(const char *name, size_t len)
 	for (i = 0; i < len; i++)
 	{
 		c = name[i];
+		if (i == 0 && c == '^')
+			continue; /* The first character is allowed to be "^" for negative refspecs */
+
 		if ((c < 'A' || c > 'Z') && c != '_')
 			return false;
 	}
@@ -908,6 +914,7 @@ int git_reference__normalize_name(
 	int segment_len, segments_count = 0, error = GIT_EINVALIDSPEC;
 	unsigned int process_flags;
 	bool normalize = (buf != NULL);
+	bool allow_caret_prefix = true;
 	bool validate = (flags & GIT_REFERENCE_FORMAT__VALIDATION_DISABLE) == 0;
 
 #ifdef GIT_USE_ICONV
@@ -945,7 +952,7 @@ int git_reference__normalize_name(
 	while (true) {
 		char may_contain_glob = process_flags & GIT_REFERENCE_FORMAT_REFSPEC_PATTERN;
 
-		segment_len = ensure_segment_validity(current, may_contain_glob);
+		segment_len = ensure_segment_validity(current, may_contain_glob, allow_caret_prefix);
 		if (segment_len < 0)
 			goto cleanup;
 
@@ -981,6 +988,12 @@ int git_reference__normalize_name(
 			break;
 
 		current += segment_len + 1;
+
+		/*
+		 * A caret prefix is only allowed in the first segment to signify a
+		 * negative refspec.
+		 */
+		allow_caret_prefix = false;
 	}
 
 	/* A refname can not be empty */
@@ -1000,12 +1013,12 @@ int git_reference__normalize_name(
 
 	if ((segments_count == 1 ) &&
 	    !(flags & GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND) &&
-		!(is_all_caps_and_underscore(name, (size_t)segment_len) ||
+		!(is_valid_normalized_name(name, (size_t)segment_len) ||
 			((flags & GIT_REFERENCE_FORMAT_REFSPEC_PATTERN) && !strcmp("*", name))))
 			goto cleanup;
 
 	if ((segments_count > 1)
-		&& (is_all_caps_and_underscore(name, strchr(name, '/') - name)))
+		&& (is_valid_normalized_name(name, strchr(name, '/') - name)))
 			goto cleanup;
 
 	error = 0;

--- a/tests/libgit2/refs/normalize.c
+++ b/tests/libgit2/refs/normalize.c
@@ -399,3 +399,11 @@ void test_refs_normalize__refspec_pattern(void)
 	ensure_refname_invalid(
 		ONE_LEVEL_AND_REFSPEC, "*/*/foo");
 }
+
+void test_refs_normalize__negative_refspec_pattern(void)
+{
+	ensure_refname_normalized(
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "^foo/bar", "^foo/bar");
+	ensure_refname_invalid(
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo/^bar");
+}

--- a/tests/libgit2/refs/normalize.c
+++ b/tests/libgit2/refs/normalize.c
@@ -229,8 +229,6 @@ void test_refs_normalize__jgit_suite(void)
 		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master^");
 	ensure_refname_invalid(
 		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/^master");
-	ensure_refname_invalid(
-		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "^refs/heads/master");
 
 	ensure_refname_invalid(
 		GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL, "refs/heads/master~");


### PR DESCRIPTION
Negative refspecs were added in Git v2.29.0 which allows refspecs to be
prefixed with `^`[^1]. Currently, the library is unable to normalize
negative refspecs which causes errors in different tools that rely on
`libgit2`. Specifically, when the library attempts to parse and
normalize a negative refspec, it returns a `GIT_EINVALIDSPEC` code.

Add the ability to correctly normalize negative refspecs. While this PR
will not update the behavior of `fetch`, or other actions that rely on
negative refspecs, this allows us to be able to successfully parse and
normalize them. A future change will handle updating the individual
actions.

[^1]: https://github.com/git/git/commit/c0192df6306d4d9ad77f6015a053925b13155834
