### PR TITLE
docs: correct wrong docstring info for git_remote_url

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -249,9 +249,9 @@ GIT_EXTERN(const char *) git_remote_name(const git_remote *remote);
 /**
  * Get the remote's url
  *
- * If url.*.insteadOf has been configured for this URL, it will
- * return the modified URL.  If `git_remote_set_instance_pushurl`
- * has been called for this remote, then that URL will be returned.
+ * If url.*.insteadOf has been configured for this URL, it will return
+ * the modified URL. This function does not consider if a push url has
+ * been configured for this remote (use `git_remote_pushurl` if needed).
  *
  * @param remote the remote
  * @return a pointer to the url


### PR DESCRIPTION
The docstring for `git_remote_url` incorrectly states that this function will return the push URL if it was configured. This is wrong, as it does not (and should not, but `git_remote_pushurl` does - this is probably an oversight from copy/pasting the docstring from the latter function).