### PR TITLE
indexer: Initialise all members of git_indexer_progress

### DIFF
--- a/src/libgit2/indexer.c
+++ b/src/libgit2/indexer.c
@@ -921,12 +921,13 @@ int git_indexer_append(git_indexer *idx, const void *data, size_t size, git_inde
 		if (git_vector_init(&idx->deltas, total_objects / 2, NULL) < 0)
 			return -1;
 
+		stats->total_objects = total_objects;
+		stats->indexed_objects = 0;
 		stats->received_objects = 0;
 		stats->local_objects = 0;
 		stats->total_deltas = 0;
 		stats->indexed_deltas = 0;
-		stats->indexed_objects = 0;
-		stats->total_objects = total_objects;
+		stats->received_bytes = 0;
 
 		if ((error = do_progress_callback(idx, stats)) != 0)
 			return error;

--- a/tests/libgit2/network/remote/local.c
+++ b/tests/libgit2/network/remote/local.c
@@ -16,6 +16,17 @@ static git_strarray push_array = {
 	1,
 };
 
+static int push_transfer_progress_cb(unsigned int current, unsigned int total, size_t bytes, void* payload)
+{
+	GIT_UNUSED(current);
+	GIT_UNUSED(total);
+	GIT_UNUSED(payload);
+
+	cl_assert(bytes == 0);
+
+	return 0;
+}
+
 void test_network_remote_local__initialize(void)
 {
 	cl_git_pass(git_repository_init(&repo, "remotelocal/", 0));
@@ -201,6 +212,7 @@ void test_network_remote_local__push_to_bare_remote(void)
 
 	/* Should be able to push to a bare remote */
 	git_remote *localremote;
+	git_push_options opts = GIT_PUSH_OPTIONS_INIT;
 
 	/* Get some commits */
 	connect_to_local_repository(cl_fixture("testrepo.git"));
@@ -218,7 +230,8 @@ void test_network_remote_local__push_to_bare_remote(void)
 	cl_git_pass(git_remote_connect(localremote, GIT_DIRECTION_PUSH, NULL, NULL, NULL));
 
 	/* Try to push */
-	cl_git_pass(git_remote_upload(localremote, &push_array, NULL));
+	opts.callbacks.push_transfer_progress = push_transfer_progress_cb;
+	cl_git_pass(git_remote_upload(localremote, &push_array, &opts));
 
 	/* Clean up */
 	git_remote_free(localremote);


### PR DESCRIPTION
I have a push_transfer_progress callback registered when calling git_remote_push, where I forward on the "bytes" argument to some progress reporting. For local pushes, the received_bytes member is uninitialized. If you take the change I made to the attached test and run it through valgrind:

valgrind  ./libgit2_tests -snetwork::remote::local::push_to_bare_remote

you'll see:

`
==2411490== Memcheck, a memory error detector
==2411490== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==2411490== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==2411490== Command: ./libgit2_tests -snetwork::remote::local::push_to_bare_remote
==2411490== 
Loaded 385 suites: 
Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
==2411490== Conditional jump or move depends on uninitialised value(s)
==2411490==    at 0x14F360: clar__assert (clar.c:756)
==2411490==    by 0x26166E: push_transfer_progress_cb (local.c:21)
==2411490==    by 0x4467C7: transfer_to_push_transfer (local.c:371)
==2411490==    by 0x3BF633: do_progress_callback (indexer.c:636)
==2411490==    by 0x3BFF2D: git_indexer_append (indexer.c:932)
==2411490==    by 0x3ED607: write_cb (pack-objects.c:1409)
==2411490==    by 0x3EB2E2: write_pack (pack-objects.c:659)
==2411490==    by 0x3ED4FA: git_packbuilder_foreach (pack-objects.c:1390)
==2411490==    by 0x3ED7C8: git_packbuilder_write (pack-objects.c:1461)
==2411490==    by 0x44697E: local_push (local.c:419)
==2411490==    by 0x3FE7F4: do_push (push.c:486)
==2411490==    by 0x3FE994: git_push_finish (push.c:534)
==2411490== 
F.

  1) Failure:
network::remote::local::push_to_bare_remote [/local-ssd/lmcglash/libgit2/libgit2/tests/libgit2/network/remote/local.c:21]
  Expression is not true: bytes == 0
`

I suppose it's fundamentally more to do with transfer_to_push_transfer doing something clever for local pushes (what does received_bytes mean there?).
