### PR TITLE
mailmap: keep empty name and email when resolving a signature

### DIFF
--- a/src/libgit2/mailmap.c
+++ b/src/libgit2/mailmap.c
@@ -490,11 +490,12 @@ int git_mailmap_resolve_signature(
 	if (error < 0)
 		return error;
 
-	error = git_signature_new(out, name, email, sig->when.time, sig->when.offset);
-	if (error < 0)
-		return error;
-
-	/* Copy over the sign, as git_signature_new doesn't let you pass it. */
-	(*out)->when.sign = sig->when.sign;
-	return 0;
+	/*
+	 * Signatures that come out of an object can have an empty name or
+	 * email; git accepts such commits and our own parser reads them back,
+	 * so resolving one must not reject it. git_signature_new() is the
+	 * constructor for brand new signatures and refuses empty fields, so
+	 * build the resolved signature from the existing one instead.
+	 */
+	return git_signature__resolved(out, sig, name, email);
 }

--- a/src/libgit2/signature.c
+++ b/src/libgit2/signature.c
@@ -103,6 +103,41 @@ int git_signature_new(git_signature **sig_out, const char *name, const char *ema
 	return 0;
 }
 
+int git_signature__resolved(
+	git_signature **dest,
+	const git_signature *source,
+	const char *name,
+	const char *email)
+{
+	git_signature *signature;
+
+	GIT_ASSERT_ARG(source);
+	GIT_ASSERT_ARG(name);
+	GIT_ASSERT_ARG(email);
+
+	*dest = NULL;
+
+	if (contains_angle_brackets(name) ||
+		contains_angle_brackets(email)) {
+		return signature_error(
+			"Neither `name` nor `email` should contain angle brackets chars.");
+	}
+
+	signature = git__calloc(1, sizeof(git_signature));
+	GIT_ERROR_CHECK_ALLOC(signature);
+
+	signature->name = extract_trimmed(name, strlen(name));
+	GIT_ERROR_CHECK_ALLOC(signature->name);
+	signature->email = extract_trimmed(email, strlen(email));
+	GIT_ERROR_CHECK_ALLOC(signature->email);
+
+	signature->when = source->when;
+
+	*dest = signature;
+
+	return 0;
+}
+
 int git_signature_dup(git_signature **dest, const git_signature *source)
 {
 	git_signature *signature;

--- a/src/libgit2/signature.h
+++ b/src/libgit2/signature.h
@@ -18,5 +18,6 @@ int git_signature__parse(git_signature *sig, const char **buffer_out, const char
 void git_signature__writebuf(git_str *buf, const char *header, const git_signature *sig);
 bool git_signature__equal(const git_signature *one, const git_signature *two);
 int git_signature__pdup(git_signature **dest, const git_signature *source, git_pool *pool);
+int git_signature__resolved(git_signature **dest, const git_signature *source, const char *name, const char *email);
 
 #endif

--- a/tests/libgit2/mailmap/basic.c
+++ b/tests/libgit2/mailmap/basic.c
@@ -3,6 +3,7 @@
 
 #include "common.h"
 #include "mailmap.h"
+#include "signature.h"
 
 static git_mailmap *mailmap = NULL;
 
@@ -98,4 +99,77 @@ void test_mailmap_basic__name_matching(void)
 		"Other Name That Doesn't Match", "yetanotheremail@foo.com"));
 	cl_assert_equal_s(name, "Other Name That Doesn't Match");
 	cl_assert_equal_s(email, "yetanotheremail@foo.com");
+}
+
+static void parse_signature(git_signature *sig, const char *header)
+{
+	const char *buf = header;
+
+	cl_git_pass(git_signature__parse(
+		sig, &buf, header + strlen(header), "author ", '\n'));
+}
+
+/*
+ * A commit can legitimately carry an empty name or email; git writes and reads
+ * those back happily. Resolving such a signature through a mailmap that has
+ * nothing to say about it must hand it back unchanged rather than fail.
+ */
+void test_mailmap_basic__resolve_signature_keeps_empty_email(void)
+{
+	git_signature parsed = {0};
+	git_signature *resolved = NULL;
+
+	parse_signature(&parsed, "author An Author <> 1461698487 +0000\n");
+	cl_assert_equal_s("An Author", parsed.name);
+	cl_assert_equal_s("", parsed.email);
+
+	cl_git_pass(git_mailmap_resolve_signature(&resolved, mailmap, &parsed));
+	cl_assert_equal_s("An Author", resolved->name);
+	cl_assert_equal_s("", resolved->email);
+	cl_assert_equal_i(1461698487, resolved->when.time);
+	git_signature_free(resolved);
+
+	/* the same holds with no mailmap at all */
+	cl_git_pass(git_mailmap_resolve_signature(&resolved, NULL, &parsed));
+	cl_assert_equal_s("An Author", resolved->name);
+	cl_assert_equal_s("", resolved->email);
+	git_signature_free(resolved);
+
+	git__free(parsed.name);
+	git__free(parsed.email);
+}
+
+void test_mailmap_basic__resolve_signature_keeps_empty_name(void)
+{
+	git_signature parsed = {0};
+	git_signature *resolved = NULL;
+
+	parse_signature(&parsed, "author  <an@author.com> 1461698487 +0000\n");
+	cl_assert_equal_s("", parsed.name);
+	cl_assert_equal_s("an@author.com", parsed.email);
+
+	cl_git_pass(git_mailmap_resolve_signature(&resolved, NULL, &parsed));
+	cl_assert_equal_s("", resolved->name);
+	cl_assert_equal_s("an@author.com", resolved->email);
+	git_signature_free(resolved);
+
+	git__free(parsed.name);
+	git__free(parsed.email);
+}
+
+/* a mailmap entry still replaces what it matches */
+void test_mailmap_basic__resolve_signature_applies_mailmap(void)
+{
+	git_signature parsed = {0};
+	git_signature *resolved = NULL;
+
+	parse_signature(&parsed, "author Some One <foo@baz.com> 1461698487 +0000\n");
+
+	cl_git_pass(git_mailmap_resolve_signature(&resolved, mailmap, &parsed));
+	cl_assert_equal_s("Foo bar", resolved->name);
+	cl_assert_equal_s("foo@bar.com", resolved->email);
+	git_signature_free(resolved);
+
+	git__free(parsed.name);
+	git__free(parsed.email);
 }


### PR DESCRIPTION
Fixes #7313.

The crash in that issue is already gone (36b88791 checks `hunk_from_entry()`'s return), but the underlying failure is still there: blame now returns an error instead of segfaulting, so a file whose history contains a commit with an empty author email cannot be blamed at all.

### What happens

`git_mailmap_resolve_signature()` rebuilds the signature with `git_signature_new()`, which rejects an empty name or email. That check belongs to creating a *new* signature; here the input came out of an object that git accepted and that `git_signature__parse()` reads back without complaint. The result is that resolution fails even when there is no mailmap, because `git_commit_author_with_mailmap()` goes through the same call.

`git_blame_file()` is where users notice it: `hunk_from_entry()` calls `git_commit_author_with_mailmap()` and gives up if it fails, so one such commit anywhere in the history breaks the whole blame. v1.8.x handled these histories, and they exist in real repositories (`3bff9d37116fbe0981fa3f97c1f623397847db45` in rubocop/rubocop, as the issue notes).

Repro from the issue, against `main` before this change:

```
git_blame_file failed: -1 failed to parse signature - Signature cannot have an empty name or email
```

After:

```
hunks: 3
  hunk 0: lines 1..+1 57d87a0ad5d74a9d5d037a6341ecc19b65d3eb68 author=t
  hunk 1: lines 2..+1 c51e6169a2dc2d0355fea7566d2e24b833b1a1c4 author=no-email
  hunk 2: lines 3..+1 13641c7fbb22387feff6699c79deb3c84cc1dcf9 author=t
```

which matches `git blame` on the same repo, line for line.

### The change

`git_signature__resolved()` builds the resolved signature from the existing one. It keeps what `git_signature_new()` does about angle brackets and trimming, and carries `when` over verbatim (which also removes the "copy over the sign afterwards" dance the old code needed). It drops only the emptiness constraint, which does not apply to a signature that already exists. `git_signature_new()` itself is untouched, so you still cannot create an empty signature through the public API.

### Tests

Three cases in `mailmap::basic`: an empty email survives resolution with and without a mailmap, an empty name likewise, and a signature the mailmap does match is still rewritten. The first two fail on `main` with `Signature cannot have an empty name or email`; the third passes before and after, so the mapping path is unchanged.

Full `libgit2_tests` suite passes locally (Linux, no HTTPS/SSH backends).

I used Claude Code while working on this; I reproduced the failure, wrote the change and ran the suites myself.