### PR TITLE
smart_pkt: parse object-format when it is the last capability

### DIFF
--- a/src/libgit2/transports/smart_pkt.c
+++ b/src/libgit2/transports/smart_pkt.c
@@ -244,10 +244,10 @@ static int set_data(
 	}
 
 	if (format_str) {
-		if ((eos = memchr(format_str, ' ', len - (format_str - line))) == NULL)
-			eos = memchr(format_str, '\0', len - (format_str - line));
-
-		GIT_ASSERT(eos);
+		if ((eos = memchr(format_str, ' ', len - (format_str - line))) == NULL &&
+		    (eos = memchr(format_str, '\n', len - (format_str - line))) == NULL &&
+		    (eos = memchr(format_str, '\0', len - (format_str - line))) == NULL)
+			eos = line + len;
 
 		format_len = eos - format_str;
 

--- a/tests/libgit2/transports/smart/packet.c
+++ b/tests/libgit2/transports/smart/packet.c
@@ -351,3 +351,41 @@ void test_transports_smart_packet__ref_pkt(void)
 		"00360000000000000000000000000000000000000000 HEAD HEAD",
 		"0000000000000000000000000000000000000000", "HEAD HEAD", NULL);
 }
+
+void test_transports_smart_packet__ref_pkt_object_format(void)
+{
+	const char *endptr;
+	git_pkt *pkt;
+	git_pkt_parse_data pkt_parse_data = { 0 };
+	static const char unknown_format[] =
+		"00600000000000000000000000000000000000000000 refs/heads/master\0report-status object-format=bogus";
+
+	/* object-format followed by another capability */
+	assert_ref_parses(
+		"00700000000000000000000000000000000000000000 refs/heads/master\0report-status object-format=sha1 agent=git/2.42.0",
+		"0000000000000000000000000000000000000000", "refs/heads/master",
+		"report-status object-format=sha1 agent=git/2.42.0");
+
+	/*
+	 * object-format as the final capability: terminated by the end of
+	 * the pkt-line, a trailing newline or a NUL. Some servers (e.g.
+	 * tangled.org) advertise this shape, which previously failed a
+	 * GIT_ASSERT instead of parsing.
+	 */
+	assert_ref_parses(
+		"005F0000000000000000000000000000000000000000 refs/heads/master\0report-status object-format=sha1",
+		"0000000000000000000000000000000000000000", "refs/heads/master",
+		"report-status object-format=sha1");
+	assert_ref_parses(
+		"00600000000000000000000000000000000000000000 refs/heads/master\0report-status object-format=sha1\n",
+		"0000000000000000000000000000000000000000", "refs/heads/master",
+		"report-status object-format=sha1");
+	assert_ref_parses(
+		"00600000000000000000000000000000000000000000 refs/heads/master\0report-status object-format=sha1\0",
+		"0000000000000000000000000000000000000000", "refs/heads/master",
+		"report-status object-format=sha1");
+
+	/* an unknown object format is an error, not an assertion failure */
+	cl_git_fail(git_pkt_parse_line(&pkt, &endptr, unknown_format,
+		sizeof(unknown_format), &pkt_parse_data));
+}


### PR DESCRIPTION
When a ref advertisement lists object-format=... as the final capability with no trailing space or NUL, set_data fails GIT_ASSERT(eos) and the operation errors with unrecoverable internal error: 'eos'. Some servers (e.g. tangled.org) advertise this shape; git parses it fine. A newline-terminated advertisement ending in object-format=... hits the same assert, so this isn't specific to one server. Reproduces on main and v1.9.

Treat a trailing newline or the end of the pkt-line as valid terminators for the object-format value, and add regression tests covering each terminator variant. The new tests fail on unpatched main with the 'eos' assert and pass with this change.

Context: this broke pushes for users of ngit, a libgit2-based git remote helper so I added a fallback to use git for this operation until this is fixed. See https://gitworkshop.dev/nevent1qqsfamrgatjyyxgdquvsykfw9plgq3yhnk2a6qfg3y20xw6p2whxpnqpz3mhxue69uhhyetvv9ujumn8d96zuer9wcccnyv5