### PR TITLE
hashsig: carry partial runs across file read blocks

### DIFF
--- a/src/libgit2/hashsig.c
+++ b/src/libgit2/hashsig.c
@@ -130,6 +130,12 @@ static void hashsig_heap_insert(hashsig_heap *h, hashsig_t val)
 
 typedef struct {
 	int use_ignores;
+	/*
+	 * The run being accumulated, carried between calls so that a run
+	 * spanning two blocks of a file hashes as a single run.
+	 */
+	hashsig_state state;
+	int len;
 	uint8_t ignore_ch[256];
 } hashsig_in_progress;
 
@@ -154,7 +160,22 @@ static int hashsig_in_progress_init(
 		memset(prog, 0, sizeof(*prog));
 	}
 
+	prog->state = HASHSIG_HASH_START;
+	prog->len = 0;
+
 	return 0;
+}
+
+/* Add the run accumulated so far, if any, to the signature. */
+static void hashsig_flush_hashes(git_hashsig *sig, hashsig_in_progress *prog)
+{
+	if (prog->len > 0) {
+		hashsig_heap_insert(&sig->mins, (hashsig_t)prog->state);
+		hashsig_heap_insert(&sig->maxs, (hashsig_t)prog->state);
+	}
+
+	prog->state = HASHSIG_HASH_START;
+	prog->len = 0;
 }
 
 static int hashsig_add_hashes(
@@ -164,14 +185,14 @@ static int hashsig_add_hashes(
 	hashsig_in_progress *prog)
 {
 	const uint8_t *scan = data, *end = data + size;
-	hashsig_state state = HASHSIG_HASH_START;
-	int use_ignores = prog->use_ignores, len;
+	hashsig_state state = prog->state;
+	int use_ignores = prog->use_ignores, len = prog->len;
 	uint8_t ch;
 
 	while (scan < end) {
-		state = HASHSIG_HASH_START;
+		int done = 0;
 
-		for (len = 0; scan < end && len < HASHSIG_MAX_RUN; ) {
+		for (; scan < end && len < HASHSIG_MAX_RUN; ) {
 			ch = *scan;
 
 			if (use_ignores)
@@ -193,12 +214,23 @@ static int hashsig_add_hashes(
 			/* check run terminator */
 			if (ch == '\n' || ch == '\0') {
 				sig->lines++;
+				done = 1;
 				break;
 			}
 
 			++len;
 			HASHSIG_HASH_MIX(state, ch);
 		}
+
+		if (len >= HASHSIG_MAX_RUN)
+			done = 1;
+
+		/*
+		 * Only record the run once we know it has ended; running out
+		 * of data means it continues in the next block.
+		 */
+		if (!done)
+			break;
 
 		if (len > 0) {
 			hashsig_heap_insert(&sig->mins, (hashsig_t)state);
@@ -207,9 +239,14 @@ static int hashsig_add_hashes(
 			while (scan < end && (*scan == '\n' || !*scan))
 				++scan;
 		}
+
+		state = HASHSIG_HASH_START;
+		len = 0;
 	}
 
 	prog->use_ignores = use_ignores;
+	prog->state = state;
+	prog->len = len;
 
 	return 0;
 }
@@ -258,8 +295,10 @@ int git_hashsig_create(
 
 	error = hashsig_add_hashes(sig, (const uint8_t *)buf, buflen, &prog);
 
-	if (!error)
+	if (!error) {
+		hashsig_flush_hashes(sig, &prog);
 		error = hashsig_finalize_hashes(sig);
+	}
 
 	if (!error)
 		*out = sig;
@@ -304,8 +343,10 @@ int git_hashsig_create_fromfile(
 
 	p_close(fd);
 
-	if (!error)
+	if (!error) {
+		hashsig_flush_hashes(sig, &prog);
 		error = hashsig_finalize_hashes(sig);
+	}
 
 	if (!error)
 		*out = sig;

--- a/tests/libgit2/core/hashsig.c
+++ b/tests/libgit2/core/hashsig.c
@@ -180,3 +180,35 @@ void test_core_hashsig__similarity_metric_whitespace(void)
 
 	git_str_dispose(&buf);
 }
+
+/*
+ * `git_hashsig_create_fromfile` reads the file in fixed-size blocks, so a
+ * signature it produces must still match the one computed over the same
+ * content in memory - including when a run of characters spans a block
+ * boundary, as it does in a file with very long lines.
+ */
+void test_core_hashsig__similarity_metric_long_lines(void)
+{
+	git_hashsig *a, *b;
+	git_str buf = GIT_STR_INIT;
+	size_t i;
+
+	/* deterministic content, no newlines, several read blocks long */
+	for (i = 0; i < 12000; i++)
+		cl_git_pass(git_str_putc(&buf, (char)('a' + ((i * 7 + i / 13) % 26))));
+
+	cl_git_pass(git_hashsig_create(&a, buf.ptr, buf.size, GIT_HASHSIG_NORMAL));
+
+	cl_git_pass(git_futils_mkdir("scratch", 0755, GIT_MKDIR_PATH));
+	cl_git_mkfile("scratch/longlines", buf.ptr);
+	cl_git_pass(git_hashsig_create_fromfile(
+		&b, "scratch/longlines", GIT_HASHSIG_NORMAL));
+
+	cl_assert_equal_i(100, git_hashsig_compare(a, b));
+
+	git_hashsig_free(a);
+	git_hashsig_free(b);
+
+	git_str_dispose(&buf);
+	git_futils_rmdir_r("scratch", NULL, GIT_RMDIR_REMOVE_FILES);
+}


### PR DESCRIPTION
## What

`git_hashsig_create_fromfile` reads the file in 4096-byte blocks and calls
`hashsig_add_hashes` once per block. That function started a fresh run at the
beginning of every call, and recorded whatever run was in progress when it ran
out of data. A run of characters spanning a block boundary was therefore hashed
as two shorter runs rather than one.

For content whose lines are shorter than a block this never shows, because every
run ends at a newline anyway. For a file with lines longer than 4096 characters
the block boundaries land in the middle of runs, so the signature no longer
matches the one `git_hashsig_create` computes over the same bytes in memory.

Rename detection compares an in-memory blob against an on-disk file, so
identical content scored as dissimilar and renames of such files were missed.
That is the behaviour reported in #7196.

## The fix

Keep the in-progress run in `hashsig_in_progress` so it continues across calls,
record a run only once it has actually ended, and flush the trailing run before
finalizing. The in-memory path is unaffected: it makes a single call, so the
trailing run that used to be recorded at the end of the buffer is now recorded
by the flush instead.

## Reproduction and evidence

Using the reporter's recipe (six files of random characters on a single line,
sizes 1024 to 32768, all renamed, `GIT_DIFF_FIND_RENAMES | GIT_DIFF_FIND_FOR_UNTRACKED`,
threshold 50):

Before — only the files at or under one block are matched, exactly as reported:

```
[R] random.1024.txt -> random.1024.txt.moved
[D] random.16384.txt
[?] random.16384.txt.moved
[R] random.2048.txt -> random.2048.txt.moved
[D] random.32768.txt
[?] random.32768.txt.moved
[R] random.4096.txt -> random.4096.txt.moved
[D] random.8192.txt
[?] random.8192.txt.moved
renames detected: 3
```

After:

```
[R] random.1024.txt -> random.1024.txt.moved
[R] random.16384.txt -> random.16384.txt.moved
[R] random.2048.txt -> random.2048.txt.moved
[R] random.32768.txt -> random.32768.txt.moved
[R] random.4096.txt -> random.4096.txt.moved
[R] random.8192.txt -> random.8192.txt.moved
renames detected: 6
```

## Test

`core::hashsig::similarity_metric_long_lines` extends the invariant the existing
`similarity_metric` test already checks for short data — that a signature built
from a file equals one built from the same bytes in memory — to content that
spans several read blocks with no newlines. It uses deterministic content rather
than random data.

Without the change it fails with `100 != 68`; with the change it passes.

## Testing performed

Built with CMake 4.3.3 / Ninja 1.13.2 / Apple clang 21, Debug, macOS arm64.

- `libgit2_tests` — 3031 passed, 22 skipped, 0 failed
- `util_tests` — 441 passed, 10 skipped, 0 failed
- Targeted before and after: `core::hashsig`, `diff` (219), `status` (84),
  `merge` (181), `rebase` (53), `checkout` (168) — all green

Note this changes the signature computed for on-disk files with lines longer
than 4096 characters, which is the point of the fix; similarity scores for such
files move toward the in-memory result. No existing test changed behaviour.

Only tested on macOS arm64; I have not run the Windows or Linux CI matrix
locally.

---

AI assistance disclosure: this change — the diagnosis, the patch, the test, and
this description — was produced with AI assistance. The reproduction, the
red/green verification, and the test runs reported above were actually executed
and the numbers are real. No human has separately reviewed the change.
