### PR TITLE
Introduce git_libgit2_buildinfo

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -568,6 +568,29 @@ typedef enum {
  */
 GIT_EXTERN(int) git_libgit2_opts(int option, ...);
 
+/**
+ * Build information items to query. This is the information type
+ * passed to `git_libgit2_buildinfo` to get particular information
+ * about the libgit2 build.
+ */
+typedef enum {
+	/** The CPU type that libgit2 was built for. */
+	GIT_BUILDINFO_CPU = 1,
+
+	/** The commit that libgit2 was built from. */
+	GIT_BUILDINFO_COMMIT
+} git_buildinfo_t;
+
+/**
+ * Query information about the compile-time information about
+ * libgit2.
+ *
+ * @param info the build information to query
+ * @return the requested information, or `NULL` on error
+ */
+GIT_EXTERN(const char *) git_libgit2_buildinfo(
+	git_buildinfo_t info);
+
 /** @} */
 GIT_END_DECL
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,14 @@ if(AMIGA)
 endif()
 
 #
+# Set build time information
+#
+
+set(GIT_BUILD_CPU "${CMAKE_SYSTEM_PROCESSOR}")
+execute_process(COMMAND git rev-parse HEAD
+	OUTPUT_VARIABLE GIT_BUILD_COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+#
 # Include child projects
 #
 

--- a/src/cli/cmd_version.c
+++ b/src/cli/cmd_version.c
@@ -91,6 +91,9 @@ int cmd_version(int argc, char **argv)
 				printf("%s: %s\n", i->name, value);
 		}
 
+		printf("sizeof-long: %" PRIuZ "\n", sizeof(long));
+		printf("sizeof-size_t: %" PRIuZ "\n", sizeof(size_t));
+
 		for (i = feature_names; i->key; i++) {
 			if (!(supported_features & i->key))
 				continue;

--- a/src/cli/cmd_version.c
+++ b/src/cli/cmd_version.c
@@ -14,24 +14,30 @@
 
 static int build_options;
 
-struct feature_names {
-	int feature;
+struct info_names {
+	int key;
 	const char *name;
 };
 
-static const struct feature_names feature_names[] = {
-	{ GIT_FEATURE_SHA1,           "sha1"           },
-	{ GIT_FEATURE_SHA256,         "sha256"         },
-	{ GIT_FEATURE_THREADS,        "threads"        },
-	{ GIT_FEATURE_NSEC,           "nsec"           },
-	{ GIT_FEATURE_COMPRESSION,    "compression"    },
-	{ GIT_FEATURE_I18N,           "i18n"           },
-	{ GIT_FEATURE_REGEX,          "regex"          },
-	{ GIT_FEATURE_SSH,            "ssh"            },
-	{ GIT_FEATURE_HTTPS,          "https"          },
-	{ GIT_FEATURE_HTTP_PARSER,    "http_parser"    },
-	{ GIT_FEATURE_AUTH_NTLM,      "auth_ntlm"      },
-	{ GIT_FEATURE_AUTH_NEGOTIATE, "auth_negotiate" },
+static const struct info_names buildinfo_names[] = {
+	{ GIT_BUILDINFO_CPU,          "cpu"               },
+	{ GIT_BUILDINFO_COMMIT,       "built from commit" },
+	{ 0, NULL }
+};
+
+static const struct info_names feature_names[] = {
+	{ GIT_FEATURE_SHA1,           "sha1"              },
+	{ GIT_FEATURE_SHA256,         "sha256"            },
+	{ GIT_FEATURE_THREADS,        "threads"           },
+	{ GIT_FEATURE_NSEC,           "nsec"              },
+	{ GIT_FEATURE_COMPRESSION,    "compression"       },
+	{ GIT_FEATURE_I18N,           "i18n"              },
+	{ GIT_FEATURE_REGEX,          "regex"             },
+	{ GIT_FEATURE_SSH,            "ssh"               },
+	{ GIT_FEATURE_HTTPS,          "https"             },
+	{ GIT_FEATURE_HTTP_PARSER,    "http_parser"       },
+	{ GIT_FEATURE_AUTH_NTLM,      "auth_ntlm"         },
+	{ GIT_FEATURE_AUTH_NEGOTIATE, "auth_negotiate"    },
 	{ 0, NULL }
 };
 
@@ -61,7 +67,7 @@ static int print_help(void)
 int cmd_version(int argc, char **argv)
 {
 	cli_opt invalid_opt;
-	const struct feature_names *f;
+	const struct info_names *i;
 	const char *backend;
 	int supported_features;
 
@@ -78,12 +84,19 @@ int cmd_version(int argc, char **argv)
 	if (build_options) {
 		supported_features = git_libgit2_features();
 
-		for (f = feature_names; f->feature; f++) {
-			if (!(supported_features & f->feature))
+		for (i = buildinfo_names; i->key; i++) {
+			const char *value = git_libgit2_buildinfo(i->key);
+
+			if (value && *value)
+				printf("%s: %s\n", i->name, value);
+		}
+
+		for (i = feature_names; i->key; i++) {
+			if (!(supported_features & i->key))
 				continue;
 
-			backend = git_libgit2_feature_backend(f->feature);
-			printf("backend-%s: %s\n", f->name, backend);
+			backend = git_libgit2_feature_backend(i->key);
+			printf("backend-%s: %s\n", i->name, backend);
 		}
 	}
 

--- a/src/libgit2/settings.c
+++ b/src/libgit2/settings.c
@@ -468,3 +468,26 @@ int git_libgit2_opts(int key, ...)
 
 	return error;
 }
+
+const char *git_libgit2_buildinfo(git_buildinfo_t key)
+{
+	switch (key) {
+
+#ifdef GIT_BUILD_CPU
+	case GIT_BUILDINFO_CPU:
+		return GIT_BUILD_CPU;
+		break;
+#endif
+
+#ifdef GIT_BUILD_COMMIT
+	case GIT_BUILDINFO_COMMIT:
+		return GIT_BUILD_COMMIT;
+		break;
+#endif
+
+	default:
+		break;
+	}
+
+	return NULL;
+}

--- a/src/util/git2_features.h.in
+++ b/src/util/git2_features.h.in
@@ -93,4 +93,9 @@
 #cmakedefine GIT_IO_WSAPOLL 1
 #cmakedefine GIT_IO_SELECT 1
 
+/* Compile-time information */
+
+#cmakedefine GIT_BUILD_CPU "@GIT_BUILD_CPU@"
+#cmakedefine GIT_BUILD_COMMIT "@GIT_BUILD_COMMIT@"
+
 #endif


### PR DESCRIPTION
Track some information about the compilation at compile time, and allow consumers to query it.