### PR TITLE
patch: accept empty-file diffs with no hunk

### DIFF
--- a/src/libgit2/patch_parse.c
+++ b/src/libgit2/patch_parse.c
@@ -428,6 +428,7 @@ static const parse_header_transition transitions[] = {
 
 	/* Next patch */
 	{ "diff --git "         , STATE_END,        0,                NULL },
+	{ "diff --git "         , STATE_INDEX,      0,                NULL },
 	{ "@@ -"                , STATE_END,        0,                NULL },
 	{ "-- "                 , STATE_INDEX,      0,                NULL },
 	{ "-- "                 , STATE_END,        0,                NULL },
@@ -486,7 +487,7 @@ static int parse_header_git(
 		}
 	}
 
-	if (state != STATE_END) {
+	if (state != STATE_END && state != STATE_INDEX) {
 		error = git_parse_err("unexpected header line %"PRIuZ, ctx->parse_ctx.line_num);
 		goto done;
 	}

--- a/tests/libgit2/patch/parse.c
+++ b/tests/libgit2/patch/parse.c
@@ -219,3 +219,47 @@ void test_patch_parse__line_number_overflow(void)
 	cl_git_fail(git_patch_from_buffer(&patch, PATCH_INTMAX_NEW_LINES, strlen(PATCH_INTMAX_NEW_LINES), NULL));
 	git_patch_free(patch);
 }
+
+/*
+ * A newly added, empty (zero-byte) file produces a diff with a `diff --git`
+ * line, a `new file mode` line, and an `index` line -- and nothing else,
+ * since there is no content to show. Confirm this parses successfully
+ * instead of failing with "unexpected header line" (#6778).
+ */
+void test_patch_parse__issue_6778_added_empty_file(void)
+{
+	git_patch *patch;
+	const git_diff_delta *delta;
+
+	cl_git_pass(git_patch_from_buffer(&patch, PATCH_ADD_EMPTY_FILE,
+		strlen(PATCH_ADD_EMPTY_FILE), NULL));
+
+	cl_assert((delta = git_patch_get_delta(patch)) != NULL);
+	cl_assert_equal_i(GIT_DELTA_ADDED, delta->status);
+	cl_assert_equal_s("file", delta->new_file.path);
+	cl_assert(delta->new_file.mode == GIT_FILEMODE_BLOB);
+	cl_assert_equal_i(0, (int)git_patch_num_hunks(patch));
+
+	git_patch_free(patch);
+}
+
+/*
+ * An empty-file add followed immediately by another file's `diff --git`
+ * header (no `---`/`+++`/hunk in between) must not be mistaken for an
+ * invalid header (#6778).
+ */
+void test_patch_parse__issue_6778_added_empty_file_multiple(void)
+{
+	git_patch *patch;
+	const git_diff_delta *delta;
+
+	cl_git_pass(git_patch_from_buffer(&patch, PATCH_ADD_EMPTY_FILE_MULTIPLE,
+		strlen(PATCH_ADD_EMPTY_FILE_MULTIPLE), NULL));
+
+	cl_assert((delta = git_patch_get_delta(patch)) != NULL);
+	cl_assert_equal_i(GIT_DELTA_ADDED, delta->status);
+	cl_assert_equal_s("file", delta->new_file.path);
+	cl_assert_equal_i(0, (int)git_patch_num_hunks(patch));
+
+	git_patch_free(patch);
+}

--- a/tests/libgit2/patch/patch_common.h
+++ b/tests/libgit2/patch/patch_common.h
@@ -942,6 +942,21 @@
 	"@@ -1 +0,0 @@\n" \
 	"-a\n"
 
+/* a newly added, empty (zero-byte) file has no hunk at all: see #6778 */
+#define PATCH_ADD_EMPTY_FILE \
+	"diff --git a/file b/file\n" \
+	"new file mode 100644\n" \
+	"index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\n"
+
+/* an added empty file immediately followed by another file's header: see #6778 */
+#define PATCH_ADD_EMPTY_FILE_MULTIPLE \
+	"diff --git a/file b/file\n" \
+	"new file mode 100644\n" \
+	"index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\n" \
+	"diff --git a/other b/other\n" \
+	"new file mode 100644\n" \
+	"index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\n"
+
 #define PATCH_CRLF \
 	"diff --git a/test-file b/test-file\r\n" \
 	"new file mode 100644\r\n" \


### PR DESCRIPTION
## What

Parsing a diff that adds an **empty** file fails with `unexpected header line`. Staging a new zero-byte file and taking a plain `git diff` produces a header with no hunk:

```
diff --git a/new_file b/new_file
new file mode 100644
index 0000000..e69de29
```

There is no content, so there is no `---`/`+++` pair and no hunk — the header simply ends at the `index` line. `git_patch_from_buffer` / `git_diff_from_buffer` reject this valid diff.

## Why it happens

In `parse_header_git()` the header state machine reaches `STATE_INDEX` after the `index` line but has no accepting transition out of it when the header ends there. `STATE_INDEX` is not treated as a terminal state, and a following `diff --git` (the multi-file case, where an empty-file add is followed by another file) is not recognized from `STATE_INDEX` either, so parsing errors out.

#5248 previously handled empty files in `git format-patch` output, which terminate with a `-- ` signature line (the `{ "-- ", STATE_INDEX, ... }` transition). Plain `git diff` output has no `-- ` line, so that path doesn't apply and the header ends directly at `index` — the case this change covers.

## Fix

Two additive changes mirroring the existing `STATE_END` handling:

1. Accept `STATE_INDEX` as a second terminal state (for a header that ends at end-of-buffer):
   ```c
   if (state != STATE_END && state != STATE_INDEX) {
   ```
2. Recognize a new `diff --git` header beginning from `STATE_INDEX` (for the multi-file case), mirroring the existing next-patch row for `STATE_END`:
   ```c
   { "diff --git ", STATE_INDEX, 0, NULL },
   ```

A non-empty file diff still transitions out of `STATE_INDEX` via the `--- ` row, so real modifications are unaffected. A truncated modification (bare `index` with no hunks) is still rejected by the existing `check_patch()` "patch with no hunks" guard, matching `git apply`.

## Tests

Adds parser tests in `tests/libgit2/patch/parse.c` for an empty-file add (both at end-of-buffer and followed by a second file in a multi-file patch), reproducing the issue's exact input.

Fixes #6778.
