### PR TITLE
ci: Update macos-13 to macos-14 images on GitHub Actions

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -37,7 +37,7 @@ jobs:
             CMAKE_OPTIONS: -DUSE_HTTPS=OpenSSL -DDEPRECATE_HARD=ON -DDEBUG_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=ON -DEXPERIMENTAL_SHA256=ON
         - name: "macOS (SHA256)"
           id: macos-sha256
-          os: macos-13
+          os: macos-14
           setup-script: osx
           env:
             CC: clang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
             CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DDEBUG_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2
         - name: "macOS"
           id: macos
-          os: macos-13
+          os: macos-14
           setup-script: osx
           env:
             CC: clang

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
             CMAKE_OPTIONS: -DUSE_HTTPS=mbedTLS -DUSE_SHA1=HTTPS -DDEPRECATE_HARD=ON -DDEBUG_LEAK_CHECKER=valgrind -DUSE_GSSAPI=ON -DUSE_SSH=libssh2
         - name: "macOS"
           id: macos
-          os: macos-13
+          os: macos-14
           setup-script: osx
           env:
             CC: clang
@@ -76,7 +76,7 @@ jobs:
             SKIP_NEGOTIATE_TESTS: true
         - name: "iOS"
           id: ios
-          os: macos-13
+          os: macos-14
           setup-script: ios
           env:
             CC: clang
@@ -356,7 +356,7 @@ jobs:
           os: ubuntu-latest
         - name: "macOS (SHA256)"
           id: macos-sha256
-          os: macos-13
+          os: macos-14
           setup-script: osx
           env:
             CC: clang

--- a/script/leaks.sh
+++ b/script/leaks.sh
@@ -4,5 +4,5 @@ export MallocScribble=1
 export MallocLogFile=/dev/null
 # Exclude known Apple Security framework leak in CryptKit::FEEKeyInfoProvider
 # which occurs during SSL/TLS handshakes and is not in libgit2's control
-export CLAR_AT_EXIT="leaks -quiet -exclude SSLHandshake \$PPID"
+export CLAR_AT_EXIT="leaks -quiet -exclude=SSLHandshake \$PPID"
 exec "$@"

--- a/script/leaks.sh
+++ b/script/leaks.sh
@@ -2,5 +2,7 @@
 export MallocStackLogging=1
 export MallocScribble=1
 export MallocLogFile=/dev/null
-export CLAR_AT_EXIT="leaks -quiet \$PPID"
+# Exclude known Apple Security framework leak in CryptKit::FEEKeyInfoProvider
+# which occurs during SSL/TLS handshakes and is not in libgit2's control
+export CLAR_AT_EXIT="leaks -quiet -exclude SSLHandshake \$PPID"
 exec "$@"


### PR DESCRIPTION
macos-13 is no longer available, any PR triggering Mac builds is currently failing.