### PR TITLE
revparse: Allow `HEAD` abbreviation `@`

### DIFF
--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -894,6 +894,9 @@ static bool is_valid_normalized_name(const char *name, size_t len)
 		if (i == 0 && c == '^')
 			continue; /* The first character is allowed to be "^" for negative refspecs */
 
+		if (len == 1 && c == '@')
+			return true; /* Abbreviation for HEAD */
+
 		if ((c < 'A' || c > 'Z') && c != '_')
 			return false;
 	}
@@ -965,11 +968,16 @@ int git_reference__normalize_name(
 				process_flags &= ~GIT_REFERENCE_FORMAT_REFSPEC_PATTERN;
 
 			if (normalize) {
-				size_t cur_len = git_str_len(buf);
+				/* `<empty>@` (i.e. just `@`) is an alias for `HEAD` */
+				if (segments_count == 0 && segment_len == 1 && current[0] == '@') {
+					git_str_sets(buf, GIT_HEAD_FILE);
+				} else {
+					size_t cur_len = git_str_len(buf);
 
-				git_str_joinpath(buf, git_str_cstr(buf), current);
-				git_str_truncate(buf,
-					cur_len + segment_len + (segments_count ? 1 : 0));
+					git_str_joinpath(buf, git_str_cstr(buf), current);
+					git_str_truncate(buf,
+						cur_len + segment_len + (segments_count ? 1 : 0));
+				}
 
 				if (git_str_oom(buf)) {
 					error = -1;

--- a/tests/libgit2/refs/revparse.c
+++ b/tests/libgit2/refs/revparse.c
@@ -173,6 +173,14 @@ void test_refs_revparse__head(void)
 	test_object("master", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
 }
 
+void test_refs_revparse__head_abbrev(void)
+{
+	test_object("@", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
+	test_object("@^0", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
+	test_object("@~0", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
+	test_object("master", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");
+}
+
 void test_refs_revparse__full_refs(void)
 {
 	test_object("refs/heads/master", "a65fedf39aefe402d3bb6e24df4d4f5fe4547750");


### PR DESCRIPTION
The `@` alone (without predeeding refname in `<refname>@`) is an alias for HEAD, and can then be used with other modifiers for example `HEAD^{/...}`

This was bugging me for ages when using `git absorb -b ...` (e.g. during the middle of a rebase when fixing things up). I think I've put the code in the correct places but I've only skimmed the code and stepped through it using GDB.