### PR TITLE
Fix memory leak in `git_revparse()`

### DIFF
--- a/src/libgit2/revparse.c
+++ b/src/libgit2/revparse.c
@@ -956,6 +956,10 @@ int git_revparse(
 				&revspec->to,
 				repo,
 				*rstr == '\0' ? "HEAD" : rstr);
+
+			if (error < 0) {
+				git_object_free(revparse->from);
+			}
 		}
 
 		git__free((void*)lstr);

--- a/src/libgit2/revparse.c
+++ b/src/libgit2/revparse.c
@@ -958,7 +958,8 @@ int git_revparse(
 				*rstr == '\0' ? "HEAD" : rstr);
 
 			if (error < 0) {
-				git_object_free(revparse->from);
+				git_object_free(revspec->from);
+				revspec->from = NULL;
 			}
 		}
 


### PR DESCRIPTION
If an error occurs when calling `git_revparse_single()` with `revspec->to`, `revspec->from` must be freed, since it was already successfully allocated.

Fixes #7184.

I didn't set `revspec->from` to `NULL` after freeing it, since I don't generally see that pattern throughout the repo.

It's possible `revspec->from` was not being freed on purpose, since the object isn't opaque, and after receiving an error code, the caller can check if it is non-`NULL` and free it. I leaned more toward making the function atomic, but I can see how the original behavior may be preferred, especially since the `git_revspec` docs explicitly mention that freeing `from` and `to` is up to the caller.

If the original behavior is preferred, I could instead add a note to the `git_revparse` docs about this. Something like:

> If an error occurs parsing `to`, make sure to free `from`.

Just to highlight that an error does not necessarily mean nothing has been allocated.
