### PR TITLE
Add support for delta reuse

### DIFF
--- a/include/git2/sys/odb_backend.h
+++ b/include/git2/sys/odb_backend.h
@@ -46,6 +46,13 @@ struct git_odb_backend {
 		size_t *, git_object_t *, git_odb_backend *, const git_oid *);
 
 	/**
+	 * If the OID given is stored as a delta, get the OID of its delta base
+	 * and compressed delta data.
+	 */
+	int GIT_CALLBACK(get_delta)(
+		git_oid *, void **, size_t *, size_t *, git_odb_backend *, const git_oid *);
+
+	/**
 	 * Write an object into the backend. The id of the object has
 	 * already been calculated and is passed in.
 	 */

--- a/src/libgit2/odb.h
+++ b/src/libgit2/odb.h
@@ -146,6 +146,18 @@ int git_odb__read_header_or_object(
 	git_odb *db, const git_oid *id);
 
 /*
+ * If `id` is stored as a delta, get the OID of its delta base and compressed
+ * delta data.
+ */
+int git_odb__get_delta(
+        git_oid *base_p,
+        void **z_data_p,
+        size_t *size_p,
+        size_t *z_size_p,
+        git_odb *db,
+        const git_oid *id);
+
+/*
  * Attempt to get the ODB's commit-graph file. This object is still owned by
  * the ODB. If the repository does not contain a commit-graph, it will return
  * GIT_ENOTFOUND.

--- a/src/libgit2/odb_pack.c
+++ b/src/libgit2/odb_pack.c
@@ -563,6 +563,30 @@ static int pack_backend__read_header(
 	return git_packfile_resolve_header(len_p, type_p, e.p, e.offset);
 }
 
+static int pack_backend__get_delta(
+        git_oid *base_p,
+        void **z_data_p,
+        size_t *size_p,
+        size_t *z_size_p,
+        struct git_odb_backend *backend,
+        const git_oid *id)
+{
+	struct git_pack_entry e;
+	int error;
+
+	GIT_ASSERT_ARG(backend);
+	GIT_ASSERT_ARG(id);
+	GIT_ASSERT_ARG(base_p);
+	GIT_ASSERT_ARG(z_data_p);
+	GIT_ASSERT_ARG(size_p);
+	GIT_ASSERT_ARG(z_size_p);
+
+	if ((error = pack_entry_find(&e, (struct pack_backend *)backend, id)) < 0)
+		return error;
+
+	return git_packfile_get_delta(base_p, z_data_p, size_p, z_size_p, e.p, e.offset);
+}
+
 static int pack_backend__freshen(
 	git_odb_backend *backend, const git_oid *oid)
 {
@@ -907,6 +931,7 @@ static int pack_backend__alloc(
 	backend->parent.read = &pack_backend__read;
 	backend->parent.read_prefix = &pack_backend__read_prefix;
 	backend->parent.read_header = &pack_backend__read_header;
+	backend->parent.get_delta = &pack_backend__get_delta;
 	backend->parent.exists = &pack_backend__exists;
 	backend->parent.exists_prefix = &pack_backend__exists_prefix;
 	backend->parent.refresh = &pack_backend__refresh;

--- a/src/libgit2/pack-objects.c
+++ b/src/libgit2/pack-objects.c
@@ -121,6 +121,10 @@ static int packbuilder_config(git_packbuilder *pb)
 
 #undef config_get
 
+	ret = git_config_get_bool(&pb->no_reuse_delta, config, "pack.noReuseDelta");
+	if (ret == GIT_ENOTFOUND)
+		ret = 0;
+
 out:
 	git_config_free(config);
 
@@ -1339,7 +1343,8 @@ static bool reuse_delta(git_pobject *po, git_packbuilder *pb)
 	size_t z_size;
 	git_pobject *base_po;
 
-	if (git_odb__get_delta(&base_id, &z_data, &size, &z_size, pb->odb, &po->id) < 0)
+	if (pb->no_reuse_delta ||
+	    git_odb__get_delta(&base_id, &z_data, &size, &z_size, pb->odb, &po->id) < 0)
 		return false;
 
 	if (git_packbuilder_pobjectmap_get(&base_po, &pb->object_ix, &base_id) != 0) {

--- a/src/libgit2/pack-objects.c
+++ b/src/libgit2/pack-objects.c
@@ -769,8 +769,6 @@ static int try_delta(git_packbuilder *pb, struct unpacked *trg,
 
 	*ret = 0;
 
-	/* TODO: support reuse-delta */
-
 	/* Let's not bust the allowed depth. */
 	if (src->depth >= max_depth)
 		return 0;
@@ -1333,6 +1331,39 @@ static int ll_find_deltas(git_packbuilder *pb, git_pobject **list,
 #define ll_find_deltas(pb, l, ls, w, d) find_deltas(pb, l, &ls, w, d)
 #endif
 
+static bool reuse_delta(git_pobject *po, git_packbuilder *pb)
+{
+	git_oid base_id;
+	void *z_data;
+	size_t size;
+	size_t z_size;
+	git_pobject *base_po;
+
+	if (git_odb__get_delta(&base_id, &z_data, &size, &z_size, pb->odb, &po->id) < 0)
+		return false;
+
+	if (git_packbuilder_pobjectmap_get(&base_po, &pb->object_ix, &base_id) != 0) {
+		git__free(z_data);
+		return false;
+	}
+
+	po->delta = base_po;
+	po->delta_data = z_data;
+	po->delta_size = size;
+	po->z_delta_size = z_size;
+
+	/*
+	 * The base of this (reused) delta may be considered for deltification
+	 * itself.  Connect delta_child/delta_sibling network links to ensure
+	 * find_deltas() accounts for the depth of the reused deltas when
+	 * limiting depth for the deltas it creates itself.
+	 */
+	po->delta_sibling = po->delta->delta_child;
+	po->delta->delta_child = po;
+
+	return true;
+}
+
 int git_packbuilder__prepare(git_packbuilder *pb)
 {
 	git_pobject **delta_list;
@@ -1356,6 +1387,9 @@ int git_packbuilder__prepare(git_packbuilder *pb)
 
 	for (i = 0; i < pb->nr_objects; ++i) {
 		git_pobject *po = pb->object_list + i;
+
+		if (reuse_delta(po, pb))
+			continue;
 
 		/* Make sure the item is within our size limits */
 		if (po->size < 50 || po->size > pb->big_file_threshold)

--- a/src/libgit2/pack-objects.h
+++ b/src/libgit2/pack-objects.h
@@ -94,6 +94,7 @@ struct git_packbuilder {
 	size_t cache_max_small_delta_size;
 	size_t big_file_threshold;
 	size_t window_memory_limit;
+	int no_reuse_delta;
 
 	unsigned int nr_threads; /* nr of threads to use */
 

--- a/src/libgit2/pack.h
+++ b/src/libgit2/pack.h
@@ -189,6 +189,14 @@ int git_packfile_resolve_header(
 		struct git_pack_file *p,
 		off64_t offset);
 
+int git_packfile_get_delta(
+        git_oid *base_out,
+        void **z_data_out,
+        size_t *size_out,
+        size_t *z_size_out,
+        struct git_pack_file *p,
+        off64_t offset);
+
 int git_packfile_unpack(git_rawobj *obj, struct git_pack_file *p, off64_t *obj_offset);
 
 int git_packfile_stream_open(git_packfile_stream *obj, struct git_pack_file *p, off64_t curpos);

--- a/src/libgit2/pack.h
+++ b/src/libgit2/pack.h
@@ -68,6 +68,14 @@ struct git_pack_idx_header {
 	uint32_t idx_version;
 };
 
+#define PACK_RIDX_SIGNATURE 0x52494458	/* "RIDX" */
+
+struct git_pack_ridx_header {
+	uint32_t ridx_signature;
+	uint32_t ridx_version;
+	uint32_t ridx_oid_type;
+};
+
 typedef struct git_pack_cache_entry {
 	size_t last_usage; /* enough? */
 	git_atomic32 refcount;
@@ -108,7 +116,8 @@ typedef struct {
 struct git_pack_file {
 	git_mwindow_file mwf;
 	git_map index_map;
-	git_mutex lock; /* protect updates to index_map */
+	git_map revindex_map;
+	git_mutex lock; /* protect updates to index_map & revindex_map */
 	git_atomic32 refcount;
 
 	uint32_t num_objects;

--- a/src/libgit2/pack.h
+++ b/src/libgit2/pack.h
@@ -117,7 +117,8 @@ struct git_pack_file {
 	git_mwindow_file mwf;
 	git_map index_map;
 	git_map revindex_map;
-	git_mutex lock; /* protect updates to index_map & revindex_map */
+	uint32_t *revindex;
+	git_mutex lock; /* protect updates to index_map & revindex_map/revindex */
 	git_atomic32 refcount;
 
 	uint32_t num_objects;

--- a/tests/libgit2/odb/delta.c
+++ b/tests/libgit2/odb/delta.c
@@ -1,0 +1,90 @@
+#include "clar_libgit2.h"
+#include "odb.h"
+#include "zstream.h"
+
+#define DELTA_2 "8dfd652805e877abaca7383ad28d8eaa5b9a7e04"
+#define DELTA_1 "faf2dae9a5d206471233bfa8698ecbdfb24785d1"
+#define DELTA_BASE "4d25aed8f9ae7653206031efdb0b682d62ece767"
+
+static const unsigned char delta_2_expected[] = {
+	0xed, 0x03, 0xed, 0x03, 0x90, 0x2b, 0x07, 0x69,
+	0x6e, 0x63, 0x6c, 0x75, 0x64, 0x65, 0xb1, 0x32,
+	0xbb, 0x01,
+};
+
+static const unsigned char delta_1_expected[] = {
+	0x87, 0x04, 0xed, 0x03, 0xb0, 0xa9, 0x01, 0x93,
+	0xc3, 0x01, 0x44,
+};
+
+static git_odb *odb;
+
+void test_odb_delta__initialize(void)
+{
+	cl_git_pass(git_odb_open_ext(&odb, cl_fixture("testrepo.git/objects"), NULL));
+}
+
+void test_odb_delta__cleanup(void)
+{
+	git_odb_free(odb);
+	odb = NULL;
+}
+
+static void check_delta(
+        const char *oid,
+        const char *expected_base,
+        const unsigned char expected_contents[],
+        size_t expected_size)
+{
+	git_oid id, base_id;
+	void *z_delta;
+	size_t size;
+	size_t z_size;
+	git_str inflated = GIT_STR_INIT;
+
+	cl_git_pass(git_oid_from_string(&id, oid, GIT_OID_SHA1));
+
+	cl_git_pass(git_odb__get_delta(&base_id, &z_delta, &size, &z_size, odb, &id));
+
+	cl_assert_equal_s(git_oid_tostr_s(&base_id), expected_base);
+
+	cl_assert_equal_i(size, expected_size);
+	cl_assert_equal_i(z_size, expected_size + 8);
+
+	cl_git_pass(git_zstream_inflatebuf(&inflated, z_delta, z_size));
+	cl_assert_equal_i(inflated.size, expected_size);
+	cl_assert(memcmp(inflated.ptr, expected_contents, expected_size) == 0);
+
+	git_str_dispose(&inflated);
+	git__free(z_delta);
+}
+
+void test_odb_delta__get_delta_against_delta(void)
+{
+	/*
+	 * DELTA_2 is stored as a delta against DELTA_1
+	 */
+	check_delta(DELTA_2, DELTA_1, delta_2_expected, sizeof(delta_2_expected));
+}
+
+void test_odb_delta__get_delta_against_base(void)
+{
+	/*
+	 * DELTA_1 is stored as a delta against DELTA_BASE
+	 */
+	check_delta(DELTA_1, DELTA_BASE, delta_1_expected, sizeof(delta_1_expected));
+}
+
+void test_odb_delta__get_delta_for_non_delta(void)
+{
+	git_oid id, base_id;
+	void *z_delta;
+	size_t size;
+	size_t z_size;
+
+	/*
+	 * DELTA_BASE is not stored as a delta
+	 */
+	cl_git_pass(git_oid_from_string(&id, DELTA_BASE, GIT_OID_SHA1));
+	cl_git_fail(git_odb__get_delta(&base_id, &z_delta, &size, &z_size, odb, &id));
+}


### PR DESCRIPTION
This PR enables reusing existing deltas contained in pack files while pushing.

The branch is laid out so that it builds the necessary mechanisms from the ground up, but it may be easier to review this work the other way round (i.e. starting from the tip of the branch), to start from a higher level and then strip layers off.

The basic idea is simple: during a push, after enumerating objects that should end up in the pack file, for each object to be pushed check whether the ODB is able to supply it in the form of a delta; if so, and if the base of that delta is also going to be included in the pack file, get the compressed delta data from the ODB, store it in memory, and remove the current object from the list of objects considered for deltification.  This relieves the pack builder from having to deltify a lot of the objects it needs to push.

As mentioned in the penultimate commit, this drastically speeds up the deltification stage during pack file preparation for large pushes (from pack-file-backed repositories).  I am willing to prepare some specific benchmarks for this, but I thought it was wiser to get feedback on the design and the code itself before starting that particular side quest.  As far as ballpark numbers go, though, for the repositories I tested this code on, the speed-up is in the range of about 5-20x (which is not really shocking because the whole idea is to avoid "re-deltifying" objects which are already available as deltas), depending on repository contents.

This PR does *not* affect the object enumeration stage, which can also take a very long time for large repositories.

Some comments on the decisions made and the trade-offs encountered:

 1. Retrieving the delta from the ODB backend could be split into finding the base OID first and only retrieving the delta data when the pack file is written.  Doing it all in one go was just simpler and shorter (given that this logic needs to cross the ODB abstraction layer, which means quite a bit of glue code is needed for every new ODB backend callback), at the expense of slightly increased memory use (all compressed delta data for reused deltas is stored in memory, i.e. attached to `git_pobject` structures), which is already pretty massive for large pushes.  If necessary, this problem can be eliminated by only retrieving compressed delta data when it is necessary to send it to the remote side - at the expense of adding one more callback to the ODB backend interface and reducing the locality of this logic: one more perk of the simple approach proposed right now is that it enables reused delta data to be treated identically as the deltas generated by `find_deltas()` when sending them to the remote side, i.e. no modifications to `write_object()` are necessary.

 2. The last commit in this PR adds a safety mechanism to disable the new logic in case of trouble.  It does not have a counterpart in the original Git implementation (well, apart from the `--no-reuse-delta` option for `git-pack-objects`).  It can be dropped if you're feeling adventurous ;)  I made it a configuration option because the pack builder does not seem to have any API-level options (or an option structure) that would configure its behavior and AFAICT, libgit2 does not have an API for repacking existing packs, which is the obvious case I can think of that would make such a knob practically useful in the long run.

 3. The code in this PR that computes reverse index contents in memory is nowhere near as sophisticated as the [corresponding code in the original Git implementation](https://github.com/git/git/blob/03944513488db4a81fdb4c21c3b515e4cb260b05/pack-revindex.c#L34-L174) (which performs a radix sort), so it might use quite a bit of memory for repositories with a huge number of objects.  This can be nullified by providing a reverse index file on disk, which the original Git implementation supports since version 2.31 (the code in this PR is capable of using that file).

 4. While `docs/conventions.md` says to increment the default value of the `version` member whenever a transparent structure changes (like `struct git_odb_backend` does in this PR), some previous commits from the past seem to ignore that plea (e.g.  ea285904dcb1350d99703df86a5f38662935cbbc, 459ac856d94d4a59ee47b2807aa8e4b029499582, 97f9a5f0bca920e2ce260b17fa7cea0a2c0991ca), so I joyfully followed their example :-)
