### PR TITLE
Revert include path regression

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -58,7 +58,7 @@ set(LIBGIT2_SYSTEM_LIBS ${LIBGIT2_SYSTEM_LIBS} PARENT_SCOPE)
 add_library(libgit2package ${SRC_RC} ${LIBGIT2_OBJECTS})
 target_link_libraries(libgit2package ${LIBGIT2_SYSTEM_LIBS})
 target_include_directories(libgit2package SYSTEM PRIVATE ${LIBGIT2_INCLUDES})
-target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:./include/git2>)
+target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:include>)
 
 set_target_properties(libgit2package PROPERTIES C_STANDARD 90)
 set_target_properties(libgit2package PROPERTIES C_EXTENSIONS OFF)


### PR DESCRIPTION

## Problem

I've upgraded to using libgit2 v1.9, and I've been getting build errors that weren't there previously. This is caused by the custom ```<stdint.h>``` header file.

The build errors only occur when using a **installed** libgit2.
I am using Fedora Linux 41.


## Example usage code

CMakeLists.txt
```cmake
cmake_minimum_required(VERSION 3.30)
project(using_libgit2)
add_executable(my_exe main.cpp)
find_package(libgit2)
target_link_libraries(my_exe PRIVATE libgit2::libgit2package)
```

main.cpp
```cpp
#include <cstdint>
int main() {
    return 0;
}
```

Trying to build this leads to errors like this:
```
/usr/include/c++/14/cstdint:51:11: error: ‘int8_t’ has not been declared in ‘::’
   51 |   using ::int8_t;
```

## Explanation

When using the installed libgit2 the include paths will now contain ```include/git2``` instead of ```include```. This is problematic because there's a custom ```<stdint.h>``` in the ```git2``` folder.
Now any user code that has ```#include <stdint.h>```, will now include the custom ```<stdint.h>``` header instead of the standard one. Which causes the build error.

## Solution

This PR fixes this regression.