### PR TITLE
include: Fix code comment termination

### DIFF
--- a/include/git2/stdint.h
+++ b/include/git2/stdint.h
@@ -221,7 +221,7 @@ typedef uint64_t  uintmax_t;
 #endif /* __STDC_LIMIT_MACROS ] */
 
 
-/* 7.18.4 Limits of other integer types
+/* 7.18.4 Limits of other integer types */
 
 #if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS) /* [    See footnote 224 at page 260 */
 


### PR DESCRIPTION
f1cac063baada36900fa1060c665c36281a8168b, which converted the style of code comments, introduced an issue where one of the comments was not closed. This created an imbalance of opening `#ifdef` and closing `#endif` at line -222/+224 to -224/+226:

https://github.com/libgit2/libgit2/commit/f1cac06#diff-c4c8617f383bc7d0f8826c53706fc10ae74b83bc0ca961382782c4da81de1da0L222

This commit closes the comment, fixing the imbalance.