### PR TITLE
path: initialize diriter iconv state

### DIFF
--- a/src/util/fs_path.c
+++ b/src/util/fs_path.c
@@ -1409,6 +1409,10 @@ int git_fs_path_diriter_init(
 
 	memset(diriter, 0, sizeof(git_fs_path_diriter));
 
+#ifdef GIT_I18N_ICONV
+	diriter->ic.map = (iconv_t)-1;
+#endif
+
 	if (git_str_puts(&diriter->path, path) < 0)
 		return -1;
 

--- a/src/util/fs_path.h
+++ b/src/util/fs_path.h
@@ -522,7 +522,11 @@ struct git_fs_path_diriter
 #endif
 };
 
+#ifdef GIT_I18N_ICONV
+#define GIT_FS_PATH_DIRITER_INIT { GIT_STR_INIT, 0, 0, NULL, GIT_PATH_ICONV_INIT }
+#else
 #define GIT_FS_PATH_DIRITER_INIT { GIT_STR_INIT }
+#endif
 
 #endif
 

--- a/tests/util/path/core.c
+++ b/tests/util/path/core.c
@@ -843,6 +843,21 @@ void test_path_core__dirlen(void)
 	cl_assert_equal_sz(0, git_fs_path_dirlen(""));
 }
 
+void test_path_core__diriter_without_precompose(void)
+{
+	git_fs_path_diriter diriter = GIT_FS_PATH_DIRITER_INIT;
+
+	cl_git_pass(git_fs_path_diriter_init(&diriter, ".", 0));
+	git_fs_path_diriter_free(&diriter);
+}
+
+void test_path_core__diriter_uninitialized(void)
+{
+	git_fs_path_diriter diriter = GIT_FS_PATH_DIRITER_INIT;
+
+	git_fs_path_diriter_free(&diriter);
+}
+
 static void test_make_relative(
 	const char *expected_path,
 	const char *path,


### PR DESCRIPTION
 When iconv support is enabled, `git_fs_path_diriter_init()` clears the
  iterator with `memset`, leaving `ic.map` as zero if precomposition is not
  requested. `git_fs_path_diriter_free()` treats only `(iconv_t)-1` as
  uninitialized and can therefore call `iconv_close(0)`. An iterator created
  with `GIT_FS_PATH_DIRITER_INIT` and freed before initialization has the same
  problem.

  Initialize the iconv map with the existing sentinel in both the static
  initializer and after `git_fs_path_diriter_init()` clears the structure. Add
  regression coverage for freeing a statically initialized iterator and for
  initializing without precomposition.

  ## Tests

  - `util_tests -spath::core`
  - `util_tests -xiconv` (all remaining 53 suites)

  Both new tests segfault in the iconv-enabled build before the fix and pass
  after it. The complete run still has the existing platform-specific failure
  in `iconv::decomposed_to_precomposed` because glibc iconv does not normalize
  UTF-8 to UTF-8.

  Fixes #7300.