### PR TITLE
feature: add partial clone and sparse checkout support

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -90,4 +90,3 @@ might make good smaller projects by themselves.
 * Include conflicts in diff results and in status
     * GIT_DELTA_CONFLICT for items in conflict (with multiple files)
     * Appropriate flags for status
-* Support sparse checkout (i.e. "core.sparsecheckout" and ".git/info/sparse-checkout")

--- a/docs/sparse-checkout.md
+++ b/docs/sparse-checkout.md
@@ -1,0 +1,42 @@
+# Sparse checkout and filtered clone
+
+libgit2 supports cone-mode sparse checkout through `git2/sparse.h`.
+Root-level files are always included. A sparse selection contains only
+the explicitly requested directories and the direct files of required
+intermediate directories.
+
+For an existing repository, use `git_sparse_checkout_apply`:
+
+```c
+git_strarray directories = { paths, path_count };
+git_checkout_options checkout_opts = GIT_CHECKOUT_OPTIONS_INIT;
+
+error = git_sparse_checkout_apply(repo, &directories, &checkout_opts);
+```
+
+The operation writes Git-compatible `core.sparseCheckout`,
+`core.sparseCheckoutCone`, and `info/sparse-checkout` state. Clean paths
+that become excluded are removed; locally modified excluded paths are
+preserved. Use `git_sparse_checkout_disable` to restore all HEAD paths.
+
+For a filtered sparse clone, set both clone options:
+
+```c
+git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
+
+clone_opts.fetch_opts.filter_spec = "blob:none";
+clone_opts.sparse_checkout = 1;
+clone_opts.sparse_checkout_directories = directories;
+```
+
+libgit2 accepts `blob:none`, `blob:limit=<n>[kmg]`, and `tree:<depth>`
+filters. The optional `k`, `m`, and `g` suffixes denote KiB, MiB, and
+GiB.
+
+When an operation reads an omitted object, the repository-owned ODB
+fetches it transparently from the configured promisor remote. Applications
+can also fetch known object IDs explicitly with
+`git_repository_fetch_promisor`.
+
+`git_sparse_checkout_list` returns explicit selected directories and
+`git_sparse_checkout_is_enabled` reports the current enabled state.

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,3 +20,19 @@ For annotated HTML versions, see the "Examples" section of:
 such as:
 
     https://libgit2.org/libgit2/ex/HEAD/general.html
+
+Partial clone and sparse checkout
+---------------------------------
+
+`lg2 partial-clone <url> <path> <directory>...` demonstrates a filtered
+`blob:none` clone combined with cone-mode sparse checkout. Each directory is
+relative to the repository root.
+
+Build and run it from the repository root:
+
+    cmake --build build/linux-x86_64-debug --target lg2
+    build/linux-x86_64-debug/examples/lg2 partial-clone \
+        https://github.com/libgit2/libgit2.git libgit2-clone src/libgit2 tests
+
+For authenticated remotes, the command uses the shared interactive credential
+callback used by the other `lg2` network examples.

--- a/examples/common.h
+++ b/examples/common.h
@@ -72,6 +72,7 @@ extern int lg2_log(git_repository *repo, int argc, char **argv);
 extern int lg2_ls_files(git_repository *repo, int argc, char **argv);
 extern int lg2_ls_remote(git_repository *repo, int argc, char **argv);
 extern int lg2_merge(git_repository *repo, int argc, char **argv);
+extern int lg2_partial_clone(git_repository *repo, int argc, char **argv);
 extern int lg2_push(git_repository *repo, int argc, char **argv);
 extern int lg2_rebase(git_repository *repo, int argc, char **argv);
 extern int lg2_remote(git_repository *repo, int argc, char **argv);

--- a/examples/lg2.c
+++ b/examples/lg2.c
@@ -28,6 +28,7 @@ struct {
 	{ "ls-files",     lg2_ls_files,     1 },
 	{ "ls-remote",    lg2_ls_remote,    1 },
 	{ "merge",        lg2_merge,        1 },
+	{ "partial-clone", lg2_partial_clone, 0 },
 	{ "push",         lg2_push,        1  },
 	{ "rebase",       lg2_rebase,       0 },
 	{ "remote",       lg2_remote,       1 },

--- a/examples/partial-clone.c
+++ b/examples/partial-clone.c
@@ -1,0 +1,62 @@
+#include "common.h"
+
+/*
+ * Report completion of object transfer.
+ */
+static int transfer_progress(
+	const git_indexer_progress *stats,
+	void *payload)
+{
+	UNUSED(payload);
+
+	if (stats->total_objects &&
+	    stats->received_objects == stats->total_objects)
+		printf("Received %u objects\n", stats->received_objects);
+
+	return 0;
+}
+
+/*
+ * Clone a repository with a blob filter and cone-mode sparse checkout.
+ */
+int lg2_partial_clone(git_repository *repo, int argc, char **argv)
+{
+	git_clone_options options = GIT_CLONE_OPTIONS_INIT;
+	git_repository *cloned_repository = NULL;
+	git_strarray directories;
+	const git_error *last_error;
+	const char *url;
+	const char *path;
+	int error;
+
+	UNUSED(repo);
+
+	if (argc < 4) {
+		fprintf(stderr,
+			"usage: %s <url> <path> <directory>...\n",
+			argv[0]);
+		return -1;
+	}
+
+	url = argv[1];
+	path = argv[2];
+	directories.strings = argv + 3;
+	directories.count = argc - 3;
+
+	options.fetch_opts.filter_spec = "blob:none";
+	options.fetch_opts.callbacks.credentials = cred_acquire_cb;
+	options.fetch_opts.callbacks.transfer_progress = transfer_progress;
+	options.sparse_checkout = 1;
+	options.sparse_checkout_directories = directories;
+
+	error = git_clone(&cloned_repository, url, path, &options);
+	if (error < 0) {
+		last_error = git_error_last();
+		if (last_error)
+			fprintf(stderr, "Partial clone failed: %s\n",
+				last_error->message);
+	}
+
+	git_repository_free(cloned_repository);
+	return error;
+}

--- a/include/git2.h
+++ b/include/git2.h
@@ -63,6 +63,7 @@
 #include "git2/stash.h"
 #include "git2/status.h"
 #include "git2/submodule.h"
+#include "git2/sparse.h"
 #include "git2/tag.h"
 #include "git2/transport.h"
 #include "git2/transaction.h"

--- a/include/git2/checkout.h
+++ b/include/git2/checkout.h
@@ -295,6 +295,26 @@ typedef void GIT_CALLBACK(git_checkout_progress_cb)(
 	void *payload);
 
 /**
+ * Callback invoked when checkout needs a blob that is missing locally.
+ *
+ * Partial clones automatically hydrate omitted objects through their
+ * promisor remote. This callback is useful when an application needs to
+ * provide a custom hydration source. Returning zero causes checkout to
+ * retry the blob lookup. Returning a non-zero value aborts checkout.
+ *
+ * @param repo repository being checked out
+ * @param oid ID of the missing blob
+ * @param path path being checked out
+ * @param payload user-supplied callback payload
+ * @return 0 on success, or an error code
+ */
+typedef int GIT_CALLBACK(git_checkout_missing_blob_cb)(
+	git_repository *repo,
+	const git_oid *oid,
+	const char *path,
+	void *payload);
+
+/**
  * Checkout performance data reporting function.
  *
  * @param perfdata the performance data for the checkout
@@ -388,11 +408,18 @@ typedef struct git_checkout_options {
 
 	/** Payload passed to perfdata_cb */
 	void *perfdata_payload;
+
+	/**
+	 * Optional callback to hydrate a blob from an application-provided source.
+	 */
+	git_checkout_missing_blob_cb missing_blob_cb;
+
+	/** Payload passed to missing_blob_cb */
+	void *missing_blob_payload;
 } git_checkout_options;
 
-
 /** Current version for the `git_checkout_options` structure */
-#define GIT_CHECKOUT_OPTIONS_VERSION 1
+#define GIT_CHECKOUT_OPTIONS_VERSION 2
 
 /** Static constructor for `git_checkout_options` */
 #define GIT_CHECKOUT_OPTIONS_INIT { GIT_CHECKOUT_OPTIONS_VERSION }

--- a/include/git2/clone.h
+++ b/include/git2/clone.h
@@ -11,6 +11,7 @@
 #include "types.h"
 #include "indexer.h"
 #include "checkout.h"
+#include "strarray.h"
 #include "remote.h"
 #include "transport.h"
 
@@ -168,10 +169,16 @@ typedef struct git_clone_options {
 	 * This parameter is ignored unless remote_cb is non-NULL.
 	 */
 	void *remote_cb_payload;
+
+	/** Directories to materialize with cone-mode sparse checkout. */
+	git_strarray sparse_checkout_directories;
+
+	/** Enable cone-mode sparse checkout during clone. */
+	int sparse_checkout;
 } git_clone_options;
 
 /** Current version for the `git_clone_options` structure */
-#define GIT_CLONE_OPTIONS_VERSION 1
+#define GIT_CLONE_OPTIONS_VERSION 3
 
 /** Static constructor for `git_clone_options` */
 #define GIT_CLONE_OPTIONS_INIT \

--- a/include/git2/odb.h
+++ b/include/git2/odb.h
@@ -172,6 +172,8 @@ GIT_EXTERN(void) git_odb_free(git_odb *db);
  *
  * This method queries all available ODB backends
  * trying to read the given OID.
+ * For a repository-owned ODB configured as a partial clone, an omitted
+ * object is fetched from its promisor remote and read again.
  *
  * The returned object is reference counted and
  * internally cached, so it should be closed
@@ -222,6 +224,8 @@ GIT_EXTERN(int) git_odb_read_prefix(git_odb_object **obj, git_odb *db, const git
  * Note that most backends do not support reading only the header
  * of an object, so the whole object will be read and then the
  * header will be returned.
+ * For a repository-owned ODB configured as a partial clone, an omitted
+ * object is fetched from its promisor remote and read again.
  *
  * @param[out] len_out pointer where to store the length
  * @param[out] type_out pointer where to store the type

--- a/include/git2/remote.h
+++ b/include/git2/remote.h
@@ -11,6 +11,7 @@
 #include "repository.h"
 #include "refspec.h"
 #include "net.h"
+#include "oidarray.h"
 #include "indexer.h"
 #include "strarray.h"
 #include "transport.h"
@@ -849,10 +850,23 @@ typedef struct {
 	 * Extra headers for this fetch operation
 	 */
 	git_strarray custom_headers;
+
+	/**
+	 * Object filter specification to send to the server during fetch.
+	 *
+	 * NULL performs an unfiltered fetch. This release supports
+	 * "blob:none", "blob:limit=<n>[kmg]", and "tree:<depth>". A filtered
+	 * fetch requires a server that advertises the `filter` upload-pack
+	 * capability.
+	 *
+	 * A filtered clone records the remote as its promisor remote so
+	 * omitted objects can be fetched on demand.
+	 */
+	const char *filter_spec;
 } git_fetch_options;
 
 /** Current version for the `git_fetch_options` structure */
-#define GIT_FETCH_OPTIONS_VERSION 1
+#define GIT_FETCH_OPTIONS_VERSION 2
 
 /** Static constructor for `git_fetch_options` */
 #define GIT_FETCH_OPTIONS_INIT { \
@@ -861,7 +875,11 @@ typedef struct {
 	GIT_FETCH_PRUNE_UNSPECIFIED, \
 	GIT_REMOTE_UPDATE_FETCHHEAD, \
 	GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED, \
-	GIT_PROXY_OPTIONS_INIT }
+	GIT_PROXY_OPTIONS_INIT, \
+	0, \
+	0, \
+	{ NULL, 0 }, \
+	NULL }
 
 /**
  * Initialize git_fetch_options structure
@@ -1139,6 +1157,44 @@ GIT_EXTERN(int) git_remote_fetch(
 		const git_strarray *refspecs,
 		const git_fetch_options *opts,
 		const char *reflog_message);
+
+/**
+ * Fetch individual object IDs from a remote.
+ *
+ * This is useful for backfilling objects omitted by a partial clone.
+ * The remote server must support fetching reachable objects by object ID.
+ *
+ * The supplied object IDs are fetched without an object filter and without
+ * automatic tag following. Fetch callbacks in `opts` are honored.
+ *
+ * @param remote remote to fetch from
+ * @param oids object IDs to fetch
+ * @param opts fetch options, or NULL for defaults
+ * @return 0 on success or an error code
+ */
+GIT_EXTERN(int) git_remote_fetch_oids(
+	git_remote *remote,
+	const git_oidarray *oids,
+	const git_fetch_options *opts);
+
+/**
+ * Fetch individual object IDs from this repository's promisor remote.
+ *
+ * The promisor remote is configured by `extensions.partialClone`, as in a
+ * Git partial clone. This is useful for hydrating objects omitted by a
+ * filtered fetch while keeping authentication, progress, and cancellation
+ * under the caller's control through `opts`.
+ *
+ * @param repo partial-clone repository
+ * @param oids object IDs to fetch
+ * @param opts fetch options, or NULL for defaults
+ * @return 0 on success, GIT_ENOTFOUND if no promisor remote is configured,
+ *         or an error code
+ */
+GIT_EXTERN(int) git_repository_fetch_promisor(
+	git_repository *repo,
+	const git_oidarray *oids,
+	const git_fetch_options *opts);
 
 /**
  * Prune tracking refs that are no longer present on remote.

--- a/include/git2/sparse.h
+++ b/include/git2/sparse.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#ifndef INCLUDE_git_sparse_h__
+#define INCLUDE_git_sparse_h__
+
+#include "common.h"
+#include "checkout.h"
+#include "repository.h"
+#include "strarray.h"
+
+/**
+ * @file git2/sparse.h
+ * @brief Sparse checkout configuration
+ * @defgroup git_sparse Sparse checkout configuration
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+/**
+ * Configure cone-mode sparse checkout directories.
+ *
+ * This writes Git-compatible cone-mode patterns to
+ * `$GIT_DIR/info/sparse-checkout` and enables both
+ * `core.sparseCheckout` and `core.sparseCheckoutCone`.
+ *
+ * Directory names must be non-empty, relative paths using forward
+ * slashes. The root-level files of the working tree are always
+ * included, as required by cone-mode sparse checkout.
+ *
+ * This function only persists sparse-checkout state. Applying that
+ * state to the index and working directory is performed separately.
+ *
+ * @param repo repository to configure; must not be bare
+ * @param directories directories to include in the cone
+ * @return 0 on success, or an error code
+ */
+GIT_EXTERN(int) git_sparse_checkout_set(
+	git_repository *repo,
+	const git_strarray *directories);
+
+/**
+ * Update index skip-worktree flags from sparse-checkout patterns.
+ *
+ * This reads the cone-mode patterns in `$GIT_DIR/info/sparse-checkout`
+ * and marks excluded stage-zero index entries with
+ * `GIT_INDEX_ENTRY_SKIP_WORKTREE`. Included entries have that flag
+ * cleared.
+ *
+ * This function does not add, remove, or otherwise modify files in the
+ * working directory.
+ *
+ * @param repo repository whose index will be updated
+ * @return 0 on success, or an error code
+ */
+GIT_EXTERN(int) git_sparse_checkout_update_index(git_repository *repo);
+
+/**
+ * Initialize an empty index from HEAD and apply sparse-checkout flags.
+ *
+ * This is intended for repositories cloned with `GIT_CHECKOUT_NONE`.
+ * The index must be empty; an existing index is left untouched to avoid
+ * discarding staged changes.
+ *
+ * This function does not modify the working directory.
+ *
+ * @param repo repository whose empty index will be initialized
+ * @return 0 on success, GIT_EUNCOMMITTED if the index is non-empty,
+ *         or an error code
+ */
+GIT_EXTERN(int) git_sparse_checkout_initialize_index(git_repository *repo);
+
+/**
+ * Materialize included sparse-checkout paths from HEAD.
+ *
+ * The repository index must already have been initialized with
+ * `git_sparse_checkout_initialize_index`. Only stage-zero entries
+ * without `GIT_INDEX_ENTRY_SKIP_WORKTREE` are checked out.
+ *
+ * Existing excluded files are not removed from the working directory.
+ *
+ * @param repo repository whose sparse paths will be checked out
+ * @param opts optional checkout options; callbacks are preserved while
+ *        sparse checkout controls the strategy, baseline, and paths
+ * @return 0 on success, or an error code
+ */
+GIT_EXTERN(int) git_sparse_checkout_checkout(
+	git_repository *repo,
+	const git_checkout_options *opts);
+
+/**
+ * Configure and materialize a cone-mode sparse checkout.
+ *
+ * This writes the sparse-checkout configuration, initializes an empty
+ * index from HEAD or updates an existing index, and materializes the
+ * included paths. Conflicted indexes and indexes with staged changes are
+ * rejected. An empty index is initialized from HEAD.
+ *
+ * Clean paths that become excluded are removed from the working directory;
+ * locally modified excluded paths are preserved.
+ *
+ * @param repo repository to configure and check out
+ * @param directories directories to include in the cone
+ * @param opts optional checkout options passed to materialization
+ * @return 0 on success, GIT_ECONFLICT for an unmerged index,
+ *         GIT_EUNCOMMITTED for staged changes, or an error code
+ */
+GIT_EXTERN(int) git_sparse_checkout_apply(
+	git_repository *repo,
+	const git_strarray *directories,
+	const git_checkout_options *opts);
+
+/** Disable sparse checkout and materialize all HEAD paths. */
+GIT_EXTERN(int) git_sparse_checkout_disable(
+	git_repository *repo,
+	const git_checkout_options *opts);
+
+/** List explicitly selected cone-mode sparse checkout directories. */
+GIT_EXTERN(int) git_sparse_checkout_list(
+	git_strarray *out,
+	git_repository *repo);
+
+/** Determine whether cone-mode sparse checkout is enabled. */
+GIT_EXTERN(int) git_sparse_checkout_is_enabled(
+	int *out,
+	git_repository *repo);
+
+/** @} */
+GIT_END_DECL
+
+#endif

--- a/include/git2/sys/transport.h
+++ b/include/git2/sys/transport.h
@@ -38,6 +38,7 @@ typedef struct {
 	git_oid *shallow_roots;
 	size_t shallow_roots_len;
 	int depth;
+	const char *filter_spec;
 } git_fetch_negotiation;
 
 struct git_transport {

--- a/src/libgit2/checkout.c
+++ b/src/libgit2/checkout.c
@@ -1748,6 +1748,29 @@ static int checkout_safe_for_update_only(
 	return 0;
 }
 
+static int checkout_lookup_blob(
+	git_blob **out,
+	checkout_data *data,
+	const git_oid *oid,
+	const char *path)
+{
+	int error;
+
+	if ((error = git_blob_lookup(out, data->repo, oid)) != GIT_ENOTFOUND ||
+	    !data->opts.missing_blob_cb)
+		return error;
+
+	git_error_clear();
+
+	if ((error = data->opts.missing_blob_cb(
+			 data->repo, oid, path, data->opts.missing_blob_payload)) != 0) {
+		return git_error_set_after_callback_function(
+			error, "git_checkout missing blob");
+	}
+
+	return git_blob_lookup(out, data->repo, oid);
+}
+
 static int checkout_write_content(
 	checkout_data *data,
 	const git_oid *oid,
@@ -1759,7 +1782,7 @@ static int checkout_write_content(
 	int error = 0;
 	git_blob *blob;
 
-	if ((error = git_blob_lookup(&blob, data->repo, oid)) < 0)
+	if ((error = checkout_lookup_blob(&blob, data, oid, hint_path)) < 0)
 		return error;
 
 	if (S_ISLNK(mode))

--- a/src/libgit2/clone.c
+++ b/src/libgit2/clone.c
@@ -15,6 +15,7 @@
 #include "git2/checkout.h"
 #include "git2/commit.h"
 #include "git2/tree.h"
+#include "git2/sparse.h"
 
 #include "checkout.h"
 #include "remote.h"
@@ -369,7 +370,7 @@ static int should_checkout(
 {
 	int error;
 
-	if (!opts || is_bare ||
+	if (!opts || is_bare || opts->sparse_checkout ||
 	    opts->checkout_opts.checkout_strategy == GIT_CHECKOUT_NONE) {
 		*out = false;
 		return 0;
@@ -380,6 +381,21 @@ static int should_checkout(
 
 	*out = !error;
 	return 0;
+}
+
+static int sparse_checkout_clone(git_repository *repo, const git_clone_options *opts)
+{
+	int error;
+
+	if (!opts->sparse_checkout)
+		return 0;
+
+	git_repository__set_promisor_fetch_options(repo, &opts->fetch_opts);
+	error = git_sparse_checkout_apply(
+		repo, &opts->sparse_checkout_directories, &opts->checkout_opts);
+	git_repository__set_promisor_fetch_options(repo, NULL);
+
+	return error;
 }
 
 static int checkout_branch(
@@ -452,7 +468,8 @@ static int clone_into(
 	if ((error = git_remote_fetch(remote, NULL, &opts->fetch_opts, git_str_cstr(&reflog_message))) != 0)
 		goto cleanup;
 
-	error = checkout_branch(repo, remote, opts, git_str_cstr(&reflog_message));
+	if ((error = checkout_branch(repo, remote, opts, git_str_cstr(&reflog_message))) == 0)
+		error = sparse_checkout_clone(repo, opts);
 
 cleanup:
 	git_remote_free(remote);
@@ -557,7 +574,8 @@ static int clone_local_into(
 	if ((error = git_remote_fetch(remote, NULL, &opts->fetch_opts, git_str_cstr(&reflog_message))) != 0)
 		goto cleanup;
 
-	error = checkout_branch(repo, remote, opts, git_str_cstr(&reflog_message));
+	if ((error = checkout_branch(repo, remote, opts, git_str_cstr(&reflog_message))) == 0)
+		error = sparse_checkout_clone(repo, opts);
 
 cleanup:
 	git_str_dispose(&reflog_message);
@@ -622,6 +640,21 @@ static int clone_repo(
 
 	GIT_ERROR_CHECK_VERSION(&options, GIT_CLONE_OPTIONS_VERSION, "git_clone_options");
 
+	if (options.sparse_checkout_directories.count &&
+	    !options.sparse_checkout_directories.strings) {
+		git_error_set(
+			GIT_ERROR_INVALID,
+			"sparse checkout directories must not be NULL");
+		return GIT_EINVALID;
+	}
+	if (!options.sparse_checkout &&
+	    options.sparse_checkout_directories.count) {
+		git_error_set(
+			GIT_ERROR_INVALID,
+			"sparse checkout directories require sparse checkout to be enabled");
+		return GIT_EINVALID;
+	}
+
 	/* enforce some behavior on fetch */
 	options.fetch_opts.update_fetchhead = 0;
 
@@ -650,7 +683,9 @@ static int clone_repo(
 	if (!(error = create_and_configure_origin(&origin, repo, url, &options))) {
 		bool clone_local;
 
-		if ((error = git_clone__should_clone_local(&clone_local, url, options.local)) < 0) {
+		if (options.fetch_opts.filter_spec)
+			clone_local = false;
+		else if ((error = git_clone__should_clone_local(&clone_local, url, options.local)) < 0) {
 			git_remote_free(origin);
 			return error;
 		}

--- a/src/libgit2/fetch.c
+++ b/src/libgit2/fetch.c
@@ -21,6 +21,58 @@
 #include "refs.h"
 #include "transports/smart.h"
 
+static bool filter_spec_is_blob_limit(const char *filter_spec)
+{
+	const char *size;
+
+	if (strncmp(filter_spec, "blob:limit=", 11))
+		return false;
+
+	size = filter_spec + 11;
+	if (!*size)
+		return false;
+
+	while (git__isdigit(*size))
+		size++;
+
+	return !*size || (!size[1] && strchr("kmg", *size));
+}
+
+static bool filter_spec_is_tree_depth(const char *filter_spec)
+{
+	const char *depth;
+
+	if (strncmp(filter_spec, "tree:", 5))
+		return false;
+
+	depth = filter_spec + 5;
+	if (!*depth)
+		return false;
+
+	while (git__isdigit(*depth))
+		depth++;
+
+	return !*depth;
+}
+
+static int validate_filter_spec(const char *filter_spec)
+{
+	if (!filter_spec)
+		return 0;
+
+	if (!strcmp(filter_spec, "blob:none") ||
+	    filter_spec_is_blob_limit(filter_spec) ||
+	    filter_spec_is_tree_depth(filter_spec))
+		return 0;
+
+	git_error_set(
+	        GIT_ERROR_INVALID,
+	        "unsupported fetch filter '%s'; supported filters are "
+	        "'blob:none', 'blob:limit=<n>[kmg]', and 'tree:<depth>'",
+	        filter_spec);
+	return GIT_EINVALIDSPEC;
+}
+
 static int maybe_want(git_remote *remote, git_remote_head *head, git_refspec *tagspec, git_remote_autotag_option_t tagopt)
 {
 	int match = 0, valid;
@@ -142,6 +194,14 @@ static int filter_wants(git_remote *remote, const git_fetch_options *opts)
 		if (!git_oid__is_hexstr(spec->src, remote->repo->oid_type))
 			continue;
 
+		if (!(remote_caps & (GIT_REMOTE_CAPABILITY_TIP_OID |
+		                     GIT_REMOTE_CAPABILITY_REACHABLE_OID))) {
+			git_error_set(
+				GIT_ERROR_NET,
+				"server does not support fetching objects by ID");
+			error = GIT_ENOTSUPPORTED;
+			goto cleanup;
+		}
 
 		if ((error = maybe_want_oid(remote, spec)) < 0)
 			goto cleanup;
@@ -166,11 +226,25 @@ int git_fetch_negotiate(git_remote *remote, const git_fetch_options *opts)
 	int error;
 
 	remote->need_pack = 0;
+	remote->nego.filter_spec = NULL;
 
 	if (opts) {
 		GIT_ASSERT_ARG(opts->depth >= 0);
 		remote->nego.depth = opts->depth;
+
+		if (opts->version >= 2)
+			remote->nego.filter_spec = opts->filter_spec;
 	}
+
+	if (remote->nego.filter_spec && !remote->name) {
+		git_error_set(
+			GIT_ERROR_INVALID,
+			"filtered fetch requires a named remote");
+		return GIT_EINVALID;
+	}
+
+	if ((error = validate_filter_spec(remote->nego.filter_spec)) < 0)
+		return error;
 
 	if (filter_wants(remote, opts) < 0)
 		return -1;
@@ -206,17 +280,23 @@ int git_fetch_download_pack(git_remote *remote)
 	git_transport *t = remote->transport;
 	int error;
 
-	if (!remote->need_pack)
-		return 0;
+	if (remote->need_pack) {
+		if ((error = t->download_pack(t, remote->repo, &remote->stats)) != 0 ||
+		    (error = t->shallow_roots(&shallow_roots, t)) != 0)
+			return error;
 
-	if ((error = t->download_pack(t, remote->repo, &remote->stats)) != 0 ||
-	    (error = t->shallow_roots(&shallow_roots, t)) != 0)
-		return error;
+		error = git_repository__shallow_roots_write(remote->repo, &shallow_roots);
+		git_oidarray_dispose(&shallow_roots);
 
-	error = git_repository__shallow_roots_write(remote->repo, &shallow_roots);
+		if (error < 0)
+			return error;
+	}
 
-	git_oidarray_dispose(&shallow_roots);
-	return error;
+	if (remote->nego.filter_spec)
+		return git_repository__set_partial_clone(
+			remote->repo, remote->name, remote->nego.filter_spec);
+
+	return 0;
 }
 
 int git_fetch_options_init(git_fetch_options *opts, unsigned int version)

--- a/src/libgit2/odb.c
+++ b/src/libgit2/odb.c
@@ -15,6 +15,7 @@
 #include "delta.h"
 #include "filter.h"
 #include "repository.h"
+#include "remote.h"
 #include "blob.h"
 #include "oid.h"
 
@@ -51,6 +52,28 @@ static git_cache *odb_cache(git_odb *odb)
 	}
 
 	return &odb->own_cache;
+}
+
+static int odb_fetch_promisor(git_odb *db, const git_oid *id)
+{
+	git_repository *repo = GIT_REFCOUNT_OWNER(db);
+	git_oid oid;
+	git_oidarray oids = { &oid, 1 };
+	int error;
+
+	if (!repo)
+		return GIT_ENOTFOUND;
+
+	if (git_atomic32_inc(&db->promisor_fetching) != 1) {
+		git_atomic32_dec(&db->promisor_fetching);
+		return GIT_ENOTFOUND;
+	}
+
+	git_oid_cpy(&oid, id);
+	error = git_repository_fetch_promisor(
+		repo, &oids, repo->promisor_fetch_options);
+	git_atomic32_dec(&db->promisor_fetching);
+	return error;
 }
 
 static int odb_otype_fast(git_object_t *type_p, git_odb *db, const git_oid *id);
@@ -1052,6 +1075,15 @@ int git_odb__read_header_or_object(
 	if (error == GIT_ENOTFOUND && !git_odb_refresh(db))
 		error = odb_read_header_1(len_p, type_p, db, id, true);
 
+	if (error == GIT_ENOTFOUND) {
+		int fetch_error = odb_fetch_promisor(db, id);
+
+		if (!fetch_error && !git_odb_refresh(db))
+			error = odb_read_header_1(len_p, type_p, db, id, false);
+		else if (fetch_error != GIT_ENOTFOUND)
+			error = fetch_error;
+	}
+
 	if (error == GIT_ENOTFOUND)
 		return git_odb__error_notfound("cannot read header for", id, git_oid_hexsize(db->options.oid_type));
 
@@ -1171,6 +1203,15 @@ int git_odb_read(git_odb_object **out, git_odb *db, const git_oid *id)
 
 	if (error == GIT_ENOTFOUND && !git_odb_refresh(db))
 		error = odb_read_1(out, db, id, true);
+
+	if (error == GIT_ENOTFOUND) {
+		int fetch_error = odb_fetch_promisor(db, id);
+
+		if (!fetch_error && !git_odb_refresh(db))
+			error = odb_read_1(out, db, id, false);
+		else if (fetch_error != GIT_ENOTFOUND)
+			error = fetch_error;
+	}
 
 	if (error == GIT_ENOTFOUND)
 		return git_odb__error_notfound("no match for id", id, git_oid_hexsize(git_oid_type(id)));

--- a/src/libgit2/odb.h
+++ b/src/libgit2/odb.h
@@ -51,6 +51,7 @@ struct git_odb {
 	git_vector backends;
 	git_cache own_cache;
 	git_commit_graph *cgraph;
+	git_atomic32 promisor_fetching;
 	unsigned int do_fsync :1;
 };
 

--- a/src/libgit2/remote.c
+++ b/src/libgit2/remote.c
@@ -1429,6 +1429,94 @@ done:
 	return error;
 }
 
+int git_remote_fetch_oids(
+	git_remote *remote,
+	const git_oidarray *oids,
+	const git_fetch_options *given_opts)
+{
+	git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;
+	git_strarray refspecs = { 0 };
+	char **refspec_strings = NULL;
+	size_t i;
+	int error;
+
+	GIT_ASSERT_ARG(remote);
+	GIT_ASSERT_ARG(oids);
+
+	if (!oids->count)
+		return 0;
+
+	if (given_opts)
+		memcpy(&opts, given_opts, sizeof(git_fetch_options));
+
+	if ((refspec_strings = git__calloc(oids->count, sizeof(char *))) == NULL)
+		return -1;
+
+	for (i = 0; i < oids->count; i++) {
+		char oid[GIT_OID_MAX_HEXSIZE + 1];
+
+		if (git_oid_is_zero(&oids->ids[i])) {
+			git_error_set(GIT_ERROR_INVALID, "cannot fetch a zero object ID");
+			error = GIT_EINVALID;
+			goto done;
+		}
+
+		git_oid_tostr(oid, sizeof(oid), &oids->ids[i]);
+		if ((refspec_strings[i] = git__strdup(oid)) == NULL) {
+			error = -1;
+			goto done;
+		}
+	}
+
+	refspecs.strings = refspec_strings;
+	refspecs.count = oids->count;
+
+	opts.download_tags = GIT_REMOTE_DOWNLOAD_TAGS_NONE;
+	opts.filter_spec = NULL;
+	error = git_remote_fetch(remote, &refspecs, &opts, NULL);
+
+done:
+	for (i = 0; i < oids->count; i++)
+		git__free(refspec_strings[i]);
+
+	git__free(refspec_strings);
+	return error;
+}
+
+int git_repository_fetch_promisor(
+	git_repository *repo,
+	const git_oidarray *oids,
+	const git_fetch_options *opts)
+{
+	git_config *config = NULL;
+	git_remote *remote = NULL;
+	const char *remote_name;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+	GIT_ASSERT_ARG(oids);
+
+	if (!oids->count)
+		return 0;
+
+	if ((error = git_repository_config_snapshot(&config, repo)) < 0)
+		goto done;
+
+	if ((error = git_config_get_string(
+			 &remote_name, config, "extensions.partialclone")) < 0)
+		goto done;
+
+	if ((error = git_remote_lookup(&remote, repo, remote_name)) < 0)
+		goto done;
+
+	error = git_remote_fetch_oids(remote, oids, opts);
+
+done:
+	git_remote_free(remote);
+	git_config_free(config);
+	return error;
+}
+
 static int remote_head_for_fetchspec_src(git_remote_head **out, git_vector *update_heads, const char *fetchspec_src)
 {
 	unsigned int i;

--- a/src/libgit2/repository.c
+++ b/src/libgit2/repository.c
@@ -1923,6 +1923,7 @@ static const char *builtin_extensions[] = {
 	"preciousobjects",
 	"refstorage",
 	"relativeworktrees",
+	"partialclone",
 };
 
 static git_vector user_extensions = { 0, git__strcmp_cb };
@@ -2057,6 +2058,49 @@ int git_repository__set_objectformat(
 	}
 
 	return 0;
+}
+
+int git_repository__set_partial_clone(
+	git_repository *repo,
+	const char *remote_name,
+	const char *filter_spec)
+{
+	git_config *config;
+	git_str promisor_key = GIT_STR_INIT;
+	git_str filter_key = GIT_STR_INIT;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+	GIT_ASSERT_ARG(remote_name);
+	GIT_ASSERT_ARG(filter_spec);
+
+	if ((error = git_repository_config__weakptr(&config, repo)) < 0)
+		goto done;
+
+	if ((error = git_config_set_int32(
+			 config, "core.repositoryformatversion", 1)) < 0 ||
+	    (error = git_config_set_string(
+			 config, "extensions.partialclone", remote_name)) < 0 ||
+	    (error = git_str_printf(
+			 &promisor_key, "remote.%s.promisor", remote_name)) < 0 ||
+	    (error = git_config_set_bool(config, promisor_key.ptr, true)) < 0 ||
+	    (error = git_str_printf(
+			 &filter_key, "remote.%s.partialclonefilter", remote_name)) < 0 ||
+	    (error = git_config_set_string(
+			 config, filter_key.ptr, filter_spec)) < 0)
+		goto done;
+
+done:
+	git_str_dispose(&promisor_key);
+	git_str_dispose(&filter_key);
+	return error;
+}
+
+void git_repository__set_promisor_fetch_options(
+	git_repository *repo,
+	const git_fetch_options *opts)
+{
+	repo->promisor_fetch_options = opts;
 }
 
 static int load_refstorage_format(git_repository *repo, git_config *config)

--- a/src/libgit2/repository.h
+++ b/src/libgit2/repository.h
@@ -14,6 +14,7 @@
 #include "git2/odb.h"
 #include "git2/repository.h"
 #include "git2/object.h"
+#include "git2/remote.h"
 #include "git2/config.h"
 #include "git2/sys/repository.h"
 
@@ -168,6 +169,8 @@ struct git_repository {
 
 	git_atomic32 attr_session_key;
 
+	const git_fetch_options *promisor_fetch_options;
+
 	intptr_t configmap_cache[GIT_CONFIGMAP_CACHE_MAX];
 	git_submodule_cache *submodule_cache;
 };
@@ -281,5 +284,14 @@ void git_repository__free_extensions(void);
 int git_repository__set_objectformat(
 	git_repository *repo,
 	git_oid_t oid_type);
+
+int git_repository__set_partial_clone(
+	git_repository *repo,
+	const char *remote_name,
+	const char *filter_spec);
+
+void git_repository__set_promisor_fetch_options(
+	git_repository *repo,
+	const git_fetch_options *opts);
 
 #endif

--- a/src/libgit2/sparse.c
+++ b/src/libgit2/sparse.c
@@ -1,0 +1,669 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "git2/sparse.h"
+#include "git2/checkout.h"
+#include "git2/diff.h"
+#include "git2/index.h"
+#include "git2/tree.h"
+
+#include "repository.h"
+#include "config.h"
+#include "filebuf.h"
+#include "futils.h"
+#include "path.h"
+#include "vector.h"
+
+static int validate_directory(git_repository *repo, const char *directory)
+{
+	const char *component, *slash;
+
+	if (!directory || !*directory || directory[0] == '/' ||
+	    directory[strlen(directory) - 1] == '/' ||
+	    strchr(directory, '\\') || strstr(directory, "//")) {
+		git_error_set(
+		        GIT_ERROR_INVALID,
+		        "sparse checkout directory must be a relative path");
+		return GIT_EINVALID;
+	}
+
+	for (component = directory; component; component = slash + 1) {
+		slash = strchr(component, '/');
+
+		if ((slash && slash == component) ||
+		    (!slash && component[0] == '\0') ||
+		    ((slash ? (size_t)(slash - component) :
+		              strlen(component)) == 1 &&
+		     component[0] == '.') ||
+		    ((slash ? (size_t)(slash - component) :
+		              strlen(component)) == 2 &&
+		     component[0] == '.' && component[1] == '.')) {
+			git_error_set(
+			        GIT_ERROR_INVALID,
+			        "sparse checkout directory contains an invalid component");
+			return GIT_EINVALID;
+		}
+
+		if (!slash)
+			break;
+	}
+
+	if (!git_path_is_valid(
+	            repo, directory, GIT_FILEMODE_TREE,
+	            GIT_PATH_REJECT_WORKDIR_DEFAULTS)) {
+		git_error_set(
+		        GIT_ERROR_INVALID,
+		        "invalid sparse checkout directory '%s'", directory);
+		return GIT_EINVALID;
+	}
+
+	return 0;
+}
+
+static int
+write_cone_patterns(git_filebuf *file, const git_strarray *directories)
+{
+	size_t i;
+	int error;
+
+	if ((error = git_filebuf_write(file, "/*\n!/*/\n", 8)) < 0)
+		return error;
+
+	for (i = 0; i < directories->count; i++) {
+		const char *directory = directories->strings[i];
+		const char *slash;
+		size_t length;
+
+		for (slash = directory;; slash++) {
+			if (*slash != '/' && *slash != '\0')
+				continue;
+
+			length = (size_t)(slash - directory);
+
+			if ((error = git_filebuf_printf(
+			             file, "/%.*s/\n", (int)length,
+			             directory)) < 0)
+				return error;
+
+			if (*slash == '\0')
+				break;
+
+			if ((error = git_filebuf_printf(
+			             file, "!/%.*s/*/\n", (int)length,
+			             directory)) < 0)
+				return error;
+		}
+	}
+
+	return 0;
+}
+
+static int sparse_checkout_path(git_str *path, git_repository *repo)
+{
+	if (git_repository__item_path(path, repo, GIT_REPOSITORY_ITEM_INFO) < 0)
+		return -1;
+
+	return git_str_joinpath(path, path->ptr, "sparse-checkout");
+}
+
+static bool sparse_checkout_pattern_is_parent(
+        const char *pattern,
+        size_t pattern_len,
+        const char *next,
+        const char *end)
+{
+	const char *next_end;
+	size_t next_len;
+
+	if (!next || next >= end)
+		return false;
+
+	next_end = memchr(next, '\n', (size_t)(end - next));
+	if (!next_end)
+		next_end = end;
+
+	next_len = (size_t)(next_end - next);
+
+	return next_len == pattern_len + 3 && next[0] == '!' &&
+	       memcmp(next + 1, pattern, pattern_len - 1) == 0 &&
+	       memcmp(next + pattern_len, "/*/", 3) == 0;
+}
+
+static bool
+sparse_checkout_path_is_in_cone(const char *path, const git_str *patterns)
+{
+	const char *line = patterns->ptr;
+	const char *end = patterns->ptr + patterns->size;
+
+	if (!strchr(path, '/'))
+		return true;
+
+	while (line < end) {
+		const char *line_end = memchr(line, '\n', (size_t)(end - line));
+		const char *next;
+		size_t line_len, directory_len;
+		bool is_parent;
+
+		if (!line_end)
+			line_end = end;
+
+		line_len = (size_t)(line_end - line);
+		next = line_end == end ? NULL : line_end + 1;
+
+		if (line_len < 3 || line[0] != '/' ||
+		    line[line_len - 1] != '/' || line[1] == '*')
+			goto next;
+
+		directory_len = line_len - 2;
+
+		if (strncmp(path, line + 1, directory_len) != 0 ||
+		    path[directory_len] != '/')
+			goto next;
+
+		is_parent = sparse_checkout_pattern_is_parent(
+		        line, line_len, next, end);
+
+		if (!is_parent || !strchr(path + directory_len + 1, '/'))
+			return true;
+
+	next:
+		line = line_end == end ? end : line_end + 1;
+	}
+
+	return false;
+}
+
+int git_sparse_checkout_set(
+        git_repository *repo,
+        const git_strarray *directories)
+{
+	git_config *config;
+	git_filebuf file = GIT_FILEBUF_INIT;
+	git_str path = GIT_STR_INIT;
+	size_t i;
+	int error = 0;
+	bool file_open = false;
+
+	GIT_ASSERT_ARG(repo);
+	GIT_ASSERT_ARG(directories);
+
+	if (git_repository_is_bare(repo)) {
+		git_error_set(
+		        GIT_ERROR_REPOSITORY,
+		        "cannot configure sparse checkout in a bare repository");
+		return GIT_EBAREREPO;
+	}
+
+	if (directories->count && !directories->strings)
+		return GIT_EINVALID;
+
+	for (i = 0; i < directories->count; i++) {
+		if ((error = validate_directory(
+		             repo, directories->strings[i])) < 0)
+			goto done;
+	}
+
+	if ((error = sparse_checkout_path(&path, repo)) < 0 ||
+	    (error = git_filebuf_open(
+	             &file, path.ptr, GIT_FILEBUF_CREATE_LEADING_DIRS, 0666)) <
+	            0)
+		goto done;
+
+	file_open = true;
+
+	if ((error = write_cone_patterns(&file, directories)) < 0 ||
+	    (error = git_filebuf_commit(&file)) < 0)
+		goto done;
+
+	file_open = false;
+
+	if ((error = git_repository_config__weakptr(&config, repo)) < 0 ||
+	    (error = git_config_set_bool(config, "core.sparsecheckout", true)) <
+	            0 ||
+	    (error = git_config_set_bool(
+	             config, "core.sparsecheckoutcone", true)) < 0)
+		goto done;
+
+done:
+	if (file_open)
+		git_filebuf_cleanup(&file);
+
+	git_str_dispose(&path);
+	return error;
+}
+
+int git_sparse_checkout_update_index(git_repository *repo)
+{
+	git_index *index = NULL;
+	git_index_iterator *iterator = NULL;
+	const git_index_entry *entry;
+	git_str path = GIT_STR_INIT;
+	git_str patterns = GIT_STR_INIT;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+
+	if (git_repository_is_bare(repo)) {
+		git_error_set(
+		        GIT_ERROR_REPOSITORY,
+		        "cannot update sparse checkout index in a bare repository");
+		return GIT_EBAREREPO;
+	}
+
+	if ((error = sparse_checkout_path(&path, repo)) < 0 ||
+	    (error = git_futils_readbuffer(&patterns, path.ptr)) < 0 ||
+	    (error = git_repository_index(&index, repo)) < 0 ||
+	    (error = git_index_iterator_new(&iterator, index)) < 0)
+		goto done;
+
+	while ((error = git_index_iterator_next(&entry, iterator)) == 0) {
+		git_index_entry updated = *entry;
+		bool included =
+		        sparse_checkout_path_is_in_cone(entry->path, &patterns);
+
+		if (GIT_INDEX_ENTRY_STAGE(entry) != 0)
+			continue;
+
+		if (included)
+			updated.flags_extended &=
+			        ~GIT_INDEX_ENTRY_SKIP_WORKTREE;
+		else
+			updated.flags_extended |= GIT_INDEX_ENTRY_SKIP_WORKTREE;
+
+		if (updated.flags_extended != entry->flags_extended &&
+		    (error = git_index_add(index, &updated)) < 0)
+			goto done;
+	}
+
+	if (error == GIT_ITEROVER)
+		error = git_index_write(index);
+
+done:
+	git_index_iterator_free(iterator);
+	git_index_free(index);
+	git_str_dispose(&patterns);
+	git_str_dispose(&path);
+	return error;
+}
+
+int git_sparse_checkout_initialize_index(git_repository *repo)
+{
+	git_index *index = NULL;
+	git_tree *tree = NULL;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+
+	if (git_repository_is_bare(repo)) {
+		git_error_set(
+		        GIT_ERROR_REPOSITORY,
+		        "cannot initialize sparse checkout index in a bare repository");
+		return GIT_EBAREREPO;
+	}
+
+	if ((error = git_repository_index(&index, repo)) < 0 ||
+	    (error = git_repository_head_tree(&tree, repo)) < 0)
+		goto done;
+
+	if (git_index_entrycount(index) != 0) {
+		git_error_set(
+		        GIT_ERROR_INDEX,
+		        "cannot initialize sparse checkout with a non-empty index");
+		error = GIT_EUNCOMMITTED;
+		goto done;
+	}
+
+	if ((error = git_index_read_tree(index, tree)) < 0 ||
+	    (error = git_index_write(index)) < 0)
+		goto done;
+
+	error = git_sparse_checkout_update_index(repo);
+
+done:
+	git_tree_free(tree);
+	git_index_free(index);
+	return error;
+}
+
+static int
+sparse_checkout_collect_paths(git_vector *paths, git_repository *repo)
+{
+	git_index *index = NULL;
+	git_index_iterator *iterator = NULL;
+	const git_index_entry *entry;
+	int error;
+
+	if ((error = git_repository_index(&index, repo)) < 0 ||
+	    (error = git_index_iterator_new(&iterator, index)) < 0)
+		goto done;
+
+	while ((error = git_index_iterator_next(&entry, iterator)) == 0) {
+		char *path;
+
+		if (GIT_INDEX_ENTRY_STAGE(entry) != 0 ||
+		    (entry->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) !=
+		            0)
+			continue;
+
+		if ((path = git__strdup(entry->path)) == NULL ||
+		    (error = git_vector_insert(paths, path)) < 0) {
+			git__free(path);
+			goto done;
+		}
+	}
+
+	if (error == GIT_ITEROVER)
+		error = 0;
+
+done:
+	git_index_iterator_free(iterator);
+	git_index_free(index);
+	return error;
+}
+
+int git_sparse_checkout_checkout(
+        git_repository *repo,
+        const git_checkout_options *opts)
+{
+	git_checkout_options checkout_opts;
+	git_index *index = NULL;
+	git_tree *head = NULL;
+	git_vector paths = GIT_VECTOR_INIT;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+	GIT_ERROR_CHECK_VERSION(
+	        opts, GIT_CHECKOUT_OPTIONS_VERSION, "git_checkout_options");
+
+	if (opts)
+		checkout_opts = *opts;
+	else
+		checkout_opts = (git_checkout_options)GIT_CHECKOUT_OPTIONS_INIT;
+
+	if (git_repository_is_bare(repo)) {
+		git_error_set(
+		        GIT_ERROR_REPOSITORY,
+		        "cannot checkout sparse paths in a bare repository");
+		return GIT_EBAREREPO;
+	}
+
+	if ((error = git_repository_index(&index, repo)) < 0 ||
+	    (error = git_repository_head_tree(&head, repo)) < 0)
+		goto done;
+
+	if (git_index_entrycount(index) == 0) {
+		git_error_set(
+		        GIT_ERROR_INDEX,
+		        "sparse checkout index has not been initialized");
+		error = GIT_EUNCOMMITTED;
+		goto done;
+	}
+
+	if ((error = git_vector_init(
+	             &paths, git_index_entrycount(index), NULL)) < 0 ||
+	    (error = sparse_checkout_collect_paths(&paths, repo)) < 0 ||
+	    (error = git_repository_head_tree(&head, repo)) < 0)
+		goto done;
+
+	checkout_opts.checkout_strategy |= GIT_CHECKOUT_RECREATE_MISSING;
+	checkout_opts.paths.strings = (char **)paths.contents;
+	checkout_opts.paths.count = paths.length;
+
+	error = git_checkout_tree(repo, (git_object *)head, &checkout_opts);
+
+done:
+	git_vector_dispose_deep(&paths);
+	git_tree_free(head);
+	git_index_free(index);
+	return error;
+}
+
+static int sparse_checkout_remove_excluded(git_repository *repo)
+{
+	git_diff_options diff_opts = GIT_DIFF_OPTIONS_INIT;
+	git_diff *diff = NULL;
+	git_index *index = NULL;
+	git_tree *tree = NULL;
+	const char *workdir;
+	size_t i;
+	int error;
+
+	if ((error = git_repository_head_tree(&tree, repo)) < 0 ||
+	    (error = git_repository_index(&index, repo)) < 0)
+		goto done;
+
+	diff_opts.flags |= GIT_DIFF_INCLUDE_UNMODIFIED;
+	if ((error = git_diff_tree_to_workdir(&diff, repo, tree, &diff_opts)) <
+	    0)
+		goto done;
+
+	workdir = git_repository_workdir(repo);
+	for (i = 0; i < git_diff_num_deltas(diff); i++) {
+		const git_diff_delta *delta = git_diff_get_delta(diff, i);
+		const git_index_entry *entry;
+
+		if (delta->status != GIT_DELTA_UNMODIFIED)
+			continue;
+
+		entry = git_index_get_bypath(index, delta->old_file.path, 0);
+		if (!entry || (entry->flags_extended &
+		               GIT_INDEX_ENTRY_SKIP_WORKTREE) == 0)
+			continue;
+
+		if ((error = git_futils_rmdir_r(
+		             delta->old_file.path, workdir,
+		             GIT_RMDIR_EMPTY_PARENTS |
+		                     GIT_RMDIR_REMOVE_FILES)) < 0)
+			goto done;
+	}
+
+done:
+	git_diff_free(diff);
+	git_index_free(index);
+	git_tree_free(tree);
+	return error;
+}
+
+static int
+sparse_checkout_index_is_clean(git_repository *repo, git_index *index)
+{
+	git_diff *diff = NULL;
+	git_tree *tree = NULL;
+	int error;
+
+	if ((error = git_repository_head_tree(&tree, repo)) < 0 ||
+	    (error = git_diff_tree_to_index(&diff, repo, tree, index, NULL)) < 0)
+		goto done;
+
+	if (git_diff_num_deltas(diff) > 0) {
+		git_error_set(
+		        GIT_ERROR_INDEX,
+		        "cannot apply sparse checkout with staged changes");
+		error = GIT_EUNCOMMITTED;
+	}
+
+done:
+	git_diff_free(diff);
+	git_tree_free(tree);
+	return error;
+}
+
+int git_sparse_checkout_apply(
+        git_repository *repo,
+        const git_strarray *directories,
+        const git_checkout_options *opts)
+{
+	git_index *index = NULL;
+	bool initialize_index;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+	GIT_ASSERT_ARG(directories);
+	GIT_ERROR_CHECK_VERSION(
+	        opts, GIT_CHECKOUT_OPTIONS_VERSION, "git_checkout_options");
+
+	if ((error = git_repository_index(&index, repo)) < 0)
+		goto done;
+
+	if (git_index_has_conflicts(index)) {
+		git_error_set(
+		        GIT_ERROR_INDEX,
+		        "cannot apply sparse checkout with unresolved conflicts");
+		error = GIT_ECONFLICT;
+		goto done;
+	}
+
+	initialize_index = git_index_entrycount(index) == 0;
+	if (!initialize_index &&
+	    (error = sparse_checkout_index_is_clean(repo, index)) < 0)
+		goto done;
+
+	git_index_free(index);
+	index = NULL;
+
+	if ((error = git_sparse_checkout_set(repo, directories)) < 0)
+		goto done;
+
+	if (initialize_index)
+		error = git_sparse_checkout_initialize_index(repo);
+	else
+		error = git_sparse_checkout_update_index(repo);
+
+	if (error < 0)
+		goto done;
+
+	if (!initialize_index &&
+	    (error = sparse_checkout_remove_excluded(repo)) < 0)
+		goto done;
+
+	error = git_sparse_checkout_checkout(repo, opts);
+
+done:
+	git_index_free(index);
+	return error;
+}
+
+int git_sparse_checkout_disable(
+        git_repository *repo,
+        const git_checkout_options *opts)
+{
+	git_config *config;
+	git_index *index = NULL;
+	size_t i;
+	int error;
+
+	GIT_ASSERT_ARG(repo);
+	GIT_ERROR_CHECK_VERSION(
+	        opts, GIT_CHECKOUT_OPTIONS_VERSION, "git_checkout_options");
+
+	if ((error = git_repository_config__weakptr(&config, repo)) < 0 ||
+	    (error = git_config_set_bool(
+	             config, "core.sparsecheckout", false)) < 0 ||
+	    (error = git_config_set_bool(
+	             config, "core.sparsecheckoutcone", false)) < 0 ||
+	    (error = git_repository_index(&index, repo)) < 0)
+		goto done;
+
+	for (i = 0; i < git_index_entrycount(index); i++) {
+		const git_index_entry *entry = git_index_get_byindex(index, i);
+		git_index_entry updated = *entry;
+
+		if (GIT_INDEX_ENTRY_STAGE(entry) != 0 ||
+		    (updated.flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) ==
+		            0)
+			continue;
+
+		updated.flags_extended &= ~GIT_INDEX_ENTRY_SKIP_WORKTREE;
+		if ((error = git_index_add(index, &updated)) < 0)
+			goto done;
+	}
+
+	if ((error = git_index_write(index)) < 0)
+		goto done;
+
+	error = git_sparse_checkout_checkout(repo, opts);
+
+done:
+	git_index_free(index);
+	return error;
+}
+
+int git_sparse_checkout_list(git_strarray *out, git_repository *repo)
+{
+	git_str path = GIT_STR_INIT, patterns = GIT_STR_INIT;
+	git_vector directories = GIT_VECTOR_INIT;
+	const char *line, *end;
+	int error = 0;
+
+	GIT_ASSERT_ARG(out);
+	GIT_ASSERT_ARG(repo);
+	memset(out, 0, sizeof(*out));
+
+	if ((error = sparse_checkout_path(&path, repo)) < 0 ||
+	    (error = git_futils_readbuffer(&patterns, path.ptr)) < 0 ||
+	    (error = git_vector_init(&directories, 0, NULL)) < 0)
+		goto done;
+
+	line = patterns.ptr;
+	end = patterns.ptr + patterns.size;
+	while (line < end) {
+		const char *line_end = memchr(line, '\n', (size_t)(end - line));
+		const char *next;
+		size_t line_len;
+		char *directory;
+
+		if (!line_end)
+			line_end = end;
+		line_len = (size_t)(line_end - line);
+		next = line_end == end ? NULL : line_end + 1;
+
+		if (line_len >= 3 && line[0] == '/' &&
+		    line[line_len - 1] == '/' && line[1] != '*' &&
+		    !sparse_checkout_pattern_is_parent(
+		            line, line_len, next, end)) {
+			if ((directory = git__strndup(
+			             line + 1, line_len - 2)) == NULL ||
+			    (error = git_vector_insert(
+			             &directories, directory)) < 0) {
+				git__free(directory);
+				goto done;
+			}
+		}
+
+		line = line_end == end ? end : line_end + 1;
+	}
+
+	out->strings =
+	        (char **)git_vector_detach(&out->count, NULL, &directories);
+
+done:
+	git_vector_dispose_deep(&directories);
+	git_str_dispose(&patterns);
+	git_str_dispose(&path);
+	return error;
+}
+
+int git_sparse_checkout_is_enabled(int *out, git_repository *repo)
+{
+	git_config *config;
+	int error;
+
+	GIT_ASSERT_ARG(out);
+	GIT_ASSERT_ARG(repo);
+	*out = 0;
+
+	if ((error = git_repository_config__weakptr(&config, repo)) < 0)
+		return error;
+
+	error = git_config_get_bool(out, config, "core.sparsecheckout");
+	if (error == GIT_ENOTFOUND) {
+		git_error_clear();
+		return 0;
+	}
+
+	return error;
+}

--- a/src/libgit2/transports/local.c
+++ b/src/libgit2/transports/local.c
@@ -297,10 +297,13 @@ static int local_negotiate_fetch(
 	git_remote_head *rhead;
 	unsigned int i;
 
-	GIT_UNUSED(wants);
-
 	if (wants->depth) {
 		git_error_set(GIT_ERROR_NET, "shallow fetch is not supported by the local transport");
+		return GIT_ENOTSUPPORTED;
+	}
+
+	if (wants->filter_spec) {
+		git_error_set(GIT_ERROR_NET, "filtered fetch is not supported by the local transport");
 		return GIT_ENOTSUPPORTED;
 	}
 

--- a/src/libgit2/transports/smart.h
+++ b/src/libgit2/transports/smart.h
@@ -36,6 +36,7 @@
 #define GIT_CAP_WANT_TIP_SHA1 "allow-tip-sha1-in-want"
 #define GIT_CAP_WANT_REACHABLE_SHA1 "allow-reachable-sha1-in-want"
 #define GIT_CAP_SHALLOW "shallow"
+#define GIT_CAP_FILTER "filter"
 #define GIT_CAP_OBJECT_FORMAT "object-format="
 #define GIT_CAP_AGENT "agent="
 #define GIT_CAP_PUSH_OPTIONS "push-options"
@@ -148,6 +149,7 @@ typedef struct transport_smart_caps {
 	             want_tip_sha1:1,
 	             want_reachable_sha1:1,
 	             shallow:1,
+	             filter:1,
 	             push_options:1;
 	char *object_format;
 	char *agent;

--- a/src/libgit2/transports/smart_pkt.c
+++ b/src/libgit2/transports/smart_pkt.c
@@ -698,6 +698,7 @@ static int buffer_want_with_caps(
 	const git_remote_head *head,
 	transport_smart_caps *caps,
 	git_oid_t oid_type,
+	const git_fetch_negotiation *wants,
 	git_str *buf)
 {
 	git_str str = GIT_STR_INIT;
@@ -730,6 +731,14 @@ static int buffer_want_with_caps(
 
 	if (caps->shallow)
 		git_str_puts(&str, GIT_CAP_SHALLOW " ");
+
+	if (wants->filter_spec)
+		git_str_puts(&str, GIT_CAP_FILTER " ");
+
+	if (caps->want_reachable_sha1)
+		git_str_puts(&str, GIT_CAP_WANT_REACHABLE_SHA1 " ");
+	else if (caps->want_tip_sha1)
+		git_str_puts(&str, GIT_CAP_WANT_TIP_SHA1 " ");
 
 	if (git_str_oom(&str))
 		return -1;
@@ -784,7 +793,7 @@ int git_pkt_buffer_wants(
 				break;
 		}
 
-		if (buffer_want_with_caps(wants->refs[i], caps, oid_type, buf) < 0)
+		if (buffer_want_with_caps(wants->refs[i], caps, oid_type, wants, buf) < 0)
 			return -1;
 
 		i++;
@@ -831,6 +840,20 @@ int git_pkt_buffer_wants(
 		git_str_printf(buf,"%04x%s", (unsigned int)git_str_len(&deepen_buf) + 4, git_str_cstr(&deepen_buf));
 
 		git_str_dispose(&deepen_buf);
+
+		if (git_str_oom(buf))
+			return -1;
+	}
+
+	if (wants->filter_spec) {
+		git_str filter_buf = GIT_STR_INIT;
+
+		git_str_printf(&filter_buf, "filter %s\n", wants->filter_spec);
+		git_str_printf(
+			buf, "%04x%s",
+			(unsigned int)git_str_len(&filter_buf) + 4,
+			git_str_cstr(&filter_buf));
+		git_str_dispose(&filter_buf);
 
 		if (git_str_oom(buf))
 			return -1;

--- a/src/libgit2/transports/smart_protocol.c
+++ b/src/libgit2/transports/smart_protocol.c
@@ -255,6 +255,12 @@ int git_smart__detect_caps(
 			continue;
 		}
 
+		if (!git__prefixcmp(ptr, GIT_CAP_FILTER)) {
+			caps->common = caps->filter = 1;
+			ptr += strlen(GIT_CAP_FILTER);
+			continue;
+		}
+
 		/* We don't know this capability, so skip it */
 		ptr = strchr(ptr, ' ');
 	}
@@ -385,6 +391,11 @@ static int setup_caps(
 	} else {
 		caps->shallow = 0;
 	}
+
+	if (wants->filter_spec && !caps->filter)
+		return cap_not_sup_err(GIT_CAP_FILTER);
+	else if (!wants->filter_spec)
+		caps->filter = 0;
 
 	return 0;
 }

--- a/tests/libgit2/checkout/tree.c
+++ b/tests/libgit2/checkout/tree.c
@@ -9,6 +9,28 @@ static git_repository *g_repo;
 static git_checkout_options g_opts;
 static git_object *g_object;
 
+typedef struct {
+	const char *content;
+	bool called;
+} missing_blob_data;
+
+static int hydrate_missing_blob(
+	git_repository *repo,
+	const git_oid *oid,
+	const char *path,
+	void *payload)
+{
+	missing_blob_data *data = payload;
+	git_oid hydrated_id;
+
+	cl_assert_equal_s("hydrated.txt", path);
+	cl_git_pass(git_blob_create_from_buffer(
+		&hydrated_id, repo, data->content, strlen(data->content)));
+	cl_assert_equal_oid(oid, &hydrated_id);
+	data->called = true;
+	return 0;
+}
+
 static void assert_status_entrycount(git_repository *repo, size_t count)
 {
 	git_status_list *status;
@@ -43,6 +65,43 @@ void test_checkout_tree__cannot_checkout_a_non_treeish(void)
 	/* blob */
 	cl_git_pass(git_revparse_single(&g_object, g_repo, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd"));
 	cl_git_fail(git_checkout_tree(g_repo, g_object, NULL));
+}
+
+void test_checkout_tree__hydrates_missing_blob(void)
+{
+	static const char content[] = "hydrated content\n";
+	git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+	git_object_id_options id_opts = GIT_OBJECT_ID_OPTIONS_INIT;
+	git_treebuilder *builder;
+	git_tree *tree;
+	git_oid blob_id;
+	git_oid tree_id;
+	missing_blob_data data = { content, false };
+
+	id_opts.object_type = GIT_OBJECT_BLOB;
+	cl_git_pass(git_object_id_from_buffer(
+		&blob_id, content, strlen(content), &id_opts));
+
+	cl_git_pass(git_treebuilder_new(&builder, g_repo, NULL));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 0));
+	cl_git_pass(git_treebuilder_insert(
+		NULL, builder, "hydrated.txt", &blob_id, GIT_FILEMODE_BLOB));
+	cl_git_pass(git_treebuilder_write(&tree_id, builder));
+	cl_git_pass(git_libgit2_opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, 1));
+	git_treebuilder_free(builder);
+
+	cl_git_pass(git_tree_lookup(&tree, g_repo, &tree_id));
+
+	opts.checkout_strategy = GIT_CHECKOUT_FORCE;
+	opts.missing_blob_cb = hydrate_missing_blob;
+	opts.missing_blob_payload = &data;
+
+	cl_git_pass(git_checkout_tree(g_repo, (git_object *)tree, &opts));
+	cl_assert(data.called);
+	cl_assert_equal_file(
+		content, strlen(content), "./testrepo/hydrated.txt");
+
+	git_tree_free(tree);
 }
 
 void test_checkout_tree__can_checkout_a_subdirectory_from_a_commit(void)

--- a/tests/libgit2/clone/local.c
+++ b/tests/libgit2/clone/local.c
@@ -1,6 +1,8 @@
 #include "clar_libgit2.h"
 
 #include "git2/clone.h"
+#include "git2/index.h"
+#include "git2/sparse.h"
 #include "clone.h"
 #include "path.h"
 #include "posix.h"
@@ -265,6 +267,187 @@ void test_clone_local__shallow_fails(void)
 	opts.fetch_opts.depth = 4;
 
 	cl_git_fail_with(GIT_ENOTSUPPORTED, git_clone(&repo, cl_fixture("testrepo.git"), "./clone.git", &opts));
+}
+
+void test_clone_local__filtered_clone_reaches_transport(void)
+{
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.filter_spec = "blob:none";
+
+	cl_git_fail_with(
+	        GIT_ENOTSUPPORTED, git_clone(
+	                                   &repo, cl_fixture("testrepo.git"),
+	                                   "./clone.git", &opts));
+}
+
+void test_clone_local__filtered_sparse_clone_reaches_transport(void)
+{
+	char *directories[] = { "source" };
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.filter_spec = "blob:none";
+	opts.sparse_checkout_directories = sparse_directories;
+	opts.sparse_checkout = 1;
+
+	cl_git_fail_with(
+		GIT_ENOTSUPPORTED,
+		git_clone(&repo, cl_fixture("testrepo.git"), "./clone.git", &opts));
+}
+
+void test_clone_local__blob_limit_filtered_sparse_clone_reaches_transport(void)
+{
+	char *directories[] = { "source" };
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.filter_spec = "blob:limit=1k";
+	opts.sparse_checkout_directories = sparse_directories;
+	opts.sparse_checkout = 1;
+
+	cl_git_fail_with(
+	        GIT_ENOTSUPPORTED, git_clone(
+	                                   &repo, cl_fixture("testrepo.git"),
+	                                   "./clone.git", &opts));
+}
+
+void test_clone_local__tree_depth_filtered_sparse_clone_reaches_transport(void)
+{
+	char *directories[] = { "source" };
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.filter_spec = "tree:2";
+	opts.sparse_checkout_directories = sparse_directories;
+	opts.sparse_checkout = 1;
+
+	cl_git_fail_with(
+	        GIT_ENOTSUPPORTED, git_clone(
+	                                   &repo, cl_fixture("testrepo.git"),
+	                                   "./clone.git", &opts));
+}
+
+void test_clone_local__rejects_invalid_blob_limit_filter(void)
+{
+	char *directories[] = { "source" };
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.filter_spec = "blob:limit=1x";
+	opts.sparse_checkout_directories = sparse_directories;
+	opts.sparse_checkout = 1;
+
+	cl_git_fail_with(
+	        GIT_EINVALIDSPEC, git_clone(
+	                                  &repo, cl_fixture("testrepo.git"),
+	                                  "./clone.git", &opts));
+}
+
+void test_clone_local__rejects_invalid_tree_depth_filter(void)
+{
+	char *directories[] = { "source" };
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_repository *repo;
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+
+	opts.fetch_opts.filter_spec = "tree:";
+	opts.sparse_checkout_directories = sparse_directories;
+	opts.sparse_checkout = 1;
+
+	cl_git_fail_with(
+	        GIT_EINVALIDSPEC, git_clone(
+	                                  &repo, cl_fixture("testrepo.git"),
+	                                  "./clone.git", &opts));
+}
+
+void test_clone_local__sparse_checkout(void)
+{
+	char *directories[] = { "selected" };
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_strarray root_only = { NULL, 0 };
+	git_clone_options opts = GIT_CLONE_OPTIONS_INIT;
+	git_index *index;
+	git_repository *source, *clone, *full;
+	int sparse_enabled;
+
+	cl_git_pass(git_repository_init(&source, "./source", 0));
+	cl_git_mkfile("./source/root.txt", "root\n");
+	cl_git_pass(p_mkdir("./source/selected", 0777));
+	cl_git_mkfile("./source/selected/keep.txt", "keep\n");
+	cl_git_pass(p_mkdir("./source/excluded", 0777));
+	cl_git_mkfile("./source/excluded/drop.txt", "drop\n");
+
+	cl_git_pass(git_repository_index(&index, source));
+	cl_git_pass(git_index_add_all(index, NULL, 0, NULL, NULL));
+	cl_git_pass(git_index_write(index));
+	cl_repo_commit_from_index(NULL, source, NULL, 0, "initial commit");
+	cl_git_pass(git_clone(&full, "./source", "./full", NULL));
+
+	cl_git_pass(git_sparse_checkout_apply(
+		full, &sparse_directories, NULL));
+	cl_assert(!git_fs_path_isfile("./full/excluded/drop.txt"));
+
+	cl_git_pass(p_mkdir("./full/excluded", 0777));
+	cl_git_mkfile("./full/excluded/drop.txt", "modified\n");
+	cl_git_pass(git_sparse_checkout_apply(full, &root_only, NULL));
+	cl_assert(git_fs_path_isfile("./full/excluded/drop.txt"));
+
+	opts.sparse_checkout_directories = sparse_directories;
+	opts.sparse_checkout = 1;
+	cl_git_pass(git_clone(&clone, "./source", "./clone", &opts));
+
+	cl_assert(git_fs_path_isfile("./clone/root.txt"));
+	cl_assert(git_fs_path_isfile("./clone/selected/keep.txt"));
+	cl_assert(!git_fs_path_isfile("./clone/excluded/drop.txt"));
+	cl_git_pass(git_sparse_checkout_disable(clone, NULL));
+	cl_git_pass(git_sparse_checkout_is_enabled(&sparse_enabled, clone));
+	cl_assert(!sparse_enabled);
+	cl_assert(git_fs_path_isfile("./clone/excluded/drop.txt"));
+
+	git_repository_free(clone);
+	opts.sparse_checkout_directories.strings = NULL;
+	opts.sparse_checkout_directories.count = 0;
+	cl_git_pass(git_clone(&clone, "./source", "./root-only", &opts));
+	cl_assert(git_fs_path_isfile("./root-only/root.txt"));
+	cl_assert(!git_fs_path_isfile("./root-only/selected/keep.txt"));
+	cl_assert(!git_fs_path_isfile("./root-only/excluded/drop.txt"));
+
+	git_index_free(index);
+	git_repository_free(clone);
+	git_repository_free(full);
+	git_repository_free(source);
+	cl_git_pass(
+	        git_futils_rmdir_r("./clone", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_git_pass(git_futils_rmdir_r(
+	        "./root-only", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_git_pass(
+	        git_futils_rmdir_r("./full", NULL, GIT_RMDIR_REMOVE_FILES));
+	cl_git_pass(
+	        git_futils_rmdir_r("./source", NULL, GIT_RMDIR_REMOVE_FILES));
 }
 
 void test_clone_local__sha256_via_no_local(void)

--- a/tests/libgit2/core/opts.c
+++ b/tests/libgit2/core/opts.c
@@ -34,13 +34,14 @@ void test_core_opts__extensions_query(void)
 
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 6);
+	cl_assert_equal_sz(out.count, 7);
 	cl_assert_equal_s("noop", out.strings[0]);
 	cl_assert_equal_s("objectformat", out.strings[1]);
-	cl_assert_equal_s("preciousobjects", out.strings[2]);
-	cl_assert_equal_s("refstorage", out.strings[3]);
-	cl_assert_equal_s("relativeworktrees", out.strings[4]);
-	cl_assert_equal_s("worktreeconfig", out.strings[5]);
+	cl_assert_equal_s("partialclone", out.strings[2]);
+	cl_assert_equal_s("preciousobjects", out.strings[3]);
+	cl_assert_equal_s("refstorage", out.strings[4]);
+	cl_assert_equal_s("relativeworktrees", out.strings[5]);
+	cl_assert_equal_s("worktreeconfig", out.strings[6]);
 
 	git_strarray_dispose(&out);
 }
@@ -53,14 +54,15 @@ void test_core_opts__extensions_add(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 7);
+	cl_assert_equal_sz(out.count, 8);
 	cl_assert_equal_s("foo", out.strings[0]);
 	cl_assert_equal_s("noop", out.strings[1]);
 	cl_assert_equal_s("objectformat", out.strings[2]);
-	cl_assert_equal_s("preciousobjects", out.strings[3]);
-	cl_assert_equal_s("refstorage", out.strings[4]);
-	cl_assert_equal_s("relativeworktrees", out.strings[5]);
-	cl_assert_equal_s("worktreeconfig", out.strings[6]);
+	cl_assert_equal_s("partialclone", out.strings[3]);
+	cl_assert_equal_s("preciousobjects", out.strings[4]);
+	cl_assert_equal_s("refstorage", out.strings[5]);
+	cl_assert_equal_s("relativeworktrees", out.strings[6]);
+	cl_assert_equal_s("worktreeconfig", out.strings[7]);
 
 	git_strarray_dispose(&out);
 }
@@ -73,14 +75,15 @@ void test_core_opts__extensions_remove(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 7);
+	cl_assert_equal_sz(out.count, 8);
 	cl_assert_equal_s("bar", out.strings[0]);
 	cl_assert_equal_s("baz", out.strings[1]);
 	cl_assert_equal_s("objectformat", out.strings[2]);
-	cl_assert_equal_s("preciousobjects", out.strings[3]);
-	cl_assert_equal_s("refstorage", out.strings[4]);
-	cl_assert_equal_s("relativeworktrees", out.strings[5]);
-	cl_assert_equal_s("worktreeconfig", out.strings[6]);
+	cl_assert_equal_s("partialclone", out.strings[3]);
+	cl_assert_equal_s("preciousobjects", out.strings[4]);
+	cl_assert_equal_s("refstorage", out.strings[5]);
+	cl_assert_equal_s("relativeworktrees", out.strings[6]);
+	cl_assert_equal_s("worktreeconfig", out.strings[7]);
 
 	git_strarray_dispose(&out);
 }
@@ -93,15 +96,16 @@ void test_core_opts__extensions_uniq(void)
 	cl_git_pass(git_libgit2_opts(GIT_OPT_SET_EXTENSIONS, in, ARRAY_SIZE(in)));
 	cl_git_pass(git_libgit2_opts(GIT_OPT_GET_EXTENSIONS, &out));
 
-	cl_assert_equal_sz(out.count, 8);
+	cl_assert_equal_sz(out.count, 9);
 	cl_assert_equal_s("bar", out.strings[0]);
 	cl_assert_equal_s("foo", out.strings[1]);
 	cl_assert_equal_s("noop", out.strings[2]);
 	cl_assert_equal_s("objectformat", out.strings[3]);
-	cl_assert_equal_s("preciousobjects", out.strings[4]);
-	cl_assert_equal_s("refstorage", out.strings[5]);
-	cl_assert_equal_s("relativeworktrees", out.strings[6]);
-	cl_assert_equal_s("worktreeconfig", out.strings[7]);
+	cl_assert_equal_s("partialclone", out.strings[4]);
+	cl_assert_equal_s("preciousobjects", out.strings[5]);
+	cl_assert_equal_s("refstorage", out.strings[6]);
+	cl_assert_equal_s("relativeworktrees", out.strings[7]);
+	cl_assert_equal_s("worktreeconfig", out.strings[8]);
 
 	git_strarray_dispose(&out);
 }

--- a/tests/libgit2/network/fetchlocal.c
+++ b/tests/libgit2/network/fetchlocal.c
@@ -2,6 +2,7 @@
 
 #include "path.h"
 #include "remote.h"
+#include "repository.h"
 
 static const char* tagger_name = "Vicent Marti";
 static const char* tagger_email = "vicent@github.com";
@@ -18,6 +19,32 @@ static int transfer_cb(const git_indexer_progress *stats, void *payload)
 static void cleanup_local_repo(void *path)
 {
 	cl_fixture_cleanup((char *)path);
+}
+
+static void setup_promisor_repository(
+        git_repository **repo_out,
+        git_remote **remote_out,
+        git_odb **odb_out)
+{
+	const char *url = cl_git_fixture_url("testrepo.git");
+
+	cl_set_cleanup(&cleanup_local_repo, "foo");
+	cl_git_pass(git_repository_init(repo_out, "foo", true));
+	cl_git_pass(git_remote_create(
+	        remote_out, *repo_out, GIT_REMOTE_ORIGIN, url));
+	cl_git_pass(git_repository__set_partial_clone(
+	        *repo_out, GIT_REMOTE_ORIGIN, "blob:none"));
+	cl_git_pass(git_repository_odb(odb_out, *repo_out));
+}
+
+static void cleanup_promisor_repository(
+        git_repository *repo,
+        git_remote *remote,
+        git_odb *odb)
+{
+	git_odb_free(odb);
+	git_remote_free(remote);
+	git_repository_free(repo);
 }
 
 void test_network_fetchlocal__cleanup(void)
@@ -51,6 +78,135 @@ void test_network_fetchlocal__complete(void)
 	git_strarray_dispose(&refnames);
 	git_remote_free(origin);
 	git_repository_free(repo);
+}
+
+void test_network_fetchlocal__fetch_oids(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+	git_odb *odb;
+	git_oid oid;
+	git_oidarray oids;
+	const char *url = cl_git_fixture_url("testrepo.git");
+
+	cl_set_cleanup(&cleanup_local_repo, "foo");
+	cl_git_pass(git_repository_init(&repo, "foo", true));
+	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
+	cl_git_pass(git_oid_from_string(
+		&oid, "a8233120f6ad708f843d861ce2b7228ec4e3dec6", GIT_OID_SHA1));
+
+	oids.ids = &oid;
+	oids.count = 1;
+
+	cl_git_pass(git_remote_fetch_oids(origin, &oids, NULL));
+	cl_git_pass(git_repository_odb(&odb, repo));
+	cl_assert(git_odb_exists(odb, &oid));
+
+	git_odb_free(odb);
+	git_remote_free(origin);
+	git_repository_free(repo);
+}
+
+void test_network_fetchlocal__fetch_promisor_oids(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+	git_odb *odb;
+	git_oid oid;
+	git_oidarray oids;
+	const char *url = cl_git_fixture_url("testrepo.git");
+
+	cl_set_cleanup(&cleanup_local_repo, "foo");
+	cl_git_pass(git_repository_init(&repo, "foo", true));
+	cl_git_pass(git_remote_create(&origin, repo, GIT_REMOTE_ORIGIN, url));
+	cl_git_pass(git_repository__set_partial_clone(
+	        repo, GIT_REMOTE_ORIGIN, "blob:none"));
+	cl_git_pass(git_oid_from_string(
+	        &oid, "a8233120f6ad708f843d861ce2b7228ec4e3dec6", GIT_OID_SHA1));
+
+	oids.ids = &oid;
+	oids.count = 1;
+
+	cl_git_pass(git_repository_fetch_promisor(repo, &oids, NULL));
+	cl_git_pass(git_repository_odb(&odb, repo));
+	cl_assert(git_odb_exists(odb, &oid));
+
+	git_odb_free(odb);
+	git_remote_free(origin);
+	git_repository_free(repo);
+}
+
+void test_network_fetchlocal__reads_promisor_objects(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+	git_odb *odb;
+	git_odb_object *object;
+	git_oid oid;
+
+	setup_promisor_repository(&repo, &origin, &odb);
+	cl_git_pass(git_oid_from_string(
+	        &oid, "a8233120f6ad708f843d861ce2b7228ec4e3dec6",
+	        GIT_OID_SHA1));
+
+	cl_assert(!git_odb_exists(odb, &oid));
+	cl_git_pass(git_odb_read(&object, odb, &oid));
+	cl_assert_equal_oid(&oid, git_odb_object_id(object));
+
+	git_odb_object_free(object);
+	cleanup_promisor_repository(repo, origin, odb);
+}
+
+void test_network_fetchlocal__reads_promisor_objects_with_fetch_options(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+	git_odb *odb;
+	git_odb_object *object;
+	git_oid oid;
+	git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;
+	int callcount = 0;
+
+	setup_promisor_repository(&repo, &origin, &odb);
+	cl_git_pass(git_oid_from_string(
+		&oid, "a8233120f6ad708f843d861ce2b7228ec4e3dec6",
+		GIT_OID_SHA1));
+
+	opts.callbacks.transfer_progress = transfer_cb;
+	opts.callbacks.payload = &callcount;
+	git_repository__set_promisor_fetch_options(repo, &opts);
+
+	cl_assert(!git_odb_exists(odb, &oid));
+	cl_git_pass(git_odb_read(&object, odb, &oid));
+	cl_assert_equal_oid(&oid, git_odb_object_id(object));
+	cl_assert(callcount > 0);
+
+	git_odb_object_free(object);
+	git_repository__set_promisor_fetch_options(repo, NULL);
+	cleanup_promisor_repository(repo, origin, odb);
+}
+
+void test_network_fetchlocal__reads_promisor_object_headers(void)
+{
+	git_repository *repo;
+	git_remote *origin;
+	git_odb *odb;
+	git_object_t type;
+	git_oid oid;
+	size_t length;
+
+	setup_promisor_repository(&repo, &origin, &odb);
+	cl_git_pass(git_oid_from_string(
+	        &oid, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd",
+	        GIT_OID_SHA1));
+
+	cl_assert(!git_odb_exists(odb, &oid));
+	cl_git_pass(git_odb_read_header(&length, &type, odb, &oid));
+	cl_assert_equal_i(GIT_OBJECT_BLOB, type);
+	cl_assert_equal_i(12, length);
+	cl_assert(git_odb_exists(odb, &oid));
+
+	cleanup_promisor_repository(repo, origin, odb);
 }
 
 void test_network_fetchlocal__prune(void)

--- a/tests/libgit2/repo/extensions.c
+++ b/tests/libgit2/repo/extensions.c
@@ -1,5 +1,6 @@
 #include "clar_libgit2.h"
 #include "futils.h"
+#include "repository.h"
 #include "sysdir.h"
 #include <ctype.h>
 
@@ -86,6 +87,40 @@ void test_repo_extensions__relativeworktrees(void)
 	git_repository *extended = NULL;
 
 	cl_repo_set_string(repo, "extensions.relativeWorktrees", "true");
+
+	cl_git_pass(git_repository_open(&extended, "empty_bare.git"));
+	git_repository_free(extended);
+}
+
+void test_repo_extensions__partialclone(void)
+{
+	git_config *config;
+	git_repository *extended;
+	const char *remote_name;
+	const char *filter_spec;
+	int version;
+	int promisor;
+
+	cl_git_pass(git_repository__set_partial_clone(repo, "origin", "blob:none"));
+	cl_git_pass(git_repository_config_snapshot(&config, repo));
+
+	cl_git_pass(git_config_get_int32(
+		&version, config, "core.repositoryformatversion"));
+	cl_assert_equal_i(1, version);
+
+	cl_git_pass(git_config_get_string(
+		&remote_name, config, "extensions.partialclone"));
+	cl_assert_equal_s("origin", remote_name);
+
+	cl_git_pass(git_config_get_bool(
+		&promisor, config, "remote.origin.promisor"));
+	cl_assert(promisor);
+
+	cl_git_pass(git_config_get_string(
+		&filter_spec, config, "remote.origin.partialclonefilter"));
+	cl_assert_equal_s("blob:none", filter_spec);
+
+	git_config_free(config);
 
 	cl_git_pass(git_repository_open(&extended, "empty_bare.git"));
 	git_repository_free(extended);

--- a/tests/libgit2/repo/sparse.c
+++ b/tests/libgit2/repo/sparse.c
@@ -1,0 +1,193 @@
+#include "clar_libgit2.h"
+#include "repository.h"
+#include "futils.h"
+
+static git_repository *g_repo;
+
+void test_repo_sparse__initialize(void)
+{
+	g_repo = cl_git_sandbox_init("testrepo");
+}
+
+void test_repo_sparse__cleanup(void)
+{
+	cl_git_sandbox_cleanup();
+}
+
+void test_repo_sparse__configures_cone_mode(void)
+{
+	char *directories[] = {
+		"src/libgit2",
+		"tests",
+	};
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_config *config;
+	git_strarray listed_directories = { 0 };
+	git_str path = GIT_STR_INIT;
+	git_str patterns = GIT_STR_INIT;
+	int value;
+	int enabled;
+
+	cl_git_pass(git_sparse_checkout_set(g_repo, &sparse_directories));
+	cl_git_pass(git_sparse_checkout_is_enabled(&enabled, g_repo));
+	cl_assert(enabled);
+	cl_git_pass(git_sparse_checkout_list(&listed_directories, g_repo));
+	cl_assert_equal_i(2, listed_directories.count);
+	cl_assert_equal_s("src/libgit2", listed_directories.strings[0]);
+	cl_assert_equal_s("tests", listed_directories.strings[1]);
+
+	cl_git_pass(git_repository_config(&config, g_repo));
+	cl_git_pass(git_config_get_bool(&value, config, "core.sparsecheckout"));
+	cl_assert(value);
+	cl_git_pass(
+	        git_config_get_bool(&value, config, "core.sparsecheckoutcone"));
+	cl_assert(value);
+
+	cl_git_pass(git_repository__item_path(
+	        &path, g_repo, GIT_REPOSITORY_ITEM_INFO));
+	cl_git_pass(git_str_joinpath(&path, path.ptr, "sparse-checkout"));
+	cl_git_pass(git_futils_readbuffer(&patterns, path.ptr));
+
+	cl_assert_equal_s(
+	        "/*\n"
+	        "!/*/\n"
+	        "/src/\n"
+	        "!/src/*/\n"
+	        "/src/libgit2/\n"
+	        "/tests/\n",
+	        patterns.ptr);
+
+	git_str_dispose(&patterns);
+	git_str_dispose(&path);
+	git_strarray_dispose(&listed_directories);
+	git_config_free(config);
+}
+
+void test_repo_sparse__updates_skip_worktree_flags(void)
+{
+	char *directories[] = {
+		"src/libgit2",
+	};
+	git_strarray sparse_directories = {
+		directories,
+		ARRAY_SIZE(directories),
+	};
+	git_index *index;
+	git_index_entry entry = { 0 };
+	const git_index_entry *indexed;
+
+	entry.mode = GIT_FILEMODE_BLOB;
+	cl_git_pass(git_oid_from_string(
+	        &entry.id, "a71586c1dfe8a71c6cbf6c129f404c5642ff31bd",
+	        GIT_OID_SHA1));
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_clear(index));
+
+	entry.path = "README";
+	cl_git_pass(git_index_add(index, &entry));
+	entry.path = "src/README";
+	cl_git_pass(git_index_add(index, &entry));
+	entry.path = "src/libgit2/repository.c";
+	cl_git_pass(git_index_add(index, &entry));
+	entry.path = "src/other/file.c";
+	cl_git_pass(git_index_add(index, &entry));
+	entry.path = "docs/guide.md";
+	cl_git_pass(git_index_add(index, &entry));
+	entry.path = "conflicted.c";
+	GIT_INDEX_ENTRY_STAGE_SET(&entry, GIT_INDEX_STAGE_OURS);
+	cl_git_pass(git_index_add(index, &entry));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_sparse_checkout_set(g_repo, &sparse_directories));
+	cl_git_pass(git_sparse_checkout_update_index(g_repo));
+
+	indexed = git_index_get_bypath(index, "README", 0);
+	cl_assert(
+	        (indexed->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) == 0);
+	indexed = git_index_get_bypath(index, "src/README", 0);
+	cl_assert(
+	        (indexed->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) == 0);
+	indexed = git_index_get_bypath(index, "src/libgit2/repository.c", 0);
+	cl_assert(
+	        (indexed->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) == 0);
+	indexed = git_index_get_bypath(index, "src/other/file.c", 0);
+	cl_assert(
+	        (indexed->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) != 0);
+	indexed = git_index_get_bypath(index, "docs/guide.md", 0);
+	cl_assert(
+	        (indexed->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) != 0);
+	indexed = git_index_get_bypath(
+	        index, "conflicted.c", GIT_INDEX_STAGE_OURS);
+	cl_assert(
+	        (indexed->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) == 0);
+
+	git_index_free(index);
+}
+
+void test_repo_sparse__empty_index_is_initialized_from_head(void)
+{
+	git_strarray sparse_directories = {
+		NULL,
+		0,
+	};
+	git_index *index;
+	const git_index_entry *entry;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_clear(index));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_pass(git_sparse_checkout_set(g_repo, &sparse_directories));
+	cl_git_pass(git_sparse_checkout_initialize_index(g_repo));
+
+	cl_assert_equal_i(4, git_index_entrycount(index));
+
+	entry = git_index_get_bypath(index, "README", 0);
+	cl_assert(entry);
+	cl_assert((entry->flags_extended & GIT_INDEX_ENTRY_SKIP_WORKTREE) == 0);
+
+	git_index_free(index);
+}
+
+void test_repo_sparse__checks_out_included_paths(void)
+{
+	git_strarray sparse_directories = {
+		NULL,
+		0,
+	};
+	git_index *index;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_clear(index));
+	cl_git_pass(git_index_write(index));
+	cl_assert(!git_fs_path_isfile("testrepo/README"));
+
+	cl_git_pass(
+	        git_sparse_checkout_apply(g_repo, &sparse_directories, NULL));
+	cl_assert(git_fs_path_isfile("testrepo/README"));
+
+	git_index_free(index);
+}
+
+void test_repo_sparse__rejects_staged_changes(void)
+{
+	git_strarray sparse_directories = {
+		NULL,
+		0,
+	};
+	git_index *index;
+
+	cl_git_pass(git_repository_index(&index, g_repo));
+	cl_git_pass(git_index_remove_bypath(index, "README"));
+	cl_git_pass(git_index_write(index));
+
+	cl_git_fail_with(
+	        git_sparse_checkout_apply(g_repo, &sparse_directories, NULL),
+	        GIT_EUNCOMMITTED);
+
+	git_index_free(index);
+}

--- a/tests/libgit2/transports/smart/packet.c
+++ b/tests/libgit2/transports/smart/packet.c
@@ -351,3 +351,72 @@ void test_transports_smart_packet__ref_pkt(void)
 		"00360000000000000000000000000000000000000000 HEAD HEAD",
 		"0000000000000000000000000000000000000000", "HEAD HEAD", NULL);
 }
+
+void test_transports_smart_packet__filter_capability(void)
+{
+	git_pkt_ref pkt = { 0 };
+	transport_smart_caps caps = { 0 };
+	git_vector symrefs = GIT_VECTOR_INIT;
+
+	pkt.capabilities = GIT_CAP_FILTER;
+
+	cl_git_pass(git_smart__detect_caps(&pkt, &caps, &symrefs));
+	cl_assert(caps.common);
+	cl_assert(caps.filter);
+
+	git_vector_dispose(&symrefs);
+}
+
+void test_transports_smart_packet__blob_none_filter_request(void)
+{
+	static const char expected[] =
+		"003awant 0000000000000000000000000000000000000000 filter \n"
+		"0015filter blob:none\n"
+		"0000";
+	git_remote_head head = { 0 };
+	const git_remote_head *refs[] = { &head };
+	git_fetch_negotiation wants = { 0 };
+	transport_smart_caps caps = { 0 };
+	git_str packet = GIT_STR_INIT;
+
+	cl_git_pass(git_oid_from_string(
+		&head.oid, "0000000000000000000000000000000000000000", GIT_OID_SHA1));
+
+	wants.refs = refs;
+	wants.refs_len = 1;
+	wants.filter_spec = "blob:none";
+	caps.common = 1;
+	caps.filter = 1;
+
+	cl_git_pass(git_pkt_buffer_wants(&wants, &caps, &packet));
+	cl_assert_equal_i(sizeof(expected) - 1, packet.size);
+	cl_assert_equal_strn(expected, packet.ptr, packet.size);
+
+	git_str_dispose(&packet);
+}
+
+void test_transports_smart_packet__reachable_oid_capability(void)
+{
+	static const char expected[] =
+		"0050want 0000000000000000000000000000000000000000 allow-reachable-sha1-in-want \n"
+		"0000";
+	git_remote_head head = { 0 };
+	const git_remote_head *refs[] = { &head };
+	git_fetch_negotiation wants = { 0 };
+	transport_smart_caps caps = { 0 };
+	git_str packet = GIT_STR_INIT;
+
+	cl_git_pass(git_oid_from_string(
+		&head.oid, "0000000000000000000000000000000000000000", GIT_OID_SHA1));
+
+	wants.refs = refs;
+	wants.refs_len = 1;
+	caps.common = 1;
+	caps.want_reachable_sha1 = 1;
+
+	cl_git_pass(git_pkt_buffer_wants(&wants, &caps, &packet));
+	cl_assert_equal_i(sizeof(expected) - 1, packet.size);
+	cl_assert_equal_strn(expected, packet.ptr, packet.size);
+
+	git_str_dispose(&packet);
+}


### PR DESCRIPTION
Add filtered fetches, promisor-object hydration, and cone-mode sparse checkout.
Support blob and tree filters, sparse clone materialization, and automatic fetching o
omitted objects from a configured promisor remote. 
Include API documentation, a generic lg2 example, and coverage for the new workflows.