### PR TITLE
ci: drop coverity, add sonarqube

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -447,31 +447,31 @@ jobs:
       with:
         paths: 'test-results-*/*.xml'
 
-  coverity:
+  sonarqube:
     # Only run scheduled workflows on the main repository; prevents people
     # from using build minutes on their forks.
     if: github.repository == 'libgit2/libgit2'
 
-    name: Coverity
+    name: SonarQube
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
       with:
-        path: source
         fetch-depth: 0
-    - name: Set up container
-      uses: ./source/.github/actions/download-or-build-container
+    - name: Run SonarQube
+      uses: SonarSource/sonarqube-scan-action@v8
       with:
-        registry: ${{ env.docker-registry }}
-        config-path: ${{ env.docker-config-path }}
-        container: xenial
-        github_token: ${{ secrets.github_token }}
-      if: matrix.platform.container.name != ''
-    - name: Run Coverity
-      run: source/ci/coverity.sh
+        args: >
+          -Dsonar.organization=libgit2_libgit2
+          -Dsonar.organization=libgit2
+          -Dsonar.projectKey=libgit2
+          -Dsonar.projectName=libgit2
+          -Dsonar.sources=src
+          -Dsonar.tests=tests
+          -Dsonar.test.exclusions="tests/resources/**/*"
       env:
-        COVERITY_TOKEN: ${{ secrets.coverity_token }}
+        SONAR_TOKEN: ${{ secrets.sonar_token }}
 
   codeql:
     # Only run scheduled workflows on the main repository; prevents people


### PR DESCRIPTION
Coverity has appeared to stop working with no status updates. Remove it.

Add SonarQube.