### PR TITLE
Fix circular includes between types.h and oid.h

### DIFF
--- a/include/git2/oid.h
+++ b/include/git2/oid.h
@@ -8,7 +8,6 @@
 #define INCLUDE_git_oid_h__
 
 #include "common.h"
-#include "types.h"
 #include "experimental.h"
 
 /**


### PR DESCRIPTION
Fix the following warning reported by clang-tidy:
```
contrib/libs/libgit2/include/git2/oid.h:11:10: error: circular header file dependency detected while including 'types.h', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   11 | #include "types.h"
      |          ^
contrib/libs/libgit2/include/git2/types.h:70:10: note: 'oid.h' included from here
   70 | #include "oid.h"
```