### PR TITLE
Fixed a heap-buffer-overflow in the smart_pkt.c:set_data function.

### DIFF
--- a/src/libgit2/transports/smart_pkt.c
+++ b/src/libgit2/transports/smart_pkt.c
@@ -238,13 +238,13 @@ static int set_data(
 
 		if (strncmp(caps, "object-format=", CONST_STRLEN("object-format=")) == 0)
 			format_str = caps + CONST_STRLEN("object-format=");
-		else if ((format_str = strstr(caps, " object-format=")) != NULL)
+		else if ((format_str = git__memmem(caps, len - (caps - line), " object-format=", CONST_STRLEN(" object-format="))) != NULL)
 			format_str += CONST_STRLEN(" object-format=");
 	}
 
 	if (format_str) {
-		if ((eos = strchr(format_str, ' ')) == NULL)
-			eos = strchr(format_str, '\0');
+		if ((eos = memchr(format_str, ' ', len - (format_str - line))) == NULL)
+			eos = memchr(format_str, '\0', len - (format_str - line));
 
 		GIT_ASSERT(eos);
 


### PR DESCRIPTION
The strstr call used to find the " object-format=" capability string did not have a length limit, potentially reading past the end of the allocated buffer if the capabilities string was not null-terminated within the buffer bounds. Replaced strstr with git__memmem and subsequent strchr calls with memchr, providing the remaining buffer length as a limit to prevent out-of-bounds reads.

https://oss-fuzz.com/testcase-detail/4895812384325632
https://issues.oss-fuzz.com/issues/42524461
