### PR TITLE
clar: Fix compilation on systems without ‘PATH_MAX’ (GNU/Hurd).

### DIFF
--- a/tests/clar/clar.h
+++ b/tests/clar/clar.h
@@ -14,6 +14,8 @@
 # define CLAR_MAX_PATH 4096
 #elif defined(_WIN32)
 # define CLAR_MAX_PATH MAX_PATH
+#elif !defined(PATH_MAX)			  /* GNU/Hurd */
+# define CLAR_MAX_PATH 4096
 #else
 # define CLAR_MAX_PATH PATH_MAX
 #endif


### PR DESCRIPTION
This fixes a regression introduced in
72d49bb0de6fe6e246120eeec80b90ad3e23b774 (between 1.9.0 and 1.9.1) preventing (cross-)compilation to the Hurd, where ‘PATH_MAX’ is undefined (there is no predefined limit on the maximum size of a file name).

I realize libgit2 is downstream of clar but thought it might still make sense to include it here.  WDYT?