### PR TITLE
config: refactor freeing config list after getting entry

### DIFF
--- a/src/libgit2/config_file.c
+++ b/src/libgit2/config_file.c
@@ -295,8 +295,8 @@ static int config_file_snapshot(git_config_backend **out, git_config_backend *ba
 static int config_file_set(git_config_backend *cfg, const char *name, const char *value)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
-	git_config_list *config_list;
-	git_config_list_entry *existing;
+	git_config_list *config_list = NULL;
+	git_config_list_entry *existing = NULL;
 	char *key, *esc_value = NULL;
 	int error;
 
@@ -328,6 +328,7 @@ static int config_file_set(git_config_backend *cfg, const char *name, const char
 		goto out;
 
 out:
+	git_config_list_entry_free((git_config_backend_entry *)existing);
 	git_config_list_free(config_list);
 	git__free(esc_value);
 	git__free(key);
@@ -353,14 +354,14 @@ static int config_file_get(
 	if ((error = config_file_take_list(&config_list, h)) < 0)
 		return error;
 
-	if ((error = (git_config_list_get(&entry, config_list, key))) < 0) {
-		git_config_list_free(config_list);
-		return error;
-	}
+	if ((error = (git_config_list_get(&entry, config_list, key))) < 0)
+		goto out;
 
 	*out = &entry->base;
 
-	return 0;
+ out:
+	git_config_list_free(config_list);
+	return error;
 }
 
 static int config_file_set_multivar(
@@ -394,7 +395,7 @@ static int config_file_delete(git_config_backend *cfg, const char *name)
 {
 	config_file_backend *b = GIT_CONTAINER_OF(cfg, config_file_backend, parent);
 	git_config_list *config_list = NULL;
-	git_config_list_entry *entry;
+	git_config_list_entry *entry = NULL;
 	char *key = NULL;
 	int error;
 
@@ -415,6 +416,7 @@ static int config_file_delete(git_config_backend *cfg, const char *name)
 		goto out;
 
 out:
+	git_config_list_entry_free((git_config_backend_entry *)entry);
 	git_config_list_free(config_list);
 	git__free(key);
 	return error;
@@ -448,6 +450,7 @@ static int config_file_delete_multivar(git_config_backend *cfg, const char *name
 		goto out;
 
 out:
+	git_config_list_entry_free((git_config_backend_entry *)entry);
 	git_config_list_free(config_list);
 	git__free(key);
 	git_regexp_dispose(&preg);

--- a/src/libgit2/config_list.c
+++ b/src/libgit2/config_list.c
@@ -197,6 +197,7 @@ int git_config_list_get(git_config_list_entry **out, git_config_list *config_lis
 	if (git_config_list_headmap_get(&entry, &config_list->map, key) != 0)
 		return GIT_ENOTFOUND;
 
+	git_config_list_incref(config_list);
 	*out = entry->entry;
 	return 0;
 }
@@ -218,6 +219,7 @@ int git_config_list_get_unique(git_config_list_entry **out, git_config_list *con
 		return -1;
 	}
 
+	git_config_list_incref(config_list);
 	*out = entry->entry;
 	return 0;
 }
@@ -265,6 +267,10 @@ int git_config_list_iterator_new(git_config_iterator **out, git_config_list *con
 void git_config_list_entry_free(git_config_backend_entry *e)
 {
 	git_config_list_entry *entry = (git_config_list_entry *)e;
+
+	if (entry == NULL)
+		return;
+
 	git_config_list_free(entry->config_list);
 }
 

--- a/src/libgit2/config_mem.c
+++ b/src/libgit2/config_mem.c
@@ -199,7 +199,6 @@ static int config_memory_get(git_config_backend *backend, const char *key, git_c
 	if ((error = git_config_list_get(&entry, memory_backend->config_list, key)) != 0)
 		return error;
 
-	git_config_list_incref(memory_backend->config_list);
 	*out = &entry->base;
 	return 0;
 }

--- a/src/libgit2/config_snapshot.c
+++ b/src/libgit2/config_snapshot.c
@@ -60,13 +60,14 @@ static int config_snapshot_get(
 	git_config_list_incref(config_list);
 	git_mutex_unlock(&b->values_mutex);
 
-	if ((error = (git_config_list_get(&entry, config_list, key))) < 0) {
-		git_config_list_free(config_list);
-		return error;
-	}
+	if ((error = (git_config_list_get(&entry, config_list, key))) < 0)
+		goto out;
 
 	*out = &entry->base;
-	return 0;
+
+out:
+	git_config_list_free(config_list);
+	return error;
 }
 
 static int config_snapshot_set(git_config_backend *cfg, const char *name, const char *value)


### PR DESCRIPTION
Follow-up to #7232, this is intended to provide a more holistic fix, with config backends being refactored to support  `git_config_list_get` and `git_config_list_get_unique` calling `git_config_list_incref` before returning an entry, rather than it needing to be handled externally.

However, this still relies on assumption backends using `git_config_list` will create entries using `git_config_list_entry_free` for clean-up before appending to the list.