### PR TITLE
ssh: use more compatible git commands over ssh

### DIFF
--- a/src/libgit2/transports/ssh_exec.c
+++ b/src/libgit2/transports/ssh_exec.c
@@ -158,7 +158,7 @@ static int get_ssh_cmdline(
 	else if ((error = git_config__get_string_buf(&ssh_cmd, cfg, "core.sshcommand")) < 0 && error != GIT_ENOTFOUND)
 		goto done;
 
-	error = git_str_printf(out, "%s %s %s \"%s%s%s\" \"%s\" \"%s\"",
+	error = git_str_printf(out, "%s %s %s \"%s%s%s\" \"%s '%s'\"",
 		ssh_cmd.size > 0 ? ssh_cmd.ptr : default_ssh_cmd,
 		url->port_specified ? "-p" : "",
 		url->port_specified ? url->port : "",


### PR DESCRIPTION
git runs commands as "git-upload-pack 'path-to-repo'", and some servers enforce the single-quoted syntax. Emulate this.

Fixes #7063