### PR TITLE
Avoid uninitialized variable warnings in gcc

### DIFF
--- a/src/cli/opt.c
+++ b/src/cli/opt.c
@@ -359,7 +359,7 @@ GIT_INLINE(const cli_opt_spec *) spec_for_sort(
 	const char *arg)
 {
 	int is_negated, has_value = 0;
-	const char *value;
+	const char *value = NULL;
 	const cli_opt_spec *spec = NULL;
 	size_t idx = 0;
 

--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -1210,7 +1210,7 @@ static int canonicalize_directory_path(
 {
 	const git_index_entry *match, *best = NULL;
 	char *search, *sep;
-	size_t pos, search_len, best_len;
+	size_t pos, search_len, best_len = 0;
 
 	if (!index->ignore_case)
 		return 0;

--- a/src/libgit2/midx.c
+++ b/src/libgit2/midx.c
@@ -460,7 +460,7 @@ int git_midx_foreach_entry(
 {
 	git_oid oid;
 	size_t oid_size, i;
-	int error;
+	int error = 0;
 
 	GIT_ASSERT_ARG(idx);
 

--- a/src/util/hashmap.h
+++ b/src/util/hashmap.h
@@ -107,6 +107,7 @@ typedef uint32_t git_hashmap_iter_t;
 	} \
 	GIT_INLINE(int) name##__idx(uint32_t *out, name *h, key_t key) \
 	{ \
+		*out = UINT_MAX; \
 		if (h->n_buckets) { \
 			uint32_t k, i, last, mask, step = 0; \
 			GIT_ASSERT((h)->flags); \

--- a/src/util/runtime.c
+++ b/src/util/runtime.c
@@ -16,7 +16,7 @@ static git_atomic32 init_count;
 static int init_common(git_runtime_init_fn init_fns[], size_t cnt)
 {
 	size_t i;
-	int ret;
+	int ret = 0;
 
 	/* Initialize subsystems that have global state */
 	for (i = 0; i < cnt; i++) {

--- a/src/util/runtime.c
+++ b/src/util/runtime.c
@@ -110,7 +110,7 @@ GIT_INLINE(int) init_unlock(void)
 
 int git_runtime_init(git_runtime_init_fn init_fns[], size_t cnt)
 {
-	int ret;
+	int ret = 0;
 
 	if (init_lock() < 0)
 		return -1;


### PR DESCRIPTION
gcc 4.8.5 is showing warnings for uninitialized variables in a handful of spaces. Initialize those variables, even where these are obviously unnecessary.