### PR TITLE
Update documentation to clarify that cert cb is always called

### DIFF
--- a/include/git2/proxy.h
+++ b/include/git2/proxy.h
@@ -70,9 +70,8 @@ typedef struct {
 	git_credential_acquire_cb credentials;
 
 	/**
-	 * If cert verification fails, this will be called to let the
-	 * user make the final decision of whether to allow the
-	 * connection to proceed. Returns 0 to allow the connection
+	 * This will be called to let the user make the final decision of whether
+	 * to allow the connection to proceed. Returns 0 to allow the connection
 	 * or a negative value to indicate an error.
 	 */
 	git_transport_certificate_check_cb certificate_check;

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -596,9 +596,8 @@ struct git_remote_callbacks {
 	git_credential_acquire_cb credentials;
 
 	/**
-	 * If cert verification fails, this will be called to let the
-	 * user make the final decision of whether to allow the
-	 * connection to proceed. Returns 0 to allow the connection
+	 * This will be called to let the user make the final decision of whether
+	 * to allow the connection to proceed. Returns 0 to allow the connection
 	 * or a negative value to indicate an error.
 	 */
 	git_transport_certificate_check_cb certificate_check;


### PR DESCRIPTION
This removes the phrase "if cert verification fails" because the certificate callback is *always* called whether it fails or not. This was changed in
https://github.com/libgit2/libgit2/pull/2464/commits/17491f6e5660b82cb8163eea58805df6398af16e, but presumably this piece of documentation was not updated.