### PR TITLE
Support for shallow-since clones/fetches

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -762,7 +762,10 @@ typedef enum {
 	GIT_FETCH_DEPTH_FULL = 0,
 
 	/** The fetch should "unshallow" and fetch missing data. */
-	GIT_FETCH_DEPTH_UNSHALLOW = 2147483647
+	GIT_FETCH_DEPTH_UNSHALLOW = 2147483647,
+
+	/** No "shallow-since" date specified. */
+	GIT_FETCH_SINCE_UNSPECIFIED = -1
 } git_fetch_depth_t;
 
 /**
@@ -808,11 +811,21 @@ typedef struct {
 	/**
 	 * Depth of the fetch to perform, or `GIT_FETCH_DEPTH_FULL`
 	 * (or `0`) for full history, or `GIT_FETCH_DEPTH_UNSHALLOW`
-	 * to "unshallow" a shallow repository.
+	 * to "unshallow" a shallow repository. Cannot be used in
+	 * conjunction with a specific shallow_since date.
 	 *
 	 * The default is full (`GIT_FETCH_DEPTH_FULL` or `0`).
 	 */
 	int depth;
+
+	/**
+	 * Date from which to fetch history, or 'GIT_FETCH_SINCE_UNSPECIFIED'
+	 * to fetch all history.
+	 * Cannot be used in conjuction with a specific depth.
+	 *
+	 * The default is to fetch all history (`GIT_FETCH_SINCE_UNSPECIFIED` or `-1`).
+	 */
+	git_time_t shallow_since;
 
 	/**
 	 * Whether to allow off-site redirects.  If this is not
@@ -837,7 +850,11 @@ typedef struct {
 	GIT_FETCH_PRUNE_UNSPECIFIED, \
 	GIT_REMOTE_UPDATE_FETCHHEAD, \
 	GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED, \
-	GIT_PROXY_OPTIONS_INIT }
+	GIT_PROXY_OPTIONS_INIT, \
+	GIT_FETCH_DEPTH_FULL, \
+	GIT_FETCH_SINCE_UNSPECIFIED, \
+	GIT_REMOTE_REDIRECT_NONE \
+}
 
 /**
  * Initialize git_fetch_options structure

--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -38,6 +38,7 @@ typedef struct {
 	git_oid *shallow_roots;
 	size_t shallow_roots_len;
 	int depth;
+	git_time_t shallow_since;
 } git_fetch_negotiation;
 
 struct git_transport {

--- a/src/libgit2/fetch.c
+++ b/src/libgit2/fetch.c
@@ -177,6 +177,7 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 	if (opts) {
 		GIT_ASSERT_ARG(opts->depth >= 0);
 		remote->nego.depth = opts->depth;
+		remote->nego.shallow_since = opts->shallow_since;
 	}
 
 	if (filter_wants(remote, opts) < 0)

--- a/src/libgit2/fetch.c
+++ b/src/libgit2/fetch.c
@@ -178,6 +178,8 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 		GIT_ASSERT_ARG(opts->depth >= 0);
 		remote->nego.depth = opts->depth;
 		remote->nego.shallow_since = opts->shallow_since;
+	} else {
+		remote->nego.shallow_since = GIT_FETCH_SINCE_UNSPECIFIED;
 	}
 
 	if (filter_wants(remote, opts) < 0)

--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -303,6 +303,12 @@ static int local_negotiate_fetch(
 		git_error_set(GIT_ERROR_NET, "shallow fetch is not supported by the local transport");
 		return GIT_ENOTSUPPORTED;
 	}
+	if (wants->shallow_since != GIT_FETCH_SINCE_UNSPECIFIED) {
+		git_error_set(
+		        GIT_ERROR_NET,
+		        "shallow-since fetch is not supported by the local transport");
+		return GIT_ENOTSUPPORTED;
+	}
 
 	/* Fill in the loids */
 	git_vector_foreach(&t->refs, i, rhead) {

--- a/src/libgit2/transports/smart_pkt.c
+++ b/src/libgit2/transports/smart_pkt.c
@@ -828,12 +828,39 @@ int git_pkt_buffer_wants(
 	}
 
 	if (wants->depth > 0) {
+
+		if (wants->shallow_since != GIT_FETCH_SINCE_UNSPECIFIED) {
+			git_error_set(
+			        GIT_ERROR_NET,
+			        "depth and shallow-since must not be used together");
+			return GIT_ENOTSUPPORTED;
+		}
+
 		git_str deepen_buf = GIT_STR_INIT;
 
 		git_str_printf(&deepen_buf, "deepen %d\n", wants->depth);
 		git_str_printf(buf,"%04x%s", (unsigned int)git_str_len(&deepen_buf) + 4, git_str_cstr(&deepen_buf));
 
 		git_str_dispose(&deepen_buf);
+
+		if (git_str_oom(buf))
+			return -1;
+
+	} else if (wants->shallow_since != GIT_FETCH_SINCE_UNSPECIFIED) {
+
+		git_str shallow_since_buf = GIT_STR_INIT;
+
+		/* The git command-line option is "shallow-since", but the protocol uses "deepen-since" */
+		git_str_printf(
+		        &shallow_since_buf, "deepen-since %d\n",
+		        wants->shallow_since);
+
+		git_str_printf(
+		        buf, "%04x%s",
+		        (unsigned int)git_str_len(&shallow_since_buf) + 4,
+		        git_str_cstr(&shallow_since_buf));
+
+		git_str_dispose(&shallow_since_buf);
 
 		if (git_str_oom(buf))
 			return -1;

--- a/src/libgit2/transports/smart_protocol.c
+++ b/src/libgit2/transports/smart_protocol.c
@@ -435,7 +435,7 @@ int git_smart__negotiate_fetch(
 	if ((error = git_revwalk__push_glob(walk, "refs/*", &opts)) < 0)
 		goto on_error;
 
-	if (wants->depth > 0) {
+	if (wants->depth > 0 || wants->shallow_since != GIT_FETCH_SINCE_UNSPECIFIED) {
 		git_pkt_shallow *pkt;
 
 		if ((error = git_smart__negotiation_step(&t->parent, data.ptr, data.size)) < 0)

--- a/tests/libgit2/online/shallow.c
+++ b/tests/libgit2/online/shallow.c
@@ -137,7 +137,7 @@ void test_online_shallow__clone_since_oldest(void)
 	size_t num_commits = 0;
 	int error = 0;
 
-	/* Specify a date before the old commit. */
+	/* Specify a date before the oldest commit. */
 	git_time_t since_date;
 	cl_git_pass(git_date_parse(&since_date,"2005-04-05"));
 	clone_opts.fetch_opts.shallow_since = since_date;
@@ -234,7 +234,7 @@ void test_online_shallow__clone_since_recent(void)
 	size_t num_commits = 0;
 	int error = 0;
 
-	/* Specify a date between the oldest and most recent commit. */
+	/* Specify a date newer than the most recent commit. */
 	git_time_t since_date;
 	cl_git_pass(git_date_parse(&since_date, "2025-04-07 22:30:00 UTC"));
 	clone_opts.fetch_opts.shallow_since = since_date;

--- a/tests/libgit2/online/shallow.c
+++ b/tests/libgit2/online/shallow.c
@@ -1,6 +1,7 @@
 #include "clar_libgit2.h"
 #include "futils.h"
 #include "repository.h"
+#include "date.h"
 
 static int remote_single_branch(git_remote **out, git_repository *repo, const char *name, const char *url, void *payload)
 {
@@ -121,6 +122,135 @@ void test_online_shallow__clone_depth_five(void)
 	git__free(roots);
 	git_str_dispose(&path);
 	git_revwalk_free(walk);
+	git_repository_free(repo);
+}
+
+void test_online_shallow__clone_since_oldest(void)
+{
+	git_str path = GIT_STR_INIT;
+	git_repository *repo;
+	git_revwalk *walk;
+	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+	git_oid oid;
+	git_oid *roots;
+	size_t roots_len;
+	size_t num_commits = 0;
+	int error = 0;
+
+	/* Specify a date before the old commit. */
+	git_time_t since_date;
+	cl_git_pass(git_date_parse(&since_date,"2005-04-05"));
+	clone_opts.fetch_opts.shallow_since = since_date;
+	clone_opts.remote_cb = remote_single_branch;
+
+	git_str_joinpath(&path, clar_sandbox_path(), "shallowclone_old");
+
+	cl_git_pass(git_clone(
+	        &repo, "https://github.com/libgit2/TestGitRepository",
+	        git_str_cstr(&path), &clone_opts));
+
+	cl_assert_equal_b(false, git_repository_is_shallow(repo));
+
+	cl_git_pass(git_repository__shallow_roots(&roots, &roots_len, repo));
+	cl_assert_equal_i(0, roots_len);
+
+	git_revwalk_new(&walk, repo);
+
+	git_revwalk_push_head(walk);
+
+	while ((error = git_revwalk_next(&oid, walk)) == GIT_OK) {
+		num_commits++;
+	}
+
+	cl_assert_equal_i(num_commits, 21);
+	cl_assert_equal_i(error, GIT_ITEROVER);
+
+	git__free(roots);
+	git_str_dispose(&path);
+	git_revwalk_free(walk);
+	git_repository_free(repo);
+}
+
+void test_online_shallow__clone_since_midpoint(void)
+{
+	git_str path = GIT_STR_INIT;
+	git_repository *repo;
+	git_revwalk *walk;
+	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+	git_oid oid;
+	git_oid *roots;
+	size_t roots_len;
+	size_t num_commits = 0;
+	int error = 0;
+
+	/* Specify a date between the oldest and most recent commit. */
+	git_time_t since_date;
+	cl_git_pass(git_date_parse(&since_date, "2005-04-07 22:30:00 UTC"));
+	clone_opts.fetch_opts.shallow_since = since_date;
+	clone_opts.remote_cb = remote_single_branch;
+
+	git_str_joinpath(&path, clar_sandbox_path(), "shallowclone_midpoint");
+
+	cl_git_pass(git_clone(
+	        &repo, "https://github.com/libgit2/TestGitRepository",
+	        git_str_cstr(&path), &clone_opts));
+
+	cl_assert_equal_b(true, git_repository_is_shallow(repo));
+
+	cl_git_pass(git_repository__shallow_roots(&roots, &roots_len, repo));
+	cl_assert_equal_i(3, roots_len);
+	cl_assert_equal_s(
+	        "d0114ab8ac326bab30e3a657a0397578c5a1af88",
+	        git_oid_tostr_s(&roots[0]));
+	cl_assert_equal_s(
+	        "49322bb17d3acc9146f98c97d078513228bbf3c0",
+	        git_oid_tostr_s(&roots[1]));
+	cl_assert_equal_s(
+	        "f73b95671f326616d66b2afb3bdfcdbbce110b44",
+	        git_oid_tostr_s(&roots[2]));
+
+	git_revwalk_new(&walk, repo);
+
+	git_revwalk_push_head(walk);
+
+	while ((error = git_revwalk_next(&oid, walk)) == GIT_OK) {
+		num_commits++;
+	}
+
+	cl_assert_equal_i(num_commits, 1);
+	cl_assert_equal_i(error, GIT_ITEROVER);
+
+	git__free(roots);
+	git_str_dispose(&path);
+	git_revwalk_free(walk);
+	git_repository_free(repo);
+}
+
+void test_online_shallow__clone_since_recent(void)
+{
+	git_str path = GIT_STR_INIT;
+	git_repository *repo;
+	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+	size_t num_commits = 0;
+	int error = 0;
+
+	/* Specify a date between the oldest and most recent commit. */
+	git_time_t since_date;
+	cl_git_pass(git_date_parse(&since_date, "2025-04-07 22:30:00 UTC"));
+	clone_opts.fetch_opts.shallow_since = since_date;
+	clone_opts.remote_cb = remote_single_branch;
+
+	git_str_joinpath(&path, clar_sandbox_path(), "shallowclone_recent");
+
+	error = git_clone(
+	        &repo, "https://github.com/libgit2/TestGitRepository",
+	        git_str_cstr(&path), &clone_opts);
+
+	/* Command-line git gives a different (but no more useful) error in this
+	 * case - "error processing shallow info: 4". */
+	cl_assert_equal_i(error, GIT_EEOF);
+
+	git_str_dispose(&path);
 	git_repository_free(repo);
 }
 


### PR DESCRIPTION
Support for the Git "shallow-since" option for clone/fetch. In the Git protocol the term "deepen-since" is used. The implementation below works well when the specified date is older than the newest commit - i.e. when there are commits to fetch.

The Git command-line gives a very poor error when the date specified is newer than newest last commit - i.e. no commits to fetch. The message is "error processing shallow info: 4".

Unfortunately, with this change libgit2 gives an even poorer error (GIT_EEOF). See the function: test_online_shallow__clone_since_recent.

With packet tracing enabled in the Git command-line I can see a "0002" message arriving after the one about "refs/tags/nearly-dangling". But in my test this doesn't seem to arrive, and we get GIT_EEOF in the call to recv_pkt at smart_protocol.c:447 instead.