### PR TITLE
CVE-2026-5917: Escape repo path in gen_proto()

### DIFF
--- a/src/libgit2/transports/ssh_libssh2.c
+++ b/src/libgit2/transports/ssh_libssh2.c
@@ -78,7 +78,7 @@ static int gen_proto(git_str *request, const char *cmd, git_net_url *url)
 
 	git_str_puts(request, cmd);
 	git_str_puts(request, " '");
-	git_str_puts(request, repo);
+	git_str_puts_escaped(request, repo, "'!", "'\\", "'");
 	git_str_puts(request, "'");
 
 	if (git_str_oom(request))


### PR DESCRIPTION
Takes inspiration from 346f28b89d6aae0c3ea0b9f0b0bc0f0afa177fab

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>