### PR TITLE
repo: put a newline on the .git link file

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -2506,7 +2506,7 @@ static int repo_write_gitlink(
 		error = git_fs_path_make_relative(&path_to_repo, in_dir);
 
 	if (!error)
-		error = git_str_join(&buf, ' ', GIT_FILE_CONTENT_PREFIX, path_to_repo.ptr);
+		error = git_str_printf(&buf, "%s %s\n", GIT_FILE_CONTENT_PREFIX, path_to_repo.ptr);
 
 	if (!error)
 		error = repo_write_template(in_dir, true, DOT_GIT, 0666, true, buf.ptr);

--- a/tests/libgit2/repo/init.c
+++ b/tests/libgit2/repo/init.c
@@ -489,7 +489,7 @@ void test_repo_init__relative_gitdir(void)
 
 	/* Verify gitlink */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
-	cl_assert_equal_s("gitdir: ../my_repository/", dot_git_content.ptr);
+	cl_assert_equal_s("gitdir: ../my_repository/\n", dot_git_content.ptr);
 
 	git_str_dispose(&dot_git_content);
 	cleanup_repository("root");
@@ -526,7 +526,7 @@ void test_repo_init__relative_gitdir_2(void)
 
 	/* Verify gitlink */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
-	cl_assert_equal_s("gitdir: ../my_repository/", dot_git_content.ptr);
+	cl_assert_equal_s("gitdir: ../my_repository/\n", dot_git_content.ptr);
 
 	git_str_dispose(&dot_git_content);
 	cleanup_repository("root");

--- a/tests/libgit2/repo/setters.c
+++ b/tests/libgit2/repo/setters.c
@@ -56,7 +56,7 @@ void test_repo_setters__setting_a_workdir_creates_a_gitlink(void)
 
 	cl_git_pass(git_futils_readbuffer(&content, "./new_workdir/.git"));
 	cl_assert(git__prefixcmp(git_str_cstr(&content), "gitdir: ") == 0);
-	cl_assert(git__suffixcmp(git_str_cstr(&content), "testrepo.git/") == 0);
+	cl_assert(git__suffixcmp(git_str_cstr(&content), "testrepo.git/\n") == 0);
 	git_str_dispose(&content);
 
 	cl_git_pass(git_repository_config(&cfg, repo));

--- a/tests/libgit2/submodule/add.c
+++ b/tests/libgit2/submodule/add.c
@@ -60,7 +60,7 @@ void test_submodule_add__url_absolute(void)
 
 	/* Verify gitdir path is relative */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "submod2/" "sm_libgit2" "/.git"));
-	cl_assert_equal_s("gitdir: ../.git/modules/sm_libgit2/", dot_git_content.ptr);
+	cl_assert_equal_s("gitdir: ../.git/modules/sm_libgit2/\n", dot_git_content.ptr);
 
 	git_repository_free(repo);
 	git_str_dispose(&dot_git_content);

--- a/tests/libgit2/submodule/repository_init.c
+++ b/tests/libgit2/submodule/repository_init.c
@@ -24,7 +24,7 @@ void test_submodule_repository_init__basic(void)
 
 	/* Verify gitlink */
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "submod2/" "sm_gitmodules_only" "/.git"));
-	cl_assert_equal_s("gitdir: ../.git/modules/sm_gitmodules_only/", dot_git_content.ptr);
+	cl_assert_equal_s("gitdir: ../.git/modules/sm_gitmodules_only/\n", dot_git_content.ptr);
 
 	cl_assert(git_fs_path_isfile("submod2/" "sm_gitmodules_only" "/.git"));
 


### PR DESCRIPTION
The `.git` file, when containing a `gitdir: ` link, should be suffixed with a trailing newline.