### PR TITLE
repository: use commondir for is_shallow

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -4008,7 +4008,7 @@ int git_repository_is_shallow(git_repository *repo)
 	struct stat st;
 	int error;
 
-	if ((error = git_str_joinpath(&path, repo->gitdir, "shallow")) < 0)
+	if ((error = git_str_joinpath(&path, repo->commondir, "shallow")) < 0)
 		return error;
 
 	error = git_fs_path_lstat(path.ptr, &st);

--- a/tests/libgit2/repo/shallow.c
+++ b/tests/libgit2/repo/shallow.c
@@ -1,6 +1,8 @@
 #include "clar_libgit2.h"
 #include "futils.h"
 
+#include "git2/worktree.h"
+
 static git_repository *g_repo;
 
 void test_repo_shallow__initialize(void)
@@ -36,4 +38,26 @@ void test_repo_shallow__clears_errors(void)
 	g_repo = cl_git_sandbox_init("testrepo.git");
 	cl_assert_equal_i(0, git_repository_is_shallow(g_repo));
 	cl_assert_equal_i(GIT_ERROR_NONE, git_error_last()->klass);
+}
+
+void test_repo_shallow__worktree_of_shallow_parent(void)
+{
+	git_worktree *wt;
+	git_repository *wt_repo;
+	git_str path = GIT_STR_INIT;
+
+	g_repo = cl_git_sandbox_init("testrepo");
+
+	/* any non-empty content marks the parent as shallow */
+	cl_git_mkfile("testrepo/.git/shallow", "x");
+
+	cl_git_pass(git_str_joinpath(&path, git_repository_workdir(g_repo), "../wt"));
+	cl_git_pass(git_worktree_add(&wt, g_repo, "wt", path.ptr, NULL));
+	cl_git_pass(git_repository_open_from_worktree(&wt_repo, wt));
+
+	cl_assert_equal_i(1, git_repository_is_shallow(wt_repo));
+
+	git_repository_free(wt_repo);
+	git_worktree_free(wt);
+	git_str_dispose(&path);
 }


### PR DESCRIPTION
Just a little fix.
The `shallow` file resides in `<parent>/.git`, not `<parent>/.git/worktrees/foo`.

Found through Nix.