### PR TITLE
Add an option for CREATE_NO_WINDOW

### DIFF
--- a/src/libgit2/transports/ssh_exec.c
+++ b/src/libgit2/transports/ssh_exec.c
@@ -225,6 +225,7 @@ static int start_ssh(
 	process_opts.capture_in = 1;
 	process_opts.capture_out = 1;
 	process_opts.capture_err = 0;
+	process_opts.create_no_window = 1;
 
 	switch (action) {
 	case GIT_SERVICE_UPLOADPACK_LS:

--- a/src/util/process.h
+++ b/src/util/process.h
@@ -11,11 +11,12 @@
 typedef struct git_process git_process;
 
 typedef struct {
-	unsigned int use_shell   : 1,
-	             capture_in  : 1,
-	             capture_out : 1,
-	             capture_err : 1,
-	             exclude_env : 1;
+	unsigned int use_shell        : 1,
+	             capture_in       : 1,
+	             capture_out      : 1,
+	             capture_err      : 1,
+	             exclude_env      : 1,
+	             create_no_window : 1;
 
 	char *cwd;
 } git_process_options;

--- a/src/util/win32/process.c
+++ b/src/util/win32/process.c
@@ -27,9 +27,10 @@ struct git_process {
 
 	wchar_t *cwd;
 
-	unsigned int capture_in  : 1,
-	             capture_out : 1,
-	             capture_err : 1;
+	unsigned int capture_in       : 1,
+	             capture_out      : 1,
+	             capture_err      : 1,
+	             create_no_window : 1;
 
 	PROCESS_INFORMATION process_info;
 
@@ -203,6 +204,7 @@ static int process_new(
 		process->capture_in = opts->capture_in;
 		process->capture_out = opts->capture_out;
 		process->capture_err = opts->capture_err;
+		process->create_no_window = opts->create_no_window;
 	}
 
 done:
@@ -260,6 +262,9 @@ int git_process_start(git_process *process)
 	HANDLE in[2]  = { NULL, NULL },
 	       out[2] = { NULL, NULL },
 	       err[2] = { NULL, NULL };
+
+	if (process->create_no_window)
+		flags |= CREATE_NO_WINDOW;
 
 	if (process->app_name) {
 		git_str cmd_path = GIT_STR_INIT;


### PR DESCRIPTION
Add an option for creating git process with CREATE_NO_WINDOW flag, otherwise using libgit2 in a GUI app will result in a console window being opened during git operations.