### PR TITLE
load_known_hosts: do not fail if homedir is invalid

### DIFF
--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -439,8 +439,8 @@ static int load_known_hosts(LIBSSH2_KNOWNHOSTS **hosts, LIBSSH2_SESSION *session
 
 	GIT_ASSERT_ARG(hosts);
 
-	if ((error = git_sysdir_expand_homedir_file(&sshdir, SSH_DIR)) < 0 ||
-	    (error = git_str_joinpath(&path, git_str_cstr(&sshdir), KNOWN_HOSTS_FILE)) < 0)
+        git_sysdir_expand_homedir_file(&sshdir, SSH_DIR);
+        if ((error = git_str_joinpath(&path, git_str_cstr(&sshdir), KNOWN_HOSTS_FILE)) < 0)
 		goto out;
 
 	if ((known_hosts = libssh2_knownhost_init(session)) == NULL) {


### PR DESCRIPTION
My suggested patch for #6550.

Without it, checking the known_hosts will always fail if the homedir is invalid, even if `certificate_check` is set. With this patch, it will ignore the known_hosts check and fallback to `certificate_check` (if set).