### PR TITLE
fix(pack): ensure pack_backend__read returns null terminated buffer

### DIFF
--- a/src/libgit2/pack.c
+++ b/src/libgit2/pack.c
@@ -941,6 +941,9 @@ static int packfile_unpack_compressed(
 		goto out;
 	}
 
+	/* zlib may have garbled the trailing buffer */
+	data[size] = '\0';
+
 	obj->type = type;
 	obj->len = size;
 	obj->data = data;


### PR DESCRIPTION
Depending on the zlib library used, the inflate() function may write beyond the object size into the additional trailing buffer for aligned memory copies. This may cause out-of-bounds memory read if the object buffer is later used without checking the object size, as in git_commit__extract_signature.

Link: https://github.com/zlib-ng/zlib-ng/issues/1767