### PR TITLE
Use CMAKE_INSTALL_INCLUDEDIR for libgit2package INSTALL_INTERFACE

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -58,7 +58,7 @@ set(LIBGIT2_SYSTEM_LIBS ${LIBGIT2_SYSTEM_LIBS} PARENT_SCOPE)
 add_library(libgit2package ${SRC_RC} ${LIBGIT2_OBJECTS})
 target_link_libraries(libgit2package ${LIBGIT2_SYSTEM_LIBS})
 target_include_directories(libgit2package SYSTEM PRIVATE ${LIBGIT2_INCLUDES})
-target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:include>)
+target_include_directories(libgit2package INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 set_target_properties(libgit2package PROPERTIES C_STANDARD 90)
 set_target_properties(libgit2package PROPERTIES C_EXTENSIONS OFF)


### PR DESCRIPTION
The `target_include_directories` for `libgit2package` are not consistent with the `install` commands found later inside `src/libgit2/CMakeLists.txt`.

When `CMAKE_INSTALL_INCLUDEDIR` is set to an absolute path this can cause a mismatch in the `INTERFACE_INCLUDE_DIRECTORIES` for the `libgit2::libgit2package` target in the generated `libgit2Targets.cmake` file.

For example, NixOS sets `CMAKE_INSTALL_INCLUDEDIR` in its packaging of `libgit2` to split the package into a standard and a "dev" variants. Because of the mismatch, the generated `libgit2Targets.cmake` file sets the include directory relative to the standard package location, instead of the "dev" package location where the headers are installed (thanks to the use of `CMAKE_INSTALL_INCLUDEDIR`).