### PR TITLE
cmake: allow for using external sha1dc

### DIFF
--- a/cmake/SelectHashes.cmake
+++ b/cmake/SelectHashes.cmake
@@ -8,7 +8,7 @@ sanitizebool(USE_SHA256)
 # sha1
 
 if(USE_SHA1 STREQUAL "" OR USE_SHA1 STREQUAL ON)
-	SET(USE_SHA1 "CollisionDetection")
+	SET(USE_SHA1 "builtin")
 elseif(USE_SHA1 STREQUAL "HTTPS")
 	if(USE_HTTPS STREQUAL "SecureTransport")
 		set(USE_SHA1 "CommonCrypto")
@@ -23,7 +23,13 @@ elseif(USE_SHA1 STREQUAL "HTTPS")
 	endif()
 endif()
 
-if(USE_SHA1 STREQUAL "CollisionDetection")
+if(USE_SHA1 STREQUAL "Builtin" OR USE_SHA1 STREQUAL "CollisionDetect")
+	set(USE_SHA1 "builtin")
+endif()
+
+if(USE_SHA1 STREQUAL "builtin")
+	set(GIT_SHA1_BUILTIN 1)
+elseif(USE_SHA1 STREQUAL "SHA1CollisionDetection")
 	set(GIT_SHA1_COLLISIONDETECT 1)
 elseif(USE_SHA1 STREQUAL "OpenSSL")
 	set(GIT_SHA1_OPENSSL 1)
@@ -90,6 +96,11 @@ else()
 endif()
 
 # add library requirements
+if(USE_SHA1 STREQUAL "SHA1CollisionDetection")
+	list(APPEND LIBGIT2_SYSTEM_LIBS "-lsha1detectcoll")
+	list(APPEND LIBGIT2_PC_LIBS "-lsha1detectcoll")
+endif()
+
 if(USE_SHA1 STREQUAL "OpenSSL" OR USE_SHA256 STREQUAL "OpenSSL" OR
    USE_SHA1 STREQUAL "OpenSSL-FIPS" OR USE_SHA256 STREQUAL "OpenSSL-FIPS")
 	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
@@ -115,7 +126,7 @@ add_feature_info(SHA256 ON "using ${USE_SHA256}")
 
 # warn for users who do not use sha1dc
 
-if(NOT "${USE_SHA1}" STREQUAL "CollisionDetection")
+if(NOT "${USE_SHA1}" STREQUAL "builtin" AND NOT "${USE_SHA1}" STREQUAL "SHA1CollisionDetection")
 	list(APPEND WARNINGS "SHA1 support is set to ${USE_SHA1} which is not recommended - git's hash algorithm is sha1dc, it is *not* SHA1. Using SHA1 may leave you and your users susceptible to SHAttered-style attacks.")
 	set(WARNINGS ${WARNINGS} PARENT_SCOPE)
 endif()

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -29,11 +29,13 @@ endif()
 # Hash backend selection
 #
 
-if(USE_SHA1 STREQUAL "CollisionDetection")
+if(USE_SHA1 STREQUAL "builtin")
 	file(GLOB UTIL_SRC_SHA1 hash/collisiondetect.* hash/sha1dc/*)
 	target_compile_definitions(util PRIVATE SHA1DC_NO_STANDARD_INCLUDES=1)
         target_compile_definitions(util PRIVATE SHA1DC_CUSTOM_INCLUDE_SHA1_C=\"git2_util.h\")
         target_compile_definitions(util PRIVATE SHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C=\"git2_util.h\")
+elseif(USE_SHA1 STREQUAL "SHA1CollisionDetection")
+	file(GLOB UTIL_SRC_SHA1 hash/collisiondetect.*)
 elseif(USE_SHA1 STREQUAL "OpenSSL" OR USE_SHA1 STREQUAL "OpenSSL-Dynamic" OR USE_SHA1 STREQUAL "OpenSSL-FIPS")
 	add_definitions(-DOPENSSL_API_COMPAT=0x10100000L)
 	file(GLOB UTIL_SRC_SHA1 hash/openssl.*)

--- a/src/util/git2_features.h.in
+++ b/src/util/git2_features.h.in
@@ -50,6 +50,7 @@
 #cmakedefine GIT_HTTPPARSER_LLHTTP 1
 #cmakedefine GIT_HTTPPARSER_BUILTIN 1
 
+#cmakedefine GIT_SHA1_BUILTIN 1
 #cmakedefine GIT_SHA1_COLLISIONDETECT 1
 #cmakedefine GIT_SHA1_WIN32 1
 #cmakedefine GIT_SHA1_COMMON_CRYPTO 1

--- a/src/util/hash/sha.h
+++ b/src/util/hash/sha.h
@@ -13,6 +13,10 @@
 typedef struct git_hash_sha1_ctx git_hash_sha1_ctx;
 typedef struct git_hash_sha256_ctx git_hash_sha256_ctx;
 
+#if defined(GIT_SHA1_BUILTIN) || defined(GIT_SHA1_COLLISIONDETECT)
+# include "collisiondetect.h"
+#endif
+
 #if defined(GIT_SHA1_COMMON_CRYPTO) || defined(GIT_SHA256_COMMON_CRYPTO)
 # include "common_crypto.h"
 #endif
@@ -30,10 +34,6 @@ typedef struct git_hash_sha256_ctx git_hash_sha256_ctx;
 
 #if defined(GIT_SHA1_MBEDTLS) || defined(GIT_SHA256_MBEDTLS)
 # include "mbedtls.h"
-#endif
-
-#if defined(GIT_SHA1_COLLISIONDETECT)
-# include "collisiondetect.h"
 #endif
 
 #if defined(GIT_SHA256_BUILTIN)

--- a/tests/libgit2/core/features.c
+++ b/tests/libgit2/core/features.c
@@ -186,8 +186,10 @@ void test_core_features__backends(void)
 	cl_assert(0);
 #endif
 
-#if defined(GIT_SHA1_COLLISIONDETECT)
+#if defined(GIT_SHA1_BUILTIN)
 	cl_assert_equal_s("builtin", sha1);
+#elif defined(GIT_SHA1_COLLISIONDETECT)
+	cl_assert_equal_s("sha1collisiondetect", sha1);
 #elif defined(GIT_SHA1_OPENSSL)
 	cl_assert_equal_s("openssl", sha1);
 #elif defined(GIT_SHA1_OPENSSL_FIPS)


### PR DESCRIPTION
Allow users to use an external sha1collisiondetection library build.

This may be of interest to distribution maintainers, who want to use external dependencies whenever possible.