### PR TITLE
cli: add version command

### DIFF
--- a/src/cli/cmd.h
+++ b/src/cli/cmd.h
@@ -33,5 +33,6 @@ extern int cmd_hash_object(int argc, char **argv);
 extern int cmd_help(int argc, char **argv);
 extern int cmd_index_pack(int argc, char **argv);
 extern int cmd_init(int argc, char **argv);
+extern int cmd_version(int argc, char **argv);
 
 #endif /* CLI_cmd_h__ */

--- a/src/cli/cmd_version.c
+++ b/src/cli/cmd_version.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include <stdio.h>
+#include <git2.h>
+#include "common.h"
+#include "cmd.h"
+
+#define COMMAND_NAME "version"
+
+static int build_options;
+
+struct feature_names {
+	int feature;
+	const char *name;
+};
+
+static const struct feature_names feature_names[] = {
+	{ GIT_FEATURE_SHA1,           "sha1"           },
+	{ GIT_FEATURE_SHA256,         "sha256"         },
+	{ GIT_FEATURE_THREADS,        "threads"        },
+	{ GIT_FEATURE_NSEC,           "nsec"           },
+	{ GIT_FEATURE_COMPRESSION,    "compression"    },
+	{ GIT_FEATURE_I18N,           "i18n"           },
+	{ GIT_FEATURE_REGEX,          "regex"          },
+	{ GIT_FEATURE_SSH,            "ssh"            },
+	{ GIT_FEATURE_HTTPS,          "https"          },
+	{ GIT_FEATURE_HTTP_PARSER,    "http_parser"    },
+	{ GIT_FEATURE_AUTH_NTLM,      "auth_ntlm"      },
+	{ GIT_FEATURE_AUTH_NEGOTIATE, "auth_negotiate" },
+	{ 0, NULL }
+};
+
+static const cli_opt_spec opts[] = {
+	CLI_COMMON_OPT,
+
+	{ CLI_OPT_TYPE_SWITCH,    "build-options",  0,  &build_options, 1,
+	  CLI_OPT_USAGE_DEFAULT,   NULL,           "show compile-time options" },
+	{ 0 },
+};
+
+static int print_help(void)
+{
+	cli_opt_usage_fprint(stdout, PROGRAM_NAME, COMMAND_NAME, opts, 0);
+	printf("\n");
+
+	printf("Display version information for %s.\n", PROGRAM_NAME);
+	printf("\n");
+
+	printf("Options:\n");
+
+	cli_opt_help_fprint(stdout, opts);
+
+	return 0;
+}
+
+int cmd_version(int argc, char **argv)
+{
+	cli_opt invalid_opt;
+	const struct feature_names *f;
+	const char *backend;
+	int supported_features;
+
+	if (cli_opt_parse(&invalid_opt, opts, argv + 1, argc - 1, CLI_OPT_PARSE_GNU))
+		return cli_opt_usage_error(COMMAND_NAME, opts, &invalid_opt);
+
+	if (cli_opt__show_help) {
+		print_help();
+		return 0;
+	}
+
+	printf("%s version %s\n", PROGRAM_NAME, LIBGIT2_VERSION);
+
+	if (build_options) {
+		supported_features = git_libgit2_features();
+
+		for (f = feature_names; f->feature; f++) {
+			if (!(supported_features & f->feature))
+				continue;
+
+			backend = git_libgit2_feature_backend(f->feature);
+			printf("backend-%s: %s\n", f->name, backend);
+		}
+	}
+
+	return 0;
+}

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -38,6 +38,7 @@ const cli_cmd_spec cli_cmds[] = {
 	{ "help",        cmd_help,        "Display help information" },
 	{ "index-pack",  cmd_index_pack,  "Create an index for a packfile" },
 	{ "init",        cmd_init,        "Create a new git repository" },
+	{ "version",     cmd_version,     "Show application version information" },
 	{ NULL }
 };
 
@@ -76,6 +77,12 @@ static void help_args(int *argc, char **argv)
 	*argc = 1;
 }
 
+static void version_args(int *argc, char **argv)
+{
+	argv[0] = "version";
+	*argc = 1;
+}
+
 int main(int argc, char **argv)
 {
 	const cli_cmd_spec *cmd;
@@ -110,7 +117,8 @@ int main(int argc, char **argv)
 	}
 
 	if (show_version) {
-		printf("%s version %s\n", PROGRAM_NAME, LIBGIT2_VERSION);
+		version_args(&argc, argv);
+		ret = cmd_version(argc, argv);
 		goto done;
 	}
 


### PR DESCRIPTION
Move the `--version` information into its own command, so that we can support `--build-options`.