### PR TITLE
deps/reftable: update to 0b75ef5168

### DIFF
--- a/deps/reftable/basics.c
+++ b/deps/reftable/basics.c
@@ -152,6 +152,9 @@ size_t binsearch(size_t sz, int (*f)(size_t k, void *args), void *args)
 	size_t lo = 0;
 	size_t hi = sz;
 
+	if (!sz)
+		return 0;
+
 	/* Invariants:
 	 *
 	 *  (hi == sz) || f(hi) == true

--- a/deps/reftable/block.c
+++ b/deps/reftable/block.c
@@ -260,6 +260,15 @@ int reftable_block_init(struct reftable_block *block,
 			goto done;
 	}
 
+	/*
+	 * Verify that the block size covers at least the table header, block
+	 * header and the 2 byte restart counter.
+	 */
+	if (block_size < header_size + 4 + 2) {
+		err = REFTABLE_FORMAT_ERROR;
+		goto done;
+	}
+
 	if (block_type == REFTABLE_BLOCK_TYPE_LOG) {
 		uint32_t block_header_skip = 4 + header_size;
 		uLong dst_len = block_size - block_header_skip;
@@ -331,8 +340,21 @@ int reftable_block_init(struct reftable_block *block,
 		full_block_size = block_size;
 	}
 
+	/*
+	 * Ensure that we have sufficient data available now to satisfy the
+	 * claimed block size.
+	 */
+	if (block_size > block->block_data.len) {
+		err = REFTABLE_FORMAT_ERROR;
+		goto done;
+	}
+
 	restart_count = reftable_get_be16(block->block_data.data + block_size - 2);
 	restart_off = block_size - 2 - 3 * restart_count;
+	if (restart_off < header_size + 4 || restart_off > block_size - 2) {
+		err = REFTABLE_FORMAT_ERROR;
+		goto done;
+	}
 
 	block->block_type = block_type;
 	block->hash_size = hash_size;
@@ -419,6 +441,15 @@ static int restart_needle_less(size_t idx, void *_args)
 	int n;
 
 	/*
+	 * The restart offset must point to a record, which is stored before
+	 * the restart table. Verify that this is the case.
+	 */
+	if (off >= args->block->restart_off) {
+		args->error = 1;
+		return -1;
+	}
+
+	/*
 	 * Records at restart points are stored without prefix compression, so
 	 * there is no need to fully decode the record key here. This removes
 	 * the need for allocating memory.
@@ -495,6 +526,10 @@ int block_iter_seek_key(struct block_iter *it, struct reftable_buf *want)
 	int err = 0;
 	size_t i;
 
+	err = reftable_record_init(&rec, reftable_block_type(it->block));
+	if (err < 0)
+		goto done;
+
 	/*
 	 * Perform a binary search over the block's restart points, which
 	 * avoids doing a linear scan over the whole block. Like this, we
@@ -535,10 +570,6 @@ int block_iter_seek_key(struct block_iter *it, struct reftable_buf *want)
 		it->next_off = block_restart_offset(it->block, i - 1);
 	else
 		it->next_off = it->block->header_off + 4;
-
-	err = reftable_record_init(&rec, reftable_block_type(it->block));
-	if (err < 0)
-		goto done;
 
 	/*
 	 * We're looking for the last entry less than the wanted key so that

--- a/deps/reftable/record.c
+++ b/deps/reftable/record.c
@@ -388,7 +388,6 @@ static int reftable_ref_record_decode(void *rec, struct reftable_buf key,
 	r->refname[key.len] = 0;
 
 	r->update_index = update_index;
-	r->value_type = val_type;
 	switch (val_type) {
 	case REFTABLE_REF_VAL1:
 		if (in.len < hash_size) {
@@ -426,9 +425,10 @@ static int reftable_ref_record_decode(void *rec, struct reftable_buf key,
 	case REFTABLE_REF_DELETION:
 		break;
 	default:
-		abort();
-		break;
+		err = REFTABLE_FORMAT_ERROR;
+		goto done;
 	}
+	r->value_type = val_type;
 
 	return start.len - in.len;
 

--- a/deps/reftable/reftable-stack.h
+++ b/deps/reftable/reftable-stack.h
@@ -26,11 +26,31 @@
  */
 struct reftable_stack;
 
+/* Options related to opening a stack. */
+struct reftable_stack_options {
+	/*
+	 * 4-byte identifier ("sha1", "s256") of the hash. Defaults to SHA1 if
+	 * unset.
+	 */
+	enum reftable_hash hash_id;
+
+	/*
+	 * Callback function to execute whenever the stack is being reloaded.
+	 * This can be used e.g. to discard cached information that relies on
+	 * the old stack's data. The payload data will be passed as argument to
+	 * the callback.
+	 */
+	void (*on_reload)(void *payload);
+	void *on_reload_payload;
+
+	int suppress_deletions;
+};
+
 /* open a new reftable stack. The tables along with the table list will be
  *  stored in 'dir'. Typically, this should be .git/reftables.
  */
 int reftable_new_stack(struct reftable_stack **dest, const char *dir,
-		       const struct reftable_write_options *opts);
+		       const struct reftable_stack_options *opts);
 
 /* returns the update_index at which a next table should be written. */
 uint64_t reftable_stack_next_update_index(struct reftable_stack *st);
@@ -52,6 +72,7 @@ enum {
  */
 int reftable_stack_new_addition(struct reftable_addition **dest,
 				struct reftable_stack *st,
+				const struct reftable_write_options *opts,
 				unsigned int flags);
 
 /* Adds a reftable to transaction. */
@@ -77,7 +98,9 @@ void reftable_addition_destroy(struct reftable_addition *add);
 int reftable_stack_add(struct reftable_stack *st,
 		       int (*write_table)(struct reftable_writer *wr,
 					  void *write_arg),
-		       void *write_arg, unsigned flags);
+		       void *write_arg,
+		       const struct reftable_write_options *opts,
+		       unsigned flags);
 
 struct reftable_iterator;
 
@@ -122,6 +145,7 @@ struct reftable_log_expiry_config {
 /* compacts all reftables into a giant table. Expire reflog entries if config is
  * non-NULL */
 int reftable_stack_compact_all(struct reftable_stack *st,
+			       const struct reftable_write_options *opts,
 			       struct reftable_log_expiry_config *config);
 
 /*
@@ -132,11 +156,13 @@ int reftable_stack_compact_all(struct reftable_stack *st,
  * compacted to maintain geometric progression.
  */
 int reftable_stack_compaction_required(struct reftable_stack *st,
+				       const struct reftable_write_options *opts,
 				       bool use_heuristics,
 				       bool *required);
 
 /* heuristically compact unbalanced table stack. */
-int reftable_stack_auto_compact(struct reftable_stack *st);
+int reftable_stack_auto_compact(struct reftable_stack *st,
+				const struct reftable_write_options *opts);
 
 /* delete stale .ref tables. */
 int reftable_stack_clean(struct reftable_stack *st);

--- a/deps/reftable/reftable-writer.h
+++ b/deps/reftable/reftable-writer.h
@@ -28,11 +28,6 @@ struct reftable_write_options {
 	/* how often to write complete keys in each block. */
 	uint16_t restart_interval;
 
-	/* 4-byte identifier ("sha1", "s256") of the hash.
-	 * Defaults to SHA1 if unset
-	 */
-	enum reftable_hash hash_id;
-
 	/* Default mode for creating files. If unset, use 0666 (+umask) */
 	unsigned int default_permissions;
 
@@ -60,15 +55,6 @@ struct reftable_write_options {
 	 * negative value will cause us to block indefinitely.
 	 */
 	long lock_timeout_ms;
-
-	/*
-	 * Callback function to execute whenever the stack is being reloaded.
-	 * This can be used e.g. to discard cached information that relies on
-	 * the old stack's data. The payload data will be passed as argument to
-	 * the callback.
-	 */
-	void (*on_reload)(void *payload);
-	void *on_reload_payload;
 };
 
 /* reftable_block_stats holds statistics for a single block type */
@@ -114,7 +100,8 @@ struct reftable_writer;
 int reftable_writer_new(struct reftable_writer **out,
 			ssize_t (*writer_func)(void *, const void *, size_t),
 			int (*flush_func)(void *),
-			void *writer_arg, const struct reftable_write_options *opts);
+			void *writer_arg, enum reftable_hash hash_id,
+			const struct reftable_write_options *opts);
 
 /*
  * Set the range of update indices for the records we will add. When writing a

--- a/deps/reftable/stack.c
+++ b/deps/reftable/stack.c
@@ -171,7 +171,8 @@ void reftable_stack_destroy(struct reftable_stack *st)
 		st->merged = NULL;
 	}
 
-	err = read_lines(st->list_file, &names);
+	if (st->list_file)
+		err = read_lines(st->list_file, &names);
 	if (err < 0) {
 		REFTABLE_FREE_AND_NULL(names);
 	}
@@ -337,7 +338,7 @@ static int reftable_stack_reload_once(struct reftable_stack *st,
 	/* Update the stack to point to the new tables. */
 	if (st->merged)
 		reftable_merged_table_free(st->merged);
-	new_merged->suppress_deletions = 1;
+	new_merged->suppress_deletions = st->opts.suppress_deletions;
 	st->merged = new_merged;
 
 	if (st->tables)
@@ -501,10 +502,10 @@ out:
 }
 
 int reftable_new_stack(struct reftable_stack **dest, const char *dir,
-		       const struct reftable_write_options *_opts)
+		       const struct reftable_stack_options *_opts)
 {
 	struct reftable_buf list_file_name = REFTABLE_BUF_INIT;
-	struct reftable_write_options opts = { 0 };
+	struct reftable_stack_options opts = { 0 };
 	struct reftable_stack *p;
 	int err;
 
@@ -629,6 +630,7 @@ int reftable_stack_reload(struct reftable_stack *st)
 struct reftable_addition {
 	struct reftable_flock tables_list_lock;
 	struct reftable_stack *stack;
+	struct reftable_write_options opts;
 
 	char **new_tables;
 	size_t new_tables_len, new_tables_cap;
@@ -657,6 +659,7 @@ static void reftable_addition_close(struct reftable_addition *add)
 
 static int reftable_stack_init_addition(struct reftable_addition *add,
 					struct reftable_stack *st,
+					const struct reftable_write_options *opts,
 					unsigned int flags)
 {
 	struct reftable_buf lock_file_name = REFTABLE_BUF_INIT;
@@ -664,15 +667,17 @@ static int reftable_stack_init_addition(struct reftable_addition *add,
 
 	memset(add, 0, sizeof(*add));
 	add->stack = st;
+	if (opts)
+		add->opts = *opts;
 
 	err = flock_acquire(&add->tables_list_lock, st->list_file,
-			    st->opts.lock_timeout_ms);
+			    add->opts.lock_timeout_ms);
 	if (err < 0)
 		goto done;
 
-	if (st->opts.default_permissions) {
+	if (add->opts.default_permissions) {
 		if (chmod(add->tables_list_lock.path,
-			  st->opts.default_permissions) < 0) {
+			  add->opts.default_permissions) < 0) {
 			err = REFTABLE_IO_ERROR;
 			goto done;
 		}
@@ -702,12 +707,14 @@ done:
 static int stack_try_add(struct reftable_stack *st,
 			 int (*write_table)(struct reftable_writer *wr,
 					    void *arg),
-			 void *arg, unsigned flags)
+			 void *arg,
+			 const struct reftable_write_options *opts,
+			 unsigned flags)
 {
 	struct reftable_addition add;
 	int err;
 
-	err = reftable_stack_init_addition(&add, st, flags);
+	err = reftable_stack_init_addition(&add, st, opts, flags);
 	if (err < 0)
 		goto done;
 
@@ -723,9 +730,11 @@ done:
 
 int reftable_stack_add(struct reftable_stack *st,
 		       int (*write)(struct reftable_writer *wr, void *arg),
-		       void *arg, unsigned flags)
+		       void *arg,
+		       const struct reftable_write_options *opts,
+		       unsigned flags)
 {
-	int err = stack_try_add(st, write, arg, flags);
+	int err = stack_try_add(st, write, arg, opts, flags);
 	if (err < 0) {
 		if (err == REFTABLE_OUTDATED_ERROR) {
 			/* Ignore error return, we want to propagate
@@ -810,7 +819,7 @@ int reftable_addition_commit(struct reftable_addition *add)
 	if (err)
 		goto done;
 
-	if (!add->stack->opts.disable_auto_compact) {
+	if (!add->opts.disable_auto_compact) {
 		/*
 		 * Auto-compact the stack to keep the number of tables in
 		 * control. It is possible that a concurrent writer is already
@@ -820,7 +829,7 @@ int reftable_addition_commit(struct reftable_addition *add)
 		 * concurrent writer, which causes `REFTABLE_OUTDATED_ERROR`.
 		 * Both of these errors are benign, so we simply ignore them.
 		 */
-		err = reftable_stack_auto_compact(add->stack);
+		err = reftable_stack_auto_compact(add->stack, &add->opts);
 		if (err < 0 && err != REFTABLE_LOCK_ERROR &&
 		    err != REFTABLE_OUTDATED_ERROR)
 			goto done;
@@ -834,6 +843,7 @@ done:
 
 int reftable_stack_new_addition(struct reftable_addition **dest,
 				struct reftable_stack *st,
+				const struct reftable_write_options *opts,
 				unsigned int flags)
 {
 	int err;
@@ -842,7 +852,7 @@ int reftable_stack_new_addition(struct reftable_addition **dest,
 	if (!*dest)
 		return REFTABLE_OUT_OF_MEMORY_ERROR;
 
-	err = reftable_stack_init_addition(*dest, st, flags);
+	err = reftable_stack_init_addition(*dest, st, opts, flags);
 	if (err) {
 		reftable_free(*dest);
 		*dest = NULL;
@@ -862,7 +872,7 @@ int reftable_addition_add(struct reftable_addition *add,
 	struct reftable_writer *wr = NULL;
 	struct reftable_tmpfile tab_file = REFTABLE_TMPFILE_INIT;
 	struct fd_writer writer = {
-		.opts = &add->stack->opts,
+		.opts = &add->opts,
 	};
 	int err = 0;
 
@@ -883,9 +893,9 @@ int reftable_addition_add(struct reftable_addition *add,
 	err = tmpfile_from_pattern(&tab_file, temp_tab_file_name.buf);
 	if (err < 0)
 		goto done;
-	if (add->stack->opts.default_permissions) {
+	if (add->opts.default_permissions) {
 		if (chmod(tab_file.path,
-			  add->stack->opts.default_permissions)) {
+			  add->opts.default_permissions)) {
 			err = REFTABLE_IO_ERROR;
 			goto done;
 		}
@@ -893,7 +903,7 @@ int reftable_addition_add(struct reftable_addition *add,
 
 	writer.fd = tab_file.fd;
 	err = reftable_writer_new(&wr, fd_writer_write, fd_writer_flush,
-				  &writer, &add->stack->opts);
+				  &writer, add->stack->opts.hash_id, &add->opts);
 	if (err < 0)
 		goto done;
 
@@ -1066,13 +1076,14 @@ done:
 static int stack_compact_locked(struct reftable_stack *st,
 				size_t first, size_t last,
 				struct reftable_log_expiry_config *config,
+				const struct reftable_write_options *opts,
 				struct reftable_tmpfile *tab_file_out)
 {
 	struct reftable_buf next_name = REFTABLE_BUF_INIT;
 	struct reftable_buf tab_file_path = REFTABLE_BUF_INIT;
 	struct reftable_writer *wr = NULL;
 	struct fd_writer writer=  {
-		.opts = &st->opts,
+		.opts = opts,
 	};
 	struct reftable_tmpfile tab_file = REFTABLE_TMPFILE_INIT;
 	int err = 0;
@@ -1094,15 +1105,15 @@ static int stack_compact_locked(struct reftable_stack *st,
 	if (err < 0)
 		goto done;
 
-	if (st->opts.default_permissions &&
-	    chmod(tab_file.path, st->opts.default_permissions) < 0) {
+	if (opts->default_permissions &&
+	    chmod(tab_file.path, opts->default_permissions) < 0) {
 		err = REFTABLE_IO_ERROR;
 		goto done;
 	}
 
 	writer.fd = tab_file.fd;
 	err = reftable_writer_new(&wr, fd_writer_write, fd_writer_flush,
-				  &writer, &st->opts);
+				  &writer, st->opts.hash_id, opts);
 	if (err < 0)
 		goto done;
 
@@ -1150,6 +1161,7 @@ enum stack_compact_range_flags {
 static int stack_compact_range(struct reftable_stack *st,
 			       size_t first, size_t last,
 			       struct reftable_log_expiry_config *expiry,
+			       const struct reftable_write_options *opts,
 			       unsigned int flags)
 {
 	struct reftable_buf tables_list_buf = REFTABLE_BUF_INIT;
@@ -1175,7 +1187,7 @@ static int stack_compact_range(struct reftable_stack *st,
 	 * Hold the lock so that we can read "tables.list" and lock all tables
 	 * which are part of the user-specified range.
 	 */
-	err = flock_acquire(&tables_list_lock, st->list_file, st->opts.lock_timeout_ms);
+	err = flock_acquire(&tables_list_lock, st->list_file, opts->lock_timeout_ms);
 	if (err < 0)
 		goto done;
 
@@ -1274,7 +1286,7 @@ static int stack_compact_range(struct reftable_stack *st,
 	 * these tables may end up with an empty new table in case tombstones
 	 * end up cancelling out all refs in that range.
 	 */
-	err = stack_compact_locked(st, first, last, expiry, &new_table);
+	err = stack_compact_locked(st, first, last, expiry, opts, &new_table);
 	if (err < 0) {
 		if (err != REFTABLE_EMPTY_TABLE_ERROR)
 			goto done;
@@ -1286,13 +1298,13 @@ static int stack_compact_range(struct reftable_stack *st,
 	 * "tables.list". We'll then replace the compacted range of tables with
 	 * the new table.
 	 */
-	err = flock_acquire(&tables_list_lock, st->list_file, st->opts.lock_timeout_ms);
+	err = flock_acquire(&tables_list_lock, st->list_file, opts->lock_timeout_ms);
 	if (err < 0)
 		goto done;
 
-	if (st->opts.default_permissions) {
+	if (opts->default_permissions) {
 		if (chmod(tables_list_lock.path,
-			  st->opts.default_permissions) < 0) {
+			  opts->default_permissions) < 0) {
 			err = REFTABLE_IO_ERROR;
 			goto done;
 		}
@@ -1513,10 +1525,16 @@ done:
 }
 
 int reftable_stack_compact_all(struct reftable_stack *st,
+			       const struct reftable_write_options *opts,
 			       struct reftable_log_expiry_config *config)
 {
+	struct reftable_write_options opts_default = { 0 };
 	size_t last = st->merged->tables_len ? st->merged->tables_len - 1 : 0;
-	return stack_compact_range(st, 0, last, config, 0);
+
+	if (!opts)
+		opts = &opts_default;
+
+	return stack_compact_range(st, 0, last, config, opts, 0);
 }
 
 static int segment_size(struct segment *s)
@@ -1601,6 +1619,7 @@ struct segment suggest_compaction_segment(uint64_t *sizes, size_t n,
 }
 
 static int stack_segments_for_compaction(struct reftable_stack *st,
+					 const struct reftable_write_options *opts,
 					 struct segment *seg)
 {
 	int version = (st->opts.hash_id == REFTABLE_HASH_SHA1) ? 1 : 2;
@@ -1615,13 +1634,14 @@ static int stack_segments_for_compaction(struct reftable_stack *st,
 		sizes[i] = st->tables[i]->size - overhead;
 
 	*seg = suggest_compaction_segment(sizes, st->merged->tables_len,
-					  st->opts.auto_compaction_factor);
+					  opts->auto_compaction_factor);
 	reftable_free(sizes);
 
 	return 0;
 }
 
 static int update_segment_if_compaction_required(struct reftable_stack *st,
+						 const struct reftable_write_options *opts,
 						 struct segment *seg,
 						 bool use_geometric,
 						 bool *required)
@@ -1638,7 +1658,7 @@ static int update_segment_if_compaction_required(struct reftable_stack *st,
 		return 0;
 	}
 
-	err = stack_segments_for_compaction(st, seg);
+	err = stack_segments_for_compaction(st, opts, seg);
 	if (err)
 		return err;
 
@@ -1647,27 +1667,40 @@ static int update_segment_if_compaction_required(struct reftable_stack *st,
 }
 
 int reftable_stack_compaction_required(struct reftable_stack *st,
+				       const struct reftable_write_options *opts,
 				       bool use_heuristics,
 				       bool *required)
 {
+	struct reftable_write_options opts_default = { 0 };
 	struct segment seg;
-	return update_segment_if_compaction_required(st, &seg, use_heuristics,
-						     required);
+
+	if (!opts)
+		opts = &opts_default;
+
+	return update_segment_if_compaction_required(st, opts, &seg,
+						     use_heuristics, required);
 }
 
-int reftable_stack_auto_compact(struct reftable_stack *st)
+int reftable_stack_auto_compact(struct reftable_stack *st,
+				const struct reftable_write_options *opts)
 {
+	struct reftable_write_options opts_default = { 0 };
 	struct segment seg;
 	bool required;
 	int err;
 
-	err = update_segment_if_compaction_required(st, &seg, true, &required);
+	if (!opts)
+		opts = &opts_default;
+
+	err = update_segment_if_compaction_required(st, opts, &seg, true,
+						    &required);
 	if (err)
 		return err;
 
 	if (required)
 		return stack_compact_range(st, seg.start, seg.end - 1,
-					   NULL, STACK_COMPACT_RANGE_BEST_EFFORT);
+					   NULL, opts,
+					   STACK_COMPACT_RANGE_BEST_EFFORT);
 
 	return 0;
 }
@@ -1807,7 +1840,7 @@ static int reftable_stack_clean_locked(struct reftable_stack *st)
 int reftable_stack_clean(struct reftable_stack *st)
 {
 	struct reftable_addition *add = NULL;
-	int err = reftable_stack_new_addition(&add, st, 0);
+	int err = reftable_stack_new_addition(&add, st, NULL, 0);
 	if (err < 0) {
 		goto done;
 	}

--- a/deps/reftable/stack.h
+++ b/deps/reftable/stack.h
@@ -20,7 +20,7 @@ struct reftable_stack {
 
 	char *reftable_dir;
 
-	struct reftable_write_options opts;
+	struct reftable_stack_options opts;
 
 	struct reftable_table **tables;
 	size_t tables_len;

--- a/deps/reftable/system.h
+++ b/deps/reftable/system.h
@@ -84,7 +84,7 @@ struct reftable_flock {
  * to acquire the lock. If `timeout_ms` is 0 we don't wait, if it is negative
  * we block indefinitely.
  *
- * Retrun 0 on success, a reftable error code on error. Specifically,
+ * Return 0 on success, a reftable error code on error. Specifically,
  * `REFTABLE_LOCK_ERROR` should be returned in case the target path is already
  * locked.
  */

--- a/deps/reftable/table.c
+++ b/deps/reftable/table.c
@@ -242,6 +242,8 @@ static int table_iter_seek_to(struct table_iter *ti, uint64_t off, uint8_t typ)
 	int err;
 
 	err = table_init_block(ti->table, &ti->block, off, typ);
+	if (err > 0)
+		return REFTABLE_FORMAT_ERROR;
 	if (err != 0)
 		return err;
 
@@ -560,6 +562,11 @@ int reftable_table_new(struct reftable_table **out,
 		goto done;
 	}
 
+	if (file_size < header_size(t->version) + footer_size(t->version)) {
+		err = REFTABLE_FORMAT_ERROR;
+		goto done;
+	}
+
 	t->size = file_size - footer_size(t->version);
 	t->source = *source;
 	t->name = reftable_strdup(name);
@@ -709,6 +716,10 @@ out:
 		if (ti)
 			table_iter_close(ti);
 		reftable_free(ti);
+		if (filter) {
+			reftable_buf_release(&filter->oid);
+			reftable_free(filter);
+		}
 	}
 	return err;
 }

--- a/deps/reftable/writer.c
+++ b/deps/reftable/writer.c
@@ -80,9 +80,6 @@ static void options_set_defaults(struct reftable_write_options *opts)
 		opts->restart_interval = 16;
 	}
 
-	if (opts->hash_id == 0) {
-		opts->hash_id = REFTABLE_HASH_SHA1;
-	}
 	if (opts->block_size == 0) {
 		opts->block_size = DEFAULT_BLOCK_SIZE;
 	}
@@ -90,7 +87,7 @@ static void options_set_defaults(struct reftable_write_options *opts)
 
 static int writer_version(struct reftable_writer *w)
 {
-	return (w->opts.hash_id == 0 || w->opts.hash_id == REFTABLE_HASH_SHA1) ?
+	return (w->hash_id == 0 || w->hash_id == REFTABLE_HASH_SHA1) ?
 			     1 :
 			     2;
 }
@@ -107,7 +104,7 @@ static int writer_write_header(struct reftable_writer *w, uint8_t *dest)
 	if (writer_version(w) == 2) {
 		uint32_t hash_id;
 
-		switch (w->opts.hash_id) {
+		switch (w->hash_id) {
 		case REFTABLE_HASH_SHA1:
 			hash_id = REFTABLE_FORMAT_ID_SHA1;
 			break;
@@ -134,7 +131,7 @@ static int writer_reinit_block_writer(struct reftable_writer *w, uint8_t typ)
 	reftable_buf_reset(&w->last_key);
 	ret = block_writer_init(&w->block_writer_data, typ, w->block,
 				w->opts.block_size, block_start,
-				hash_size(w->opts.hash_id));
+				hash_size(w->hash_id));
 	if (ret < 0)
 		return ret;
 
@@ -147,20 +144,25 @@ static int writer_reinit_block_writer(struct reftable_writer *w, uint8_t typ)
 int reftable_writer_new(struct reftable_writer **out,
 			ssize_t (*writer_func)(void *, const void *, size_t),
 			int (*flush_func)(void *),
-			void *writer_arg, const struct reftable_write_options *_opts)
+			void *writer_arg,
+			enum reftable_hash hash_id,
+			const struct reftable_write_options *_opts)
 {
 	struct reftable_write_options opts = {0};
 	struct reftable_writer *wp;
-
-	wp = reftable_calloc(1, sizeof(*wp));
-	if (!wp)
-		return REFTABLE_OUT_OF_MEMORY_ERROR;
 
 	if (_opts)
 		opts = *_opts;
 	options_set_defaults(&opts);
 	if (opts.block_size >= (1 << 24))
 		return REFTABLE_API_ERROR;
+
+	if (!hash_id)
+		hash_id = REFTABLE_HASH_SHA1;
+
+	wp = reftable_calloc(1, sizeof(*wp));
+	if (!wp)
+		return REFTABLE_OUT_OF_MEMORY_ERROR;
 
 	reftable_buf_init(&wp->block_writer_data.last_key);
 	reftable_buf_init(&wp->last_key);
@@ -173,6 +175,7 @@ int reftable_writer_new(struct reftable_writer **out,
 	wp->write = writer_func;
 	wp->write_arg = writer_arg;
 	wp->opts = opts;
+	wp->hash_id = hash_id;
 	wp->flush = flush_func;
 	writer_reinit_block_writer(wp, REFTABLE_BLOCK_TYPE_REF);
 
@@ -367,7 +370,7 @@ int reftable_writer_add_ref(struct reftable_writer *w,
 	if (!w->opts.skip_index_objects && reftable_ref_record_val1(ref)) {
 		reftable_buf_reset(&w->scratch);
 		err = reftable_buf_add(&w->scratch, (char *)reftable_ref_record_val1(ref),
-				       hash_size(w->opts.hash_id));
+				       hash_size(w->hash_id));
 		if (err < 0)
 			goto out;
 
@@ -379,7 +382,7 @@ int reftable_writer_add_ref(struct reftable_writer *w,
 	if (!w->opts.skip_index_objects && reftable_ref_record_val2(ref)) {
 		reftable_buf_reset(&w->scratch);
 		err = reftable_buf_add(&w->scratch, reftable_ref_record_val2(ref),
-				       hash_size(w->opts.hash_id));
+				       hash_size(w->hash_id));
 		if (err < 0)
 			goto out;
 

--- a/deps/reftable/writer.h
+++ b/deps/reftable/writer.h
@@ -27,6 +27,7 @@ struct reftable_writer {
 	uint64_t next;
 	uint64_t min_update_index, max_update_index;
 	struct reftable_write_options opts;
+	enum reftable_hash hash_id;
 
 	/* memory buffer for writing */
 	uint8_t *block;

--- a/src/libgit2/refdb_reftable.c
+++ b/src/libgit2/refdb_reftable.c
@@ -147,6 +147,7 @@ static int refdb_reftable_stack_for(refdb_reftable_stack **out,
 #else
 	options.hash_id = REFTABLE_HASH_SHA1;
 #endif
+	options.suppress_deletions = 1;
 
 	switch (which) {
 	case REFDB_REFTABLE_STACK_WORKTREE:

--- a/src/libgit2/refdb_reftable.c
+++ b/src/libgit2/refdb_reftable.c
@@ -42,6 +42,7 @@ typedef struct {
 	git_repository *repo;
 	refdb_reftable_stack *stack;
 	refdb_reftable_stack *worktree_stack;
+	struct reftable_write_options write_opts;
 } refdb_reftable;
 
 typedef struct {
@@ -123,7 +124,7 @@ static void refdb_reftable_return_stack(refdb_reftable *backend,
 static int refdb_reftable_stack_for(refdb_reftable_stack **out,
 				    refdb_reftable *backend, refdb_reftable_stack_t which)
 {
-	struct reftable_write_options options = { 0 };
+	struct reftable_stack_options options = { 0 };
 	refdb_reftable_stack **stack_ptr, *stack;
 	const char *parent_directory;
 	git_str path = GIT_STR_INIT;
@@ -146,7 +147,6 @@ static int refdb_reftable_stack_for(refdb_reftable_stack **out,
 #else
 	options.hash_id = REFTABLE_HASH_SHA1;
 #endif
-	options.lock_timeout_ms = 100;
 
 	switch (which) {
 	case REFDB_REFTABLE_STACK_WORKTREE:
@@ -520,7 +520,7 @@ static int refdb_reftable_init(git_refdb_backend *_backend,
 			data.error = 0;
 
 			if ((error = reftable_stack_add(stack->stack, refdb_reftable_write_head_table,
-							&data, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+							&data, &backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 				if (data.error)
 					error = data.error;
 				else
@@ -1010,7 +1010,7 @@ static int refdb_reftable_write(git_refdb_backend *_backend,
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_write_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1165,7 +1165,7 @@ static int refdb_reftable_delete(git_refdb_backend *_backend,
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_write_delete_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1355,7 +1355,7 @@ static int refdb_reftable_rename(git_reference **out,
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_write_rename_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1454,7 +1454,7 @@ static int refdb_reftable_ensure_log(git_refdb_backend *_backend,
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_write_log_existence_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1657,7 +1657,7 @@ static int refdb_reftable_reflog_write(git_refdb_backend *_backend, git_reflog *
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_write_reflog_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1724,7 +1724,7 @@ static int refdb_reftable_reflog_rename(git_refdb_backend *_backend, const char 
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_reflog_write_rename_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1780,7 +1780,7 @@ static int refdb_reftable_reflog_delete(git_refdb_backend *_backend, const char 
 		goto out;
 
 	if ((error = reftable_stack_add(data.stack->stack, refdb_reftable_reflog_write_delete_table, &data,
-					REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
+					&backend->write_opts, REFTABLE_STACK_NEW_ADDITION_RELOAD)) < 0) {
 		if (data.error)
 			error = data.error;
 		else
@@ -1802,7 +1802,7 @@ static int refdb_reftable_compress(git_refdb_backend *_backend)
 	if ((error = refdb_reftable_stack_for(&stack, backend, REFDB_REFTABLE_STACK_MAIN)) < 0)
 		goto out;
 
-	if ((error = reftable_stack_compact_all(stack->stack, NULL)) < 0) {
+	if ((error = reftable_stack_compact_all(stack->stack, &backend->write_opts, NULL)) < 0) {
 		error = refdb_reftable_error(error, "could not compact stack");
 		goto out;
 	}
@@ -1812,7 +1812,7 @@ static int refdb_reftable_compress(git_refdb_backend *_backend)
 						      REFDB_REFTABLE_STACK_WORKTREE)) < 0)
 			goto out;
 
-		if ((error = reftable_stack_compact_all(wt_stack->stack, NULL)) < 0) {
+		if ((error = reftable_stack_compact_all(wt_stack->stack, &backend->write_opts, NULL)) < 0) {
 			error = refdb_reftable_error(error, "could not compact worktree stack");
 			goto out;
 		}
@@ -1866,6 +1866,8 @@ int git_refdb_backend_reftable(git_refdb_backend **out,
 	backend->parent.reflog_delete = refdb_reftable_reflog_delete;
 	backend->parent.compress = refdb_reftable_compress;
 	/* TODO: transaction API */
+
+	backend->write_opts.lock_timeout_ms = 100;
 
 	*out = (git_refdb_backend *)backend;
 	backend = NULL;


### PR DESCRIPTION
Update the reftable dependency to 0b75ef5168 (Merge branch
'js/coverity-fixes-null-safety', 2026-07-19). This commit contains a
bunch of changes:

  - Several bugs have been fixed when parsing corrupted reftables.
  - The ability to not suppress deletions was introduced.
  - The reftable write options were split up into options that relate to
    a stack and options that relate to a write.

Besides updating the reftable library, this PR also adapts to these changes as required.