### PR TITLE
Use git_oid_raw_cmp instead of custom loop in git_oid_is_zero

### DIFF
--- a/src/libgit2/oid.c
+++ b/src/libgit2/oid.c
@@ -22,6 +22,8 @@ const git_oid git_oid__empty_tree_sha1 =
 	  { 0x4b, 0x82, 0x5d, 0xc6, 0x42, 0xcb, 0x6e, 0xb9, 0xa0, 0x60,
 	    0xe5, 0x4b, 0xf8, 0xd6, 0x92, 0x88, 0xfb, 0xee, 0x49, 0x04 });
 
+static const unsigned char git_oid_zero[GIT_OID_MAX_SIZE] = {0};
+
 static int oid_error_invalid(const char *msg)
 {
 	git_error_set(GIT_ERROR_INVALID, "unable to parse OID - %s", msg);
@@ -292,7 +294,7 @@ int git_oid_streq(const git_oid *oid_a, const char *str)
 int git_oid_is_zero(const git_oid *oid_a)
 {
 	const unsigned char *a = oid_a->id;
-	size_t size = git_oid_size(git_oid_type(oid_a)), i;
+	size_t size = git_oid_size(git_oid_type(oid_a));
 
 #ifdef GIT_EXPERIMENTAL_SHA256
 	if (!oid_a->type)
@@ -301,10 +303,7 @@ int git_oid_is_zero(const git_oid *oid_a)
 		return 0;
 #endif
 
-	for (i = 0; i < size; ++i, ++a)
-		if (*a != 0)
-			return 0;
-	return 1;
+	return git_oid_raw_cmp(a, git_oid_zero, size) == 0 ? 1 : 0;
 }
 
 #ifndef GIT_DEPRECATE_HARD


### PR DESCRIPTION
This is in the category of low-hanging fruit. Isolated, this produces far more optimised code for git_oid_is_zero, but the impact can be anything from non-existing to a couple of percent depending on how frequently it's called. Running blame on this project's root CMakeLists.txt for example, gives a 1% performance increase. 

At the core though, this results in very optimised code. On x86_64 and GCC 15.2.1, instead of looped byte access (which is the result of the prior code), this results in 8 byte reads where `git_oid_zero` is entirely optimised away.
```
(gdb) disassemble git_oid_is_zero
Dump of assembler code for function git_oid_is_zero:
   0x000000000047dd90 <+0>:     mov    (%rdi),%rax
   0x000000000047dd93 <+3>:     or     0x8(%rdi),%rax
   0x000000000047dd97 <+7>:     jne    0x47dda0 <git_oid_is_zero+16>
   0x000000000047dd99 <+9>:     mov    0x10(%rdi),%eax
   0x000000000047dd9c <+12>:    test   %eax,%eax
   0x000000000047dd9e <+14>:    je     0x47ddb0 <git_oid_is_zero+32>
   0x000000000047dda0 <+16>:    mov    $0x1,%eax
   0x000000000047dda5 <+21>:    xor    $0x1,%eax
   0x000000000047dda8 <+24>:    ret
   0x000000000047dda9 <+25>:    nopl   0x0(%rax)
   0x000000000047ddb0 <+32>:    xor    %eax,%eax
   0x000000000047ddb2 <+34>:    xor    $0x1,%eax
   0x000000000047ddb5 <+37>:    ret
End of assembler dump.
```