### PR TITLE
Adding missing includes in public header files

### DIFF
--- a/include/git2/blame.h
+++ b/include/git2/blame.h
@@ -10,6 +10,7 @@
 
 #include "common.h"
 #include "oid.h"
+#include "types.h"
 
 /**
  * @file git2/blame.h

--- a/include/git2/notes.h
+++ b/include/git2/notes.h
@@ -8,6 +8,7 @@
 #define INCLUDE_git_note_h__
 
 #include "oid.h"
+#include "types.h"
 
 /**
  * @file git2/notes.h


### PR DESCRIPTION
This matters if one has the need to use the headers under git2/ directly rather than including them all via git2.h