### PR TITLE
Fix MSVC cross compilation

### DIFF
--- a/cmake/DefaultCFlags.cmake
+++ b/cmake/DefaultCFlags.cmake
@@ -56,7 +56,7 @@ if(MSVC)
 	set(CMAKE_C_FLAGS_MINSIZEREL "/DNDEBUG /O1 /Oy /GL /Gy ${CRT_FLAG_RELEASE}")
 
 	# /IGNORE:4221 - Ignore empty compilation units
-	set(CMAKE_STATIC_LINKER_FLAGS "/IGNORE:4221")
+	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /IGNORE:4221")
 
 	# /DYNAMICBASE - Address space load randomization (ASLR)
 	# /NXCOMPAT - Data execution prevention (DEP)


### PR DESCRIPTION
Currently, the DefaultCFlags.cmake overrides the
CMAKE_STATIC_LINKER_FLAGS to suppress linker warnings about files with no symbols defined.

This has the side effect of breaking MSVC cross compilation (where CMAKE_STATIC_LINKER_FLAGS is used to specify the /MACHINE:ARCH flag)

This commit make sure we append to CMAKE_STATIC_LINKER_FLAGS instead of replacing its values

The error when trying to cross compile with MSVC is the following:
```
[100%] Linking C static library ..\..\git2.lib
LINK : warning LNK4068: /MACHINE not specified; defaulting to X64
..\util\CMakeFiles\util.dir\alloc.c.obj : fatal error LNK1112: module machine type 'ARM64' conflicts with target machine type 'x64'
```