### PR TITLE
repo: don't require option when `template_path` is specified

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -2538,7 +2538,8 @@ static int repo_init_structure(
 	int error = 0;
 	repo_template_item *tpl;
 	bool external_tpl =
-		((opts->flags & GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE) != 0);
+		 opts->template_path != NULL ||
+		(opts->flags & GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE) != 0;
 	mode_t dmode = pick_dir_mode(opts);
 	bool chmod = opts->mode != GIT_REPOSITORY_INIT_SHARED_UMASK;
 

--- a/tests/libgit2/repo/template.c
+++ b/tests/libgit2/repo/template.c
@@ -228,8 +228,7 @@ void test_repo_template__extended_with_template_and_shared_mode(void)
 	const char *repo_path;
 	int filemode;
 
-	opts.flags = GIT_REPOSITORY_INIT_MKPATH |
-		GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE;
+	opts.flags = GIT_REPOSITORY_INIT_MKPATH;
 	opts.template_path = "template";
 	opts.mode = GIT_REPOSITORY_INIT_SHARED_GROUP;
 


### PR DESCRIPTION
When a `template_path` is explicitly specified, don't _also_ require an option to indicate that we should use templates. We, obviously, should.