### PR TITLE
New function git_message_trailers_ext, providing the same options as "git interpret-trailers"

### DIFF
--- a/include/git2/message.h
+++ b/include/git2/message.h
@@ -60,6 +60,18 @@ typedef struct {
 } git_message_trailer_array;
 
 /**
+ * Options to be passed to git_message_trailers_ext.
+ */
+typedef struct {
+       int trim_empty;
+       int no_divider;
+       int unfold;
+} git_message_trailers_options;
+
+/** Static constructor for `git_message_trailers_options` */
+#define GIT_MESSAGE_TRAILERS_OPTIONS_INIT { FALSE, FALSE, FALSE }
+
+/**
  * Parse trailers out of a message, filling the array pointed to by +arr+.
  *
  * Trailers are key/value pairs in the last paragraph of a message, not
@@ -71,6 +83,15 @@ typedef struct {
  * @return 0 on success, or non-zero on error.
  */
 GIT_EXTERN(int) git_message_trailers(git_message_trailer_array *arr, const char *message);
+
+/**
+ * Parse trailers out of a message, with extended options.
+ */
+GIT_EXTERN(int)
+git_message_trailers_ext(
+        git_message_trailer_array *arr,
+        const char *message,
+        const git_message_trailers_options *opts);
 
 /**
  * Clean's up any allocated memory in the git_message_trailer_array filled by

--- a/src/libgit2/trailer.c
+++ b/src/libgit2/trailer.c
@@ -21,6 +21,12 @@ static const char *const git_generated_prefixes[] = {
 	NULL
 };
 
+static int is_linear_whitespace(char c)
+{
+	/* See RFC 822 */
+	return c == ' ' || c == '\t';
+}
+
 static int is_blank_line(const char *str)
 {
 	const char *s = str;
@@ -95,7 +101,8 @@ static bool find_separator(size_t *out, const char *line, const char *separators
 
 		if (!whitespace_found && (git__isalnum(*c) || *c == '-'))
 			continue;
-		if (c != line && (*c == ' ' || *c == '\t')) {
+		if (c != line && is_linear_whitespace(*c))
+			{
 			whitespace_found = 1;
 			continue;
 		}
@@ -258,9 +265,13 @@ static size_t find_trailer_end(const char *buf, size_t len)
 	return len - ignore_non_trailer(buf, len);
 }
 
-static char *extract_trailer_block(const char *message, size_t *len)
+static char *extract_trailer_block(
+        const char *message,
+        size_t *len,
+        const git_message_trailers_options* options)
 {
-	size_t patch_start = find_patch_start(message);
+	int no_divider = options && options->no_divider;
+	size_t patch_start = (no_divider) ? strlen(message) : find_patch_start(message);
 	size_t trailer_end = find_trailer_end(message, patch_start);
 	size_t trailer_start = find_trailer_start(message, trailer_end);
 
@@ -285,8 +296,9 @@ enum trailer_state {
 	S_SEP_WS = 3,
 	S_VALUE = 4,
 	S_VALUE_NL = 5,
-	S_VALUE_END = 6,
-	S_IGNORE = 7
+	S_VALUE_CONT = 6,
+	S_VALUE_END = 7,
+	S_IGNORE = 8
 };
 
 #define NEXT(st) { state = (st); ptr++; continue; }
@@ -294,7 +306,10 @@ enum trailer_state {
 
 typedef git_array_t(git_message_trailer) git_array_trailer_t;
 
-int git_message_trailers(git_message_trailer_array *trailer_arr, const char *message)
+int git_message_trailers_ext(
+        git_message_trailer_array *trailer_arr,
+        const char *message,
+        const git_message_trailers_options *options)
 {
 	enum trailer_state state = S_START;
 	int rc = 0;
@@ -303,8 +318,11 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 	char *value = NULL;
 	git_array_trailer_t arr = GIT_ARRAY_INIT;
 
+	int unfold = options && options->unfold;
+	char *unfolded_value_end = NULL;
+
 	size_t trailer_len;
-	char *trailer = extract_trailer_block(message, &trailer_len);
+	char *trailer = extract_trailer_block(message, &trailer_len, options);
 	if (trailer == NULL)
 		return -1;
 
@@ -328,7 +346,7 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 					NEXT(S_KEY);
 				}
 
-				if (*ptr == ' ' || *ptr == '\t') {
+				if (is_linear_whitespace(*ptr)) {
 					/* optional whitespace before separator */
 					*ptr = 0;
 					NEXT(S_KEY_WS);
@@ -347,7 +365,7 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 					goto ret;
 				}
 
-				if (*ptr == ' ' || *ptr == '\t') {
+				if (is_linear_whitespace(*ptr)) {
 					NEXT(S_KEY_WS);
 				}
 
@@ -363,7 +381,7 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 					goto ret;
 				}
 
-				if (*ptr == ' ' || *ptr == '\t') {
+				if (is_linear_whitespace(*ptr)) {
 					NEXT(S_SEP_WS);
 				}
 
@@ -385,32 +403,60 @@ int git_message_trailers(git_message_trailer_array *trailer_arr, const char *mes
 					NEXT(S_VALUE_NL);
 				}
 
+				if (unfolded_value_end)
+				        *unfolded_value_end++ = *ptr;
+
 				NEXT(S_VALUE);
 			}
 			case S_VALUE_NL: {
-				if (*ptr == ' ') {
+			        if (is_linear_whitespace(*ptr)) {
 					/* continuation; */
-					NEXT(S_VALUE);
+				        if (unfold) {
+					        if (!unfolded_value_end) {
+						        unfolded_value_end =
+						                ptr - 1;
+					        }
+					        /* replace newline with a single space. */
+					        *unfolded_value_end++ = ' ';
+				        }
+				        NEXT(S_VALUE_CONT);
 				}
 
 				/* Trim trailing whitespace. */
 			        char *end_of_value = ptr - 1;
 			        while (end_of_value > value &&
-			               (*(end_of_value - 1) == ' ' ||
-			                *(end_of_value - 1) == '\t'))
+			               is_linear_whitespace(*(end_of_value - 1)))
 				        end_of_value--;
 			        *end_of_value = 0;
 
 				GOTO(S_VALUE_END);
 			}
-			case S_VALUE_END: {
-				git_message_trailer *t = git_array_alloc(arr);
+		        case S_VALUE_CONT: {
+			        if (is_linear_whitespace(*ptr)) {
+				        /* leading whitespace before continuation of value; */
+				        NEXT(S_VALUE_CONT);
+			        }
+			        if (unfold) {
+				        *unfolded_value_end++ = *ptr;
+			        }
+			        NEXT(S_VALUE);
+		        }
+		        case S_VALUE_END: {
 
-				t->key = key;
-				t->value = value;
+				if (unfolded_value_end) {
+				        *unfolded_value_end++ = 0;
+				}
+
+				if (!options || !options->trim_empty || strlen(value)) {
+				        git_message_trailer *t =
+				                git_array_alloc(arr);
+				        t->key = key;
+				        t->value = value;
+			        }
 
 				key = NULL;
 				value = NULL;
+			        unfolded_value_end = NULL;
 
 				GOTO(S_START);
 			}
@@ -435,6 +481,12 @@ ret:
 
 	return rc;
 }
+
+int git_message_trailers(git_message_trailer_array *trailer_arr, const char *message)
+{
+	return git_message_trailers_ext(trailer_arr, message, NULL);
+}
+
 
 void git_message_trailer_array_free(git_message_trailer_array *arr)
 {

--- a/tests/libgit2/message/trailer.c
+++ b/tests/libgit2/message/trailer.c
@@ -1,23 +1,49 @@
 #include "clar_libgit2.h"
 
+
+static assert_trailer_array(
+        const git_message_trailer_array *actual,
+        git_message_trailer *expected)
+
+{
+	size_t i, count;
+	for (i = 0, count = 0; expected[i].key != NULL; i++, count++)
+		;
+
+	cl_assert_equal_i((int)actual->count, (int)count); /* see issue #7095. */
+
+	for (i = 0; i < actual->count; i++) {
+		cl_assert_equal_s(actual->trailers[i].key, expected[i].key);
+		cl_assert_equal_s(
+		        actual->trailers[i].value, expected[i].value);
+	}
+}
+
 static void assert_trailers(const char *message, git_message_trailer *trailers)
 {
 	git_message_trailer_array arr;
-	size_t i, count;
 
 	int rc = git_message_trailers(&arr, message);
 
 	cl_assert_equal_i(0, rc);
 
-	for (i = 0, count = 0; trailers[i].key != NULL; i++, count++)
-		;
+	assert_trailer_array(&arr, trailers);
 
-	cl_assert_equal_sz(arr.count, count);
+	git_message_trailer_array_free(&arr);
+}
 
-	for (i=0; i < count; i++) {
-		cl_assert_equal_s(arr.trailers[i].key, trailers[i].key);
-		cl_assert_equal_s(arr.trailers[i].value, trailers[i].value);
-	}
+static void assert_trailers_ext(
+        const char *message,
+        git_message_trailer *trailers,
+        const git_message_trailers_options *opts)
+{
+	git_message_trailer_array arr;
+
+	int rc = git_message_trailers_ext(&arr, message, opts);
+
+	cl_assert_equal_i(0, rc);
+
+	assert_trailer_array(&arr, trailers);
 
 	git_message_trailer_array_free(&arr);
 }
@@ -30,12 +56,23 @@ void test_message_trailer__simple(void)
 		{NULL, NULL},
 	};
 
-	assert_trailers(
-		"Message\n"
+	const char* message = "Message\n"
 		"\n"
 		"Signed-off-by: foo@bar.com\n"
-		"Signed-off-by: someone@else.com\n"
-	, trailers);
+		"Signed-off-by: someone@else.com\n";
+
+	assert_trailers(message, trailers);
+	assert_trailers_ext(message, trailers,NULL);
+
+	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+	assert_trailers_ext(message, trailers,&options);
+
+	/* The options all make no difference in this simple case. */
+	options.trim_empty = TRUE;
+	options.no_divider = TRUE;
+	options.unfold = TRUE;
+	assert_trailers_ext(message, trailers, &options);
 }
 
 void test_message_trailer__no_whitespace(void)
@@ -52,6 +89,18 @@ void test_message_trailer__no_whitespace(void)
 	, trailers);
 }
 
+void test_message_trailer__no_empty_line(void)
+{
+	git_message_trailer trailers[] = {
+		{ NULL, NULL },
+	};
+
+	assert_trailers(
+	        "Message\n"
+	        "Key:value\n",
+	        trailers);
+}
+
 void test_message_trailer__extra_whitespace(void)
 {
 	git_message_trailer trailers[] = {
@@ -66,7 +115,7 @@ void test_message_trailer__extra_whitespace(void)
 	, trailers);
 }
 
-void test_message_trailer__no_newline(void)
+void test_message_trailer__no_trailing_newline(void)
 {
 	git_message_trailer trailers[] = {
 		{"Key", "value"},
@@ -103,13 +152,21 @@ void test_message_trailer__empty_value(void)
 		{ "YetAnother", "trailer" },
 		{ NULL, NULL },
 	};
-	assert_trailers(
-	        "Message\n"
-	        "\n"
-	        "EmptyValue:     \n"
-	        "Another: trailer here\n"
-	        "YetAnother: trailer\n",
-	    trailers);
+	const char *message = "Message\n"
+	                      "\n"
+	                      "EmptyValue:     \n"
+	                      "Another: trailer here\n"
+	                      "YetAnother: trailer\n";
+	assert_trailers(message, trailers);
+	assert_trailers_ext(message, trailers,NULL);
+
+    	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+
+	assert_trailers_ext(message, trailers, &options);
+
+	options.trim_empty = TRUE;
+	assert_trailers_ext(message, &trailers[1], &options);
 }
 
 void test_message_trailer__conflicts(void)
@@ -131,60 +188,155 @@ void test_message_trailer__conflicts(void)
 
 void test_message_trailer__patch(void)
 {
+	/* When the "---" line is treated as a divider the
+	 * "Key" line is a trailer.
+	 */
 	git_message_trailer trailers[] = {
 		{"Key", "value"},
 		{NULL, NULL},
 	};
 
-	assert_trailers(
-		"Message\n"
-		"\n"
-		"Key: value\n"
-		"\n"
-		"---\n"
-		"More: stuff\n"
-	, trailers);
+	/* When the "---" is not treated as a divider the
+	 * "More" line is the trailer.
+	 */
+	git_message_trailer ext_trailers[] = {
+		{ "More", "stuff" },
+		{ NULL, NULL },
+	};
+	const char *message = "Message\n"
+	                      "\n"
+	                      "Key: value\n"
+	                      "\n"
+	                      "---\n"
+	                      "\n"
+	                      "More: stuff\n";
+	assert_trailers(message, trailers);
+
+	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+	assert_trailers_ext(message, trailers, &options);
+
+	options.no_divider = TRUE;
+	assert_trailers_ext(message, ext_trailers, &options);
+}
+
+void test_message_trailer__groups(void)
+{
+	git_message_trailer trailers[] = {
+		{ "More", "stuff" },
+		{ NULL, NULL },
+	};
+
+	const char *message = "Message\n"
+	                      "\n"
+	                      "Key: value\n"
+	                      "\n"
+	                      "A non-trailer line between two lines that look like trailers\n"
+	                      "\n"
+	                      "More: stuff\n";
+	assert_trailers(message, trailers);
+
+	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+	assert_trailers_ext(message, trailers, &options);
+
+	options.no_divider = TRUE;
+	assert_trailers_ext(message, trailers, &options);
 }
 
 void test_message_trailer__continuation(void)
 {
 	git_message_trailer trailers[] = {
-		{"A", "b\n c"},
-		{"D", "e\n f: g h"},
+		{"A", "bxy\n    cdef"},
+		{"D", "e\n    f: g  h"},
 		{"I", "j"},
 		{NULL, NULL},
 	};
 
-	assert_trailers(
-		"Message\n"
-		"\n"
-		"A: b\n"
-		" c\n"
-		"D: e\n"
-		" f: g h\n"
-		"I: j\n"
-	, trailers);
+	git_message_trailer unfolded_trailers[] = {
+		{ "A", "bxy cdef" },
+		{ "D", "e f: g  h" },
+		{ "I", "j" },
+		{ NULL, NULL },
+	};
+
+	const char *message = "Message\n"
+	                "\n"
+	                "A: bxy\n"
+	                "    cdef\n"
+	                "D: e\n"
+	                "    f: g  h\n"
+	                "I: j\n";
+	assert_trailers(message, trailers);
+
+	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+	assert_trailers_ext(message, trailers, &options);
+
+	options.unfold = TRUE;
+	assert_trailers_ext(message, unfolded_trailers, &options);
+}
+
+void test_message_trailer__continuation_tab(void)
+{
+	git_message_trailer trailers[] = {
+		{ "A", "b\n c" },
+		{ "D", "e\n\t\tf: g \th" },
+		{ "I", "j" },
+		{ NULL, NULL },
+	};
+
+	git_message_trailer unfolded_trailers[] = {
+		{ "A", "b c" },
+		{ "D", "e f: g \th" },
+		{ "I", "j" },
+		{ NULL, NULL },
+	};
+
+	const char *message = "Message\n"
+	                      "\n"
+	                      "A: b\n"
+	                      " c\n"
+	                      "D: e\n"
+	                      "\t\tf: g \th\n"
+	                      "I: j\n";
+	assert_trailers(message, trailers);
+
+	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+	assert_trailers_ext(message, trailers, &options);
+
+	options.unfold = TRUE;
+	assert_trailers_ext(message, unfolded_trailers, &options);
 }
 
 void test_message_trailer__invalid(void)
 {
+	/* A badly-formed trailer between two valid trailers
+	 * is ignored as long as there are no empty lines inbetween.
+	 */
 	git_message_trailer trailers[] = {
 		{"Signed-off-by", "some@one.com"},
 		{"Another", "trailer"},
 		{NULL, NULL},
 	};
 
-	assert_trailers(
-		"Message\n"
-		"\n"
-		"Signed-off-by: some@one.com\n"
-		"Not a trailer\n"
-		"Another: trailer\n"
-	, trailers);
+	const char *message = "Message\n"
+	                      "\n"
+	                      "Signed-off-by: some@one.com\n"
+	                      "Not a trailer\n"
+	                      "Another: trailer\n";
+	assert_trailers(message, trailers);
+
+	git_message_trailers_options options =
+	        GIT_MESSAGE_TRAILERS_OPTIONS_INIT;
+	options.unfold = TRUE;
+	assert_trailers_ext(message, trailers, &options);
 }
 
 void test_message_trailer__ignores_dashes(void)
 {
+	/* More than three dashes is not a divider. */
 	git_message_trailer trailers[] = {
 		{ "Signed-off-by", "some@one.com" },
 		{ "Another", "trailer" },


### PR DESCRIPTION
To provide the full trailer-parsing behaviour of "git interpret-trailers", this new function provides additional options to the git_message_trailers functionality. Specifically:

* trim_empty - which optionally discards trailers with empty values.
* no_divider - which optionally ignores "---" lines, that otherwise indicate the end of the message and the beginning of a "patch".
* unfold - which optionally combines multi-line trailer values into a single line.

closes #6864