### PR TITLE
Don't export API symbols on static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,10 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+if(NOT BUILD_SHARED_LIBS)
+	add_definitions(-DGIT_STATIC_BUILD=1)
+endif()
+
 
 # Modules
 

--- a/include/git2/common.h
+++ b/include/git2/common.h
@@ -37,14 +37,22 @@ typedef size_t size_t;
 #endif
 
 /** Declare a public function exported for application use. */
-#if __GNUC__ >= 4
-# define GIT_EXTERN(type) extern \
-			 __attribute__((visibility("default"))) \
-			 type
-#elif defined(_MSC_VER)
-# define GIT_EXTERN(type) __declspec(dllexport) type __cdecl
+#if !defined(GIT_STATIC_BUILD)
+# if __GNUC__ >= 4
+#  define GIT_DECL_EXTERN extern __attribute__((visibility("default")))
+# elif defined(_MSC_VER)
+#  define GIT_DECL_EXTERN __declspec(dllexport)
+# else
+#  define GIT_DECL_EXTERN extern
+# endif
 #else
-# define GIT_EXTERN(type) extern type
+# define GIT_DECL_EXTERN  /* empty */
+#endif
+
+#if defined(_MSC_VER)
+# define GIT_EXTERN(type) GIT_DECL_EXTERN type __cdecl
+#else
+# define GIT_EXTERN(type) GIT_DECL_EXTERN type
 #endif
 
 /** Declare a callback function for application use. */


### PR DESCRIPTION
When linking to a static library that contains symbols with `__declspec(dllexport)`, all these symbols will be part of the final executable, even if they are not needed. Maybe this is not the intended behavior. Although both ELF and PE (at least) can do this, most people don't load symbols of an executable, AFAIK.  
  
Before:
~~~PowerShell
❯ Get-Item .\util_tests.exe | % { "Size of $($_.Name): $($_.Length / 1kb)kb" }
Size of util_tests.exe: 2594kb

❯ dumpbin -nologo -exports .\util_tests.exe

Dump of file .\util_tests.exe

File Type: EXECUTABLE IMAGE

  Section contains the following exports for util_tests.exe

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
         956 number of functions
         956 number of names

    ordinal hint RVA      name

          1    0 0001E0F0 git_annotated_commit_free
          2    1 0001DF70 git_annotated_commit_from_fetchhead
          3    2 0001DC80 git_annotated_commit_from_ref
          .
          .
          956  3BB 000036F0 giterr_set_str

  Summary

        D000 .data
       15000 .pdata
       94000 .rdata
        2000 .reloc
        1000 .rsrc
      1D8000 .text
        1000 _RDATA
~~~

After:
~~~PowerShell
❯ Get-Item .\util_tests.exe | % { "Size of $($_.Name): $($_.Length / 1kb)kb" }
Size of util_tests.exe: 1705.5kb

❯ dumpbin -nologo -exports .\util_tests.exe

Dump of file .\util_tests.exe

File Type: EXECUTABLE IMAGE

  Summary

        D000 .data
        C000 .pdata
       77000 .rdata
        2000 .reloc
        1000 .rsrc
      122000 .text
        1000 _RDATA
~~~

I'm not sure if this is the right way to do it, though.