### PR TITLE
fix(zstream): fail on truncated input instead of looping forever

### DIFF
--- a/src/util/zstream.c
+++ b/src/util/zstream.c
@@ -151,6 +151,17 @@ int git_zstream_get_output(void *out, size_t *out_len, git_zstream *zstream)
 		if (git_zstream_get_output_chunk(out, &out_written, zstream) < 0)
 			return -1;
 
+		/*
+		 * with output space still available, a Z_BUF_ERROR that wrote
+		 * nothing could be the input is exhausted in the middle of the stream.
+		 * It is unlikely further input will arrive within this loop,
+		 * so we fail it.
+		 */
+		if (!out_written && zstream->zerr == Z_BUF_ERROR) {
+			git_error_set(GIT_ERROR_ZLIB, "premature end of zlib stream");
+			return -1;
+		}
+
 		out_remain -= out_written;
 		out = ((char *)out) + out_written;
 	}

--- a/tests/libgit2/odb/loose.c
+++ b/tests/libgit2/odb/loose.c
@@ -23,6 +23,21 @@ static void write_object_files(object_data *d)
 	p_close(fd);
 }
 
+static void write_truncated_object_file(object_data *d, size_t len)
+{
+	int fd;
+
+	cl_assert(len < d->blen);
+
+	if (p_mkdir(d->dir, GIT_OBJECT_DIR_MODE) < 0)
+		cl_assert(errno == EEXIST);
+
+	cl_assert((fd = p_creat(d->file, S_IREAD | S_IWRITE)) >= 0);
+	cl_must_pass(p_write(fd, d->bytes, len));
+
+	p_close(fd);
+}
+
 static void cmp_objects(git_rawobj *o, object_data *d)
 {
 	cl_assert(o->type == git_object_string2type(d->type));
@@ -118,6 +133,56 @@ static void test_readstream_object(object_data *data, size_t blocksize)
 	cmp_objects(&tmp, data);
 
 	git_odb_stream_free(stream);
+	git_odb_free(odb);
+}
+
+static void test_read_truncated_object(object_data *data, size_t len)
+{
+	git_oid id;
+	git_odb_object *obj;
+	git_odb *odb;
+	git_odb_options opts = GIT_ODB_OPTIONS_INIT;
+
+	opts.oid_type = data->id_type;
+
+	write_truncated_object_file(data, len);
+
+	cl_git_pass(git_odb_open_ext(&odb, "test-objects", &opts));
+	cl_git_pass(git_oid_from_string(&id, data->id, data->id_type));
+	cl_git_fail(git_odb_read(&obj, odb, &id));
+
+	git_odb_free(odb);
+}
+
+static void test_readstream_truncated_object(object_data *data, size_t len)
+{
+	git_oid id;
+	git_odb *odb;
+	git_odb_stream *stream;
+	git_object_t type;
+	size_t obj_len;
+	char buf[128];
+	int error;
+	git_odb_options opts = GIT_ODB_OPTIONS_INIT;
+
+	opts.oid_type = data->id_type;
+
+	write_truncated_object_file(data, len);
+
+	cl_git_pass(git_odb_open_ext(&odb, "test-objects", &opts));
+	cl_git_pass(git_oid_from_string(&id, data->id, data->id_type));
+
+	/* truncation may already be detected when inflating the header */
+	error = git_odb_open_rstream(&stream, &obj_len, &type, odb, &id);
+
+	if (!error) {
+		while ((error = git_odb_stream_read(stream, buf, sizeof(buf))) > 0)
+			;
+		git_odb_stream_free(stream);
+	}
+
+	cl_assert(error < 0);
+
 	git_odb_free(odb);
 }
 
@@ -238,6 +303,40 @@ void test_odb_loose__streaming_reads_sha256(void)
 		test_readstream_object(&two_sha256, blocksizes[i]);
 		test_readstream_object(&some_sha256, blocksizes[i]);
 	}
+}
+
+void test_odb_loose__read_truncated_zlib_header_fails_sha1(void)
+{
+	/* only the first two bytes of the zlib stream are left on disk */
+	test_read_truncated_object(&commit, 2);
+}
+
+void test_odb_loose__read_truncated_zlib_header_fails_sha256(void)
+{
+	test_read_truncated_object(&commit_sha256, 2);
+}
+
+void test_odb_loose__read_truncated_object_body_fails_sha1(void)
+{
+	/* the stream is cut off in the middle of the object body */
+	test_read_truncated_object(&commit, commit.blen / 2);
+}
+
+void test_odb_loose__read_truncated_object_body_fails_sha256(void)
+{
+	test_read_truncated_object(&commit_sha256, commit_sha256.blen / 2);
+}
+
+void test_odb_loose__streaming_read_truncated_fails_sha1(void)
+{
+	test_readstream_truncated_object(&commit, 2);
+	test_readstream_truncated_object(&commit, commit.blen / 2);
+}
+
+void test_odb_loose__streaming_read_truncated_fails_sha256(void)
+{
+	test_readstream_truncated_object(&commit_sha256, 2);
+	test_readstream_truncated_object(&commit_sha256, commit_sha256.blen / 2);
 }
 
 void test_odb_loose__read_header_sha1(void)

--- a/tests/util/zstream.c
+++ b/tests/util/zstream.c
@@ -76,6 +76,24 @@ void test_zstream__fails_on_trailing_garbage(void)
 	git_str_dispose(&inflated);
 }
 
+void test_zstream__fails_on_truncated_input(void)
+{
+	git_str deflated = GIT_STR_INIT, inflated = GIT_STR_INIT;
+
+	cl_git_pass(git_zstream_deflatebuf(&deflated, data, strlen(data) + 1));
+	cl_assert(deflated.size > 2);
+
+	/* only the two-byte zlib header survives */
+	cl_git_fail(git_zstream_inflatebuf(&inflated, deflated.ptr, 2));
+	git_str_dispose(&inflated);
+
+	/* the stream is cut off in the middle of the body */
+	cl_git_fail(git_zstream_inflatebuf(&inflated, deflated.ptr, deflated.size / 2));
+
+	git_str_dispose(&deflated);
+	git_str_dispose(&inflated);
+}
+
 void test_zstream__buffer(void)
 {
 	git_str out = GIT_STR_INIT;


### PR DESCRIPTION
### What does this fix?

Fixes <https://github.com/libgit2/libgit2/issues/7342>.

`inflate()` reports `Z_BUF_ERROR` when a truncated stream exhausts its input before reaching `Z_STREAM_END`.

The stock `zstream_seterr` suggests treating that as non-fatal so callers can retry with more input or output space.

https://github.com/libgit2/libgit2/blob/d5354500620558b54a1217c11406d6316574d013/deps/zlib/zlib.h#L513-L515

However, the drain loop in `git_zstream_get_output` can supply neither because

* output space is still available
* input is only refilled outside the loop

It would leads to zero-progress forever.

The problematic behavior was found in `git_odb_read` on a truncated loose object.

The proposed fix here: Detect the stuck state in the drain loop and report an error.


### How to review

Commit by commit.

cb4c34485c2357da0e3d3eafed5b87275f54b0be the odb test will loop forever if you drop the first fix commit.

---

🤖 LLM disclosure: This bug was found by LLM. Tests were generated by LLM. I've review carefully all the generated content and analysis.