### PR TITLE
remote: don't create empty FETCH_HEAD file when update suppressed

### DIFF
--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -2092,7 +2092,9 @@ cleanup:
 	return error;
 }
 
-static int truncate_fetch_head(const char *gitdir)
+static int truncate_fetch_head(
+	const char *gitdir,
+	unsigned int update_flags)
 {
 	git_str path = GIT_STR_INIT;
 	int error;
@@ -2100,9 +2102,15 @@ static int truncate_fetch_head(const char *gitdir)
 	if ((error = git_str_joinpath(&path, gitdir, GIT_FETCH_HEAD_FILE)) < 0)
 		return error;
 
-	error = git_futils_truncate(path.ptr, GIT_REFS_FILE_MODE);
-	git_str_dispose(&path);
+	/* When update suppressed, skip truncate when file doesn't exist to prevent creating empty file */
+	if (!(update_flags & GIT_REMOTE_UPDATE_FETCHHEAD) &&
+	    !git_fs_path_exists(path.ptr))
+		goto out;
 
+	error = git_futils_truncate(path.ptr, GIT_REFS_FILE_MODE);
+
+out:
+	git_str_dispose(&path);
 	return error;
 }
 
@@ -2136,7 +2144,7 @@ int git_remote_update_tips(
 	else
 		tagopt = download_tags;
 
-	if ((error = truncate_fetch_head(git_repository_path(remote->repo))) < 0)
+	if ((error = truncate_fetch_head(git_repository_path(remote->repo), update_flags)) < 0)
 		goto out;
 
 	if (tagopt == GIT_REMOTE_DOWNLOAD_TAGS_ALL) {


### PR DESCRIPTION
During a clone/fetch operation, when the option to update fetch head isn't specified, an empty file is still created currently when it is truncated/cleared (before updating otherwise).

In scenarios where repositories are being initialized with custom backends to operate in-memory, it's preferable to avoid creating any files on disk.

To prevent creating an empty fetch head file in this scenario, this change suppresses truncating when the file doesn't already exist, and the option to update fetch head hasn't been specified.