### PR TITLE
signature: allow empty email addresses

### DIFF
--- a/src/libgit2/signature.c
+++ b/src/libgit2/signature.c
@@ -26,13 +26,13 @@ void git_signature_free(git_signature *sig)
 
 static int signature_parse_error(const char *msg)
 {
-	git_error_set(GIT_ERROR_INVALID, "failed to parse signature - %s", msg);
+	git_error_set(GIT_ERROR_INVALID, "cannot parse signature - %s", msg);
 	return GIT_EINVALID;
 }
 
 static int signature_error(const char *msg)
 {
-	git_error_set(GIT_ERROR_INVALID, "failed to parse signature - %s", msg);
+	git_error_set(GIT_ERROR_INVALID, "cannot parse signature - %s", msg);
 	return -1;
 }
 
@@ -76,11 +76,11 @@ int git_signature_new(git_signature **sig_out, const char *name, const char *ema
 
 	*sig_out = NULL;
 
-	if (contains_angle_brackets(name) ||
-		contains_angle_brackets(email)) {
-		return signature_error(
-			"Neither `name` nor `email` should contain angle brackets chars.");
-	}
+	if (contains_angle_brackets(name))
+		return signature_error("name cannot contain angle brackets");
+
+	if (contains_angle_brackets(email))
+		return signature_error("email cannot contain angle brackets");
 
 	p = git__calloc(1, sizeof(git_signature));
 	GIT_ERROR_CHECK_ALLOC(p);
@@ -90,9 +90,9 @@ int git_signature_new(git_signature **sig_out, const char *name, const char *ema
 	p->email = extract_trimmed(email, strlen(email));
 	GIT_ERROR_CHECK_ALLOC(p->email);
 
-	if (p->name[0] == '\0' || p->email[0] == '\0') {
+	if (!p->name[0]) {
 		git_signature_free(p);
-		return signature_error("Signature cannot have an empty name or email");
+		return signature_error("name cannot be empty");
 	}
 
 	p->when.time = time;

--- a/tests/libgit2/commit/signature.c
+++ b/tests/libgit2/commit/signature.c
@@ -84,15 +84,19 @@ void test_commit_signature__angle_brackets_in_email_are_not_supported(void)
 	cl_git_fail(try_build_signature("Phil Haack", "<phil@haack>", 1234567890, 60));
 }
 
-void test_commit_signature__create_empties(void)
+void test_commit_signature__create_empty_name(void)
 {
-	/* can not create a signature with empty name or email */
+	/* can not create a signature with empty name */
 	cl_git_pass(try_build_signature("nulltoken", "emeric.fermas@gmail.com", 1234567890, 60));
 
 	cl_git_fail(try_build_signature("", "emeric.fermas@gmail.com", 1234567890, 60));
 	cl_git_fail(try_build_signature("   ", "emeric.fermas@gmail.com", 1234567890, 60));
-	cl_git_fail(try_build_signature("nulltoken", "", 1234567890, 60));
-	cl_git_fail(try_build_signature("nulltoken", "  ", 1234567890, 60));
+}
+
+void test_commit_signature__create_empty_email(void)
+{
+	assert_name_and_email("nulltoken", "", "nulltoken", "");
+	assert_name_and_email("nulltoken", "", "nulltoken", "   ");
 }
 
 void test_commit_signature__create_one_char(void)


### PR DESCRIPTION
git allows empty email addresses; we should, too.