### PR TITLE
git_merge_file_from_index: handle cases when a child (ours or theirs) is null

### DIFF
--- a/src/libgit2/merge.h
+++ b/src/libgit2/merge.h
@@ -165,6 +165,10 @@ GIT_INLINE(const char *) git_merge_file__best_path(
 	if (!ancestor) {
 		if (ours && theirs && strcmp(ours, theirs) == 0)
 			return ours;
+		if (ours && !theirs)
+			return ours;
+		if (theirs && !ours)
+			return theirs;
 
 		return NULL;
 	}

--- a/tests/libgit2/merge/files.c
+++ b/tests/libgit2/merge/files.c
@@ -175,6 +175,52 @@ void test_merge_files__automerge_from_index(void)
 	git_merge_file_result_free(&result);
 }
 
+void test_merge_files__automerge_from_index_delete_file(void)
+{
+	git_merge_file_result result = {0};
+	git_index_entry ancestor, theirs, *ours = NULL;
+
+	git_oid_from_string(&ancestor.id, "d427e0b2e138501a3d15cc376077a3631e15bd46", GIT_OID_SHA1);
+	ancestor.path = "automergeable.txt";
+	ancestor.mode = GIT_FILEMODE_BLOB;
+
+	git_oid_from_string(&theirs.id, "d427e0b2e138501a3d15cc376077a3631e15bd46", GIT_OID_SHA1);
+	theirs.path = "automergeable.txt";
+	theirs.mode = GIT_FILEMODE_BLOB;
+
+	cl_git_pass(git_merge_file_from_index(&result, repo,
+		&ancestor, ours, &theirs, 0));
+
+	cl_assert_equal_i(1, result.automergeable);
+
+	cl_assert_equal_s(NULL, result.path);
+	cl_assert_equal_i(GIT_FILEMODE_UNREADABLE, result.mode);
+
+	cl_assert_equal_i(0, result.len);
+
+	git_merge_file_result_free(&result);
+}
+
+void test_merge_files__automerge_from_index_add_file(void)
+{
+	git_merge_file_result result = {0};
+	git_index_entry *ancestor=NULL, ours, *theirs=NULL;
+
+	git_oid_from_string(&ours.id, "d427e0b2e138501a3d15cc376077a3631e15bd46", GIT_OID_SHA1);
+	ours.path = "automergeable.txt";
+	ours.mode = GIT_FILEMODE_BLOB;
+
+	cl_git_pass(git_merge_file_from_index(&result, repo,
+		ancestor, &ours, theirs, 0));
+
+	cl_assert_equal_i(1, result.automergeable);
+
+	cl_assert_equal_s("automergeable.txt", result.path);
+	cl_assert_equal_i(GIT_FILEMODE_BLOB, result.mode);
+
+	git_merge_file_result_free(&result);
+}
+
 void test_merge_files__automerge_whitespace_eol(void)
 {
 	git_merge_file_input ancestor = GIT_MERGE_FILE_INPUT_INIT,


### PR DESCRIPTION
Within `git_merge_file_from_index`, it should be possible to handle cases where either one of the children is `NULL`.

- When a file is deleted, `ancestor` and one child will be set and the other one is `NULL`.
- When a file is added, one child will be set and `ancestor` and the other child will be `NULL`.

Improve `git_merge_file_from_index` by adding support to having one (or both) children being `NULL`.