### PR TITLE
feat(remote): expose `git_remote_oid_type`

### DIFF
--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -418,6 +418,19 @@ GIT_EXTERN(int) git_remote_ls(const git_remote_head ***out,  size_t *size, git_r
 GIT_EXTERN(int) git_remote_connected(const git_remote *remote);
 
 /**
+ * Get the remote repository's object format.
+ *
+ * The remote (or more exactly its transport) must have connected to
+ * the remote repository. This format is available as soon as the
+ * connection to the remote is initiated and stays connected.
+ *
+ * @param out the resulting object format type
+ * @param remote the remote
+ * @return 0 on success, or an error code
+ */
+GIT_EXTERN(int) git_remote_oid_type(git_oid_t *out, git_remote *remote);
+
+/**
  * Cancel the operation
  *
  * At certain points in its operation, the network code checks whether

--- a/src/libgit2/remote.h
+++ b/src/libgit2/remote.h
@@ -58,7 +58,6 @@ int git_remote_connect_options_normalize(
 	const git_remote_connect_options *src);
 
 int git_remote_capabilities(unsigned int *out, git_remote *remote);
-int git_remote_oid_type(git_oid_t *out, git_remote *remote);
 
 
 #define git_remote_connect_options__copy_opts(out, in) \


### PR DESCRIPTION
This would be useful for user to determine whether they want to proceed
or bail further remote operations. Particularily useful for downstream
libgit2 bindings and applications to experiment SHA256 support behind a
runtime feature flag.

For example, `cargo` could compile with sha256 support unconditionally,
but reject SHA256 usage at runtime if the `-Zgit=sha256` nightly flag
was not on. Cargo would leverage this new API to determine if users are
trying to fetch a SHA256 remote repository and bail when needed before
any fetches happen.

---

If there is any better alternative than this to do runtime SHA256 support check for tools like Cargo, please share!

cc https://github.com/rust-lang/git2-rs/issues/1090 and https://github.com/rust-lang/cargo/issues/14942