### PR TITLE
fix(sha256): pass correct oid type

### DIFF
--- a/src/libgit2/commit_graph.c
+++ b/src/libgit2/commit_graph.c
@@ -817,8 +817,7 @@ int git_commit_graph_writer_add_index_file(
 	if (error < 0)
 		goto cleanup;
 
-	/* TODO: SHA256 */
-	error = git_mwindow_get_pack(&p, idx_path, 0);
+	error = git_mwindow_get_pack(&p, idx_path, repo->oid_type);
 	if (error < 0)
 		goto cleanup;
 

--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -579,8 +579,7 @@ int git_midx_writer_add(
 	if (error < 0)
 		return error;
 
-	/* TODO: SHA256 */
-	error = git_mwindow_get_pack(&p, git_str_cstr(&idx_path_buf), 0);
+	error = git_mwindow_get_pack(&p, git_str_cstr(&idx_path_buf), w->oid_type);
 	git_str_dispose(&idx_path_buf);
 	if (error < 0)
 		return error;

--- a/src/libgit2/pack-objects.c
+++ b/src/libgit2/pack-objects.c
@@ -1437,12 +1437,10 @@ int git_packbuilder_write(
 	opts.progress_cb = progress_cb;
 	opts.progress_cb_payload = progress_cb_payload;
 
-	/* TODO: SHA256 */
-
 #ifdef GIT_EXPERIMENTAL_SHA256
 	opts.mode = mode;
 	opts.odb = pb->odb;
-	opts.oid_type = GIT_OID_SHA1;
+	opts.oid_type = pb->oid_type;
 
 	error = git_indexer_new(&indexer, path, &opts);
 #else


### PR DESCRIPTION
These are SHA256 TODO leftover.
In the surrounding context they all have the required oid type around,
so I just picked up them and pass in.

Found during SHA256 support integration with Rust git2-rs binding

Related: <https://github.com/rust-lang/git2-rs/issues/1090>


---

[This test](https://github.com/rust-lang/git2-rs/blob/e9690cf0e0f158bf017c77745f6f2b3a7c273897/src/packbuilder.rs?plain=1#L343-L353) will fail if changing repo to SHA256 such as:

```rust
#[test]
fn smoke_write_sha256() {
    let (_td, repo) = crate::test::repo_init_sha256();
    let mut builder = t!(repo.packbuilder());
    t!(builder.write(repo.path(), 0));
    #[allow(deprecated)]
    {
        assert!(
            builder.hash().unwrap()
                == Oid::from_str(EMPTY_PACKFILE_OID, crate::ObjectFormat::Sha256).unwrap()
        );
    }
    assert!(builder.name().unwrap() == EMPTY_PACKFILE_OID);
}
```
