### PR TITLE
stream: define ssize_t in the public header for Win32

### DIFF
--- a/include/git2/sys/stream.h
+++ b/include/git2/sys/stream.h
@@ -11,6 +11,20 @@
 #include "git2/types.h"
 #include "git2/proxy.h"
 
+/*
+ * The stream read and write callbacks use `ssize_t`, a POSIX type that
+ * MSVC and clang-cl do not provide. Define it to match the definition
+ * that libgit2 itself is built with (`SSIZE_T`) so that this header
+ * remains consumable on Win32. MinGW provides the type itself; the
+ * `_SSIZE_T_DEFINED` guard is the convention that it and other projects
+ * that define `ssize_t` use to avoid conflicting definitions.
+ */
+#if defined(_WIN32) && !defined(__MINGW32__) && !defined(_SSIZE_T_DEFINED)
+# include <basetsd.h>
+typedef SSIZE_T ssize_t;
+# define _SSIZE_T_DEFINED
+#endif
+
 /**
  * @file git2/sys/stream.h
  * @brief Streaming file I/O functionality

--- a/src/util/win32/msvc-compat.h
+++ b/src/util/win32/msvc-compat.h
@@ -10,7 +10,16 @@
 #if defined(_MSC_VER)
 
 typedef unsigned short mode_t;
+
+/*
+ * `ssize_t` is also defined by our public `git2/sys/stream.h` header
+ * (for Win32 consumers of the custom stream API); both definitions
+ * honor `_SSIZE_T_DEFINED` so that they do not collide.
+ */
+#ifndef _SSIZE_T_DEFINED
 typedef SSIZE_T ssize_t;
+# define _SSIZE_T_DEFINED
+#endif
 
 #ifdef _WIN64
 # define SSIZE_MAX _I64_MAX

--- a/tests/headertest/headertest.c
+++ b/tests/headertest/headertest.c
@@ -7,6 +7,13 @@
  */
 #include "git2.h"
 
+/*
+ * `git2/sys/stream.h` is not included by `git2.h`, but it is a public
+ * header that must be consumable on its own; in particular, on Win32 it
+ * is responsible for providing `ssize_t` for its callbacks.
+ */
+#include "git2/sys/stream.h"
+
 int main(void)
 {
     return 0;


### PR DESCRIPTION
Fixes #7286.

`git2/sys/stream.h` declares the `git_stream` read/write callbacks with `ssize_t`, a POSIX type that MSVC and clang-cl don't provide; the only definition in the tree is in the internal (not installed) `src/util/win32/msvc-compat.h`. So a Win32 consumer that includes `git2/sys/stream.h` — e.g. to register a custom stream backend via `git_stream_register` — fails with `error: unknown type name 'ssize_t'`.

As suggested in the issue, this makes the header self-sufficient:

* `include/git2/sys/stream.h` defines `ssize_t` (as `SSIZE_T`, matching the internal definition that libgit2 itself is built with) when the compiler doesn't provide it. The block is skipped on MinGW and honors `_SSIZE_T_DEFINED`, the guard convention shared by MinGW-w64 and other projects that define `ssize_t` (e.g. libuv), so include order can't produce conflicting definitions.
* the internal `msvc-compat.h` now honors the same guard, so internal builds see exactly one definition regardless of include order.
* `tests/headertest` now also includes `git2/sys/stream.h`: it's a public header that must be consumable on its own, and it's the only public header that needs `ssize_t`. On MSVC this test fails before this change and passes with it.

### Verification

Tested with clang targeting `x86_64-pc-windows-msvc` and `i686-pc-windows-msvc` (against stubbed SDK headers), plus host clang for the POSIX side:

* before: including `git2/sys/stream.h` fails with the exact error from the issue; after: compiles cleanly as C and C++, x64 and x86, with `-Wall -Wextra -Werror`
* headertest passes with `-Wall -Wextra -pedantic -Werror` (default standard, `-std=c90`, and C++)
* a consumer that already typedefs `ssize_t` itself before including the header (msvc-compat-style `SSIZE_T`, or libuv-style `intptr_t` with `_SSIZE_T_DEFINED` set) still compiles with no duplicate-definition errors
* MinGW (64/32) targets skip the block and keep using MinGW's own `ssize_t`
* the new block is invisible to the API docs validation, which preprocesses without `_WIN32`

🤖 Generated with [Claude Code](https://claude.com/claude-code)