### PR TITLE
Config Memory Backend Corruption Fix

### DIFF
--- a/src/libgit2/config_mem.c
+++ b/src/libgit2/config_mem.c
@@ -199,6 +199,7 @@ static int config_memory_get(git_config_backend *backend, const char *key, git_c
 	if ((error = git_config_list_get(&entry, memory_backend->config_list, key)) != 0)
 		return error;
 
+	git_config_list_incref(memory_backend->config_list);
 	*out = &entry->base;
 	return 0;
 }

--- a/tests/libgit2/config/memory.c
+++ b/tests/libgit2/config/memory.c
@@ -20,6 +20,7 @@ static void assert_config_contains(git_config_backend *backend,
 	git_config_entry *entry = NULL;
 	cl_git_pass(git_config_backend_get_string(&entry, backend, name));
 	cl_assert_equal_s(entry->value, value);
+	git_config_entry_free(entry);
 }
 
 struct expected_entry {


### PR DESCRIPTION
Reproduces and fixes crash when using config memory backend, where the underlying config list is freed when a config entry is, leading to a crash during the next config entry lookup.

Fixes #7219