### PR TITLE
docs: fix six @param names that do not match the signatures

### DIFF
--- a/include/git2/sys/refdb_backend.h
+++ b/include/git2/sys/refdb_backend.h
@@ -136,7 +136,7 @@ struct git_refdb_backend {
 	 *
 	 * A refdb implementation must provide this function.
 	 *
-	 * @param out The implementation shall set this to the allocated
+	 * @param iter The implementation shall set this to the allocated
 	 *          reference iterator. A custom structure may be used with an
 	 *          embedded `git_reference_iterator` structure. Both `next`
 	 *          and `next_name` functions of `git_reference_iterator` need
@@ -339,7 +339,7 @@ struct git_refdb_backend {
 	 * @param update_reflog `1` in case the reflog should be updated, `0`
 	 *                    otherwise.
 	 * @param ref The reference which should be unlocked.
-	 * @param who The person updating the reference. Shall be used to create
+	 * @param sig The person updating the reference. Shall be used to create
 	 *          a reflog entry in case `update_reflog` is set.
 	 * @param message The message detailing what kind of reference update is
 	 *              performed. Shall be used to create a reflog entry in

--- a/src/util/win32/path_w32.h
+++ b/src/util/win32/path_w32.h
@@ -72,7 +72,7 @@ extern int git_win32_path_readlink_w(git_win32_path dest, const git_win32_path p
  * Removes any trailing backslashes from a path, except in the case of a drive
  * letter path (C:\, D:\, etc.). This function cannot fail.
  *
- * @param path The path which should be trimmed.
+ * @param str The path which should be trimmed.
  * @return The length of the modified string (<= the input length)
  */
 size_t git_win32_path_trim_end(wchar_t *str, size_t len);
@@ -81,7 +81,7 @@ size_t git_win32_path_trim_end(wchar_t *str, size_t len);
  * Removes any of the following namespace prefixes from a path,
  * if found: "\??\", "\\?\", "\\?\UNC\". This function cannot fail.
  *
- * @param path The path which should be converted.
+ * @param str The path which should be converted.
  * @return The length of the modified string (<= the input length)
  */
 size_t git_win32_path_remove_namespace(wchar_t *str, size_t len);

--- a/src/util/win32/utf-conv.h
+++ b/src/util/win32/utf-conv.h
@@ -50,7 +50,6 @@ int git_utf8_to_16_with_len(
  * @param dest The buffer to receive the UTF-8 string.
  * @param dest_size The size of the buffer, in bytes.
  * @param src The wide string to convert.
- * @param src_len The length of the string to convert.
  * @return The length of the UTF-8 string, in bytes
  *         (not counting the NULL terminator), or < 0 for failure
  */

--- a/src/util/win32/w32_util.h
+++ b/src/util/win32/w32_util.h
@@ -67,7 +67,7 @@ extern int git_win32__file_attribute_to_stat(
 /**
  * Converts a FILETIME structure to a struct timespec.
  *
- * @param FILETIME A pointer to a FILETIME
+ * @param ft A pointer to a FILETIME
  * @param ts A pointer to the timespec structure to fill in
  */
 GIT_INLINE(void) git_win32__filetime_to_timespec(


### PR DESCRIPTION
six `@param` names that no function of that name takes

- `sys/refdb_backend.h` — the iterator callback documents `out`, the argument is `iter`. unlock documents `who`, which is what `rename` calls its signature argument; unlock itself takes `sig`
- `utf-conv.h` — git_utf8_from_16 documents `src_len`, an argument only git_utf8_from_16_with_len has. looks like the block was copied from its longer sibling
- `path_w32.h` — both trim_end and remove_namespace document `path` while the argument is `str`
- `w32_util.h` — filetime_to_timespec documents `FILETIME`, which is the type, not the name. argument is `ft`

comments only, nothing else touched

by the way path_w32 also leaves the second argument `len` undocumented in both, I left that alone to keep the diff to one thing

found with a checker I wrote that reads `@param` names against the declaration below them, each of these read by hand
