### PR TITLE
Add support for user TLS authentication #7016

### DIFF
--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -257,7 +257,9 @@ typedef enum {
 	GIT_OPT_GET_SERVER_TIMEOUT,
 	GIT_OPT_SET_USER_AGENT_PRODUCT,
 	GIT_OPT_GET_USER_AGENT_PRODUCT,
-	GIT_OPT_ADD_SSL_X509_CERT
+	GIT_OPT_ADD_SSL_X509_CERT,
+	GIT_OPT_SET_SSL_PASSWORD_CALLBACK,
+	GIT_OPT_SET_SSL_USER_KEY
 } git_libgit2_opt_t;
 
 /**
@@ -562,6 +564,29 @@ typedef enum {
  *   opts(GIT_OPT_SET_SERVER_TIMEOUT, int timeout)
  *      > Sets the timeout (in milliseconds) for reading from and writing
  *      > to a remote server. Set to 0 to use the system default.
+ *
+ *   opts(GIT_OPT_SET_SSL_PASSWORD_CALLBACK, callback *cb, void *userdata)
+ *      > Set callback to acquire password for user key.  This MUST be
+ *      > set before calling GIT_OPT_SET_SSL_USER_KEY otherwise the default
+ *      > behavior will be to prompt on the console for password.  NULL can
+ *      > be used for either option.
+ *      >
+ *      > - `cb` is a callback function with the following arguments
+ *      >    int cb (char *outBuf, int size, int rwflag, void *userdata)
+ *      >     where 'outBuf' is the buf to write the password into.  It is
+ *      >     'size' bytes long.  The callback can use the 'rwflag' to check
+ *      >     whether an item shall be encrypted (`rwflag`=1).  `userdata` is
+ *      >     the pointer passed to 'userdata'.
+ *
+ *   opts(GIT_OPT_SET_SSL_USER_KEY, const char *key, const char *cert)
+ *      > Set the SSL user private key and certificate for TLS
+ *      > authentication.  See GIT_OPT_SET_SSL_PASSWORD_CALLBACK (above)
+ *      > for setting a callback to acquire passphrase for key.
+ *      >
+ *      > - `key` is the path of the user private key
+ *      > - `cert` is the path of the user public cert
+ *      >
+ *      > Both files are required and MUST exist.
  *
  * @param option Option key
  * @return 0 on success, <0 on failure

--- a/src/libgit2/settings.c
+++ b/src/libgit2/settings.c
@@ -222,6 +222,32 @@ int git_libgit2_opts(int key, ...)
 #endif
 		break;
 
+	case GIT_OPT_SET_SSL_PASSWORD_CALLBACK:
+#if defined(GIT_HTTPS_OPENSSL) || defined(GIT_HTTPS_OPENSSL_DYNAMIC)
+	{
+		pem_password_cb *cb = va_arg(ap, pem_password_cb *);
+		void *ud = va_arg(ap, void *);
+		error = git_openssl__set_user_password_callback(cb, ud);
+	}
+#else
+		git_error_set(GIT_ERROR_SSL, "TLS backend doesn't support user key authentication");
+		error = -1;
+#endif
+		break;
+
+	case GIT_OPT_SET_SSL_USER_KEY:
+#if defined(GIT_HTTPS_OPENSSL) || defined(GIT_HTTPS_OPENSSL_DYNAMIC)
+		{
+			const char *key = va_arg(ap, const char *);
+			const char *cert = va_arg(ap, const char *);
+			error = git_openssl__set_user_keys(key, cert);
+		}
+#else
+		git_error_set(GIT_ERROR_SSL, "TLS backend doesn't support user key authentication");
+		error = -1;
+#endif
+		break;
+
 	case GIT_OPT_ADD_SSL_X509_CERT:
 #if defined(GIT_HTTPS_OPENSSL) || defined(GIT_HTTPS_OPENSSL_DYNAMIC)
 		{

--- a/src/libgit2/streams/openssl.h
+++ b/src/libgit2/streams/openssl.h
@@ -24,6 +24,8 @@ extern int git_openssl_stream_global_init(void);
 
 #if defined(GIT_HTTPS_OPENSSL) || defined(GIT_HTTPS_OPENSSL_DYNAMIC)
 extern int git_openssl__set_cert_location(const char *file, const char *path);
+extern int git_openssl__set_user_keys(const char *keyPath, const char *certPath);
+extern int git_openssl__set_user_password_callback(pem_password_cb *cb, void *userdata);
 extern int git_openssl__add_x509_cert(X509 *cert);
 extern int git_openssl__reset_context(void);
 extern int git_openssl_stream_new(git_stream **out, const char *host, const char *port);


### PR DESCRIPTION
This allows for the use case where a user is providing an openssl key and certificate as their authentication to an HTTPS server.

New option GIT_OPT_SET_SSL_USER_KEY to set paths for user private key and certificate files.
New option GIT_OPT_SET_SSL_PASSWORD_CALLBACK provides a means for a callback function to prompt for password to unlock the key.