### PR TITLE
test: check the correct filesystem for case-sensitivity

### DIFF
--- a/tests/libgit2/iterator/index.c
+++ b/tests/libgit2/iterator/index.c
@@ -280,11 +280,23 @@ static const char *expected_index_ci[] = {
 void test_iterator_index__case_folding(void)
 {
 	git_str path = GIT_STR_INIT;
+	git_index *index;
 	int fs_is_ci = 0;
+	int index_is_ci = 0;
 
-	cl_git_pass(git_str_joinpath(&path, cl_fixture("icase"), ".gitted/CoNfIg"));
+	g_repo = cl_git_sandbox_init("icase");
+
+	/* check filesystem case-sensitivity in the sandbox where tests will be executing */
+	cl_git_pass(git_str_joinpath(&path, git_repository_workdir(g_repo), ".git/CoNfIg"));
 	fs_is_ci = git_fs_path_exists(path.ptr);
 	git_str_dispose(&path);
+
+	/* verify index capability matches filesystem detection */
+	cl_git_pass(git_repository_index(&index, g_repo));
+	index_is_ci = (git_index_caps(index) & GIT_INDEX_CAPABILITY_IGNORE_CASE) != 0;
+	cl_assert_equal_i(fs_is_ci, index_is_ci);
+	git_index_free(index);
+	cl_git_sandbox_cleanup();
 
 	index_iterator_test(
 		"icase", NULL, NULL, 0, ARRAY_SIZE(expected_index_cs),


### PR DESCRIPTION
It's certainly possible for the root filesystem to be case-sensitive while /tmp is not, or vice versa. One example where this might happen is when running Docker containers (like ci/docker/fedora) on macOS with the repository checkout on AppleFS (not case sensitive) while the container's /tmp is case sensitive.

This fix allows the test to pass under those circumstances as well.