### PR TITLE
tag: Refuse to use HEAD as a tagname

### DIFF
--- a/src/libgit2/tag.c
+++ b/src/libgit2/tag.c
@@ -263,8 +263,10 @@ static bool tag_name_is_valid(const char *tag_name)
 	/*
 	 * Discourage tag name starting with dash,
 	 * https://github.com/git/git/commit/4f0accd638b8d2
+	 * and refuse to use HEAD as a tagname,
+	 * https://github.com/git/git/commit/bbd445d5efd415
 	 */
-	return tag_name[0] != '-';
+	return tag_name[0] != '-' && git__strcmp(tag_name, "HEAD");
 }
 
 static int git_tag_create__internal(

--- a/tests/libgit2/refs/tags/name.c
+++ b/tests/libgit2/refs/tags/name.c
@@ -11,7 +11,9 @@ void test_refs_tags_name__is_name_valid(void)
 {
 	cl_assert_equal_i(true, name_is_valid("sometag"));
 	cl_assert_equal_i(true, name_is_valid("test/sometag"));
+	cl_assert_equal_i(true, name_is_valid("test/HEAD"));
 
 	cl_assert_equal_i(false, name_is_valid(""));
 	cl_assert_equal_i(false, name_is_valid("-dash"));
+	cl_assert_equal_i(false, name_is_valid("HEAD"));
 }


### PR DESCRIPTION
Sync with vanilla Git, cf. https://github.com/git/git/commit/bbd445d5efd415