### PR TITLE
delta: fix undefined behavior in hdr_sz varint parsing

### DIFF
--- a/src/libgit2/delta.c
+++ b/src/libgit2/delta.c
@@ -477,8 +477,12 @@ static int hdr_sz(
 			return -1;
 		}
 
+		if (shift >= (sizeof(size_t) * 8)) {
+			git_error_set(GIT_ERROR_INVALID, "delta header overflow");
+			return -1;
+		}
 		c = *d++;
-		r |= (c & 0x7f) << shift;
+		r |= ((size_t)(c & 0x7f)) << shift;
 		shift += 7;
 	} while (c & 0x80);
 	*delta = d;

--- a/tests/libgit2/delta/shift_overflow.c
+++ b/tests/libgit2/delta/shift_overflow.c
@@ -1,0 +1,16 @@
+#include "clar_libgit2.h"
+#include "delta.h"
+
+void test_delta_shift_overflow__hdr_sz_shift_limit(void)
+{
+	unsigned char base[16] = { 0 };
+	unsigned char delta[] = {
+		0x80, 0x80, 0x80, 0x80, 0x80,
+		0x80, 0x80, 0x80, 0x80,
+		0x80, 0x01
+	};
+	void *out;
+	size_t outlen;
+
+	cl_git_fail(git_delta_apply(&out, &outlen, base, sizeof(base), delta, sizeof(delta)));
+}


### PR DESCRIPTION
The expression (c & 0x7f) << shift in hdr_sz() causes undefined behavior when shift >= 32, because (c & 0x7f) is an unsigned int (32-bit type). A malicious delta with a long varint can trigger this.


Detected with UBSan: delta.c:481:19: runtime error: shift exponent 35 is too large for 32-bit type 'unsigned int'

Fix by:

1. Casting to size_t before shifting to support 64-bit shifts
2. Adding a shift limit check to reject overlong varints

Testing

- Added `tests/libgit2/delta/shift_overflow.c` with test cases
- All existing delta tests pass
- Full test suite passes
