### PR TITLE
meta: revert soname version update

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,11 +33,10 @@ This means that v2.0 will have API and ABI changes to support SHA256.
   so that the blame functionality can be benchmarked by our benchmark
   suite.
 
-* **SONAME changed**
-  libgit2 will now properly update its SONAME version information when
-  ABI chnages occur. We hope that by correcting this oversight, users
-  and distribution vendors, will be able to integrate new versions of
-  libgit2 more easily.
+* **More CLI commands**
+  libgit2 has added `blame` and `init` commands, which have allowed for
+  [further benchmarking](https://benchmarks.libgit2.org/) and several API
+  improvements and git compatibility updates.
 
 ## Breaking changes
 

--- a/include/git2/version.h
+++ b/include/git2/version.h
@@ -46,7 +46,7 @@ GIT_BEGIN_DECL
  * only be changed when the library has a breaking ABI change, and so
  * may not reflect the library's API version number.
  */
-#define LIBGIT2_SOVERSION         "2.0"
+#define LIBGIT2_SOVERSION         "1.9"
 
 /**
  * An integer value representing the libgit2 version number. For example,


### PR DESCRIPTION
Regarding our SONAME policy, it was suggested to me that even if we're doing it wrong, we've been doing it _consistently_ wrong. And that changing our behavior could be a breaking change for consumers who are expecting such consistency. 🥴 

Thus, changing our SONAME / ABI version update policy without an announcement is a breaking change. We'll continue our existing SONAME versioning for v1.9 and will announce this for our next version update.