### PR TITLE
Add Git2Dart to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ Here are the bindings to libgit2 that are currently available:
     * chicken-git <https://wiki.call-cc.org/egg/git>
 * D
     * dlibgit <https://github.com/s-ludwig/dlibgit>
+* Dart
+    * git2dart <https://github.com/DartGit-dev/git2dart>
 * Delphi
     * GitForDelphi <https://github.com/libgit2/GitForDelphi>
     * libgit2-delphi <https://github.com/todaysoftware/libgit2-delphi>


### PR DESCRIPTION
I've been using [Git2Dart](https://github.com/DartGit-dev/git2dart) and noticed it wasn't in your list of language bindings, so this PR adds it.