### PR TITLE
Fixed memory leak in openssl fips modes

### DIFF
--- a/src/util/hash/openssl.c
+++ b/src/util/hash/openssl.c
@@ -193,8 +193,6 @@ int git_hash_sha1_final(unsigned char *out, git_hash_sha1_ctx *ctx)
 		return -1;
 	}
 
-	ctx->c = NULL;
-
 	return 0;
 }
 
@@ -345,8 +343,6 @@ int git_hash_sha256_final(unsigned char *out, git_hash_sha256_ctx *ctx)
 		git_error_set(GIT_ERROR_SHA, "failed to finalize sha256");
 		return -1;
 	}
-
-	ctx->c = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
Version 1.9.0 introduced a memory leak when using the new FIPS-compliant mode (-DUSE_SHA256=OpenSSL-FIPS). 

The culprit turned out to be the `ctx->c = NULL;` line added to `git_hash_sha256_final` function, which too hastily cleans up a pointer. Because of that, the cleanup function call to EVP_MD_CTX_free(nullptr) doesn't have any effect and the memory is never freed. 

The same applies to SHA1 fips mode. 