### PR TITLE
ssh: use credentials from a custom ssh-agent

### DIFF
--- a/include/git2/credential.h
+++ b/include/git2/credential.h
@@ -294,6 +294,20 @@ GIT_EXTERN(int) git_credential_ssh_key_from_agent(
 	const char *username);
 
 /**
+ * Create a new ssh key credential object used for querying a custom ssh-agent.
+ * The supplied parameters will be internally duplicated.
+ *
+ * @param out The newly created credential object.
+ * @param username username to use to authenticate
+ * @param identity_path path to an agent's identity socket
+ * @return 0 for success or an error code for failure
+ */
+GIT_EXTERN(int) git_credential_ssh_key_from_custom_agent(
+	git_credential **out,
+	const char *username,
+	const char *identity_path);
+
+/**
  * Callback for credential signing.
  *
  * @param session the libssh2 session

--- a/include/git2/sys/credential.h
+++ b/include/git2/sys/credential.h
@@ -48,6 +48,7 @@ struct git_credential_username {
 struct git_credential_ssh_key {
 	git_credential parent; /**< The parent credential */
 	char *username;        /**< The username to authenticate as */
+	char *identity_path;   /**< The path to an agent's identity socket (e.g. $SSH_AUTH_SOCK) */
 	char *publickey;       /**< The path to a public key */
 	char *privatekey;      /**< The path to a private key */
 	char *passphrase;      /**< Passphrase to decrypt the private key */

--- a/src/libgit2/transports/credential.c
+++ b/src/libgit2/transports/credential.c
@@ -120,6 +120,9 @@ static void ssh_key_free(struct git_credential *cred)
 
 	git__free(c->username);
 
+	if (c->identity_path)
+		git__free(c->identity_path);
+
 	if (c->privatekey) {
 		/* Zero the memory which previously held the private key */
 		size_t key_len = strlen(c->privatekey);
@@ -311,6 +314,24 @@ int git_credential_ssh_key_from_agent(git_credential **cred, const char *usernam
 	c->privatekey = NULL;
 
 	*cred = &c->parent;
+	return 0;
+}
+
+int git_credential_ssh_key_from_custom_agent(git_credential **cred, const char *username, const char *identity_path) {
+	git_credential_ssh_key *c;
+	int rc;
+
+	GIT_ASSERT_ARG(identity_path);
+
+	rc = git_credential_ssh_key_from_agent(cred, username);
+
+	if (rc != 0)
+		return rc;
+
+	c = (git_credential_ssh_key *)*cred;
+	c->identity_path = git__strdup(identity_path);
+	GIT_ERROR_CHECK_ALLOC(c->identity_path);
+
 	return 0;
 }
 

--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -243,6 +243,9 @@ static int ssh_agent_auth(LIBSSH2_SESSION *session, git_credential_ssh_key *c) {
 	if (agent == NULL)
 		return -1;
 
+	if (c->identity_path)
+		libssh2_agent_set_identity_path(agent, c->identity_path);
+
 	rc = libssh2_agent_connect(agent);
 
 	if (rc != LIBSSH2_ERROR_NONE) {


### PR DESCRIPTION
Add a public API `git_credential_ssh_key_from_custom_agent` to get an ssh key from a custom ssh-agent. The function takes an `identity_path` parameter which is the path to an alternative agent identity socket.