### PR TITLE
cli: fix undefined alloca() on CYGWIN

### DIFF
--- a/src/cli/opt.c
+++ b/src/cli/opt.c
@@ -19,7 +19,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#if defined(__sun) || defined(__illumos__)
+#if defined(__sun) || defined(__illumos__) || defined(__CYGWIN__)
 # include <alloca.h>
 #endif
 


### PR DESCRIPTION
I tried to build my libgit2-1.9.0 package for CYGWIN but I got an error.
This message appears when compiling:
```
[199/671] Building C object src/cli/CMakeFiles/git2_cli.dir/opt.c.o libgit2-1.9.0/src/cli/opt.c:
In function ‘cli_opt_parse’: libgit2-1.9.0/src/cli/opt.c:564:23: warning: implicit declaration of function ‘alloca’; did you mean ‘malloc’? [-Wimplicit-function-declaration]
  564 |         given_specs = alloca(sizeof(const cli_opt_spec *) * (args_len + 1));
      |                       ^~~~~~
      |                       malloc
```
and later the linker emits this error message:
```
[668/671] Linking C executable git2.exe
FAILED: git2.exe
/usr/x86_64-pc-cygwin/bin/ld: src/cli/CMakeFiles/git2_cli.dir/opt.c.o: in function `cli_opt_parse':
/usr/src/debug/libgit2-1.9.0-1/src/cli/opt.c:564:(.text+0xce3): undefined reference to `alloca' collect2: error: ld returned 1 exit status
```
The error is fixed by adding `alloca.h` to included headers.
Hopefully, `opt.c` already allows to add `alloca.h` for some platforms, so I just added an additional test for the preprocessor for checking if the target is CYGWIN.