### PR TITLE
Fix potential access to uninitialized variables

### DIFF
--- a/src/cli/opt_usage.c
+++ b/src/cli/opt_usage.c
@@ -201,7 +201,7 @@ int cli_opt_help_fprint(
 {
 	git_str help = GIT_BUF_INIT;
 	const cli_opt_spec *spec;
-	bool required;
+	bool required = true;
 	int error = 0;
 
 	/* Display required arguments first */

--- a/src/libgit2/diff_driver.c
+++ b/src/libgit2/diff_driver.c
@@ -225,7 +225,7 @@ static int git_diff_driver_load(
 {
 	int error = 0;
 	git_diff_driver_registry *reg;
-	git_diff_driver *drv;
+	git_diff_driver *drv = NULL;
 	size_t namelen;
 	git_config *cfg = NULL;
 	git_str name = GIT_STR_INIT;


### PR DESCRIPTION
```
opt_usage.c:214:59: warning: 'required' may be used uninitialized [-Wmaybe-uninitialized]
  214 |                     ((spec->usage & CLI_OPT_USAGE_CHOICE) && required));
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~

diff_driver.c:343:17: warning: 'drv' may be used uninitialized [-Wmaybe-uninitialized]
  343 |         if (drv && drv != *out)
      |             ~~~~^~~~~~~~~~~~~~
```