### PR TITLE
Fix mishandling of empty trailer values. Strip trailing whitespace from trailer values.

### DIFF
--- a/src/libgit2/trailer.c
+++ b/src/libgit2/trailer.c
@@ -368,6 +368,12 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 				}
 
 				value = ptr;
+
+				if (*ptr == '\n')
+			        {
+				        NEXT(S_VALUE_NL);
+			        }
+
 				NEXT(S_VALUE);
 			}
 			case S_VALUE: {
@@ -387,7 +393,14 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 					NEXT(S_VALUE);
 				}
 
-				ptr[-1] = 0;
+				/* Trim trailing whitespace. */
+			        char *end_of_value = ptr - 1;
+			        while (end_of_value > value &&
+			               (*(end_of_value - 1) == ' ' ||
+			                *(end_of_value - 1) == '\t'))
+				        end_of_value--;
+			        *end_of_value = 0;
+
 				GOTO(S_VALUE_END);
 			}
 			case S_VALUE_END: {

--- a/tests/libgit2/message/trailer.c
+++ b/tests/libgit2/message/trailer.c
@@ -55,14 +55,14 @@ void test_message_trailer__no_whitespace(void)
 void test_message_trailer__extra_whitespace(void)
 {
 	git_message_trailer trailers[] = {
-		{"Key", "value"},
+		{"Key", "value with leading and trailing spaces"},
 		{NULL, NULL},
 	};
 
 	assert_trailers(
 		"Message\n"
 		"\n"
-		"Key   :   value\n"
+		"Key   :   value with leading and trailing spaces  \n"
 	, trailers);
 }
 
@@ -93,6 +93,23 @@ void test_message_trailer__not_last_paragraph(void)
 		"\n"
 		"More stuff\n"
 	, trailers);
+}
+
+void test_message_trailer__empty_value(void)
+{
+	git_message_trailer trailers[] = {
+		{ "EmptyValue", "" },
+		{ "Another", "trailer here" },
+		{ "YetAnother", "trailer" },
+		{ NULL, NULL },
+	};
+	assert_trailers(
+	        "Message\n"
+	        "\n"
+	        "EmptyValue:     \n"
+	        "Another: trailer here\n"
+	        "YetAnother: trailer\n",
+	    trailers);
 }
 
 void test_message_trailer__conflicts(void)


### PR DESCRIPTION
Adjust behaviour of git_message_trailers to match that of "git interpret-trailers" when the trailer has an empty value or trailing whitespace.

closes #7094