### PR TITLE
fix(refs): attach refdb owner to loose pseudorefs 

### DIFF
--- a/src/libgit2/refdb_fs.c
+++ b/src/libgit2/refdb_fs.c
@@ -524,14 +524,20 @@ int git_reference__lookup_loose(
 
 		if (!(target = loose_parse_symbolic(&buf)))
 			error = -1;
-		else if (out != NULL)
+		else if (out != NULL) {
 			*out = git_reference__alloc_symbolic(ref_name, target);
+			if (*out == NULL)
+				error = -1;
+		}
 	} else {
 		git_oid oid;
 
 		if (!(error = loose_parse_oid(&oid, ref_name, &buf, oid_type)) &&
-			out != NULL)
+			out != NULL) {
 			*out = git_reference__alloc(ref_name, &oid, NULL);
+			if (*out == NULL)
+				error = -1;
+		}
 	}
 
 	git_str_dispose(&buf);

--- a/src/libgit2/refs.c
+++ b/src/libgit2/refs.c
@@ -236,8 +236,21 @@ int git_reference_lookup_resolved(
 	 * contain additional data that doesn't even follow the normal ref
 	 * format. So we look these up as "loose" refs directly.
 	 */
-	if (git_reference__is_pseudoref(name))
-		return git_reference__lookup_loose(ref_out, repo->gitdir, name, repo->oid_type);
+	if (git_reference__is_pseudoref(name)) {
+		if ((error = git_reference__lookup_loose(ref_out, repo->gitdir, name, repo->oid_type)) < 0)
+			return error;
+
+		if ((error = git_repository_refdb__weakptr(&refdb, repo)) < 0) {
+			git_reference_free(*ref_out);
+			*ref_out = NULL;
+			return error;
+		}
+
+		GIT_REFCOUNT_INC(refdb);
+		(*ref_out)->db = refdb;
+
+		return 0;
+	}
 
 	if ((error = reference_normalize_for_repo(normalized, repo, name, true)) < 0 ||
 	    (error = git_repository_refdb__weakptr(&refdb, repo)) < 0 ||

--- a/tests/libgit2/refs/pseudoref.c
+++ b/tests/libgit2/refs/pseudoref.c
@@ -14,6 +14,7 @@ void test_refs_pseudoref__lookup_fetch_head_after_fetch(void)
 	git_repository *dst;
 	git_remote *remote;
 	git_reference *ref;
+	git_object *commit;
 	git_str url = GIT_STR_INIT;
 
 	cl_git_sandbox_init("testrepo.git");
@@ -28,8 +29,10 @@ void test_refs_pseudoref__lookup_fetch_head_after_fetch(void)
 
 	cl_git_pass(git_reference_lookup(&ref, dst, "FETCH_HEAD"));
 	cl_assert_equal_i(GIT_REFERENCE_DIRECT, git_reference_type(ref));
-	cl_assert(ref->db == NULL);
+	cl_assert(ref->db != NULL);
+	cl_git_pass(git_reference_peel(&commit, ref, GIT_OBJECT_COMMIT));
 
+	git_object_free(commit);
 	git_reference_free(ref);
 	git_repository_free(dst);
 }

--- a/tests/libgit2/refs/pseudoref.c
+++ b/tests/libgit2/refs/pseudoref.c
@@ -1,0 +1,35 @@
+#include "clar_libgit2.h"
+
+#include "futils.h"
+#include "refs.h"
+
+void test_refs_pseudoref__cleanup(void)
+{
+	git_futils_rmdir_r("dst.git", NULL, GIT_RMDIR_REMOVE_FILES);
+	cl_git_sandbox_cleanup();
+}
+
+void test_refs_pseudoref__lookup_fetch_head_after_fetch(void)
+{
+	git_repository *dst;
+	git_remote *remote;
+	git_reference *ref;
+	git_str url = GIT_STR_INIT;
+
+	cl_git_sandbox_init("testrepo.git");
+
+	cl_git_pass(git_repository_init(&dst, "dst.git", true));
+
+	cl_git_pass(git_str_printf(&url, "%s", cl_git_path_url("testrepo.git")));
+	cl_git_pass(git_remote_create_anonymous(&remote, dst, url.ptr));
+	cl_git_pass(git_remote_fetch(remote, NULL, NULL, NULL));
+	git_remote_free(remote);
+	git_str_dispose(&url);
+
+	cl_git_pass(git_reference_lookup(&ref, dst, "FETCH_HEAD"));
+	cl_assert_equal_i(GIT_REFERENCE_DIRECT, git_reference_type(ref));
+	cl_assert(ref->db == NULL);
+
+	git_reference_free(ref);
+	git_repository_free(dst);
+}


### PR DESCRIPTION
### What is the bug

b17ecb2 changed pseudoref lookup to read loose refs directly, bypassing refdb lookup. It introduced a bug that a looked-up `FETCH_HEAD` pseudoref has no owning refdb attached.

The test in c0a5341635f3116e3bab2f3a8bee2bfd5608d7f9 shows that caller may still expect `ref->db` to have an associated db, hence `git_reference_peel` failed and gave us a segmentation fault.

This was found this during the integration of Cargo with SHA256 support. In Cargo test suite we have things like [this](https://github.com/rust-lang/cargo/blob/6264f746c0610f2823ccb1f41a527de548a3bde3/tests/testsuite/package.rs#L7537-L7541) that peels FETCH_HEAD to a commit

```rust
repo.find_reference("FETCH_HEAD")?.peel_to_commit()?;
```

### The fix

Attach the repo's refdb after the loose pseudoref is read so
owner-dependent ops such as peeling can safely resolve objects.

Also found a bug in `git_reference__lookup_loose` that it didn't check allocation error before.

### How to reviews

This PR is best reviewed commit by commit, and is bisect-friendly.

* The first commit documents the problematic behavior, and can be served as minimal reproducer (you can checkout to the commit and confirm the buggy behavior exist).
* The second commit contains the fix and the test assertion updates. The diff in test shows the behavior change.
