### PR TITLE
ci: only build docs on main branch pushes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Generate Documentation
 
 on:
   push:
-    branches: [ main, maint/* ]
+    branches: [ main ]
   release:
   workflow_dispatch:
     inputs:
@@ -37,12 +37,10 @@ jobs:
         ssh-key: ${{ secrets.DOCS_PUBLISH_KEY }}
     - name: Prepare branches
       run: |
-        if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
-          git branch --track main origin/main
-        fi
-
-        for a in $(git branch -r --list 'origin/maint/*' | sed -e "s/^  origin\///"); do
-          git branch --track "$a" "origin/$a"
+        for a in main $(git branch -r --list 'origin/maint/*' | sed -e "s/^  origin\///"); do
+          if [ "$(git rev-parse --abbrev-ref HEAD)" != "${a}" ]; then
+            git branch --track "$a" "origin/$a"
+          fi
         done
       working-directory: source
     - name: Generate documentation


### PR DESCRIPTION
Don't build docs on pushes to maint branches; those docs should only be built _on release_. In addition, be safer about not creating an existing branch from a tracking branch.