### PR TITLE
cmake: fix linker error when using ninja build generator

### DIFF
--- a/benchmarks/libgit2/CMakeLists.txt
+++ b/benchmarks/libgit2/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(libgit2_benchmarks ${CLAR_SRC}
 	${LIBGIT2_DEPENDENCY_OBJECTS})
 
 target_link_libraries(libgit2_benchmarks libgit2package ${LIBGIT2_SYSTEM_LIBS})
-if(NOT MSVC_IDE)
+if(NOT MSVC)
 	target_link_libraries(libgit2_benchmarks m)
 endif()
 

--- a/tests/libgit2/CMakeLists.txt
+++ b/tests/libgit2/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(libgit2_tests PRIVATE ${TEST_INCLUDES} ${LIBGIT2_INCL
 target_include_directories(libgit2_tests SYSTEM PRIVATE ${LIBGIT2_SYSTEM_INCLUDES})
 
 target_link_libraries(libgit2_tests ${LIBGIT2_SYSTEM_LIBS})
-if(NOT MSVC_IDE)
+if(NOT MSVC)
 	target_link_libraries(libgit2_tests m)
 endif()
 

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(util_tests PRIVATE ${TEST_INCLUDES} ${LIBGIT2_INCLUDE
 target_include_directories(util_tests SYSTEM PRIVATE ${LIBGIT2_SYSTEM_INCLUDES})
 
 target_link_libraries(util_tests ${LIBGIT2_SYSTEM_LIBS})
-if(NOT MSVC_IDE)
+if(NOT MSVC)
 	target_link_libraries(util_tests m)
 endif()
 


### PR DESCRIPTION
Fixes linker 'cannot open m.lib' error when building latest version of main using Visual Studio and the default ninja build generator.