### PR TITLE
Documentation: clean up old documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,7 +54,7 @@ jobs:
         fi
 
         npm install
-        ./generate $args ../.. ../../../www/docs
+        ./generate --verbose $args ../.. ../../../www/docs
       working-directory: source/script/api-docs
     - name: Examine changes
       run: |

--- a/script/api-docs/docs-generator.js
+++ b/script/api-docs/docs-generator.js
@@ -1084,6 +1084,19 @@ async function produceDocumentationMetadata(version, apiData) {
     await fs.writeFile(filename, JSON.stringify(apiData.info, null, 2) + "\n");
 }
 
+async function cleanupOldDocumentation(version) {
+    const versionDir = `${outputPath}/${version}`;
+
+    for (const fn of await fs.readdir(versionDir)) {
+        if (fn === '.metadata') {
+            continue;
+        }
+
+        const path = `${versionDir}/${fn}`;
+        await fs.rm(path, { recursive: true });
+    }
+}
+
 async function produceDocumentationForVersion(version, apiData) {
     if (!options.force && await documentationIsUpToDateForVersion(version, apiData)) {
         if (options.verbose) {
@@ -1096,6 +1109,8 @@ async function produceDocumentationForVersion(version, apiData) {
     if (options.verbose) {
         console.log(`Producing documentation for ${version}...`);
     }
+
+    await cleanupOldDocumentation(version);
 
     await produceDocumentationForApis(version, apiData);
 


### PR DESCRIPTION
Clean up the outdated documentation folder before re-generating it in place. This accomodates a deleted API.