### PR TITLE
cli: Set remote_cb clone option when branch and depth are specified

### DIFF
--- a/src/cli/cmd_clone.c
+++ b/src/cli/cmd_clone.c
@@ -122,6 +122,19 @@ static void interrupt_cleanup(void)
 	exit(130);
 }
 
+static int create_remote_cb(git_remote **out, git_repository *repo,
+							const char *name, const char *url, void *payload)
+{
+    const char *branch = payload;
+	git_str fetchspec = GIT_STR_INIT;
+
+	git_str_printf(&fetchspec, "+refs/heads/%s:refs/remotes/%s/%s",
+				   branch, name, branch);
+
+    return git_remote_create_with_fetchspec(out, repo, name, url,
+											git_str_cstr(&fetchspec));
+}
+
 int cmd_clone(int argc, char **argv)
 {
 	git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
@@ -146,6 +159,11 @@ int cmd_clone(int argc, char **argv)
 	clone_opts.bare = !!bare;
 	clone_opts.checkout_branch = branch;
 	clone_opts.fetch_opts.depth = compute_depth(depth);
+
+	if (depth && branch) {
+		clone_opts.remote_cb = create_remote_cb;
+		clone_opts.remote_cb_payload = branch;
+	}
 
 	if (!checkout)
 		clone_opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_NONE;


### PR DESCRIPTION
In order to mimic the default behavior of Git, this change sets the 'remote_cb' field of 'git_clone_options' so the cloning at depth is only done for 'branch'.

* src/cli/cmd_clone.c (create_remote_cb): New procedure.
(cmd_clone): Adjust to clone at DEPTH only for BRANCH if possible.