### PR TITLE
config: Fix potential null value passed to %s

### DIFF
--- a/src/libgit2/config.c
+++ b/src/libgit2/config.c
@@ -1442,6 +1442,8 @@ int git_config_parse_bool(int *out, const char *value)
 	if (git__parse_bool(out, value) == 0)
 		return 0;
 
+	/* git__parse_bool returns 0 for NULL, so this assertion should be correct */
+	GIT_ASSERT_ARG(value);
 	if (git_config_parse_int32(out, value) == 0) {
 		*out = !!(*out);
 		return 0;


### PR DESCRIPTION
```
config.c:1448:59: warning: '%s' directive argument is null [-Wformat-overflow=]
 1448 |         git_error_set(GIT_ERROR_CONFIG, "failed to parse '%s' as a boolean value", value);
      |                                                           ^~
```