### PR TITLE
Documentation: don't resort versions

### DIFF
--- a/script/api-docs/docs-generator.js
+++ b/script/api-docs/docs-generator.js
@@ -1264,8 +1264,7 @@ async function produceSearch(versions) {
 }
 
 async function produceMainIndex(versions) {
-    const versionList = versions.sort(versionSort);
-    const versionDefault = versionList[versionList.length - 1];
+    const versionDefault = versions[0];
 
     if (options.verbose) {
         console.log(`Producing documentation index...`);


### PR DESCRIPTION
Array.sort() mutates the array _and_ returns it; don't mutate the version array.