### PR TITLE
No `.git` for separate workdir

### DIFF
--- a/include/git2/deprecated.h
+++ b/include/git2/deprecated.h
@@ -748,6 +748,17 @@ GIT_EXTERN(int) git_tag_create_frombuffer(
 
 /**@}*/
 
+/** @name Deprecated Repository Constants
+ *
+ * These enumeration values are retained for backward compatibility.
+ */
+
+/**
+ * @deprecated This option is deprecated; it is now implied when
+ * a separate working directory is specified to `git_repository_init`.
+ */
+#define GIT_REPOSITORY_INIT_NO_DOTGIT_DIR 0
+
 /** @name Deprecated Revspec Constants
  *
  * These enumeration values are retained for backward compatibility.

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -259,13 +259,6 @@ typedef enum {
 	GIT_REPOSITORY_INIT_NO_REINIT         = (1u << 1),
 
 	/**
-	 * Normally a "/.git/" will be appended to the repo path for
-	 * non-bare repos (if it is not already there), but passing this flag
-	 * prevents that behavior.
-	 */
-	GIT_REPOSITORY_INIT_NO_DOTGIT_DIR     = (1u << 2),
-
-	/**
 	 * Make the repo_path (and workdir_path) as needed. Init is always willing
 	 * to create the ".git" directory even without this flag. This flag tells
 	 * init to create the trailing component of the repo and workdir paths

--- a/src/cli/cmd_init.c
+++ b/src/cli/cmd_init.c
@@ -82,9 +82,7 @@ int cmd_init(int argc, char **argv)
 	init_opts.initial_head = branch;
 
 	if (git_dir) {
-		init_opts.flags |= GIT_REPOSITORY_INIT_NO_DOTGIT_DIR;
 		init_opts.workdir_path = path;
-
 		repo_path = git_dir;
 	} else {
 		repo_path = path;

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -2690,8 +2690,7 @@ static int repo_init_directories(
 	is_bare = ((opts->flags & GIT_REPOSITORY_INIT_BARE) != 0);
 
 	add_dotgit =
-		(opts->flags & GIT_REPOSITORY_INIT_NO_DOTGIT_DIR) == 0 &&
-		!is_bare &&
+		!is_bare && !opts->workdir_path &&
 		git__suffixcmp(given_repo, "/" DOT_GIT) != 0 &&
 		git__suffixcmp(given_repo, "/" GIT_DIR) != 0;
 

--- a/src/libgit2/submodule.c
+++ b/src/libgit2/submodule.c
@@ -757,7 +757,6 @@ static int submodule_repo_init(
 
 		initopt.workdir_path = workdir.ptr;
 		initopt.flags |=
-			GIT_REPOSITORY_INIT_NO_DOTGIT_DIR |
 			GIT_REPOSITORY_INIT_RELATIVE_GITLINK;
 
 		error = git_repository_init_ext(&subrepo, repodir.ptr, &initopt);
@@ -1289,7 +1288,6 @@ static int submodule_repo_create(
 	initopt.flags =
 		GIT_REPOSITORY_INIT_MKPATH |
 		GIT_REPOSITORY_INIT_NO_REINIT |
-		GIT_REPOSITORY_INIT_NO_DOTGIT_DIR |
 		GIT_REPOSITORY_INIT_RELATIVE_GITLINK;
 
 	/* Workdir: path to sub-repo working directory */

--- a/tests/libgit2/repo/init.c
+++ b/tests/libgit2/repo/init.c
@@ -425,8 +425,7 @@ void test_repo_init__extended_1(void)
 	struct stat st;
 	git_repository_init_options opts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
 
-	opts.flags = GIT_REPOSITORY_INIT_MKPATH |
-		GIT_REPOSITORY_INIT_NO_DOTGIT_DIR;
+	opts.flags = GIT_REPOSITORY_INIT_MKPATH;
 	opts.mode = GIT_REPOSITORY_INIT_SHARED_GROUP;
 	opts.workdir_path = "../c_wd";
 	opts.description = "Awesomest test repository evah";
@@ -466,16 +465,18 @@ void test_repo_init__extended_1(void)
 void test_repo_init__relative_gitdir(void)
 {
 	git_repository_init_options opts = GIT_REPOSITORY_INIT_OPTIONS_INIT;
+	git_str head_content = GIT_STR_INIT;
 	git_str dot_git_content = GIT_STR_INIT;
 
 	opts.workdir_path = "../c_wd";
 	opts.flags =
 		GIT_REPOSITORY_INIT_MKPATH |
-		GIT_REPOSITORY_INIT_RELATIVE_GITLINK |
-		GIT_REPOSITORY_INIT_NO_DOTGIT_DIR;
+		GIT_REPOSITORY_INIT_RELATIVE_GITLINK;
 
 	/* make the directory first, then it should succeed */
 	cl_git_pass(git_repository_init_ext(&g_repo, "root/b/my_repository", &opts));
+	cl_git_pass(git_futils_readbuffer(&head_content, "root/b/my_repository/HEAD"));
+	cl_assert_equal_s("ref: refs/heads/master\n", head_content.ptr);
 
 	cl_assert(!git__suffixcmp(git_repository_workdir(g_repo), "root/b/c_wd/"));
 	cl_assert(!git__suffixcmp(git_repository_path(g_repo), "root/b/my_repository/"));
@@ -491,6 +492,7 @@ void test_repo_init__relative_gitdir(void)
 	cl_git_pass(git_futils_readbuffer(&dot_git_content, "root/b/c_wd/.git"));
 	cl_assert_equal_s("gitdir: ../my_repository/\n", dot_git_content.ptr);
 
+	git_str_dispose(&head_content);
 	git_str_dispose(&dot_git_content);
 	cleanup_repository("root");
 }
@@ -507,8 +509,7 @@ void test_repo_init__relative_gitdir_2(void)
 	opts.workdir_path = full_path.ptr;
 	opts.flags =
 		GIT_REPOSITORY_INIT_MKPATH |
-		GIT_REPOSITORY_INIT_RELATIVE_GITLINK |
-		GIT_REPOSITORY_INIT_NO_DOTGIT_DIR;
+		GIT_REPOSITORY_INIT_RELATIVE_GITLINK;
 
 	/* make the directory first, then it should succeed */
 	cl_git_pass(git_repository_init_ext(&g_repo, "root/b/my_repository", &opts));


### PR DESCRIPTION
When specifying a separate working directory path, the given repository path should never have a `.git` directory created beneath it. That simply doesn't make sense.