### PR TITLE
index: improve file/dir conflicts handling

### DIFF
--- a/src/libgit2/index.c
+++ b/src/libgit2/index.c
@@ -1313,7 +1313,7 @@ static void index_existing_and_best(
 	}
 
 	*existing = NULL;
-	*existing_position = 0;
+	*existing_position = pos;
 	*best = NULL;
 
 	if (GIT_INDEX_ENTRY_STAGE(entry) == 0) {

--- a/tests/libgit2/index/collision.c
+++ b/tests/libgit2/index/collision.c
@@ -96,6 +96,64 @@ void test_index_collision__add_blob_with_conflicting_dir(void)
 	git_tree_free(tree);
 }
 
+/*
+ * The two tests above only ever have a single pre-existing entry in the
+ * index at the time of the collision, so the correct sorted insertion
+ * position for the new path happens to be position zero anyway.  That
+ * masks issue #7160: index_existing_and_best() discarded the insertion
+ * position it had just computed and reported position zero whenever the
+ * new path did not already exist in the index, so the directory/file
+ * collision scan started from the wrong spot and walked off the first
+ * unrelated entry instead of ever reaching the real conflict.  Seed the
+ * index with sibling entries that sort before the conflicting path so the
+ * true insertion position is non-zero, which is what actually exercises
+ * the bug.
+ */
+void test_index_collision__add_blob_with_conflicting_dir_not_at_start(void)
+{
+	git_index_entry entry;
+	git_tree_entry *tentry;
+	git_oid tree_id;
+	git_tree *tree;
+
+	memset(&entry, 0, sizeof(entry));
+	entry.ctime.seconds = 12346789;
+	entry.mtime.seconds = 12346789;
+	entry.mode  = 0100644;
+	entry.file_size = 0;
+	git_oid_cpy(&entry.id, &g_empty_id);
+
+	entry.path = "another blob";
+	cl_git_pass(git_index_add(g_index, &entry));
+
+	entry.path = "blobtree/conflict";
+	cl_git_pass(git_index_add(g_index, &entry));
+
+	entry.path = "some blob";
+	cl_git_pass(git_index_add(g_index, &entry));
+
+	/* Check blobtree/conflict exists here */
+	cl_git_pass(git_index_write_tree(&tree_id, g_index));
+	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
+	cl_git_pass(git_tree_entry_bypath(&tentry, tree, "blobtree/conflict"));
+	git_tree_entry_free(tentry);
+	git_tree_free(tree);
+
+	/* create a blob/tree collision; "blobtree"'s correct sorted position
+	 * is between "another blob" and "blobtree/conflict", not position 0
+	 */
+	entry.path = "blobtree";
+	cl_git_pass(git_index_add(g_index, &entry));
+
+	/* blobtree should now be a blob, blobtree/conflict should be gone */
+	cl_git_pass(git_index_write_tree(&tree_id, g_index));
+	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
+	cl_git_pass(git_tree_entry_bypath(&tentry, tree, "blobtree"));
+	cl_git_fail(git_tree_entry_bypath(&tentry, tree, "blobtree/conflict"));
+	git_tree_entry_free(tentry);
+	git_tree_free(tree);
+}
+
 void test_index_collision__add_with_highstage_1(void)
 {
 	git_index_entry entry;


### PR DESCRIPTION
## Problem

`git_index_add` silently ignores a file/directory conflict: adding a blob at a path that collides with an existing tree entry (or vice versa) should replace the conflicting entry the way git does, but the stale entry is left in place and the add "succeeds".

## Cause

In `index_existing_and_best()` (`src/libgit2/index.c`), when the entry is not already in the index, `index_find` has computed `pos` — the sorted insertion position — but the function discards it and hardcodes the out-param to `0`:

```c
    *existing = NULL;
    *existing_position = 0;   /* discards the computed pos */
    *best = NULL;
```

The sole caller, `index_insert`, passes that position into `check_file_directory_collision()` → `has_file_name()`, which scans forward from it. Starting the scan at `0` instead of the real insertion position means an earlier-sorting sibling entry can end the prefix scan before the actual conflict is reached, so the collision is never found. The bug is only observable when the insertion position is non-zero — which is why the existing collision tests (each with a single prior entry, whose insertion position happens to be `0`) don't catch it.

## Fix

Report the real insertion position on the not-found branch:

```c
-    *existing_position = 0;
+    *existing_position = pos;
```

`pos` is valid here: `git__bsearch` sets it to the insertion index even on `GIT_ENOTFOUND`, and the stage-matching loop just below already relies on it. `index_existing_and_best` is static with one caller, and nothing depends on the old `existing == NULL ⇒ position == 0` behaviour.

## Test

Adds `add_blob_with_conflicting_dir_not_at_start`, which seeds sibling entries so the conflicting `blobtree` lands at a non-zero insertion position, reproducing the missed conflict that the fix resolves.

Fixes #7160.
