### PR TITLE
ignore: honor nested negation across rule sources

### DIFF
--- a/src/libgit2/ignore.c
+++ b/src/libgit2/ignore.c
@@ -19,154 +19,6 @@
 
 #define GIT_IGNORE_DEFAULT_RULES ".\n..\n.git\n"
 
-/**
- * A negative ignore pattern can negate a positive one without
- * wildcards if it is a basename only and equals the basename of
- * the positive pattern. Thus
- *
- * foo/bar
- * !bar
- *
- * would result in foo/bar being unignored again while
- *
- * moo/foo/bar
- * !foo/bar
- *
- * would do nothing. The reverse also holds true: a positive
- * basename pattern can be negated by unignoring the basename in
- * subdirectories. Thus
- *
- * bar
- * !foo/bar
- *
- * would result in foo/bar being unignored again. As with the
- * first case,
- *
- * foo/bar
- * !moo/foo/bar
- *
- * would do nothing, again.
- */
-static int does_negate_pattern(git_attr_fnmatch *rule, git_attr_fnmatch *neg)
-{
-	int (*cmp)(const char *, const char *, size_t);
-	git_attr_fnmatch *longer, *shorter;
-	char *p;
-
-	if ((rule->flags & GIT_ATTR_FNMATCH_NEGATIVE) != 0
-	    || (neg->flags & GIT_ATTR_FNMATCH_NEGATIVE) == 0)
-		return false;
-
-	if (neg->flags & GIT_ATTR_FNMATCH_ICASE)
-		cmp = git__strncasecmp;
-	else
-		cmp = git__strncmp;
-
-	/* If lengths match we need to have an exact match */
-	if (rule->length == neg->length) {
-		return cmp(rule->pattern, neg->pattern, rule->length) == 0;
-	} else if (rule->length < neg->length) {
-		shorter = rule;
-		longer = neg;
-	} else {
-		shorter = neg;
-		longer = rule;
-	}
-
-	/* Otherwise, we need to check if the shorter
-	 * rule is a basename only (that is, it contains
-	 * no path separator) and, if so, if it
-	 * matches the tail of the longer rule */
-	p = longer->pattern + longer->length - shorter->length;
-
-	if (p[-1] != '/')
-		return false;
-	if (memchr(shorter->pattern, '/', shorter->length) != NULL)
-		return false;
-
-	return cmp(p, shorter->pattern, shorter->length) == 0;
-}
-
-/**
- * A negative ignore can only unignore a file which is given explicitly before, thus
- *
- *    foo
- *    !foo/bar
- *
- * does not unignore 'foo/bar' as it's not in the list. However
- *
- *    foo/<star>
- *    !foo/bar
- *
- * does unignore 'foo/bar', as it is contained within the 'foo/<star>' rule.
- */
-static int does_negate_rule(int *out, git_vector *rules, git_attr_fnmatch *match)
-{
-	int error = 0, wildmatch_flags, effective_flags;
-	size_t i;
-	git_attr_fnmatch *rule;
-	char *path;
-	git_str buf = GIT_STR_INIT;
-
-	*out = 0;
-
-	wildmatch_flags = WM_PATHNAME;
-	if (match->flags & GIT_ATTR_FNMATCH_ICASE)
-		wildmatch_flags |= WM_CASEFOLD;
-
-	/* path of the file relative to the workdir, so we match the rules in subdirs */
-	if (match->containing_dir) {
-		git_str_puts(&buf, match->containing_dir);
-	}
-	if (git_str_puts(&buf, match->pattern) < 0)
-		return -1;
-
-	path = git_str_detach(&buf);
-
-	git_vector_foreach(rules, i, rule) {
-		if (!(rule->flags & GIT_ATTR_FNMATCH_HASWILD)) {
-			if (does_negate_pattern(rule, match)) {
-				error = 0;
-				*out = 1;
-				goto out;
-			}
-			else
-				continue;
-		}
-
-		git_str_clear(&buf);
-		if (rule->containing_dir)
-			git_str_puts(&buf, rule->containing_dir);
-		git_str_puts(&buf, rule->pattern);
-
-		if (git_str_oom(&buf))
-			goto out;
-
-		/*
-		 * if rule isn't for full path we match without PATHNAME flag
-		 * as lines like *.txt should match something like dir/test.txt
-		 * requiring * to also match /
-		 */
-		effective_flags = wildmatch_flags;
-		if (!(rule->flags & GIT_ATTR_FNMATCH_FULLPATH))
-			effective_flags &= ~WM_PATHNAME;
-
-		/* if we found a match, we want to keep this rule */
-		if ((wildmatch(git_str_cstr(&buf), path, effective_flags)) == WM_MATCH) {
-			*out = 1;
-			error = 0;
-			goto out;
-		}
-	}
-
-	error = 0;
-
-out:
-	git__free(path);
-	git_str_dispose(&buf);
-	return error;
-}
-
 static int parse_ignore_file(
 	git_repository *repo, git_attr_file *attrs, const char *data, bool allow_macros)
 {
@@ -192,8 +44,6 @@ static int parse_ignore_file(
 	}
 
 	while (!error && *scan) {
-		int valid_rule = 1;
-
 		if (!match && !(match = git__calloc(1, sizeof(*match)))) {
 			error = -1;
 			break;
@@ -212,21 +62,10 @@ static int parse_ignore_file(
 
 			scan = git__next_line(scan);
 
-			/*
-			 * If a negative match doesn't actually do anything,
-			 * throw it away. As we cannot always verify whether a
-			 * rule containing wildcards negates another rule, we
-			 * do not optimize away these rules, though.
-			 * */
-			if (match->flags & GIT_ATTR_FNMATCH_NEGATIVE
-			    && !(match->flags & GIT_ATTR_FNMATCH_HASWILD))
-				error = does_negate_rule(&valid_rule, &attrs->rules, match);
-
-			if (!error && valid_rule)
-				error = git_vector_insert(&attrs->rules, match);
+			error = git_vector_insert(&attrs->rules, match);
 		}
 
-		if (error != 0 || !valid_rule) {
+		if (error != 0) {
 			match->pattern = NULL;
 
 			if (error == GIT_ENOTFOUND)
@@ -563,21 +402,31 @@ int git_ignore_path_is_ignored(
 
 	while (1) {
 		/* first process builtins - success means path was found */
-		if (ignore_lookup_in_rules(ignored, ignores.ign_internal, &path))
-			goto cleanup;
+		if (ignore_lookup_in_rules(ignored, ignores.ign_internal, &path)) {
+			if (*ignored)
+				goto cleanup;
+			goto next_path;
+		}
 
 		/* next process files in the path */
 		git_vector_foreach(&ignores.ign_path, i, file) {
-			if (ignore_lookup_in_rules(ignored, file, &path))
-				goto cleanup;
+			if (ignore_lookup_in_rules(ignored, file, &path)) {
+				if (*ignored)
+					goto cleanup;
+				goto next_path;
+			}
 		}
 
 		/* last process global ignores */
 		git_vector_foreach(&ignores.ign_global, i, file) {
-			if (ignore_lookup_in_rules(ignored, file, &path))
-				goto cleanup;
+			if (ignore_lookup_in_rules(ignored, file, &path)) {
+				if (*ignored)
+					goto cleanup;
+				goto next_path;
+			}
 		}
 
+next_path:
 		/* move up one directory */
 		if (path.basename == path.path)
 			break;

--- a/src/libgit2/iterator.c
+++ b/src/libgit2/iterator.c
@@ -1169,8 +1169,13 @@ static void filesystem_iterator_frame_push_ignores(
 		/* push new ignores for files in this directory */
 		relative_path = frame_entry->path + previous_frame->path_len;
 
-		/* inherit ignored from parent if no rule specified */
-		if (new_frame->is_ignored <= GIT_IGNORE_NOTFOUND)
+		/*
+		 * Inherit ignored from the parent if no rule was specified or
+		 * if a negative rule cannot reinclude an ignored parent.
+		 */
+		if (new_frame->is_ignored <= GIT_IGNORE_NOTFOUND ||
+		    (new_frame->is_ignored == GIT_IGNORE_FALSE &&
+		     previous_frame->is_ignored == GIT_IGNORE_TRUE))
 			new_frame->is_ignored = previous_frame->is_ignored;
 
 		git_ignore__push_dir(&iter->ignores, relative_path);
@@ -1739,11 +1744,15 @@ static void filesystem_iterator_update_ignored(filesystem_iterator *iter)
 		iter->current_is_ignored = GIT_IGNORE_NOTFOUND;
 	}
 
-	/* use ignore from containing frame stack */
-	if (iter->current_is_ignored <= GIT_IGNORE_NOTFOUND) {
-		frame = filesystem_iterator_current_frame(iter);
+	/*
+	 * Use ignore from the containing frame if no rule was specified or
+	 * if a negative rule cannot reinclude an entry in an ignored parent.
+	 */
+	frame = filesystem_iterator_current_frame(iter);
+	if (iter->current_is_ignored <= GIT_IGNORE_NOTFOUND ||
+	    (iter->current_is_ignored == GIT_IGNORE_FALSE &&
+	     frame->is_ignored == GIT_IGNORE_TRUE))
 		iter->current_is_ignored = frame->is_ignored;
-	}
 }
 
 GIT_INLINE(bool) filesystem_iterator_current_is_ignored(

--- a/tests/libgit2/ignore/path.c
+++ b/tests/libgit2/ignore/path.c
@@ -308,6 +308,73 @@ void test_ignore_path__nested_negation_cannot_reinclude_ignored_parent(void)
 	assert_is_ignored(true, "blocked/vendor/file");
 }
 
+void test_ignore_path__negation_overrides_info_exclude(void)
+{
+	cl_git_rewritefile(
+		"attr/.git/info/exclude",
+		"vendor/\n"
+		"*.txt\n");
+	cl_git_rewritefile(
+		"attr/.gitignore",
+		"!vendor\n"
+		"!other/file.txt\n");
+	cl_git_pass(git_futils_mkdir_r("attr/vendor", 0777));
+	cl_git_pass(git_futils_mkdir_r("attr/other", 0777));
+	cl_git_mkfile("attr/vendor/file.bin", "content\n");
+	cl_git_mkfile("attr/other/file.txt", "content\n");
+
+	assert_is_ignored(false, "vendor");
+	assert_is_ignored(false, "vendor/file.bin");
+	assert_is_ignored(false, "other/file.txt");
+}
+
+void test_ignore_path__negation_overrides_global_excludes(void)
+{
+	git_config *cfg;
+	git_str excludesfile = GIT_STR_INIT;
+
+	cl_git_pass(git_str_joinpath(
+		&excludesfile, git_repository_path(g_repo), "globalexclude"));
+	cl_git_mkfile(excludesfile.ptr, "vendor/\n");
+
+	cl_git_pass(git_repository_config(&cfg, g_repo));
+	cl_git_pass(git_config_set_string(
+		cfg, "core.excludesfile", excludesfile.ptr));
+	git_config_free(cfg);
+
+	cl_git_rewritefile("attr/.gitignore", "!vendor\n");
+	cl_git_pass(git_futils_mkdir_r("attr/vendor", 0777));
+	cl_git_mkfile("attr/vendor/file.bin", "content\n");
+	git_attr_cache_flush(g_repo);
+
+	assert_is_ignored(false, "vendor");
+	assert_is_ignored(false, "vendor/file.bin");
+
+	git_str_dispose(&excludesfile);
+}
+
+void test_ignore_path__internal_negation_overrides_ignore_file(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "vendor/\n");
+	cl_git_pass(git_futils_mkdir_r("attr/vendor", 0777));
+	cl_git_mkfile("attr/vendor/file.bin", "content\n");
+	cl_git_pass(git_ignore_add_rule(g_repo, "!vendor\n"));
+
+	assert_is_ignored(false, "vendor");
+	assert_is_ignored(false, "vendor/file.bin");
+}
+
+void test_ignore_path__wildcard_negation_cannot_reinclude_parent(void)
+{
+	cl_git_rewritefile("attr/.git/info/exclude", "vendor/\n");
+	cl_git_rewritefile("attr/.gitignore", "!vendor/**\n");
+	cl_git_pass(git_futils_mkdir_r("attr/vendor", 0777));
+	cl_git_mkfile("attr/vendor/file.bin", "content\n");
+
+	assert_is_ignored(true, "vendor");
+	assert_is_ignored(true, "vendor/file.bin");
+}
+
 void test_ignore_path__expand_tilde_to_homedir(void)
 {
 	git_str homefile = GIT_STR_INIT;

--- a/tests/libgit2/ignore/path.c
+++ b/tests/libgit2/ignore/path.c
@@ -284,6 +284,30 @@ void test_ignore_path__subdirectory_gitignore(void)
 	assert_is_ignored(false, "dir/file3");
 }
 
+void test_ignore_path__nested_negation_reincludes_parent_rule(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "**/vendor/\n");
+	cl_must_pass(p_mkdir("attr/nested", 0777));
+	cl_must_pass(p_mkdir("attr/nested/vendor", 0777));
+	cl_git_mkfile("attr/nested/.gitignore", "!vendor\n");
+	cl_git_mkfile("attr/nested/vendor/file", "content\n");
+
+	assert_is_ignored(false, "nested/vendor");
+	assert_is_ignored(false, "nested/vendor/file");
+}
+
+void test_ignore_path__nested_negation_cannot_reinclude_ignored_parent(void)
+{
+	cl_git_rewritefile("attr/.gitignore", "blocked/\n");
+	cl_must_pass(p_mkdir("attr/blocked", 0777));
+	cl_must_pass(p_mkdir("attr/blocked/vendor", 0777));
+	cl_git_mkfile("attr/blocked/.gitignore", "!vendor\n");
+	cl_git_mkfile("attr/blocked/vendor/file", "content\n");
+
+	assert_is_ignored(true, "blocked/vendor");
+	assert_is_ignored(true, "blocked/vendor/file");
+}
+
 void test_ignore_path__expand_tilde_to_homedir(void)
 {
 	git_str homefile = GIT_STR_INIT;

--- a/tests/libgit2/ignore/status.c
+++ b/tests/libgit2/ignore/status.c
@@ -710,6 +710,107 @@ void test_ignore_status__issue_1766_negated_ignores(void)
 	}
 }
 
+void test_ignore_status__negation_overrides_info_exclude(void)
+{
+	unsigned int status;
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+	cl_git_rewritefile(
+		"empty_standard_repo/.git/info/exclude",
+		"vendor/\n"
+		"*.txt\n");
+	cl_git_rewritefile(
+		"empty_standard_repo/.gitignore",
+		"!vendor\n"
+		"!other/file.txt\n");
+	cl_git_pass(git_futils_mkdir_r(
+		"empty_standard_repo/vendor", 0777));
+	cl_git_pass(git_futils_mkdir_r(
+		"empty_standard_repo/other", 0777));
+	cl_git_mkfile("empty_standard_repo/vendor/file.bin", "content\n");
+	cl_git_mkfile("empty_standard_repo/other/file.txt", "content\n");
+
+	refute_is_ignored("vendor/file.bin");
+	refute_is_ignored("other/file.txt");
+	cl_git_pass(git_status_file(&status, g_repo, "vendor/file.bin"));
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, (int)status);
+	cl_git_pass(git_status_file(&status, g_repo, "other/file.txt"));
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, (int)status);
+}
+
+void test_ignore_status__internal_negation_overrides_ignore_file(void)
+{
+	unsigned int status;
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+	cl_git_rewritefile("empty_standard_repo/.gitignore", "vendor/\n");
+	cl_git_pass(git_futils_mkdir_r(
+		"empty_standard_repo/vendor", 0777));
+	cl_git_mkfile("empty_standard_repo/vendor/file.bin", "content\n");
+	cl_git_pass(git_ignore_add_rule(g_repo, "!vendor\n"));
+
+	refute_is_ignored("vendor/file.bin");
+	cl_git_pass(git_status_file(&status, g_repo, "vendor/file.bin"));
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, (int)status);
+}
+
+void test_ignore_status__wildcard_negation_cannot_reinclude_parent(void)
+{
+	unsigned int status;
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+	cl_git_rewritefile(
+		"empty_standard_repo/.git/info/exclude", "vendor/\n");
+	cl_git_rewritefile("empty_standard_repo/.gitignore", "!vendor/**\n");
+	cl_git_pass(git_futils_mkdir_r(
+		"empty_standard_repo/vendor", 0777));
+	cl_git_mkfile("empty_standard_repo/vendor/file.bin", "content\n");
+
+	assert_is_ignored("vendor/file.bin");
+	cl_git_pass(git_status_file(&status, g_repo, "vendor/file.bin"));
+	cl_assert_equal_i(GIT_STATUS_IGNORED, (int)status);
+}
+
+void test_ignore_status__deep_negation_inherits_ignored_parent(void)
+{
+	git_status_list *statuslist;
+	git_status_options opts = GIT_STATUS_OPTIONS_INIT;
+	const git_status_entry *status;
+
+	g_repo = cl_git_sandbox_init("empty_standard_repo");
+	cl_git_rewritefile("empty_standard_repo/.gitignore", "ignored/\n");
+	cl_git_pass(git_futils_mkdir_r(
+		"empty_standard_repo/ignored/one/two/vendor", 0777));
+	cl_git_mkfile(
+		"empty_standard_repo/ignored/one/two/.gitignore", "!vendor\n");
+	cl_git_mkfile(
+		"empty_standard_repo/ignored/one/two/vendor/file.bin", "content\n");
+
+	opts.flags = GIT_STATUS_OPT_DEFAULTS |
+		GIT_STATUS_OPT_RECURSE_IGNORED_DIRS;
+	cl_git_pass(git_status_list_new(&statuslist, g_repo, &opts));
+	cl_assert_equal_sz(3, git_status_list_entrycount(statuslist));
+
+	status = git_status_byindex(statuslist, 0);
+	cl_assert_equal_s(
+		".gitignore", status->index_to_workdir->old_file.path);
+	cl_assert_equal_i(GIT_STATUS_WT_NEW, status->status);
+
+	status = git_status_byindex(statuslist, 1);
+	cl_assert_equal_s(
+		"ignored/one/two/.gitignore",
+		status->index_to_workdir->old_file.path);
+	cl_assert_equal_i(GIT_STATUS_IGNORED, status->status);
+
+	status = git_status_byindex(statuslist, 2);
+	cl_assert_equal_s(
+		"ignored/one/two/vendor/file.bin",
+		status->index_to_workdir->old_file.path);
+	cl_assert_equal_i(GIT_STATUS_IGNORED, status->status);
+
+	git_status_list_free(statuslist);
+}
+
 static void add_one_to_index(const char *file)
 {
 	git_index *index;


### PR DESCRIPTION
## Summary

Fix ignore negation when the excluding and re-including rules come from different sources.

A nested .gitignore can now re-include a directory excluded by a parent .gitignore, matching core Git. Higher-precedence internal and per-directory rules can also override lower-precedence info/exclude or global excludes. Descendants of an ignored parent remain ignored unless the parent itself is re-included.

The parser now retains negation rules regardless of whether the matching positive rule is in the same source. Path lookup continues to parent components after a negative match, while the workdir iterator preserves the ignored state inherited from an ignored parent.

Closes #7284.

## Tests

- Debug targeted ignore::path and ignore::status: 84/84 passed.
- Git CLI compatibility matrix: 252 scenarios, 378 paths, 0 mismatches.
- Release non-network CTest: 7/7 passed.
- ASan full offline and util CTest: 2/2 passed.
- ASan+UBSan targeted ignore tests: 84/84 passed.
- Werror compilation for the two touched source objects: 2/2 passed.

A local 10,000-file iterator benchmark, after warmup, measured approximately 0.107 s at ignore depth 1 and 0.235 s at depth 80. The previous implementation measured approximately 0.952 s at depth 80.

The online suite was attempted but did not complete because network operations timed out.

Two broader baseline failures are unrelated to this change:

- The combined-sanitizer full run reports a misaligned uint32_t access in the unchanged bundled sha1dc/sha1.c.
- The full Werror build reports a maybe-uninitialized warning in the unchanged deps/reftable/stack.c.