### PR TITLE
Avoid duplicate definition of git_http_auth_dummy.

### DIFF
--- a/src/libgit2/transports/auth_sspi.c
+++ b/src/libgit2/transports/auth_sspi.c
@@ -333,11 +333,13 @@ int git_http_auth_negotiate(
 }
 #endif
 
+#ifdef GIT_AUTH_NTLM
 int git_http_auth_ntlm(
 	git_http_auth_context **out,
 	const git_net_url *url)
 {
 	return sspi_init_context(out, GIT_HTTP_AUTH_NTLM, url);
 }
+#endif
 
 #endif /* GIT_WIN32 */

--- a/src/libgit2/transports/auth_sspi.c
+++ b/src/libgit2/transports/auth_sspi.c
@@ -324,12 +324,14 @@ static int sspi_init_context(
 	return 0;
 }
 
+#ifdef GIT_AUTH_NEGOTIATE
 int git_http_auth_negotiate(
 	git_http_auth_context **out,
 	const git_net_url *url)
 {
 	return sspi_init_context(out, GIT_HTTP_AUTH_NEGOTIATE, url);
 }
+#endif
 
 int git_http_auth_ntlm(
 	git_http_auth_context **out,


### PR DESCRIPTION
src\libgit2\transports\auth_negotiate.h redefines git_http_auth_negotiate as git_http_auth_dummy if GIT_AUTH_NEGOTIATE is not defined, which thus leads to the uncommented code actually being a redifintion of git_http_auth_dummy. The linker complained [Windows 11, MSVC 2022 64bit].