### PR TITLE
docs: proceed when version folder doesn't exist

### DIFF
--- a/script/api-docs/docs-generator.js
+++ b/script/api-docs/docs-generator.js
@@ -1087,6 +1087,13 @@ async function produceDocumentationMetadata(version, apiData) {
 async function cleanupOldDocumentation(version) {
     const versionDir = `${outputPath}/${version}`;
 
+    try {
+        await fs.stat(versionDir);
+    }
+    catch (err) {
+        return;
+    }
+
     for (const fn of await fs.readdir(versionDir)) {
         if (fn === '.metadata') {
             continue;


### PR DESCRIPTION
A version folder may not exists (for example, when adding a new version). Proceed!