### PR TITLE
fix: `git_remote_download` assumes oid capability

### DIFF
--- a/src/libgit2/fetch.c
+++ b/src/libgit2/fetch.c
@@ -101,8 +101,6 @@ static int filter_wants(git_remote *remote, const git_fetch_options *opts)
 	int error = 0;
 	size_t i, heads_len;
 	unsigned int remote_caps;
-	unsigned int oid_mask = GIT_REMOTE_CAPABILITY_TIP_OID |
-	                        GIT_REMOTE_CAPABILITY_REACHABLE_OID;
 	git_remote_autotag_option_t tagopt = remote->download_tags;
 
 	if (opts && opts->download_tags != GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED)
@@ -144,11 +142,6 @@ static int filter_wants(git_remote *remote, const git_fetch_options *opts)
 		if (!git_oid__is_hexstr(spec->src, remote->repo->oid_type))
 			continue;
 
-		if (!(remote_caps & oid_mask)) {
-			git_error_set(GIT_ERROR_INVALID, "cannot fetch a specific object from the remote repository");
-			error = -1;
-			goto cleanup;
-		}
 
 		if ((error = maybe_want_oid(remote, spec)) < 0)
 			goto cleanup;


### PR DESCRIPTION
Stop throwing error when requesting oids from a git server that doesn't explicitly advertise that capability.

The overwhelming majority of git servers will serve this request even when they don't advertise this capability, e.g. git-http-backend.

For many years, the git reference implementation has assumed servers have this capability even when `allow-tip-sha1-in-want` or `allow-reachable-sha1-in-want` isnt included in
`git-upload-pack-advertisement`, e.g. with `git fetch <remote> <oid>`.

closes https://github.com/libgit2/libgit2/issues/7078