### PR TITLE
Fixing install of headers when using an experimental feature

### DIFF
--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -41,7 +41,12 @@ ide_split_sources(libgit2)
 list(APPEND LIBGIT2_OBJECTS $<TARGET_OBJECTS:util> $<TARGET_OBJECTS:libgit2> ${LIBGIT2_DEPENDENCY_OBJECTS})
 list(APPEND LIBGIT2_INCLUDES ${LIBGIT2_DEPENDENCY_INCLUDES})
 
-target_include_directories(libgit2 PRIVATE ${LIBGIT2_INCLUDES} ${LIBGIT2_DEPENDENCY_INCLUDES} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+# Build should look at headers in source tree but installed target should point to the possibly mutated
+# includes which will be generated
+target_include_directories(libgit2 PRIVATE ${LIBGIT2_INCLUDES} ${LIBGIT2_DEPENDENCY_INCLUDES}
+		PUBLIC
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>)
 target_include_directories(libgit2 SYSTEM PRIVATE ${LIBGIT2_SYSTEM_INCLUDES})
 
 set(LIBGIT2_INCLUDES ${LIBGIT2_INCLUDES} PARENT_SCOPE)
@@ -96,12 +101,22 @@ endif()
 
 configure_file(experimental.h.in "${PROJECT_BINARY_DIR}/include/git2/experimental.h")
 
-# translate filenames in the git2.h so that they match the install directory
+# translate filenames in the headers so that they match the install directory
 # (allows for side-by-side installs of libgit2 and libgit2-experimental.)
 
-FILE(READ "${PROJECT_SOURCE_DIR}/include/git2.h" LIBGIT2_INCLUDE)
-STRING(REGEX REPLACE "#include \"git2\/" "#include \"${LIBGIT2_FILENAME}/" LIBGIT2_INCLUDE "${LIBGIT2_INCLUDE}")
-FILE(WRITE "${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}.h" ${LIBGIT2_INCLUDE})
+foreach(HEADER_SOURCE ${SRC_H})
+  # Compute desired path in the binary dir
+  FILE(RELATIVE_PATH HEADER_RELATIVE ${PROJECT_SOURCE_DIR} ${HEADER_SOURCE})
+  STRING(REPLACE "git2/" "git2-experimental/" HEADER_RELATIVE ${HEADER_RELATIVE})
+  SET(HEADER_OUT ${PROJECT_BINARY_DIR}/${HEADER_RELATIVE})
+
+  FILE(READ "${HEADER_SOURCE}" HEADER_CONTENTS)
+  STRING(REGEX REPLACE "#include \"git2\/" "#include \"${LIBGIT2_FILENAME}/" HEADER_CONTENTS "${HEADER_CONTENTS}")
+  FILE(WRITE "${HEADER_OUT}" "${HEADER_CONTENTS}")
+endforeach()
+
+# Rename git2.h after the regex & move
+FILE(RENAME "${PROJECT_BINARY_DIR}/include/git2.h" "${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}.h")
 
 # cmake package targets
 
@@ -132,9 +147,7 @@ install(TARGETS libgit2package
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/git2/
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBGIT2_FILENAME}")
-install(FILES ${PROJECT_BINARY_DIR}/include/git2/experimental.h
+install(DIRECTORY ${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}/
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBGIT2_FILENAME}")
 install(FILES "${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}.h"
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Trying to use the experimental sha256 feature via vcpkg I ran into this issue: https://github.com/libgit2/libgit2/issues/7199

So here I've made a small modification to the cmake script so that all header files in the include directory are updated to point at git2-experimental/. The target's install interface had to be modified so that it uses the unmodified include/ headers from the source tree to build but points the installed target to the modified, installed headers.

I verified that this worked by creating a custom vcpkg port and overriding our usage of libgit2 to point to this change. It built and installed without incident and our tool can now properly interact with sha256 repos as expected.