### PR TITLE
fix(transport): get oid_type on local transport

### DIFF
--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -41,6 +41,9 @@ typedef struct {
 	git_vector refs;
 	unsigned connected : 1,
 		have_refs : 1;
+#ifdef GIT_EXPERIMENTAL_SHA256
+	git_oid_t oid_type;
+#endif
 } transport_local;
 
 static void free_head(git_remote_head *head)
@@ -231,6 +234,10 @@ static int local_connect(
 
 	t->repo = repo;
 
+#ifdef GIT_EXPERIMENTAL_SHA256
+	t->oid_type = repo->oid_type;
+#endif
+
 	if (store_refs(t) < 0)
 		return -1;
 
@@ -267,7 +274,7 @@ static int local_oid_type(git_oid_t *out, git_transport *transport)
 {
 	transport_local *t = (transport_local *)transport;
 
-	*out = t->repo->oid_type;
+	*out = t->oid_type;
 
 	return 0;
 }

--- a/tests/libgit2/network/remote/local.c
+++ b/tests/libgit2/network/remote/local.c
@@ -467,6 +467,30 @@ void test_network_remote_local__push_delete(void)
 	cl_git_sandbox_cleanup();
 }
 
+void test_network_remote_local__sha256_oid_type(void)
+{
+#ifndef GIT_EXPERIMENTAL_SHA256
+	cl_skip();
+#else
+	git_oid_t oid_type;
+
+	connect_to_local_repository(cl_fixture("testrepo_256.git"));
+
+	cl_git_pass(git_remote_oid_type(&oid_type, remote));
+	cl_assert_equal_i(GIT_OID_SHA256, oid_type);
+
+	git_remote_disconnect(remote);
+
+	/*
+	 * Uncomment to reproduce SIGSEGV: local_oid_type dereferences
+	 * t->repo->oid_type, but local_close already freed t->repo.
+	 *
+	 * cl_git_pass(git_remote_oid_type(&oid_type, remote));
+	 * cl_assert_equal_i(GIT_OID_SHA256, oid_type);
+	 */
+#endif
+}
+
 void test_network_remote_local__anonymous_remote_inmemory_repo(void)
 {
 	git_repository *inmemory;

--- a/tests/libgit2/network/remote/local.c
+++ b/tests/libgit2/network/remote/local.c
@@ -481,13 +481,9 @@ void test_network_remote_local__sha256_oid_type(void)
 
 	git_remote_disconnect(remote);
 
-	/*
-	 * Uncomment to reproduce SIGSEGV: local_oid_type dereferences
-	 * t->repo->oid_type, but local_close already freed t->repo.
-	 *
-	 * cl_git_pass(git_remote_oid_type(&oid_type, remote));
-	 * cl_assert_equal_i(GIT_OID_SHA256, oid_type);
-	 */
+	/* oid_type remains available after disconnect */
+	cl_git_pass(git_remote_oid_type(&oid_type, remote));
+	cl_assert_equal_i(GIT_OID_SHA256, oid_type);
 #endif
 }
 


### PR DESCRIPTION
## What to fix

`git_remote_oid_type()` didn't work on local transport after disconnect.
This results in SIGSEGV because local_oid_type has dereferenced `t->repo`.

This PR caches `oid_type` in `transport_local` struct during `connect()` so `git_remote_oid_type()` keeps working after disconnect.
This matches the smart transport behavior.

## How to review

Commit by commit, though since this is segmentation fault I can't really have a way to show it in a commit and keep commit bisect-safe. Please remove the commit in the first commit and run the command below to repro the SIGSEGV:

```console
cmake .. -DGIT_EXPERIMENTAL_SHA256=ON -DBUILD_TESTS=ON
cmake --build .
./libgit2_tests -snetwork::remote::local::sha256_oid_type
```

## Note

This is found during the SHA256 integration in Cargo, which Cargo probes remote to get oid type and then clone to a specific directories. It works for remote transport, but Cargo's test suite relies on local repos hence catching it.




