### PR TITLE
fix(clone): propagate object format in local clone

### DIFF
--- a/src/libgit2/clone.c
+++ b/src/libgit2/clone.c
@@ -519,6 +519,12 @@ static int clone_local_into(
 		return error;
 	}
 
+	/* Propagate the source repository's object format to the target
+	 * so that it can read the copied object database. */
+	if ((error = git_repository__set_objectformat(
+			repo, git_repository_oid_type(src))) < 0)
+		goto cleanup;
+
 	if (git_repository__item_path(&src_odb, src, GIT_REPOSITORY_ITEM_OBJECTS) < 0 ||
 	    git_repository__item_path(&dst_odb, repo, GIT_REPOSITORY_ITEM_OBJECTS) < 0) {
 		error = -1;

--- a/tests/libgit2/clone/local.c
+++ b/tests/libgit2/clone/local.c
@@ -266,3 +266,69 @@ void test_clone_local__shallow_fails(void)
 
 	cl_git_fail_with(GIT_ENOTSUPPORTED, git_clone(&repo, cl_fixture("testrepo.git"), "./clone.git", &opts));
 }
+
+void test_clone_local__sha256_via_no_local(void)
+{
+#ifndef GIT_EXPERIMENTAL_SHA256
+	cl_skip();
+#else
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	/*
+         * file:// URL + GIT_CLONE_NO_LOCAL -> remote code path
+	 *
+	 * Should correctly propagate the object format
+	 */
+	opts.bare = true;
+	opts.local = GIT_CLONE_NO_LOCAL;
+	cl_git_pass(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
+
+	cl_assert_equal_i(GIT_OID_SHA256, git_repository_oid_type(repo));
+
+	git_repository_free(repo);
+	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
+#endif
+}
+
+void test_clone_local__sha256_object_format_is_propagated(void)
+{
+#ifndef GIT_EXPERIMENTAL_SHA256
+	cl_skip();
+#else
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	/*
+	 * file:// URL + GIT_CLONE_LOCAL -> local code path with hardlinks
+	 *
+	 * Should correctly propagate the object format
+	 */
+	opts.bare = true;
+	opts.local = GIT_CLONE_LOCAL;
+	cl_git_fail(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
+
+	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
+#endif
+}
+
+void test_clone_local__sha256_no_links_object_format_is_propagated(void)
+{
+#ifndef GIT_EXPERIMENTAL_SHA256
+	cl_skip();
+#else
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	/*
+	 * file:// URL + GIT_CLONE_LOCAL_NO_LINKS -> local code path with copy
+	 *
+	 * Should correctly propagate the object format
+	 */
+	opts.bare = true;
+	opts.local = GIT_CLONE_LOCAL_NO_LINKS;
+	cl_git_fail(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
+
+	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
+#endif
+}

--- a/tests/libgit2/clone/local.c
+++ b/tests/libgit2/clone/local.c
@@ -306,8 +306,11 @@ void test_clone_local__sha256_object_format_is_propagated(void)
 	 */
 	opts.bare = true;
 	opts.local = GIT_CLONE_LOCAL;
-	cl_git_fail(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
+	cl_git_pass(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
 
+	cl_assert_equal_i(GIT_OID_SHA256, git_repository_oid_type(repo));
+
+	git_repository_free(repo);
 	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
 #endif
 }
@@ -327,8 +330,11 @@ void test_clone_local__sha256_no_links_object_format_is_propagated(void)
 	 */
 	opts.bare = true;
 	opts.local = GIT_CLONE_LOCAL_NO_LINKS;
-	cl_git_fail(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
+	cl_git_pass(git_clone(&repo, cl_git_fixture_url("testrepo_256.git"), "./clone.git", &opts));
 
+	cl_assert_equal_i(GIT_OID_SHA256, git_repository_oid_type(repo));
+
+	git_repository_free(repo);
 	cl_git_pass(git_futils_rmdir_r("./clone.git", NULL, GIT_RMDIR_REMOVE_FILES));
 #endif
 }

--- a/tests/libgit2/clone/local.c
+++ b/tests/libgit2/clone/local.c
@@ -276,8 +276,7 @@ void test_clone_local__sha256_via_no_local(void)
 	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
 
 	/*
-         * file:// URL + GIT_CLONE_NO_LOCAL -> remote code path
-	 *
+	 * file:// URL + GIT_CLONE_NO_LOCAL -> remote code path
 	 * Should correctly propagate the object format
 	 */
 	opts.bare = true;
@@ -301,7 +300,6 @@ void test_clone_local__sha256_object_format_is_propagated(void)
 
 	/*
 	 * file:// URL + GIT_CLONE_LOCAL -> local code path with hardlinks
-	 *
 	 * Should correctly propagate the object format
 	 */
 	opts.bare = true;
@@ -325,7 +323,6 @@ void test_clone_local__sha256_no_links_object_format_is_propagated(void)
 
 	/*
 	 * file:// URL + GIT_CLONE_LOCAL_NO_LINKS -> local code path with copy
-	 *
 	 * Should correctly propagate the object format
 	 */
 	opts.bare = true;


### PR DESCRIPTION
### What is fixed in this PR

Local clone didn't propagate object format (sha2, sha256) from the source repo. In contrast, remote clone already did that

https://github.com/libgit2/libgit2/blob/1f34e2a57a3d03f174771203b64aed2b17e8522c/src/libgit2/clone.c#L448-L450

This PR follows suite.

A couple of tests are added

* `sha256_via_no_local`
  * `file://` URL + `GIT_CLONE_NO_LOCAL` -> remote code path
* `sha256_object_format_is_propagated`
  * `file://` URL + `GIT_CLONE_LOCAL` -> local code path with hardlinks
* `sha256_no_links_object_format_is_propagated`
  * `file://` URL + `GIT_CLONE_LOCAL_NO_LINKS` -> local code path with copy
  
### How to reviews

I run this command to run tests:

```bash
mkdir -p build && cd build
cmake .. -DGIT_EXPERIMENTAL_SHA256=ON -DBUILD_TESTS=ON
cmake --build .
./libgit2_tests -sclone::local
```

This PR is best reviewed commit by commit.

* The first commit documents the problematic behavior, and can be served as minimal reproducer (you can checkout to the commit and confirm the buggy behavior exist).
* The second commit contains the fix and the test assertion updates. The diff in test shows the behavior change.

### Note

This issue was found during adding the sha256 to in Cargo with my current not-yet-merged integration in git2-rs: <https://github.com/rust-lang/git2-rs/pull/1206>. Cargo leverages local clones a lot for git database caches.

It is quite hard for me to find every issues in a unstable-not-release PR. If we can get a new v1.9 release out it would help test out the sha256 feature :)

Not sure if I should open a PR against v1.9 branch though