### PR TITLE
ssh: fix custom ssh heap buffer overflow

### DIFF
--- a/src/libgit2/transports/credential.c
+++ b/src/libgit2/transports/credential.c
@@ -161,7 +161,7 @@ static void ssh_custom_free(struct git_credential *cred)
 
 	if (c->publickey) {
 		/* Zero the memory which previously held the publickey */
-		size_t key_len = strlen(c->publickey);
+		size_t key_len = c->publickey_len;
 		git__memzero(c->publickey, key_len);
 		git__free(c->publickey);
 	}


### PR DESCRIPTION
The `publickey` field in `git_credential_ssh_custom` stores binary data, not a null-terminated string. When freeing this memory, `ssh_custom_free()` uses `strlen()` to determine the key length instead of the `publickey_len` field. This causes a heap buffer overflow.

Below is the code flow.

1. [`git_credential_ssh_custom_new()`](https://libgit2.org/docs/reference/main/credential/git_credential_ssh_custom_new.html) is a wrapper around [`libssh2_userauth_publickey()`](https://libssh2.org/libssh2_userauth_publickey.html):

https://github.com/libssh2/libssh2/blob/2dae3024897e1898d389835151f4e9606227721d/src/userauth.c#L2094

`libssh2_userauth_publickey()` is undocumented, but accepts `const unsigned char * pubkeydata` and an explicit length `size_t pubkeydata_len`, strongly indicating that this is not a null-terminated string.

2. `git_credential_ssh_custom_new()` allocates and copies the binary data:

https://github.com/libgit2/libgit2/blob/58d9363f02f1fa39e46d49b604f27008e75b72f2/src/libgit2/transports/credential.c#L339-L344

3. `git_credential_ssh_custom_new()` assigns `ssh_custom_free()` as the memory-freeing function:

https://github.com/libgit2/libgit2/blob/58d9363f02f1fa39e46d49b604f27008e75b72f2/src/libgit2/transports/credential.c#L334

4. However, `ssh_custom_free()` treats the public key as a null-terminated string:

https://github.com/libgit2/libgit2/blob/58d9363f02f1fa39e46d49b604f27008e75b72f2/src/libgit2/transports/credential.c#L164

Instead, it should use the stored length:

```c
size_t key_len = c->publickey_len;
```

The heap buffer overflow was detected by Apple's [Address Sanitizer](https://developer.apple.com/documentation/xcode/diagnosing-memory-thread-and-crash-issues-early#Locate-memory-corruption-issues-in-your-code).

Closes https://github.com/libgit2/libgit2/issues/7147