### PR TITLE
ci: Fix cases of -Werror=discarded-qualifiers raised by gcc 15.2

### DIFF
--- a/src/cli/opt.c
+++ b/src/cli/opt.c
@@ -50,7 +50,7 @@ GIT_INLINE(const cli_opt_spec *) spec_for_long(
 	const char *arg)
 {
 	const cli_opt_spec *spec;
-	char *eql;
+	const char *eql;
 	size_t eql_pos;
 
 	eql = strchr(arg, '=');

--- a/src/libgit2/attr_file.c
+++ b/src/libgit2/attr_file.c
@@ -811,7 +811,7 @@ int git_attr_fnmatch__parse(
 	}
 
 	if (context) {
-		char *slash = strrchr(context, '/');
+		const char *slash = strrchr(context, '/');
 		size_t len;
 		if (slash) {
 			/* include the slash for easier matching */

--- a/src/libgit2/config_file.c
+++ b/src/libgit2/config_file.c
@@ -1135,7 +1135,8 @@ static int config_file_write(
 	const char *value)
 
 {
-	char *orig_section = NULL, *section = NULL, *orig_name, *name, *ldot;
+	char *orig_section = NULL, *section = NULL;
+	const char *orig_name, *name, *ldot;
 	git_str buf = GIT_STR_INIT, contents = GIT_STR_INIT;
 	git_config_parser parser = GIT_CONFIG_PARSER_INIT;
 	git_filebuf file = GIT_FILEBUF_INIT;

--- a/src/libgit2/config_parse.c
+++ b/src/libgit2/config_parse.c
@@ -282,7 +282,8 @@ static int skip_bom(git_parse_ctx *parser)
 /* '\"' -> '"' etc */
 static int unescape_line(char **out, bool *is_multi, const char *ptr, int *quote_count)
 {
-	char *str, *fixed, *esc;
+	char *str, *fixed;
+	const char *esc;
 	size_t ptr_len = strlen(ptr), alloc_len;
 
 	*is_multi = false;

--- a/src/libgit2/message.c
+++ b/src/libgit2/message.c
@@ -33,7 +33,7 @@ static int git_message__prettify(
 
 	int consecutive_empty_lines = 0;
 	size_t i, line_length, rtrimmed_line_length;
-	char *next_newline;
+	const char *next_newline;
 
 	for (i = 0; i < strlen(message); i += line_length) {
 		next_newline = memchr(message + i, '\n', message_len - i);

--- a/src/libgit2/transports/git.c
+++ b/src/libgit2/transports/git.c
@@ -39,7 +39,7 @@ typedef struct {
  */
 static int gen_proto(git_str *request, const char *cmd, const char *url)
 {
-	char *delim, *repo;
+	const char *delim, *repo;
 	char host[] = "host=";
 	size_t len;
 

--- a/src/util/unix/process.c
+++ b/src/util/unix/process.c
@@ -44,7 +44,7 @@ struct git_process {
 
 GIT_INLINE(bool) is_delete_env(const char *env)
 {
-	char *c = strchr(env, '=');
+	const char *c = strchr(env, '=');
 
 	if (c == NULL)
 		return false;

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -336,7 +336,7 @@ char *git__strsep(char **end, const char *sep)
 
 size_t git__linenlen(const char *buffer, size_t buffer_len)
 {
-	char *nl = memchr(buffer, '\n', buffer_len);
+	const char *nl = memchr(buffer, '\n', buffer_len);
 	return nl ? (size_t)(nl - buffer) + 1 : buffer_len;
 }
 

--- a/tests/clar/clar/print.h
+++ b/tests/clar/clar/print.h
@@ -102,7 +102,7 @@ static void clar_print_tap_error(int num, const struct clar_report *report, cons
 
 static void print_escaped(const char *str)
 {
-	char *c;
+	const char *c;
 
 	while ((c = strchr(str, '\'')) != NULL) {
 		printf("%.*s", (int)(c - str), str);

--- a/tests/libgit2/diff/drivers.c
+++ b/tests/libgit2/diff/drivers.c
@@ -18,7 +18,7 @@ void test_diff_drivers__cleanup(void)
 static void overwrite_filemode(const char *expected, git_buf *actual)
 {
 	size_t offset;
-	char *found;
+	const char *found;
 
 	found = strstr(expected, "100644");
 	if (!found)

--- a/tests/libgit2/refs/reflog/reflog.c
+++ b/tests/libgit2/refs/reflog/reflog.c
@@ -244,7 +244,7 @@ void test_refs_reflog_reflog__reading_a_reflog_with_invalid_format_succeeds(void
 	 */
 	cl_git_pass(git_str_join_n(&logpath, '/', 3, git_repository_path(g_repo), GIT_REFLOG_DIR, refname));
 	cl_git_pass(git_futils_readbuffer(&logcontents, git_str_cstr(&logpath)));
-	cl_assert((star = strchr(git_str_cstr(&logcontents), '*')) != NULL);
+	cl_assert((star = strchr(logcontents.ptr, '*')) != NULL);
 	*star = '\n';
 	cl_git_rewritefile(git_str_cstr(&logpath), git_str_cstr(&logcontents));
 


### PR DESCRIPTION
With yesterday's update to the Fedora rawhide Docker image, the new gcc 15.2 started reporting some discarded qualifier warnings, that we treat as errors:

```
/home/libgit2/source/src/libgit2/attr_file.c: In function 'git_attr_fnmatch__parse':
/home/libgit2/source/src/libgit2/attr_file.c:814:31: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
  814 |                 char *slash = strrchr(context, '/');
      |                               ^~~~~~~
At top level:
cc1: all warnings being treated as errors
```

This PR fixes all of them so the build passes in Docker.