### PR TITLE
socket: Continue on GIT_TIMEOUT.

### DIFF
--- a/src/libgit2/streams/socket.c
+++ b/src/libgit2/streams/socket.c
@@ -233,7 +233,7 @@ static int socket_connect(git_stream *stream)
 		s = INVALID_SOCKET;
 
 		if (error == GIT_TIMEOUT)
-			break;
+			continue;
 	}
 
 	/* Oops, we couldn't connect to any address */


### PR DESCRIPTION
So the next address is tried on a timeout.

On a system with broken IPv6 connectivity, I'm seeing libgit2 not try the IPv4 address after the IPv6 address times out.