### PR TITLE
Add swift-libgit2 language binding to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Here are the bindings to libgit2 that are currently available:
 * Swift
     * SwiftGit2 <https://github.com/SwiftGit2/SwiftGit2>
     * SwiftGitX <https://github.com/ibrahimcetin/SwiftGitX>
+    * swift-libgit2 <https://github.com/swift-developer-tools/swift-libgit2>
 * Tcl
     * lg2 <https://github.com/apnadkarni/tcl-libgit2>
 * Vala


### PR DESCRIPTION
This adds a new Swift binding to the README.

https://github.com/swift-developer-tools/swift-libgit2

https://swift-developer-tools.github.io/swift-libgit2/documentation/swiftlibgit2/