### PR TITLE
repository: compare safe.directory case-insensitively on Windows

### DIFF
--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -584,6 +584,18 @@ typedef struct {
 	bool *is_safe;
 } validate_ownership_data;
 
+/*
+ * Windows paths are compared case-insensitively; Git canonicalizes
+ * both the repository path and the configured `safe.directory` entry
+ * to their on-disk form, so eg `c:/repo` matches `C:/Repo`. POSIX
+ * filesystems are case-sensitive, so compare exactly there.
+ */
+#ifdef GIT_WIN32
+# define OWNERSHIP_PATH_IGNORE_CASE 1
+#else
+# define OWNERSHIP_PATH_IGNORE_CASE 0
+#endif
+
 static int validate_ownership_cb(const git_config_entry *entry, void *payload)
 {
 	validate_ownership_data *data = payload;
@@ -647,8 +659,11 @@ static int validate_ownership_cb(const git_config_entry *entry, void *payload)
 			test_path += strlen("%(prefix)/");
 
 		match = is_prefix ?
-			(git__prefixcmp(data->repo_path, test_path) == 0) :
-			(strcmp(test_path, data->repo_path) == 0);
+			(CASESELECT(OWNERSHIP_PATH_IGNORE_CASE,
+				git__prefixcmp_icase(data->repo_path, test_path),
+				git__prefixcmp(data->repo_path, test_path)) == 0) :
+			(STRCMP_CASESELECT(OWNERSHIP_PATH_IGNORE_CASE,
+				test_path, data->repo_path) == 0);
 
 		if (match)
 			*data->is_safe = true;

--- a/tests/libgit2/repo/open.c
+++ b/tests/libgit2/repo/open.c
@@ -640,6 +640,52 @@ void test_repo_open__can_allowlist_dirs_with_problematic_ownership(void)
 	git_str_dispose(&path);
 }
 
+void test_repo_open__safe_directory_ignores_drive_letter_case(void)
+{
+#ifdef GIT_WIN32
+	git_str path = GIT_STR_INIT;
+	char drive;
+
+	/*
+	 * Git compares Windows paths case-insensitively; the drive letter
+	 * is the most common mismatch. Configure the repository path with
+	 * the opposite drive-letter case and ensure the repository opens.
+	 */
+	cl_git_pass(git_str_printf(&path, "%s/%s",
+		clar_sandbox_path(), "empty_standard_repo"));
+
+	drive = path.ptr[0];
+	cl_assert(isalpha((unsigned char)drive) && path.ptr[1] == ':');
+	path.ptr[0] = (char)(isupper((unsigned char)drive) ?
+		tolower((unsigned char)drive) : toupper((unsigned char)drive));
+
+	cl_git_pass(test_safe_path(path.ptr));
+	git_str_dispose(&path);
+#endif
+}
+
+void test_repo_open__safe_directory_ignores_path_case(void)
+{
+#ifdef GIT_WIN32
+	git_str path = GIT_STR_INIT;
+	size_t i;
+
+	/*
+	 * Windows paths are case-insensitive for their whole length, not
+	 * just the drive letter. Configure the entire repository path in a
+	 * different case and ensure the repository still opens.
+	 */
+	cl_git_pass(git_str_printf(&path, "%s/%s",
+		clar_sandbox_path(), "empty_standard_repo"));
+
+	for (i = 0; i < path.size; i++)
+		path.ptr[i] = (char)toupper((unsigned char)path.ptr[i]);
+
+	cl_git_pass(test_safe_path(path.ptr));
+	git_str_dispose(&path);
+#endif
+}
+
 void test_repo_open__safe_directory_fails_with_trailing_slash(void)
 {
 	git_str path = GIT_STR_INIT;


### PR DESCRIPTION
Fixes #7037

## Problem

On Windows, opening a repository whose ownership check relies on a `safe.directory` allowlist entry fails with `GIT_EOWNER` when the entry differs in case from the repository path -- in practice, the drive letter (`c:` vs `C:`). `git.exe` accepts the same entry.

## Root cause

`validate_ownership_cb` compares the configured `safe.directory` entry against the repository path with a case-sensitive `strcmp`/prefix compare.

Git does not have a case rule here at all: `ensure_valid_ownership` (setup.c) canonicalizes **both** the repository path and each entry to their real on-disk form via `real_pathdup` (which, on Windows, resolves through `GetFinalPathNameByHandle` and so normalizes drive-letter case), then compares. `safe.directory` is read from protected (system/global) config only, so the repo's `core.ignorecase` never enters the decision -- the match comes from canonicalization, not case-folding.

libgit2 already resolves the repository path with `git_fs_path_prettify` (`p_realpath`), but on Windows that uses `GetLongPathName`, which corrects path-component case but **not** the drive letter -- and the entry is not canonicalized at all. Hence the drive-letter-only mismatch.

## Fix

Compare the configured entry against the repository path case-insensitively on Windows; POSIX filesystems stay case-sensitive. This is a lightweight **approximation of git's `real_pathdup` canonicalization** -- it resolves the reported drive-letter symptom (and tolerates component-case variants, as git does), without re-implementing full real-path resolution of the entry.

Known divergence (low risk): on a case-sensitive Windows volume/dir, git would compare canonicalized paths case-sensitively, whereas this compare always folds case. It can only ever make an explicitly allowlisted path match a case variant of itself.

## Tests

Adds two Windows-only tests in `repo::open`:
- allowlist entry with the opposite drive-letter case
- allowlist entry with the entire path in a different case

The full test suite passes.
