### PR TITLE
Add SwiftGitX to README bindings list

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ Here are the bindings to libgit2 that are currently available:
     * git2-rs <https://github.com/rust-lang/git2-rs>
 * Swift
     * SwiftGit2 <https://github.com/SwiftGit2/SwiftGit2>
+    * SwiftGitX <https://github.com/ibrahimcetin/SwiftGitX>
 * Tcl
     * lg2 <https://github.com/apnadkarni/tcl-libgit2>
 * Vala


### PR DESCRIPTION
[SwiftGitX](https://github.com/ibrahimcetin/SwiftGitX.git) is a modern Swift binding for libgit2. It uses new Swift features, including concurrency, throws-based error handling, and full SPM support. It runs on Apple platforms, Linux, and Android.

Since [SwiftGit2](https://github.com/SwiftGit2/SwiftGit2.git) hasn’t been maintained for a long time, I’d like to propose adding SwiftGitX as an updated alternative.