### PR TITLE
build(msvc): don't compile a static libgit2 with /GL (avoids forcing /LTCG on consumers)

### DIFF
--- a/cmake/DefaultCFlags.cmake
+++ b/cmake/DefaultCFlags.cmake
@@ -50,13 +50,19 @@ if(MSVC)
 	# /Oy - Enable frame pointer omission (FPO) (otherwise CMake will automatically turn it off)
 	# /GL - Link time code generation (whole program optimization)
 	# /Gy - Function-level linking
-	set(CMAKE_C_FLAGS_RELEASE "/DNDEBUG /O2 /Oy /GL /Gy ${CRT_FLAG_RELEASE}")
+	# /GL pays off only when the matching link runs /LTCG; a static libgit2 archive
+	# does no LTCG, so /GL would just force /LTCG onto every consumer. Shared/exe only.
+	if(BUILD_SHARED_LIBS)
+		set(GIT_WPO_C " /GL")
+		set(GIT_WPO_LINK " /LTCG")
+	endif()
+	set(CMAKE_C_FLAGS_RELEASE "/DNDEBUG /O2 /Oy${GIT_WPO_C} /Gy ${CRT_FLAG_RELEASE}")
 
 	# /Oy- - Disable frame pointer omission (FPO)
-	set(CMAKE_C_FLAGS_RELWITHDEBINFO "/DNDEBUG /Zi /O2 /Oy- /GL /Gy ${CRT_FLAG_RELEASE}")
+	set(CMAKE_C_FLAGS_RELWITHDEBINFO "/DNDEBUG /Zi /O2 /Oy-${GIT_WPO_C} /Gy ${CRT_FLAG_RELEASE}")
 
 	# /O1 - Optimize for size
-	set(CMAKE_C_FLAGS_MINSIZEREL "/DNDEBUG /O1 /Oy /GL /Gy ${CRT_FLAG_RELEASE}")
+	set(CMAKE_C_FLAGS_MINSIZEREL "/DNDEBUG /O1 /Oy${GIT_WPO_C} /Gy ${CRT_FLAG_RELEASE}")
 
 	# /IGNORE:4221 - Ignore empty compilation units
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /IGNORE:4221")
@@ -78,9 +84,9 @@ if(MSVC)
 	# /INCREMENTAL:NO - Required to use /LTCG
 	# /DEBUGTYPE:cv,fixup - Additional data embedded in the PDB (requires /INCREMENTAL:NO, so not on for Debug)
 	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "/DEBUG")
-	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/RELEASE /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
-	set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /RELEASE /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO /DEBUGTYPE:cv,fixup")
-	set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "/RELEASE /LTCG /OPT:REF /OPT:ICF /INCREMENTAL:NO")
+	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/RELEASE${GIT_WPO_LINK} /OPT:REF /OPT:ICF /INCREMENTAL:NO")
+	set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG /RELEASE${GIT_WPO_LINK} /OPT:REF /OPT:ICF /INCREMENTAL:NO /DEBUGTYPE:cv,fixup")
+	set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "/RELEASE${GIT_WPO_LINK} /OPT:REF /OPT:ICF /INCREMENTAL:NO")
 
 	# Same linker settings for DLL as EXE
 	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
### Problem

Building libgit2 as a **static** library with MSVC compiles the objects with `/GL` (whole-program optimization). A static archive performs no LTCG, so the `/GL` objects force `/LTCG` onto **every consumer's** link — the consumer link restarts and emits:

```text
git2.lib(diff.c.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
```

`/GL` objects are also pinned to the exact MSVC toolset, so a distributed static `git2.lib` can trigger `LNK1257`/version-mismatch on consumers built with a different toolset. The archive is also much larger (≈82 MB vs ≈5 MB in my build) because `/GL` embeds compiler IR.

### Fix

`/GL` only pays off when the matching link runs `/LTCG`. libgit2 emits `/LTCG` for its shared library and executables but never for the static archive, so for a static build `/GL` is pure downside. Gate both `/GL` and the matching `/LTCG` on `BUILD_SHARED_LIBS`:

- `BUILD_SHARED_LIBS=ON` (default): unchanged — `/GL` + `/LTCG` as before.
- `BUILD_SHARED_LIBS=OFF`: drop `/GL` (and the then-pointless `/LTCG`), so the static lib no longer forces `/LTCG` on consumers.

No new options.

Fixes #7294.
