### PR TITLE
Handle redirects with `Content-Length: 0` correctly

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -299,7 +299,7 @@ if should_run "ONLINE_TESTS"; then
 	echo "## Running networking (online) tests"
 	echo "##############################################################################"
 
-	export GITTEST_REMOTE_REDIRECT_INITIAL="http://localhost:9000/initial-redirect/libgit2/TestGitRepository"
+	export GITTEST_REMOTE_REDIRECT_INITIAL="http://localhost:9000/initial-redirect:none/libgit2/TestGitRepository"
 	export GITTEST_REMOTE_REDIRECT_SUBSEQUENT="http://localhost:9000/subsequent-redirect/libgit2/TestGitRepository"
 	export GITTEST_REMOTE_SPEED_SLOW="http://localhost:9000/speed:9600/test.git"
 	export GITTEST_REMOTE_SPEED_TIMESOUT="http://localhost:9000/speed:0.5/test.git"

--- a/src/libgit2/transports/httpclient.c
+++ b/src/libgit2/transports/httpclient.c
@@ -379,7 +379,7 @@ static int on_headers_complete(git_http_parser *parser)
 	ctx->response->resend_credentials = resend_needed(ctx->client,
 	                                                  ctx->response);
 
-	if (ctx->response->content_type || ctx->response->chunked)
+	if (ctx->response->content_length || ctx->response->chunked)
 		ctx->client->state = READING_BODY;
 	else
 		ctx->client->state = DONE;

--- a/src/libgit2/transports/httpclient.c
+++ b/src/libgit2/transports/httpclient.c
@@ -1243,13 +1243,16 @@ GIT_INLINE(int) client_read_and_parse(git_http_client *client)
 }
 
 /*
- * See if we've consumed the entire response body.  If the client was
- * reading the body but did not consume it entirely, it's possible that
- * they knew that the stream had finished (in a git response, seeing a
- * final flush) and stopped reading.  But if the response was chunked,
- * we may have not consumed the final chunk marker.  Consume it to
- * ensure that we don't have it waiting in our socket.  If there's
- * more than just a chunk marker, close the connection.
+ * Try to consume any remaining response body. The client may have
+ * decided that it did not need to consume the entire response body.
+ * For example, the client saw a redirect in the header and ignored
+ * the body. Or the client saw a particular sequence (like a final
+ * flush in a git response) and stopped reading (but there were
+ * additional response bytes, perhaps because the response was chunked).
+ * Do one more read to try to clear this out; this takes care of small
+ * remainders, like a chunk response or a small redirect message. If
+ * there is too much data, we'll just leave it and close the
+ * connection.
  */
 static void complete_response_body(git_http_client *client)
 {


### PR DESCRIPTION
In `httpclient`, when we were done reading headers, we checked if we needed to read a body, or if we were done. The body check was done by looking at the transfer encoding type and the content type. If we were chunked, then we know we have a body (it may be a zero byte body, but we would need to read the chunk length to know this). But looking at the content _type_ was erroneous; we should have been looking at the content _length_.

The effect of this is that when a server sends a zero byte response with a content _type_, we try to go read the body, which does not exist. We will hang waiting for the body that the server will never send.

Correct this typo. Now we will try to read the body if there was a content _length_ specified, or if the transfer encoding is chunked.

We didn't catch this because our test infrastructure sent a redirect response with a `Content-Length: 0`, but crucially, also with a `Connection: close`. This meant that we avoided the whole problem of trying to consume the remainder of the response body; since the connection was being closed, we aren't reusing a keep-alive connection, and we don't need to burn down our input buffer. 🥴 