### PR TITLE
tests: Fix stat tests on 32bit systems

### DIFF
--- a/.github/actions/run-build/action.yml
+++ b/.github/actions/run-build/action.yml
@@ -42,7 +42,6 @@ runs:
           -e CMAKE_OPTIONS \
           -e CMAKE_GLOBAL_OPTIONS \
           -e GITTEST_NEGOTIATE_PASSWORD \
-          -e GITTEST_FLAKY_STAT \
           -e PKG_CONFIG_PATH \
           -e SKIP_NEGOTIATE_TESTS \
           -e SKIP_SSH_TESTS \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -282,7 +282,6 @@ jobs:
             RUN_INVASIVE_TESTS: true
             SKIP_PROXY_TESTS: true
             SKIP_PUSHOPTIONS_TESTS: true
-            GITTEST_FLAKY_STAT: true
           os: ubuntu-latest
         - name: "Linux (arm64, Bionic, GCC, OpenSSL)"
           id: bionic-arm64-gcc-openssl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,14 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 
+#
+# Common settings across all projects, dependencies, etc. Always support
+# 64 bit file operations, even 32 bit platforms.
+#
+
+add_definitions(-D_FILE_OFFSET_BITS=64)
+
+
 # Modules
 
 include(FeatureSummary)

--- a/tests/libgit2/CMakeLists.txt
+++ b/tests/libgit2/CMakeLists.txt
@@ -19,7 +19,6 @@ add_definitions(-DCLAR_FIXTURE_PATH=\"${CLAR_FIXTURES}\")
 add_definitions(-DCLAR_TMPDIR=\"libgit2_tests\")
 add_definitions(-DCLAR_WIN32_LONGPATHS)
 add_definitions(-DCLAR_HAS_REALPATH)
-add_definitions(-D_FILE_OFFSET_BITS=64)
 
 # Ensure that we do not use deprecated functions internally
 add_definitions(-DGIT_DEPRECATE_HARD)

--- a/tests/libgit2/diff/workdir.c
+++ b/tests/libgit2/diff/workdir.c
@@ -1291,8 +1291,7 @@ void test_diff_workdir__can_diff_empty_file(void)
 
 	cl_git_pass(git_fs_path_lstat("attr_index/README.txt", &st));
 
-	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
-		cl_assert_equal_sz(0, st.st_size);
+	cl_assert_equal_sz(0, st.st_size);
 
 	cl_git_pass(git_diff_tree_to_workdir(&diff, g_repo, tree, &opts));
 	cl_assert_equal_i(3, (int)git_diff_num_deltas(diff));

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -19,7 +19,6 @@ add_definitions(-DCLAR_FIXTURE_PATH=\"${CLAR_FIXTURES}\")
 add_definitions(-DCLAR_TMPDIR=\"libgit2_tests\")
 add_definitions(-DCLAR_WIN32_LONGPATHS)
 add_definitions(-DCLAR_HAS_REALPATH)
-add_definitions(-D_FILE_OFFSET_BITS=64)
 
 # Ensure that we do not use deprecated functions internally
 add_definitions(-DGIT_DEPRECATE_HARD)

--- a/tests/util/copy.c
+++ b/tests/util/copy.c
@@ -14,8 +14,7 @@ void test_copy__file(void)
 	cl_git_pass(git_fs_path_lstat("copy_me_two", &st));
 	cl_assert(S_ISREG(st.st_mode));
 
-	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
-		cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
+	cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
 
 	cl_git_pass(p_unlink("copy_me_two"));
 	cl_git_pass(p_unlink("copy_me"));
@@ -41,8 +40,7 @@ void test_copy__file_in_dir(void)
 	cl_git_pass(git_fs_path_lstat("an_dir/second_dir/and_more/copy_me_two", &st));
 	cl_assert(S_ISREG(st.st_mode));
 
-	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
-		cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
+	cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
 
 	cl_git_pass(git_futils_rmdir_r("an_dir", NULL, GIT_RMDIR_REMOVE_FILES));
 	cl_assert(!git_fs_path_isdir("an_dir"));
@@ -105,8 +103,7 @@ void test_copy__tree(void)
 	cl_git_pass(git_fs_path_lstat("t1/c/f3", &st));
 	cl_assert(S_ISREG(st.st_mode));
 
-	if (!cl_is_env_set("GITTEST_FLAKY_STAT"))
-		cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
+	cl_assert_equal_sz(strlen(content), (size_t)st.st_size);
 
 #ifndef GIT_WIN32
 	memset(&st, 0, sizeof(struct stat));


### PR DESCRIPTION
On 32bit systems the git_fs_path_lstat from libgit2 by default uses 32bit stat
structs while the tests are being compiled with struct stat64 via
_FILE_OFFSET_BITS=64.

This discrepancy causes the "flaky" stat failures in tests.

The solution is to use the same _FILE_OFFSET_BITS as the library by
leaving it up to the user to define _FILE_OFFSET_BIT.

Also remove GITTEST_FLAKY_STAT (in as separate commit) as it should no longer be necessary.

Fixes: https://github.com/libgit2/libgit2/issues/7169