### PR TITLE
cmake: separate generated headers from translated headers

### DIFF
--- a/deps/reftable/CMakeLists.txt
+++ b/deps/reftable/CMakeLists.txt
@@ -8,14 +8,12 @@ list(SORT SRC_REFTABLE)
 set_property(TARGET reftable PROPERTY C_STANDARD 99)
 target_sources(reftable PRIVATE ${SRC_REFTABLE})
 target_include_directories(reftable PRIVATE
-	include
-	"${PROJECT_BINARY_DIR}/src/util"
-	"${PROJECT_BINARY_DIR}/include"
+	"include"
 	"${PROJECT_SOURCE_DIR}/src/util"
 	"${PROJECT_SOURCE_DIR}/include"
+	"${PROJECT_BINARY_DIR}/gen_headers"
 	${LIBGIT2_DEPENDENCY_INCLUDES}
-	${LIBGIT2_SYSTEM_INCLUDES}
-)
+	${LIBGIT2_SYSTEM_INCLUDES})
 
 # The reftable library is not warning-free, so we disable turning warnings into
 # errors.

--- a/deps/xdiff/CMakeLists.txt
+++ b/deps/xdiff/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(xdiff OBJECT ${SRC_XDIFF})
 target_include_directories(xdiff SYSTEM PRIVATE
 	"${PROJECT_SOURCE_DIR}/include"
 	"${PROJECT_SOURCE_DIR}/src/util"
-	"${PROJECT_BINARY_DIR}/src/util"
+	"${PROJECT_BINARY_DIR}/gen_headers"
 	${LIBGIT2_SYSTEM_INCLUDES}
 	${LIBGIT2_DEPENDENCY_INCLUDES})
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(CLI_INCLUDES
-	"${libgit2_BINARY_DIR}/src/util"
-	"${libgit2_BINARY_DIR}/include"
 	"${libgit2_SOURCE_DIR}/src/util"
 	"${libgit2_SOURCE_DIR}/src/cli"
 	"${libgit2_SOURCE_DIR}/include"
+	"${libgit2_BINARY_DIR}/gen_headers"
 	"${LIBGIT2_DEPENDENCY_INCLUDES}"
 	"${LIBGIT2_SYSTEM_INCLUDES}")
 

--- a/src/libgit2/CMakeLists.txt
+++ b/src/libgit2/CMakeLists.txt
@@ -7,11 +7,10 @@ include(PkgBuildConfig)
 include(CMakePackageConfigHelpers)
 
 set(LIBGIT2_INCLUDES
-	"${PROJECT_BINARY_DIR}/src/util"
-	"${PROJECT_BINARY_DIR}/include"
 	"${PROJECT_SOURCE_DIR}/src/libgit2"
 	"${PROJECT_SOURCE_DIR}/src/util"
-	"${PROJECT_SOURCE_DIR}/include")
+	"${PROJECT_SOURCE_DIR}/include"
+	"${PROJECT_BINARY_DIR}/gen_headers")
 
 # Collect sourcefiles
 file(GLOB SRC_H
@@ -104,7 +103,7 @@ endif()
 
 # support experimental features and functionality
 
-configure_file(experimental.h.in "${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}/experimental.h")
+configure_file(experimental.h.in "${PROJECT_BINARY_DIR}/gen_headers/experimental.h")
 
 # translate filenames in the headers so that they match the install directory
 # (allows for side-by-side installs of libgit2 and libgit2-experimental.)
@@ -119,6 +118,8 @@ foreach(HEADER_SOURCE ${SRC_H})
 	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${HEADER_RELATIVE}.tmp" "${HEADER_CONTENTS}")
 	configure_file("${CMAKE_CURRENT_BINARY_DIR}/${HEADER_RELATIVE}.tmp" "${PROJECT_BINARY_DIR}/${HEADER_RELATIVE}" COPYONLY)
 endforeach()
+
+configure_file("${PROJECT_BINARY_DIR}/gen_headers/experimental.h" "${PROJECT_BINARY_DIR}/include/${LIBGIT2_FILENAME}/experimental.h" COPYONLY)
 
 # cmake package targets
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,13 +2,12 @@
 
 add_library(util OBJECT)
 
-configure_file(git2_features.h.in git2_features.h)
+configure_file(git2_features.h.in "${PROJECT_BINARY_DIR}/gen_headers/git2_features.h")
 
 set(UTIL_INCLUDES
-	"${PROJECT_BINARY_DIR}/src/util"
-	"${PROJECT_BINARY_DIR}/include"
 	"${PROJECT_SOURCE_DIR}/src/util"
-	"${PROJECT_SOURCE_DIR}/include")
+	"${PROJECT_SOURCE_DIR}/include"
+	"${PROJECT_BINARY_DIR}/gen_headers")
 
 file(GLOB UTIL_SRC *.c *.h allocators/*.c allocators/*.h hash.h)
 list(SORT UTIL_SRC)


### PR DESCRIPTION
Make a distinction between generated headers and "translated" headers. This is important to support build-time dependencies when headers are updated.

Generated headers are those which contain build-time feature specifications, like `git2_features.h` that are internal to the build and `experimental.h` that contain API information.

Translated headers are the headers that are in `include/git2`, but may be translated to have a unique prefix like `incklude/git2-experimental`.

This distinction is important so that the CMakeFiles.txt depend on the in-tree include files (`src/include`) and the generated header files _but not_ the translated header files. Otherwise there are two `pack.h` and it's unclear whether the in-tree build is targeting the one in `src/include` or the one in the build tree.

Without this, updating an in-tree header file like `pack.h` would not cause a rebuild of its dependencies.