### PR TITLE
cmake: apply -fvisibility=hidden to all builds

### DIFF
--- a/cmake/DefaultCFlags.cmake
+++ b/cmake/DefaultCFlags.cmake
@@ -110,11 +110,11 @@ else()
 
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG -O0")
 
+	add_c_flag_IF_SUPPORTED(-fvisibility=hidden)
+
 	if(MINGW OR MSYS) # MinGW and MSYS always do PIC and complain if we tell them to
 		string(REGEX REPLACE "-fPIC" "" CMAKE_SHARED_LIBRARY_C_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
 	elseif(BUILD_SHARED_LIBS)
-		add_c_flag_IF_SUPPORTED(-fvisibility=hidden)
-
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 	endif()
 


### PR DESCRIPTION
Move `add_c_flag_IF_SUPPORTED(-fvisibility=hidden)` out of the `elseif(BUILD_SHARED_LIBS)` branch so it applies to every build, not just when libgit2 itself is built as a shared object.

The visibility flag was inadvertently restricted to shared-library builds: commit b41e24a only intended to scope -fPIC to that case, but the visibility flag was placed in the same branch. As a result, a static libgit2 is compiled with default (public) symbol visibility, and every libgit2 symbol, including those of bundled dependencies, leaks into whatever shared object links it statically.

This surfaced downstream in rugged (libgit2/rugged#1000). Since libgit2 1.8 bundles llhttp as the default HTTP parser, statically linking libgit2 into rugged.so exported all ~119 llhttp symbols. When both rugged and the llhttp-ffi gem are loaded in the same process, the dynamic linker interposes llhttp-ffi's calls onto rugged's exported symbols. The two llhttp major versions have incompatible callback signatures and state struct layouts, so the parser invokes the wrong function pointers against misinterpreted data and fails.