### PR TITLE
SSH exec updates

### DIFF
--- a/src/libgit2/transports/ssh_exec.c
+++ b/src/libgit2/transports/ssh_exec.c
@@ -121,6 +121,7 @@ GIT_INLINE(int) ensure_transport_state(
 
 static int get_ssh_cmdline(
 	git_vector *args,
+	bool *use_shell,
 	ssh_exec_subtransport *transport,
 	git_net_url *url,
 	const char *command)
@@ -152,8 +153,12 @@ static int get_ssh_cmdline(
 	if ((error = git_repository_config_snapshot(&cfg, repo)) < 0)
 		return error;
 
-	if ((error = git__getenv(&ssh_cmd, "GIT_SSH")) == 0)
-		;
+	if ((error = git__getenv(&ssh_cmd, "GIT_SSH_COMMAND")) == 0)
+		*use_shell = true;
+	else if (error != GIT_ENOTFOUND)
+		goto done;
+	else if ((error = git__getenv(&ssh_cmd, "GIT_SSH")) == 0)
+		*use_shell = false;
 	else if (error != GIT_ENOTFOUND)
 		goto done;
 	else if ((error = git_config__get_string_buf(&ssh_cmd, cfg, "core.sshcommand")) < 0 && error != GIT_ENOTFOUND)
@@ -213,6 +218,7 @@ static int start_ssh(
 	git_process_options process_opts = GIT_PROCESS_OPTIONS_INIT;
 	git_net_url url = GIT_NET_URL_INIT;
 	git_vector args = GIT_VECTOR_INIT;
+	bool use_shell = false;
 	const char *command;
 	int error;
 
@@ -243,8 +249,11 @@ static int start_ssh(
 	if (error < 0)
 		goto done;
 
-	if ((error = get_ssh_cmdline(&args, transport, &url, command)) < 0)
+	if ((error = get_ssh_cmdline(&args, &use_shell,
+			transport, &url, command)) < 0)
 		goto done;
+
+	process_opts.use_shell = use_shell;
 
 	if ((error = git_process_new(&transport->process,
 	     (const char **)args.contents, args.length,

--- a/src/libgit2/transports/ssh_exec.c
+++ b/src/libgit2/transports/ssh_exec.c
@@ -120,7 +120,7 @@ GIT_INLINE(int) ensure_transport_state(
 }
 
 static int get_ssh_cmdline(
-	git_str *out,
+	git_vector *args,
 	ssh_exec_subtransport *transport,
 	git_net_url *url,
 	const char *command)
@@ -128,7 +128,8 @@ static int get_ssh_cmdline(
 	git_remote *remote = ((transport_smart *)transport->owner)->owner;
 	git_repository *repo = remote->repo;
 	git_config *cfg;
-	git_str ssh_cmd = GIT_STR_INIT;
+	git_str ssh_cmd = GIT_STR_INIT, url_and_host = GIT_STR_INIT,
+		remote_cmd = GIT_STR_INIT;
 	const char *default_ssh_cmd = "ssh";
 	int error;
 
@@ -158,18 +159,46 @@ static int get_ssh_cmdline(
 	else if ((error = git_config__get_string_buf(&ssh_cmd, cfg, "core.sshcommand")) < 0 && error != GIT_ENOTFOUND)
 		goto done;
 
-	error = git_str_printf(out, "%s %s %s \"%s%s%s\" \"%s '%s'\"",
-		ssh_cmd.size > 0 ? ssh_cmd.ptr : default_ssh_cmd,
-		url->port_specified ? "-p" : "",
-		url->port_specified ? url->port : "",
-		url->username ? url->username : "",
-		url->username ? "@" : "",
-		url->host,
-		command,
-		url->path);
+	git_error_clear();
+
+	if (!ssh_cmd.size &&
+	    git_str_puts(&ssh_cmd, default_ssh_cmd) < 0)
+		goto done;
+
+	if ((error = git_vector_insert(args, git_str_detach(&ssh_cmd))) < 0)
+		goto done;
+
+	if (url->port_specified) {
+		char *p = git__strdup("-p");
+		char *port = git__strdup(url->port);
+
+		if (!p || !port ||
+		    (error = git_vector_insert(args, p)) < 0 ||
+		    (error = git_vector_insert(args, port)) < 0)
+			goto done;
+	}
+
+	if (url->username) {
+		if ((error = git_str_puts(&url_and_host, url->username)) < 0 ||
+		    (error = git_str_putc(&url_and_host, '@')) < 0)
+			goto done;
+	}
+
+	if ((error = git_str_puts(&url_and_host, url->host)) < 0 ||
+	    (error = git_vector_insert(args, git_str_detach(&url_and_host))) < 0)
+		goto done;
+
+	if ((error = git_str_puts(&remote_cmd, command)) < 0 ||
+	    (error = git_str_puts(&remote_cmd, " '")) < 0 ||
+	    (error = git_str_puts(&remote_cmd, url->path)) < 0 ||
+	    (error = git_str_puts(&remote_cmd, "'")) < 0 ||
+	    (error = git_vector_insert(args, git_str_detach(&remote_cmd))) < 0)
+		goto done;
 
 done:
 	git_str_dispose(&ssh_cmd);
+	git_str_dispose(&url_and_host);
+	git_str_dispose(&remote_cmd);
 	git_config_free(cfg);
 	return error;
 }
@@ -183,7 +212,7 @@ static int start_ssh(
 
 	git_process_options process_opts = GIT_PROCESS_OPTIONS_INIT;
 	git_net_url url = GIT_NET_URL_INIT;
-	git_str ssh_cmdline = GIT_STR_INIT;
+	git_vector args = GIT_VECTOR_INIT;
 	const char *command;
 	int error;
 
@@ -214,11 +243,12 @@ static int start_ssh(
 	if (error < 0)
 		goto done;
 
-	if ((error = get_ssh_cmdline(&ssh_cmdline, transport, &url, command)) < 0)
+	if ((error = get_ssh_cmdline(&args, transport, &url, command)) < 0)
 		goto done;
 
-	if ((error = git_process_new_from_cmdline(&transport->process,
-	     ssh_cmdline.ptr, env, ARRAY_SIZE(env), &process_opts)) < 0 ||
+	if ((error = git_process_new(&transport->process,
+	     (const char **)args.contents, args.length,
+	     env, ARRAY_SIZE(env), &process_opts)) < 0 ||
 	    (error = git_process_start(transport->process)) < 0) {
 		git_process_free(transport->process);
 		transport->process = NULL;
@@ -226,7 +256,7 @@ static int start_ssh(
 	}
 
 done:
-	git_str_dispose(&ssh_cmdline);
+	git_vector_dispose_deep(&args);
 	git_net_url_dispose(&url);
 	return error;
 }

--- a/src/libgit2/transports/ssh_exec.c
+++ b/src/libgit2/transports/ssh_exec.c
@@ -190,7 +190,7 @@ static int get_ssh_cmdline(
 
 	if ((error = git_str_puts(&remote_cmd, command)) < 0 ||
 	    (error = git_str_puts(&remote_cmd, " '")) < 0 ||
-	    (error = git_str_puts(&remote_cmd, url->path)) < 0 ||
+	    (error = git_str_puts_escaped(&remote_cmd, url->path, "'!", "'\\", "'")) < 0 ||
 	    (error = git_str_puts(&remote_cmd, "'")) < 0 ||
 	    (error = git_vector_insert(args, git_str_detach(&remote_cmd))) < 0)
 		goto done;

--- a/src/util/fs_path.h
+++ b/src/util/fs_path.h
@@ -205,6 +205,12 @@ extern bool git_fs_path_isdir(const char *path);
 extern bool git_fs_path_isfile(const char *path);
 
 /**
+ * Check if the given path points to an executable.
+ * @return true or false
+ */
+extern bool git_fs_path_isexecutable(const char *path);
+
+/**
  * Check if the given path points to a symbolic link.
  * @return true or false
  */

--- a/src/util/process.h
+++ b/src/util/process.h
@@ -11,7 +11,8 @@
 typedef struct git_process git_process;
 
 typedef struct {
-	unsigned int capture_in  : 1,
+	unsigned int use_shell   : 1,
+	             capture_in  : 1,
 	             capture_out : 1,
 	             capture_err : 1,
 	             exclude_env : 1;

--- a/src/util/str.c
+++ b/src/util/str.c
@@ -1065,10 +1065,13 @@ int git_str_puts_escaped(
 	git_str *buf,
 	const char *string,
 	const char *esc_chars,
-	const char *esc_with)
+	const char *esc_prefix,
+	const char *esc_suffix)
 {
 	const char *scan;
-	size_t total = 0, esc_len = strlen(esc_with), count, alloclen;
+	size_t total = 0, count, alloclen;
+	size_t esc_prefix_len = esc_prefix ? strlen(esc_prefix) : 0;
+	size_t esc_suffix_len = esc_suffix ? strlen(esc_suffix) : 0;
 
 	if (!string)
 		return 0;
@@ -1080,7 +1083,7 @@ int git_str_puts_escaped(
 		scan += count;
 		/* count run of escaped characters */
 		count = strspn(scan, esc_chars);
-		total += count * (esc_len + 1);
+		total += count * (esc_prefix_len + esc_suffix_len + 1);
 		scan += count;
 	}
 
@@ -1096,13 +1099,22 @@ int git_str_puts_escaped(
 		buf->size += count;
 
 		for (count = strspn(scan, esc_chars); count > 0; --count) {
-			/* copy escape sequence */
-			memmove(buf->ptr + buf->size, esc_with, esc_len);
-			buf->size += esc_len;
+			/* copy escape prefix sequence */
+			if (esc_prefix) {
+				memmove(buf->ptr + buf->size, esc_prefix, esc_prefix_len);
+				buf->size += esc_prefix_len;
+			}
+
 			/* copy character to be escaped */
 			buf->ptr[buf->size] = *scan;
 			buf->size++;
 			scan++;
+
+			/* copy escape suffix sequence */
+			if (esc_suffix) {
+				memmove(buf->ptr + buf->size, esc_suffix, esc_suffix_len);
+				buf->size += esc_suffix_len;
+			}
 		}
 	}
 

--- a/src/util/str.h
+++ b/src/util/str.h
@@ -268,21 +268,23 @@ int git_str_splice(
  * @param str String buffer to append data to
  * @param string String to escape and append
  * @param esc_chars Characters to be escaped
- * @param esc_with String to insert in from of each found character
+ * @param esc_prefix String to insert as prefix of each found character
+ * @param esc_suffix String to insert as suffix of each found character
  * @return 0 on success, <0 on failure (probably allocation problem)
  */
 extern int git_str_puts_escaped(
 	git_str *str,
 	const char *string,
 	const char *esc_chars,
-	const char *esc_with);
+	const char *esc_prefix,
+	const char *esc_suffix);
 
 /**
  * Append string escaping characters that are regex special
  */
 GIT_INLINE(int) git_str_puts_escape_regex(git_str *str, const char *string)
 {
-	return git_str_puts_escaped(str, string, "^.[]$()|*+?{}\\", "\\");
+	return git_str_puts_escaped(str, string, "^.[]$()|*+?{}\\", "\\", NULL);
 }
 
 /**

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -269,13 +269,26 @@ int git__prefixncmp_icase(const char *str, size_t str_n, const char *prefix)
 	return prefixcmp(str, str_n, prefix, true);
 }
 
-int git__suffixcmp(const char *str, const char *suffix)
+static int suffixcmp(const char *str, const char *suffix, bool icase)
 {
 	size_t a = strlen(str);
 	size_t b = strlen(suffix);
+
 	if (a < b)
 		return -1;
-	return strcmp(str + (a - b), suffix);
+
+	return icase ? strcasecmp(str + (a - b), suffix) :
+	               strcmp(str + (a - b), suffix);
+}
+
+int git__suffixcmp(const char *str, const char *suffix)
+{
+	return suffixcmp(str, suffix, false);
+}
+
+int git__suffixcmp_icase(const char *str, const char *suffix)
+{
+	return suffixcmp(str, suffix, true);
 }
 
 char *git__strtok(char **end, const char *sep)

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -57,6 +57,7 @@ extern int git__prefixcmp_icase(const char *str, const char *prefix);
 extern int git__prefixncmp(const char *str, size_t str_n, const char *prefix);
 extern int git__prefixncmp_icase(const char *str, size_t str_n, const char *prefix);
 extern int git__suffixcmp(const char *str, const char *suffix);
+extern int git__suffixcmp_icase(const char *str, const char *suffix);
 
 GIT_INLINE(int) git__signum(int val)
 {

--- a/src/util/win32/path_w32.c
+++ b/src/util/win32/path_w32.c
@@ -153,6 +153,7 @@ int git_win32_path_canonicalize(git_win32_path path)
 
 static int git_win32_path_join(
 	git_win32_path dest,
+	size_t *dest_len,
 	const wchar_t *one,
 	size_t one_len,
 	const wchar_t *two,
@@ -175,6 +176,9 @@ static int git_win32_path_join(
 
 	memcpy(dest + one_len + backslash, two, two_len * sizeof(wchar_t));
 	dest[one_len + backslash + two_len] = L'\0';
+
+	if (dest_len)
+		*dest_len = one_len + backslash + two_len;
 
 	return 0;
 }
@@ -258,21 +262,12 @@ struct executable_suffix {
 	size_t len;
 };
 
-int git_win32_path_find_executable(git_win32_path fullpath, wchar_t *exe)
+static struct executable_suffix suffixes[] = { { NULL, 0 }, { L".exe", 4 }, { L".cmd", 4 } };
+
+static bool has_executable_suffix(wchar_t *exe, size_t exe_len)
 {
-	struct win32_path_iter path_iter;
-	const wchar_t *dir;
-	size_t dir_len, exe_len = wcslen(exe);
-	bool found = false;
-	static struct executable_suffix suffixes[] = { { NULL, 0 }, { L".exe", 4 }, { L".cmd", 4 } };
-	size_t skip_bare = 1, i;
+	size_t i;
 
-	if (win32_path_iter_init(&path_iter) < 0)
-		return -1;
-
-	/* see if the given executable has an executable suffix; if so we will
-	 * look for the explicit name directly, as well as with added suffixes.
-	 */
 	for (i = 0; i < ARRAY_SIZE(suffixes); i++) {
 		struct executable_suffix *suffix = &suffixes[i];
 
@@ -282,40 +277,80 @@ int git_win32_path_find_executable(git_win32_path fullpath, wchar_t *exe)
 		if (exe_len < suffix->len)
 			continue;
 
-		if (memcmp(&exe[exe_len - suffix->len], suffix->suffix, suffix->len) == 0) {
-			skip_bare = 0;
-			break;
-		}
+		if (memcmp(&exe[exe_len - suffix->len], suffix->suffix, suffix->len) == 0)
+			return true;
 	}
 
-	while (win32_path_iter_next(&dir, &dir_len, &path_iter) != GIT_ITEROVER && !found) {
-		/*
-		 * if the given name has an executable suffix, then try looking for it
-		 * directly. in all cases, append executable extensions
-		 * (".exe", ".cmd"...)
-		 */
-		for (i = skip_bare; i < ARRAY_SIZE(suffixes); i++) {
-			struct executable_suffix *suffix = &suffixes[i];
+	return false;
+}
 
-			if (git_win32_path_join(fullpath, dir, dir_len, exe, exe_len) < 0)
+static int is_executable(git_win32_path path, size_t path_len, bool suffixed)
+{
+	size_t i;
+
+	/*
+	 * if the given name has an executable suffix, then try looking for it
+	 * directly. in all cases, append executable extensions
+	 * (".exe", ".cmd"...)
+	 */
+	for (i = suffixed ? 0 : 1; i < ARRAY_SIZE(suffixes); i++) {
+		struct executable_suffix *suffix = &suffixes[i];
+
+		if (suffix->len) {
+			if (path_len + suffix->len > MAX_PATH)
 				continue;
 
-			if (suffix->len) {
-				if (dir_len + exe_len + 1 + suffix->len > MAX_PATH)
-					continue;
+			wcscat(path, suffix->suffix);
+		}
 
-				wcscat(fullpath, suffix->suffix);
-			}
+		if (_waccess(path, 0) == 0)
+			return true;
 
-			if (_waccess(fullpath, 0) == 0) {
-				found = true;
-				break;
-			}
+		path[path_len] = L'\0';
+	}
+
+	return false;
+}
+
+int git_win32_path_find_executable(git_win32_path fullpath, wchar_t *exe)
+{
+	struct win32_path_iter path_iter;
+	const wchar_t *dir;
+	size_t dir_len, exe_len, fullpath_len;
+	bool suffixed = false, found = false;
+
+	if ((exe_len = wcslen(exe)) > MAX_PATH)
+		goto done;
+
+	/* see if the given executable has an executable suffix; if so we will
+	 * look for the explicit name directly, as well as with added suffixes.
+	 */
+	suffixed = has_executable_suffix(exe, exe_len);
+
+	/* For fully-qualified paths we do not look in PATH */
+	if (wcschr(exe, L'\\') != NULL || wcschr(exe, L'/') != NULL) {
+		if ((found = is_executable(exe, exe_len, suffixed)))
+			wcscpy(fullpath, exe);
+
+		goto done;
+	}
+
+	if (win32_path_iter_init(&path_iter) < 0)
+		return -1;
+
+	while (win32_path_iter_next(&dir, &dir_len, &path_iter) != GIT_ITEROVER && !found) {
+		if (git_win32_path_join(fullpath, &fullpath_len, dir, dir_len, exe, exe_len) < 0)
+			continue;
+
+		if (is_executable(fullpath, fullpath_len, suffixed)) {
+			found = true;
+			break;
 		}
 	}
 
 	win32_path_iter_dispose(&path_iter);
 
+done:
 	if (found)
 		return 0;
 

--- a/tests/libgit2/online/clone.c
+++ b/tests/libgit2/online/clone.c
@@ -105,13 +105,13 @@ void test_online_clone__initialize(void)
 	_orig_https_proxy = cl_getenv("HTTPS_PROXY");
 	_orig_no_proxy = cl_getenv("NO_PROXY");
 
-	_orig_ssh_cmd = cl_getenv("GIT_SSH");
+	_orig_ssh_cmd = cl_getenv("GIT_SSH_COMMAND");
 	_ssh_cmd = cl_getenv("GITTEST_SSH_CMD");
 
 	if (_ssh_cmd)
-		cl_setenv("GIT_SSH", _ssh_cmd);
+		cl_setenv("GIT_SSH_COMMAND", _ssh_cmd);
 	else
-		cl_setenv("GIT_SSH", NULL);
+		cl_setenv("GIT_SSH_COMMAND", NULL);
 
 	if (_remote_expectcontinue)
 		git_libgit2_opts(GIT_OPT_ENABLE_HTTP_EXPECT_CONTINUE, 1);
@@ -174,7 +174,7 @@ void test_online_clone__cleanup(void)
 	git__free(_orig_https_proxy);
 	git__free(_orig_no_proxy);
 
-	cl_setenv("GIT_SSH", _orig_ssh_cmd);
+	cl_setenv("GIT_SSH_COMMAND", _orig_ssh_cmd);
 	git__free(_orig_ssh_cmd);
 
 	git__free(_ssh_cmd);

--- a/tests/libgit2/online/push.c
+++ b/tests/libgit2/online/push.c
@@ -376,13 +376,13 @@ void test_online_push__initialize(void)
 	_remote_push_options = cl_getenv("GITTEST_PUSH_OPTIONS");
 	_remote = NULL;
 
-	_orig_ssh_cmd = cl_getenv("GIT_SSH");
+	_orig_ssh_cmd = cl_getenv("GIT_SSH_COMMAND");
 	_ssh_cmd = cl_getenv("GITTEST_SSH_CMD");
 
 	if (_ssh_cmd)
-		cl_setenv("GIT_SSH", _ssh_cmd);
+		cl_setenv("GIT_SSH_COMMAND", _ssh_cmd);
 	else
-		cl_setenv("GIT_SSH", NULL);
+		cl_setenv("GIT_SSH_COMMAND", NULL);
 
 	/* Skip the test if we're missing the remote URL */
 	if (!_remote_url)
@@ -439,6 +439,7 @@ void test_online_push__cleanup(void)
 	git__free(_remote_expectcontinue);
 	git__free(_remote_push_options);
 
+	cl_setenv("GIT_SSH_COMMAND", _orig_ssh_cmd);
 	git__free(_orig_ssh_cmd);
 	git__free(_ssh_cmd);
 

--- a/tests/util/gitstr.c
+++ b/tests/util/gitstr.c
@@ -691,16 +691,32 @@ void test_gitstr__puts_escaped(void)
 	git_str a = GIT_STR_INIT;
 
 	git_str_clear(&a);
-	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "", ""));
+	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "", "", ""));
 	cl_assert_equal_s("this is a test", a.ptr);
 
 	git_str_clear(&a);
-	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "t", "\\"));
+	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "", NULL, NULL));
+	cl_assert_equal_s("this is a test", a.ptr);
+
+	git_str_clear(&a);
+	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "t", "\\", ""));
 	cl_assert_equal_s("\\this is a \\tes\\t", a.ptr);
 
 	git_str_clear(&a);
-	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "i ", "__"));
+	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "t", "\\", NULL));
+	cl_assert_equal_s("\\this is a \\tes\\t", a.ptr);
+
+	git_str_clear(&a);
+	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "i ", "__", NULL));
 	cl_assert_equal_s("th__is__ __is__ a__ test", a.ptr);
+
+	git_str_clear(&a);
+	cl_git_pass(git_str_puts_escaped(&a, "this is a test", "i ", "__", "!!"));
+	cl_assert_equal_s("th__i!!s__ !!__i!!s__ !!a__ !!test", a.ptr);
+
+	git_str_clear(&a);
+	cl_git_pass(git_str_puts_escaped(&a, "this' is' an' escape! ", "'!", "'\\", "'"));
+	cl_assert_equal_s("this'\\'' is'\\'' an'\\'' escape'\\!' ", a.ptr);
 
 	git_str_clear(&a);
 	cl_git_pass(git_str_puts_escape_regex(&a, "^match\\s*[A-Z]+.*"));

--- a/tests/util/process/start.c
+++ b/tests/util/process/start.c
@@ -78,6 +78,52 @@ void test_process_start__not_found(void)
 	git_process_free(process);
 }
 
+void test_process_start__finds_in_path(void)
+{
+#ifdef GIT_WIN32
+	const char *args_array[] = { "cmd", "/c", "exit", "0" };
+#else
+	const char *args_array[] = { "true" };
+#endif
+
+	git_process *process;
+	git_process_options opts = GIT_PROCESS_OPTIONS_INIT;
+	git_process_result result = GIT_PROCESS_RESULT_INIT;
+
+	cl_git_pass(git_process_new(&process, args_array, ARRAY_SIZE(args_array), NULL, 0, &opts));
+	cl_git_pass(git_process_start(process));
+	cl_git_pass(git_process_wait(&result, process));
+
+	cl_assert_equal_i(GIT_PROCESS_STATUS_NORMAL, result.status);
+	cl_assert_equal_i(0, result.exitcode);
+	cl_assert_equal_i(0, result.signal);
+
+	git_process_free(process);
+}
+
+void test_process_start__adds_suffix(void)
+{
+#ifdef GIT_WIN32
+	const char *args_array[] = { "C:\\Windows\\System32\\cmd", "/c", "exit", "0" };
+
+	git_process *process;
+	git_process_options opts = GIT_PROCESS_OPTIONS_INIT;
+	git_process_result result = GIT_PROCESS_RESULT_INIT;
+
+	cl_git_pass(git_process_new(&process, args_array, ARRAY_SIZE(args_array), NULL, 0, &opts));
+	cl_git_pass(git_process_start(process));
+	cl_git_pass(git_process_wait(&result, process));
+
+	cl_assert_equal_i(GIT_PROCESS_STATUS_NORMAL, result.status);
+	cl_assert_equal_i(0, result.exitcode);
+	cl_assert_equal_i(0, result.signal);
+
+	git_process_free(process);
+#else
+	cl_skip();
+#endif
+}
+
 static void write_all(git_process *process, char *buf)
 {
 	size_t buf_len = strlen(buf);


### PR DESCRIPTION
Prior to this change, a bug in the external SSH execution can cause arbitrary command execution. Remote repository names were improperly sent to the shell without quoting. Arguments to the external SSH command are now sent parameterized.

This pull request refactors the SSH command execution logic and improves executable path resolution across platforms. It introduces a more robust method for building SSH command arguments, adds platform-specific checks for executable files, and enhances process spawning to better support shell usage and argument handling. Additionally, it updates utility functions for string escaping and suffix comparison, and refactors executable path searching to handle qualified paths and environment lookups more reliably.