### PR TITLE
ci: use poxygit v0.8.1 in the tests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -198,7 +198,7 @@ if should_run "PROXY_TESTS"; then
 fi
 
 if should_run "NTLM_TESTS" || should_run "ONLINE_TESTS"; then
-	curl --location --silent --show-error https://github.com/ethomson/poxygit/releases/download/v0.6.0/poxygit-0.6.0.jar >poxygit.jar
+	curl --location --silent --show-error https://github.com/ethomson/poxygit/releases/download/v0.8.1/poxygit-0.8.1.jar >poxygit.jar
 
 	echo "Starting HTTP server..."
 	HTTP_DIR=`mktemp -d ${TMPDIR}/http.XXXXXXXX`
@@ -301,8 +301,8 @@ if should_run "ONLINE_TESTS"; then
 
 	export GITTEST_REMOTE_REDIRECT_INITIAL="http://localhost:9000/initial-redirect/libgit2/TestGitRepository"
 	export GITTEST_REMOTE_REDIRECT_SUBSEQUENT="http://localhost:9000/subsequent-redirect/libgit2/TestGitRepository"
-	export GITTEST_REMOTE_SPEED_SLOW="http://localhost:9000/speed-9600/test.git"
-	export GITTEST_REMOTE_SPEED_TIMESOUT="http://localhost:9000/speed-0.5/test.git"
+	export GITTEST_REMOTE_SPEED_SLOW="http://localhost:9000/speed:9600/test.git"
+	export GITTEST_REMOTE_SPEED_TIMESOUT="http://localhost:9000/speed:0.5/test.git"
 	run_test online
 	unset GITTEST_REMOTE_REDIRECT_INITIAL
 	unset GITTEST_REMOTE_REDIRECT_SUBSEQUENT


### PR DESCRIPTION
Update our CI to use poxygit v0.8.1, which has additional mocking and debugging capabilities.

As part of this, the paths to the `speed` test routes changed - now they are `speed:<n>` where `<n>` is the speed to emulate in bps.