### PR TITLE
Introduction of the "refFormat" extension

### DIFF
--- a/include/git2/refdb.h
+++ b/include/git2/refdb.h
@@ -21,6 +21,11 @@
  */
 GIT_BEGIN_DECL
 
+/** The type of the refdb as determined by "extensions.refStorage". */
+typedef enum {
+	GIT_REFDB_FILES = 1 /**< Files backend using loose and packed refs. */
+} git_refdb_t;
+
 /**
  * Create a new reference database with no backends.
  *

--- a/include/git2/repository.h
+++ b/include/git2/repository.h
@@ -11,6 +11,7 @@
 #include "types.h"
 #include "oid.h"
 #include "odb.h"
+#include "refdb.h"
 #include "buffer.h"
 #include "commit.h"
 
@@ -377,6 +378,12 @@ typedef struct {
 	 */
 	git_oid_t oid_type;
 #endif
+
+	/**
+	 * Type of the reference database to use for this repository, or 0 for
+	 * default (currently "files").
+	 */
+	git_refdb_t refdb_type;
 } git_repository_init_options;
 
 /** Current version for the `git_repository_init_options` structure */

--- a/include/git2/sys/refdb_backend.h
+++ b/include/git2/sys/refdb_backend.h
@@ -56,9 +56,47 @@ struct git_reference_iterator {
 		git_reference_iterator *iter);
 };
 
+typedef enum {
+	/**
+	 * The refdb that is to be initialized is for a worktree.
+	 */
+	GIT_REFDB_BACKEND_INIT_IS_WORKTREE = (1u << 0),
+
+	/*
+	 * Force-overwrite HEAD in case the refdb is already (partially)
+	 * initialized.
+	 */
+	GIT_REFDB_BACKEND_INIT_FORCE_HEAD = (1u << 1)
+} git_refdb_backend_init_flag_t;
+
 /** An instance for a custom backend */
 struct git_refdb_backend {
 	unsigned int version; /**< The backend API version */
+
+	/**
+	 * Create a new refdb and initialize its structures.
+	 *
+	 * A refdb implementation may provide this function; if it is not
+	 * provided, no data structures will be initialized for the refdb when
+	 * a new repository is created.
+	 *
+	 * @param path The path of the Git directory that shall be initialized.
+	 * @param initial_head The target that HEAD should point to. This value
+	 *             should only be applied when there isn't yet a HEAD
+	 *             reference, or when `GIT_REFDB_BACKEND_INIT_FORCE_HEAD`
+	 *             is passed. Optional, if unset the backend should not set
+	 *             up HEAD, either.
+	 * @param mode The mode that shall be used to create files and
+	 *             directories. May be one of `git_repository_init_mode_t`
+	 *             or normal Unix permission bits.
+	 * @param flags A combination of `git_refdb_backend_init_flag_t` flags.
+	 * @return `0` on success, a negative error value code.
+	 */
+	int GIT_CALLBACK(init)(
+		git_refdb_backend *backend,
+		const char *head_target,
+		mode_t mode,
+		uint32_t flags);
 
 	/**
 	 * Queries the refdb backend for the existence of a reference.

--- a/src/libgit2/refdb.c
+++ b/src/libgit2/refdb.c
@@ -122,6 +122,16 @@ void git_refdb_free(git_refdb *db)
 	GIT_REFCOUNT_DEC(db, git_refdb__free);
 }
 
+int git_refdb_init(git_refdb *refdb, const char *head_target, mode_t mode, uint32_t flags)
+{
+	GIT_ASSERT_ARG(refdb);
+	GIT_ASSERT_ARG(refdb->backend);
+
+	if (!refdb->backend->init)
+		return 0;
+	return refdb->backend->init(refdb->backend, head_target, mode, flags);
+}
+
 int git_refdb_exists(int *exists, git_refdb *refdb, const char *ref_name)
 {
 	GIT_ASSERT_ARG(exists);

--- a/src/libgit2/refdb.c
+++ b/src/libgit2/refdb.c
@@ -39,28 +39,36 @@ int git_refdb_new(git_refdb **out, git_repository *repo)
 
 int git_refdb_open(git_refdb **out, git_repository *repo)
 {
+	git_refdb_backend *backend;
 	git_refdb *db;
-	git_refdb_backend *dir;
+	int error;
 
 	GIT_ASSERT_ARG(out);
 	GIT_ASSERT_ARG(repo);
 
 	*out = NULL;
 
-	if (git_refdb_new(&db, repo) < 0)
-		return -1;
+	if ((error = git_refdb_new(&db, repo)) < 0)
+		goto out;
 
-	/* Add the default (filesystem) backend */
-	if (git_refdb_backend_fs(&dir, repo) < 0) {
-		git_refdb_free(db);
-		return -1;
+	switch (repo->refdb_type) {
+	case GIT_REFDB_FILES:
+		if ((error = git_refdb_backend_fs(&backend, repo)) < 0)
+			goto out;
+		break;
+	default:
+		git_error_set(GIT_ERROR_REFERENCE, "unknown reference storage format");
+		error = GIT_EINVALID;
+		goto out;
 	}
 
 	db->repo = repo;
-	db->backend = dir;
-
+	db->backend = backend;
 	*out = db;
-	return 0;
+out:
+	if (error)
+		git_refdb_free(db);
+	return error;
 }
 
 static void refdb_free_backend(git_refdb *db)

--- a/src/libgit2/refdb.h
+++ b/src/libgit2/refdb.h
@@ -125,6 +125,16 @@ int git_refdb_ensure_log(git_refdb *refdb, const char *refname);
 int git_refdb_lock(void **payload, git_refdb *db, const char *refname);
 int git_refdb_unlock(git_refdb *db, void *payload, int success, int update_reflog, const git_reference *ref, const git_signature *sig, const char *message);
 
+GIT_INLINE(const char *) git_refdb_type_name(git_refdb_t type)
+{
+	switch (type) {
+	case GIT_REFDB_FILES:
+		return "files";
+	default:
+		return "unknown";
+	}
+}
+
 GIT_INLINE(git_refdb_t) git_refdb_type_fromstr(const char *name)
 {
 	if (strcmp(name, "files") == 0)

--- a/src/libgit2/refdb.h
+++ b/src/libgit2/refdb.h
@@ -125,4 +125,11 @@ int git_refdb_ensure_log(git_refdb *refdb, const char *refname);
 int git_refdb_lock(void **payload, git_refdb *db, const char *refname);
 int git_refdb_unlock(git_refdb *db, void *payload, int success, int update_reflog, const git_reference *ref, const git_signature *sig, const char *message);
 
+GIT_INLINE(git_refdb_t) git_refdb_type_fromstr(const char *name)
+{
+	if (strcmp(name, "files") == 0)
+		return GIT_REFDB_FILES;
+	return 0;
+}
+
 #endif

--- a/src/libgit2/refdb.h
+++ b/src/libgit2/refdb.h
@@ -12,6 +12,8 @@
 #include "git2/refdb.h"
 #include "repository.h"
 
+#define GIT_INVALID_HEAD "refs/heads/.invalid"
+
 struct git_refdb {
 	git_refcount rc;
 	git_repository *repo;
@@ -19,6 +21,11 @@ struct git_refdb {
 };
 
 void git_refdb__free(git_refdb *db);
+
+int git_refdb_init(git_refdb *refdb,
+		   const char *head_target,
+		   mode_t mode,
+		   uint32_t flags);
 
 int git_refdb_exists(
 	int *exists,

--- a/src/libgit2/repo_template.h
+++ b/src/libgit2/repo_template.h
@@ -45,8 +45,6 @@ typedef struct {
 static repo_template_item repo_template[] = {
 	{ GIT_OBJECTS_INFO_DIR, GIT_OBJECT_DIR_MODE, NULL }, /* '/objects/info/' */
 	{ GIT_OBJECTS_PACK_DIR, GIT_OBJECT_DIR_MODE, NULL }, /* '/objects/pack/' */
-	{ GIT_REFS_HEADS_DIR, GIT_REFS_DIR_MODE, NULL },     /* '/refs/heads/' */
-	{ GIT_REFS_TAGS_DIR, GIT_REFS_DIR_MODE, NULL },      /* '/refs/tags/' */
 	{ GIT_HOOKS_DIR, GIT_HOOKS_DIR_MODE, NULL },         /* '/hooks/' */
 	{ GIT_INFO_DIR, GIT_INFO_DIR_MODE, NULL },           /* '/info/' */
 	{ GIT_DESC_FILE, GIT_DESC_MODE, GIT_DESC_CONTENT },

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -159,6 +159,7 @@ struct git_repository {
 	         is_bare:1,
 	         is_worktree:1;
 	git_oid_t oid_type;
+	git_refdb_t refdb_type;
 
 	unsigned int lru_counter;
 

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -179,7 +179,6 @@ GIT_INLINE(git_attr_cache *) git_repository_attr_cache(git_repository *repo)
 
 int git_repository_head_commit(git_commit **commit, git_repository *repo);
 int git_repository_head_tree(git_tree **tree, git_repository *repo);
-int git_repository_create_head(const char *git_dir, const char *ref_name);
 
 typedef int (*git_repository_foreach_worktree_cb)(git_repository *, void *);
 

--- a/tests/libgit2/config/conditionals.c
+++ b/tests/libgit2/config/conditionals.c
@@ -112,7 +112,9 @@ void test_config_conditionals__invalid_conditional_fails(void)
 
 static void set_head(git_repository *repo, const char *name)
 {
-	cl_git_pass(git_repository_create_head(git_repository_path(repo), name));
+	struct git_reference *ref;
+	cl_git_pass(git_reference_symbolic_create(&ref, repo, GIT_HEAD_FILE, name, 1, NULL));
+	git_reference_free(ref);
 }
 
 void test_config_conditionals__onbranch(void)
@@ -123,12 +125,12 @@ void test_config_conditionals__onbranch(void)
 	assert_condition_includes("onbranch", "master/", false);
 	assert_condition_includes("onbranch", "foo", false);
 
-	set_head(_repo, "foo");
+	set_head(_repo, "refs/heads/foo");
 	assert_condition_includes("onbranch", "master", false);
 	assert_condition_includes("onbranch", "foo", true);
 	assert_condition_includes("onbranch", "f*o", true);
 
-	set_head(_repo, "dir/ref");
+	set_head(_repo, "refs/heads/dir/ref");
 	assert_condition_includes("onbranch", "dir/ref", true);
 	assert_condition_includes("onbranch", "dir/", true);
 	assert_condition_includes("onbranch", "dir/*", true);
@@ -137,7 +139,7 @@ void test_config_conditionals__onbranch(void)
 	assert_condition_includes("onbranch", "dir", false);
 	assert_condition_includes("onbranch", "dir*", false);
 
-	set_head(_repo, "dir/subdir/ref");
+	set_head(_repo, "refs/heads/dir/subdir/ref");
 	assert_condition_includes("onbranch", "dir/subdir/", true);
 	assert_condition_includes("onbranch", "dir/subdir/*", true);
 	assert_condition_includes("onbranch", "dir/subdir/ref", true);

--- a/tests/libgit2/core/opts.c
+++ b/tests/libgit2/core/opts.c
@@ -34,11 +34,12 @@ void test_core_opts__extensions_query(void)
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 4);
+	cl_assert_equal_sz(out.count, 5);
 	cl_assert_equal_s("noop", out.strings[0]);
 	cl_assert_equal_s("objectformat", out.strings[1]);
 	cl_assert_equal_s("preciousobjects", out.strings[2]);
-	cl_assert_equal_s("worktreeconfig", out.strings[3]);
+	cl_assert_equal_s("refstorage", out.strings[3]);
+	cl_assert_equal_s("worktreeconfig", out.strings[4]);
 
 	git_strarray_dispose(&out);
 }
@@ -51,12 +52,13 @@ void test_core_opts__extensions_add(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 5);
+	cl_assert_equal_sz(out.count, 6);
 	cl_assert_equal_s("foo", out.strings[0]);
 	cl_assert_equal_s("noop", out.strings[1]);
 	cl_assert_equal_s("objectformat", out.strings[2]);
 	cl_assert_equal_s("preciousobjects", out.strings[3]);
-	cl_assert_equal_s("worktreeconfig", out.strings[4]);
+	cl_assert_equal_s("refstorage", out.strings[4]);
+	cl_assert_equal_s("worktreeconfig", out.strings[5]);
 
 	git_strarray_dispose(&out);
 }
@@ -69,12 +71,13 @@ void test_core_opts__extensions_remove(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 5);
+	cl_assert_equal_sz(out.count, 6);
 	cl_assert_equal_s("bar", out.strings[0]);
 	cl_assert_equal_s("baz", out.strings[1]);
 	cl_assert_equal_s("objectformat", out.strings[2]);
 	cl_assert_equal_s("preciousobjects", out.strings[3]);
-	cl_assert_equal_s("worktreeconfig", out.strings[4]);
+	cl_assert_equal_s("refstorage", out.strings[4]);
+	cl_assert_equal_s("worktreeconfig", out.strings[5]);
 
 	git_strarray_dispose(&out);
 }
@@ -87,13 +90,14 @@ void test_core_opts__extensions_uniq(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 6);
+	cl_assert_equal_sz(out.count, 7);
 	cl_assert_equal_s("bar", out.strings[0]);
 	cl_assert_equal_s("foo", out.strings[1]);
 	cl_assert_equal_s("noop", out.strings[2]);
 	cl_assert_equal_s("objectformat", out.strings[3]);
 	cl_assert_equal_s("preciousobjects", out.strings[4]);
-	cl_assert_equal_s("worktreeconfig", out.strings[5]);
+	cl_assert_equal_s("refstorage", out.strings[5]);
+	cl_assert_equal_s("worktreeconfig", out.strings[6]);
 
 	git_strarray_dispose(&out);
 }

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -874,3 +874,26 @@ void test_repo_open__can_reset_safe_directory_list(void)
 	git_str_dispose(&config_filename);
 	git_str_dispose(&config_data);
 }
+
+void test_repo_open__refstorage_extension(void)
+{
+	git_repository *repo, *tmp;
+	git_config *config;
+
+	repo = cl_git_sandbox_init("empty_bare.git");
+
+	cl_git_pass(git_repository_open(&repo, "empty_bare.git"));
+	cl_git_pass(git_repository_config(&config, repo));
+	cl_git_pass(git_config_set_int32(config, "core.repositoryformatversion", 1));
+	cl_git_pass(git_config_set_string(config, "extensions.refStorage", "files"));
+
+	cl_git_pass(git_repository_open(&tmp, "empty_bare.git"));
+	git_repository_free(tmp);
+
+	cl_git_pass(git_config_set_string(config, "extensions.refStorage", "garbage"));
+	cl_git_fail_with(GIT_EINVALID, git_repository_open(&tmp, "empty_bare.git"));
+	git_repository_free(tmp);
+
+	git_config_free(config);
+	git_repository_free(repo);
+}


### PR DESCRIPTION
This pull request introduces support for the "refFormat" extension. On the one hand it introduces support for reading repositories that have this extension, even though we naturally only understand the `files` format right now. On the other hand this pull request moves the logic to initialize the refdb into the refdb backends so that the logic can be customized for every ref format.

I've decided to pull out these changes into a separate pull request in preparation for the `reftable` format. It's already somewhat non-trivial, so I think that reviewing it separately might be easier.