### PR TITLE
cmake: bring back hidden visibility for the static build

### DIFF
--- a/cmake/DefaultCFlags.cmake
+++ b/cmake/DefaultCFlags.cmake
@@ -112,9 +112,11 @@ else()
 
 	if(MINGW OR MSYS) # MinGW and MSYS always do PIC and complain if we tell them to
 		string(REGEX REPLACE "-fPIC" "" CMAKE_SHARED_LIBRARY_C_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
-	elseif(BUILD_SHARED_LIBS)
-		add_c_flag_IF_SUPPORTED(-fvisibility=hidden)
+	else()
+		add_c_flag_if_supported(-fvisibility=hidden)
+	endif()
 
+	if(BUILD_SHARED_LIBS)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 	endif()
 


### PR DESCRIPTION
We've had `-fvisibility=hidden` from the beginning of the project, and the code setting it has gone through multiple iterations.

In b41e24a65c (2013-01-10; Add -fPIC only if BUILD_SHARED_LIBS is ON) as part of building for Amiga, this option was changed to bet set only for shared builds, erroneously believing that this visibility would not affect static builds.

Not so. The recent introduction of llhttp has made some users of the static library end up exporting the symbols for that library which conflict with this library being used via other means in the same program.

Bring back the logic of not enabling `-fvisibility=hidden` for MINGW to avoid it complaining which was the reason why it was grouped with `-fPIC` in the first place.

As pointed out by https://github.com/libgit2/rugged/pull/1000

The PR that introduced this change was #1218 and this did come up but it was convincing enough that we figured it wouldn't affect static builds.