### PR TITLE
remote: Handle fetching negative refspecs

### DIFF
--- a/include/git2/refspec.h
+++ b/include/git2/refspec.h
@@ -79,6 +79,15 @@ GIT_EXTERN(int) git_refspec_force(const git_refspec *refspec);
 GIT_EXTERN(git_direction) git_refspec_direction(const git_refspec *spec);
 
 /**
+ * Check if a refspec's source descriptor matches a negative reference
+ *
+ * @param refspec the refspec
+ * @param refname the name of the reference to check
+ * @return 1 if the refspec matches, 0 otherwise
+ */
+GIT_EXTERN(int) git_refspec_src_matches_negative(const git_refspec *refspec, const char *refname);
+
+/**
  * Check if a refspec's source descriptor matches a reference
  *
  * @param refspec the refspec

--- a/src/libgit2/refspec.c
+++ b/src/libgit2/refspec.c
@@ -225,6 +225,14 @@ int git_refspec_force(const git_refspec *refspec)
 	return refspec->force;
 }
 
+int git_refspec_src_matches_negative(const git_refspec *refspec, const char *refname)
+{
+	if (refspec == NULL || refspec->src == NULL || !git_refspec_is_negative(refspec))
+		return false;
+
+	return (wildmatch(refspec->src + 1, refname, 0) == 0);
+}
+
 int git_refspec_src_matches(const git_refspec *refspec, const char *refname)
 {
 	if (refspec == NULL || refspec->src == NULL)
@@ -338,6 +346,14 @@ int git_refspec_is_wildcard(const git_refspec *spec)
 	GIT_ASSERT_ARG(spec->src);
 
 	return (spec->src[strlen(spec->src) - 1] == '*');
+}
+
+int git_refspec_is_negative(const git_refspec *spec)
+{
+	GIT_ASSERT_ARG(spec);
+	GIT_ASSERT_ARG(spec->src);
+
+	return (spec->src[0] == '^' && spec->dst == NULL);
 }
 
 git_direction git_refspec_direction(const git_refspec *spec)

--- a/src/libgit2/refspec.c
+++ b/src/libgit2/refspec.c
@@ -22,6 +22,7 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 	const char *lhs, *rhs;
 	int valid = 0;
 	unsigned int flags;
+	bool is_neg_refspec = false;
 
 	GIT_ASSERT_ARG(refspec);
 	GIT_ASSERT_ARG(input);
@@ -33,6 +34,9 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 	if (*lhs == '+') {
 		refspec->force = 1;
 		lhs++;
+	}
+	if (*lhs == '^') {
+		is_neg_refspec = true;
 	}
 
 	rhs = strrchr(lhs, ':');
@@ -62,7 +66,14 @@ int git_refspec__parse(git_refspec *refspec, const char *input, bool is_fetch)
 
 	llen = (rhs ? (size_t)(rhs - lhs - 1) : strlen(lhs));
 	if (1 <= llen && memchr(lhs, '*', llen)) {
-		if ((rhs && !is_glob) || (!rhs && is_fetch))
+		/*
+		 * If the lefthand side contains a glob, then one of the following must be
+		 * true, otherwise the spec is invalid
+		 *   1) the rhs exists and also contains a glob
+		 *   2) it is a negative refspec (i.e. no rhs)
+		 *   3) the rhs doesn't exist and we're fetching
+		 */
+		if ((rhs && !is_glob) || (rhs && is_neg_refspec) || (!rhs && is_fetch && !is_neg_refspec))
 			goto invalid;
 		is_glob = 1;
 	} else if (rhs && is_glob)

--- a/src/libgit2/refspec.h
+++ b/src/libgit2/refspec.h
@@ -46,6 +46,14 @@ int git_refspec__serialize(git_str *out, const git_refspec *refspec);
 int git_refspec_is_wildcard(const git_refspec *spec);
 
 /**
+ * Determines if a refspec is a negative refspec.
+ *
+ * @param spec the refspec
+ * @return 1 if the refspec is a negative, 0 otherwise
+ */
+int git_refspec_is_negative(const git_refspec *spec);
+
+/**
  * DWIM `spec` with `refs` existing on the remote, append the dwim'ed
  * result in `out`.
  */

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -2628,17 +2628,21 @@ done:
 git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refname)
 {
 	git_refspec *spec;
+	git_refspec *match = NULL;
 	size_t i;
 
 	git_vector_foreach(&remote->active_refspecs, i, spec) {
 		if (spec->push)
 			continue;
 
+		if (git_refspec_is_negative(spec) && git_refspec_src_matches_negative(spec, refname))
+			return NULL;
+
 		if (git_refspec_src_matches(spec, refname))
-			return spec;
+			match = spec;
 	}
 
-	return NULL;
+	return match;
 }
 
 git_refspec *git_remote__matching_dst_refspec(git_remote *remote, const char *refname)

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -2638,7 +2638,7 @@ git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refnam
 		if (git_refspec_src_matches_negative(spec, refname))
 			return NULL;
 
-		if (git_refspec_src_matches(spec, refname))
+		if (git_refspec_src_matches(spec, refname) && match == NULL)
 			match = spec;
 	}
 

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -2635,7 +2635,7 @@ git_refspec *git_remote__matching_refspec(git_remote *remote, const char *refnam
 		if (spec->push)
 			continue;
 
-		if (git_refspec_is_negative(spec) && git_refspec_src_matches_negative(spec, refname))
+		if (git_refspec_src_matches_negative(spec, refname))
 			return NULL;
 
 		if (git_refspec_src_matches(spec, refname))

--- a/tests/libgit2/refs/normalize.c
+++ b/tests/libgit2/refs/normalize.c
@@ -402,6 +402,8 @@ void test_refs_normalize__negative_refspec_pattern(void)
 {
 	ensure_refname_normalized(
 		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "^foo/bar", "^foo/bar");
+	ensure_refname_normalized(
+		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "^foo/bar/*", "^foo/bar/*");
 	ensure_refname_invalid(
 		GIT_REFERENCE_FORMAT_REFSPEC_PATTERN, "foo/^bar");
 }

--- a/tests/libgit2/remote/fetch.c
+++ b/tests/libgit2/remote/fetch.c
@@ -205,10 +205,7 @@ static void do_fetch_repo_with_ref_matching_negative_refspec(git_oid *commit1id)
 	/* fetch the remote with negative refspec for references prefixed with '_' */
 	{
 		char *refspec_strs = { NEGATIVE_SPEC };
-		git_strarray refspecs = {
-			.count = 1,
-			.strings = &refspec_strs,
-		};
+		git_strarray refspecs = { &refspec_strs, 1 };
 
 		git_remote *remote;
 


### PR DESCRIPTION
Add support for fetching with negative refspecs. Fetching from the
remote with a negative refspec will now validate any references fetched
do not match _any_ negative refspecs and at least one non-negative
refspec. As we must ensure that fetched references do not match any of
the negative refspecs provided, we cannot short-circuit when checking
for matching refspecs.

https://github.com/libgit2/libgit2/issues/6741