### PR TITLE
Fix the null reference vulnerability.

### DIFF
--- a/tests/libgit2/checkout/checkout_helpers.c
+++ b/tests/libgit2/checkout/checkout_helpers.c
@@ -90,8 +90,10 @@ int checkout_count_callback(
 		if (ct->debug) {
 			if (workdir)
 				fprintf(stderr, "M %s\n", workdir->path);
-			else if(baseline)
+			else if (baseline)
 				fprintf(stderr, "D %s\n", baseline->path);
+			else
+				fprintf(stderr, "invalid notification - no workdir or baseline path\n");
 		}
 	}
 

--- a/tests/libgit2/checkout/checkout_helpers.c
+++ b/tests/libgit2/checkout/checkout_helpers.c
@@ -90,7 +90,7 @@ int checkout_count_callback(
 		if (ct->debug) {
 			if (workdir)
 				fprintf(stderr, "M %s\n", workdir->path);
-			else
+			else if(baseline)
 				fprintf(stderr, "D %s\n", baseline->path);
 		}
 	}


### PR DESCRIPTION
Hello,
Our team has recently been conducting research on a null-pointer-dereference (NPD) vulnerability detection tool and used it to scan libgit2 (the version on the master branch). After a manual review, we have identified some potentially vulnerable code snippets that may lead to null-pointer-dereference bugs. 
The NULL Dereference vulnerability happens in  int checkout_count_callback（), tests/libgit2/checkout/checkout_helpers.c
How the NULL Pointer Dereference happens:
1. When `workdir`, `baseline` and `target` are null. 
2. Dereference of NULL variable `baseline` in `baseline->path`
```
int checkout_count_callback(
    git_checkout_notify_t why,
    const char *path,
    const git_diff_file *baseline,
    const git_diff_file *target,
    const git_diff_file *workdir,
    void *payload)
{
    checkout_counts *ct = payload;

    GIT_UNUSED(baseline); GIT_UNUSED(target); GIT_UNUSED(workdir);

    if (why & GIT_CHECKOUT_NOTIFY_CONFLICT) {
        ct->n_conflicts++;

=>      if (ct->debug) {
=>          if (workdir) { //false
               ......
            } else {
=>              if (baseline) {//false
                    ......
                } else {
=>                  if (target)//false
                        ......
                    else
                        fprintf(stderr, "How can a nonexistent file be a conflict (%s)\n", path);
                }
            }
        }
    }

    if (why & GIT_CHECKOUT_NOTIFY_DIRTY) {
        ct->n_dirty++;

        if (ct->debug) {
            if (workdir)
                fprintf(stderr, "M %s\n", workdir->path);
=>          else 
=>              fprintf(stderr, "D %s\n", baseline->path);
        }
    }

    .......
}
```