### PR TITLE
alternates: allow relative paths in all repositories

### DIFF
--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -788,12 +788,8 @@ static int load_alternates(git_odb *odb, const char *objects_dir, int alternate_
 		if (*alternate == '\0' || *alternate == '#')
 			continue;
 
-		/*
-		 * Relative path: build based on the current `objects`
-		 * folder. However, relative paths are only allowed in
-		 * the current repository.
-		 */
-		if (*alternate == '.' && !alternate_depth) {
+		/* Relative path: build based on the current `objects` folder. */
+		if (*alternate == '.') {
 			if ((result = git_str_joinpath(&alternates_path, objects_dir, alternate)) < 0)
 				break;
 			alternate = git_str_cstr(&alternates_path);


### PR DESCRIPTION
Git does not limit relative paths in alternates to the first repository, so libgit2 shouldn't either.