### PR TITLE
http: Close the proxy connection in ‘reset_parser’.

### DIFF
--- a/src/libgit2/transports/httpclient.c
+++ b/src/libgit2/transports/httpclient.c
@@ -914,6 +914,10 @@ GIT_INLINE(git_http_parser_settings *) http_client_parser_settings(void)
 
 static void reset_parser(git_http_client *client)
 {
+	/* Force the proxy connection to be closed so a fresh connection is
+	   opened for the next CONNECT request.  */
+	client->proxy_connected = 0;
+
 	git_http_parser_init(&client->parser,
 	                     GIT_HTTP_PARSER_RESPONSE,
 	                     http_client_parser_settings());


### PR DESCRIPTION
Fixes #7081

Previously the HTTP transport would fail to follow HTTP redirects to a different server when using a proxy because the proxy connection would be marked as “alive” even though the proxy had closed it following completion of the ‘CONNECT’ request to the initial server.

This patch ensures the proxy connection is closed so a fresh connection is later opened by ‘generate_connect_request’ when connecting to the target server.