### PR TITLE
Documentation: update refdb_backend docs

### DIFF
--- a/include/git2/sys/refdb_backend.h
+++ b/include/git2/sys/refdb_backend.h
@@ -65,9 +65,9 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg exists The implementation shall set this to `0` if a ref does
+	 * @param exists The implementation shall set this to `0` if a ref does
 	 *             not exist, otherwise to `1`.
-	 * @arg ref_name The reference's name that should be checked for
+	 * @param ref_name The reference's name that should be checked for
 	 *               existence.
 	 * @return `0` on success, a negative error value code.
 	 */
@@ -81,9 +81,9 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg out The implementation shall set this to the allocated
+	 * @param out The implementation shall set this to the allocated
 	 *          reference, if it could be found, otherwise to `NULL`.
-	 * @arg ref_name The reference's name that should be checked for
+	 * @param ref_name The reference's name that should be checked for
 	 *               existence.
 	 * @return `0` on success, `GIT_ENOTFOUND` if the reference does
 	 *         exist, otherwise a negative error code.
@@ -98,12 +98,12 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg out The implementation shall set this to the allocated
+	 * @param out The implementation shall set this to the allocated
 	 *          reference iterator. A custom structure may be used with an
 	 *          embedded `git_reference_iterator` structure. Both `next`
 	 *          and `next_name` functions of `git_reference_iterator` need
 	 *          to be populated.
-	 * @arg glob A pattern to filter references by. If given, the iterator
+	 * @param glob A pattern to filter references by. If given, the iterator
 	 *           shall only return references that match the glob when
 	 *           passed to `wildmatch`.
 	 * @return `0` on success, otherwise a negative error code.
@@ -118,20 +118,20 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg ref The reference to persist. May either be a symbolic or
+	 * @param ref The reference to persist. May either be a symbolic or
 	 *          direct reference.
-	 * @arg force Whether to write the reference if a reference with the
+	 * @param force Whether to write the reference if a reference with the
 	 *            same name already exists.
-	 * @arg who The person updating the reference. Shall be used to create
+	 * @param who The person updating the reference. Shall be used to create
 	 *          a reflog entry.
-	 * @arg message The message detailing what kind of reference update is
+	 * @param message The message detailing what kind of reference update is
 	 *              performed. Shall be used to create a reflog entry.
-	 * @arg old If not `NULL` and `force` is not set, then the
+	 * @param old If not `NULL` and `force` is not set, then the
 	 *          implementation needs to ensure that the reference is currently at
 	 *          the given OID before writing the new value. If both `old`
 	 *          and `old_target` are `NULL`, then the reference should not
 	 *          exist at the point of writing.
-	 * @arg old_target If not `NULL` and `force` is not set, then the
+	 * @param old_target If not `NULL` and `force` is not set, then the
 	 *                 implementation needs to ensure that the symbolic
 	 *                 reference is currently at the given target before
 	 *                 writing the new value. If both `old` and
@@ -149,15 +149,15 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg out The implementation shall set this to the newly created
+	 * @param out The implementation shall set this to the newly created
 	 *          reference or `NULL` on error.
-	 * @arg old_name The current name of the reference that is to be renamed.
-	 * @arg new_name The new name that the old reference shall be renamed to.
-	 * @arg force Whether to write the reference if a reference with the
+	 * @param old_name The current name of the reference that is to be renamed.
+	 * @param new_name The new name that the old reference shall be renamed to.
+	 * @param force Whether to write the reference if a reference with the
 	 *            target name already exists.
-	 * @arg who The person updating the reference. Shall be used to create
+	 * @param who The person updating the reference. Shall be used to create
 	 *          a reflog entry.
-	 * @arg message The message detailing what kind of reference update is
+	 * @param message The message detailing what kind of reference update is
 	 *              performed. Shall be used to create a reflog entry.
 	 * @return `0` on success, otherwise a negative error code.
 	 */
@@ -173,11 +173,11 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg ref_name The name of the reference name that shall be deleted.
-	 * @arg old_id If not `NULL` and `force` is not set, then the
+	 * @param ref_name The name of the reference name that shall be deleted.
+	 * @param old_id If not `NULL` and `force` is not set, then the
 	 *             implementation needs to ensure that the reference is currently at
 	 *             the given OID before writing the new value.
-	 * @arg old_target If not `NULL` and `force` is not set, then the
+	 * @param old_target If not `NULL` and `force` is not set, then the
 	 *                 implementation needs to ensure that the symbolic
 	 *                 reference is currently at the given target before
 	 *                 writing the new value.
@@ -243,7 +243,7 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg reflog The complete reference log for a given reference. Note
+	 * @param reflog The complete reference log for a given reference. Note
 	 *             that this may contain entries that have already been
 	 *             written to disk.
 	 * @return `0` on success, a negative error code otherwise
@@ -255,8 +255,8 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg old_name The name of old reference whose reflog shall be renamed from.
-	 * @arg new_name The name of new reference whose reflog shall be renamed to.
+	 * @param old_name The name of old reference whose reflog shall be renamed from.
+	 * @param new_name The name of new reference whose reflog shall be renamed to.
 	 * @return `0` on success, a negative error code otherwise
 	 */
 	int GIT_CALLBACK(reflog_rename)(git_refdb_backend *_backend, const char *old_name, const char *new_name);
@@ -266,7 +266,7 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @arg name The name of the reference whose reflog shall be deleted.
+	 * @param name The name of the reference whose reflog shall be deleted.
 	 * @return `0` on success, a negative error code otherwise
 	 */
 	int GIT_CALLBACK(reflog_delete)(git_refdb_backend *backend, const char *name);
@@ -277,9 +277,9 @@ struct git_refdb_backend {
 	 * A refdb implementation may provide this function; if it is not
 	 * provided, the transaction API will fail to work.
 	 *
-	 * @arg payload_out Opaque parameter that will be passed verbosely to
+	 * @param payload_out Opaque parameter that will be passed verbosely to
 	 *                  `unlock`.
-	 * @arg refname Reference that shall be locked.
+	 * @param refname Reference that shall be locked.
 	 * @return `0` on success, a negative error code otherwise
 	 */
 	int GIT_CALLBACK(lock)(void **payload_out, git_refdb_backend *backend, const char *refname);
@@ -294,16 +294,16 @@ struct git_refdb_backend {
 	 * A refdb implementation must provide this function if a `lock`
 	 * implementation is provided.
 	 *
-	 * @arg payload The payload returned by `lock`.
-	 * @arg success `1` if a reference should be updated, `2` if
+	 * @param payload The payload returned by `lock`.
+	 * @param success `1` if a reference should be updated, `2` if
 	 *              a reference should be deleted, `0` if the lock must be
 	 *              discarded.
-	 * @arg update_reflog `1` in case the reflog should be updated, `0`
+	 * @param update_reflog `1` in case the reflog should be updated, `0`
 	 *                    otherwise.
-	 * @arg ref The reference which should be unlocked.
-	 * @arg who The person updating the reference. Shall be used to create
+	 * @param ref The reference which should be unlocked.
+	 * @param who The person updating the reference. Shall be used to create
 	 *          a reflog entry in case `update_reflog` is set.
-	 * @arg message The message detailing what kind of reference update is
+	 * @param message The message detailing what kind of reference update is
 	 *              performed. Shall be used to create a reflog entry in
 	 *              case `update_reflog` is set.
 	 * @return `0` on success, a negative error code otherwise


### PR DESCRIPTION
Parameters are documented by `@param`, not `@arg`