### PR TITLE
Create external ssh process with flag CREATE_NO_WINDOW

### DIFF
--- a/src/util/win32/process.c
+++ b/src/util/win32/process.c
@@ -256,7 +256,7 @@ int git_process_start(git_process *process)
 {
 	STARTUPINFOW startup_info;
 	SECURITY_ATTRIBUTES security_attrs;
-	DWORD flags = CREATE_UNICODE_ENVIRONMENT;
+	DWORD flags = CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW;
 	HANDLE in[2]  = { NULL, NULL },
 	       out[2] = { NULL, NULL },
 	       err[2] = { NULL, NULL };


### PR DESCRIPTION
I noticed that a window (a terminal) is created when starting the ssh process to download data. The flag CREATE_NO_WINDOW avoids this.

https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags