### PR TITLE
index: support USE_NSEC=OFF

### DIFF
--- a/tests/libgit2/index/nsec.c
+++ b/tests/libgit2/index/nsec.c
@@ -26,6 +26,9 @@ void test_index_nsec__cleanup(void)
 
 static bool try_create_file_with_nsec_timestamp(const char *path)
 {
+#ifndef GIT_NSEC
+	GIT_UNUSED(path);
+#else
 	struct stat st;
 	int try;
 
@@ -38,6 +41,7 @@ static bool try_create_file_with_nsec_timestamp(const char *path)
 		if (st.st_ctime_nsec && st.st_mtime_nsec)
 			return true;
 	}
+#endif
 
 	return false;
 }

--- a/tests/libgit2/index/racy.c
+++ b/tests/libgit2/index/racy.c
@@ -126,7 +126,9 @@ static void setup_race(void)
 
 	/* force a race */
 	entry->mtime.seconds = (int32_t)st.st_mtime;
+#ifdef GIT_NSEC
 	entry->mtime.nanoseconds = (int32_t)st.st_mtime_nsec;
+#endif
 
 	git_str_dispose(&path);
 }

--- a/tests/libgit2/odb/freshen.c
+++ b/tests/libgit2/odb/freshen.c
@@ -176,8 +176,11 @@ void test_odb_freshen__packed_object(void)
 	cl_must_pass(p_lstat("testrepo.git/objects/pack/" PACKED_FN, &after));
 
 	cl_assert(before.st_atime == after.st_atime);
-	cl_assert(before.st_atime_nsec == after.st_atime_nsec);
 	cl_assert(before.st_mtime == after.st_mtime);
+
+#ifdef GIT_NSEC
+	cl_assert(before.st_atime_nsec == after.st_atime_nsec);
 	cl_assert(before.st_mtime_nsec == after.st_mtime_nsec);
+#endif
 }
 


### PR DESCRIPTION
Ideally, nobody should be building without nanosecond precision. But support them if they do.

Fixes #7036