### PR TITLE
Fix segfault on Android when no HOME set

### DIFF
--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -439,6 +439,12 @@ static int load_known_hosts(LIBSSH2_KNOWNHOSTS **hosts, LIBSSH2_SESSION *session
 
 	GIT_ASSERT_ARG(hosts);
 
+	if ((known_hosts = libssh2_knownhost_init(session)) == NULL) {
+		ssh_error(session, "error initializing known hosts");
+		error = -1;
+		goto out;
+	}
+
 	if ((error = git_sysdir_expand_homedir_file(&sshdir, SSH_DIR)) < 0) {
 		if (error == GIT_ENOTFOUND)
 			error = 0;
@@ -448,12 +454,6 @@ static int load_known_hosts(LIBSSH2_KNOWNHOSTS **hosts, LIBSSH2_SESSION *session
 
         if ((error = git_str_joinpath(&path, git_str_cstr(&sshdir), KNOWN_HOSTS_FILE)) < 0)
 		goto out;
-
-	if ((known_hosts = libssh2_knownhost_init(session)) == NULL) {
-		ssh_error(session, "error initializing known hosts");
-		error = -1;
-		goto out;
-	}
 
 	/*
 	 * Try to read the file and consider not finding it as not trusting the

--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -452,7 +452,7 @@ static int load_known_hosts(LIBSSH2_KNOWNHOSTS **hosts, LIBSSH2_SESSION *session
 		goto out;
 	}
 
-        if ((error = git_str_joinpath(&path, git_str_cstr(&sshdir), KNOWN_HOSTS_FILE)) < 0)
+	if ((error = git_str_joinpath(&path, git_str_cstr(&sshdir), KNOWN_HOSTS_FILE)) < 0)
 		goto out;
 
 	/*


### PR DESCRIPTION
The fix for https://github.com/libgit2/libgit2/issues/6550, commit https://github.com/libgit2/libgit2/commit/45567bebb757ac1832999d15184a15bfd7d84671, has a bug: the `libssh2_knownhost_init` call a few lines down is skipped in the missing HOME case, but since `error` is set to `0`, the `hosts` pointer remains null, when calling functions expect it to be safe to dereference.  This was causing my app to crash with a segfault.

This PR moves the `libssh2_knownhost_init` call earlier to avoid passing back null pointers.

Fixes #6550

(I have tested this updated fix on Android with a certificate_check callback set, but no known_hosts file or even HOME set, and it succeeds without errors.)