### PR TITLE
hash: allow `unsigned int` != `size_t` in sha256

### DIFF
--- a/src/util/hash/builtin.c
+++ b/src/util/hash/builtin.c
@@ -32,13 +32,23 @@ int git_hash_sha256_init(git_hash_sha256_ctx *ctx)
 	return 0;
 }
 
-int git_hash_sha256_update(git_hash_sha256_ctx *ctx, const void *data, size_t len)
+int git_hash_sha256_update(git_hash_sha256_ctx *ctx, const void *_data, size_t len)
 {
+	const unsigned char *data = _data;
 	GIT_ASSERT_ARG(ctx);
-	if (SHA256Input(&ctx->c, data, len)) {
-		git_error_set(GIT_ERROR_SHA, "SHA256 error");
-		return -1;
+
+	while (len > 0) {
+		unsigned int chunk = (len > UINT_MAX) ? UINT_MAX : (unsigned int)len;
+
+		if (SHA256Input(&ctx->c, data, chunk)) {
+			git_error_set(GIT_ERROR_SHA, "SHA256 error");
+			return -1;
+		}
+
+		data += chunk;
+		len -= chunk;
 	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Our bundled SHA256 implementation passes a `size_t` as an `unsigned int`. Stop doing that.