### PR TITLE
Update GIT_DIFF_OPTIONS_INIT macro

### DIFF
--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -477,7 +477,7 @@ typedef struct {
  * `git_diff_options_init` programmatic initialization.
  */
 #define GIT_DIFF_OPTIONS_INIT \
-	{GIT_DIFF_OPTIONS_VERSION, 0, GIT_SUBMODULE_IGNORE_UNSPECIFIED, {NULL,0}, NULL, NULL, NULL, 3}
+	{GIT_DIFF_OPTIONS_VERSION, 0, GIT_SUBMODULE_IGNORE_UNSPECIFIED, {NULL,0}, NULL, NULL, NULL, 3, 0, (git_oid_t)0, 0, 0, 0, 0}
 
 /**
  * Initialize git_diff_options structure

--- a/include/git2/diff.h
+++ b/include/git2/diff.h
@@ -477,7 +477,7 @@ typedef struct {
  * `git_diff_options_init` programmatic initialization.
  */
 #define GIT_DIFF_OPTIONS_INIT \
-	{GIT_DIFF_OPTIONS_VERSION, 0, GIT_SUBMODULE_IGNORE_UNSPECIFIED, {NULL,0}, NULL, NULL, NULL, 3, 0, (git_oid_t)0, 0, 0, 0, 0}
+	{GIT_DIFF_OPTIONS_VERSION, 0, GIT_SUBMODULE_IGNORE_UNSPECIFIED, {NULL,0}, NULL, NULL, NULL, 3, 0, (git_oid_t)0, 0, 0, NULL, NULL}
 
 /**
  * Initialize git_diff_options structure


### PR DESCRIPTION
Previous macro had several items left implicitly initialized (set to 0).

This meant that warnings would be created in user code if using this macro.