### PR TITLE
ci: update ci/docker/fedora to work with Rawhide 44

### DIFF
--- a/ci/docker/fedora
+++ b/ci/docker/fedora
@@ -15,7 +15,7 @@ RUN yum install -y \
 	openssl-devel \
 	openssh-server \
 	git-daemon \
-	java-1.8.0-openjdk-headless \
+	java-21-openjdk-headless \
 	sudo \
 	python3 \
 	valgrind \
@@ -46,7 +46,7 @@ RUN if [ "${UID}" != "" ]; then USER_ARG="--uid ${UID}"; fi && \
     useradd ${USER_ARG} --gid libgit2 --shell /bin/bash --create-home libgit2
 
 FROM adduser AS configure
-ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
-RUN mkdir /var/run/sshd
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+RUN mkdir -p /var/run/sshd
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local && \
     ldconfig


### PR DESCRIPTION
Small changes, but required for the build to pass.

Closes #7151.

<details>
<summary>Log of a successful build</summary>
<pre>
    ❯ docker build --no-cache -t libgit2-fedora -f ci/docker/fedora .
    [+] Building 55.8s (11/11) FINISHED                                                                      docker:desktop-linux
     => [internal] load build definition from fedora                                                                         0.0s
     => => transferring dockerfile: 1.16kB                                                                                   0.0s
     => [internal] load metadata for docker.io/library/fedora:rawhide                                                        0.5s
     => [internal] load .dockerignore                                                                                        0.0s
     => => transferring context: 2B                                                                                          0.0s
     => CACHED [stream 1/2] FROM docker.io/library/fedora:rawhide@sha256:8a396124f358d2922f1b1c40aee2e7f1dd016b26b3d525d433  0.0s
     => [stream 2/2] RUN dnf -y distro-sync                                                                                  6.7s
     => [yum 1/1] RUN yum install -y  which  bzip2  git  libarchive  cmake  gcc  make  openssl-devel  openssh-server  git-  32.5s
     => [libssh2 1/1] RUN cd /tmp &&     curl --location --silent --show-error https://www.libssh2.org/download/libssh2-1.  14.3s
     => [adduser 1/1] RUN if [ "" != "" ]; then USER_ARG="--uid "; fi &&     if [ "" != "" ]; then GROUP_ARG="--gid "; fi &  0.2s
     => [configure 1/2] RUN mkdir -p /var/run/sshd                                                                           0.1s
     => [configure 2/2] RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local &&     ldconfig                                  0.1s
     => exporting to image                                                                                                   1.4s
     => => exporting layers                                                                                                  1.4s
     => => writing image sha256:cd17f5c7bb60a9dbc30e95c7cab3bd298fc0f4b677aabd81b54e105025635a7e                             0.0s
     => => naming to docker.io/library/libgit2-fedora                                                                        0.0s
</pre>
</details>
