### PR TITLE
refspec: Detect DEL character in is_valid_name

### DIFF
--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -819,7 +819,7 @@ int git_reference_list(
 
 static int is_valid_ref_char(char ch)
 {
-	if ((unsigned) ch <= ' ')
+	if ((unsigned) ch <= ' ' || ch == '\177') /* ASCII control characters */
 		return 0;
 
 	switch (ch) {

--- a/tests/libgit2/refs/isvalidname.c
+++ b/tests/libgit2/refs/isvalidname.c
@@ -21,6 +21,7 @@ void test_refs_isvalidname__can_detect_invalid_formats(void)
 	cl_assert_equal_i(false, is_valid_name("/"));
 	cl_assert_equal_i(false, is_valid_name("//"));
 	cl_assert_equal_i(false, is_valid_name(""));
+	cl_assert_equal_i(false, is_valid_name("refs/heads/\177"));
 	cl_assert_equal_i(false, is_valid_name("refs/heads/sub.lock/webmatrix"));
 }
 


### PR DESCRIPTION
Prior to this patch the code correctly barfed on
control characters with values lower than \040 (space), but failed to account for DEL.

This patch fixes the behavior to be consistent with git [1]:

> They cannot have ASCII control characters (i.e. bytes whose values are
> lower than \040, or \177 DEL)

[1]: https://git-scm.com/docs/git-check-ref-format#_description