### PR TITLE
blame: guard against NULL hunk summary when duplicating

### DIFF
--- a/src/libgit2/blame.c
+++ b/src/libgit2/blame.c
@@ -108,7 +108,12 @@ static git_blame_hunk *dup_hunk(git_blame_hunk *hunk, git_blame *blame)
 	if (git_signature_dup(&newhunk->final_signature, hunk->final_signature) < 0 ||
 	    git_signature_dup(&newhunk->final_committer, hunk->final_committer) < 0 ||
 	    git_signature_dup(&newhunk->orig_signature, hunk->orig_signature) < 0 ||
-	    git_signature_dup(&newhunk->orig_committer, hunk->orig_committer) < 0 ||
+	    git_signature_dup(&newhunk->orig_committer, hunk->orig_committer) < 0) {
+		free_hunk(newhunk);
+		return NULL;
+	}
+
+	if (hunk->summary &&
 	    (newhunk->summary = git__strdup(hunk->summary)) == NULL) {
 		free_hunk(newhunk);
 		return NULL;

--- a/tests/libgit2/blame/buffer.c
+++ b/tests/libgit2/blame/buffer.c
@@ -418,3 +418,19 @@ def\n";
 	check_blame_hunk_index(g_repo, g_bufferblame, 3, 11, 5, 0, "aa06ecca", "b.txt");
 	check_blame_hunk_index(g_repo, g_bufferblame, 4, 16, 2, 0, "00000000", "b.txt");
 }
+
+void test_blame_buffer__reblame_buffer_result(void)
+{
+	git_blame *reblame = NULL;
+	const char *buffer = "abc\ndef\n";
+
+	/*
+	 * Hunks introduced by blaming a buffer have no associated commit, so
+	 * their summary stays NULL. Blaming again against that result must
+	 * duplicate those hunks without dereferencing the NULL summary.
+	 */
+	cl_git_pass(git_blame_buffer(&g_bufferblame, g_fileblame, buffer, strlen(buffer)));
+	cl_git_pass(git_blame_buffer(&reblame, g_bufferblame, buffer, strlen(buffer)));
+
+	git_blame_free(reblame);
+}


### PR DESCRIPTION
`dup_hunk()` calls `git__strdup(hunk->summary)` unconditionally, but hunks introduced by `git_blame_buffer()` have no associated commit and so their `summary` is NULL. Blaming a buffer a second time (i.e. passing a previous `git_blame_buffer()` result back in as the reference) reaches `dup_hunk()` with such a hunk and dereferences NULL in `strlen`, segfaulting.

This mirrors how `new_hunk()` already treats `orig_path` (`path ? git__strdup(path) : NULL`) and how `free_hunk()` already tolerates a NULL summary. Added a regression test that blames a buffer twice.

Fixes #7311.