### PR TITLE
Add support for reading bloom filter chunks

### DIFF
--- a/src/libgit2/commit_graph.c
+++ b/src/libgit2/commit_graph.c
@@ -198,6 +198,42 @@ static int commit_graph_parse_extra_edge_list(
 	return 0;
 }
 
+static int commit_graph_parse_bloom_filter(
+		git_commit_graph_file *file,
+		const unsigned char *data,
+		struct git_commit_graph_chunk *bloom_filter_index,
+		struct git_commit_graph_chunk *bloom_filter_data
+)
+{
+	const uint32_t *data_header = (const uint32_t *)(data + bloom_filter_data->offset);
+	uint32_t hash_version;
+	/*
+	 * Both index and data need to be present to have a valid bloom filter
+	 * For the filter data, there's a 12 byte header at the beginning,
+	 *  thus we need at the very least 12 bytes to consider it usable
+	 */
+	if (bloom_filter_index->length == 0 ||
+		bloom_filter_data->length < 12)
+		return 0;
+
+	if (bloom_filter_index->length != file->num_commits * sizeof(uint32_t))
+		return commit_graph_error("malformed Bloom Filter Index chunk");
+	
+	hash_version = ntohl(data_header[0]);
+
+	if (hash_version < 1 || hash_version > 2)
+		return commit_graph_error("unknown Bloom Filter Hash version");
+
+	file->bloom_filter_indexes = (const uint32_t *)(data + bloom_filter_index->offset);
+
+	file->bloom_filter_hash_version = hash_version;
+	file->bloom_filter_num_hashes = ntohl(data_header[1]);
+	file->bloom_filter_bits = ntohl(data_header[2]);
+	file->bloom_filter_data = data + bloom_filter_data->offset + 12;
+	return 0;
+}
+
+
 int git_commit_graph_file_parse(
 		git_commit_graph_file *file,
 		const unsigned char *data,
@@ -212,7 +248,8 @@ int git_commit_graph_file_parse(
 	int error;
 	struct git_commit_graph_chunk chunk_oid_fanout = {0}, chunk_oid_lookup = {0},
 				      chunk_commit_data = {0}, chunk_extra_edge_list = {0},
-				      chunk_unsupported = {0};
+				      chunk_bloom_filter_index = {0}, chunk_bloom_filter_data = {0},
+					  chunk_unsupported = {0};
 
 	GIT_ASSERT_ARG(file);
 
@@ -276,7 +313,15 @@ int git_commit_graph_file_parse(
 			break;
 
 		case COMMIT_GRAPH_BLOOM_FILTER_INDEX_ID:
+			chunk_bloom_filter_index.offset = last_chunk_offset;
+			last_chunk = &chunk_bloom_filter_index;
+			break;
+
 		case COMMIT_GRAPH_BLOOM_FILTER_DATA_ID:
+			chunk_bloom_filter_data.offset = last_chunk_offset;
+			last_chunk = &chunk_bloom_filter_data;
+			break;
+
 		case COMMIT_GRAPH_GENERATION_DATA_ID:
 		case COMMIT_GRAPH_GENERATION_DATA_OVERFLOW_ID:
 			chunk_unsupported.offset = last_chunk_offset;
@@ -289,17 +334,12 @@ int git_commit_graph_file_parse(
 	}
 	last_chunk->length = (size_t)(trailer_offset - last_chunk_offset);
 
-	error = commit_graph_parse_oid_fanout(file, data, &chunk_oid_fanout);
-	if (error < 0)
-		return error;
-	error = commit_graph_parse_oid_lookup(file, data, &chunk_oid_lookup);
-	if (error < 0)
-		return error;
-	error = commit_graph_parse_commit_data(file, data, &chunk_commit_data);
-	if (error < 0)
-		return error;
-	error = commit_graph_parse_extra_edge_list(file, data, &chunk_extra_edge_list);
-	if (error < 0)
+	if ((error = commit_graph_parse_oid_fanout(file, data, &chunk_oid_fanout)) < 0 ||
+		(error = commit_graph_parse_oid_lookup(file, data, &chunk_oid_lookup)) < 0 ||
+		(error = commit_graph_parse_commit_data(file, data, &chunk_commit_data)) < 0 ||
+		(error = commit_graph_parse_extra_edge_list(file, data, &chunk_extra_edge_list)) < 0 ||
+		(error = commit_graph_parse_bloom_filter(file, data,
+			&chunk_bloom_filter_index, &chunk_bloom_filter_data)) < 0)
 		return error;
 
 	return 0;

--- a/src/libgit2/commit_graph.c
+++ b/src/libgit2/commit_graph.c
@@ -202,11 +202,11 @@ static int commit_graph_parse_bloom_filter(
 		git_commit_graph_file *file,
 		const unsigned char *data,
 		struct git_commit_graph_chunk *bloom_filter_index,
-		struct git_commit_graph_chunk *bloom_filter_data
-)
+		struct git_commit_graph_chunk *bloom_filter_data)
 {
 	const uint32_t *data_header = (const uint32_t *)(data + bloom_filter_data->offset);
 	uint32_t hash_version;
+
 	/*
 	 * Both index and data need to be present to have a valid bloom filter
 	 * For the filter data, there's a 12 byte header at the beginning,
@@ -232,7 +232,6 @@ static int commit_graph_parse_bloom_filter(
 	file->bloom_filter_data = data + bloom_filter_data->offset + 12;
 	return 0;
 }
-
 
 int git_commit_graph_file_parse(
 		git_commit_graph_file *file,

--- a/src/libgit2/commit_graph.h
+++ b/src/libgit2/commit_graph.h
@@ -59,6 +59,32 @@ typedef struct git_commit_graph_file {
 	/* The number of entries in the Extra Edge List table. Each entry is 4 bytes wide. */
 	size_t num_extra_edge_list;
 
+	/*
+	 * Bloom filter index data storing offsets in the filter data.
+	 * The ith entry stores the number of bytes from commit 0 to i.
+	 * The filter for the ith element are the bytes indexes[i-1] to indexes[i] in
+	 * the bloom filter data. indexes[-1] is defined as 0.
+	 * 
+	 * NOTE: The implication of the above is that the bloom filter fields are 
+	 * only valid if both indexes and data pointers are non-NULL
+	 */
+	const uint32_t *bloom_filter_indexes;
+
+	/* Concatenated computed bloom filters */
+	const unsigned char *bloom_filter_data;
+
+	/* 
+	 * Hash version used in the bloom filter
+	 * Valid values are 1 and 2, both corresponding to murmur3
+	 */
+	uint32_t bloom_filter_hash_version;
+
+	/* Number of times a path is hashed */
+	uint32_t bloom_filter_num_hashes;
+
+	/* Minimum number of bits per entry */
+	uint32_t bloom_filter_bits;
+
 	/* The trailer of the file. Contains the SHA1-checksum of the whole file. */
 	unsigned char checksum[GIT_HASH_SHA1_SIZE];
 } git_commit_graph_file;


### PR DESCRIPTION
The filter settings are split out as a separate struct to make it easier to
 avoid circular dependencies later down the line.

Related to #5758 