### PR TITLE
Ref DB: Expose method to allocate a new reflog

### DIFF
--- a/include/git2/reflog.h
+++ b/include/git2/reflog.h
@@ -21,6 +21,19 @@
 GIT_BEGIN_DECL
 
 /**
+ * Create a new in-memory reflog for the given reference
+ *
+ * The reflog must be freed manually by using
+ * git_reflog_free().
+ *
+ * @param reflog pointer to reflog to initialize
+ * @param name name of the reference
+ * @param oid_type the type of the OID
+ * @return 0 or an error code
+*/
+GIT_EXTERN(int) git_reflog__alloc(git_reflog **reflog, const char *name, git_oid_t oid_type);
+
+/**
  * Read the reflog for the given reference
  *
  * If there is no reflog file for the given

--- a/src/libgit2/refdb_fs.c
+++ b/src/libgit2/refdb_fs.c
@@ -1975,34 +1975,6 @@ done:
 	return out;
 }
 
-static int reflog_alloc(
-	git_reflog **reflog,
-	const char *name,
-	git_oid_t oid_type)
-{
-	git_reflog *log;
-
-	*reflog = NULL;
-
-	log = git__calloc(1, sizeof(git_reflog));
-	GIT_ERROR_CHECK_ALLOC(log);
-
-	log->ref_name = git__strdup(name);
-	GIT_ERROR_CHECK_ALLOC(log->ref_name);
-
-	log->oid_type = oid_type;
-
-	if (git_vector_init(&log->entries, 0, NULL) < 0) {
-		git__free(log->ref_name);
-		git__free(log);
-		return -1;
-	}
-
-	*reflog = log;
-
-	return 0;
-}
-
 static int reflog_parse(git_reflog *log, const char *buf, size_t buf_size)
 {
 	git_parse_ctx parser = GIT_PARSE_CTX_INIT;
@@ -2140,7 +2112,7 @@ static int refdb_reflog_fs__read(
 	backend = GIT_CONTAINER_OF(_backend, refdb_fs_backend, parent);
 	repo = backend->repo;
 
-	if (reflog_alloc(&log, name, backend->oid_type) < 0)
+	if (git_reflog__alloc(&log, name, backend->oid_type) < 0)
 		return -1;
 
 	if (reflog_path(&log_path, repo, name) < 0)

--- a/src/libgit2/reflog.c
+++ b/src/libgit2/reflog.c
@@ -44,6 +44,34 @@ void git_reflog_free(git_reflog *reflog)
 	git__free(reflog);
 }
 
+int git_reflog__alloc(
+	git_reflog **reflog,
+	const char *name,
+	git_oid_t oid_type)
+{
+	git_reflog *log;
+
+	*reflog = NULL;
+
+	log = git__calloc(1, sizeof(git_reflog));
+	GIT_ERROR_CHECK_ALLOC(log);
+
+	log->ref_name = git__strdup(name);
+	GIT_ERROR_CHECK_ALLOC(log->ref_name);
+
+	log->oid_type = oid_type;
+
+	if (git_vector_init(&log->entries, 0, NULL) < 0) {
+		git__free(log->ref_name);
+		git__free(log);
+		return -1;
+	}
+
+	*reflog = log;
+
+	return 0;
+}
+
 int git_reflog_read(git_reflog **reflog, git_repository *repo,  const char *name)
 {
 	git_refdb *refdb;


### PR DESCRIPTION
Hi there,

I was trying to interop with C# and create a custom refdb backend. I was unable to allocate a new `git_reflog` to implement `read_reflog`. The `reflog_alloc` that already existed in the fs implementation of a ref db has nothing restricting it to file system usage, so I moved to collocate with other `reflog` implementations and exposed it as part of the API (as a semi-private).