### PR TITLE
fuzzers: Fix CFLAGS

### DIFF
--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -23,7 +23,9 @@ foreach(fuzz_target_src ${SRC_FUZZERS})
 	target_include_directories(${fuzz_target_name} SYSTEM PRIVATE ${LIBGIT2_SYSTEM_INCLUDES})
 
 	target_link_libraries(${fuzz_target_name} ${LIBGIT2_SYSTEM_LIBS})
-	target_link_options(${fuzz_target_name} PRIVATE "-fsanitize=fuzzer")
+	if(NOT USE_STANDALONE_FUZZERS)
+		target_link_options(${fuzz_target_name} PRIVATE "-fsanitize=fuzzer")
+	endif()
 
 	add_test(${fuzz_target_name} "${CMAKE_CURRENT_BINARY_DIR}/${fuzz_target_name}" "${CMAKE_CURRENT_SOURCE_DIR}/corpora/${fuzz_name}")
 endforeach()

--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -2,7 +2,6 @@
 
 if(BUILD_FUZZERS AND NOT USE_STANDALONE_FUZZERS)
 	set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer-no-link")
-	add_c_flag(-fsanitize=fuzzer)
 	add_c_flag(-fsanitize=fuzzer-no-link)
 	unset(CMAKE_REQUIRED_FLAGS)
 endif()
@@ -24,6 +23,7 @@ foreach(fuzz_target_src ${SRC_FUZZERS})
 	target_include_directories(${fuzz_target_name} SYSTEM PRIVATE ${LIBGIT2_SYSTEM_INCLUDES})
 
 	target_link_libraries(${fuzz_target_name} ${LIBGIT2_SYSTEM_LIBS})
+	target_link_options(${fuzz_target_name} PRIVATE "-fsanitize=fuzzer")
 
 	add_test(${fuzz_target_name} "${CMAKE_CURRENT_BINARY_DIR}/${fuzz_target_name}" "${CMAKE_CURRENT_SOURCE_DIR}/corpora/${fuzz_name}")
 endforeach()


### PR DESCRIPTION
I'm seeing the current fuzzer build fail (during `cmake`) like so:

```
-- Performing Test IS_FSANITIZE_FUZZER_NO_LINK_SUPPORTED
-- Performing Test IS_FSANITIZE_FUZZER_NO_LINK_SUPPORTED - Failed
CMake Error at cmake/AddCFlagIfSupported.cmake:17 (message):
  Required flag -fsanitize=fuzzer-no-link is not supported
Call Stack (most recent call first):
  fuzzers/CMakeLists.txt:6 (add_c_flag)
```

The cmake log output contains something like so:

```
        /src/aflplusplus/libAFLDriver.a(aflpp_driver.o): in function `main':
        aflpp_driver.c:(.text+0x11b): undefined reference to `LLVMFuzzerTestOneInput'
        clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I haven't figured out exactly what's happening, but I believe that once line 5 has added `-fsanitize=fuzzer` to `CFLAGS`, future compile- tests **also** use it during linking. This in turn pulls in the fuzzer `main`, which expects an `LLVMFuzzerTestOneInput` symbol, and thus fails.

Instead, just add `-fsanitize=fuzzer-no-link` to CFLAGS (as suggested [by the documentation][libfuzzer]), and then use `-fsanitize=fuzzer` only for linking the fuzzer targets. At least in my environment, this results in a working fuzzer build.

[libfuzzer]: https://llvm.org/docs/LibFuzzer.html#fuzzer-usage