### PR TITLE
cmake: fix creation of static lib in xcode

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -55,6 +55,12 @@ set(LIBGIT2_SYSTEM_LIBS ${LIBGIT2_SYSTEM_LIBS} PARENT_SCOPE)
 # Compile and link libgit2
 #
 
+if (NOT BUILD_SHARED_LIBS AND XCODE_VERSION)
+	# This is required for Xcode to actually create the static libgit2 library
+	file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.c "")
+	list(APPEND LIBGIT2_OBJECTS ${CMAKE_CURRENT_BINARY_DIR}/dummy.c)
+endif()
+
 add_library(libgit2package ${SRC_RC} ${LIBGIT2_OBJECTS})
 target_link_libraries(libgit2package ${LIBGIT2_SYSTEM_LIBS})
 target_include_directories(libgit2package SYSTEM PRIVATE ${LIBGIT2_INCLUDES})


### PR DESCRIPTION
When I was trying to use libgit2 as a submodule building static library for another project under Xcode 16.1, I got linker errors and realized that the static library was not being created. In the process I found that - as far as I can tell - Xcode needs a workaround (a dummy C file) in order to actually create a static library file.

Libgit used to have this workaround built-in, but it was removed in d7b49ed4427bf4823ac5a18a176f317c6d2717ac (#6133).

As far as I can tell, this workaround is still needed when one wants to create a static library under Xcode. 

For reference, this is what I used to build a static library:
```sh
mkdir build && cd build
cmake -G Xcode -D BUILD_SHARED_LIBS=OFF -D BUILD_CLI=OFF -D BUILD_EXAMPLES=OFF ..
cmake --build . --config RelWithDebInfo
```