### PR TITLE
cmake: warn for not using sha1dc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,3 +150,9 @@ endif()
 
 feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")
 feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Disabled features:")
+
+# warn for not using sha1dc
+
+foreach(WARNING ${WARNINGS})
+	message(WARNING ${WARNING})
+endforeach()

--- a/cmake/SelectHashes.cmake
+++ b/cmake/SelectHashes.cmake
@@ -112,3 +112,10 @@ endif()
 
 add_feature_info(SHA1 ON "using ${USE_SHA1}")
 add_feature_info(SHA256 ON "using ${USE_SHA256}")
+
+# warn for users who do not use sha1dc
+
+if(NOT "${USE_SHA1}" STREQUAL "CollisionDetection")
+	list(APPEND WARNINGS "SHA1 support is set to ${USE_SHA1} which is not recommended - git's hash algorithm is sha1dc, it is *not* SHA1. Using SHA1 may leave you and your users susceptible to SHAttered-style attacks.")
+	set(WARNINGS ${WARNINGS} PARENT_SCOPE)
+endif()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -253,6 +253,8 @@ will introduce a number of breaking changes in v2.0:
   https://github.com/libgit2/libgit2/pull/6924
 * ci: port latest fixes to nightlies by @ethomson in
   https://github.com/libgit2/libgit2/pull/6926
+* cmake: warn for not using sha1dc by @ethomson in
+  https://github.com/libgit2/libgit2/pull/6986
 
 ### Documentation improvements
 


### PR DESCRIPTION
git's hash algorithm is sha1dc, it is not sha1. Per Linus:

> Honestly, git has effectively already moved from SHA1 to SHA1DC.
>
> So the actual known attack and weakness of SHA1 should simply not be
> part of the discussion for the next hash. You can basically say "we're
> _already_ on the second hash, we just picked one that was so
> compatible with SHA1 that nobody even really noticed.

Warn users who try to compile with SHA1 instead of SHA1DC.