### PR TITLE
Handle cases where content length of an http response is zero

### DIFF
--- a/src/libgit2/transports/httpclient.c
+++ b/src/libgit2/transports/httpclient.c
@@ -379,7 +379,9 @@ static int on_headers_complete(git_http_parser *parser)
 	ctx->response->resend_credentials = resend_needed(ctx->client,
 	                                                  ctx->response);
 
-	if (ctx->response->content_type || ctx->response->chunked)
+	if (ctx->response->chunked)
+		ctx->client->state = READING_BODY;
+	else if (ctx->response->content_type && ctx->response->content_length)
 		ctx->client->state = READING_BODY;
 	else
 		ctx->client->state = DONE;

--- a/src/libgit2/transports/httpparser.c
+++ b/src/libgit2/transports/httpparser.c
@@ -102,10 +102,7 @@ size_t git_http_parser_execute(
 	 * code.
 	 */
 
-	if (data == NULL || len == 0)
-		error = llhttp_finish(parser);
-	else
-		error = llhttp_execute(parser, data, len);
+	error = llhttp_execute(parser, data, len);
 
 	parsed_len = len;
 


### PR DESCRIPTION
There's a behaviour change between 1.8.0 and 1.9.0. I have a Git server that's used for testing, and for private repositories it initially returns a 401 with an empty body:

> TRACE: Sending GET request to http://hostname:1234/user/repo/info/refs?service=git-upload-pack
> TRACE: Connecting to remote hostname port 1234
> TRACE: Sending request:
> GET /user/repo/info/refs?service=git-upload-pack HTTP/1.1
> User-Agent: git/2.0 (libgit2 1.9.0)
> Host: localhost:1000
> Accept: */*
>
> TRACE: Received:
> HTTP/1.1 401 Unauthorized
> Content-Type: text/plain
> Set-Cookie: lang=en-US; Path=/; Max-Age=2147483647
> Set-Cookie: i_like_gogs=xxxx; Path=/; HttpOnly
> Set-Cookie: _csrf=xxxx; Path=/; Expires=Tue, 14 Jan 2025
> Www-Authenticate: Basic realm="."
> Date: Mon, 13 Jan 2025
> Content-Length: 0

At this point we're then waiting indefinitely to read from a stream:

```
#0  0x00007fd6aa729899 in __libc_recv (fd=3, buf=0x56452326e390, len=16384, flags=0) at ../sysdeps/unix/sysv/linux/recv.c:28
#1  0x0000564521408c76 in socket_read (stream=0x56452324d170, data=0x56452326e390, len=16384) at src/libgit2/streams/socket.c:280
#2  0x000056452141a871 in git_stream_read (st=0x56452324d170, data=0x56452326e390, len=16384) at src/libgit2/stream.h:50
#3  0x000056452141cf34 in client_read (client=0x56452325cfb0) at src/libgit2/transports/httpclient.c:1150
#4  0x000056452141cfc8 in client_read_and_parse (client=0x56452325cfb0) at src/libgit2/transports/httpclient.c:1175
#5  0x000056452141dd37 in git_http_client_skip_body (client=0x56452325cfb0) at src/libgit2/transports/httpclient.c:1545
#6  0x00005645214193d3 in handle_response (complete=0x7ffda378351f, stream=0x564523258260, response=0x7ffda3783520, allow_replay=true) at src/libgit2/transports/http.c:269
#7  0x00005645214199dd in http_stream_read (s=0x564523258260, buffer=0x56452325e380 "", buffer_size=65536, out_len=0x7ffda3783680) at src/libgit2/transports/http.c:429
#8  0x000056452141fb59 in git_smart__recv (t=0x56452325e150) at src/libgit2/transports/smart.c:29
#9  0x00005645214233cf in git_smart__store_refs (t=0x56452325e150, flushes=2) at src/libgit2/transports/smart_protocol.c:58
#10 0x0000564521420115 in git_smart__connect (transport=0x56452325e150, url=0x56452324d470 "http://localhost/user/repo", direction=0, connect_opts=0x7ffda37837d0) at src/libgit2/transports/smart.c:171
#11 0x00005645213eae2d in git_remote_connect_ext (remote=0x564523186dd0, direction=GIT_DIRECTION_FETCH, given_opts=0x7ffda37838e0) at src/libgit2/remote.c:963
#12 0x00005645213573aa in clone_into (repo=0x5645231f0250, _remote=0x564523188750, opts=0x7ffda3783a20) at src/libgit2/clone.c:444
```

I will investigate further, the attached change works around this issue for me but I'd like to understand what changed (I know the http parser changed?).
