### PR TITLE
cmake: disable warnings for operands with different enum types

### DIFF
--- a/cmake/DefaultCFlags.cmake
+++ b/cmake/DefaultCFlags.cmake
@@ -13,6 +13,9 @@ if(MSVC)
 	# /Gd - explicitly set cdecl calling convention
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Gd")
 
+	# Remove warnings about operands that use different enum types.
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd5287")
+
 	if(NOT (MSVC_VERSION LESS 1900))
 		# /guard:cf - Enable Control Flow Guard
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /guard:cf")


### PR DESCRIPTION
With a recent upgrade to a newer version of MSVC we now get a bunch of warnings when two operands use different enum types. While sensible in theory, in practice we have a couple of non-public enums that extend public enums, like for example with `GIT_SUBMODULE_STATUS`.

Let's for now disable this warning to unblock our builds. The alternative would be to add casts all over the place, but that feels rather cumbersome.