### PR TITLE
fix(smart): keep caps across RPC stream resets

### DIFF
--- a/src/libgit2/transports/smart.c
+++ b/src/libgit2/transports/smart.c
@@ -64,13 +64,13 @@ GIT_INLINE(int) git_smart__reset_stream(transport_smart *t, bool close_subtransp
 
 		if (t->wrapped->close(t->wrapped) < 0)
 			return -1;
+
+		git__free(t->caps.object_format);
+		t->caps.object_format = NULL;
+
+		git__free(t->caps.agent);
+		t->caps.agent = NULL;
 	}
-
-	git__free(t->caps.object_format);
-	t->caps.object_format = NULL;
-
-	git__free(t->caps.agent);
-	t->caps.agent = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
Preserve ref-advertised capabilities when only the stream is reset.

This prevents losing `object-format` before `git_remote_oid_type()`
and fixes SHA256 clone pack trailer mismatch.

Fixes libgit2/libgit2#7182